### PR TITLE
ndk_patches: add patches for sem and shm

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Common porting problems
 * mempcpy(3) is a GNU extension. We have added it to &lt;string.h&gt; provided TERMUX_EXPOSE_MEMPCPY is defined,
   so use something like CFLAGS+=" -DTERMUX_EXPOSE_MEMPCPY=1" for packages expecting that function to exist.
 
+* Android uses a customized version of shared memory managemnt known as ashmem. Standard shm and semaphore
+  libc wrappers (semget(2), shmat(2) and others) aren't available. Direct syscalls are used here.
+
 dlopen() and RTLD&#95;&#42; flags
 =================================
 &lt;dlfcn.h&gt; originally declares

--- a/README.md
+++ b/README.md
@@ -122,8 +122,9 @@ Common porting problems
 * mempcpy(3) is a GNU extension. We have added it to &lt;string.h&gt; provided TERMUX_EXPOSE_MEMPCPY is defined,
   so use something like CFLAGS+=" -DTERMUX_EXPOSE_MEMPCPY=1" for packages expecting that function to exist.
 
-* Android uses a customized version of shared memory managemnt known as ashmem. Standard shm and semaphore
-  libc wrappers (semget(2), shmat(2) and others) aren't available. Direct syscalls are used here.
+* Android uses a customized version of shared memory managemnt known as ashmem. Standard shm and semaphore libc
+  wrappers (semget(2), shmat(2) and others) aren't available. Direct syscalls can be used with
+  `CFLAGS+=" -DTERMUX_SHMEM_STUBS=1 -DTERMUX_SEMOPS_STUBS=1"`.
 
 dlopen() and RTLD&#95;&#42; flags
 =================================

