### PR TITLE
golang: fix runtime init on chromeos

### DIFF
--- a/packages/golang/build.sh
+++ b/packages/golang/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Go programming language compiler"
 _MAJOR_VERSION=1.7.4
 # Use the ~ deb versioning construct in the future:
 TERMUX_PKG_VERSION=2:${_MAJOR_VERSION}
+TERMUX_PKG_BUILD_REVISION=1
 TERMUX_PKG_SRCURL=https://storage.googleapis.com/golang/go${_MAJOR_VERSION}.src.tar.gz
 TERMUX_PKG_SHA256=4c189111e9ba651a2bb3ee868aa881fab36b2f2da3409e80885ca758a6b614cc
 TERMUX_PKG_FOLDERNAME=go

--- a/packages/golang/src-runtime-os_linux.patch
+++ b/packages/golang/src-runtime-os_linux.patch
@@ -1,0 +1,14 @@
+diff --git a/src/runtime/os_linux.go b/src/runtime/os_linux.go
+index 542f214..9151aff 100644
+--- a/src/runtime/os_linux.go
++++ b/src/runtime/os_linux.go
+@@ -91,6 +91,9 @@ func getproccount() int32 {
+ 	const maxCPUs = 64 * 1024
+ 	var buf [maxCPUs / (sys.PtrSize * 8)]uintptr
+ 	r := sched_getaffinity(0, unsafe.Sizeof(buf), &buf[0])
++	if r <= 0 {
++		return 1
++	}
+ 	n := int32(0)
+ 	for _, v := range buf[:r/sys.PtrSize] {
+ 		for v != 0 {


### PR DESCRIPTION
Android on ChromeOS uses a restrictive seccomp filter that blocks
sched_getaffinity. Simply assume 1 CPU on any error.

Fixes https://github.com/termux/termux-packages/issues/496