### PR TITLE
Boost libs

### DIFF
--- a/packages/boost/build.sh
+++ b/packages/boost/build.sh
@@ -1,0 +1,34 @@
+TERMUX_PKG_HOMEPAGE=https://boost.org
+TERMUX_PKG_DESCRIPTION="cpp libs"
+TERMUX_PKG_VERSION=1.64.0
+TERMUX_PKG_SRCURL=http://sourceforge.net/projects/boost/files/boost/1.64.0/boost_1_64_0.tar.bz2
+TERMUX_PKG_SHA256=7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332
+TERMUX_PKG_FOLDERNAME="boost_1_64_0"
+TERMUX_PKG_BUILD_IN_SRC=yes
+TERMUX_PKG_DEPENDS="libbz2"
+termux_step_configure(){
+	return 0;
+}
+termux_step_make() {
+	return 0;
+}
+termux_step_make_install() {
+	rm $TERMUX_PREFIX/lib/libboost* -f
+	rm $TERMUX_PREFIX/include/boost -rf
+	./bootstrap.sh
+	echo "using clang : $TERMUX_ARCH : $CXX : <linkflags>-L/data/data/com.termux/files/usr/lib ; " >> project-config.jam
+	./b2  target-os=android -j${TERMUX_MAKE_PROCESSES} \
+		include=/data/data/com.termux/files/usr/include \
+		include=/data/data/com.termux/files/usr/include/python2.7 \
+		toolset=clang-$TERMUX_ARCH \
+		--prefix="$TERMUX_PREFIX"  \
+		-q \
+		--without-coroutine2 \
+		--without-coroutine \
+		--without-context \
+		--without-log \
+		cxxflags="$CXXFLAGS" \
+		link=shared \
+		threading=multi \
+		install
+}

--- a/packages/boost/build.sh
+++ b/packages/boost/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_SRCURL=http://sourceforge.net/projects/boost/files/boost/1.64.0/boost
 TERMUX_PKG_SHA256=7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332
 TERMUX_PKG_FOLDERNAME="boost_1_64_0"
 TERMUX_PKG_BUILD_IN_SRC=yes
-TERMUX_PKG_DEPENDS="libbz2"
+TERMUX_PKG_DEPENDS="libbz2, libicu"
 termux_step_configure(){
 	return 0;
 }
@@ -13,6 +13,7 @@ termux_step_make() {
 	return 0;
 }
 termux_step_make_install() {
+	CXXFLAGS+="  -std=c++11"
 	rm $TERMUX_PREFIX/lib/libboost* -f
 	rm $TERMUX_PREFIX/include/boost -rf
 	./bootstrap.sh

--- a/packages/boost/python.jam.patch
+++ b/packages/boost/python.jam.patch
@@ -1,0 +1,11 @@
+--- ../cache/boost_1_64_0/tools/build/src/tools/python.jam	2017-04-17 02:22:26.000000000 +0000
++++ ./tools/build/src/tools/python.jam	2017-04-30 06:12:15.748537322 +0000
+@@ -651,7 +651,7 @@
+ 
+         case aix : return  <library>pthread <library>dl ;
+ 
+-        case * : return  <library>pthread <library>dl
++        case * : return  <library>dl
+             <toolset>gcc:<library>util <toolset-intel:platform>linux:<library>util ;
+     }
+ }


### PR DESCRIPTION
a few things the python lib won't compile unless you add a symlink so -lpthread works as it is on device. I haven't really tested all the libs yet.   