### PR TITLE
PHP package enhanced with curl, gd and mcrypt extensions

### DIFF
--- a/packages/libgd/build.sh
+++ b/packages/libgd/build.sh
@@ -1,0 +1,5 @@
+TERMUX_PKG_HOMEPAGE=http://libgd.org
+TERMUX_PKG_DESCRIPTION="GD is an open source code library for the dynamic creation of images by programmers"
+TERMUX_PKG_VERSION=2.1.1
+TERMUX_PKG_SRCURL=https://github.com/libgd/libgd/releases/download/gd-${TERMUX_PKG_VERSION}/libgd-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_DEPENDS="freetype, fontconfig, libjpeg-turbo, libpng, libtiff"

--- a/packages/libmcrypt/build.sh
+++ b/packages/libmcrypt/build.sh
@@ -1,6 +1,6 @@
 TERMUX_PKG_HOMEPAGE=http://mcrypt.sourceforge.net/
 TERMUX_PKG_DESCRIPTION="MCrypt is a replacement for the old crypt() package and crypt(1) command, with extensions"
 TERMUX_PKG_VERSION=2.5.8
-TERMUX_PKG_SRCURL=http://downloads.sourceforge.net/project/mcrypt/Libmcrypt/2.5.8/libmcrypt-2.5.8.tar.bz2
+TERMUX_PKG_SRCURL=http://downloads.sourceforge.net/project/mcrypt/Libmcrypt/${TERMUX_PKG_VERSION}/libmcrypt-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_BUILD_IN_SRC=yes
 

--- a/packages/libmcrypt/build.sh
+++ b/packages/libmcrypt/build.sh
@@ -1,0 +1,6 @@
+TERMUX_PKG_HOMEPAGE=http://mcrypt.sourceforge.net/
+TERMUX_PKG_DESCRIPTION="MCrypt is a replacement for the old crypt() package and crypt(1) command, with extensions"
+TERMUX_PKG_VERSION=2.5.8
+TERMUX_PKG_SRCURL=http://downloads.sourceforge.net/project/mcrypt/Libmcrypt/2.5.8/libmcrypt-2.5.8.tar.bz2
+TERMUX_PKG_BUILD_IN_SRC=yes
+

--- a/packages/php/build.sh
+++ b/packages/php/build.sh
@@ -1,13 +1,13 @@
 TERMUX_PKG_HOMEPAGE=http://php.net/
 TERMUX_PKG_DESCRIPTION="Server-side, HTML-embedded scripting language"
 TERMUX_PKG_VERSION=5.6.20
-TERMUX_PKG_BUILD_REVISION=1
+TERMUX_PKG_BUILD_REVISION=2
 TERMUX_PKG_SRCURL=http://php.net/get/php-${TERMUX_PKG_VERSION}.tar.xz/from/this/mirror
 TERMUX_PKG_NO_SRC_CACHE=yes # Caching with filename does not work for 'mirror'
 # Build native php for phar to build (see pear-Makefile.frag.patch):
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_FOLDERNAME=php-${TERMUX_PKG_VERSION}
-TERMUX_PKG_DEPENDS="libandroid-glob, libxml2, liblzma, openssl, pcre, libcrypt"
+TERMUX_PKG_DEPENDS="libandroid-glob, libxml2, liblzma, openssl, pcre, libcrypt, libmcrypt, libcurl"
 # http://php.net/manual/en/libxml.installation.php
 # "If configure cannot find xml2-config in the directory specified by --with-libxml-dir,
 # then it'll continue on and check the default locations."
@@ -16,6 +16,9 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-openssl=$TERMUX_PREFIX"
 # http://php.net/manual/en/pcre.installation.php: pcre always enabled, use platform library:
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-pcre-regex=$TERMUX_PREFIX"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-iconv=$TERMUX_PREFIX"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-curl=$TERMUX_PREFIX"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-mcrypt=$TERMUX_PREFIX"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-gd=$TERMUX_PREFIX"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-zlib"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --enable-zip"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_func_res_nsearch=no"
@@ -35,4 +38,5 @@ termux_step_pre_configure () {
 
 termux_step_post_configure () {
 	perl -p -i -e 's/#define HAVE_RES_NSEARCH 1//' $TERMUX_PKG_BUILDDIR/main/php_config.h
+	perl -p -i -e 's/#define HAVE_GD_XPM 1//' $TERMUX_PKG_BUILDDIR/main/php_config.h
 }


### PR DESCRIPTION
I'm a PHP developer and I missed some extensions on Termux's PHP build. I added support for cURL with existing libcurl package and added new libraries to build libgd (for creating images) and libmcrypt (required by modern frameworks like Laravel/Lumen).

I compiled libgd with wide format support (PNG, JPEG, TIFF) and also added FreeType and Fontconfig dependencies.

I tested each extension with examples from PHP.net, and here is screenshot with the enabled modules after compile:

![screenshot_20160427-001833](https://cloud.githubusercontent.com/assets/478660/14836109/0a566b50-0c0e-11e6-8ea5-7a27ebc9016b.png)
