### PR TITLE
Add par2 package

### DIFF
--- a/packages/par2/build.sh
+++ b/packages/par2/build.sh
@@ -1,0 +1,13 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/Parchive/par2cmdline
+TERMUX_PKG_DESCRIPTION="par2cmdline is a PAR 2.0 compatible file verification and repair tool."
+TERMUX_PKG_VERSION=0.6.13
+TERMUX_PKG_MAINTAINER="Oliver Schmidhauser @Neo-Oli"
+TERMUX_PKG_SRCURL=https://github.com/Parchive/par2cmdline/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_FOLDERNAME=par2cmdline-$TERMUX_PKG_VERSION
+TERMUX_PKG_BUILD_IN_SRC=yes
+
+termux_step_pre_configure() {
+	aclocal
+	automake --add-missing
+	autoconf
+}


### PR DESCRIPTION
Parity Archives are very usefull for working with long term storage,
which may have degraded over time. It allows to restore the files, even
if chunks of it are corrupted. https://en.wikipedia.org/wiki/Parchive

I tested it by creating a par2 archive, corrupting the original data and
restoring it.

This program is named par2cmdline, but I named the package par2 because
that's what it is called in the Ubuntu Repo,