### PR TITLE
Added mp3splt, libmp3splt, libmad and libid3tag packages

### DIFF
--- a/packages/libid3tag/build.sh
+++ b/packages/libid3tag/build.sh
@@ -1,0 +1,5 @@
+TERMUX_PKG_HOMEPAGE=http://www.underbit.com/products/mad/
+TERMUX_PKG_DESCRIPTION="MAD ID3 tag manipulation library"
+TERMUX_PKG_VERSION=0.15.1b
+TERMUX_PKG_BUILD_REVISION=1
+TERMUX_PKG_SRCURL=ftp://ftp.mars.org/pub/mpeg/libid3tag-${TERMUX_PKG_VERSION}.tar.gz

--- a/packages/libmad/build.sh
+++ b/packages/libmad/build.sh
@@ -1,0 +1,10 @@
+TERMUX_PKG_HOMEPAGE=http://www.underbit.com/products/mad/
+TERMUX_PKG_DESCRIPTION="MAD is a high-quality MPEG audio decoder"
+TERMUX_PKG_VERSION=0.15.1b
+TERMUX_PKG_BUILD_REVISION=1
+TERMUX_PKG_SRCURL=ftp://ftp.mars.org/pub/mpeg/libmad-${TERMUX_PKG_VERSION}.tar.gz
+
+termux_post_configure() {
+	cd $TERMUX_PKG_SRCDIR
+	sed -i -e 's/-force-mem//g' Makefile
+}

--- a/packages/libmp3splt/build.sh
+++ b/packages/libmp3splt/build.sh
@@ -1,0 +1,7 @@
+TERMUX_PKG_HOMEPAGE=http://mp3splt.sourceforge.net
+TERMUX_PKG_DESCRIPTION="Mp3Splt-project is a utility to split mp3, ogg vorbis and native FLAC files selecting a begin and an end time position, without decoding"
+TERMUX_PKG_VERSION=0.9.2
+TERMUX_PKG_BUILD_REVISION=1
+TERMUX_PKG_SRCURL=http://prdownloads.sourceforge.net/mp3splt/libmp3splt-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_DEPENDS="libmad, libid3tag, pcre"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-flac --disable-ogg --disable-cutter"

--- a/packages/mp3splt/build.sh
+++ b/packages/mp3splt/build.sh
@@ -1,0 +1,13 @@
+TERMUX_PKG_HOMEPAGE=http://mp3splt.sourceforge.net
+TERMUX_PKG_DESCRIPTION="Mp3Splt-project is a utility to split mp3, ogg vorbis and native FLAC files selecting a begin and an end time position, without decoding"
+TERMUX_PKG_VERSION=2.6.2
+TERMUX_PKG_BUILD_REVISION=1
+TERMUX_PKG_SRCURL=http://prdownloads.sourceforge.net/mp3splt/mp3splt-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_DEPENDS="libmp3splt"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--mandir=$TERMUX_PREFIX/share/man"
+
+termux_step_post_configure() {
+	cd $TERMUX_PKG_SRCDIR/src
+	sed -i -e 's/BEOS/ANDROID/g' freedb.c
+	touch langinfo.h
+}


### PR DESCRIPTION
I added mp3splt and its dependencies:

> Mp3Splt-project is a utility to split mp3, ogg vorbis and native FLAC files selecting a begin and an end time position, without decoding. It's very useful to split large mp3/ogg vorbis/FLAC to make smaller files or to split entire albums to obtain original tracks. If you want to split an album, you can select split points and filenames manually or you can get them automatically from CDDB (internet or a local file) or from .cue files. Supports also automatic silence split, that can be used also to adjust cddb/cue splitpoints. Trimming using silence detection is also available. You can extract tracks from Mp3Wrap or AlbumWrap files in few seconds. For mp3 files, both ID3v1 & ID3v2 tags are supported. 

This tool, used together with _youtube-dl_ (pip install youtube-dl) and _ffmpeg_ allows to download any video from YouTube, extract audio and split the MP3.