### PR TITLE
python: Make os.set_inheritable work on sockets

### DIFF
--- a/packages/python/fileutils.c.patch
+++ b/packages/python/fileutils.c.patch
@@ -1,0 +1,11 @@
+--- Python-3.5.1/Python/fileutils.c	2015-12-07 02:39:11.000000000 +0100
++++ src/Python/fileutils.c	2016-05-17 21:46:09.006285776 +0200
+@@ -856,7 +856,7 @@
+             return 0;
+         }
+ 
+-        if (errno != ENOTTY) {
++        if (errno != ENOTTY && errno != EACCES) {
+             if (raise)
+                 PyErr_SetFromErrno(PyExc_OSError);
+             return -1;


### PR DESCRIPTION
As SELinux policy disallows `ioctl` on sockets we have to fall back
to `fcntl` on EACCES

Fixes [issue with Flask reported by Irvel N on Google+ community](https://plus.google.com/+IrvelN/posts/SC7T8Qj7xFy), however now Flask can be only run with debug mode disabled, as in debug mode it calls `ip link list` shell command which hangs waiting for netlink response after having failed sending request to kernel (also due to SELinux). That can be fixed with `rm /data/data/com.termux/files/usr/bin/ip` but that doesn't seem to be right solution.