### PR TITLE
Added zbar package

### DIFF
--- a/packages/zbar/build.sh
+++ b/packages/zbar/build.sh
@@ -1,0 +1,7 @@
+TERMUX_PKG_HOMEPAGE=http://zbar.sourceforge.net
+TERMUX_PKG_DESCRIPTION="ZBar is an open source software suite for reading bar codes from various sources"
+TERMUX_PKG_VERSION=0.10
+TERMUX_PKG_BUILD_REVISION=1
+TERMUX_PKG_SRCURL=http://downloads.sourceforge.net/project/zbar/zbar/0.10/zbar-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_DEPENDS="imagemagick"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-pthread --disable-video --without-xshm --without-xv --without-gtk --without-qt --without-python --mandir=$TERMUX_PREFIX/share/man"


### PR DESCRIPTION
Another interesting package is [ZBar](http://zbar.sourceforge.net):

> ZBar is an open source software suite for reading bar codes from various sources, such as video streams, image files and raw intensity sensors. It supports many popular symbologies (types of bar codes) including EAN-13/UPC-A, UPC-E, EAN-8, Code 128, Code 39, Interleaved 2 of 5 and QR Code.

Is compiled without obvious dependencies (QT, GTK, X11) and without Python. Depends on ImageMagick and uses iconv, so don't know if I must add libandroid-support as dependency (feel free to add it).

I tested with QR and EAN codes:

![screenshot_20160329-235045](https://cloud.githubusercontent.com/assets/478660/14125109/ae9039fa-f609-11e5-9b6c-ae8c1c38f506.png)
