### PR TITLE
Do not gzip tar and sleep to microsecond precision.

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -379,9 +379,8 @@ termux_step_start_build() {
 	# Keep track of when build started so we can see what files have been created.
 	# We start by sleeping so that any generated files above (such as zlib.pc) get
 	# an older timestamp than the TERMUX_BUILD_TS_FILE.
-	sleep 1
-	TERMUX_BUILD_TS_FILE=$TERMUX_PKG_TMPDIR/timestamp_$TERMUX_PKG_NAME
-	touch "$TERMUX_BUILD_TS_FILE"
+	sleep $(echo "scale=6;(1000000-$(date +'%6N'))/1000000" | bc)
+	TERMUX_BUILD_START_TIME=$(date +"%FT%T")
 }
 
 # Run just after sourcing $TERMUX_PKG_BUILDER_SCRIPT. May be overridden by packages.
@@ -821,7 +820,7 @@ termux_step_extract_into_massagedir() {
 
 	# Build diff tar with what has changed during the build:
 	cd $TERMUX_PREFIX
-	tar -N "$TERMUX_BUILD_TS_FILE" -cf "$TARBALL_ORIG" .
+	tar -N "$TERMUX_BUILD_START_TIME" -cf "$TARBALL_ORIG" .
 
 	# Extract tar in order to massage it
 	mkdir -p "$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX"

--- a/build-package.sh
+++ b/build-package.sh
@@ -817,11 +817,11 @@ termux_step_post_make_install() {
 }
 
 termux_step_extract_into_massagedir() {
-	local TARBALL_ORIG=$TERMUX_PKG_PACKAGEDIR/${TERMUX_PKG_NAME}_orig.tar.gz
+	local TARBALL_ORIG=$TERMUX_PKG_PACKAGEDIR/${TERMUX_PKG_NAME}_orig.tar
 
 	# Build diff tar with what has changed during the build:
 	cd $TERMUX_PREFIX
-	tar -N "$TERMUX_BUILD_TS_FILE" -czf "$TARBALL_ORIG" .
+	tar -N "$TERMUX_BUILD_TS_FILE" -cf "$TARBALL_ORIG" .
 
 	# Extract tar in order to massage it
 	mkdir -p "$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX"

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -5,6 +5,7 @@ PACKAGES=""
 PACKAGES+=" ant" # Used by apksigner.
 PACKAGES+=" asciidoc"
 PACKAGES+=" automake"
+PACKAGES+=" bc"
 PACKAGES+=" bison"
 PACKAGES+=" clang" # Used by golang, useful to have same compiler building.
 PACKAGES+=" curl" # Used for fetching sources.


### PR DESCRIPTION
Gzipping tar won't make the whole process faster as time wasted in gzipping is longer than that wasted in copying.