### PR TITLE
Added ØMQ (zeromq, 0mq, zeromq) and Sodium crypto libraries

### DIFF
--- a/packages/libsodium/build.sh
+++ b/packages/libsodium/build.sh
@@ -1,0 +1,5 @@
+TERMUX_PKG_HOMEPAGE=https://libsodium.org/
+TERMUX_PKG_DESCRIPTION="Network communication, cryptography and signaturing library."
+TERMUX_PKG_VERSION=1.0.10
+TERMUX_PKG_BUILD_REVISION=1
+TERMUX_PKG_SRCURL=https://github.com/jedisct1/libsodium/releases/download/${TERMUX_PKG_VERSION}/libsodium-${TERMUX_PKG_VERSION}.tar.gz

--- a/packages/libzmq/build.sh
+++ b/packages/libzmq/build.sh
@@ -1,0 +1,6 @@
+TERMUX_PKG_HOMEPAGE=http://zeromq.org/
+TERMUX_PKG_DESCRIPTION="Fast messaging system built on sockets. C and C++ bindings. aka 0MQ, ZMQ."
+TERMUX_PKG_VERSION=4.1.4
+TERMUX_PKG_BUILD_REVISION=1
+TERMUX_PKG_SRCURL=http://download.zeromq.org/zeromq-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_DEPENDS="libsodium"


### PR DESCRIPTION
Nothing fancy. These simple build.sh scripts just work.

These packages are needed for the Python binding for ØMQ (I'm making another PR for it).