### PR TITLE
Podbeuter download fix

### DIFF
--- a/packages/newsbeuter/009_podbeuter_crash.patch
+++ b/packages/newsbeuter/009_podbeuter_crash.patch
@@ -1,0 +1,92 @@
+From e11b656bda59ca31b4f9ab4c5a14696813b0f6f4 Mon Sep 17 00:00:00 2001
+From: Tilman Keskinoz <arved@FreeBSD.org>
+Date: Thu, 12 Mar 2015 11:03:50 +0100
+Subject: [PATCH 1/3] Detach thread, to avoid thread being destructed when it
+ is going out of scope
+
+---
+ src/pb_controller.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/pb_controller.cpp b/src/pb_controller.cpp
+index 09b5e89..da8ffcb 100644
+--- a/src/pb_controller.cpp
++++ b/src/pb_controller.cpp
+@@ -287,6 +287,7 @@ void pb_controller::start_downloads() {
+ 		if (it->status() == DL_QUEUED) {
+ 			std::thread t {poddlthread(&(*it), cfg)};
+ 			--dl2start;
++			t.detach();
+ 		}
+ 	}
+ }
+
+From f79e5527ba5f54677540637f5b8d287215cfa051 Mon Sep 17 00:00:00 2001
+From: Tilman Keskinoz <arved@FreeBSD.org>
+Date: Thu, 12 Mar 2015 11:04:49 +0100
+Subject: [PATCH 2/3] Fix segfault
+
+I think somewhere the poddlthread is copied and the memory messed up.
+Make it a shared_ptr to fix segfault.
+
+Why is this a pointer anyway?
+---
+ include/poddlthread.h | 3 ++-
+ src/poddlthread.cpp   | 1 -
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/poddlthread.h b/include/poddlthread.h
+index a10b9e7..cf0f1da 100644
+--- a/include/poddlthread.h
++++ b/include/poddlthread.h
+@@ -7,6 +7,7 @@
+ 
+ #include <sys/time.h>
+ #include <time.h>
++#include <memory>
+ 
+ #include <configcontainer.h>
+ 
+@@ -24,7 +25,7 @@ class poddlthread {
+ 	private:
+ 		void mkdir_p(const char * file);
+ 		download * dl;
+-		std::ofstream *f;
++		std::shared_ptr<std::ofstream> f;
+ 		timeval tv1;
+ 		timeval tv2;
+ 		size_t bytecount;
+diff --git a/src/poddlthread.cpp b/src/poddlthread.cpp
+index 583481e..3a1b390 100644
+--- a/src/poddlthread.cpp
++++ b/src/poddlthread.cpp
+@@ -22,7 +22,6 @@ poddlthread::poddlthread(download * dl_, newsbeuter::configcontainer * c) : dl(d
+ }
+ 
+ poddlthread::~poddlthread() {
+-	delete f;
+ }
+ 
+ void poddlthread::operator()() {
+
+From 49dbf84d9500860c48c1d3137cf0d7ab89588726 Mon Sep 17 00:00:00 2001
+From: Tilman Keskinoz <arved@FreeBSD.org>
+Date: Thu, 12 Mar 2015 11:30:24 +0100
+Subject: [PATCH 3/3] Another threa.detach() missing
+
+---
+ src/pb_view.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/pb_view.cpp b/src/pb_view.cpp
+index fb61c72..f3cb478 100644
+--- a/src/pb_view.cpp
++++ b/src/pb_view.cpp
+@@ -111,6 +111,7 @@ void pb_view::run(bool auto_download) {
+ 			if (idx != -1) {
+ 				if (ctrl->downloads()[idx].status() != DL_DOWNLOADING) {
+ 					std::thread t {poddlthread(&ctrl->downloads()[idx], ctrl->get_cfgcont())};
++					t.detach();
+ 				}
+ 			}
+ 		}

--- a/packages/newsbeuter/010_podbeuter_redownload.patch
+++ b/packages/newsbeuter/010_podbeuter_redownload.patch
@@ -1,0 +1,71 @@
+From c841c4a7871d2f79f9b7e2d53734f55e8410e231 Mon Sep 17 00:00:00 2001
+From: Alexander Batischev <eual.jp@gmail.com>
+Date: Fri, 22 Jan 2016 22:55:48 +0300
+Subject: [PATCH] Re-download, not delete, existing files. Fixes #169
+
+---
+ include/poddlthread.h |  1 +
+ src/poddlthread.cpp   | 19 +++++++++++++++++--
+ 2 files changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/include/poddlthread.h b/include/poddlthread.h
+index cf0f1da..99299f3 100644
+--- a/include/poddlthread.h
++++ b/include/poddlthread.h
+@@ -23,6 +23,7 @@ class poddlthread {
+ 	protected:
+ 		double compute_kbps();
+ 	private:
++		void run();
+ 		void mkdir_p(const char * file);
+ 		download * dl;
+ 		std::shared_ptr<std::ofstream> f;
+diff --git a/src/poddlthread.cpp b/src/poddlthread.cpp
+index 3a1b390..afa6762 100644
+--- a/src/poddlthread.cpp
++++ b/src/poddlthread.cpp
+@@ -25,6 +25,13 @@ poddlthread::~poddlthread() {
+ }
+ 
+ void poddlthread::operator()() {
++	run();
++}
++
++void poddlthread::run() {
++	// are we resuming previous download?
++	bool resumed_download = false;
++
+ 	gettimeofday(&tv1, NULL);
+ 	++bytecount;
+ 
+@@ -55,11 +62,13 @@ void poddlthread::operator()() {
+ 		mkdir_p(dl->filename());
+ 		f->open(dl->filename(), std::fstream::out);
+ 		dl->set_offset(0);
++		resumed_download = false;
+ 	} else {
+ 		LOG(LOG_INFO, "poddlthread::run: stat ok: starting download from %u", sb.st_size);
+ 		curl_easy_setopt(easyhandle, CURLOPT_RESUME_FROM, sb.st_size);
+ 		dl->set_offset(sb.st_size);
+ 		f->open(dl->filename(), std::fstream::out | std::fstream::app);
++		resumed_download = true;
+ 	}
+ 
+ 	if (f->is_open()) {
+@@ -75,8 +84,14 @@ void poddlthread::operator()() {
+ 		if (0 == success)
+ 			dl->set_status(DL_READY);
+ 		else if (dl->status() != DL_CANCELLED) {
+-			dl->set_status(DL_FAILED);
+-			::unlink(dl->filename());
++			// attempt complete re-download
++			if (resumed_download) {
++				::unlink(dl->filename());
++				this->run();
++			} else {
++				dl->set_status(DL_FAILED);
++				::unlink(dl->filename());
++			}
+ 		}
+ 	} else {
+ 		dl->set_status(DL_FAILED);


### PR DESCRIPTION
Add two newsbeuter upstream fixes - makes podbeuter sucessfully start and not crash on download.

Plays podcasts successfully with `player "mpv --no-video"` in ~/.newsbeuter/config