### PR TITLE
add more disabled packages

### DIFF
--- a/disabled-packages/alsa-lib/build.sh
+++ b/disabled-packages/alsa-lib/build.sh
@@ -1,0 +1,16 @@
+# patches taken from https://github.com/michaelwu/alsa-lib
+TERMUX_PKG_HOMEPAGE=http://www.alsa-project.org
+TERMUX_PKG_VERSION=1.1.3
+TERMUX_PKG_MAINTAINER='Vishal Biswas @vishalbiswas'
+TERMUX_PKG_DEPENDS="python2"
+TERMUX_PKG_SRCURL=ftp://ftp.alsa-project.org/pub/lib/alsa-lib-$TERMUX_PKG_VERSION.tar.bz2
+TERMUX_PKG_SHA256=71282502184c592c1a008e256c22ed0ba5728ca65e05273ceb480c70f515969c
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" --with-pythonlibs=\"-lpython2.7\" --with-pythonincludes=-I/$TERMUX_PREFIX/include/python2.7"
+
+termux_step_pre_configure () {
+	#LDFLAGS="$LDFLAGS -landroid-shmem"
+	#_files='src/pcm/pcm_dsnoop.c src/pcm/pcm_mmap.c src/pcm/pcm_shm.c src/pcm/pcm_dmix.c src/pcm/pcm_dshare.c src/pcm/pcm_direct.c src/shmarea.c src/control/control_shm.c aserver/aserver.c'
+	#for _file in $_files; do sed -i 's%#include <sys/shm.h>%#include <shmem/shm.h>%' "$TERMUX_PKG_SRCDIR/$_file"; done
+	#export ac_cv_header_sys_shm_h='no'
+	CPPFLAGS="$CPPFLAGS -DTERMUX_SHMEM_STUBS"
+}

--- a/disabled-packages/alsa-lib/pcm_direct.c.patch
+++ b/disabled-packages/alsa-lib/pcm_direct.c.patch
@@ -1,0 +1,17 @@
+--- ./src/pcm/pcm_direct.c	2016-08-02 23:18:38.000000000 +0530
++++ ./src/pcm/pcm_direct.c	2016-12-02 23:19:30.771819040 +0530
+@@ -44,12 +44,14 @@
+  *
+  */
+  
++#if !defined(ANDROID) && !defined(__ANDROID__)
+ union semun {
+ 	int              val;    /* Value for SETVAL */
+ 	struct semid_ds *buf;    /* Buffer for IPC_STAT, IPC_SET */
+ 	unsigned short  *array;  /* Array for GETALL, SETALL */
+ 	struct seminfo  *__buf;  /* Buffer for IPC_INFO (Linux specific) */
+ };
++#endif
+  
+ /*
+  * FIXME:

--- a/disabled-packages/alsa-lib/pcm_mmap.c.patch.old
+++ b/disabled-packages/alsa-lib/pcm_mmap.c.patch.old
@@ -1,0 +1,20 @@
+--- ./src/pcm/pcm_mmap.c	2016-08-02 23:18:38.000000000 +0530
++++ /home/vishal/AndroidDev/alsa/src/pcm/pcm_mmap.c	2016-12-03 00:06:36.620336924 +0530
+@@ -344,7 +344,7 @@
+ 			i->addr = ptr;
+ 			break;
+ 		case SND_PCM_AREA_SHM:
+-#ifdef HAVE_SYS_SHM_H
++#if 0
+ 			if (i->u.shm.shmid < 0) {
+ 				int id;
+ 				/* FIXME: safer permission? */
+@@ -474,7 +474,7 @@
+ 			errno = 0;
+ 			break;
+ 		case SND_PCM_AREA_SHM:
+-#ifdef HAVE_SYS_SHM_H
++#if 0
+ 			if (i->u.shm.area) {
+ 				snd_shm_area_destroy(i->u.shm.area);
+ 				i->u.shm.area = NULL;

--- a/disabled-packages/alsa-lib/versionsort.patch
+++ b/disabled-packages/alsa-lib/versionsort.patch
@@ -1,0 +1,24 @@
+diff -ruN ./src/conf.c /home/vishal/AndroidDev/alsa/src/conf.c
+--- ./src/conf.c	2016-08-02 23:18:38.000000000 +0530
++++ /home/vishal/AndroidDev/alsa/src/conf.c	2016-12-02 23:42:04.689785910 +0530
+@@ -3558,7 +3558,7 @@
+ 			int n;
+ 
+ #ifndef DOC_HIDDEN
+-#if defined(_GNU_SOURCE) && !defined(__NetBSD__) && !defined(__FreeBSD__) && !defined(__sun)
++#if defined(_GNU_SOURCE) && !defined(__NetBSD__) && !defined(__FreeBSD__) && !defined(__sun) && !defined(__ANDROID__) && !defined(ANDROID)
+ #define SORTFUNC	versionsort
+ #else
+ #define SORTFUNC	alphasort
+diff -ruN ./src/ucm/parser.c /home/vishal/AndroidDev/alsa/src/ucm/parser.c
+--- ./src/ucm/parser.c	2016-08-02 23:18:38.000000000 +0530
++++ /home/vishal/AndroidDev/alsa/src/ucm/parser.c	2016-12-02 23:42:17.406370931 +0530
+@@ -1274,7 +1274,7 @@
+ 		"%s", env ? env : ALSA_USE_CASE_DIR);
+ 	filename[MAX_FILE-1] = '\0';
+ 
+-#if defined(_GNU_SOURCE) && !defined(__NetBSD__) && !defined(__FreeBSD__) && !defined(__sun)
++#if defined(_GNU_SOURCE) && !defined(__NetBSD__) && !defined(__FreeBSD__) && !defined(__sun) && !defined(__ANDROID__) && !defined(ANDROID)
+ #define SORTFUNC	versionsort
+ #else
+ #define SORTFUNC	alphasort

--- a/disabled-packages/alsa-utils/build.sh
+++ b/disabled-packages/alsa-utils/build.sh
@@ -1,0 +1,11 @@
+TERMUX_PKG_HOMEPAGE=http://www.alsa-project.org
+TERMUX_PKG_VERSION=1.1.3
+TERMUX_PKG_MAINTAINER='Vishal Biswas @vishalbiswas'
+TERMUX_PKG_SRCURL=ftp://ftp.alsa-project.org/pub/utils/alsa-utils-$TERMUX_PKG_VERSION.tar.bz2
+TERMUX_PKG_SHA256=127217a54eea0f9a49700a2f239a2d4f5384aa094d68df04a8eb80132eb6167c
+TERMUX_PKG_DEPENDS="alsa-lib"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" --with-alsa-prefix=$TERMUX_PREFIX/lib --with-alsa-inc-prefix=$TERMUX_PREFIX/include --with-udev-rules-dir=$TERMUX_PREFIX/lib/udev/rules.d --disable-bat"
+
+termux_step_pre_configure () {
+    LDFLAGS+=" -llog"
+}

--- a/disabled-packages/alsa-utils/configure.patch
+++ b/disabled-packages/alsa-utils/configure.patch
@@ -1,0 +1,27 @@
+--- ./configure	2016-08-02 22:44:23.000000000 +0530
++++ ../configure	2016-12-03 23:06:46.641370754 +0530
+@@ -7123,7 +7123,7 @@
+ 	LDFLAGS="$LDFLAGS $ALSA_LIBS"
+ fi
+ 
+-ALSA_LIBS="$ALSA_LIBS -lasound -lm -ldl -lpthread"
++ALSA_LIBS="$ALSA_LIBS -lasound -lm -ldl"
+ LIBS="$ALSA_LIBS $LIBS"
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ALSA_LIBS" >&5
+ $as_echo "$ALSA_LIBS" >&6; }
+@@ -7741,7 +7741,6 @@
+   $as_echo_n "(cached) " >&6
+ else
+   ac_check_lib_save_LIBS=$LIBS
+-LIBS="-lpthread  $LIBS"
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+@@ -7776,7 +7775,6 @@
+ #define HAVE_LIBPTHREAD 1
+ _ACEOF
+ 
+-  LIBS="-lpthread $LIBS"
+ 
+ else
+   as_fn_error $? "Error: need PTHREAD library" "$LINENO" 5

