### PR TITLE
valac: add package

### DIFF
--- a/packages/valac/build.sh
+++ b/packages/valac/build.sh
@@ -1,0 +1,11 @@
+TERMUX_PKG_HOMEPAGE=https://wiki.gnome.org/Projects/Vala
+_VALA_MAJOR=0
+_VALA_MINOR=34
+_VALA_PATCH=4
+TERMUX_PKG_VERSION=$_VALA_MAJOR.$_VALA_MINOR.$_VALA_PATCH
+TERMUX_PKG_MAINTAINER='Vishal Biswas @vishalbiswas'
+TERMUX_PKG_SRCURL=http://download.gnome.org/sources/vala/$_VALA_MAJOR.$_VALA_MINOR/vala-$TERMUX_PKG_VERSION.tar.xz
+TERMUX_PKG_DESCRIPTION='C# like language for the GObject system'
+TERMUX_PKG_DEPENDS="glib"
+TERMUX_PKG_SHA256=6b17bd339414563ebc51f64b0b837919ea7552d8a8ffa71cdc837d25c9696b83
+


### PR DESCRIPTION
Built and tested on arm.
Successfully compiled sample vala code.
This is a big package (comes in around 28 mb), most of which are vapi files, which I'm not sure should be kept in termux.

Closes #644 