### PR TITLE
blogc: initial packaging

### DIFF
--- a/packages/blogc/build.sh
+++ b/packages/blogc/build.sh
@@ -1,0 +1,11 @@
+# using a snapshot tarball because blogc-0.13.0 is not ready for release yet
+# (documentation updates pending), but it is already useful and stable enough
+
+TERMUX_PKG_HOMEPAGE=https://blogc.rgm.io/
+TERMUX_PKG_DESCRIPTION="A blog compiler"
+TERMUX_PKG_VERSION=0.12.0.123.acf1
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_MAINTAINER="Rafael Martins @rafaelmartins"
+TERMUX_PKG_SRCURL="https://travis-distfiles.rgm.io/blogc/blogc-0.12.0.123-acf1/blogc-0.12.0.123-acf1.tar.xz"
+TERMUX_PKG_SHA256=c1885fd8d0068cb24fda899a236591af9daf492aec3601690e7d9a7badf97616
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-git-receiver --enable-make --enable-runserver --disable-tests --disable-valgrind"

--- a/packages/blogc/termux-prefix.patch
+++ b/packages/blogc/termux-prefix.patch
@@ -1,0 +1,26 @@
+diff --git a/src/blogc-make/atom.c b/src/blogc-make/atom.c
+index d5f5387..5154bb9 100644
+--- a/src/blogc-make/atom.c
++++ b/src/blogc-make/atom.c
+@@ -55,7 +55,7 @@ bm_atom_deploy(bm_settings_t *settings, bc_error_t **err)
+         return NULL;
+ 
+     // this is not really portable
+-    char fname[] = "/tmp/blogc-make_XXXXXX";
++    char fname[] = "@TERMUX_PREFIX@/tmp/blogc-make_XXXXXX";
+     int fd;
+     if (-1 == (fd = mkstemp(fname))) {
+         *err = bc_error_new_printf(BLOGC_MAKE_ERROR_ATOM,
+diff --git a/src/blogc-make/exec.c b/src/blogc-make/exec.c
+index db20cae..86e8d25 100644
+--- a/src/blogc-make/exec.c
++++ b/src/blogc-make/exec.c
+@@ -116,7 +116,7 @@ bm_exec_command(const char *cmd, const char *input, char **output,
+         dup2(fd_err[1], STDERR_FILENO);
+ 
+         char *const argv[] = {
+-            "/bin/sh",
++            "@TERMUX_PREFIX@/bin/sh",
+             "-c",
+             (char*) cmd,
+             NULL,


### PR DESCRIPTION
blogc is a blogging tool written in C, without any external
dependencies. It is released under BSD license, and targeted to
developers.

The package is based on a snapshot version. Version 0.13.0 should
be release soon, but the snapshot is stable and useful enough.

For more info, see: https://blogc.rgm.io/