### PR TITLE
tasksh: Add package (shell command that wraps Taskwarrior commands)

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -299,7 +299,18 @@ termux_step_extract_package () {
 	fi
 	rm -Rf $folder
 	if [ ${file##*.} = zip ]; then
-		unzip $file
+		unzip -d _unzipped $file
+		if [ -d _unzipped/$folder ]; then
+			# Zip archive was expected to contain a single top folder.
+			mv _unzipped/$folder $folder
+			# It's reasonably expected here that $folder would be the single subfolder in _unzipped.
+			# If there are any other subfolders, building should stop for clearing the situation and
+			# tuning building process. And rmdir does that.
+			rmdir _unzipped
+		else
+			# Zip archive contains multiple top files and folders.
+			mv _unzipped $folder
+		fi
 	else
 		$TERMUX_TAR xf $file
 	fi

--- a/build-package.sh
+++ b/build-package.sh
@@ -190,6 +190,7 @@ TERMUX_PKG_RM_AFTER_INSTALL=""
 TERMUX_PKG_DEPENDS=""
 TERMUX_PKG_HOMEPAGE=""
 TERMUX_PKG_DESCRIPTION="FIXME:Add description"
+TERMUX_PKG_RENAME_DISTFILE_TO=""
 TERMUX_PKG_FOLDERNAME=""
 TERMUX_PKG_KEEP_STATIC_LIBRARIES="false"
 TERMUX_PKG_KEEP_HEADER_FILES="false"
@@ -283,7 +284,11 @@ termux_step_extract_package () {
         fi
 	cd $TERMUX_PKG_TMPDIR
 	filename=`basename $TERMUX_PKG_SRCURL`
-	file=$TERMUX_PKG_CACHEDIR/$filename
+	if [ "x$TERMUX_PKG_RENAME_DISTFILE_TO" = "x" ]; then
+		file=$TERMUX_PKG_CACHEDIR/$filename
+	else
+		file=$TERMUX_PKG_CACHEDIR/$TERMUX_PKG_RENAME_DISTFILE_TO
+	fi
 	# Set "TERMUX_PKG_NO_SRC_CACHE=yes" in package to never cache packages, such as in git builds:
 	test -n ${TERMUX_PKG_NO_SRC_CACHE-""} -o ! -f $file && curl --retry 3 -o $file -L $TERMUX_PKG_SRCURL
 	if [ "x$TERMUX_PKG_FOLDERNAME" = "x" ]; then

--- a/packages/tasksh/CMakeLists.patch
+++ b/packages/tasksh/CMakeLists.patch
@@ -1,0 +1,22 @@
+diff -u -r ../tasksh-726a1630bfd60fdfba36e4a3aa8b21ee04ab970a/CMakeLists.txt ./CMakeLists.txt
+--- ../tasksh-726a1630bfd60fdfba36e4a3aa8b21ee04ab970a/CMakeLists.txt	2016-05-25 02:20:42.000000000 +0000
++++ ./CMakeLists.txt	2016-05-25 02:30:39.000000000 +0000
+@@ -81,15 +81,15 @@
+ SET (TASKSH_BINDIR  bin                 CACHE STRING "Installation directory for the binary")
+ 
+ message ("-- Looking for SHA1 references")
+-if (EXISTS ${CMAKE_SOURCE_DIR}/.git/index)
++if (EXISTS ${CMAKE_SOURCE_DIR}/commit.sha1.savedbytermuxbuildsh.txt)
+   set (HAVE_COMMIT true)
+-  execute_process (COMMAND git log -1 --pretty=format:%h
++  execute_process (COMMAND cat commit.sha1.savedbytermuxbuildsh.txt
+                    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                    OUTPUT_VARIABLE COMMIT)
+   configure_file ( ${CMAKE_SOURCE_DIR}/commit.h.in
+                    ${CMAKE_SOURCE_DIR}/commit.h)
+   message ("-- Found SHA1 reference: ${COMMIT}")
+-endif (EXISTS ${CMAKE_SOURCE_DIR}/.git/index)
++endif (EXISTS ${CMAKE_SOURCE_DIR}/commit.sha1.savedbytermuxbuildsh.txt)
+ 
+ set (PACKAGE "${PROJECT_NAME}")
+ set (VERSION "${PROJECT_VERSION}")

--- a/packages/tasksh/build.sh
+++ b/packages/tasksh/build.sh
@@ -1,0 +1,52 @@
+TERMUX_PKG_HOMEPAGE=https://tasktools.org/projects/tasksh.html
+TERMUX_PKG_DESCRIPTION="Shell command that wraps Taskwarrior commands"
+# Package version scheme until release:
+#
+#     <version>~git<commit-date>.<package-version-for-that-date>.<commit-short-sha1>
+#
+# Because `dpkg --compare-versions '1.1.0~git3.1.337' lt 1.1.0` is true.
+#
+# <package-version-for-that-date> should increase for every package with the
+# same <commit-date> part because <commit-short-sha1> could contain "random"
+# character out of the desired sorting order. <package-version-for-that-date>
+# should be 1 for package with new <commit-date>.
+TERMUX_PKG_VERSION=1.1.0~git20160330.1.726a163
+# https://git.tasktools.org/projects/EX/repos/tasksh/commits?until=refs%2Fheads%2F1.1.0
+# Look for link "Download" at the top right corner.
+TERMUX_PKG_SRCURL=https://git.tasktools.org/plugins/servlet/archive/projects/EX/repos/tasksh?at=726a1630bfd60fdfba36e4a3aa8b21ee04ab970a
+TERMUX_PKG_RENAME_DISTFILE_TO=tasksh-${TERMUX_PKG_VERSION}.zip
+TERMUX_PKG_DEPENDS="libgnustl, libandroid-glob, readline"
+
+LDFLAGS+=" -landroid-glob"
+
+termux_step_post_extract_package () {
+	# Saved commit SHA1 is used by patched CMakeFiles.txt.
+	echo -n "${TERMUX_PKG_VERSION##*.}" \
+		> "${TERMUX_PKG_SRCDIR}/commit.sha1.savedbytermuxbuildsh.txt"
+}
+
+termux_step_configure () {
+	cd $TERMUX_PKG_BUILDDIR
+	# Point to libandroid-glob header location through
+	# -DTASKSH_INCLUDE_DIRS.
+	#
+	# Other -D values were copied from taskwarrior package with removing
+	# some of them that CMake detected as not used in the building process.
+	cmake -G "Unix Makefiles" .. \
+		-DTASKSH_INCLUDE_DIRS="${TERMUX_PREFIX}/include" \
+		-DCMAKE_AR=`which ${TERMUX_HOST_PLATFORM}-ar` \
+		-DCMAKE_BUILD_TYPE=MinSizeRel \
+		-DCMAKE_C_FLAGS="$CFLAGS $CPPFLAGS" \
+		-DCMAKE_CROSSCOMPILING=True \
+		-DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+		-DCMAKE_FIND_ROOT_PATH=$TERMUX_PREFIX \
+		-DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
+		-DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
+		-DCMAKE_INSTALL_PREFIX=$TERMUX_PREFIX \
+		-DCMAKE_LINKER=`which ${TERMUX_HOST_PLATFORM}-ld` \
+		-DCMAKE_MAKE_PROGRAM=`which make` \
+		-DCMAKE_RANLIB=`which ${TERMUX_HOST_PLATFORM}-ranlib` \
+		-DCMAKE_SKIP_INSTALL_RPATH=ON \
+		-DCMAKE_SYSTEM_NAME=Linux \
+		$TERMUX_PKG_SRCDIR
+}


### PR DESCRIPTION
https://tasktools.org/projects/tasksh.html

Tasksh is a shell command that wraps Taskwarrior commands. It is intended to provide simpler Taskwarrior access, and add a few new features of its own.

Tasksh replaces the built-in shell command of older releases, and the bundled tasksh program of version 2.3.0. The former was very limited and the latter unsupported, buggy and flawed. This project represents GBF taking control of this project.