### PR TITLE
Added fwknop package

### DIFF
--- a/packages/fwknop/build.sh
+++ b/packages/fwknop/build.sh
@@ -1,0 +1,5 @@
+TERMUX_PKG_HOMEPAGE=http://www.cipherdyne.org/fwknop/
+TERMUX_PKG_DESCRIPTION="fwknop: Single Packet Authorization > Port Knocking"
+TERMUX_PKG_VERSION=2.6.9
+TERMUX_PKG_SRCURL=http://www.cipherdyne.org/fwknop/download/fwknop-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-server"


### PR DESCRIPTION
An [interesting package](http://www.cipherdyne.org/fwknop/) to connect to machines with fwknopd server:

> fwknop stands for the "FireWall KNock OPerator", and implements an authorization scheme called Single Packet Authorization (SPA). This method of authorization is based around a default-drop packet filter (fwknop supports iptables and firewalld on Linux, ipfw on FreeBSD and Mac OS X, and PF on OpenBSD) and libpcap. SPA is essentially next generation port knocking.

Is only the client and has no dependencies.

