### PR TITLE
Update .gitattributes to force lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-*       text=auto
+*       text=lf
 
 *.sh    text eol=lf
 *.ps1   text eol=crlf


### PR DESCRIPTION
I don't know if this was expected but using * text=auto on windows will simply break all the builds inside docker because scripts like config.guess, *.py will be crlf and inside docker shebang won't work.