### PR TITLE
Add bc dependency to fish shell

### DIFF
--- a/packages/fish/build.sh
+++ b/packages/fish/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_SRCURL=https://github.com/fish-shell/fish-shell/releases/download/$TE
 TERMUX_PKG_SHA256=f8c0edadca2de379ccf305aeace660a9255fa2180c72e85e97705a24c256b2a5
 # fish calls 'tput' from ncurses-utils, at least when cancelling (Ctrl+C) a command line.
 # man is needed since fish calls apropos during command completion.
-TERMUX_PKG_DEPENDS="ncurses, libandroid-support, ncurses-utils, man"
+TERMUX_PKG_DEPENDS="ncurses, libandroid-support, ncurses-utils, man, bc"
 TERMUX_PKG_BUILD_IN_SRC=yes
 TERMUX_PKG_FOLDERNAME=fish-$TERMUX_PKG_VERSION
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="ac_cv_file__proc_self_stat=yes"


### PR DESCRIPTION
See https://github.com/fish-shell/fish-shell/issues/2974

This will only fail at runtime in some autocomplete commands, if the dependency is not installed.