### PR TITLE
Add privoxy package

### DIFF
--- a/packages/privoxy/GNUmakefile.in.patch
+++ b/packages/privoxy/GNUmakefile.in.patch
@@ -1,0 +1,90 @@
+--- ../../build/privoxy/cache/privoxy-3.0.24-stable/GNUmakefile.in	2015-12-27 13:50:57.000000000 +0100
++++ ./GNUmakefile.in	2016-09-13 23:30:12.518162391 +0200
+@@ -471,8 +471,8 @@
+ 	mkdir -p doc/source/temp && cd doc/source/temp && $(RM) * ;\
+ 	nsgmls ../privoxy-man-page.sgml  | sgmlspl ../../../utils/docbook2man/docbook2man-spec.pl &&\
+ 	perl -pi.bak -e 's/ <URL:.*>//; s/\[ /\[/g' $(MAN_PAGE) ;\
+-	perl -pi.bak -e "s/\[ /\[/g;s/á/\\\\['a]/g;s/é/\\\\['e]/g" $(MAN_PAGE); \
+-	perl -pi.bak -e "s/ö/\\\\[:o]/g" $(MAN_PAGE); \
++	perl -pi.bak -e "s/\[ /\[/g;s/\\\\['a]/g;s/ï¿½/\\\\['e]/g" $(MAN_PAGE); \
++	perl -pi.bak -e "s/\\\\[:o]/g" $(MAN_PAGE); \
+ 	perl -pi.bak -e 's/([ {])-([a-z])/$$1\\-$$2/g' $(MAN_PAGE); \
+ 	perl -pi.bak -e 's/ --([a-z])/ \\-\\-$$1/g' $(MAN_PAGE); \
+ 	perl -pi.bak -e 's/\\fB--/\\fB\\-\\-/g' $(MAN_PAGE); \
+@@ -872,41 +872,41 @@
+ 		$(INSTALL) $(INSTALL_T) $$i $(DESTDIR)$(CONF_DEST)/templates ;\
+ 	done
+ 
+-	@# FIXME: group/user validation is overly convoluted.
+-	@# If superuser install ... we require a minimum of group ownership
+-	@# of those files the daemon writes to, to be non-root owned.
+-	@if [ "`$(ID) |sed 's/(.*//' |sed 's/.*=//'`" = "0" ] ;then\
+-		if [ x$(USER) = x ] || [ $(USER) = root ]; then \
+-			if [ x$(GROUP) = x ] || [ $(GROUP) = root ]; then \
+-				if [ "`$(ID) privoxy`" ] && \
+-					$(GROUPS) privoxy | $(SED) 's/^.*://' |$(GREP) "\<privoxy\>" >/dev/null; then \
+-					$(ECHO) "Warning: Setting group owner to privoxy";\
+-					GROUP_T=privoxy ;\
+-				else \
+-					$(ECHO)  "******************************************************************" ;\
+-					$(ECHO)  " WARNING! WARNING! installing config files as root!" ;\
+-					$(ECHO)  " It is strongly recommended to run $(PROGRAM) as a non-root user," ;\
+-					$(ECHO)  " and to install the config files as that user and/or group!" ;\
+-					$(ECHO)  " Please read INSTALL, and create a privoxy user and group!" ;\
+-					$(ECHO)  "*******************************************************************" ;\
+-					exit 1 ;\
+-				fi ;\
+-			else \
+-				GROUP_T=$(GROUP) ;\
+-			fi ;\
+-			INSTALL_CONF="$(INSTALL_R) -g $$GROUP_T " ;\
+-		else \
+-			$(ECHO) "Superuser install, installing config files as $(USER):$(GROUP_T)" ;\
+-			INSTALL_CONF="$(INSTALL_R) -o $(USER) -g $(GROUP_T)" ;\
+-			GROUP_T=$(GROUP_T) ;\
+-		fi ;\
+-	else \
+-		if [ ! "`id $(USER)`" = "`id`" ] ;then \
+-			$(ECHO) "** WARNING ** current install user different from configured user!!" ;\
+-			$(ECHO) "Edit may fail." ;\
+-		fi ;\
+-		INSTALL_CONF="$(INSTALL_R)" ;\
+-	fi ;\
++#	@# FIXME: group/user validation is overly convoluted.
++#	@# If superuser install ... we require a minimum of group ownership
++#	@# of those files the daemon writes to, to be non-root owned.
++#	@if [ "`$(ID) |sed 's/(.*//' |sed 's/.*=//'`" = "0" ] ;then\
++#		if [ x$(USER) = x ] || [ $(USER) = root ]; then \
++#			if [ x$(GROUP) = x ] || [ $(GROUP) = root ]; then \
++#				if [ "`$(ID) privoxy`" ] && \
++#					$(GROUPS) privoxy | $(SED) 's/^.*://' |$(GREP) "\<privoxy\>" >/dev/null; then \
++#					$(ECHO) "Warning: Setting group owner to privoxy";\
++#					GROUP_T=privoxy ;\
++#				else \
++#					$(ECHO)  "******************************************************************" ;\
++#					$(ECHO)  " WARNING! WARNING! installing config files as root!" ;\
++#					$(ECHO)  " It is strongly recommended to run $(PROGRAM) as a non-root user," ;\
++#					$(ECHO)  " and to install the config files as that user and/or group!" ;\
++#					$(ECHO)  " Please read INSTALL, and create a privoxy user and group!" ;\
++#					$(ECHO)  "*******************************************************************" ;\
++#					exit 1 ;\
++#				fi ;\
++#			else \
++#				GROUP_T=$(GROUP) ;\
++#			fi ;\
++#			INSTALL_CONF="$(INSTALL_R) -g $$GROUP_T " ;\
++#		else \
++#			$(ECHO) "Superuser install, installing config files as $(USER):$(GROUP_T)" ;\
++#			INSTALL_CONF="$(INSTALL_R) -o $(USER) -g $(GROUP_T)" ;\
++#			GROUP_T=$(GROUP_T) ;\
++#		fi ;\
++#	else \
++#		if [ ! "`id $(USER)`" = "`id`" ] ;then \
++#			$(ECHO) "** WARNING ** current install user different from configured user!!" ;\
++#			$(ECHO) "Edit may fail." ;\
++#		fi ;\
++#		INSTALL_CONF="$(INSTALL_R)" ;\
++#	fi ;\
+ 	$(ECHO) Installing configuration files to $(DESTDIR)$(CONF_DEST);\
+ 	for i in $(CONFIGS); do \
+ 		if [ "$$i" = "default.action" ] || [ "$$i" = "default.filter" ] ; then \

