### PR TITLE
krb5: specify conffiles, default cache locations and ports

### DIFF
--- a/packages/krb5/build.sh
+++ b/packages/krb5/build.sh
@@ -1,12 +1,13 @@
 TERMUX_PKG_HOMEPAGE=https://web.mit.edu/kerberos
 TERMUX_PKG_DESCRIPTION="The Kerberos network authentication system"
 TERMUX_PKG_VERSION=1.15.1
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_DEPENDS="libandroid-support, libandroid-glob, readline, openssl, libutil, libdb"
 TERMUX_PKG_SRCURL="https://web.mit.edu/kerberos/dist/krb5/1.15/krb5-$TERMUX_PKG_VERSION.tar.gz"
 TERMUX_PKG_SHA256=437c8831ddd5fde2a993fef425dedb48468109bb3d3261ef838295045a89eb45
 TERMUX_PKG_FOLDERNAME="krb5-$TERMUX_PKG_VERSION/src"
 TERMUX_PKG_MAINTAINER="Vishal Biswas @vishalbiswas"
+TERMUX_PKG_CONFFILES="etc/krb5.conf var/krb5kdc/kdc.conf"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-readline
 --without-system-verto
 --with-netlib=-lc
@@ -14,6 +15,9 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-readline
 --sbindir=$TERMUX_PREFIX/bin
 --with-size-optimizations
 --with-system-db
+DEFCCNAME=$TERMUX_PREFIX/tmp/krb5cc_%{uid}
+DEFKTNAME=$TERMUX_PREFIX/etc/krb5.keytab
+DEFCKTNAME=$TERMUX_PREFIX/var/krb5/user/%{euid}/client.keytab
 "
 
 termux_step_pre_configure () {
@@ -29,6 +33,9 @@ termux_step_pre_configure () {
 }
 
 termux_step_post_make_install () {
+	# Enable logging to STDERR by default
+	echo -e "\tdefault = STDERR" >> $TERMUX_PKG_SRCDIR/config-files/krb5.conf
+
 	# Sample KDC config file
 	install -dm 700 $TERMUX_PREFIX/var/krb5kdc
 	install -pm 600 $TERMUX_PKG_SRCDIR/config-files/kdc.conf $TERMUX_PREFIX/var/krb5kdc/kdc.conf

--- a/packages/krb5/include-osconf.hin.patch
+++ b/packages/krb5/include-osconf.hin.patch
@@ -1,0 +1,28 @@
+--- ./include/osconf.hin	2017-03-03 03:36:02.000000000 +0530
++++ ../osconf.hin	2017-04-03 10:45:03.475924421 +0530
+@@ -81,12 +81,12 @@
+ 
+ #define KDC_PORTNAME            "kerberos" /* for /etc/services or equiv. */
+ 
+-#define KRB5_DEFAULT_PORT       88
++#define KRB5_DEFAULT_PORT       1088
+ 
+-#define DEFAULT_KPASSWD_PORT    464
++#define DEFAULT_KPASSWD_PORT    1464
+ 
+-#define DEFAULT_KDC_UDP_PORTLIST "88"
+-#define DEFAULT_KDC_TCP_PORTLIST "88"
++#define DEFAULT_KDC_UDP_PORTLIST "1088"
++#define DEFAULT_KDC_TCP_PORTLIST "1088"
+ #define DEFAULT_TCP_LISTEN_BACKLOG 5
+ 
+ /*
+@@ -94,7 +94,7 @@
+  */
+ #define DEFAULT_KADM5_KEYTAB    KDC_DIR "/kadm5.keytab"
+ #define DEFAULT_KADM5_ACL_FILE  KDC_DIR "/kadm5.acl"
+-#define DEFAULT_KADM5_PORT      749 /* assigned by IANA */
++#define DEFAULT_KADM5_PORT      1749 /* assigned by IANA */
+ 
+ #define KRB5_DEFAULT_SUPPORTED_ENCTYPES                 \
+     "aes256-cts-hmac-sha1-96:normal "                   \


### PR DESCRIPTION
Some more polish to prevent end user from having to set these in configs.