### PR TITLE
add myrepos

### DIFF
--- a/packages/myrepos/build.sh
+++ b/packages/myrepos/build.sh
@@ -1,0 +1,6 @@
+TERMUX_PKG_HOMEPAGE=http://myrepos.branchable.com/
+TERMUX_PKG_DESCRIPTION="tool to manage all your version control repos"
+TERMUX_PKG_VERSION=1.20160123
+TERMUX_PKG_SRCURL=http://http.debian.net/debian/pool/main/m/myrepos/myrepos_${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_DEPENDS="make, perl"
+TERMUX_PKG_BUILD_IN_SRC=yes

--- a/packages/myrepos/myrepos.patch
+++ b/packages/myrepos/myrepos.patch
@@ -1,0 +1,25 @@
+--- ../Makefile	2017-01-12 15:06:54.492104920 +1100
++++ Makefile	2017-01-12 15:07:14.468081324 +1100
+@@ -1,6 +1,8 @@
+-PREFIX:=/usr
++#PREFIX:=/usr
+ 
+-mans=mr.1 webcheckout.1
++# Man page building disabled as pod2man is not in PATH despite perl being
++# installed.
++mans=
+ 
+ build: $(mans)
+ 
+@@ -23,8 +25,9 @@
+ 	install -m0755 mr ${DESTDIR}${PREFIX}/bin/
+ 	install -m0755 webcheckout ${DESTDIR}${PREFIX}/bin/
+ 
+-	install -m0644 mr.1 ${DESTDIR}${PREFIX}/share/man/man1/
+-	install -m0644 webcheckout.1 ${DESTDIR}${PREFIX}/share/man/man1/
++# Man pages not built
++#	install -m0644 mr.1 ${DESTDIR}${PREFIX}/share/man/man1/
++#	install -m0644 webcheckout.1 ${DESTDIR}${PREFIX}/share/man/man1/
+ 
+ 	install -m0644 lib/* ${DESTDIR}${PREFIX}/share/mr/
+ 


### PR DESCRIPTION
myrepos will be useful for termux users with several git (etc) repos. It's also a pre-requisite for vcsh.

For some reason pod2man was not found in PATH when building in docker, so I patched the makefile not to build man pages.