### PR TITLE
more ndk_patches to mimic standard glibc headers

### DIFF
--- a/ndk_patches/sys-stat.h.patch
+++ b/ndk_patches/sys-stat.h.patch
@@ -1,0 +1,13 @@
+--- /home/fornwall/lib/android-ndk/platforms/android-21/arch-arm/usr/include/sys/stat.h	2016-10-12 15:11:58.000000000 +0530
++++ ./usr/include/sys/stat.h	2016-12-03 21:17:42.104829064 +0530
+@@ -136,6 +136,10 @@
+ #define st_mtimensec st_mtime_nsec
+ #define st_ctimensec st_ctime_nsec
+ 
++#define S_IREAD S_IRUSR
++#define S_IWRITE S_IWUSR
++#define S_IEXEC S_IXUSR
++
+ #ifdef __USE_BSD
+ /* Permission macros provided by glibc for compatibility with BSDs. */
+ #define ACCESSPERMS (S_IRWXU | S_IRWXG | S_IRWXO) /* 0777 */

--- a/ndk_patches/syscall.h.patch
+++ b/ndk_patches/syscall.h.patch
@@ -1,0 +1,4 @@
+--- /home/fornwall/lib/android-ndk/platforms/android-21/arch-arm/usr/include/syscall.h	2016-12-03 21:40:40.033159200 +0530
++++ ./usr/include/syscall.h	2016-12-03 19:52:16.226951188 +0530
+@@ -1 +0,0 @@
++#include <sys/syscall.h>


### PR DESCRIPTION
glibc has I_SREAD, I_SWRITE and I_SEXEC which are aliases to I_SRUSR, I_SWUSR and I_SXUSR.
Also added dummy syscall.h to include sys/syscall.h