### PR TITLE
Enable libcaca support in mpv

### DIFF
--- a/packages/mpv/build.sh
+++ b/packages/mpv/build.sh
@@ -1,9 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://mpv.io/
 TERMUX_PKG_DESCRIPTION="Command-line media player"
 TERMUX_PKG_VERSION=0.20.0
+TERMUX_PKG_BUILD_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/mpv-player/mpv/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_FOLDERNAME=mpv-${TERMUX_PKG_VERSION}
-TERMUX_PKG_DEPENDS="ffmpeg, openal-soft"
+TERMUX_PKG_DEPENDS="ffmpeg, openal-soft, libcaca"
 
 termux_step_make_install () {
 	cd $TERMUX_PKG_SRCDIR
@@ -16,7 +17,8 @@ termux_step_make_install () {
 		--disable-jpeg \
 		--disable-lcms2 \
 		--disable-libass \
-		--enable-openal
+		--enable-openal \
+		--enable-caca
 
 	./waf install
 


### PR DESCRIPTION
If libcaca support isn't specified (either enable or disable) the
buildorder script decides about this feature, because it is
autodetected. If mpv is built after libcaca it will be compiled in.
So if, at any point you rebuild it, without removing libcaca first, it
will be compiled in and throw an error on termux if libcaca isn't
installed.