### PR TITLE
texlive: remove -N option from wget command in termux-install-tl.

### DIFF
--- a/packages/texlive/termux-install-tl.sh
+++ b/packages/texlive/termux-install-tl.sh
@@ -6,7 +6,7 @@ export TMPDIR=$PREFIX/tmp/
 mkdir -p $TMPDIR/termux-tl-installer
 cd $TMPDIR/termux-tl-installer
 
-wget -N http://mirror.ctan.org/systems/texlive/Source/install-tl-unx.tar.gz
+wget http://mirror.ctan.org/systems/texlive/Source/install-tl-unx.tar.gz -O install-tl-unx.tar.gz
 tar xzfv install-tl-unx.tar.gz > flist
 
 cd $(head -1 flist) 


### PR DESCRIPTION
Busybox version of wget doesn't support -N so wget shouldn't use -N (or be added to package dependencies).