### PR TITLE
sqlite: update from 3.15.2 to 3.16.0

### DIFF
--- a/packages/libsqlite/build.sh
+++ b/packages/libsqlite/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.sqlite.org
 TERMUX_PKG_DESCRIPTION="Software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine"
 # Note: Updating this version requires bumping the tcl package as well.
 _SQLITE_MAJOR=3
-_SQLITE_MINOR=15
-_SQLITE_PATCH=2
+_SQLITE_MINOR=16
+_SQLITE_PATCH=0
 TERMUX_PKG_VERSION=${_SQLITE_MAJOR}.${_SQLITE_MINOR}.${_SQLITE_PATCH}
-TERMUX_PKG_SRCURL=https://www.sqlite.org/2016/sqlite-autoconf-${_SQLITE_MAJOR}${_SQLITE_MINOR}0${_SQLITE_PATCH}00.tar.gz
-TERMUX_PKG_SHA256=07b35063b9386865b78226cdaca9a299d938a87aaa8fdc4d73edb0cef30f3149
+TERMUX_PKG_SRCURL=https://www.sqlite.org/2017/sqlite-autoconf-${_SQLITE_MAJOR}${_SQLITE_MINOR}0${_SQLITE_PATCH}00.tar.gz
+TERMUX_PKG_SHA256=5102404047054b2cec2f43463293f94dea39425d42bf386d24596ab4fac7c7ff
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-readline"


### PR DESCRIPTION
Is the bump in tcl package still required? If no, please, remove the note from here