### PR TITLE
add php-pgsql and php-fpm

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -935,6 +935,8 @@ termux_step_massage() {
 		test ! -z "$TERMUX_SUBPKG_CONFLICTS" && echo "Conflicts: $TERMUX_SUBPKG_CONFLICTS" >> control
 		$TERMUX_TAR -cJf "$SUB_PKG_PACKAGE_DIR/control.tar.xz" .
 
+		for f in $TERMUX_SUBPKG_CONFFILES; do echo "$TERMUX_PREFIX/$f" >> conffiles; done
+
 		# Create the actual .deb file:
 		TERMUX_SUBPKG_DEBFILE=$TERMUX_DEBDIR/${SUB_PKG_NAME}_${TERMUX_PKG_FULLVERSION}_${SUB_PKG_ARCH}.deb
 		test ! -f "$TERMUX_COMMON_CACHEDIR/debian-binary" && echo "2.0" > "$TERMUX_COMMON_CACHEDIR/debian-binary"

--- a/packages/php/build.sh
+++ b/packages/php/build.sh
@@ -1,8 +1,8 @@
 TERMUX_PKG_HOMEPAGE=https://php.net
 TERMUX_PKG_DESCRIPTION="Server-side, HTML-embedded scripting language"
-TERMUX_PKG_VERSION=7.1.2
+TERMUX_PKG_VERSION=7.1.3
 TERMUX_PKG_SRCURL=http://www.php.net/distributions/php-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=d815a0c39fd57bab1434a77ff0610fb507c22f790c66cd6f26e27030c4b3e971
+TERMUX_PKG_SHA256=e4887c2634778e37fd962fbdf5c4a7d32cd708482fe07b448804625570cb0bb0
 # Build native php for phar to build (see pear-Makefile.frag.patch):
 TERMUX_PKG_HOSTBUILD=true
 # Build the native php without xml support as we only need phar:

--- a/packages/php/php-fpm.patch
+++ b/packages/php/php-fpm.patch
@@ -1,0 +1,11 @@
+--- ./sapi/fpm/www.conf.in
++++ ./sapi/fpm/www.conf.in
+@@ -33,7 +33,7 @@
+ ;                            (IPv6 and IPv4-mapped) on a specific port;
+ ;   '/path/to/unix/socket' - to listen on a unix socket.
+ ; Note: This value is mandatory.
+-listen = 127.0.0.1:9000
++listen = @TERMUX_PREFIX@/var/run/php-fpm.sock
+ 
+ ; Set listen(2) backlog.
+ ; Default Value: 511 (-1 on FreeBSD and OpenBSD)

--- a/packages/php/php-fpm.subpackage.sh
+++ b/packages/php/php-fpm.subpackage.sh
@@ -1,0 +1,4 @@
+TERMUX_SUBPKG_INCLUDE="bin/php-fpm etc/php-fpm.conf etc/php-fpm.d/www.conf share/man/man8/php-fpm.8"
+TERMUX_SUBPKG_CONFFILES="etc/php-fpm.conf etc/php-fpm.d/www.conf"
+TERMUX_SUBPKG_DEPENDS="php"
+TERMUX_SUBPKG_DESCRIPTION="FastCGI Process Manager for PHP"

--- a/packages/php/php-pgsql.subpackage.sh
+++ b/packages/php/php-pgsql.subpackage.sh
@@ -1,0 +1,3 @@
+TERMUX_SUBPKG_INCLUDE="lib/php/pgsql.so lib/php/pdo_pgsql.so"
+TERMUX_SUBPKG_DEPENDS="php, postgresql"
+TERMUX_SUBPKG_DESCRIPTION="PostgreSQL modules for PHP"


### PR DESCRIPTION
I had to enable `TERMUX_SUBPKG_CONFFILES` as php-fpm is 11 MB and it makes sense to have it as a subpackage.
Also, changed `EXTENSION_DIR` to `$TERMUX_PREFIX/lib/php`, so, now the opcache shared module resides there.