### PR TITLE
Add stag package

### DIFF
--- a/packages/stag/Makefile.patch
+++ b/packages/stag/Makefile.patch
@@ -1,0 +1,9 @@
+--- stag/Makefile	2016-08-31 15:10:57.847902802 +0200
++++ Makefile	2016-08-31 15:09:34.507902834 +0200
+@@ -1,5 +1,5 @@
+ CC ?= gcc
+-CFLAGS=-Wall -Werror -Wextra -std=c99 -pedantic -Wno-unused-parameter
++CFLAGS+=-Wall -Werror -Wextra -std=c99 -pedantic -Wno-unused-parameter
+ # D_BSD_SOURCE for strsep
+ LIBS=-lncurses -lm -D_DEFAULT_SOURCE
+ PREFIX ?= /usr/local

--- a/packages/stag/build.sh
+++ b/packages/stag/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/seenaburns/stag
+TERMUX_PKG_DESCRIPTION="Streaming bar graphs. For stats and stuff."
+TERMUX_PKG_VERSION=1.0.0
+TERMUX_PKG_SRCURL=https://github.com/seenaburns/stag/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_FOLDERNAME=stag-$TERMUX_PKG_VERSION
+TERMUX_PKG_DEPENDS="ncurses"
+TERMUX_PKG_BUILD_IN_SRC=yes
+CFLAGS+=" $CPPFLAGS"
+CFLAGS+=" $LDFLAGS"

--- a/packages/stag/stag.c.patch
+++ b/packages/stag/stag.c.patch
@@ -1,0 +1,11 @@
+--- stag/stag.c	2016-08-31 15:03:32.627902972 +0200
++++ stag.c	2016-08-31 15:18:34.487902628 +0200
+@@ -87,7 +87,7 @@
+   
+ 
+   // Read options
+-  char opt;
++  signed char opt;
+   int option_index = 0;
+   struct option long_options[] =
+   {


### PR DESCRIPTION
[Stag](https://github.com/seenaburns/stag) is a small programm that generates updating bar graphs for integer data piped into it.

Here's a basic usage example:
while true; do echo $RANDOM;sleep 0.3;done| stag -t "Random data over time"

I've tested it on both arm and aarch64 devices and I have used this tool ([compiled natively](https://oliverse.ch/tech/2016/01/16/compiling-stag-on-termux.html)) on Termux or a long time now.

I've compiled this program to learn how to do cross-compiling. Please let me know if I did something wrong. 