### PR TITLE
ltrace: Step towards working version

### DIFF
--- a/disabled-packages/ltrace/build.sh
+++ b/disabled-packages/ltrace/build.sh
@@ -1,5 +1,25 @@
 TERMUX_PKG_HOMEPAGE=http://www.ltrace.org/
 TERMUX_PKG_DESCRIPTION="Tracks runtime library calls in dynamically linked programs"
-TERMUX_PKG_VERSION=0.7.3
-TERMUX_PKG_SRCURL=http://www.ltrace.org/ltrace_${TERMUX_PKG_VERSION}.orig.tar.bz2
-TERMUX_PKG_FOLDERNAME=ltrace-${TERMUX_PKG_VERSION}
+TERMUX_PKG_VERSION=0.7.3.20160411
+TERMUX_PKG_DEPENDS="elfutils"
+
+# TERMUX_PKG_SRCURL=http://www.ltrace.org/ltrace_${TERMUX_PKG_VERSION}.orig.tar.bz2
+# TERMUX_PKG_FOLDERNAME=ltrace-${TERMUX_PKG_VERSION}
+
+_COMMIT=2def9f1217374cc8371105993003b2c663aefda7
+TERMUX_PKG_SRCURL=https://github.com/dkogan/ltrace/archive/${_COMMIT}.zip
+TERMUX_PKG_FOLDERNAME=ltrace-${_COMMIT}
+
+termux_step_pre_configure () {
+    autoreconf -i ../src
+}
+
+
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="ac_cv_host=$TERMUX_ARCH-generic-linux-gnu"
+
+CFLAGS+=" -Wno-error=maybe-uninitialized"
+
+# rindex is obsolete name of strrchr which is not available in Android
+# function signature stays same, so I'm replacing it with C preprocessor
+# instead of patch
+CFLAGS+=" -Drindex=strrchr"

--- a/disabled-packages/ltrace/ltrace-elf.c.patch
+++ b/disabled-packages/ltrace/ltrace-elf.c.patch
@@ -1,0 +1,13 @@
+--- ltrace-2def9f1217374cc8371105993003b2c663aefda7/ltrace-elf.c	2016-04-11 21:30:04.000000000 +0200
++++ src/ltrace-elf.c	2016-05-07 21:23:17.999754862 +0200
+@@ -423,7 +423,9 @@
+ 	debug(DEBUG_FUNCTION, "close_elf()");
+ 	elf_end(lte->elf);
+ 	close(lte->fd);
+-	VECT_DESTROY(&lte->plt_relocs, GElf_Rela, NULL, NULL);
++	if (lte->plt_relocs.elt_size) {
++		VECT_DESTROY(&lte->plt_relocs, GElf_Rela, NULL, NULL);
++	}
+ }
+ 
+ static void


### PR DESCRIPTION
- Use version from git, current release has problems with ARM
- Replace rindex with strrchr using C preprocessor
- Don't exit on ltelf_destroy on library that failed to load

Not included in pull request:
- I've used my host `libelf.h` header, the one from NDK has few definitions missing (Not included because I've altered my in `/data`, not sure how to package it to `ndk_patches` or somewhere else)
- Removed `termux_step_post_massage` in `elfutils` (Not included here because I think that there is a reason why it was put there)

It's mostly working for me, but showing a few warnings at beginning, trying to open libraries at wrong directories or main executable as library and doesn't load config from `[...]/share/ltrace/[...].so` (Probably due to wrongly recognized libraries, this means that this package out-of-the-box won't recognize parameters, can do after `cat ~/../usr/share/ltrace/*.conf > ~/.ltrace.conf` although then there are many warnings about duplicate entries)

So, not production-ready yet, but always step forward.