### PR TITLE
termux-tools: fix termux-fix-shebang script

### DIFF
--- a/packages/termux-tools/termux-fix-shebang
+++ b/packages/termux-tools/termux-fix-shebang
@@ -7,7 +7,6 @@ if [ $# = 0 -o "$1" = "-h" ]; then
 	exit 1
 fi
 
-for file in $@; do
-	# Do realpath to avoid breaking symlinks (modify original file):
-	sed -i -E "1 s@^#\!(.*)/bin/(.*)@#\!/data/data/com.termux/files/usr/bin/\2@" `realpath $@`
+for file in "$@"; do
+	sed -i -E "1 s@^#\!(.*)/[sx]?bin/(.*)@#\!/data/data/com.termux/files/usr/bin/\2@" "$(realpath "${file}")"
 done


### PR DESCRIPTION
Original script 'termux-fix-shebang' from termux-tools package is not working with multiple files or files with a whitespace character in name. I have made some changes that fixes this.