### PR TITLE
Add erlang package

### DIFF
--- a/packages/erlang/0003-erts-emulator-reorder-inclued-headers-paths.patch
+++ b/packages/erlang/0003-erts-emulator-reorder-inclued-headers-paths.patch
@@ -1,0 +1,43 @@
+From 85a3e5b4f65e5284e59dcdd90e92ea7d50ef6907 Mon Sep 17 00:00:00 2001
+From: Romain Naour <romain.naour@openwide.fr>
+Date: Sun, 8 Feb 2015 17:23:13 +0100
+Subject: [PATCH] erts/emulator: reorder inclued headers paths
+
+If the Perl Compatible Regular Expressions is installed on the
+host and the path to the headers is added to the CFLAGS, the
+pcre.h from the host is used instead of the one provided by
+erlang.
+
+Erlang use an old version of this file which is incompatible
+with the upstream one.
+
+Move INCLUDES before CFLAGS to use pcre.h from erlang.
+
+http://autobuild.buildroot.net/results/cbd/cbd8b54eef535f19d7d400fd269af1b3571d6143/build-end.log
+
+Signed-off-by: Romain Naour <romain.naour@openwide.fr>
+---
+ erts/emulator/Makefile.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/erts/emulator/Makefile.in b/erts/emulator/Makefile.in
+index 7145824..d079487 100644
+--- a/erts/emulator/Makefile.in
++++ b/erts/emulator/Makefile.in
+@@ -678,11 +678,11 @@ else
+ # Usually the same as the default rule, but certain platforms (e.g. win32) mix
+ # different compilers
+ $(OBJDIR)/beam_emu.o: beam/beam_emu.c
+-	$(V_EMU_CC) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
++	$(V_EMU_CC) $(INCLUDES) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) -c $< -o $@
+ endif
+ 
+ $(OBJDIR)/%.o: beam/%.c
+-	$(V_CC) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
++	$(V_CC) $(INCLUDES) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) -c $< -o $@
+ 
+ $(OBJDIR)/%.o: $(TARGET)/%.c
+ 	$(V_CC) $(CFLAGS) $(INCLUDES) -Idrivers/common -c $< -o $@
+-- 
+1.9.3
+

--- a/packages/erlang/build.sh
+++ b/packages/erlang/build.sh
@@ -1,0 +1,34 @@
+TERMUX_PKG_HOMEPAGE="http://www.erlang.org/"
+TERMUX_PKG_DESCRIPTION="General-purpose concurrent functional programming language developed by Ericsson"
+TERMUX_PKG_VERSION="18.3.3"
+TERMUX_PKG_DEPENDS="openssl"
+
+TERMUX_PKG_SRCURL="https://github.com/erlang/otp/archive/OTP-${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_FOLDERNAME="otp-OTP-${TERMUX_PKG_VERSION}"
+
+TERMUX_PKG_HOSTBUILD="yes"
+TERMUX_PKG_BUILD_IN_SRC="yes"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--without-javac --without-termcap --with-ssl=${TERMUX_TOPDIR}/openssl/src"
+
+termux_step_post_extract_package () {
+    rm -Rf "$TERMUX_PKG_HOSTBUILD_DIR"
+    export ERL_TOP="$TERMUX_PKG_SRCDIR"
+    cd "$ERL_TOP"
+    ./otp_build autoconf
+}
+
+termux_step_host_build () {
+    cd $ERL_TOP
+    ./configure --enable-bootstrap-only
+    make -j "$TERMUX_MAKE_PROCESSES"
+}
+
+termux_step_pre_configure () {
+    LDFLAGS+=" -llog -L${TERMUX_TOPDIR}/openssl/src"
+}
+
+termux_step_make () {
+    cp "${TERMUX_PKG_SRCDIR}/bin/x86_64-unknown-linux-gnu/"* "${TERMUX_PKG_SRCDIR}/bootstrap/bin"
+    PATH+=":${TERMUX_PKG_SRCDIR}/bootstrap/bin"
+    make -j $TERMUX_MAKE_PROCESSES noboot
+}

--- a/packages/erlang/build.sh
+++ b/packages/erlang/build.sh
@@ -1,14 +1,14 @@
 TERMUX_PKG_HOMEPAGE="http://www.erlang.org/"
 TERMUX_PKG_DESCRIPTION="General-purpose concurrent functional programming language developed by Ericsson"
 TERMUX_PKG_VERSION="18.3.3"
-TERMUX_PKG_DEPENDS="openssl"
+TERMUX_PKG_DEPENDS="openssl, ncurses"
 
 TERMUX_PKG_SRCURL="https://github.com/erlang/otp/archive/OTP-${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_FOLDERNAME="otp-OTP-${TERMUX_PKG_VERSION}"
 
 TERMUX_PKG_HOSTBUILD="yes"
 TERMUX_PKG_BUILD_IN_SRC="yes"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--without-javac --without-termcap --with-ssl=${TERMUX_TOPDIR}/openssl/src"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--without-javac --with-ssl=${TERMUX_TOPDIR}/openssl/src --with-termcap"
 
 termux_step_post_extract_package () {
     rm -Rf "$TERMUX_PKG_HOSTBUILD_DIR"


### PR DESCRIPTION
Tested build using docker.  I am not sure about the way the openssl dependency is handled in the build script but it works when you first build openssl.

Erlang runs fine on a Nexus 5 with stock Android 6.  I've tested [a small example webserver](http://stackoverflow.com/questions/2206933/how-to-write-a-simple-webserver-in-erlang#2219330) and even got elixir to compile and install, after some fiddling (shebang stuff) on the target and successfully ran some scripts I wrote.
