### PR TITLE
reenable mosh package

### DIFF
--- a/packages/mosh/build.sh
+++ b/packages/mosh/build.sh
@@ -1,0 +1,20 @@
+TERMUX_PKG_HOMEPAGE=http://mosh.mit.edu/
+TERMUX_PKG_DESCRIPTION="Mobile shell that supports roaming and intelligent local echo"
+TERMUX_PKG_VERSION=1.2.5
+TERMUX_PKG_SRCURL=https://github.com/ddrown/mosh/archive/android-unicode.zip
+TERMUX_PKG_FOLDERNAME="mosh-android-unicode"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-server"
+TERMUX_PKG_BUILD_IN_SRC="yes"
+TERMUX_PKG_DEPENDS="libandroid-support, protobuf, ncurses, openssl, libutil"
+
+termux_step_pre_configure () {
+    ./autogen.sh
+}
+
+termux_step_post_make_install () {
+    cp $TERMUX_PKG_BUILDDIR/src/frontend/mosh $TERMUX_PREFIX/bin/mosh
+}
+
+export PROTOC=$TERMUX_TOPDIR/protobuf/host-build/src/protoc
+
+LDFLAGS+=" -lgnustl_shared"

--- a/packages/mosh/mosh.cc.patch
+++ b/packages/mosh/mosh.cc.patch
@@ -1,0 +1,12 @@
+diff -p -u -r /tmp/mosh-pristine/src/frontend/mosh.cc ./src/frontend/mosh.cc
+--- /tmp/mosh-pristine/src/frontend/mosh.cc	2014-07-04 18:16:13.000000000 -0700
++++ ./src/frontend/mosh.cc	2015-10-10 08:45:06.000000000 -0700
+@@ -33,6 +33,8 @@
+ #include <sys/types.h>
+ #include <sys/wait.h>
+ #include <termios.h>
++#include <unistd.h>
++#include <fcntl.h>
+ 
+ #if HAVE_PTY_H
+ #include <pty.h>


### PR DESCRIPTION
DO NOT MERGE YET

This builds mosh, unfortunately it only half-works. I too get an uncought exceptions sometimes, tried running with gdb or generating a core dump, but I failed. Need to investigate further, seems to be some C++ string resize problem within mosh.

This is for issue #20 