### PR TITLE
gnupg: Don't have text relocations on x86

### DIFF
--- a/packages/gnupg/src-mpi-Makefile.in.patch
+++ b/packages/gnupg/src-mpi-Makefile.in.patch
@@ -1,0 +1,11 @@
+--- gnupg-1.4.20/mpi/Makefile.in	2015-12-20 08:53:15.000000000 +0100
++++ src/mpi/Makefile.in	2016-04-19 19:33:55.167315560 +0200
+@@ -713,7 +713,7 @@
+ # cancel the default rules used by libtool which do not really
+ # work and add one to cpp .S files
+ .S.o:
+-	 $(CPP) $(INCLUDES) $(DEFS) $< | grep -v '^#' > _$*.s
++	 $(CPP) $(INCLUDES) $(DEFS) -DPIC $< | grep -v '^#' > _$*.s
+ 	 $(COMPILE) $(AM_CCASFLAGS) -c _$*.s
+ 	 mv -f _$*.o $*.o
+ 


### PR DESCRIPTION
GnuPG has x86-specific assembly files that don't have text relocations only if they are preprocessed with PIC macro defined

These assembly files are src/mpi/i386/mpih-{add,sub}1.S

It appears that linker in N developer preview enforces requirement to not have text relocations in executables, so this is necessary for `apt` to work on x86 with Android N developer preview.

This change should affect only x86 and have no effect on other archs.

(The other thing not working on N is `bash`, but tested few other things on emulator and rest appears to be fine)