### PR TITLE
neovim: fix clipboard patch

### DIFF
--- a/packages/neovim/runtime-autoload-provider-clipboard.vim.patch
+++ b/packages/neovim/runtime-autoload-provider-clipboard.vim.patch
@@ -1,15 +1,16 @@
 diff -u -r ../neovim-01f1028496bd1a402ad1b11c311291ec96335b70/runtime/autoload/provider/clipboard.vim ./runtime/autoload/provider/clipboard.vim
---- ../neovim-01f1028496bd1a402ad1b11c311291ec96335b70/runtime/autoload/provider/clipboard.vim	2016-11-02 20:06:23.000000000 -0400
-+++ ./runtime/autoload/provider/clipboard.vim	2016-11-04 07:00:46.931928888 -0400
-@@ -45,6 +45,11 @@
+--- ../neovim-01f1028496bd1a402ad1b11c311291ec96335b70/runtime/autoload/provider/clipboard.vim	2016-11-04 14:04:54.419734130 -0500
++++ ./runtime/autoload/provider/clipboard.vim	2016-11-04 14:07:45.039751132 -0500
+@@ -45,6 +45,12 @@
      let s:paste['*'] = s:paste['+']
      let s:cache_enabled = 0
      return 'pbcopy'
 +  elseif executable('termux-clipboard-set')
 +    let s:copy['+'] = 'termux-clipboard-set'
 +    let s:paste['+'] = 'termux-clipboard-get'
-+    let s:copy['*'] = 'termux-clipboard-set'
-+    let s:paste['*'] = 'termux-clipboard-get'
++    let s:copy['*'] = s:copy['+']
++    let s:paste['*'] = s:paste['+']
++    return 'termux-clipboard'
    elseif exists('$DISPLAY') && executable('xsel')
      let s:copy['+'] = 'xsel --nodetach -i -b'
      let s:paste['+'] = 'xsel -o -b'


### PR DESCRIPTION
The clipboard.vim script needs to return an arbitrary string with the
name of the clipboard it will use. Run `:CheckHealth` to see that in
action.