### PR TITLE
fix _SPECSFLAG to prevent fail on certain occasions

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -578,7 +578,7 @@ if [ "$TERMUX_PKG_CLANG" = "no" ]; then
 	export AS=${TERMUX_HOST_PLATFORM}-gcc
 	export CC=$TERMUX_HOST_PLATFORM-gcc
 	export CXX=$TERMUX_HOST_PLATFORM-g++
-	_SPECSFLAG="-specs=$TERMUX_SCRIPTDIR/termux.spec"
+	_SPECSFLAG=" -specs=$TERMUX_SCRIPTDIR/termux.spec"
 else
 	export AS=${TERMUX_HOST_PLATFORM}-gcc
 	export CC=$TERMUX_HOST_PLATFORM-clang


### PR DESCRIPTION
Found this while building a package. Scripts may have something like
```
export LDFLAGS="-some-flag\ 
-some-other-flag\
$LDFLAGS"
```
In this case the final `LDFLAGS` would be 
`-some-flag -some-other-flag-specs=$TERMUX_SCRIPTDIR/termux.spec`