### PR TITLE
fix aarch64 build giving double instead of integer

### DIFF
--- a/packages/php/build.sh
+++ b/packages/php/build.sh
@@ -10,6 +10,7 @@ TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_EXTRA_HOSTBUILD_CONFIGURE_ARGS="--disable-libxml --disable-dom --disable-simplexml --disable-xml --disable-xmlreader --disable-xmlwriter --without-pear"
 TERMUX_PKG_DEPENDS="libandroid-glob, libxml2, liblzma, openssl, pcre, libbz2, libcrypt, libcurl, libgd, readline, freetype"
 TERMUX_PKG_RM_AFTER_INSTALL="php/php/fpm"
+TERMUX_PKG_CLANG=no
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 ac_cv_func_res_nsearch=no


### PR DESCRIPTION
yeah its a clang compile error. Use gcc instead and its fine. 