### PR TITLE
fixes for php

### DIFF
--- a/packages/libgd/build.sh
+++ b/packages/libgd/build.sh
@@ -6,4 +6,4 @@ TERMUX_PKG_SHA256=487a650aa614217ed08ab1bd1aa5d282f9d379cfd95c756aed0b43406381be
 TERMUX_PKG_DEPENDS="freetype, fontconfig, libjpeg-turbo, libpng, libtiff"
 # Disable vpx support for now, look at https://github.com/gagern/libgd/commit/d41eb72cd4545c394578332e5c102dee69e02ee8
 # for enabling:
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--without-vpx"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--without-vpx --without-x"

--- a/packages/php/build.sh
+++ b/packages/php/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://php.net
 TERMUX_PKG_DESCRIPTION="Server-side, HTML-embedded scripting language"
 TERMUX_PKG_VERSION=7.1.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=http://www.php.net/distributions/php-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=e4887c2634778e37fd962fbdf5c4a7d32cd708482fe07b448804625570cb0bb0
 # Build native php for phar to build (see pear-Makefile.frag.patch):
@@ -39,7 +40,7 @@ ac_cv_func_res_nsearch=no
 "
 
 termux_step_pre_configure () {
-	LDFLAGS+=" -landroid-glob -llog"
+	LDFLAGS+=" -landroid-glob -llog -lpcre"
 
 	export PATH=$PATH:$TERMUX_PKG_HOSTBUILD_DIR/sapi/cli/
 	export NATIVE_PHP_EXECUTABLE=$TERMUX_PKG_HOSTBUILD_DIR/sapi/cli/php


### PR DESCRIPTION
pgsql shared extension doesn't get linked with pcre. This may be a bug with libtool. I cannot build apache2 for a similar issue.
My build machine (Arch) picks up native X11 headers when compiling libgd, so it was required.