### PR TITLE
fix building of docker image by disabling ADD *.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,8 @@ RUN mkdir -p /data/data/com.termux/files/usr && mkdir -p /root/termux-packages &
     luarocks install lua-MessagePack && \
     luarocks install luabitop
 
-ADD *.py /root/termux-packages/
+# there are no *.py files, so ADD *.py fails if it is executed
+#ADD *.py /root/termux-packages/
 ADD *.sh /root/termux-packages/
 ADD *.spec /root/termux-packages/
 ADD packages /root/termux-packages/packages


### PR DESCRIPTION
with the current Dockerfile, the build of the docker container fails with:
> Step 8 : ADD *.py /root/termux-packages/
> INFO[0002] No source files were specified

This is because there are no *.py files in the root of the tree. I commented the 'ADD' out with an explanation. Now the build is successful.

