### PR TITLE
Add Redis package

### DIFF
--- a/packages/redis/bio.c.patch
+++ b/packages/redis/bio.c.patch
@@ -1,0 +1,43 @@
+--- ../../build/redis/cache/redis-3.2.8/src/bio.c	2017-02-12 16:14:57.000000000 +0100
++++ ./src/bio.c	2017-03-02 22:46:52.999274254 +0100
+@@ -151,8 +151,8 @@
+ 
+     /* Make the thread killable at any time, so that bioKillThreads()
+      * can work reliably. */
+-    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+-    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
++    //pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
++    //pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+ 
+     pthread_mutex_lock(&bio_mutex[type]);
+     /* Block SIGALRM so we are sure that only the main thread will
+@@ -213,15 +213,19 @@
+     int err, j;
+ 
+     for (j = 0; j < BIO_NUM_OPS; j++) {
+-        if (pthread_cancel(bio_threads[j]) == 0) {
+-            if ((err = pthread_join(bio_threads[j],NULL)) != 0) {
+-                serverLog(LL_WARNING,
+-                    "Bio thread for job type #%d can be joined: %s",
+-                        j, strerror(err));
+-            } else {
+-                serverLog(LL_WARNING,
+-                    "Bio thread for job type #%d terminated",j);
+-            }
+-        }
++        pthread_kill(bio_threads[j], 0);
++        serverLog(LL_WARNING,
++            "Bio thread for job type #%d terminated",j);
++
++        //if (pthread_cancel(bio_threads[j]) == 0) {
++        //    if ((err = pthread_join(bio_threads[j],NULL)) != 0) {
++        //        serverLog(LL_WARNING,
++        //            "Bio thread for job type #%d can be joined: %s",
++        //                j, strerror(err));
++        //    } else {
++        //        serverLog(LL_WARNING,
++        //            "Bio thread for job type #%d terminated",j);
++        //    }
++        //}
+     }
+ }

--- a/packages/redis/build.sh
+++ b/packages/redis/build.sh
@@ -1,0 +1,13 @@
+TERMUX_PKG_HOMEPAGE=https://redis.io/
+TERMUX_PKG_DESCRIPTION="Redis is an open source (BSD licensed), in-memory data structure store, used as a database, cache and message broker"
+TERMUX_PKG_VERSION=3.2.8
+TERMUX_PKG_SRCURL=http://download.redis.io/releases/redis-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=61b373c23d18e6cc752a69d5ab7f676c6216dc2853e46750a8c4ed791d68482c
+TERMUX_PKG_BUILD_IN_SRC=yes
+
+termux_step_pre_configure() {
+    export PREFIX=$TERMUX_PREFIX
+    export USE_JEMALLOC=no
+
+    LDFLAGS+=" -llog"
+}

--- a/packages/redis/build.sh
+++ b/packages/redis/build.sh
@@ -4,10 +4,15 @@ TERMUX_PKG_VERSION=3.2.8
 TERMUX_PKG_SRCURL=http://download.redis.io/releases/redis-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=61b373c23d18e6cc752a69d5ab7f676c6216dc2853e46750a8c4ed791d68482c
 TERMUX_PKG_BUILD_IN_SRC=yes
+TERMUX_PKG_CONFFILES="etc/redis.conf"
 
 termux_step_pre_configure() {
     export PREFIX=$TERMUX_PREFIX
     export USE_JEMALLOC=no
 
     LDFLAGS+=" -llog"
+}
+
+termux_step_post_make_install() {
+    cp $TERMUX_PKG_SRCDIR/redis.conf $TERMUX_PREFIX/etc/redis.conf
 }

--- a/packages/redis/config.h.patch
+++ b/packages/redis/config.h.patch
@@ -1,0 +1,11 @@
+--- ../../build/redis/cache/redis-3.2.8/src/config.h	2017-02-12 16:14:57.000000000 +0100
++++ ./src/config.h	2017-03-02 22:42:23.207883845 +0100
+@@ -96,7 +96,7 @@
+ 
+ /* Define rdb_fsync_range to sync_file_range() on Linux, otherwise we use
+  * the plain fsync() call. */
+-#ifdef __linux__
++#ifdef __android__
+ #if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+ #if (LINUX_VERSION_CODE >= 0x020611 && __GLIBC_PREREQ(2, 6))
+ #define HAVE_SYNC_FILE_RANGE 1


### PR DESCRIPTION
Widely used cache server:

> [Redis](https://redis.io) is an open source (BSD licensed), in-memory data structure store, used as a database, cache and message broker. It supports data structures such as strings, hashes, lists, sets, sorted sets with range queries, bitmaps, hyperloglogs and geospatial indexes with radius queries. Redis has built-in replication, Lua scripting, LRU eviction, transactions and different levels of on-disk persistence, and provides high availability via Redis Sentinel and automatic partitioning with Redis Cluster.

Has both server and client... It can be tested with `redis-benchmark` command included in package (my OnePlus 3 reaches 11.000 requests/second).

![screenshot_20170302-225133](https://cloud.githubusercontent.com/assets/478660/23559988/1b6be9ae-0039-11e7-87d7-34d730477d92.png)