--- a/build-package.sh
+++ b/build-package.sh
@@ -206,7 +206,7 @@ termux_step_setup_variables() {
 	TERMUX_STANDALONE_TOOLCHAIN="$TERMUX_TOPDIR/_lib/toolchain-${TERMUX_ARCH}-ndk${TERMUX_NDK_VERSION}-api${TERMUX_API_LEVEL}"
 	# Bump the below version if a change is made in toolchain setup to ensure
 	# that everyone gets an updated toolchain:
-	TERMUX_STANDALONE_TOOLCHAIN+="-v9"
+	TERMUX_STANDALONE_TOOLCHAIN+="-v10"
 
 	export TERMUX_TAR="tar"
 	export TERMUX_TOUCH="touch"

--- a/ndk_patches/sys-sem.h.patch
+++ b/ndk_patches/sys-sem.h.patch
@@ -1,15 +1,17 @@
 --- /home/vishal/Android/Sdk/ndk-bundle/platforms/android-21/arch-arm/usr/include/sys/sem.h	2016-10-12 15:11:58.000000000 +0530
-+++ ./usr/include/sys/sem.h	2017-01-22 11:38:53.969993752 +0530
-@@ -29,6 +29,12 @@
- #ifndef _SYS_SEM_H_
- #define _SYS_SEM_H_
++++ ./usr/include/sys/sem.h	2017-01-24 08:23:25.150726158 +0530
+@@ -31,4 +31,14 @@
  
-+/* all semaphore functions are available as syscalls */
  #include <linux/sem.h>
+ 
++#ifdef TERMUX_SEMOPS_STUBS
++
 +#include <sys/syscall.h>
 +
 +#define semop(semid, sops, nsops)  syscall(__NR_semop, semid, sops, nsops)
 +#define semget(key, nsems, semflg) syscall(__NR_semget, key, nsems, semflg)
 +#define semctl(semid, semnum, cmd, ...) syscall(__NR_semctl, semid, semnum, cmd, __VA_ARGS__)
- 
++
++#endif /* TERMUX_SEMOPS_STUBS */
++
  #endif /* _SYS_SEM_H_ */

--- a/ndk_patches/sys-sem.h.patch
+++ b/ndk_patches/sys-sem.h.patch
@@ -1,0 +1,15 @@
+--- /home/vishal/Android/Sdk/ndk-bundle/platforms/android-21/arch-arm/usr/include/sys/sem.h	2016-10-12 15:11:58.000000000 +0530
++++ ./usr/include/sys/sem.h	2017-01-22 11:38:53.969993752 +0530
+@@ -29,6 +29,12 @@
+ #ifndef _SYS_SEM_H_
+ #define _SYS_SEM_H_
+ 
++/* all semaphore functions are available as syscalls */
+ #include <linux/sem.h>
++#include <sys/syscall.h>
++
++#define semop(semid, sops, nsops)  syscall(__NR_semop, semid, sops, nsops)
++#define semget(key, nsems, semflg) syscall(__NR_semget, key, nsems, semflg)
++#define semctl(semid, semnum, cmd, ...) syscall(__NR_semctl, semid, semnum, cmd, __VA_ARGS__)
+ 
+ #endif /* _SYS_SEM_H_ */

--- a/ndk_patches/sys-shm.h.patch
+++ b/ndk_patches/sys-shm.h.patch
@@ -1,9 +1,11 @@
 --- /home/vishal/Android/Sdk/ndk-bundle/platforms/android-21/arch-arm/usr/include/sys/shm.h	2016-10-12 15:11:58.000000000 +0530
-+++ ./usr/include/sys/shm.h	2017-01-23 09:02:45.018819136 +0530
-@@ -30,5 +30,13 @@
- #define _SYS_SHM_H_
++++ ./usr/include/sys/shm.h	2017-01-24 08:21:49.997228838 +0530
+@@ -31,4 +31,17 @@
  
  #include <linux/shm.h>
+ 
++#ifdef TERMUX_SHMEM_STUBS
++
 +#include <sys/syscall.h>
 +#include <limits.h>
 +
@@ -12,5 +14,7 @@
 +#define shmctl(shmid, cmd, buf) syscall(__NR_shmctl, shmid, cmd, buf)
 +#define shmat(shmid, shmaddr, shmflg) syscall(__NR_shmat, shmid, shmaddr, shmflg)
 +#define shmdt(shmaddr) syscall(__NR_shmdt, shmaddr)
- 
++
++#endif /* TERMUX_SHMEM_STUBS */
++
  #endif /* _SYS_SHM_H_ */

--- a/ndk_patches/sys-shm.h.patch
+++ b/ndk_patches/sys-shm.h.patch
@@ -1,0 +1,16 @@
+--- /home/vishal/Android/Sdk/ndk-bundle/platforms/android-21/arch-arm/usr/include/sys/shm.h	2016-10-12 15:11:58.000000000 +0530
++++ ./usr/include/sys/shm.h	2017-01-23 09:02:45.018819136 +0530
+@@ -30,5 +30,13 @@
+ #define _SYS_SHM_H_
+ 
+ #include <linux/shm.h>
++#include <sys/syscall.h>
++#include <limits.h>
++
++#define SHMLBA PAGE_SIZE
++#define shmget(key, size, shmflg) syscall(__NR_shmget, key, size, shmflg)
++#define shmctl(shmid, cmd, buf) syscall(__NR_shmctl, shmid, cmd, buf)
++#define shmat(shmid, shmaddr, shmflg) syscall(__NR_shmat, shmid, shmaddr, shmflg)
++#define shmdt(shmaddr) syscall(__NR_shmdt, shmaddr)
+ 
+ #endif /* _SYS_SHM_H_ */

--- a/packages/ndk-sysroot/build.sh
+++ b/packages/ndk-sysroot/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://developer.android.com/tools/sdk/ndk/index.html
 TERMUX_PKG_DESCRIPTION="System header and library files from the Android NDK needed for compiling C programs"
 TERMUX_PKG_VERSION=$TERMUX_NDK_VERSION
-TERMUX_PKG_REVISION=7
+TERMUX_PKG_REVISION=8
 TERMUX_PKG_NO_DEVELSPLIT=yes
 # Depend on libandroid-support-dev so that iconv.h and libintl.h are available:
 TERMUX_PKG_DEPENDS="libandroid-support-dev"


### PR DESCRIPTION
These patches add macros for sem and shm libc wrappers missing from bionic.
They replace the function calls to syscalls and as such do not perform any parameter checks. Also, these will not set errno. This limits their functionality but they help compile many more programs.