### PR TITLE
Added packages libzmq and libsodium

### DIFF
--- a/packages/libsodium/build.sh
+++ b/packages/libsodium/build.sh
@@ -1,0 +1,5 @@
+TERMUX_PKG_HOMEPAGE=https://libsodium.org/
+TERMUX_PKG_DESCRIPTION="Network communication, cryptography and signaturing library."
+TERMUX_PKG_VERSION=1.0.10
+TERMUX_PKG_BUILD_REVISION=1
+TERMUX_PKG_SRCURL=https://github.com/jedisct1/libsodium/releases/download/${TERMUX_PKG_VERSION}/libsodium-${TERMUX_PKG_VERSION}.tar.gz

--- a/packages/libzmq/build.sh
+++ b/packages/libzmq/build.sh
@@ -1,0 +1,7 @@
+TERMUX_PKG_HOMEPAGE=http://zeromq.org/
+TERMUX_PKG_DESCRIPTION="Fast messaging system built on sockets. C and C++ bindings. aka 0MQ, ZMQ."
+TERMUX_PKG_VERSION=4.1.5
+TERMUX_PKG_BUILD_REVISION=1
+TERMUX_PKG_SRCURL=https://github.com/zeromq/zeromq4-1/releases/download/v${TERMUX_PKG_VERSION}/zeromq-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_DEPENDS="libsodium"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-libsodium"


### PR DESCRIPTION
Adapted version of PR https://github.com/termux/termux-packages/pull/270
- Update to libzmq 4.1.5
- Usage of libsodium added

This solves issue https://github.com/termux/termux-packages/issues/85 and makes PR https://github.com/termux/termux-packages/pull/270 and https://github.com/termux/termux-packages/pull/271 obsolete