### PR TITLE
libgpg-error: workaround no stdout atexit with constructor prior to N

### DIFF
--- a/packages/libgpg-error/atexit.patch
+++ b/packages/libgpg-error/atexit.patch
@@ -1,0 +1,14 @@
+--- src/src/estream.c	2017-02-28 09:11:05.000000000 +0000
++++ ./_patches/estream.c	2017-05-14 23:41:57.522426391 +0000
+@@ -510,7 +510,11 @@
+ {
+   static int initialized;
+ 
++#ifdef __ANDROID__
++  if (initialized < 2)
++#else
+   if (!initialized)
++#endif
+     {
+       initialized = 1;
+       atexit (do_deinit);

--- a/packages/libgpg-error/build.sh
+++ b/packages/libgpg-error/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://www.gnupg.org/related_software/libgpg-error/
 TERMUX_PKG_DESCRIPTION="Small library that defines common error values for all GnuPG components"
 TERMUX_PKG_VERSION=1.27
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=4f93aac6fecb7da2b92871bb9ee33032be6a87b174f54abf8ddf0911a22d29d2
 TERMUX_PKG_RM_AFTER_INSTALL="share/common-lisp"


### PR DESCRIPTION
To workaround for #933 

The problem is if `atexit(do_deinit)` is called from a function decorated with `__attribute__ ((__constructor__))`, then while `do_deinit` is executed, no standard fd will be presented prior to Android N.

However with `atexit(do_deinit)` called in a initial function (i.e. `gpgrt_init()`) is OK.

Thus, the sample code in #933 should look like this:
```
#define GPGRT_ENABLE_ES_MACROS
#include <gpg-error.h>
int main() { gpgrt_init(); es_putc('A', es_stdout); }
```

BTW `gpgrt_init()` is called in `init_comman_systems()` of gpgconf.c

So this workaround is just register `atexit` again, and the first `do_deinit()` is able to print message out to stdout.