### PR TITLE
Update tty-clock to version 2.3

### DIFF
--- a/packages/tty-clock/Makefile.patch
+++ b/packages/tty-clock/Makefile.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile b/Makefile
+index 5028ee4..6294b23 100644
+--- a/Makefile
++++ b/Makefile
+@@ -11,7 +11,8 @@ MANPATH = ${DESTDIR}${PREFIX}/share/man/man1
+ 
+ ifeq ($(shell sh -c 'which ncurses5-config>/dev/null 2>/dev/null && echo y'), y)
+ 	CFLAGS += -Wall -g $$(ncurses5-config --cflags)
+-	LDFLAGS += $$(ncurses5-config --libs)
++	# Overwrite instead of appending LDFLAGS, because `ncurses-config --libs` also returns -ltinfo, which it can't find
++	LDFLAGS ?= $$(ncurses5-config --libs)
+ else ifeq ($(shell sh -c 'which ncursesw5-config>/dev/null 2>/dev/null && echo y'), y)
+ 		CFLAGS += -Wall -g $$(ncursesw5-config --cflags)
+ 		LDFLAGS += $$(ncursesw5-config --libs)

--- a/packages/tty-clock/build.sh
+++ b/packages/tty-clock/build.sh
@@ -1,16 +1,13 @@
-TERMUX_PKG_HOMEPAGE=https://github.com/xorg62/tty-clock
 TERMUX_PKG_DESCRIPTION="tty-clock is a simple ncurses-based clock that shows the time and date using a large display. It has a few commandline options to customize the output."
-TERMUX_PKG_VERSION=0.1.20160928
-# The current tagged release is a few years older than the latest commit and has many problems
-_COMMIT=516afbf9f96101c0bed1c366f80d7ca087b0557d
+TERMUX_PKG_VERSION=2.3
 TERMUX_PKG_MAINTAINER="Oliver Schmidhauser @Neo-Oli"
-TERMUX_PKG_SRCURL=https://github.com/xorg62/tty-clock/archive/${_COMMIT}.tar.gz
-TERMUX_PKG_FOLDERNAME=tty-clock-${_COMMIT}
+TERMUX_PKG_SRCURL=https://github.com/xorg62/tty-clock/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_FOLDERNAME=tty-clock-${TERMUX_PKG_VERSION}
 TERMUX_PKG_DEPENDS="ncurses"
 TERMUX_PKG_BUILD_IN_SRC=yes
 
 termux_step_post_configure() {
-	LDFLAGS+=" -lncurses"
-	CFLAGS+=" $CPPFLAGS"
+    LDFLAGS+=" -lncurses"
+    CFLAGS+=" $CPPFLAGS"
 }
 


### PR DESCRIPTION
When the debian developers come ringing for a tagged release, suddenly
everything goes really fast.

In the build environment `ncurses5-config --libs` also returns
-ltinfo, which is unavailable to the linker. That's why the patch was
needed. Is this something that could be fixed in the build environment
or is this simply a badly written makefile, unsuitable for cross
compiling?