### PR TITLE
fossil: Update from 1.37 to 2.1

### DIFF
--- a/packages/fossil/build.sh
+++ b/packages/fossil/build.sh
@@ -1,10 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://www.fossil-scm.org
 TERMUX_PKG_DESCRIPTION='DSCM with built-in wiki, http interface and server, tickets database'
 TERMUX_PKG_MAINTAINER='Vishal Biswas @vishalbiswas'
-TERMUX_PKG_VERSION=1.37
-TERMUX_PKG_SRCURL=http://www.fossil-scm.org/fossil/uv/download/fossil-src-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=81c19e81c4b2b60930bab3f2147b516525c855924ccc6d089748b0f5611be492
-TERMUX_PKG_FOLDERNAME=Fossil_2017-01-16_205854_1669115ab9
+TERMUX_PKG_VERSION=2.1
+TERMUX_PKG_SRCURL=https://www.fossil-scm.org/index.html/uv/fossil-src-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=85dcdf10d0f1be41eef53839c6faaa73d2498a9a140a89327cfb092f23cfef05
+TERMUX_PKG_FOLDERNAME=fossil-${TERMUX_PKG_VERSION}
 TERMUX_PKG_DEPENDS='libsqlite, openssl'
 
 termux_step_pre_configure () {


### PR DESCRIPTION
This is a critical update because sqlite's official repo has denied access from fossil 1.x clients since March 12, 2017.

see http://www.sqlite.org/getthecode.html#clone

"As of 2017-03-12, you must use Fossil version 2.0 or later for the following instructions to work..."