### PR TITLE
debootstrap: Add package

### DIFF
--- a/packages/debootstrap/Makefile.patch
+++ b/packages/debootstrap/Makefile.patch
@@ -1,0 +1,23 @@
+diff --git a/Makefile b/Makefile
+index 8516803..0c61852 100644
+--- a/Makefile
++++ b/Makefile
+@@ -5,14 +5,12 @@ all:
+
+ clean:
+
+-DSDIR=$(DESTDIR)/usr/share/debootstrap
++DSDIR=$(DESTDIR)$(PREFIX)/share/debootstrap
+ install:
+ 	mkdir -p $(DSDIR)/scripts
+-	mkdir -p $(DESTDIR)/usr/sbin
+
+ 	cp -a scripts/* $(DSDIR)/scripts/
+-	install -o root -g root -m 0644 functions $(DSDIR)/
++	install -m 0644 functions $(DSDIR)/
+
+-	sed 's/@VERSION@/$(VERSION)/g' debootstrap >$(DESTDIR)/usr/sbin/debootstrap
+-	chown root:root $(DESTDIR)/usr/sbin/debootstrap
+-	chmod 0755 $(DESTDIR)/usr/sbin/debootstrap
++	sed 's/@VERSION@/$(VERSION)/g' debootstrap >$(DESTDIR)$(PREFIX)/bin/debootstrap
++	chmod 0755 $(DESTDIR)$(PREFIX)/bin/debootstrap

--- a/packages/debootstrap/build.sh
+++ b/packages/debootstrap/build.sh
@@ -1,0 +1,13 @@
+TERMUX_PKG_HOMEPAGE=https://wiki.debian.org/Debootstrap
+TERMUX_PKG_DESCRIPTION="Bootstrap a basic Debian system"
+TERMUX_PKG_VERSION=1.0.90
+TERMUX_PKG_SRCURL=http://http.debian.net/debian/pool/main/d/debootstrap/debootstrap_${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=4d1f434b093051a27fe9482063e2b09aa88cdcc51877228b04729e302ba9145e
+TERMUX_PKG_BUILD_IN_SRC=yes
+TERMUX_PKG_DEPENDS="wget, proot"
+TERMUX_PKG_MAINTAINER="Pierre Rudloff @Rudloff"
+
+termux_step_post_make_install() {
+    mkdir -p ${TERMUX_PREFIX}/share/man/man8/
+    install ${TERMUX_PKG_SRCDIR}/debootstrap.8 ${TERMUX_PREFIX}/share/man/man8/
+}

--- a/packages/debootstrap/debootstrap.patch
+++ b/packages/debootstrap/debootstrap.patch
@@ -1,0 +1,53 @@
+diff --git a/debootstrap b/debootstrap
+index 4658e0f..1672990 100755
+--- a/debootstrap
++++ b/debootstrap
+@@ -14,7 +14,7 @@ if [ -z "$DEBOOTSTRAP_DIR" ]; then
+ 	if [ -x /debootstrap/debootstrap ]; then
+ 		DEBOOTSTRAP_DIR=/debootstrap
+ 	else
+-		DEBOOTSTRAP_DIR=/usr/share/debootstrap
++		DEBOOTSTRAP_DIR=$PREFIX/share/debootstrap
+ 	fi
+ fi
+
+@@ -421,10 +421,10 @@ fi
+
+ if in_path dpkg && \
+      dpkg --print-architecture >/dev/null 2>&1; then
+-	HOST_ARCH=`/usr/bin/dpkg --print-architecture`
++	HOST_ARCH=`$PREFIX/bin/dpkg --print-architecture`
+ elif in_path udpkg && \
+      udpkg --print-architecture >/dev/null 2>&1; then
+-	HOST_ARCH=`/usr/bin/udpkg --print-architecture`
++	HOST_ARCH=`$PREFIX/bin/udpkg --print-architecture`
+ elif [ -e $DEBOOTSTRAP_DIR/arch ]; then
+ 	HOST_ARCH=`cat $DEBOOTSTRAP_DIR/arch`
+ fi
+@@ -465,7 +465,8 @@ fi
+ if [ "$TARGET" = "/" ]; then
+ 	CHROOT_CMD=""
+ else
+-	CHROOT_CMD="chroot $TARGET"
++	PATH=$PATH:/usr/bin:/bin:/usr/sbin:/sbin
++	CHROOT_CMD="proot -w /home -b /dev -b /proc --link2symlink -0 -r $TARGET"
+ fi
+
+ if [ -z "$SHA_SIZE" ]; then
+@@ -478,16 +479,6 @@ DEBOOTSTRAP_CHECKSUM_FIELD="SHA$SHA_SIZE"
+
+ export ARCH SUITE TARGET CHROOT_CMD SHA_SIZE DEBOOTSTRAP_CHECKSUM_FIELD
+
+-if am_doing_phase first_stage second_stage; then
+-	if in_path id && [ `id -u` -ne 0 ]; then
+-		error 1 NEEDROOT "debootstrap can only run as root"
+-	fi
+-	# Ensure that we can create working devices and executables on the target.
+-	if ! check_sane_mount "$TARGET"; then
+-		error 1 NOEXEC "Cannot install into target '$TARGET' mounted with noexec or nodev"
+-	fi
+-fi
+-
+ if [ ! -e "$SCRIPT" ]; then
+ 	error 1 NOSCRIPT "No such script: %s" "$SCRIPT"
+ fi

--- a/packages/debootstrap/functions.patch
+++ b/packages/debootstrap/functions.patch
@@ -1,0 +1,30 @@
+diff --git a/functions b/functions
+index e22d4a0..ce731b6 100644
+--- a/functions
++++ b/functions
+@@ -883,7 +883,7 @@ extract_dpkg_deb_field () {
+ extract_dpkg_deb_data () {
+ 	local pkg="$1"
+
+-	dpkg-deb --fsys-tarfile "$pkg" | tar $EXTRACT_DEB_TAR_OPTIONS -xf -
++	dpkg-deb --fsys-tarfile "$pkg" | proot --link2symlink tar $EXTRACT_DEB_TAR_OPTIONS -xf -
+ }
+
+ # Raw .deb extractors
+@@ -921,7 +921,7 @@ extract_ar_deb_data () {
+ 	esac
+
+ 	if type $cat_cmd >/dev/null 2>&1; then
+-		ar -p "$pkg" "$tarball" | $cat_cmd | tar $EXTRACT_DEB_TAR_OPTIONS -xf -
++		ar -p "$pkg" "$tarball" | $cat_cmd | proot --link2symlink tar $EXTRACT_DEB_TAR_OPTIONS -xf -
+ 	else
+ 		error 1 UNPACKCMDUNVL "Extracting %s requires the %s command, which is not available" "$pkg" "$cat_cmd"
+ 	fi
+@@ -1139,7 +1139,6 @@ setup_devices () {
+ 	    hurd*)
+ 		;;
+ 	    *)
+-		setup_devices_simple
+ 		;;
+ 	esac
+ }

--- a/packages/debootstrap/scripts.patch
+++ b/packages/debootstrap/scripts.patch
@@ -1,0 +1,42 @@
+diff --git a/scripts/sid b/scripts/sid
+index 1d96477..e899d42 100644
+--- a/scripts/sid
++++ b/scripts/sid
+@@ -58,7 +58,7 @@ first_stage_install () {
+ 	setup_etc
+ 	if [ ! -e "$TARGET/etc/fstab" ]; then
+ 		echo '# UNCONFIGURED FSTAB FOR BASE SYSTEM' > "$TARGET/etc/fstab"
+-		chown 0:0 "$TARGET/etc/fstab"; chmod 644 "$TARGET/etc/fstab"
++		chmod 644 "$TARGET/etc/fstab"
+ 	fi
+
+ 	setup_devices
+@@ -96,7 +96,6 @@ Status: install ok installed" >> "$TARGET/var/lib/dpkg/status"
+ 	if doing_variant fakechroot; then
+ 		setup_proc_fakechroot
+ 	else
+-		setup_proc
+ 		in_target /sbin/ldconfig
+ 	fi
+
+@@ -166,6 +165,20 @@ echo
+ echo \"Warning: Fake start-stop-daemon called, doing nothing\"" > "$TARGET/sbin/start-stop-daemon"
+ 	chmod 755 "$TARGET/sbin/start-stop-daemon"
+
++	# Replace problematic binaries with a stub
++	echo "" > "$TARGET/bin/chown"
++	echo "" > "$TARGET/usr/sbin/groupadd"
++	echo "" > "$TARGET/usr/sbin/groupdel"
++	echo "" > "$TARGET/usr/sbin/groupmod"
++	echo "" > "$TARGET/usr/sbin/useradd"
++	echo "" > "$TARGET/usr/sbin/userdel"
++	echo "" > "$TARGET/usr/sbin/usermod"
++	echo "" > "$TARGET/usr/bin/chage"
++	echo "" > "$TARGET/usr/bin/chfn"
++	echo "" > "$TARGET/usr/bin/dpkg-statoverride"
++
++	echo "nameserver 8.8.8.8\nnameserver 8.8.4.4" > "$TARGET/etc/resolv.conf"
++
+ 	setup_dselect_method apt
+
+ 	smallyes '' |


### PR DESCRIPTION
Hello,

Here is a port of debootstrap to Termux.
It allows to easily install a complete Debian system in a folder.
We can then use `proot` to run it inside a chroot.

Here is what I had to patch:
* Use proot instead of chroot.
* Avoid using utilities that are not permitted on Android (chown, groupadd, etc.).
* Replace Debian's version of these utilities with a stub (so packages that use them in their postinstall script don't fail).
* Fix some hardcoded paths to `/usr/`.

Note that I only patched/tested the installation of Debian stable. The installation of other Debian-based distributions will probably require more work.