### PR TITLE
fix clang cmake build left broken for arches other than aarch64

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -207,7 +207,7 @@ termux_step_setup_variables() {
 	TERMUX_STANDALONE_TOOLCHAIN="$TERMUX_TOPDIR/_lib/toolchain-${TERMUX_ARCH}-ndk${TERMUX_NDK_VERSION}-api${TERMUX_API_LEVEL}"
 	# Bump the below version if a change is made in toolchain setup to ensure
 	# that everyone gets an updated toolchain:
-	TERMUX_STANDALONE_TOOLCHAIN+="-v5"
+	TERMUX_STANDALONE_TOOLCHAIN+="-v6"
 
 	export TERMUX_TAR="tar"
 	export TERMUX_TOUCH="touch"
@@ -517,11 +517,13 @@ termux_step_setup_toolchain() {
 			--install-dir $_TERMUX_TOOLCHAIN_TMPDIR
 
 		local w
-		for w in aarch64-linux-android-clang clang; do
+		for w in ${TERMUX_ARCH}-linux-android-clang clang; do
 			cp $TERMUX_SCRIPTDIR/scripts/clang-pie-wrapper $_TERMUX_TOOLCHAIN_TMPDIR/bin/$w
 			sed -i 's/COMPILER/clang38/' $_TERMUX_TOOLCHAIN_TMPDIR/bin/$w
+			sed -i "s/TERMUX_ARCH/$TERMUX_ARCH/" $_TERMUX_TOOLCHAIN_TMPDIR/bin/$w
 			cp $TERMUX_SCRIPTDIR/scripts/clang-pie-wrapper $_TERMUX_TOOLCHAIN_TMPDIR/bin/$w++
 			sed -i 's/COMPILER/clang38++/' $_TERMUX_TOOLCHAIN_TMPDIR/bin/$w++
+			sed -i "s/TERMUX_ARCH/$TERMUX_ARCH/" $_TERMUX_TOOLCHAIN_TMPDIR/bin/$w++
 		done
 
 		if [ "$TERMUX_ARCH" = "arm" ]; then

--- a/scripts/clang-pie-wrapper
+++ b/scripts/clang-pie-wrapper
@@ -25,7 +25,7 @@ arguments=()
 # The ordinary wrapper from a NDK standalone toolchain
 # with "${arguments[@]}" added.
 if [ "$1" != "-cc1" ]; then
-    `dirname $0`/COMPILER -target aarch64-none-linux-android --sysroot `dirname $0`/../sysroot "${arguments[@]}" "$@"
+    `dirname $0`/COMPILER -target TERMUX_ARCH-none-linux-android --sysroot `dirname $0`/../sysroot "${arguments[@]}" "$@"
 else
     # target/triple already spelled out.
     `dirname $0`/COMPILER "${arguments[@]}" "$@"


### PR DESCRIPTION
The move to clang wrapper broke cmake builds for !aarch64. This fixes that.