### PR TITLE
Added byobu package

### DIFF
--- a/packages/byobu/build.sh
+++ b/packages/byobu/build.sh
@@ -1,0 +1,7 @@
+TERMUX_PKG_HOMEPAGE=http://byobu.co/
+TERMUX_PKG_DESCRIPTION="Byobu is a GPLv3 open source text-based window manager and terminal multiplexer"
+TERMUX_PKG_VERSION=5.104
+TERMUX_PKG_BUILD_REVISION=1
+TERMUX_PKG_FOLDERNAME="byobu-${TERMUX_PKG_VERSION}"
+TERMUX_PKG_SRCURL=https://launchpad.net/byobu/trunk/${TERMUX_PKG_VERSION}/+download/byobu_${TERMUX_PKG_VERSION}.orig.tar.gz
+TERMUX_PKG_DEPENDS="gawk,tmux"


### PR DESCRIPTION
I added the great [Byobu](byobu.co):

> Byobu is a GPLv3 open source text-based window manager and terminal multiplexer. It was originally designed to provide elegant enhancements to the otherwise functional, plain, practical GNU Screen, for the Ubuntu server distribution. Byobu now includes an enhanced profiles, convenient keybindings, configuration utilities, and toggle-able system status notifications for both the GNU Screen window manager and the more modern Tmux terminal multiplexer, and works on most Linux, BSD, and Mac distributions.

There are some *dependencies* that can't be satisfied easy (like *locale* or *hostname* commands), but are used for [status notifications](http://manpages.ubuntu.com/manpages/xenial/en/man1/byobu.1.html), so there's no need to add them.

![screenshot_20160403-201630](https://cloud.githubusercontent.com/assets/478660/14234064/86c6249c-f9d9-11e5-8cfa-90839c33a0c4.png)
