### PR TITLE
php: Enable glob() function

### DIFF
--- a/packages/php/build.sh
+++ b/packages/php/build.sh
@@ -6,7 +6,7 @@ TERMUX_PKG_NO_SRC_CACHE=yes # Caching with filename does not work for 'mirror'
 # Build native php for phar to build (see pear-Makefile.frag.patch):
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_FOLDERNAME=php-${TERMUX_PKG_VERSION}
-TERMUX_PKG_DEPENDS="libxml2, liblzma, openssl, pcre"
+TERMUX_PKG_DEPENDS="libandroid-glob, libxml2, liblzma, openssl, pcre"
 # http://php.net/manual/en/libxml.installation.php
 # "If configure cannot find xml2-config in the directory specified by --with-libxml-dir,
 # then it'll continue on and check the default locations."
@@ -19,6 +19,8 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --enable-zip"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_func_res_nsearch=no"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --mandir=$TERMUX_PREFIX/share/man"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --enable-sockets"
+
+LDFLAGS+=" -landroid-glob"
 
 termux_step_pre_configure () {
 	export PATH=$PATH:$TERMUX_PKG_HOSTBUILD_DIR/sapi/cli/


### PR DESCRIPTION
Make function [glob()](https://secure.php.net/glob) available in PHP, this required linking with available in Termux `libandroid-glob`