### PR TITLE
add postgresql and mariadb as disabled packages

### DIFF
--- a/disabled-packages/mariadb/build.sh
+++ b/disabled-packages/mariadb/build.sh
@@ -1,0 +1,41 @@
+TERMUX_PKG_VERSION=10.1.21
+TERMUX_PKG_HOMEPAGE=https://mariadb.org
+TERMUX_PKG_SRCURL=http://mirror.fibergrid.in/mariadb//mariadb-$TERMUX_PKG_VERSION/source/mariadb-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=5a816355781ea22a6c65a436d8162f19bd292ec90e2b7d9499c031ae4a659490
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" -DSTACK_DIRECTION=-1 -DIMPORT_EXECUTABLES=$TERMUX_PKG_HOSTBUILD_DIR/import_executables.cmake -DPLUGIN_EXAMPLE=NO
+-DCMAKE_USE_SYSTEM_LIBRARIES=True -DWITH_WSREP=False -DHAVE_UCONTEXT_H=False -DWITH_READLINE=ON -DWITH_PCRE=system -DWITH_JEMALLOC=OFF
+-DWITH_SSL=system -DPLUGIN_DAEMON_EXAMPLE=NO -DINSTALL_UNIX_ADDRDIR=$TERMUX_PREFIX/tmp/mysqld.sock -DINSTALL_SCRIPTDIR=$TERMUX_PREFIX/bin
+-DWITH_EXTRA_CHARSETS=complex -DMYSQL_DATADIR=$TERMUX_PREFIX/var/lib/mysql -DINSTALL_MANDIR=$TERMUX_PREFIX/share/man
+-DINSTALL_PLUGINDIR=$TERMUX_PREFIX/lib/mysql/plugin -DBUILD_CONFIG=mysql_release -DENABLED_LOCAL_INFILE=ON -DTMPDIR=$TERMUX_PREFIX/tmp" #-DHAVE_IB_GCC_ATOMIC_BUILTINS=True
+TERMUX_PKG_HOSTBUILD=true
+TERMUX_PKG_DEPENDS="openssl, pcre, libcrypt, libbz2, libandroid-support, libandroid-glob, krb5, libgnustl"
+TERMUX_PKG_MAINTAINER="Vishal Biswas @vishalbiswas"
+TERMUX_PKG_DESCRIPTION="A drop-in replacement for mysql server"
+TERMUX_PKG_CONFLICTS="mysql"
+
+termux_step_host_build () {
+	termux_setup_cmake
+	cmake -G "Unix Makefiles" $TERMUX_PKG_SRCDIR -DCMAKE_BUILD_TYPE=Release
+	make -j $TERMUX_MAKE_PROCESSES import_executables
+}
+
+termux_step_pre_configure () {
+	# it will try to define off64_t with off_t if unset
+	# and 32 bit Android has wrong off_t defined
+	CPPFLAGS="$CPPFLAGS -Dushort=u_short -D__off64_t_defined"
+}
+
+termux_step_post_make_install () {
+	mkdir -p $TERMUX_PREFIX/var/lib/mysql
+	# files not needed
+	rm -r $TERMUX_PREFIX/{data,mysql-test,sql-bench}
+	rm $TERMUX_PREFIX/share/man/man1/mysql-test-run.pl.1
+}
+
+termux_step_create_debscripts () {
+	return
+	echo "echo 'Initializing mysql data directory...'" > postinst
+	echo "$TERMUX_PREFIX/bin/mysql_install_db --user=\`whoami\` --datadir=$TERMUX_PREFIX/var/lib/mysql --basedir=$TERMUX_PREFIX" >> postinst
+	echo "exit 0" >> postinst
+	chmod 0755 postinst
+}

