### PR TITLE
Add abook package

### DIFF
--- a/packages/abook/build.sh
+++ b/packages/abook/build.sh
@@ -1,0 +1,5 @@
+TERMUX_PKG_HOMEPAGE=http://abook.sourceforge.net/
+TERMUX_PKG_DESCRIPTION="Abook is a text-based addressbook program designed to use with mutt mail client"
+TERMUX_PKG_VERSION=0.6.0pre2
+TERMUX_PKG_SRCURL=http://abook.sourceforge.net/devel/abook-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_DEPENDS="libandroid-support, ncurses, readline"


### PR DESCRIPTION
This adds the "abook" program, which is a relatively simple curses address book manager.  This is often paired with mutt, which is already in the termux repos.

Nothing fancy needed here.  Termux's build system figures everything out own its own, no patches needed, and the dependencies are already available.

Tested on a Nexus 5X with Android 6.0.
