### PR TITLE
ffmpeg: Enable opus codec (fixes #452)

### DIFF
--- a/packages/ffmpeg/build.sh
+++ b/packages/ffmpeg/build.sh
@@ -42,6 +42,7 @@ termux_step_configure () {
 		--enable-gpl \
 		--enable-libmp3lame \
 		--enable-libvorbis \
+		--enable-libopus \
 		--enable-libx264 \
 		--enable-libxvid \
 		--enable-nonfree \


### PR DESCRIPTION
Modify ffmpeg build script to include opus codec.
Information about the codec can be found at:
- https://en.wikipedia.org/wiki/Opus_(audio_format)
- https://www.opus-codec.org/