### PR TITLE
*.py scripts are in scripts/, now Dockerfile knows that too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN mkdir -p /data/data/com.termux/files/usr && mkdir -p /root/termux-packages &
     luarocks install lua-MessagePack && \
     luarocks install luabitop
 
-ADD *.py /root/termux-packages/
+ADD scripts /root/termux-packages/scripts
 ADD *.sh /root/termux-packages/
 ADD *.spec /root/termux-packages/
 ADD packages /root/termux-packages/packages

--- a/packages/hunspell-en-us/build.sh
+++ b/packages/hunspell-en-us/build.sh
@@ -2,7 +2,6 @@ TERMUX_PKG_HOMEPAGE=http://sourceforge.net/projects/hunspell/files/Spelling%20di
 TERMUX_PKG_DESCRIPTION="American english dictionary for hunspell"
 TERMUX_PKG_VERSION=1.1
 TERMUX_PKG_BUILD_REVISION=1
-TERMUX_PKG_DEPENDS="hunspell"
 TERMUX_PKG_PLATFORM_INDEPENDENT=yes
 
 termux_step_make_install () {


### PR DESCRIPTION
this is the correct fix as discussed here https://github.com/termux/termux-packages/pull/160
furthermore: build-all.sh was broken, because hunspell-en-us and hunspell depended on eachother, so I changed that also