### PR TITLE
Added links2 package

### DIFF
--- a/packages/links2/build.sh
+++ b/packages/links2/build.sh
@@ -1,0 +1,6 @@
+TERMUX_PKG_HOMEPAGE=http://links.twibright.com
+TERMUX_PKG_DESCRIPTION="Web browser running in text mode"
+TERMUX_PKG_VERSION=2.14
+TERMUX_PKG_SRCURL=http://links.twibright.com/download/links-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_DEPENDS="libbz2, liblzma, openssl"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--without-gpm --without-x"


### PR DESCRIPTION
Links is a graphics and text mode WWW browser, similar to Lynx. It displays tables, frames, downloads on background, uses HTTP/1.1 keepalive connections.

I used links2 like Debian/Ubuntu does...

![screenshot_20161215-232506](https://cloud.githubusercontent.com/assets/478660/21244550/7472309c-c31e-11e6-8141-0ff6232587b7.png)
