### PR TITLE
Builder script and ndk patch improvements

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -21,16 +21,18 @@ test -f $HOME/.termuxrc && . $HOME/.termuxrc
 
 # Handle command-line arguments:
 show_usage () {
-    echo "Usage: ./build-package.sh [-a ARCH] PACKAGE"
+    echo "Usage: ./build-package.sh [-a ARCH] [-d] PACKAGE"
     echo "Build a package."
+    echo "Use -d for debug build."
     echo ""
     exit 1
 }
-while getopts :a:h option
+while getopts :a:h:d option
 do
     case "$option" in
         a) TERMUX_ARCH="$OPTARG";;
         h) show_usage;;
+        d) TERMUX_DEBUG=true;;
         ?) echo "./build-package.sh: illegal option -$OPTARG"; exit 1;;
     esac
 done

--- a/build-package.sh
+++ b/build-package.sh
@@ -18,21 +18,24 @@ test -f $HOME/.termuxrc && . $HOME/.termuxrc
 : ${TERMUX_API_LEVEL:="21"}
 : ${TERMUX_ANDROID_BUILD_TOOLS_VERSION:="24.0.1"}
 : ${TERMUX_NDK_VERSION:="13"}
+: ${TERMUX_IS_DISABLED:=""}
 
 # Handle command-line arguments:
 show_usage () {
-    echo "Usage: ./build-package.sh [-a ARCH] [-d] PACKAGE"
+    echo "Usage: ./build-package.sh [-a ARCH] [-d] [-D] PACKAGE"
     echo "Build a package."
     echo "Use -d for debug build."
+    echo "-D for disabled package."
     echo ""
     exit 1
 }
-while getopts :a:h:d option
+while getopts :a:h:d:D option
 do
     case "$option" in
         a) TERMUX_ARCH="$OPTARG";;
         h) show_usage;;
         d) TERMUX_DEBUG=true;;
+        D) TERMUX_IS_DISABLED=true;;
         ?) echo "./build-package.sh: illegal option -$OPTARG"; exit 1;;
     esac
 done
@@ -60,7 +63,11 @@ if [[ $1 == *"/"* ]]; then
   export TERMUX_PKG_BUILDER_DIR=`realpath $1`
 else
   # Package name:
-  export TERMUX_PKG_BUILDER_DIR=$TERMUX_SCRIPTDIR/packages/$TERMUX_PKG_NAME
+  if [ -n $TERMUX_IS_DISABLED ]; then
+    export TERMUX_PKG_BUILDER_DIR=$TERMUX_SCRIPTDIR/disabled-packages/$TERMUX_PKG_NAME
+  else
+    export TERMUX_PKG_BUILDER_DIR=$TERMUX_SCRIPTDIR/packages/$TERMUX_PKG_NAME
+  fi
 fi
 TERMUX_PKG_BUILDER_SCRIPT=$TERMUX_PKG_BUILDER_DIR/build.sh
 if test ! -f $TERMUX_PKG_BUILDER_SCRIPT; then

--- a/ndk_patches/paths.h.patch
+++ b/ndk_patches/paths.h.patch
@@ -1,6 +1,5 @@
-diff -u -r /home/fornwall/lib/android-ndk/platforms/android-21/arch-arm64/usr/include/paths.h ./usr/include/paths.h
---- /home/fornwall/lib/android-ndk/platforms/android-21/arch-arm64/usr/include/paths.h	2016-03-03 16:54:24.000000000 -0500
-+++ ./usr/include/paths.h	2016-05-30 17:18:24.726803678 -0400
+--- /home/fornwall/lib/android-ndk/platforms/android-21/arch-arm64/usr/include/paths.h	2016-10-09 16:37:54.394746195 +0530
++++ ./usr/include/paths.h	2016-10-21 23:28:38.689411903 +0530
 @@ -33,12 +33,12 @@
  #define	_PATHS_H_
  
@@ -17,6 +16,15 @@ diff -u -r /home/fornwall/lib/android-ndk/platforms/android-21/arch-arm64/usr/in
  #define	_PATH_CONSOLE	"/dev/console"
  #define	_PATH_CSHELL	"/bin/csh"
  #define	_PATH_DEVDB	"/var/run/dev.db"
+@@ -51,7 +51,7 @@
+ #define	_PATH_MAN	"/usr/share/man"
+ #define	_PATH_MEM	"/dev/mem"
+ #define	_PATH_MNTTAB	"/etc/fstab"
+-#define	_PATH_MOUNTED	"/etc/mtab"
++#define	_PATH_MOUNTED	"/proc/mounts"
+ #define	_PATH_NOLOGIN	"/etc/nologin"
+ #define	_PATH_PRESERVE	"/var/lib"
+ #define	_PATH_RWHODIR	"/var/spool/rwho"
 @@ -66,9 +66,9 @@
  
  /* Provide trailing slash, since mostly used for building pathnames. */


### PR DESCRIPTION
Replace `MOUNTED` macro with `/proc/mounts` for a future package which uses mntent.
Added debug and disabled package switches to build-package.sh.