### PR TITLE
add bs1770gain package

### DIFF
--- a/packages/bs1770gain/build.sh
+++ b/packages/bs1770gain/build.sh
@@ -1,0 +1,7 @@
+TERMUX_PKG_HOMEPAGE=http://bs1770gain.sourceforge.net/
+TERMUX_PKG_DESCRIPTION="BS1770GAIN is a loudness scanner compliant with ITU-R BS.1770 and its flavors EBU R128, ATSC A/85, and ReplayGain 2.0. It helps normalizing the loudness of audio and video files to the same level."
+TERMUX_PKG_VERSION=0.4.12
+TERMUX_PKG_MAINTAINER="Oliver Schmidhauser @Neo-Oli"
+TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/project/bs1770gain/bs1770gain/${TERMUX_PKG_VERSION}/bs1770gain-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_DEPENDS="ffmpeg, sox, libmp3lame"
+


### PR DESCRIPTION
 BS1770GAIN is a tool to analyse audio files and apply Replaygain Tags. It can be used together with http://beets.io 