--- a/packages/privoxy/build.sh
+++ b/packages/privoxy/build.sh
@@ -1,0 +1,29 @@
+TERMUX_PKG_HOMEPAGE=https://www.privoxy.org
+TERMUX_PKG_DESCRIPTION="Privoxy is a non-caching web proxy with advanced filtering capabilities"
+TERMUX_PKG_VERSION=3.0.24
+TERMUX_PKG_SRCURL=https://www.privoxy.org/sf-download-mirror/Sources/$TERMUX_PKG_VERSION%20%28stable%29/privoxy-$TERMUX_PKG_VERSION-stable-src.tar.gz
+TERMUX_PKG_FOLDERNAME=privoxy-$TERMUX_PKG_VERSION-stable
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-dynamic-pcre --sysconfdir=$TERMUX_PREFIX/etc/privoxy"
+TERMUX_PKG_BUILD_IN_SRC=yes
+
+termux_step_pre_configure() {
+    autoheader
+    autoconf
+
+    # avoid 'aarch64-linux-android-strip': No such file or directory
+    ln -s $TERMUX_STANDALONE_TOOLCHAIN/bin/$TERMUX_ARCH-linux-android-strip .
+}
+
+termux_step_post_make_install() {
+    # delete link created to avoid errors
+    rm -f $TERMUX_PREFIX/sbin/$TERMUX_ARCH-linux-android-strip
+}
+
+termux_step_post_massage() {
+    # remove ".new" from default config files
+    mv ./etc/privoxy/config.new ./etc/privoxy/config
+    mv ./etc/privoxy/match-all.action.new ./etc/privoxy/match-all.action
+    mv ./etc/privoxy/trust.new ./etc/privoxy/trust
+    mv ./etc/privoxy/user.action.new ./etc/privoxy/user.action
+    mv ./etc/privoxy/user.filter.new ./etc/privoxy/user.filter
+}

--- a/packages/privoxy/jcc.c.patch
+++ b/packages/privoxy/jcc.c.patch
@@ -1,0 +1,17 @@
+--- ../../build/privoxy/cache/privoxy-3.0.24-stable/jcc.c	2016-01-16 13:33:36.000000000 +0100
++++ ./jcc.c	2016-08-20 08:48:12.247371024 +0200
+@@ -3655,10 +3655,10 @@
+       }
+       if (NULL != grp)
+       {
+-         if (setgroups(1, &grp->gr_gid))
+-         {
+-            log_error(LOG_LEVEL_FATAL, "setgroups() failed: %E");
+-         }
++         //if (setgroups(1, &grp->gr_gid))
++         //{
++         //   log_error(LOG_LEVEL_FATAL, "setgroups() failed: %E");
++         //}
+       }
+       else if (initgroups(pw->pw_name, pw->pw_gid))
+       {


### PR DESCRIPTION
Another interesting package: 

> [Privoxy](https://www.privoxy.org/) is a non-caching web proxy with advanced filtering capabilities for enhancing privacy, modifying web page data and HTTP headers, controlling access, and removing ads and other obnoxious Internet junk. Privoxy has a flexible configuration and can be customized to suit individual needs and tastes. It has application for both stand-alone systems and multi-user networks. 

Why is interesting? You can proxy all device traffic through this proxy, making a [system-wide ad blocker](http://blog.vanutsteen.nl/2014/01/05/installing-privoxy-with-adblock-filters-on-openwrt/) or you can use the hotspot and filter the traffic of connected devices...

Daemon needs to be launched with user detected with `whoami`. Example running from `$HOME`:

```
privoxy --user u0_a94.u0_a94 --no-daemon ../usr/etc/privoxy/config
```
