### PR TITLE
Add ed package for bc

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -8,6 +8,7 @@ PACKAGES+=" automake"
 PACKAGES+=" bison"
 PACKAGES+=" clang" # Used by golang, useful to have same compiler building.
 PACKAGES+=" curl" # Used for fetching sources.
+PACKAGES+=" ed" # Used by bc
 PACKAGES+=" flex"
 PACKAGES+=" gettext" # Provides 'msgfmt' which the apt build uses.
 PACKAGES+=" git" # Used by the neovim build.


### PR DESCRIPTION
ed is a build dependency of bc now. The build would fail if ed is not present as shown here: 
https://gitlab.com/Wetitpig/termux-packages/pipelines/8369999