### PR TITLE
ndk_patches: Add missing argument to open(, O_CREAT) in tmpfile()

### DIFF
--- a/ndk_patches/stdio.h.patch
+++ b/ndk_patches/stdio.h.patch
@@ -62,7 +62,7 @@ diff -u -r /home/fornwall/lib/android-ndk/platforms/android-21/arch-arm/usr/incl
 +	for (i = 0; i < 100; i++) {
 +		unsigned int r = arc4random();
 +		if (asprintf(&path, "@TERMUX_PREFIX@/tmp/tmpfile.%d-%u", p, r) == -1) return NULL;
-+		int fd = open(path, O_RDWR | O_CREAT | O_EXCL | O_LARGEFILE);
++		int fd = open(path, O_RDWR | O_CREAT | O_EXCL | O_LARGEFILE, 0600);
 +		free(path);
 +		if (fd >= 0) {
 +			FILE* result = fdopen(fd, "w+");


### PR DESCRIPTION
This was required for building debug elfutils and when this argument is not provided then some previous value from stack/register is used.