### PR TITLE
torsocks: fix nougat (add clone syscall)

### DIFF
--- a/packages/torsocks/0001-syscall-Add-clone.patch
+++ b/packages/torsocks/0001-syscall-Add-clone.patch
@@ -1,0 +1,75 @@
+From 3b78843ee18a3099196a61c7d07c0e2d24d1fe84 Mon Sep 17 00:00:00 2001
+From: vishalbiswas <vshlbiswas@ymail.com>
+Date: Tue, 17 Jan 2017 10:10:23 +0530
+Subject: [PATCH] syscall: Add clone
+
+Signed-off-by: vishalbiswas <vshlbiswas@ymail.com>
+---
+ src/common/compat.h |  4 ++++
+ src/lib/syscall.c   | 21 +++++++++++++++++++++
+ 2 files changed, 25 insertions(+)
+
+diff --git a/src/common/compat.h b/src/common/compat.h
+index f490113..bf42f07 100644
+--- a/src/common/compat.h
++++ b/src/common/compat.h
+@@ -126,6 +126,9 @@ void tsocks_once(tsocks_once_t *o, void (*init_routine)(void));
+ #ifndef __NR_fork
+ #define __NR_fork -18
+ #endif
++#ifndef __NR_clone
++#define __NR_clone -19
++#endif
+ 
+ #define TSOCKS_NR_SOCKET    __NR_socket
+ #define TSOCKS_NR_CONNECT   __NR_connect
+@@ -145,6 +148,7 @@ void tsocks_once(tsocks_once_t *o, void (*init_routine)(void));
+ #define TSOCKS_NR_GETTIMEOFDAY __NR_gettimeofday
+ #define TSOCKS_NR_CLOCK_GETTIME __NR_clock_gettime
+ #define TSOCKS_NR_FORK      __NR_fork
++#define TSOCKS_NR_CLONE     __NR_clone
+ 
+ /*
+  * Despite glibc providing wrappers for these calls for a long time
+diff --git a/src/lib/syscall.c b/src/lib/syscall.c
+index d0fdaaa..c8a9b46 100644
+--- a/src/lib/syscall.c
++++ b/src/lib/syscall.c
+@@ -423,6 +423,24 @@ static LIBC_SYSCALL_RET_TYPE handle_fork(void)
+ {
+ 	return tsocks_libc_syscall(TSOCKS_NR_FORK);
+ }
++
++/*
++ *  * Handle clone(2) syscall.
++ *   */
++static LIBC_SYSCALL_RET_TYPE handle_clone(va_list args)
++{
++	int (*fn)(void*);
++	void* child_stack;
++	int flags;
++	void* arg;
++
++	fn = va_arg(args, __typeof__(fn));
++	child_stack = va_arg(args, __typeof__(child_stack));
++	flags = va_arg(args, __typeof__(flags));
++	arg = va_arg(args, __typeof__(arg));
++
++        return tsocks_libc_syscall(TSOCKS_NR_CLONE, fn, child_stack, flags, arg);
++}
+ #endif /* __linux__ */
+ 
+ /*
+@@ -541,6 +559,9 @@ LIBC_SYSCALL_RET_TYPE tsocks_syscall(long int number, va_list args)
+ 	case TSOCKS_NR_FORK:
+ 		ret = handle_fork();
+ 		break;
++	case TSOCKS_NR_CLONE:
++		ret = handle_clone(args);
++		break;
+ #endif /* __linux__ */
+ 	default:
+ 		/*
+-- 
+2.11.0
+

--- a/packages/torsocks/build.sh
+++ b/packages/torsocks/build.sh
@@ -1,9 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/dgoulet/torsocks
 TERMUX_PKG_DESCRIPTION="Wrapper to safely torify applications"
-TERMUX_PKG_VERSION=2.2.0
-TERMUX_PKG_SRCURL=https://github.com/dgoulet/torsocks/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_VERSION=2.2.0.2017.1.17
+__TORSOCKS_REF=87b075dd16c675606adee792ef1e22691c51475b
+TERMUX_PKG_SRCURL=https://github.com/dgoulet/torsocks/archive/${__TORSOCKS_REF}.tar.gz
 TERMUX_PKG_DEPENDS="tor"
-TERMUX_PKG_FOLDERNAME=torsocks-$TERMUX_PKG_VERSION
+TERMUX_PKG_FOLDERNAME=torsocks-${__TORSOCKS_REF}
 
 termux_step_pre_configure () {
 	cd $TERMUX_PKG_SRCDIR


### PR DESCRIPTION
This fixes `cannot fork` errors on nougat devices.