### PR TITLE
Icecast package

### DIFF
--- a/packages/icecast/build.sh
+++ b/packages/icecast/build.sh
@@ -1,0 +1,10 @@
+TERMUX_PKG_HOMEPAGE=http://icecast.org
+TERMUX_PKG_DESCRIPTION="Icecast is a streaming media (audio/video) server"
+TERMUX_PKG_VERSION=2.4.3
+TERMUX_PKG_SRCURL=http://downloads.xiph.org/releases/icecast/icecast-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_DEPENDS="libcurl, libgnutls, libogg, libvorbis, libxml2, libxslt, openssl"
+TERMUX_PKG_BUILD_IN_SRC=yes
+
+termux_step_pre_configure() {
+    perl -p -i -e "s#/etc/mime.types#$TERMUX_PREFIX/etc/mime.types#" $TERMUX_PKG_SRCDIR/src/cfgfile.c
+}

--- a/packages/icecast/build.sh
+++ b/packages/icecast/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=http://icecast.org
 TERMUX_PKG_DESCRIPTION="Icecast is a streaming media (audio/video) server"
 TERMUX_PKG_VERSION=2.4.3
 TERMUX_PKG_SRCURL=http://downloads.xiph.org/releases/icecast/icecast-$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_DEPENDS="libcurl, libgnutls, libogg, libvorbis, libxml2, libxslt, openssl"
+TERMUX_PKG_DEPENDS="libcurl, libgnutls, libogg, libvorbis, libxml2, libxslt, mime-support, openssl"
 TERMUX_PKG_BUILD_IN_SRC=yes
 
 termux_step_pre_configure() {

--- a/packages/icecast/thread.c.patch
+++ b/packages/icecast/thread.c.patch
@@ -1,0 +1,24 @@
+--- ../../build/icecast/cache/icecast-2.4.3/src/thread/thread.c	2015-12-27 17:46:32.000000000 +0100
++++ ./src/thread/thread.c	2017-01-01 22:52:28.256272825 +0100
+@@ -294,10 +294,10 @@
+         start->thread = thread;
+ 
+         pthread_attr_setstacksize (&attr, 512*1024);
+-        pthread_attr_setinheritsched (&attr, PTHREAD_INHERIT_SCHED);
++        //pthread_attr_setinheritsched (&attr, PTHREAD_INHERIT_SCHED);
+         if (detached)
+         {
+-            pthread_attr_setdetachstate (&attr, PTHREAD_CREATE_DETACHED);
++            //pthread_attr_setdetachstate (&attr, PTHREAD_CREATE_DETACHED);
+             thread->detached = 1;
+         }
+ 
+@@ -651,7 +651,7 @@
+     LOG_INFO4("Added thread %d [%s] started at [%s:%d]", thread->thread_id, thread->name, thread->file, thread->line);
+ #endif
+ 
+-    pthread_setcancelstate (PTHREAD_CANCEL_ENABLE, NULL);
++    //pthread_setcancelstate (PTHREAD_CANCEL_ENABLE, NULL);
+     free (start);
+ 
+     (start_routine)(real_arg);

--- a/packages/mime-support/build.sh
+++ b/packages/mime-support/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE=https://packages.debian.org/en/stretch/mime-support
+TERMUX_PKG_DESCRIPTION="MIME type associations for file types"
+TERMUX_PKG_VERSION=3.60
+TERMUX_PKG_SRCURL=http://http.debian.net/debian/pool/main/m/mime-support/mime-support_$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_FOLDERNAME=mime-support
+
+termux_step_make_install() {
+	cp $TERMUX_PKG_SRCDIR/mime.types $TERMUX_PREFIX/etc
+}


### PR DESCRIPTION
Small streaming server:

> Icecast is a streaming media (audio/video) server which currently supports Ogg (Vorbis and Theora), Opus, WebM and MP3 streams.
It can be used to create an Internet radio station or a privately running jukebox and many things in between. It is very versatile in that new formats can be added relatively easily and supports open standards for communication and interaction.

It requires /etc/mime.types file so I added a package called 'mime-support' based on Debian's one.