### PR TITLE
oathtool: add package and its dependencies (xmlsec)

### DIFF
--- a/packages/oathtool/build.sh
+++ b/packages/oathtool/build.sh
@@ -3,4 +3,5 @@ TERMUX_PKG_DESCRIPTION="One-time password components"
 TERMUX_PKG_VERSION=2.6.2
 TERMUX_PKG_SRCURL=http://download.savannah.nongnu.org/releases/oath-toolkit/oath-toolkit-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=b03446fa4b549af5ebe4d35d7aba51163442d255660558cd861ebce536824aa0
+TERMUX_PKG_DEPENDS="xmlsec"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-pam"

--- a/packages/oathtool/build.sh
+++ b/packages/oathtool/build.sh
@@ -1,0 +1,6 @@
+TERMUX_PKG_HOMEPAGE=http://www.nongnu.org/oath-toolkit/
+TERMUX_PKG_DESCRIPTION="One-time password components"
+TERMUX_PKG_VERSION=2.6.2
+TERMUX_PKG_SRCURL=http://download.savannah.nongnu.org/releases/oath-toolkit/oath-toolkit-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=b03446fa4b549af5ebe4d35d7aba51163442d255660558cd861ebce536824aa0
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-pam"

--- a/packages/xmlsec/build.sh
+++ b/packages/xmlsec/build.sh
@@ -1,0 +1,6 @@
+TERMUX_PKG_HOMEPAGE=https://www.aleksey.com/xmlsec/
+TERMUX_PKG_DESCRIPTION="XML Security Library"
+TERMUX_PKG_VERSION=1.2.23
+TERMUX_PKG_SRCURL=http://www.aleksey.com/xmlsec/download/xmlsec1-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=41d463d16c9894cd3317098d027c038039c6d896b9cbb9bad9c4e29959e10e9f
+TERMUX_PKG_DEPENDS="libxml2, openssl"


### PR DESCRIPTION
I added [OATH Toolkit](http://www.nongnu.org/oath-toolkit/index.html), to generate OTPs via CLI:

> The OATH Toolkit provide components for building one-time password authentication systems. It contains shared libraries, command line tools. Supported technologies include the event-based HOTP algorithm (RFC4226) and the time-based TOTP algorithm (RFC6238). OATH stands for Open AuTHentication, which is the organization that specify the algorithms. For managing secret key files, the Portable Symmetric Key Container (PSKC) format described in RFC6030 is supported.

You can now forget Google Authenticator...

I named it like Debian does (they split in several packages, but I think here is not necessary), and is tested as usual:

![screenshot_20170302-002514](https://cloud.githubusercontent.com/assets/478660/23486163/0f52dcbe-fedf-11e6-8e10-da9bd70235de.png)
