### PR TITLE
Added Qalculate package

### DIFF
--- a/packages/libcln/build.sh
+++ b/packages/libcln/build.sh
@@ -1,0 +1,22 @@
+TERMUX_PKG_HOMEPAGE=http://www.ginac.de/CLN/
+TERMUX_PKG_DESCRIPTION="CLN is a library for efficient computations with all kinds of numbers in arbitrary precision"
+TERMUX_PKG_VERSION=1.3.4
+TERMUX_PKG_SRCURL=http://www.ginac.de/CLN/cln-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-gnu-ld=no"
+TERMUX_PKG_BUILD_IN_SRC=yes
+
+termux_step_pre_configure() {
+    cd $TERMUX_PKG_SRCDIR
+    sed -i -e 's%tests/Makefile %%' configure.ac
+    sed -i -e 's%examples/Makefile %%' configure.ac
+    sed -i -e 's%benchmarks/Makefile %%' configure.ac
+    
+    autoreconf
+}
+
+termux_step_post_configure() {
+    cd $TERMUX_PKG_SRCDIR
+    sed -i -e 's% tests%%' Makefile
+    sed -i -e 's% examples%%' Makefile
+    sed -i -e 's% benchmarks%%' Makefile
+}

--- a/packages/qalc/Calculator.cc.patch
+++ b/packages/qalc/Calculator.cc.patch
@@ -1,0 +1,39 @@
+--- ../../build/qalc/cache/libqalculate-0.9.9/libqalculate/Calculator.cc	2016-07-16 14:49:15.000000000 +0200
++++ ./libqalculate/Calculator.cc	2016-08-15 00:21:11.338822562 +0200
+@@ -203,8 +203,8 @@
+ }
+ 
+ void *calculate_proc(void *pipe) {
+-	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+-	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
++	//pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
++	//pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+ 	FILE *calculate_pipe = (FILE*) pipe;
+ 	while(true) {
+ 		bool b_parse = true;
+@@ -1616,7 +1616,7 @@
+ 	if(calculate_thread_stopped) {
+ 		b_busy = false;
+ 	} else {
+-		pthread_cancel(calculate_thread);
++		pthread_kill(calculate_thread, 0);
+ 		restoreState();
+ 		stopped_messages_count.clear();
+ 		stopped_warnings_count.clear();
+@@ -1640,14 +1640,14 @@
+ 	tmp_rpn_mstruct = NULL;
+ 	b_busy = false;
+ 	calculate_thread_stopped = true;
+-	pthread_exit(/* Solaris 2.6 needs a cast */ (void*) PTHREAD_CANCELED);
++	pthread_exit(0);
+ }
+ bool Calculator::busy() {
+ 	return b_busy;
+ }
+ void Calculator::terminateThreads() {
+ 	if(!calculate_thread_stopped) {
+-		pthread_cancel(calculate_thread);
++		pthread_kill(calculate_thread, 0);
+ 	}
+ }
+ 

--- a/packages/qalc/Number.cc.patch
+++ b/packages/qalc/Number.cc.patch
@@ -1,0 +1,11 @@
+--- ../../build/qalc/cache/libqalculate-0.9.9/libqalculate/Number.cc	2016-06-02 18:40:18.000000000 +0200
++++ ./libqalculate/Number.cc	2016-08-15 00:35:08.556225106 +0200
+@@ -2708,7 +2708,7 @@
+ 				} catch(runtime_exception &e) {
+ 					CALCULATOR->error(true, _("CLN Exception: %s"), e.what());
+ 				}
+-				pthread_testcancel();
++				//pthread_testcancel();
+ 				if(b_zero) {
+ 					try {
+ 						inr = cln::exquo(inr, last_prime);

--- a/packages/qalc/build.sh
+++ b/packages/qalc/build.sh
@@ -1,0 +1,6 @@
+TERMUX_PKG_HOMEPAGE=http://qalculate.sourceforge.net
+TERMUX_PKG_DESCRIPTION="Powerful and easy to use command line calculator"
+TERMUX_PKG_VERSION=0.9.9
+TERMUX_PKG_SRCURL=https://github.com/Qalculate/libqalculate/releases/download/v${TERMUX_PKG_VERSION}/libqalculate-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_DEPENDS="glib, gnuplot, libcln, ncurses"
+TERMUX_PKG_BUILD_IN_SRC=yes

--- a/packages/qalc/qalc.cc.patch
+++ b/packages/qalc/qalc.cc.patch
@@ -1,0 +1,49 @@
+--- ../../build/qalc/cache/libqalculate-0.9.9/src/qalc.cc	2016-07-26 14:41:40.000000000 +0200
++++ ./src/qalc.cc	2016-08-15 00:22:57.905765966 +0200
+@@ -295,7 +295,7 @@
+ 			save_defs();
+ 		}
+ 	}
+-	pthread_cancel(view_thread);
++	pthread_kill(view_thread, 0);
+ 	CALCULATOR->terminateThreads();
+ }
+ 
+@@ -1138,7 +1138,7 @@
+ 			if(!cfile) {
+ 				printf(_("Could not open \"%s\".\n"), command_file.c_str());
+ 				if(!interactive_mode) {
+-					pthread_cancel(view_thread);
++					pthread_kill(view_thread, 0);
+ 					CALCULATOR->terminateThreads();
+ 					return 0;
+ 				}
+@@ -1166,7 +1166,7 @@
+ 			execute_expression(interactive_mode);
+ 		}
+ 		if(!interactive_mode) {
+-			pthread_cancel(view_thread);
++			pthread_kill(view_thread, 0);
+ 			CALCULATOR->terminateThreads();
+ 			return 0;
+ 		}
+@@ -2619,7 +2619,7 @@
+ }
+ 
+ void on_abort_command() {
+-	pthread_cancel(command_thread);
++	pthread_kill(command_thread, 0);
+ 	CALCULATOR->restoreState();
+ 	CALCULATOR->clearBuffers();
+ 	b_busy = false;
+@@ -2629,8 +2629,8 @@
+ 
+ void *command_proc(void *pipe) {
+ 
+-	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+-	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);	
++	//pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
++	//pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+ 	FILE *command_pipe = (FILE*) pipe;
+ 	
+ 	while(true) {


### PR DESCRIPTION
I added this great calculator with a huge list of [features](https://qalculate.github.io/features.html):

> Qalculate! is a multi-purpose calculator for GNU/Linux (and Mac OS). It is small and simple to use but with much power and versatility underneath. Features include customizable 
functions, units, arbitrary precision, plotting, and a user-friendly interface

There are 2 packages: [libcln](www.ginac.de/CLN) and [qalc](https://qalculate.github.io) (I named it like Debian does, because command name is qalc, qalculate is used for desktop version).

I tested it as usual:
![screenshot_20160815-010123](https://cloud.githubusercontent.com/assets/478660/17652737/e4879dfe-6284-11e6-865e-115b4561be32.png)
