### PR TITLE
bmon: added package and its dependencies (libconfuse and libnl3)

### DIFF
--- a/packages/bmon/build.sh
+++ b/packages/bmon/build.sh
@@ -1,0 +1,12 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/tgraf/bmon
+TERMUX_PKG_DESCRIPTION="Bandwidth monitor and rate estimator"
+TERMUX_PKG_VERSION=4.0
+TERMUX_PKG_SRCURL=https://github.com/tgraf/bmon/archive/v$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_FOLDERNAME=bmon-$TERMUX_PKG_VERSION
+TERMUX_PKG_DEPENDS="libconfuse, libnl3, ncurses"
+TERMUX_PKG_BUILD_IN_SRC=yes
+
+termux_step_pre_configure() {
+    cd $TERMUX_PKG_SRCDIR
+    ./autogen.sh
+}

--- a/packages/bmon/config.h.patch
+++ b/packages/bmon/config.h.patch
@@ -1,0 +1,14 @@
+--- ../../build/bmon/cache/bmon-4.0/include/bmon/config.h	2016-12-13 11:56:40.000000000 +0100
++++ ./include/bmon/config.h	2017-02-09 00:29:18.177571494 +0100
+@@ -46,11 +46,6 @@
+ #include <syslog.h>
+ #include <sys/wait.h>
+ #include <dirent.h>
+-#ifdef SYS_BSD
+-# include <float.h>
+-#else
+-# include <values.h>
+-#endif
+ 
+ #if TIME_WITH_SYS_TIME
+ # include <sys/time.h>

--- a/packages/libconfuse/build.sh
+++ b/packages/libconfuse/build.sh
@@ -1,0 +1,4 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/martinh/libconfuse
+TERMUX_PKG_DESCRIPTION="Small configuration file parser library for C"
+TERMUX_PKG_VERSION=3.0
+TERMUX_PKG_SRCURL=https://github.com/martinh/libconfuse/releases/download/v$TERMUX_PKG_VERSION/confuse-$TERMUX_PKG_VERSION.tar.gz

--- a/packages/libnl3/build.sh
+++ b/packages/libnl3/build.sh
@@ -1,5 +1,6 @@
-TERMUX_PKG_HOMEPAGE=https://www.infradead.org/~tgr/libnl/
+TERMUX_PKG_HOMEPAGE=https://github.com/thom311/libnl
 TERMUX_PKG_DESCRIPTION="Collection of libraries providing APIs to netlink protocol based Linux kernel interfaces"
-TERMUX_PKG_VERSION=3.2.25
-TERMUX_PKG_SRCURL=https://www.infradead.org/~tgr/libnl/files/libnl-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_VERSION=3.2.29
+TERMUX_PKG_VERSION_DASH=`echo $TERMUX_PKG_VERSION | sed -e 's/\./_/g'`
+TERMUX_PKG_SRCURL=https://github.com/thom311/libnl/releases/download/libnl$TERMUX_PKG_VERSION_DASH/libnl-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-pthreads --disable-cli"

--- a/packages/libnl3/build.sh
+++ b/packages/libnl3/build.sh
@@ -1,0 +1,5 @@
+TERMUX_PKG_HOMEPAGE=https://www.infradead.org/~tgr/libnl/
+TERMUX_PKG_DESCRIPTION="Collection of libraries providing APIs to netlink protocol based Linux kernel interfaces"
+TERMUX_PKG_VERSION=3.2.25
+TERMUX_PKG_SRCURL=https://www.infradead.org/~tgr/libnl/files/libnl-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-pthreads --disable-cli"

--- a/packages/libnl3/nf-log.c.patch
+++ b/packages/libnl3/nf-log.c.patch
@@ -1,0 +1,10 @@
+--- ../../build/libnl3/cache/libnl-3.2.25/src/nf-log.c	2014-06-16 16:45:51.000000000 +0200
++++ ./src/nf-log.c	2017-02-09 00:08:20.671339521 +0100
+@@ -11,6 +11,7 @@
+  * Copyright (c) 2007 Secure Computing Corporation
+  */
+ 
++#include <sys/select.h>
+ #include <netlink/cli/utils.h>
+ #include <netlink/cli/link.h>
+ #include <linux/netfilter/nfnetlink_log.h>

--- a/packages/libnl3/nf-monitor.c.patch
+++ b/packages/libnl3/nf-monitor.c.patch
@@ -1,0 +1,10 @@
+--- ../../build/libnl3/cache/libnl-3.2.25/src/nf-monitor.c	2014-06-16 16:45:51.000000000 +0200
++++ ./src/nf-monitor.c	2017-02-09 00:09:08.904697365 +0100
+@@ -11,6 +11,7 @@
+  * Copyright (c) 2007 Secure Computing Corporation
+  */
+ 
++#include <sys/select.h>
+ #include <netlink/cli/utils.h>
+ #include <netlink/netfilter/nfnl.h>
+ 

--- a/packages/libnl3/nf-queue.c.patch
+++ b/packages/libnl3/nf-queue.c.patch
@@ -1,0 +1,11 @@
+--- ../../build/libnl3/cache/libnl-3.2.25/src/nf-queue.c	2014-06-16 16:45:51.000000000 +0200
++++ ./src/nf-queue.c	2017-02-09 00:08:34.248440250 +0100
+@@ -10,7 +10,7 @@
+  * Copyright (c) 2010  Karl Hiramoto <karl@hiramoto.org>
+  */
+ 
+-
++#include <sys/select.h>
+ #include <netlink/cli/utils.h>
+ #include <netlink/cli/link.h>
+ #include <netinet/in.h>

--- a/packages/libnl3/nl-monitor.c.patch
+++ b/packages/libnl3/nl-monitor.c.patch
@@ -1,0 +1,10 @@
+--- ../../build/libnl3/cache/libnl-3.2.25/src/nl-monitor.c	2014-06-16 16:45:51.000000000 +0200
++++ ./src/nl-monitor.c	2017-02-09 00:08:20.660339439 +0100
+@@ -9,6 +9,7 @@
+  * Copyright (c) 2003-2009 Thomas Graf <tgraf@suug.ch>
+  */
+ 
++#include <sys/select.h>
+ #include <netlink/cli/utils.h>
+ #include <netlink/cli/link.h>
+ 


### PR DESCRIPTION
I created a builder for bmon and its dependencies:
> bmon is a monitoring and debugging tool to capture networking related statistics and prepare them visually in a human friendly way. It features various output methods including an interactive curses user interface and a programmable text output for scripting.

Is very interesting for monitoring wireless traffic using it as hotspot (choose rmnetX interfaces). Interesting too if you download things in background or if you use a proxy like #406 (choose wlan0 interface)

![screenshot_20170209-003258](https://cloud.githubusercontent.com/assets/478660/22762724/1964d128-ee61-11e6-8b87-5348a98437ff.png)
