### PR TITLE
Added ne package

### DIFF
--- a/packages/ne/build.sh
+++ b/packages/ne/build.sh
@@ -1,0 +1,16 @@
+TERMUX_PKG_HOMEPAGE=http://ne.di.unimi.it/
+TERMUX_PKG_DESCRIPTION="ne is a free (GPL'd) text editor based on the POSIX standard"
+TERMUX_PKG_VERSION=3.0.1
+TERMUX_PKG_SRCURL=http://ne.di.unimi.it/ne-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_DEPENDS="libandroid-support, ncurses"
+TERMUX_PKG_RM_AFTER_INSTALL="info/"
+TERMUX_PKG_BUILD_IN_SRC=yes
+
+termux_step_make() {
+    CFLAGS+=" -I${TERMUX_PREFIX}"
+
+    sed -i -e "s%usr/local%$TERMUX_PREFIX%" makefile
+    sed -i -e "s%usr/local%$TERMUX_PREFIX%" src/makefile
+
+    make PREFIX=$TERMUX_PREFIX NE_GLOBAL_DIR=$TERMUX_PREFIX/share/ne
+}

--- a/packages/ne/makefile.patch
+++ b/packages/ne/makefile.patch
@@ -1,0 +1,26 @@
+--- ../../build/ne/cache/ne-3.0.1/src/makefile	2015-06-21 22:02:45.000000000 +0200
++++ ./src/makefile	2016-10-27 16:56:23.602142314 +0200
+@@ -81,13 +81,7 @@
+ NE_DEBUG=
+ NE_TEST=
+ 
+-CC=c99
+-
+-ifeq ($(CC),gcc)
+-GCCFLAGS=-std=c99 -Wall -Wno-parentheses
+-endif
+-
+-CFLAGS=$(OPTS) $(GCCFLAGS) \
++CFLAGS=$(OPTS) $(CPPFLAGS) -std=c99 -Wall -Wno-parentheses \
+ 	-D_REGEX_LARGE_OFFSETS -D_GNU_SOURCE -DSTDC_HEADERS -Dinline=__inline__ \
+ 	$(if $(NE_NOWCHAR), -DNOWCHAR,) \
+ 	$(if $(NE_TEST),    -DNE_TEST -coverage,) \
+@@ -96,7 +90,7 @@
+ 	$(if $(NE_ANSI),    -DTERMCAP -DANSI,)
+ 
+ 
+-LIBS=$(if $(NE_TERMCAP)$(NE_ANSI),,-lcurses)
++LIBS=$(if $(NE_TERMCAP)$(NE_ANSI),,-lncurses)
+ 
+ ne:	$(OBJS) $(if $(NE_TERMCAP)$(NE_ANSI),$(TERMCAPOBJS),)
+ 	$(CC) $(OPTS) $(LDFLAGS) $(if $(NE_TEST), -coverage -lefence,) $^ -lm $(LIBS) -o $(PROGRAM)


### PR DESCRIPTION
ne, the nice editor:

> ne is a free (GPL'd) text editor based on the POSIX standard that runs (we hope) on almost any UN*X machine. ne is easy to use for the beginner, but powerful and fully configurable for the wizard, and most sparing in its resource usage. If you have the resources and the patience to use emacs or the right mental twist to use vi then probably ne is not for you.

Fixes #521 

![screenshot_20161027-170627](https://cloud.githubusercontent.com/assets/478660/19772948/138525be-9c68-11e6-8f87-564d936e76d8.png)
