### PR TITLE
Set up home structure for authorized_keys

### DIFF
--- a/packages/openssh/build.sh
+++ b/packages/openssh/build.sh
@@ -70,6 +70,9 @@ termux_step_post_make_install () {
 
 termux_step_create_debscripts () {
 	echo "mkdir -p \$HOME/.ssh" > postinst
+	echo "touch \$HOME/.ssh/authorized_keys" >> postinst
+	echo "chmod 700 \$HOME/.ssh" >> postinst
+	echo "chmod 600 \$HOME/.ssh/authorized_keys" >> postinst
 	echo "" >> postinst
         echo "for a in rsa dsa ecdsa ed25519; do" >> postinst
         echo "    KEYFILE=$TERMUX_PREFIX/etc/ssh/ssh_host_\${a}_key" >> postinst


### PR DESCRIPTION
Since password auth is disabled by default, we depend on keys in our home dir but they're not created for us and the perms are wrong by default. This commit sets it up correctly for the user to simply add their key to the empty authorized_keys file