### PR TITLE
ncmpcpp default settings to work with mpd default

### DIFF
--- a/packages/ncmpcpp/settings.cpp.patch
+++ b/packages/ncmpcpp/settings.cpp.patch
@@ -5,7 +5,7 @@
  	p.add("ncmpcpp_directory", &ncmpcpp_directory, "~/.ncmpcpp/", adjust_directory);
  	p.add("lyrics_directory", &lyrics_directory, "~/.lyrics/", adjust_directory);
 -	p.add<void>("mpd_host", nullptr, "localhost", [](std::string host) {
-+	p.add<void>("mpd_host", nullptr, "~/.mpd/socket", [](std::string host) {
++	p.add<void>("mpd_host", nullptr, "~/../usr/tmp/mpd.socket", [](std::string host) {
  			expand_home(host);
  			Mpd.SetHostname(host);
  		});


### PR DESCRIPTION
this makes default ncmpcpp settings open up the socket because it was moved to ~/../usr/tmp not ~/.mpd/.