### PR TITLE
New packages: elinks and wol

### DIFF
--- a/packages/elinks/build.sh
+++ b/packages/elinks/build.sh
@@ -1,0 +1,7 @@
+TERMUX_PKG_HOMEPAGE=http://elinks.or.cz
+TERMUX_PKG_DESCRIPTION="Full-Featured Text WWW Browser"
+TERMUX_PKG_VERSION=0.12pre6
+TERMUX_PKG_BUILD_REVISION=1
+TERMUX_PKG_SRCURL=http://elinks.or.cz/download/elinks-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_DEPENDS="libexpat, libidn, openssl"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-256-colors --with-openssl --mandir=$TERMUX_PREFIX/share/man"

--- a/packages/wol/build.sh
+++ b/packages/wol/build.sh
@@ -1,0 +1,13 @@
+TERMUX_PKG_HOMEPAGE=http://sourceforge.net/projects/wake-on-lan/
+TERMUX_PKG_DESCRIPTION="wol implements Wake On LAN functionality in a small program. It wakes up hardware that is Magic Packet compliant"
+TERMUX_PKG_VERSION=0.7.1
+TERMUX_PKG_BUILD_REVISION=1
+TERMUX_PKG_SRCURL=http://downloads.openwrt.org/sources/wol-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--infodir=$TERMUX_PREFIX/share/info"
+
+termux_step_pre_configure() {
+	# https://dev.openwrt.org/browser/packages/net/wol/Makefile
+	export ac_cv_func_mmap_fixed_mapped=yes
+	export jm_cv_func_working_malloc=yes
+	export ac_cv_func_alloca_works=yes
+}


### PR DESCRIPTION
I use [ELinks](http://elinks.or.cz) instead of Lynx, so I missed it on Termux:

> ELinks is an advanced and well-established feature-rich text mode web (HTTP/FTP/..) browser. ELinks can render both frames and tables, is highly customizable and can be extended via Lua or Guile scripts. It is quite portable and runs on a variety of platforms. Check the about page for a more complete description.

Package is compiled with OpenSSL, libidn and expat support and with 256 colors.

I also added [wol](http://sourceforge.net/projects/wake-on-lan/), a small wake-on-lan utility:

> wol implements Wake On LAN functionality in a small program. It wakes up hardware that is Magic Packet compliant.