### PR TITLE
php: Enable zlib extension

### DIFF
--- a/packages/php/build.sh
+++ b/packages/php/build.sh
@@ -15,6 +15,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-openssl=$TERMUX_PREFIX"
 # http://php.net/manual/en/pcre.installation.php: pcre always enabled, use platform library:
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-pcre-regex=$TERMUX_PREFIX"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-iconv=$TERMUX_PREFIX"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-zlib"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --enable-zip"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_func_res_nsearch=no"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --mandir=$TERMUX_PREFIX/share/man"


### PR DESCRIPTION
Enable zlib extension in PHP (for [gzinflate](https://secure.php.net/gzinflate) and compressed PHAR support, php is linked with libz.so anyway)