### PR TITLE
Patch setting termux path to mutt smime_keys.pl

### DIFF
--- a/packages/mutt/smime_keys_path.patch
+++ b/packages/mutt/smime_keys_path.patch
@@ -1,0 +1,11 @@
+--- mutt-1.5.23/smime_keys.pl	2014-03-12 17:03:45.000000000 +0100
++++ mutt/smime_keys.pl	2015-09-27 07:13:21.000000000 +0200
+@@ -53,7 +53,7 @@
+ # Get the directories mutt uses for certificate/key storage.
+ 
+ my $mutt = $ENV{MUTT_CMDLINE} || 'mutt';
+-my $opensslbin = "/usr/bin/openssl";
++my $opensslbin = "@TERMUX_PREFIX@/bin/openssl";
+ my @tempfiles = ();
+ my @cert_tmp_file = ();
+ 


### PR DESCRIPTION
Small patch for smime_keys.pl to call correct openssl binary.