### PR TITLE
Add man-db and groff packages

### DIFF
--- a/disabled-packages/groff/build.sh
+++ b/disabled-packages/groff/build.sh
@@ -1,0 +1,5 @@
+TERMUX_PKG_HOMEPAGE=http://www.gnu.org/software/groff/
+TERMUX_PKG_DESCRIPTION="GNU troff text-formatting program"
+TERMUX_PKG_VERSION=1.22.3
+TERMUX_PKG_SRCURL=http://ftp.gnu.org/gnu/groff/groff-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-doc=no --without-gs --without-x"

--- a/disabled-packages/man-db/build.sh
+++ b/disabled-packages/man-db/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=http://www.nongnu.org/man-db/
 TERMUX_PKG_DESCRIPTION="Utilities for examining on-line help files (manual pages)"
 TERMUX_PKG_VERSION=2.7.4
 TERMUX_PKG_SRCURL=http://mirror.csclub.uwaterloo.ca/nongnu/man-db/man-db-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-db=gdbm --with-config-file=/data/data/com.termux/files/usr/etc/man_db.conf --disable-setuid --with-systemdtmpfilesdir=/data/data/com.termux/files/usr/lib/tmpfiles.d"
-TERMUX_PKG_DEPENDS="flex, gdbm, groff, less, libandroid-support, libpipeline"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-db=gdbm --with-pager=less --with-config-file=/data/data/com.termux/files/usr/etc/man_db.conf --disable-setuid --with-browser=lynx --with-gzip=gzip --with-systemdtmpfilesdir=/data/data/com.termux/files/usr/lib/tmpfiles.d"
+TERMUX_PKG_DEPENDS="flex, gdbm, groff, less, libandroid-support, libpipeline, lynx"
 
 export GROFF_TMAC_PATH="/data/data/com.termux/files/usr/lib/groff/site-tmac:/data/data/com.termux/files/usr/share/groff/site-tmac:/data/data/com.termux/files/usr/share/groff/current/tmac"

--- a/disabled-packages/man-db/build.sh
+++ b/disabled-packages/man-db/build.sh
@@ -3,6 +3,6 @@ TERMUX_PKG_DESCRIPTION="Utilities for examining on-line help files (manual pages
 TERMUX_PKG_VERSION=2.7.4
 TERMUX_PKG_SRCURL=http://mirror.csclub.uwaterloo.ca/nongnu/man-db/man-db-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-db=gdbm --with-config-file=/data/data/com.termux/files/usr/etc/man_db.conf --disable-setuid --with-systemdtmpfilesdir=/data/data/com.termux/files/usr/lib/tmpfiles.d"
-TERMUX_PKG_DEPENDS="libandroid-support, flex, gdbm, less, libpipeline"
+TERMUX_PKG_DEPENDS="flex, gdbm, groff, less, libandroid-support, libpipeline"
 
 export GROFF_TMAC_PATH="/data/data/com.termux/files/usr/lib/groff/site-tmac:/data/data/com.termux/files/usr/share/groff/site-tmac:/data/data/com.termux/files/usr/share/groff/current/tmac"

--- a/disabled-packages/man-db/build.sh
+++ b/disabled-packages/man-db/build.sh
@@ -1,0 +1,8 @@
+TERMUX_PKG_HOMEPAGE=http://www.nongnu.org/man-db/
+TERMUX_PKG_DESCRIPTION="Utilities for examining on-line help files (manual pages)"
+TERMUX_PKG_VERSION=2.7.4
+TERMUX_PKG_SRCURL=http://mirror.csclub.uwaterloo.ca/nongnu/man-db/man-db-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-db=gdbm --with-config-file=/data/data/com.termux/files/usr/etc/man_db.conf --disable-setuid --with-systemdtmpfilesdir=/data/data/com.termux/files/usr/lib/tmpfiles.d"
+TERMUX_PKG_DEPENDS="libandroid-support, flex, gdbm, less, libpipeline"
+
+export GROFF_TMAC_PATH="/data/data/com.termux/files/usr/lib/groff/site-tmac:/data/data/com.termux/files/usr/share/groff/site-tmac:/data/data/com.termux/files/usr/share/groff/current/tmac"


### PR DESCRIPTION
What this pull request contains:
* man-db 2.7.4
* groff 1.22.3

This is my first time contributing to an open source project of any kind, so there's most likely a lot of mistakes that need to be fixed. Here are a few that I've found:

1. `GROFF_TMAC_PATH` is hard coded to the defaults mentioned in the groff(1) man page (with the termux prefix).
2. I've added `$PREFIX/lib/man-db` to `LD_LIBRARY_PATH` in my `~/.profile`.
3. I've aliased `man` to be `man -E UTF-8` to bypass the iconv translation. Since libandroid-support has limited libiconv support, it doesn't handle translating to `en_US.UTF-8//TRANSLIT`.

Let me know what you think!

Some other details:

My .termuxrc:
```bash
#!/usr/bin/bash
export CC_FOR_BUILD="gcc -fdiagnostics-color=always"
export TERMUX_MAKE_PROCESSES="$(nproc)"
export TERMUX_TOPDIR="$HOME/termux"
export TERMUX_ARCH="arm"
export TERMUX_ARCH_BITS="32"
export TERMUX_HOST_PLATFORM="${TERMUX_ARCH}-linux-android"
export TERMUX_PREFIX='/data/data/com.termux/files/usr'
export TERMUX_ANDROID_HOME='/data/data/com.termux/files/home'
export TERMUX_GCC_VERSION="4.9"
export TERMUX_API_LEVEL="21"
export TERMUX_STANDALONE_TOOLCHAIN="$HOME/lib/android-standalone-toolchain-${TERMUX_ARCH}-api${TERMUX_API_LEVEL}-gcc${TERMUX_GCC_VERSION}"
export TERMUX_ANDROID_BUILD_TOOLS_VERSION="23.0.2"
```

I'm running **Ubuntu 15.10 64-bit** in VirtualBox.

Matthew