### PR TITLE
Add Pure-FTPd package

### DIFF
--- a/packages/pure-ftpd/build.sh
+++ b/packages/pure-ftpd/build.sh
@@ -1,0 +1,6 @@
+TERMUX_PKG_HOMEPAGE=https://www.pureftpd.org/project/pure-ftpd
+TERMUX_PKG_DESCRIPTION="Pure-FTPd is a free (BSD), secure, production-quality and standard-conformant FTP server"
+TERMUX_PKG_VERSION=1.0.45
+TERMUX_PKG_SRCURL=https://download.pureftpd.org/pub/pure-ftpd/releases/pure-ftpd-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=f6f26ab932e7fd2557435ee48f4fe089b2360a352b8ac7b2360cc9aaad63e92a
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-nonroot --with-minimal --with-ftpwho"

--- a/packages/pure-ftpd/pure-pwconvert.c.patch
+++ b/packages/pure-ftpd/pure-pwconvert.c.patch
@@ -1,0 +1,18 @@
+--- ../../build/pure-ftpd/cache/pure-ftpd-1.0.45/src/pure-pwconvert.c	2017-01-09 20:51:01.000000000 +0100
++++ ./src/pure-pwconvert.c	2017-02-23 20:57:25.626342233 +0100
+@@ -27,6 +27,7 @@
+ # endif
+ #endif
+ 
++#ifndef __ANDROID__
+     setpwent();
+     while ((pwd = getpwent()) != NULL) {
+         if (pwd->pw_name == NULL) {
+@@ -76,6 +77,7 @@
+                pwd->pw_gecos, pwd->pw_dir);
+     }
+     endpwent();
++#endif
+ 
+     return 0;
+ }


### PR DESCRIPTION
A small ftp server:

>  Pure-FTPd is a free (BSD), secure, production-quality and standard-conformant FTP server. It doesn't provide useless bells and whistles, but focuses on efficiency and ease of use. It provides simple answers to common needs, plus unique useful features for personal users as well as hosting providers. 

Is compiled without modules and doesn't require root (more on [README](https://download.pureftpd.org/pub/pure-ftpd/doc/README)). When compiling using `--with-nonroot` option, default port is 2121 so works without many tweaks .Works with virtual users and anonymous access.

Tested as usual:

![screenshot_20170223-233523](https://cloud.githubusercontent.com/assets/478660/23282520/d1dde598-fa21-11e6-8d60-5944333bafbe.png)


