### PR TITLE
Make PRoot work

### DIFF
--- a/disabled-packages/libtalloc/build.sh
+++ b/disabled-packages/libtalloc/build.sh
@@ -7,7 +7,7 @@ TERMUX_PKG_BUILD_IN_SRC="yes"
 
 termux_step_configure () {
 	# Make sure symlinks are installed:
-	rm $TERMUX_PREFIX/lib/libtalloc*
+	rm $TERMUX_PREFIX/lib/libtalloc* || true
 
 	cd $TERMUX_PKG_SRCDIR
 

--- a/disabled-packages/proot/src-execve-enter.c.patch
+++ b/disabled-packages/proot/src-execve-enter.c.patch
@@ -1,0 +1,42 @@
+--- PRoot-5.1.0/src/execve/enter.c	2014-12-15 15:18:11.000000000 +0100
++++ src/src/execve/enter.c	2016-03-20 12:05:08.013426156 +0100
+@@ -454,10 +454,10 @@
+ }
+ 
+ extern unsigned char _binary_loader_exe_start;
+-extern unsigned char _binary_loader_exe_size;
++extern unsigned char _binary_loader_exe_end;
+ 
+ extern unsigned char WEAK _binary_loader_m32_exe_start;
+-extern unsigned char WEAK _binary_loader_m32_exe_size;
++extern unsigned char WEAK _binary_loader_m32_exe_end;
+ 
+ /**
+  * Extract the built-in loader.  This function returns NULL if an
+@@ -483,11 +483,11 @@
+ 
+ 	if (wants_32bit_version) {
+ 		start = (void *) &_binary_loader_m32_exe_start;
+-		size  = (size_t) &_binary_loader_m32_exe_size;
++		size  = (size_t) (&_binary_loader_m32_exe_end - &_binary_loader_m32_exe_start);
+ 	}
+ 	else {
+ 		start = (void *) &_binary_loader_exe_start;
+-		size  = (size_t) &_binary_loader_exe_size;
++		size  = (size_t) (&_binary_loader_exe_end - &_binary_loader_exe_start);
+ 	}
+ 
+ 	status2 = write(fd, start, size);
+@@ -645,8 +645,10 @@
+ 
+ 		/* An ELF interpreter is supposed to be
+ 		 * standalone.  */
+-		if (tracee->load_info->interp->interp != NULL)
+-			return -EINVAL;
++		if (tracee->load_info->interp->interp != NULL) {
++			TALLOC_FREE(tracee->load_info->interp->interp);
++			// TODO: Print warning?
++		}
+ 	}
+ 
+ 	compute_load_addresses(tracee);

--- a/disabled-packages/proot/src-tracee-mem.c.patch
+++ b/disabled-packages/proot/src-tracee-mem.c.patch
@@ -1,0 +1,32 @@
+--- PRoot-5.1.0/src/tracee/mem.c	2014-12-15 15:18:11.000000000 +0100
++++ src/src/tracee/mem.c	2016-03-20 10:37:46.288702967 +0100
+@@ -131,6 +131,9 @@
+ 	/* Copy the bytes in the last word carefully since we have to
+ 	 * overwrite only the relevant ones. */
+ 
++	/* Clear errno so we won't detect previous syscall failure as ptrace one */
++	errno = 0;
++
+ 	word = ptrace(PTRACE_PEEKDATA, tracee->pid, dest + i, NULL);
+ 	if (errno != 0) {
+ 		note(tracee, WARNING, SYSTEM, "ptrace(PEEKDATA)");
+@@ -236,6 +239,9 @@
+ 	nb_trailing_bytes = size % sizeof(word_t);
+ 	nb_full_words     = (size - nb_trailing_bytes) / sizeof(word_t);
+ 
++	/* Clear errno so we won't detect previous syscall failure as ptrace one */
++	errno = 0;
++
+ 	/* Copy one word by one word, except for the last one. */
+ 	for (i = 0; i < nb_full_words; i++) {
+ 		word = ptrace(PTRACE_PEEKDATA, tracee->pid, src + i, NULL);
+@@ -366,6 +372,9 @@
+ 	nb_trailing_bytes = max_size % sizeof(word_t);
+ 	nb_full_words     = (max_size - nb_trailing_bytes) / sizeof(word_t);
+ 
++	/* Clear errno so we won't detect previous syscall failure as ptrace one */
++	errno = 0;
++
+ 	/* Copy one word by one word, except for the last one. */
+ 	for (i = 0; i < nb_full_words; i++) {
+ 		word = ptrace(PTRACE_PEEKDATA, tracee->pid, src + i, NULL);


### PR DESCRIPTION
* Don't fail `libtalloc` build if we couldn't `rm` previous version
* Clear `errno` before `ptrace(PTRACE_PEEKDATA)`
* Handle relocated embedded loader
* Don't reject binaries with linker having it's own `DT_INTERP` section

Appears to work now, through I did only simple tests, such as:
```
proot -0 id
proot -b /sdcard:/sys ls /sys
```

I think it's now might ready to be moved out of `disabled-packages`

Also, possibly I should upstream some of these changes, not sure about that.