--- a/disabled-packages/alsa-utils/volume_mapping.c.patch
+++ b/disabled-packages/alsa-utils/volume_mapping.c.patch
@@ -1,0 +1,11 @@
+--- ./alsamixer/volume_mapping.c	2016-08-02 22:39:45.000000000 +0530
++++ ../volume_mapping.c	2016-12-03 23:15:26.390744307 +0530
+@@ -37,7 +37,7 @@
+ #include <stdbool.h>
+ #include "volume_mapping.h"
+ 
+-#ifdef __UCLIBC__
++#if defined(__UCLIBC__) || defined(__ANDROID__)
+ /* 10^x = 10^(log e^x) = (e^x)^log10 = e^(x * log 10) */
+ #define exp10(x) (exp((x) * log(10)))
+ #endif /* __UCLIBC__ */

--- a/disabled-packages/easy-rsa/build.sh
+++ b/disabled-packages/easy-rsa/build.sh
@@ -1,0 +1,18 @@
+TERMUX_PKG_HOMEPAGE=https://openvpn.net/easyrsa.html
+TERMUX_PKG_VERSION=3.0.1
+TERMUX_PKG_DEPENDS="openssl-tool"
+TERMUX_PKG_SRCURL=https://github.com/OpenVPN/easy-rsa/releases/download/$TERMUX_PKG_VERSION/EasyRSA-$TERMUX_PKG_VERSION.tgz
+TERMUX_PKG_SHA256=dbdaf5b9444b99e0c5221fd4bcf15384c62380c1b63cea23d42239414d7b2d4e
+TERMUX_PKG_CONFFILES="etc/easy-rsa/openssl-1.0.cnf, etc/easy-rsa/vars"
+TERMUX_PKG_FOLDERNAME=EasyRSA-$TERMUX_PKG_VERSION
+TERMUX_PKG_MAINTAINER='Vishal Biswas @vishalbiswas'
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make_install () {
+    install -D -m0755 easyrsa "${TERMUX_PREFIX}"/bin/easyrsa
+
+    install -D -m0644 openssl-1.0.cnf "${TERMUX_PREFIX}"/etc/easy-rsa/openssl-1.0.cnf
+    install -D -m0644 vars.example "${TERMUX_PREFIX}"/etc/easy-rsa/vars
+    install -d -m0755 "${TERMUX_PREFIX}"/etc/easy-rsa/x509-types/
+    install -m0644 x509-types/* "${TERMUX_PREFIX}"/etc/easy-rsa/x509-types/
+}

--- a/disabled-packages/llvm/CMakeLists.txt.patch
+++ b/disabled-packages/llvm/CMakeLists.txt.patch
@@ -1,0 +1,67 @@
+--- ./tools/lldb/source/Host/CMakeLists.txt	2015-10-30 08:24:52.000000000 +0530
++++ ./tools/lldb/source/Host/CMakeLists.txt	2017-01-10 21:14:16.132877692 +0530
+@@ -115,7 +115,7 @@
+       macosx/cfcpp/CFCString.cpp
+       )
+ 
+-  elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
++  elseif (CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "Android")
+     if (__ANDROID_NDK__)
+       add_host_subdirectory(android
+         android/HostInfoAndroid.cpp
+--- ./tools/lldb/scripts/Python/modules/CMakeLists.txt	2015-02-13 15:52:00.000000000 +0530
++++ ./tools/lldb/scripts/Python/modules/CMakeLists.txt	2017-01-10 22:03:15.069857246 +0530
+@@ -5,7 +5,6 @@
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-macro-redefined")
+ endif ()
+ 
+-# build the Python readline suppression module only on Linux
+-if (CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT __ANDROID_NDK__)
++if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "Android")
+    add_subdirectory(readline)
+ endif()
+--- ./tools/lldb/tools/lldb-server/CMakeLists.txt	2016-01-29 17:29:57.000000000 +0530
++++ ./tools/lldb/tools/lldb-server/CMakeLists.txt	2017-01-10 22:06:03.981423698 +0530
+@@ -1,4 +1,4 @@
+-if ( CMAKE_SYSTEM_NAME MATCHES "Linux" )
++if ( CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "Android" )
+ include_directories(
+   ../../../../llvm/include
+   ../../source/Plugins/Process/Linux
+--- ./tools/lldb/source/CMakeLists.txt	2015-10-24 05:57:04.000000000 +0530
++++ ./tools/lldb/source/CMakeLists.txt	2017-01-10 22:10:44.805026352 +0530
+@@ -1,6 +1,6 @@
+ include_directories(.)
+ 
+-if ( CMAKE_SYSTEM_NAME MATCHES "Linux" )
++if ( CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "Android" )
+ include_directories(
+   Plugins/Process/Linux
+   Plugins/Process/POSIX
+--- ./tools/lldb/source/Plugins/Platform/CMakeLists.txt	2015-10-24 05:57:04.000000000 +0530
++++ ./tools/lldb/source/Plugins/Platform/CMakeLists.txt	2017-01-10 22:15:36.255075635 +0530
+@@ -1,4 +1,4 @@
+-#if (CMAKE_SYSTEM_NAME MATCHES "Linux")
++#if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "Android")
+   add_subdirectory(Linux)
+ #elseif (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+   add_subdirectory(FreeBSD)
+--- ./tools/lldb/source/Plugins/Process/CMakeLists.txt	2015-10-28 23:51:45.000000000 +0530
++++ ./tools/lldb/source/Plugins/Process/CMakeLists.txt	2017-01-10 22:18:20.019868513 +0530
+@@ -1,4 +1,4 @@
+-if (CMAKE_SYSTEM_NAME MATCHES "Linux")
++if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "Android")
+   add_subdirectory(Linux)
+   add_subdirectory(POSIX)
+ elseif (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+--- ./tools/llvm-shlib/CMakeLists.txt	2016-05-26 10:05:35.000000000 +0530
++++ ./tools/llvm-shlib/CMakeLists.txt	2017-01-12 16:43:02.136137108 +0530
+@@ -39,7 +39,7 @@
+ add_llvm_library(LLVM SHARED DISABLE_LLVM_LINK_LLVM_DYLIB SONAME ${SOURCES})
+ 
+ list(REMOVE_DUPLICATES LIB_NAMES)
+-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") # FIXME: It should be "GNU ld for elf"
++if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" OR "${CMAKE_SYSTEM_NAME}" STREQUAL "Android") # FIXME: It should be "GNU ld for elf"
+   # GNU ld doesn't resolve symbols in the version script.
+   set(LIB_NAMES -Wl,--whole-archive ${LIB_NAMES} -Wl,--no-whole-archive)
+ elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")

--- a/disabled-packages/llvm/LLDB.cmake.patch
+++ b/disabled-packages/llvm/LLDB.cmake.patch
@@ -1,0 +1,48 @@
+--- ./tools/lldb/cmake/LLDBDependencies.cmake	2016-06-29 18:00:18.000000000 +0530
++++ ./tools/lldb/cmake/LLDBDependencies.cmake	2017-01-11 09:25:05.792269231 +0530
+@@ -96,7 +96,7 @@
+ endif ()
+ 
+ # Linux-only libraries
+-if ( CMAKE_SYSTEM_NAME MATCHES "Linux" )
++if ( CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "Android" )
+   list(APPEND LLDB_USED_LIBS
+     lldbPluginProcessLinux
+     lldbPluginProcessPOSIX
+--- ./tools/lldb/cmake/modules/LLDBConfig.cmake	2016-05-26 21:41:04.000000000 +0530
++++ ./tools/lldb/cmake/modules/LLDBConfig.cmake	2017-01-11 09:45:50.021125774 +0530
+@@ -14,13 +14,8 @@
+   set(LLDB_DEFAULT_DISABLE_PYTHON 0)
+   set(LLDB_DEFAULT_DISABLE_CURSES 1)
+ else()
+-  if ( __ANDROID_NDK__ )
+-    set(LLDB_DEFAULT_DISABLE_PYTHON 1)
+-    set(LLDB_DEFAULT_DISABLE_CURSES 1)
+-  else()
+-    set(LLDB_DEFAULT_DISABLE_PYTHON 0)
+-    set(LLDB_DEFAULT_DISABLE_CURSES 0)
+-  endif()
++  set(LLDB_DEFAULT_DISABLE_PYTHON 0)
++  set(LLDB_DEFAULT_DISABLE_CURSES 0)
+ endif()
+ 
+ set(LLDB_DISABLE_PYTHON ${LLDB_DEFAULT_DISABLE_PYTHON} CACHE BOOL
+@@ -338,7 +333,7 @@
+   list(APPEND system_libs ${CMAKE_DL_LIBS})
+ endif()
+ 
+-if (CMAKE_SYSTEM_NAME MATCHES "Linux")
++if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "Android")
+     # Check for syscall used by lldb-server on linux.
+     # If these are not found, it will fall back to ptrace (slow) for memory reads.
+     check_cxx_source_compiles("
+@@ -367,7 +362,8 @@
+ if ((CMAKE_SYSTEM_NAME MATCHES "Darwin") OR
+     (CMAKE_SYSTEM_NAME MATCHES "FreeBSD") OR
+     (CMAKE_SYSTEM_NAME MATCHES "Linux") OR
+-    (CMAKE_SYSTEM_NAME MATCHES "NetBSD"))
++    (CMAKE_SYSTEM_NAME MATCHES "NetBSD") OR
++    (CMAKE_SYSTEM_NAME MATCHES "Android"))
+     set(LLDB_CAN_USE_LLDB_SERVER 1)
+ else()
+     set(LLDB_CAN_USE_LLDB_SERVER 0)

--- a/disabled-packages/llvm/build.sh
+++ b/disabled-packages/llvm/build.sh
@@ -1,0 +1,98 @@
+TERMUX_PKG_HOMEPAGE=http://llvm.org
+TERMUX_PKG_DESCRIPTION='Low Level Virtual Machine'
+TERMUX_PKG_VERSION=3.9.1
+_BASE_SRCURL=http://llvm.org/releases/${TERMUX_PKG_VERSION}
+TERMUX_PKG_SRCURL=$_BASE_SRCURL/llvm-${TERMUX_PKG_VERSION}.src.tar.xz
+TERMUX_PKG_SHA256=1fd90354b9cf19232e8f168faf2220e79be555df3aa743242700879e8fd329ee
+TERMUX_PKG_HOSTBUILD=true
+TERMUX_PKG_DEPENDS="binutils, ncurses, ndk-sysroot, ndk-stl, libgcc, libffi, readline"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DLLVM_ENABLE_PIC=ON -DLLVM_BUILD_TESTS=OFF
+-DLLVM_INCLUDE_TESTS=OFF -DLLVM_LINK_LLVM_DYLIB=ON -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_BUILD_TOOLS=OFF
+-DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_EH=ON -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_FFI=ON
+-DPYTHON_EXECUTABLE=`which python2` -DLLDB_DISABLE_PYTHON=ON -DCLANG_INCLUDE_TESTS=OFF
+-DCLANG_TOOL_C_INDEX_TEST_BUILD=OFF -DLLDB_DISABLE_LIBEDIT=ON -D__ANDROID_NDK__=True -DANDROID=True"
+TERMUX_PKG_FORCE_CMAKE=yes
+
+termux_step_post_extract_package () {
+	CLANG_SRC_TAR=cfe-${TERMUX_PKG_VERSION}.src.tar.xz
+	LLDB_SRC_TAR=lldb-${TERMUX_PKG_VERSION}.src.tar.xz
+	LIBUNWIND_SRC_TAR=libunwind-${TERMUX_PKG_VERSION}.src.tar.xz
+	test ! -f $TERMUX_PKG_CACHEDIR/$CLANG_SRC_TAR && termux_download $_BASE_SRCURL/$CLANG_SRC_TAR \
+                $TERMUX_PKG_CACHEDIR/$CLANG_SRC_TAR e6c4cebb96dee827fa0470af313dff265af391cb6da8d429842ef208c8f25e63
+	test ! -f $TERMUX_PKG_CACHEDIR/$LLDB_SRC_TAR && termux_download $_BASE_SRCURL/$LLDB_SRC_TAR \
+                $TERMUX_PKG_CACHEDIR/$LLDB_SRC_TAR 7e3311b2a1f80f4d3426e09f9459d079cab4d698258667e50a46dccbaaa460fc
+	test ! -f $TERMUX_PKG_CACHEDIR/$LIBUNWIND_SRC_TAR && termux_download $_BASE_SRCURL/$LIBUNWIND_SRC_TAR \
+		$TERMUX_PKG_CACHEDIR/$LIBUNWIND_SRC_TAR 0b0bc73264d7ab77d384f8a7498729e3c4da8ffee00e1c85ad02a2f85e91f0e6
+
+	cd $TERMUX_PKG_SRCDIR
+
+        tar -xf $TERMUX_PKG_CACHEDIR/$CLANG_SRC_TAR -C tools
+        mv tools/cfe-${TERMUX_PKG_VERSION}.src tools/clang
+	tar -xf $TERMUX_PKG_CACHEDIR/$LLDB_SRC_TAR -C tools
+        mv tools/lldb-${TERMUX_PKG_VERSION}.src tools/lldb
+	tar -xf $TERMUX_PKG_CACHEDIR/$LIBUNWIND_SRC_TAR -C tools
+	mv tools/libunwind-${TERMUX_PKG_VERSION}.src tools/libunwind
+}
+
+termux_step_host_build () {
+        cmake -G "Unix Makefiles" $TERMUX_PKG_SRCDIR \
+                -DLLVM_BUILD_TESTS=OFF \
+                -DLLVM_INCLUDE_TESTS=OFF \
+		-DLLVM_TARGETS_TO_BUILD=X86 \
+		-DLLVM_BUILD_TOOLS=OFF \
+		-DLLVM_BUILD_EXAMPLES=OFF \
+		-DLLVM_INCLUDE_EXAMPLES=OFF \
+		-DLLVM_ENABLE_ASSERTIONS=OFF \
+		-DLLVM_ENABLE_PIC=OFF \
+		-DLLVM_ENABLE_ZLIB=OFF \
+		-DLLVM_OPTIMIZED_TABLEGEN=ON
+        make -j $TERMUX_MAKE_PROCESSES llvm-tblgen clang-tblgen
+}
+
+termux_step_pre_configure () {
+	LLVM_DEFAULT_TARGET_TRIPLE=$TERMUX_HOST_PLATFORM
+	if [ $TERMUX_ARCH = "arm" ]; then
+		LLVM_TARGET_ARCH=ARM
+		# See https://github.com/termux/termux-packages/issues/282
+		LLVM_DEFAULT_TARGET_TRIPLE="armv7a-linux-androideabi"
+	elif [ $TERMUX_ARCH = "aarch64" ]; then
+		LLVM_TARGET_ARCH=AArch64
+	elif [ $TERMUX_ARCH = "i686" ]; then
+		LLVM_TARGET_ARCH=X86
+	elif [ $TERMUX_ARCH = "x86_64" ]; then
+		LLVM_TARGET_ARCH=X86
+	else
+		echo "Invalid arch: $TERMUX_ARCH"
+		exit 1
+	fi
+
+	CXXFLAGS="$CXXFLAGS -D__ANDROID_NDK__ -DANDROID"
+
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DLLVM_TABLEGEN=$TERMUX_PKG_HOSTBUILD_DIR/bin/llvm-tblgen
+                -DLLVM_DEFAULT_TARGET_TRIPLE=$LLVM_DEFAULT_TARGET_TRIPLE -DLLVM_TARGET_ARCH=$LLVM_TARGET_ARCH
+                -DLLVM_TARGETS_TO_BUILD=$LLVM_TARGET_ARCH -DCLANG_TABLEGEN=$TERMUX_PKG_HOSTBUILD_DIR/bin/clang-tblgen
+		-DC_INCLUDE_DIRS=$TERMUX_PREFIX/include"
+		#-DHAVE_UNWIND_BACKTRACE=False" # arm has two conflicting defs for __Unwind_Ptr
+}
+
+termux_step_make_install () {
+	create_file_lists
+
+        cd $TERMUX_PKG_BUILDDIR
+	make install
+}
+
+# this function creates file_lists for subpackages
+create_file_lists () {
+	mkdir $TERMUX_PKG_BUILDDIR/../{lldb,clang,libunwind}
+        make -C tools/lldb DESTDIR="$TERMUX_PKG_BUILDDIR/../lldb" install
+        make -C tools/clang DESTDIR="$TERMUX_PKG_BUILDDIR/../clang" install
+	make -C tools/libunwind DESTDIR="$TERMUX_PKG_BUILDDIR/../libunwind" install
+        cd "$TERMUX_PKG_BUILDDIR/../lldb$TERMUX_PREFIX"
+        find * -type f > "$TERMUX_PKG_BUILDDIR/file_list_lldb.txt"
+        cd "$TERMUX_PKG_BUILDDIR/../clang$TERMUX_PREFIX"
+        find * -type f > "$TERMUX_PKG_BUILDDIR/file_list_clang.txt"
+	cd "$TERMUX_PKG_BUILDDIR/../libunwind$TERMUX_PREFIX"
+	find * -type f > "$TERMUX_PKG_BUILDDIR/file_list_libunwind.txt"
+        rm -r $TERMUX_PKG_BUILDDIR/../{lldb,clang,libunwind}
+}

--- a/disabled-packages/llvm/clang-dev.subpackage.sh
+++ b/disabled-packages/llvm/clang-dev.subpackage.sh
@@ -1,0 +1,3 @@
+TERMUX_SUBPKG_INCLUDE="include/clang include/clang-c lib/cmake/clang lib/clang/$TERMUX_PKG_VERSION"
+TERMUX_SUBPKG_DESCRIPTION='C language family frontend for LLVM (development files)'
+TERMUX_SUBPKG_DEPENDS="clang"

--- a/disabled-packages/llvm/clang.subpackage.sh
+++ b/disabled-packages/llvm/clang.subpackage.sh
@@ -1,0 +1,5 @@
+TERMUX_SUBPKG_INCLUDE="bin/clang* bin/scan-build bin/scan-view bin/git-clang-format lib/libclang* "
+TERMUX_SUBPKG_INCLUDE+="libexec/ccc-analyzer libexec++-analyzer share/scan-view "
+TERMUX_SUBPKG_INCLUDE+="share/clang share/man/man1/scan-build.1 share/scan-build"
+TERMUX_SUBPKG_DESCRIPTION='C language family frontend for LLVM'
+TERMUX_SUBPKG_DEPENDS="llvm"

--- a/disabled-packages/llvm/lldb-dev.subpackage.sh
+++ b/disabled-packages/llvm/lldb-dev.subpackage.sh
@@ -1,0 +1,3 @@
+TERMUX_SUBPKG_INCLUDE="include/lldb"
+TERMUX_SUBPKG_DESCRIPTION='Next generation, high-performance debugger (development files)'
+TERMUX_SUBPKG_DEPENDS="lldb"

--- a/disabled-packages/llvm/lldb.subpackage.sh
+++ b/disabled-packages/llvm/lldb.subpackage.sh
@@ -1,0 +1,3 @@
+TERMUX_SUBPKG_INCLUDE="bin/lldb* lib/liblldb*"
+TERMUX_SUBPKG_DESCRIPTION='Next generation, high-performance debugger'
+TERMUX_SUBPKG_DEPENDS="llvm, ncurses"

--- a/disabled-packages/llvm/tools-clang-lib-Driver-ToolChain.cpp.patch
+++ b/disabled-packages/llvm/tools-clang-lib-Driver-ToolChain.cpp.patch
@@ -1,0 +1,12 @@
+diff -u -r ../llvm-3.8.0.src/tools/clang/lib/Driver/ToolChain.cpp ./tools/clang/lib/Driver/ToolChain.cpp
+--- ../llvm-3.8.0.src/tools/clang/lib/Driver/ToolChain.cpp	2015-11-25 20:02:07.000000000 -0500
++++ ./tools/clang/lib/Driver/ToolChain.cpp	2016-05-02 08:50:35.526226962 -0400
+@@ -611,7 +611,7 @@
+     break;
+ 
+   case ToolChain::CST_Libstdcxx:
+-    CmdArgs.push_back("-lstdc++");
++    CmdArgs.push_back("-lgnustl_shared");
+     break;
+   }
+ }

--- a/disabled-packages/llvm/tools-clang-lib-Driver-Tools.cpp.patch
+++ b/disabled-packages/llvm/tools-clang-lib-Driver-Tools.cpp.patch
@@ -1,0 +1,17 @@
+diff -u -r ../llvm-3.9.0.src/tools/clang/lib/Driver/Tools.cpp ./tools/clang/lib/Driver/Tools.cpp
+--- ../llvm-3.9.0.src/tools/clang/lib/Driver/Tools.cpp	2016-08-13 16:43:56.000000000 -0400
++++ ./tools/clang/lib/Driver/Tools.cpp	2016-09-04 06:15:59.703422745 -0400
+@@ -9357,9 +9357,12 @@
+   const llvm::Triple::ArchType Arch = ToolChain.getArch();
+   const bool isAndroid = ToolChain.getTriple().isAndroid();
+   const bool IsIAMCU = ToolChain.getTriple().isOSIAMCU();
++  // Termux modification: Enable pie by default for Android and support the
++  // nopie flag.
+   const bool IsPIE =
+       !Args.hasArg(options::OPT_shared) && !Args.hasArg(options::OPT_static) &&
+-      (Args.hasArg(options::OPT_pie) || ToolChain.isPIEDefault());
++      (Args.hasArg(options::OPT_pie) || ToolChain.isPIEDefault() || isAndroid) &&
++      !Args.hasArg(options::OPT_nopie);
+   const bool HasCRTBeginEndFiles =
+       ToolChain.getTriple().hasEnvironment() ||
+       (ToolChain.getTriple().getVendor() != llvm::Triple::MipsTechnologies);

--- a/disabled-packages/llvm/tools-sancov-sancov.cc.patch
+++ b/disabled-packages/llvm/tools-sancov-sancov.cc.patch
@@ -1,0 +1,15 @@
+Workaround bug https://github.com/android-ndk/ndk/issues/82 where std::to_string
+is not available yet.
+
+diff -u -r ../llvm-3.9.0.src/tools/sancov/sancov.cc ./tools/sancov/sancov.cc
+--- ../llvm-3.9.0.src/tools/sancov/sancov.cc	2016-07-13 22:24:01.000000000 -0400
++++ ./tools/sancov/sancov.cc	2016-09-04 11:48:19.647813216 -0400
+@@ -512,7 +512,7 @@
+ static std::string formatHtmlPct(size_t Pct) {
+   Pct = std::max(std::size_t{0}, std::min(std::size_t{100}, Pct));
+ 
+-  std::string Num = std::to_string(Pct);
++  std::string Num = llvm::utostr(Pct);
+   std::string Zeroes(3 - Num.size(), '0');
+   if (!Zeroes.empty())
+     Zeroes = "<span class='lz'>" + Zeroes + "</span>";

--- a/disabled-packages/openjdk-9-headless/build.sh
+++ b/disabled-packages/openjdk-9-headless/build.sh
@@ -1,0 +1,116 @@
+TERMUX_PKG_HOMEPAGE=http://openjdk.java.net
+TERMUX_PKG_DESCRIPTION='OpenJDK 9 Java Runtime Environment (prerelease)'
+_jbuild=153
+_hg_tag="jdk-9+${_jbuild}"
+TERMUX_PKG_VERSION="9b$_jbuild"
+TERMUX_PKG_MAINTAINER='Vishal Biswas @vishalbiswas'
+TERMUX_PKG_DEPENDS="freetype, alsa-lib"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" --with-zlib=system --with-libpng=system --disable-option-checking --with-debug-level=release"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --enable-headless-only --disable-warnings-as-errors --disable-hotspot-gtest --with-libffi-include=$TERMUX_PREFIX/include --with-libffi-lib=$TERMUX_PREFIX/lib"
+TERMUX_PKG_CLANG=no
+_cups_ver=2.2.2
+
+termux_step_extract_package () {
+	_url_src=http://hg.openjdk.java.net/jdk9/dev
+	targzs=(${_url_src}/archive/$_hg_tag.tar.bz2
+		${_url_src}/corba/archive/$_hg_tag.tar.bz2
+		${_url_src}/hotspot/archive/$_hg_tag.tar.bz2
+		${_url_src}/jdk/archive/$_hg_tag.tar.bz2
+		${_url_src}/jaxws/archive/$_hg_tag.tar.bz2
+		${_url_src}/jaxp/archive/$_hg_tag.tar.bz2
+		${_url_src}/langtools/archive/$_hg_tag.tar.bz2
+		${_url_src}/nashorn/archive/$_hg_tag.tar.bz2
+		"https://github.com/apple/cups/releases/download/$_cups_ver/cups-$_cups_ver-source.tar.gz")
+
+	sha256sums=('9e0748addf6214f6d2f008987978e70284054e5e0b9df5189e8f758d325c4972'
+		'32522d53be8fc48f2cdaab56df9a387684af0e775501bbe19436e228779cc7c9'
+		'7f92379fa40a621a1edc7e35792b07814ef755211b473ef87f1002c7a3c62699'
+		'9f112b2af8dfea0dabf0371a0e5ede6e71485caab06f348ec7f7324db6d5e169'
+		'636a6f119506d298571baf732aabb0fb459f8e3abf98788bcedc5bba4c7f06db'
+		'8d51802aaf9d6f02d4414baecd164f6ccd64c25679e45a507139150294b0499c'
+		'e4d0b9d8fc4f3d07b0a8f824bb2809a774dd6d5ae7e0db521082c885057a2c6b'
+		'557f954271627289508542bfe0966132d51ec5ee79c9cad654a30a5c9c800ce1'
+		'f589bb7d5d1dc3aa0915d7cf2b808571ef2e1530cd1a6ebe76ae8f9f4994e4f6')
+
+	reponames=(dev corba hotspot jdk jaxws jaxp langtools nashorn cups)
+
+	for index in "${!targzs[@]}"; do
+		if [ $index != '8' ]; then
+			filename=${reponames[index]}-`basename ${targzs[index]}`
+			folder=`basename $filename .tar.bz2`
+			folder=`echo $folder | sed 's/_/-/'`
+		else
+			filename=`basename ${targzs[index]}`
+			folder="cups-$_cups_ver"
+		fi
+		sum=${sha256sums[index]}
+		file=$TERMUX_PKG_CACHEDIR/$filename
+		test ! -f $file && termux_download ${targzs[index]} $file $sum
+		rm -Rf $folder
+		$TERMUX_TAR xf $file
+		mkdir -p $TERMUX_PKG_SRCDIR
+		mv $folder $TERMUX_PKG_SRCDIR/
+	done
+}
+
+termux_step_post_extract_package () {
+	for patch in $TERMUX_PKG_BUILDER_DIR/*.diff; do
+		sed "s%\@TAG_VER\@%${_jbuild}%g" "$patch" | \
+                        patch --silent -p1
+	done
+
+	cd $TERMUX_PKG_SRCDIR/dev-$_hg_tag
+        chmod a+x configure
+        for subrepo in corba hotspot jdk jaxws jaxp langtools nashorn; do
+                ln -s ../${subrepo}-$_hg_tag ${subrepo}
+        done
+        ln -s ../cups-$_cups_ver cups
+}
+
+termux_step_pre_configure () {
+	TERMUX_PKG_SRCDIR=$TERMUX_PKG_SRCDIR/dev-$_hg_tag
+	#export MAKEFLAGS=${MAKEFLAGS/-j*}
+	#export CFLAGS+=" -Wno-error=deprecated-declarations -DSIGCLD=SIGCHLD"
+	CFLAGS="$CFLAGS -I$TERMUX_PKG_BUILDER_DIR -I$TERMUX_PREFIX/include -DTERMUX_SHMEM_STUBS"
+	CXXFLAGS="$CXXFLAGS -I$TERMUX_PKG_BUILDER_DIR -I$TERMUX_PREFIX/include"
+	#LDFLAGS="$LDFLAGS -landroid-shmem"
+
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-cups-include=$TERMUX_PKG_SRCDIR/cups"
+	TERMUX_JVM_VARIANT=zero
+	if [ "$TERMUX_ARCH" == 'i686' -o "$TERMUX_ARCH" == 'x86_64' ]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=' --with-jvm-variants=client'
+		TERMUX_PKG_JVM_VARIANT=client
+	else
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=' --with-jvm-variants=zero'
+		TERMUX_PKG_JVM_VARIANT=zero
+	fi
+
+	cat > "$TERMUX_STANDALONE_TOOLCHAIN/devkit.info" <<HERE
+DEVKIT_NAME="Android ${TERMUX_ARCH^^}"
+DEVKIT_TOOLCHAIN_PATH="\$DEVKIT_ROOT/$TERMUX_HOST_PLATFORM/bin"
+DEVKIT_SYSROOT="\$DEVKIT_ROOT/sysroot" i
+HERE
+
+	export ANDROID_DEVKIT=$TERMUX_STANDALONE_TOOLCHAIN
+
+	cd $TERMUX_PKG_SRCDIR
+}
+
+termux_step_configure () {
+	$TERMUX_PKG_SRCDIR/configure \
+		--prefix=$TERMUX_PREFIX \
+		--host=$TERMUX_HOST_PLATFORM \
+		--target=$TERMUX_HOST_PLATFORM \
+		--with-jdk-variant=normal \
+		--libexecdir=$TERMUX_PREFIX/libexec \
+		--with-devkit=$ANDROID_DEVKIT \
+		--with-extra-cflags="$CFLAGS" \
+		--with-extra-cxxflags="$CXXFLAGS" \
+		--with-extra-ldflags="$LDFLAGS" \
+		$TERMUX_PKG_EXTRA_CONFIGURE_ARGS
+}
+
+termux_step_make () {
+	make JOBS=$TERMUX_MAKE_PROCESSES images
+}
+

--- a/disabled-packages/openjdk-9-headless/libpthread.diff
+++ b/disabled-packages/openjdk-9-headless/libpthread.diff
@@ -1,0 +1,119 @@
+--- ./dev-jdk-9+@TAG_VER@/common/autoconf/flags.m4	2016-12-21 03:14:04.000000000 +0530
++++ ../../flags.m4	2017-01-22 13:35:01.668555165 +0530
+@@ -1297,7 +1297,7 @@
+ 
+   # Set $2JVM_LIBS (per os)
+   if test "x$OPENJDK_$1_OS" = xlinux; then
+-    $2JVM_LIBS="[$]$2JVM_LIBS -lm -ldl -lpthread"
++    $2JVM_LIBS="[$]$2JVM_LIBS -lm -ldl"
+   elif test "x$OPENJDK_$1_OS" = xsolaris; then
+     # FIXME: This hard-coded path is not really proper.
+     if test "x$OPENJDK_$1_CPU" = xx86_64; then
+--- ./jdk/make/lib/Awt2dLibraries.gmk	2016-12-21 03:43:34.000000000 +0530
++++ ./jdk-jdk-9+@TAG_VER@/make/lib/Awt2dLibraries.gmk	2017-01-22 13:36:55.817520779 +0530
+@@ -330,10 +330,6 @@
+ 
+     LIBAWT_XAWT_LIBS := $(LIBM) -lawt -lXext -lX11 -lXrender $(LIBDL) -lXtst -lXi -ljava -ljvm -lc
+ 
+-    ifeq ($(OPENJDK_TARGET_OS), linux)
+-      LIBAWT_XAWT_LIBS += -lpthread
+-    endif
+-
+     ifeq ($(TOOLCHAIN_TYPE), gcc)
+       # Turn off all warnings for the following files since they contain warnings
+       # that cannot be turned of individually.
+@@ -906,7 +902,7 @@
+     LIBSPLASHSCREEN_LDFLAGS := -delayload:user32.dll
+     LIBSPLASHSCREEN_LIBS += kernel32.lib user32.lib gdi32.lib delayimp.lib $(WIN_JAVA_LIB) jvm.lib
+   else
+-    LIBSPLASHSCREEN_LIBS += $(X_LIBS) -lX11 -lXext $(LIBM) -lpthread -ldl
++    LIBSPLASHSCREEN_LIBS += $(X_LIBS) -lX11 -lXext $(LIBM) -ldl
+   endif
+ 
+   $(eval $(call SetupNativeCompilation,BUILD_LIBSPLASHSCREEN, \
+--- ./jdk/make/lib/NioLibraries.gmk	2016-12-21 03:43:34.000000000 +0530
++++ ./jdk-jdk-9+@TAG_VER@/make/lib/NioLibraries.gmk	2017-01-22 13:38:05.550161653 +0530
+@@ -69,7 +69,7 @@
+     LDFLAGS := $(LDFLAGS_JDKLIB) \
+         $(call SET_SHARED_LIBRARY_ORIGIN), \
+     LIBS_unix := -ljava -lnet, \
+-    LIBS_linux := -lpthread $(LIBDL), \
++    LIBS_linux := $(LIBDL), \
+     LIBS_solaris := -ljvm -lsocket -lposix4 $(LIBDL) \
+         -lsendfile -lc, \
+     LIBS_aix := $(LIBDL), \
+--- ./jdk/make/lib/Lib-jdk.sctp.gmk	2016-12-21 03:43:34.000000000 +0530
++++ ./jdk-jdk-9+@TAG_VER@/make/lib/Lib-jdk.sctp.gmk	2017-01-22 13:38:39.083147832 +0530
+@@ -50,7 +50,7 @@
+         LDFLAGS := $(LDFLAGS_JDKLIB) \
+             $(call SET_SHARED_LIBRARY_ORIGIN), \
+         LIBS_unix := -lnio -lnet -ljava -ljvm, \
+-        LIBS_linux := -lpthread $(LIBDL), \
++        LIBS_linux := $(LIBDL), \
+         LIBS_solaris := -lsocket -lc, \
+         OBJECT_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libsctp, \
+     ))
+--- ./jdk/make/lib/CoreLibraries.gmk	2016-12-21 03:43:34.000000000 +0530
++++ ./jdk-jdk-9+@TAG_VER@/make/lib/CoreLibraries.gmk	2017-01-22 13:39:17.676071246 +0530
+@@ -389,7 +389,7 @@
+         -export:JLI_PreprocessArg \
+         -export:JLI_GetAppArgIndex, \
+     LIBS_unix := $(LIBZ), \
+-    LIBS_linux := $(LIBDL) -lc -lpthread, \
++    LIBS_linux := $(LIBDL) -lc, \
+     LIBS_solaris := $(LIBDL) -lc, \
+     LIBS_aix := $(LIBDL),\
+     LIBS_macosx := -framework Cocoa -framework Security -framework ApplicationServices, \
+--- ./jdk/make/lib/Lib-jdk.jdwp.agent.gmk	2016-12-21 03:43:34.000000000 +0530
++++ ./jdk-jdk-9+@TAG_VER@/make/lib/Lib-jdk.jdwp.agent.gmk	2017-01-22 13:40:42.121805959 +0530
+@@ -47,7 +47,7 @@
+     LDFLAGS := $(LDFLAGS_JDKLIB) \
+         $(call SET_SHARED_LIBRARY_ORIGIN), \
+     LDFLAGS_windows := -export:jdwpTransport_OnLoad, \
+-    LIBS_linux := -lpthread, \
++    LIBS_linux := -lc, \
+     LIBS_solaris := -lnsl -lsocket -lc, \
+     LIBS_windows := $(JDKLIB_LIBS) ws2_32.lib, \
+     VERSIONINFO_RESOURCE := $(GLOBAL_VERSION_INFO_RESOURCE), \
+--- ./jdk/make/lib/NetworkingLibraries.gmk	2016-12-21 03:43:34.000000000 +0530
++++ ./jdk-jdk-9+@TAG_VER@/make/lib/NetworkingLibraries.gmk	2017-01-22 13:41:39.251151227 +0530
+@@ -41,7 +41,7 @@
+         $(call SET_SHARED_LIBRARY_ORIGIN), \
+     LDFLAGS_windows := -delayload:secur32.dll -delayload:iphlpapi.dll, \
+     LIBS_unix := -ljvm -ljava, \
+-    LIBS_linux := $(LIBDL) -lpthread, \
++    LIBS_linux := $(LIBDL), \
+     LIBS_solaris := -lnsl -lsocket $(LIBDL) -lc, \
+     LIBS_aix := $(LIBDL),\
+     LIBS_windows := ws2_32.lib jvm.lib secur32.lib iphlpapi.lib \
+--- ./jdk/make/launcher/LauncherCommon.gmk	2016-12-21 03:43:34.000000000 +0530
++++ ./jdk-jdk-9+@TAG_VER@/make/launcher/LauncherCommon.gmk	2017-01-22 13:42:01.530891130 +0530
+@@ -196,7 +196,7 @@
+       MAPFILE := $$($1_MAPFILE), \
+       LIBS := $(JDKEXE_LIBS) $$($1_LIBS), \
+       LIBS_unix := $$($1_LIBS_unix), \
+-      LIBS_linux := -lpthread -ljli $(LIBDL) -lc, \
++      LIBS_linux := -ljli $(LIBDL) -lc, \
+       LIBS_solaris := -ljli -lthread $(LIBDL) -lc, \
+       LIBS_windows := $$($1_WINDOWS_JLI_LIB) \
+           $(SUPPORT_OUTPUTDIR)/native/java.base/libjava/java.lib advapi32.lib \
+--- ./dev-jdk-9+@TAG_VER@//common/autoconf/generated-configure.sh	2016-12-21 03:14:04.000000000 +0530
++++ ../../generated-configure.sh	2017-01-22 14:01:05.792364527 +0530
+@@ -50593,7 +50593,7 @@
+ 
+   # Set JVM_LIBS (per os)
+   if test "x$OPENJDK_TARGET_OS" = xlinux; then
+-    JVM_LIBS="$JVM_LIBS -lm -ldl -lpthread"
++    JVM_LIBS="$JVM_LIBS -lm -ldl"
+   elif test "x$OPENJDK_TARGET_OS" = xsolaris; then
+     # FIXME: This hard-coded path is not really proper.
+     if test "x$OPENJDK_TARGET_CPU" = xx86_64; then
+@@ -51416,7 +51416,7 @@
+ 
+   # Set OPENJDK_BUILD_JVM_LIBS (per os)
+   if test "x$OPENJDK_BUILD_OS" = xlinux; then
+-    OPENJDK_BUILD_JVM_LIBS="$OPENJDK_BUILD_JVM_LIBS -lm -ldl -lpthread"
++    OPENJDK_BUILD_JVM_LIBS="$OPENJDK_BUILD_JVM_LIBS -lm -ldl"
+   elif test "x$OPENJDK_BUILD_OS" = xsolaris; then
+     # FIXME: This hard-coded path is not really proper.
+     if test "x$OPENJDK_BUILD_CPU" = xx86_64; then

--- a/disabled-packages/openjdk-9-headless/os_linux.cpp.diff
+++ b/disabled-packages/openjdk-9-headless/os_linux.cpp.diff
@@ -1,0 +1,71 @@
+--- ./hotspot-jdk-9+@TAG_VER@/src/os/linux/vm/os_linux.cpp	2017-01-13 05:11:16.000000000 +0530
++++ ../os_linux.cpp	2017-02-05 11:25:25.918994081 +0530
+@@ -98,7 +98,9 @@
+ # include <string.h>
+ # include <syscall.h>
+ # include <sys/sysinfo.h>
++# ifndef __ANDROID__
+ # include <gnu/libc-version.h>
++# endif
+ # include <sys/ipc.h>
+ # include <sys/shm.h>
+ # include <link.h>
+@@ -496,6 +498,7 @@
+ // detecting pthread library
+ 
+ void os::Linux::libpthread_init() {
++#ifndef __ANDROID__
+   // Save glibc and pthread version strings.
+ #if !defined(_CS_GNU_LIBC_VERSION) || \
+     !defined(_CS_GNU_LIBPTHREAD_VERSION)
+@@ -513,6 +516,10 @@
+   str = (char *)malloc(n, mtInternal);
+   confstr(_CS_GNU_LIBPTHREAD_VERSION, str, n);
+   os::Linux::set_libpthread_version(str);
++#else
++  os::Linux::set_glibc_version("bionic 21");
++  os::Linux::set_libpthread_version("pthread 21");
++#endif
+ }
+ 
+ /////////////////////////////////////////////////////////////////////////////
+@@ -2809,7 +2816,10 @@
+ // If we are running with earlier version, which did not have symbol versions,
+ // we should use the base version.
+ void* os::Linux::libnuma_dlsym(void* handle, const char *name) {
+-  void *f = dlvsym(handle, name, "libnuma_1.1");
++  void *f = NULL;
++  #ifndef __ANDROID__
++  f = dlvsym(handle, name, "libnuma_1.1");
++  #endif
+   if (f == NULL) {
+     f = dlsym(handle, name);
+   }
+@@ -5471,7 +5481,11 @@
+ // Linux doesn't yet have a (official) notion of processor sets,
+ // so just return the system wide load average.
+ int os::loadavg(double loadavg[], int nelem) {
++#ifdef __ANDROID__
++  return -1;
++#else
+   return ::getloadavg(loadavg, nelem);
++#endif
+ }
+ 
+ void os::pause() {
+@@ -6194,7 +6208,15 @@
+   struct stat st;
+   int ret = os::stat(filename, &st);
+   assert(ret == 0, "failed to stat() file '%s': %s", filename, strerror(errno));
++#ifdef __ANDROID__
++  struct timespec ts;
++  unsigned long ms = st.st_mtime;
++  ts.tv_sec = ms / 1000;
++  ts.tv_nsec = (ms % 1000) * 1000000;
++  return ts;
++#else
+   return st.st_mtim;
++#endif
+ }
+ 
+ int os::compare_file_modified_times(const char* file1, const char* file2) {

--- a/disabled-packages/openvpn/build.sh
+++ b/disabled-packages/openvpn/build.sh
@@ -1,0 +1,37 @@
+TERMUX_PKG_HOMEPAGE=https://openvpn.net
+TERMUX_PKG_DESCRIPTION='An easy-to-use, robust, and highly configurable VPN (Virtual Private Network)'
+TERMUX_PKG_VERSION=2.4.0
+TERMUX_PKG_DEPENDS="openssl, liblzo"
+TERMUX_PKG_SRCURL=https://swupdate.openvpn.net/community/releases/openvpn-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=6f23ba49a1dbeb658f49c7ae17d9ea979de6d92c7357de3d55cd4525e1b2f87e
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS=' --disable-plugin-auth-pam --disable-systemd --disable-debug'
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=' --enable-iproute2 --enable-small --enable-x509-alt-username'
+TERMUX_PKG_MAINTAINER='Vishal Biswas @vishalbiswas'
+
+termux_step_pre_configure () {
+    # we modify configure.ac
+    # uncomment if you want to apply configure.patch
+    # autoreconf -i $TERMUX_PKG_SRCDIR
+
+    export ac_cv_func_getpwnam='yes'
+    # need to provide getpass, else you "can't get console input"
+    export ac_cv_func_getpass='yes'
+    cp "$TERMUX_PKG_BUILDER_DIR/netbsd_getpass.c" "$TERMUX_PKG_SRCDIR/src/openvpn/"
+
+    # paths to external programs used by openvpn
+    export IFCONFIG="$TERMUX_PREFIX/bin/applets/ifconfig"
+    export ROUTE="$TERMUX_PREFIX/bin/applets/route"
+    export IPROUTE="$TERMUX_PREFIX/bin/ip"
+    export NETSTAT="$TERMUX_PREFIX/bin/applets/netstat"
+
+#    CFLAGS="$CFLAGS -DTARGET_ANDROID"
+    LDFLAGS="$LDFLAGS -llog "
+}
+
+termux_step_post_make_install () {
+    # helper script
+    install -m700 "${TERMUX_PKG_BUILDER_DIR}"/termux-openvpn "${TERMUX_PREFIX}"/bin/
+    # Install examples
+    install -d -m755 "${TERMUX_PREFIX}"/share/openvpn/examples
+    cp "${TERMUX_PKG_SRCDIR}"/sample/sample-config-files/* "${TERMUX_PREFIX}"/share/openvpn/examples
+}

--- a/disabled-packages/openvpn/configure.ac.patch.old
+++ b/disabled-packages/openvpn/configure.ac.patch.old
@@ -1,0 +1,13 @@
+--- ./configure.ac      2016-12-26 11:51:00.000000000 +0000
++++ ../configure.ac     2016-12-28 04:59:50.936948102 +0000
+@@ -311,6 +311,10 @@
+ 
+ AC_DEFINE_UNQUOTED([TARGET_ALIAS], ["${host}"], [A string representing our host])
+ case "$host" in
++	*-*-android*)
++		AC_DEFINE([TARGET_ANDROID], [1], [Are we running on Android?])
++		AC_DEFINE_UNQUOTED([TARGET_PREFIX], ["G"], [Target prefix])
++		;;
+ 	*-*-linux*)
+ 		AC_DEFINE([TARGET_LINUX], [1], [Are we running on Linux?])
+ 		AC_DEFINE_UNQUOTED([TARGET_PREFIX], ["L"], [Target prefix])

--- a/disabled-packages/openvpn/netbsd_getpass.c
+++ b/disabled-packages/openvpn/netbsd_getpass.c
@@ -1,0 +1,104 @@
+/*	$NetBSD: getpass.c,v 1.15 2003/08/07 16:42:50 agc Exp $	*/
+/*
+ * Copyright (c) 1988, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#if 0
+#include <sys/cdefs.h>
+#if defined(LIBC_SCCS) && !defined(lint)
+#if 0
+static char sccsid[] = "@(#)getpass.c	8.1 (Berkeley) 6/4/93";
+#else
+__RCSID("$NetBSD: getpass.c,v 1.15 2003/08/07 16:42:50 agc Exp $");
+#endif
+#endif /* LIBC_SCCS and not lint */
+#include "namespace.h"
+#endif
+#include <assert.h>
+#include <paths.h>
+#include <pwd.h>
+#include <signal.h>
+#include <stdio.h>
+#include <termios.h>
+#include <unistd.h>
+#if 0
+#ifdef __weak_alias
+__weak_alias(getpass,_getpass)
+#endif
+#endif
+char *
+getpass(prompt)
+	const char *prompt;
+{
+	struct termios term;
+	int ch;
+	char *p;
+	FILE *fp, *outfp;
+	int echo;
+	static char buf[_PASSWORD_LEN + 1];
+	sigset_t oset, nset;
+#if 0
+	_DIAGASSERT(prompt != NULL);
+#endif
+	/*
+	 * read and write to /dev/tty if possible; else read from
+	 * stdin and write to stderr.
+	 */
+	if ((outfp = fp = fopen(_PATH_TTY, "w+")) == NULL) {
+		outfp = stderr;
+		fp = stdin;
+	}
+	/*
+	 * note - blocking signals isn't necessarily the
+	 * right thing, but we leave it for now.
+	 */
+	sigemptyset(&nset);
+	sigaddset(&nset, SIGINT);
+	sigaddset(&nset, SIGTSTP);
+	(void)sigprocmask(SIG_BLOCK, &nset, &oset);
+	(void)tcgetattr(fileno(fp), &term);
+	if ((echo = (term.c_lflag & ECHO)) != 0) {
+		term.c_lflag &= ~ECHO;
+		(void)tcsetattr(fileno(fp), TCSAFLUSH /*|TCSASOFT*/, &term);
+	}
+	if (prompt != NULL)
+		(void)fputs(prompt, outfp);
+	rewind(outfp);			/* implied flush */
+	for (p = buf; (ch = getc(fp)) != EOF && ch != '\n';)
+		if (p < buf + _PASSWORD_LEN)
+			*p++ = ch;
+	*p = '\0';
+	(void)write(fileno(outfp), "\n", 1);
+	if (echo) {
+		term.c_lflag |= ECHO;
+		(void)tcsetattr(fileno(fp), TCSAFLUSH/*|TCSASOFT*/, &term);
+	}
+	(void)sigprocmask(SIG_SETMASK, &oset, NULL);
+	if (fp != stdin)
+		(void)fclose(fp);
+	return(buf);
+}

--- a/disabled-packages/openvpn/src-openvpn-console_builtin.c.patch
+++ b/disabled-packages/openvpn/src-openvpn-console_builtin.c.patch
@@ -1,0 +1,10 @@
+--- ./src/openvpn/console_builtin.c     2016-12-26 11:51:00.000000000 +0000
++++ ../console_builtin.c        2016-12-28 04:05:41.310830107 +0000
+@@ -140,6 +140,7 @@
+ 
+ 
+ #ifdef HAVE_GETPASS
++#include "netbsd_getpass.c"
+ 
+ /**
+  * Open the current console TTY for read/write operations

--- a/disabled-packages/openvpn/src-openvpn-tun.c.patch
+++ b/disabled-packages/openvpn/src-openvpn-tun.c.patch
@@ -1,0 +1,11 @@
+--- ./src/openvpn/tun.c 2016-12-26 11:51:00.000000000 +0000
++++ ../tun.c    2016-12-28 04:11:52.786734486 +0000
+@@ -1939,7 +1939,7 @@
+         const char *node = dev_node;
+         if (!node)
+         {
+-            node = "/dev/net/tun";
++            node = "/dev/tun";
+         }
+ 
+         /*

--- a/disabled-packages/openvpn/termux-openvpn
+++ b/disabled-packages/openvpn/termux-openvpn
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/sh
+su -c "export LD_LIBRARY_PATH=$PREFIX/lib; export TMPDIR=$PREFIX/tmp; $PREFIX/bin/openvpn $@"

--- a/disabled-packages/squid/CpuAffinitySet.cc.patch
+++ b/disabled-packages/squid/CpuAffinitySet.cc.patch
@@ -1,0 +1,11 @@
+--- ./src/CpuAffinitySet.cc	2016-10-10 01:28:01.000000000 +0530
++++ ../CpuAffinitySet.cc	2016-12-07 22:53:47.745146503 +0530
+@@ -37,7 +37,7 @@
+     } else {
+         cpu_set_t cpuSet;
+         memcpy(&cpuSet, &theCpuSet, sizeof(cpuSet));
+-        (void) CPU_AND(&cpuSet, &cpuSet, &theOrigCpuSet);
++        CPU_AND(&cpuSet, &cpuSet, &theOrigCpuSet);
+         if (CPU_COUNT(&cpuSet) <= 0) {
+             debugs(54, DBG_IMPORTANT, "ERROR: invalid CPU affinity for process "
+                    "PID " << getpid() << ", may be caused by an invalid core in "

--- a/disabled-packages/squid/build.sh
+++ b/disabled-packages/squid/build.sh
@@ -1,0 +1,22 @@
+TERMUX_PKG_HOMEPAGE=http://www.squid-cache.org
+TERMUX_PKG_DESCRIPTION='Full-featured Web proxy cache server'
+TERMUX_PKG_VERSION=3.5.24
+TERMUX_PKG_DEPENDS="libcrypt, krb5, openssl, libnettle"
+TERMUX_PKG_SRCURL=http://www.squid-cache.org/Versions/v3/3.5/squid-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=4fe29f582eef357faa541a53835b6885e24e6f28b80a3abcdf3b57f5393bbdb2
+# disk-io requires shmem, msgctl and store-io requires disk-io
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" --disable-strict-error-checking --disable-auto-locale --disable-disk-io --disable-storeio"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-openssl --enable-auth --with-nettle --disable-translation --with-size-optimizations"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --libexecdir=$TERMUX_PREFIX/libexec/squid --sysconfdir=$TERMUX_PREFIX/etc/squid --datarootdir=$TERMUX_PREFIX/share/squid"
+
+termux_step_pre_configure () {
+	#CPPFLAGS="$CPPFLAGS -DTERMUX_SHMEM_STUBS"
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" squid_cv_gnu_atomics=yes"
+	LDFLAGS="$LDFLAGS -llog"
+
+	# needed for building cf_gen
+	export BUILDCXX=g++
+	# else it picks up our cross CXXFLAGS
+	export BUILDCXXFLAGS=' '
+}
+


### PR DESCRIPTION
- easy-rsa: works perfectly. no faults here. No one needs it so its disabled.
- openvpn: Requires root for standard operation (just like any other distro). To implement it without root,
                heavy support from termux-api is required. Specifically, we'll need to use the management
                engine in openvpn to replace commands requiring root with VpnService calls
- squid: works, too. isn't enabled because nobody requested it. also I wanted to disable building localized
           error pages, which I was unsuccessful in doing.
- llvm: works. segregated packages need to be refined. main build.sh has function to generate file list for
         subpackages. subpackages can then have `cat file_list.txt` in subpkg_include.
- alsa-lib and alsa-utils: compiles successfully. But, the Android kernel seems to be lacking kernel space
          alsa drivers.
- openjdk-9-headless: doesn't complete compilation. I'm following the mobile/dev mailing list of openjdk
                                  and will continue updating this as soon as new tags are released. Only headless
                                  is available for mobiles