--- a/disabled-packages/mariadb/extra-readline-complete.c.patch
+++ b/disabled-packages/mariadb/extra-readline-complete.c.patch
@@ -1,0 +1,12 @@
+--- ./extra/readline/complete.c	2017-01-18 01:08:19.000000000 +0530
++++ ../complete.c	2017-02-03 08:35:29.752470580 +0530
+@@ -1854,8 +1854,8 @@
+       username = savestring (&text[first_char_loc]);
+ #if defined (HAVE_GETPWENT)
+       namelen = strlen (username);
+-#endif
+       setpwent ();
++#endif
+     }
+ 
+ #if defined (HAVE_GETPWENT)

--- a/disabled-packages/mariadb/m_ctype.h.patch
+++ b/disabled-packages/mariadb/m_ctype.h.patch
@@ -1,0 +1,14 @@
+bionic snprintf is defined as a macro, so this saves chaos
+--- ./include/m_ctype.h	2017-01-18 01:08:20.000000000 +0530
++++ ../m_ctype.h	2017-02-01 09:14:37.958658913 +0530
+@@ -398,7 +398,9 @@
+   const char *m_cannot_convert_error_pos;
+ } MY_STRCONV_STATUS;
+ 
+-
++#ifdef __ANDROID__
++#undef snprintf
++#endif
+ /* See strings/CHARSET_INFO.txt about information on this structure  */
+ struct my_charset_handler_st
+ {

--- a/disabled-packages/mariadb/my_global.h.patch32
+++ b/disabled-packages/mariadb/my_global.h.patch32
@@ -1,0 +1,12 @@
+32 bit arches have 32 bit off_t on Android
+--- ./include/my_global.h	2017-01-18 01:08:20.000000000 +0530
++++ ../my_global.h	2017-02-01 09:24:13.543592127 +0530
+@@ -974,7 +974,7 @@
+ 
+ #define MY_ERRPTR ((void*)(intptr)1)
+ 
+-#if defined(_WIN32)
++#if defined(_WIN32) || defined(__ANDROID__)
+ typedef unsigned long long my_off_t;
+ typedef unsigned long long os_off_t;
+ #else

--- a/disabled-packages/postgresql/build.sh
+++ b/disabled-packages/postgresql/build.sh
@@ -1,0 +1,15 @@
+TERMUX_PKG_MAINTAINER='Vishal Biswas @vishalbiswas'
+TERMUX_PKG_VERSION=9.6.1
+TERMUX_PKG_HOMEPAGE=https://www.postgresql.org
+TERMUX_PKG_SRCURL=https://ftp.postgresql.org/pub/source/v$TERMUX_PKG_VERSION/postgresql-$TERMUX_PKG_VERSION.tar.bz2
+TERMUX_PKG_DEPENDS="openssl, libcrypt, readline"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" --without-gssapi --with-readline --with-openssl --with-system-tzdata=/system/usr/share/zoneinfo"
+TERMUX_PKG_EXTRA_MAKE_ARGS=" -s"
+
+termux_step_pre_configure () {
+	# to use shmem and sem stubs
+	#CPPFLAGS="$CPPFLAGS -DTERMUX_SHMEM_STUBS -DTERMUX_SEMOPS_STUBS -DEXEC_BACKEND"
+	CFLAGS="$CFLAGS -DTERMUX_SHMEM_STUBS=1 -DTERMUX_SEMOPS_STUBS=1"
+	LDFLAGS="$LDFLAGS -llog"
+}
+

--- a/disabled-packages/postgresql/tempdir-fix-old.patch.old
+++ b/disabled-packages/postgresql/tempdir-fix-old.patch.old
@@ -1,0 +1,21 @@
+--- ./src/bin/pg_upgrade/test.sh	2016-10-25 01:38:51.000000000 +0530
++++ ../test.sh	2017-01-23 10:08:52.568213209 +0530
+@@ -44,15 +44,15 @@
+ 		if [ "x$PGHOST" = x ]; then
+ 			{
+ 				dir=`(umask 077 &&
+-					  mktemp -d /tmp/pg_upgrade_check-XXXXXX) 2>/dev/null` &&
++					  mktemp -d @TERMUX_PREFIX@/tmp/pg_upgrade_check-XXXXXX) 2>/dev/null` &&
+ 				[ -d "$dir" ]
+ 			} ||
+ 			{
+-				dir=/tmp/pg_upgrade_check-$$-$RANDOM
++				dir=@TERMUX_PREFIX@/tmp/pg_upgrade_check-$$-$RANDOM
+ 				(umask 077 && mkdir "$dir")
+ 			} ||
+ 			{
+-				echo "could not create socket temporary directory in \"/tmp\""
++				echo "could not create socket temporary directory in \"@TERMUX_PREFIX@/tmp\""
+ 				exit 1
+ 			}
+ 

--- a/disabled-packages/postgresql/tempdir-fix.patch.old
+++ b/disabled-packages/postgresql/tempdir-fix.patch.old
@@ -1,0 +1,346 @@
+diff -ruN src1/contrib/pg_trgm/trgm_regexp.c src/contrib/pg_trgm/trgm_regexp.c
+--- src1/contrib/pg_trgm/trgm_regexp.c	2017-01-24 09:07:07.582306509 +0530
++++ src/contrib/pg_trgm/trgm_regexp.c	2017-01-24 09:08:42.581520771 +0530
+@@ -2078,8 +2078,8 @@
+ 	appendStringInfoString(&buf, "}\n");
+ 
+ 	{
+-		/* dot -Tpng -o /tmp/source.png < /tmp/source.dot */
+-		FILE	   *fp = fopen("/tmp/source.dot", "w");
++		/* dot -Tpng -o /data/data/com.termux/files/usr/tmp/source.png < /data/data/com.termux/files/usr/tmp/source.dot */
++		FILE	   *fp = fopen("/data/data/com.termux/files/usr/tmp/source.dot", "w");
+ 
+ 		fprintf(fp, "%s", buf.data);
+ 		fclose(fp);
+@@ -2140,8 +2140,8 @@
+ 	appendStringInfoString(&buf, "}\n");
+ 
+ 	{
+-		/* dot -Tpng -o /tmp/transformed.png < /tmp/transformed.dot */
+-		FILE	   *fp = fopen("/tmp/transformed.dot", "w");
++		/* dot -Tpng -o /data/data/com.termux/files/usr/tmp/transformed.png < /data/data/com.termux/files/usr/tmp/transformed.dot */
++		FILE	   *fp = fopen("/data/data/com.termux/files/usr/tmp/transformed.dot", "w");
+ 
+ 		fprintf(fp, "%s", buf.data);
+ 		fclose(fp);
+@@ -2231,8 +2231,8 @@
+ 	appendStringInfoString(&buf, "}\n");
+ 
+ 	{
+-		/* dot -Tpng -o /tmp/packed.png < /tmp/packed.dot */
+-		FILE	   *fp = fopen("/tmp/packed.dot", "w");
++		/* dot -Tpng -o /data/data/com.termux/files/usr/tmp/packed.png < /data/data/com.termux/files/usr/tmp/packed.dot */
++		FILE	   *fp = fopen("/data/data/com.termux/files/usr/tmp/packed.dot", "w");
+ 
+ 		fprintf(fp, "%s", buf.data);
+ 		fclose(fp);
+diff -ruN src1/doc/src/sgml/html/lo-funcs.html src/doc/src/sgml/html/lo-funcs.html
+--- src1/doc/src/sgml/html/lo-funcs.html	2017-01-24 09:07:07.685638972 +0530
++++ src/doc/src/sgml/html/lo-funcs.html	2017-01-24 09:08:39.621544794 +0530
+@@ -320,7 +320,7 @@
+ INSERT INTO image (name, raster)  -- same as above, but specify OID to use
+     VALUES ('beautiful image', lo_import('/etc/motd', 68583));
+ 
+-SELECT lo_export(image.raster, '/tmp/motd') FROM image
++SELECT lo_export(image.raster, '/data/data/com.termux/files/usr/tmp/motd') FROM image
+     WHERE name = 'beautiful image';</PRE
+ ><P>
+   </P
+diff -ruN src1/doc/src/sgml/html/pgstandby.html src/doc/src/sgml/html/pgstandby.html
+--- src1/doc/src/sgml/html/pgstandby.html	2017-01-24 09:07:07.662305836 +0530
++++ src/doc/src/sgml/html/pgstandby.html	2017-01-24 09:08:39.921542358 +0530
+@@ -494,7 +494,7 @@
+         when multiple servers exist on the same system; for example
+         <TT
+ CLASS="FILENAME"
+->/tmp/pgsql.trigger.5432</TT
++>/data/data/com.termux/files/usr/tmp/pgsql.trigger.5432</TT
+ >.
+        </P
+ ></DD
+@@ -631,9 +631,9 @@
+ CLASS="PROGRAMLISTING"
+ >archive_command = 'cp %p .../archive/%f'
+ 
+-restore_command = 'pg_standby -d -s 2 -t /tmp/pgsql.trigger.5442 .../archive %f %p %r 2&#62;&#62;standby.log'
++restore_command = 'pg_standby -d -s 2 -t /data/data/com.termux/files/usr/tmp/pgsql.trigger.5442 .../archive %f %p %r 2&#62;&#62;standby.log'
+ 
+-recovery_end_command = 'rm -f /tmp/pgsql.trigger.5442'</PRE
++recovery_end_command = 'rm -f /data/data/com.termux/files/usr/tmp/pgsql.trigger.5442'</PRE
+ ><P>
+    where the archive directory is physically located on the standby server,
+    so that the <TT
+@@ -666,7 +666,7 @@
+ >     stop waiting only when a trigger file called
+      <TT
+ CLASS="FILENAME"
+->/tmp/pgsql.trigger.5442</TT
++>/data/data/com.termux/files/usr/tmp/pgsql.trigger.5442</TT
+ > appears,
+      and perform failover according to its content
+     </P
+diff -ruN src1/doc/src/sgml/html/plperl-trusted.html src/doc/src/sgml/html/plperl-trusted.html
+--- src1/doc/src/sgml/html/plperl-trusted.html	2017-01-24 09:07:07.695638888 +0530
++++ src/doc/src/sgml/html/plperl-trusted.html	2017-01-24 09:08:39.861542845 +0530
+@@ -126,7 +126,7 @@
+ </P><PRE
+ CLASS="PROGRAMLISTING"
+ >CREATE FUNCTION badfunc() RETURNS integer AS $$
+-    my $tmpfile = "/tmp/badfile";
++    my $tmpfile = "/data/data/com.termux/files/usr/tmp/badfile";
+     open my $fh, '&gt;', $tmpfile
+         or elog(ERROR, qq{could not open the file "$tmpfile": $!});
+     print $fh "Testing writing to a file\n";
+diff -ruN src1/doc/src/sgml/html/preventing-server-spoofing.html src/doc/src/sgml/html/preventing-server-spoofing.html
+--- src1/doc/src/sgml/html/preventing-server-spoofing.html	2017-01-24 09:07:07.692305583 +0530
++++ src/doc/src/sgml/html/preventing-server-spoofing.html	2017-01-24 09:08:41.148199067 +0530
+@@ -127,7 +127,7 @@
+    socket file and hence be vulnerable to spoofing, during operating system
+    startup create a symbolic link <TT
+ CLASS="FILENAME"
+->/tmp/.s.PGSQL.5432</TT
++>/data/data/com.termux/files/usr/tmp/.s.PGSQL.5432</TT
+ > that points
+    to the relocated socket file.  You also might need to modify your
+    <TT
+diff -ruN src1/doc/src/sgml/html/server-start.html src/doc/src/sgml/html/server-start.html
+--- src1/doc/src/sgml/html/server-start.html	2017-01-24 09:07:07.688972278 +0530
++++ src/doc/src/sgml/html/server-start.html	2017-01-24 09:08:41.151532373 +0530
+@@ -607,7 +607,7 @@
+ CLASS="SCREEN"
+ >psql: could not connect to server: No such file or directory
+         Is the server running locally and accepting
+-        connections on Unix domain socket "/tmp/.s.PGSQL.5432"?</PRE
++        connections on Unix domain socket "/data/data/com.termux/files/usr/tmp/.s.PGSQL.5432"?</PRE
+ ><P>
+     </P
+ ><P
+diff -ruN src1/doc/src/sgml/html/tutorial-createdb.html src/doc/src/sgml/html/tutorial-createdb.html
+--- src1/doc/src/sgml/html/tutorial-createdb.html	2017-01-24 09:07:07.685638972 +0530
++++ src/doc/src/sgml/html/tutorial-createdb.html	2017-01-24 09:08:39.284880862 +0530
+@@ -161,7 +161,7 @@
+ CLASS="SCREEN"
+ >createdb: could not connect to database postgres: could not connect to server: No such file or directory
+         Is the server running locally and accepting
+-        connections on Unix domain socket "/tmp/.s.PGSQL.5432"?</PRE
++        connections on Unix domain socket "/data/data/com.termux/files/usr/tmp/.s.PGSQL.5432"?</PRE
+ ><P>
+     This means that the server was not started, or it was not started
+     where <TT
+diff -ruN src1/doc/src/sgml/lobj.sgml src/doc/src/sgml/lobj.sgml
+--- src1/doc/src/sgml/lobj.sgml	2017-01-24 09:07:07.712305414 +0530
++++ src/doc/src/sgml/lobj.sgml	2017-01-24 09:08:38.018224484 +0530
+@@ -624,7 +624,7 @@
+ INSERT INTO image (name, raster)  -- same as above, but specify OID to use
+     VALUES ('beautiful image', lo_import('/etc/motd', 68583));
+ 
+-SELECT lo_export(image.raster, '/tmp/motd') FROM image
++SELECT lo_export(image.raster, '/data/data/com.termux/files/usr/tmp/motd') FROM image
+     WHERE name = 'beautiful image';
+ </programlisting>
+   </para>
+diff -ruN src1/doc/src/sgml/man1/pg_standby.1 src/doc/src/sgml/man1/pg_standby.1
+--- src1/doc/src/sgml/man1/pg_standby.1	2017-01-24 09:07:07.605639646 +0530
++++ src/doc/src/sgml/man1/pg_standby.1	2017-01-24 09:08:37.998224648 +0530
+@@ -159,7 +159,7 @@
+ \fB\-t\fR \fItriggerfile\fR
+ .RS 4
+ Specify a trigger file whose presence should cause failover\&. It is recommended that you use a structured file name to avoid confusion as to which server is being triggered when multiple servers exist on the same system; for example
+-/tmp/pgsql\&.trigger\&.5432\&.
++/data/data/com.termux/files/usr/tmp/pgsql\&.trigger\&.5432\&.
+ .RE
+ .PP
+ \fB\-V\fR
+@@ -221,9 +221,9 @@
+ .nf
+ archive_command = \*(Aqcp %p \&.\&.\&./archive/%f\*(Aq
+ 
+-restore_command = \*(Aqpg_standby \-d \-s 2 \-t /tmp/pgsql\&.trigger\&.5442 \&.\&.\&./archive %f %p %r 2>>standby\&.log\*(Aq
++restore_command = \*(Aqpg_standby \-d \-s 2 \-t /data/data/com.termux/files/usr/tmp/pgsql\&.trigger\&.5442 \&.\&.\&./archive %f %p %r 2>>standby\&.log\*(Aq
+ 
+-recovery_end_command = \*(Aqrm \-f /tmp/pgsql\&.trigger\&.5442\*(Aq
++recovery_end_command = \*(Aqrm \-f /data/data/com.termux/files/usr/tmp/pgsql\&.trigger\&.5442\*(Aq
+ .fi
+ .if n \{\
+ .RE
+@@ -266,7 +266,7 @@
+ .IP \(bu 2.3
+ .\}
+ stop waiting only when a trigger file called
+-/tmp/pgsql\&.trigger\&.5442
++/data/data/com.termux/files/usr/tmp/pgsql\&.trigger\&.5442
+ appears, and perform failover according to its content
+ .RE
+ .sp
+diff -ruN src1/doc/src/sgml/man1/psql.1 src/doc/src/sgml/man1/psql.1
+--- src1/doc/src/sgml/man1/psql.1	2017-01-24 09:07:07.602306341 +0530
++++ src/doc/src/sgml/man1/psql.1	2017-01-24 09:08:37.954891666 +0530
+@@ -3397,7 +3397,7 @@
+ \fBTMPDIR\fR
+ .RS 4
+ Directory for storing temporary files\&. The default is
+-/tmp\&.
++/data/data/com.termux/files/usr/tmp\&.
+ .RE
+ .PP
+ This utility, like most other
+diff -ruN src1/doc/src/sgml/pgstandby.sgml src/doc/src/sgml/pgstandby.sgml
+--- src1/doc/src/sgml/pgstandby.sgml	2017-01-24 09:07:07.592306425 +0530
++++ src/doc/src/sgml/pgstandby.sgml	2017-01-24 09:08:38.534886954 +0530
+@@ -193,7 +193,7 @@
+         It is recommended that you use a structured file name to
+         avoid confusion as to which server is being triggered
+         when multiple servers exist on the same system; for example
+-        <filename>/tmp/pgsql.trigger.5432</>.
++        <filename>/data/data/com.termux/files/usr/tmp/pgsql.trigger.5432</>.
+        </para>
+       </listitem>
+      </varlistentry>
+@@ -271,9 +271,9 @@
+ <programlisting>
+ archive_command = 'cp %p .../archive/%f'
+ 
+-restore_command = 'pg_standby -d -s 2 -t /tmp/pgsql.trigger.5442 .../archive %f %p %r 2>>standby.log'
++restore_command = 'pg_standby -d -s 2 -t /data/data/com.termux/files/usr/tmp/pgsql.trigger.5442 .../archive %f %p %r 2>>standby.log'
+ 
+-recovery_end_command = 'rm -f /tmp/pgsql.trigger.5442'
++recovery_end_command = 'rm -f /data/data/com.termux/files/usr/tmp/pgsql.trigger.5442'
+ </programlisting>
+    where the archive directory is physically located on the standby server,
+    so that the <varname>archive_command</> is accessing it across NFS,
+@@ -293,7 +293,7 @@
+    <listitem>
+     <para>
+      stop waiting only when a trigger file called
+-     <filename>/tmp/pgsql.trigger.5442</> appears,
++     <filename>/data/data/com.termux/files/usr/tmp/pgsql.trigger.5442</> appears,
+      and perform failover according to its content
+     </para>
+    </listitem>
+diff -ruN src1/doc/src/sgml/plperl.sgml src/doc/src/sgml/plperl.sgml
+--- src1/doc/src/sgml/plperl.sgml	2017-01-24 09:07:07.695638888 +0530
++++ src/doc/src/sgml/plperl.sgml	2017-01-24 09:08:41.468196470 +0530
+@@ -978,7 +978,7 @@
+    system operations are not allowed for security reasons:
+ <programlisting>
+ CREATE FUNCTION badfunc() RETURNS integer AS $$
+-    my $tmpfile = "/tmp/badfile";
++    my $tmpfile = "/data/data/com.termux/files/usr/tmp/badfile";
+     open my $fh, '&gt;', $tmpfile
+         or elog(ERROR, qq{could not open the file "$tmpfile": $!});
+     print $fh "Testing writing to a file\n";
+diff -ruN src1/doc/src/sgml/runtime.sgml src/doc/src/sgml/runtime.sgml
+--- src1/doc/src/sgml/runtime.sgml	2017-01-24 09:07:07.602306341 +0530
++++ src/doc/src/sgml/runtime.sgml	2017-01-24 09:08:38.754885166 +0530
+@@ -559,7 +559,7 @@
+ <screen>
+ psql: could not connect to server: No such file or directory
+         Is the server running locally and accepting
+-        connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
++        connections on Unix domain socket "/data/data/com.termux/files/usr/tmp/.s.PGSQL.5432"?
+ </screen>
+     </para>
+ 
+@@ -1934,7 +1934,7 @@
+    their own socket file in that directory.  If you are concerned that
+    some applications might still reference <filename>/tmp</> for the
+    socket file and hence be vulnerable to spoofing, during operating system
+-   startup create a symbolic link <filename>/tmp/.s.PGSQL.5432</> that points
++   startup create a symbolic link <filename>/data/data/com.termux/files/usr/tmp/.s.PGSQL.5432</> that points
+    to the relocated socket file.  You also might need to modify your
+    <filename>/tmp</> cleanup script to prevent removal of the symbolic link.
+   </para>
+diff -ruN src1/doc/src/sgml/start.sgml src/doc/src/sgml/start.sgml
+--- src1/doc/src/sgml/start.sgml	2017-01-24 09:07:07.712305414 +0530
++++ src/doc/src/sgml/start.sgml	2017-01-24 09:08:38.011557873 +0530
+@@ -178,7 +178,7 @@
+ <screen>
+ createdb: could not connect to database postgres: could not connect to server: No such file or directory
+         Is the server running locally and accepting
+-        connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
++        connections on Unix domain socket "/data/data/com.termux/files/usr/tmp/.s.PGSQL.5432"?
+ </screen>
+     This means that the server was not started, or it was not started
+     where <command>createdb</command> expected it.  Again, check the
+diff -ruN src1/src/backend/utils/misc/postgresql.conf.sample src/src/backend/utils/misc/postgresql.conf.sample
+--- src1/src/backend/utils/misc/postgresql.conf.sample	2017-01-24 09:07:07.852304235 +0530
++++ src/src/backend/utils/misc/postgresql.conf.sample	2017-01-24 09:08:31.664942842 +0530
+@@ -63,7 +63,7 @@
+ #port = 5432				# (change requires restart)
+ #max_connections = 100			# (change requires restart)
+ #superuser_reserved_connections = 3	# (change requires restart)
+-#unix_socket_directories = '/tmp'	# comma-separated list of directories
++#unix_socket_directories = '/data/data/com.termux/files/usr/tmp'	# comma-separated list of directories
+ 					# (change requires restart)
+ #unix_socket_group = ''			# (change requires restart)
+ #unix_socket_permissions = 0777		# begin with 0 to use octal notation
+diff -ruN src1/src/bin/initdb/initdb.c src/src/bin/initdb/initdb.c
+--- src1/src/bin/initdb/initdb.c	2017-01-24 09:07:07.792304741 +0530
++++ src/src/bin/initdb/initdb.c	2017-01-24 09:08:32.981598786 +0530
+@@ -1225,7 +1225,7 @@
+ #else
+ 	snprintf(repltok, sizeof(repltok), "#unix_socket_directories = ''");
+ #endif
+-	conflines = replace_token(conflines, "#unix_socket_directories = '/tmp'",
++	conflines = replace_token(conflines, "#unix_socket_directories = '/data/data/com.termux/files/usr/tmp'",
+ 							  repltok);
+ 
+ #if DEF_PGPORT != 5432
+diff -ruN src1/src/bin/pg_upgrade/test.sh src/src/bin/pg_upgrade/test.sh
+--- src1/src/bin/pg_upgrade/test.sh	2017-01-24 09:07:07.798971351 +0530
++++ src/src/bin/pg_upgrade/test.sh	2017-01-24 09:08:33.101597808 +0530
+@@ -44,15 +44,15 @@
+ 		if [ "x$PGHOST" = x ]; then
+ 			{
+ 				dir=`(umask 077 &&
+-					  mktemp -d /tmp/pg_upgrade_check-XXXXXX) 2>/dev/null` &&
++					  mktemp -d /data/data/com.termux/files/usr/tmp/pg_upgrade_check-XXXXXX) 2>/dev/null` &&
+ 				[ -d "$dir" ]
+ 			} ||
+ 			{
+-				dir=/tmp/pg_upgrade_check-$$-$RANDOM
++				dir=/data/data/com.termux/files/usr/tmp/pg_upgrade_check-$$-$RANDOM
+ 				(umask 077 && mkdir "$dir")
+ 			} ||
+ 			{
+-				echo "could not create socket temporary directory in \"/tmp\""
++				echo "could not create socket temporary directory in \"/data/data/com.termux/files/usr/tmp\""
+ 				exit 1
+ 			}
+ 
+diff -ruN src1/src/bin/psql/command.c src/src/bin/psql/command.c
+--- src1/src/bin/psql/command.c	2017-01-24 09:07:07.802304657 +0530
++++ src/src/bin/psql/command.c	2017-01-24 09:08:33.368262304 +0530
+@@ -2258,7 +2258,7 @@
+ 		const char *tmpdir = getenv("TMPDIR");
+ 
+ 		if (!tmpdir)
+-			tmpdir = "/tmp";
++			tmpdir = "/data/data/com.termux/files/usr/tmp";
+ #else
+ 		char		tmpdir[MAXPGPATH];
+ 		int			ret;
+diff -ruN src1/src/include/pg_config_manual.h src/src/include/pg_config_manual.h
+--- src1/src/include/pg_config_manual.h	2017-01-24 09:07:07.722305330 +0530
++++ src/src/include/pg_config_manual.h	2017-01-24 09:08:36.941566569 +0530
+@@ -164,7 +164,7 @@
+  * here's where to twiddle it.  You can also override this at runtime
+  * with the postmaster's -k switch.
+  */
+-#define DEFAULT_PGSOCKET_DIR  "/tmp"
++#define DEFAULT_PGSOCKET_DIR  "/data/data/com.termux/files/usr/tmp"
+ 
+ /*
+  * This is the default event source for Windows event log.
+diff -ruN src1/src/pl/plperl/sql/plperl_end.sql src/src/pl/plperl/sql/plperl_end.sql
+--- src1/src/pl/plperl/sql/plperl_end.sql	2017-01-24 09:07:07.892303898 +0530
++++ src/src/pl/plperl/sql/plperl_end.sql	2017-01-24 09:08:33.711592843 +0530
+@@ -5,7 +5,7 @@
+ -- Available here for manual developer testing.
+ 
+ DO $do$
+-	my $testlog = "/tmp/pgplperl_test.log";
++	my $testlog = "/data/data/com.termux/files/usr/tmp/pgplperl_test.log";
+ 
+ 	warn "Run test, then examine contents of $testlog (which must already exist)\n";
+ 	return unless -f $testlog;


### PR DESCRIPTION
*postgresql* fails because shm region creation fails with EACCESS (permission denied). I compiled util-linux with shm support and you can create shm regions as root but not as standard users. This is strange because the first time I ran this it ran flawlessly.
*mariadb* works if you can tolerate skip-grant-tables. `mysql_install_db` fails to install system tables. I have attached some debug logs.


[mariadb.txt](https://github.com/termux/termux-packages/files/752405/mariadb.txt)
