### PR TITLE
update dpkg to 1.18.23

### DIFF
--- a/packages/dpkg/build.sh
+++ b/packages/dpkg/build.sh
@@ -1,8 +1,8 @@
 TERMUX_PKG_HOMEPAGE=https://packages.debian.org/dpkg
 TERMUX_PKG_DESCRIPTION="Debian package management system"
-TERMUX_PKG_VERSION=1.18.22
+TERMUX_PKG_VERSION=1.18.23
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/debian/pool/main/d/dpkg/dpkg_${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=eaf2ae88eae71f164167f75e9229af87fa9451bc58966fdec40db265b146ad69
+TERMUX_PKG_SHA256=cc08802a0cea2ccd0c10716bc71531ff9b9234dd454b83a59f71117a37f36923
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 ac_cv_lib_selinux_setexecfilecon=no
 --disable-dselect


### PR DESCRIPTION
1.18.22 isn't available anymore on https://mirrors.kernel.org/debian/pool/main/d/dpkg/