### PR TITLE
Build Profanity with libmesode instead of libstrophe

### DIFF
--- a/packages/libmesode/build.sh
+++ b/packages/libmesode/build.sh
@@ -1,0 +1,12 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/boothj5/libmesode
+TERMUX_PKG_DESCRIPTION="libmesode is a minimal XMPP library written in C. Fork of libstrophe for use with Profanity XMPP Client. Provides extra TLS functionality such as manual SSL certificate verfication"
+TERMUX_PKG_VERSION=0.9.1
+TERMUX_PKG_MAINTAINER="Oliver Schmidhauser @Neo-Oli"
+TERMUX_PKG_SRCURL=https://github.com/boothj5/libmesode/archive/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_FOLDERNAME=libmesode-$TERMUX_PKG_VERSION
+TERMUX_PKG_DEPENDS="openssl,libexpat"
+TERMUX_PKG_BUILD_IN_SRC=yes
+
+termux_step_pre_configure() {
+./bootstrap.sh
+}

--- a/packages/profanity/build.sh
+++ b/packages/profanity/build.sh
@@ -1,9 +1,10 @@
 TERMUX_PKG_HOMEPAGE=http://profanity.im
 TERMUX_PKG_DESCRIPTION="Profanity is a console based XMPP client written in C using ncurses and libstrophe, inspired by Irssi"
 TERMUX_PKG_VERSION=0.5.0
+TERMUX_PKG_BUILD_REVISION=1
 TERMUX_PKG_MAINTAINER="Oliver Schmidhauser @Neo-Oli"
 TERMUX_PKG_SRCURL=http://profanity.im/profanity-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_DEPENDS="ncurses,glib,libstrophe,libcurl,readline,libuuid,libotr,gpgme,python"
+TERMUX_PKG_DEPENDS="ncurses,glib,libmesode,libcurl,readline,libuuid,libotr,gpgme,python"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" --disable-python-plugins"
 TERMUX_PKG_BUILD_IN_SRC=yes
 


### PR DESCRIPTION
[libmesode ](https://github.com/boothj5/libmesode) is a fork of libstrophe providing additional functionality to profanity. It's made by the author of profanity. 

Libstrophe is now no longer needed by profanity. I am unsure if I should remove it or not. Libstrophe could still be used for developing jabber bots or clients. 