### PR TITLE
Texlive: fix #1068, #1069 by upgrading to texlive 2017

### DIFF
--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -78,6 +78,10 @@ termux_step_pre_configure() {
 
 termux_step_post_make_install () {
 	cp $TERMUX_PKG_BUILDER_DIR/termux-install-tl.sh $TERMUX_PREFIX/bin/termux-install-tl
+	mkdir -p $TERMUX_PREFIX/etc/profile.d/
+	echo "export PATH=\$PATH:$TERMUX_PREFIX/opt/texlive/${TERMUX_PKG_VERSION:0:4}/bin/custom/" >> $TERMUX_PREFIX/etc/profile.d/texlive.sh
+	echo "export TMPDIR=$TERMUX_PREFIX/tmp/" >> $TERMUX_PREFIX/etc/profile.d/texlive.sh
+	chmod 0744 $TERMUX_PREFIX/etc/profile.d/texlive.sh
 }
 
 termux_step_create_debscripts () {

--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -94,10 +94,17 @@ termux_step_create_debscripts () {
 	chmod 0755 postinst
 
 	# Clean texlive's folder if needed.
-	echo "if [ ! -f $TL_ROOT/install-tl ]; then exit 0; else echo 'Removing residual files from old version of TeX Live for Termux'; fi" > preinst
+	echo "if [ ! -f $TERMUX_PREFIX/opt/texlive/2016/install-tl ]; then exit 0; else echo 'Removing residual files from old version of TeX Live for Termux'; fi" > preinst
 	echo "rm -rf $TERMUX_PREFIX/{etc/profile.d/texlive.sh,opt/texlive}" >> preinst
 	echo "exit 0" >> preinst
 	chmod 0755 preinst
 
-
+	# Remove all files installed/downloaded through termux-install-tl
+	echo 'if [ $1 != "remove" ]; then exit 0; fi' > prerm
+	echo "echo Running texlinks --unlink" >> prerm
+	echo "texlinks --unlink" >> prerm
+	echo "echo Removing bin/custom and texmf-dist" >> prerm
+	echo "rm -rf $TL_ROOT/{bin/custom,texmf-dist}" >> prerm
+	echo "exit 0" >> prerm
+	chmod 0755 prerm
 }

--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -1,5 +1,6 @@
 TERMUX_PKG_HOMEPAGE=https://www.tug.org/texlive/
 TERMUX_PKG_DESCRIPTION="TeX Live is a distribution of the TeX typesetting system."
+TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
 _MAJOR_VERSION=20160523
 _MINOR_VERSION=b
 TERMUX_PKG_VERSION=${_MAJOR_VERSION}${_MINOR_VERSION}

--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -3,11 +3,13 @@ TERMUX_PKG_DESCRIPTION="TeX Live is a distribution of the TeX typesetting system
 _MAJOR_VERSION=20160523
 _MINOR_VERSION=b
 TERMUX_PKG_VERSION=${_MAJOR_VERSION}${_MINOR_VERSION}
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=ftp://tug.org/historic/systems/texlive/${TERMUX_PKG_VERSION:0:4}/texlive-${TERMUX_PKG_VERSION}-source.tar.xz
 TERMUX_PKG_SHA256="a8b32ca47f0a403661a09e202f4567a995beb718c18d8f81ca6d76daa1da21ed"
 TERMUX_PKG_DEPENDS="freetype, libpng, libgd, libgmp, libmpfr, libicu, liblua, poppler, libgraphite, harfbuzz-icu, perl, xz-utils, wget"
 TERMUX_PKG_FOLDERNAME=texlive-${_MAJOR_VERSION}-source
+
+TL_ROOT=$TERMUX_PREFIX/opt/texlive/${TERMUX_PKG_VERSION:0:4}
 
 # change the bin directory to "$TERMUX_PREFIX/opt/texlive/2016/bin/pkg" because the installer will symlink this to the actual bin dir..
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
@@ -16,12 +18,18 @@ RANLIB=ranlib \
 BUILDAR=ar \
 BUILDRANLIB=ranlib \
 ac_cv_c_bigendian=no \
---prefix=$TERMUX_PREFIX/opt/texlive/${TERMUX_PKG_VERSION:0:4} \
---bindir=$TERMUX_PREFIX/opt/texlive/${TERMUX_PKG_VERSION:0:4}/bin/pkg \
+--prefix=$TL_ROOT \
+--bindir=$TL_ROOT/bin/pkg \
+--datarootdir=$TL_ROOT \
+--datadir=$TERMUX_PREFIX/share \
+--mandir=$TERMUX_PREFIX/share/man \
+--docdir=$TERMUX_PREFIX/share/doc \
+--infodir=$TERMUX_PREFIX/share/info \
 --libdir=$TERMUX_PREFIX/lib \
+--includedir=$TERMUX_PREFIX/include \
 --build=$TERMUX_BUILD_TUPLE \
 --enable-ttfdump=no \
---enable-makeindexk=no \
+--enable-makeindexk=yes \
 --enable-makejvf=no \
 --enable-mendexk=no \
 --enable-musixtnt=no \
@@ -69,9 +77,6 @@ termux_step_pre_configure() {
 }
 
 termux_step_post_make_install () {
-	mkdir -p $TERMUX_PREFIX/share/man/man{1,5}/
-	mv $TERMUX_PREFIX/opt/texlive/2016/share/man/man1/* $TERMUX_PREFIX/share/man/man1/
-        mv $TERMUX_PREFIX/opt/texlive/2016/share/man/man5/* $TERMUX_PREFIX/share/man/man5/
 	cp $TERMUX_PKG_BUILDER_DIR/termux-install-tl.sh $TERMUX_PREFIX/bin/termux-install-tl
 }
 

--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -6,7 +6,7 @@ _MINOR_VERSION=
 TERMUX_PKG_VERSION=${_MAJOR_VERSION}${_MINOR_VERSION}
 TERMUX_PKG_SRCURL=ftp://tug.org/historic/systems/texlive/${TERMUX_PKG_VERSION:0:4}/texlive-${TERMUX_PKG_VERSION}-source.tar.xz
 TERMUX_PKG_SHA256="0161695304e941334dc0b3b5dabcf8edf46c09b7bc33eea8229b5ead7ccfb2aa"
-TERMUX_PKG_DEPENDS="freetype, libpng, libgd, libgmp, libmpfr, libicu, liblua, poppler, libgraphite, harfbuzz-icu, perl, xz-utils, wget"
+TERMUX_PKG_DEPENDS="freetype, libpng, libgd, libgmp, libmpfr, libicu, liblua, poppler, libgraphite, harfbuzz-icu, perl, xz-utils, wget, gnupg"
 TERMUX_PKG_FOLDERNAME=texlive-${_MAJOR_VERSION}-source
 
 TL_ROOT=$TERMUX_PREFIX/opt/texlive/${TERMUX_PKG_VERSION:0:4}

--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -1,18 +1,16 @@
 TERMUX_PKG_HOMEPAGE=https://www.tug.org/texlive/
 TERMUX_PKG_DESCRIPTION="TeX Live is a distribution of the TeX typesetting system."
 TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
-_MAJOR_VERSION=20160523
-_MINOR_VERSION=b
+_MAJOR_VERSION=20170524
+_MINOR_VERSION=
 TERMUX_PKG_VERSION=${_MAJOR_VERSION}${_MINOR_VERSION}
-TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=ftp://tug.org/historic/systems/texlive/${TERMUX_PKG_VERSION:0:4}/texlive-${TERMUX_PKG_VERSION}-source.tar.xz
-TERMUX_PKG_SHA256="a8b32ca47f0a403661a09e202f4567a995beb718c18d8f81ca6d76daa1da21ed"
+TERMUX_PKG_SHA256="0161695304e941334dc0b3b5dabcf8edf46c09b7bc33eea8229b5ead7ccfb2aa"
 TERMUX_PKG_DEPENDS="freetype, libpng, libgd, libgmp, libmpfr, libicu, liblua, poppler, libgraphite, harfbuzz-icu, perl, xz-utils, wget"
 TERMUX_PKG_FOLDERNAME=texlive-${_MAJOR_VERSION}-source
 
 TL_ROOT=$TERMUX_PREFIX/opt/texlive/${TERMUX_PKG_VERSION:0:4}
 
-# change the bin directory to "$TERMUX_PREFIX/opt/texlive/2016/bin/pkg" because the installer will symlink this to the actual bin dir..
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 AR=ar \
 RANLIB=ranlib \
@@ -67,10 +65,6 @@ ac_cv_c_bigendian=no \
 --with-system-lua \
 --without-x \
 --with-banner-add=/Termux"
-
-termux_step_post_extract_package () {
-	rm -rdf $TERMUX_PKG_SRCDIR/libs/luajit
-}
 
 termux_step_pre_configure() {
 	# When building against libicu 59.1 or later we need c++11:

--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -92,4 +92,12 @@ termux_step_create_debscripts () {
 	echo "termux-install-tl" >> postinst
 	echo "exit 0" >> postinst
 	chmod 0755 postinst
+
+	# Clean texlive's folder if needed.
+	echo "if [ ! -f $TL_ROOT/install-tl ]; then exit 0; else echo 'Removing residual files from old version of TeX Live for Termux'; fi" > preinst
+	echo "rm -rf $TERMUX_PREFIX/{etc/profile.d/texlive.sh,opt/texlive}" >> preinst
+	echo "exit 0" >> preinst
+	chmod 0755 preinst
+
+
 }

--- a/packages/texlive/termux-install-tl.sh
+++ b/packages/texlive/termux-install-tl.sh
@@ -6,7 +6,7 @@ export TMPDIR=$PREFIX/tmp/
 mkdir -p $TMPDIR/termux-tl-installer
 cd $TMPDIR/termux-tl-installer
 
-wget http://mirror.ctan.org/systems/texlive/Source/install-tl-unx.tar.gz -O install-tl-unx.tar.gz
+wget ftp://ftp.tug.org/texlive/historic/$TL_VERSION/install-tl-unx.tar.gz -O install-tl-unx.tar.gz
 tar xzfv install-tl-unx.tar.gz > flist
 
 cd $(head -1 flist) 
@@ -51,13 +51,6 @@ XXHEREXX
 
 #start installer with a profile and premade binaries
 perl ./install-tl --custom-bin=$TL_ROOT/${TL_VERSION}/bin/pkg --profile texlive_inst.profile 
-
-mkdir -p $PREFIX/etc/profile.d/
-
-cat > $PREFIX/etc/profile.d/texlive.sh << XXHEREXX
-export PATH=\$PATH:$TL_ROOT/${TL_VERSION}/bin/custom
-export TMPDIR=$PREFIX/tmp/
-XXHEREXX
 
 #fix tlpkg
 sed -E -i "s@/bin/sh@$PREFIX/bin/sh@" ${TL_ROOT}/${TL_VERSION}/tlpkg/TeXLive/TLUtils.pm

--- a/packages/texlive/termux-install-tl.sh
+++ b/packages/texlive/termux-install-tl.sh
@@ -12,7 +12,7 @@ tar xzfv install-tl-unx.tar.gz > flist
 cd $(head -1 flist) 
 
 #patch install-tl
-sed -E -i "s@/bin/sh@$PREFIX/bin/sh@" tlpkg/TeXLive/TLUtils.pm 
+sed -E -i "s@\`/bin/sh@\`$PREFIX/bin/sh@g" tlpkg/TeXLive/TLUtils.pm 
 
 cat > texlive_inst.profile << XXHEREXX
 
@@ -53,7 +53,7 @@ XXHEREXX
 perl ./install-tl --custom-bin=$TL_ROOT/${TL_VERSION}/bin/pkg --profile texlive_inst.profile 
 
 #fix tlpkg
-sed -E -i "s@/bin/sh@$PREFIX/bin/sh@" ${TL_ROOT}/${TL_VERSION}/tlpkg/TeXLive/TLUtils.pm
+sed -E -i "s@\`/bin/sh@\`$PREFIX/bin/sh@g" ${TL_ROOT}/${TL_VERSION}/tlpkg/TeXLive/TLUtils.pm
 
 #fix shebangs
 sed -i -E "1 s@^#\!(.*)/[sx]?bin/(.*)@#\!$PREFIX/bin/\2@" ${TL_ROOT}/${TL_VERSION}/texmf-dist/web2c/*

--- a/packages/texlive/termux-install-tl.sh
+++ b/packages/texlive/termux-install-tl.sh
@@ -1,5 +1,5 @@
 
-TL_VERSION=2016
+TL_VERSION=2017
 TL_ROOT=$PREFIX/opt/texlive
 
 export TMPDIR=$PREFIX/tmp/ 
@@ -15,38 +15,35 @@ cd $(head -1 flist)
 sed -E -i "s@\`/bin/sh@\`$PREFIX/bin/sh@g" tlpkg/TeXLive/TLUtils.pm 
 
 cat > texlive_inst.profile << XXHEREXX
-
-selected_scheme scheme-custom
-TEXDIR ${TL_ROOT}/${TL_VERSION}
-TEXMFCONFIG ~/.texlive${TL_VERSION}/texmf-config
+selected_scheme scheme-basic
+TEXDIR $TL_ROOT/$TL_VERSION
+TEXMFCONFIG ~/.texlive$TL_VERSION/texmf-config
 TEXMFHOME ~/texmf
-TEXMFLOCAL ${TL_ROOT}/texmf-local
-TEXMFSYSCONFIG ${TL_ROOT}/${TL_VERSION}/texmf-config
-TEXMFSYSVAR ${TL_ROOT}/${TL_VERSION}/texmf-var
-TEXMFVAR ~/.texlive${TL_VERSION}/texmf-var
+TEXMFLOCAL $TL_ROOT/texmf-local
+TEXMFSYSCONFIG $TL_ROOT/$TL_VERSION/texmf-config
+TEXMFSYSVAR $TL_ROOT/$TL_VERSION/texmf-var
+TEXMFVAR ~/.texlive$TL_VERSION/texmf-var
 collection-basic 1
 collection-latex 1
 collection-luatex 1
-in_place 0
-option_adjustrepo 1
-option_autobackup 1
-option_backupdir tlpkg/backups
-option_desktop_integration 0
-option_doc 0
-option_file_assocs 0
-option_fmt 1
-option_letter 0
-option_menu_integration 1
-option_path 0
-option_post_code 1
-option_src 0
-option_sys_bin $PREFIX/bin
-option_sys_info $PREFIX/share/info
-option_sys_man $PREFIX/share/man
-option_w32_multi_user 0
-option_write18_restricted 1
-portable 0
-
+instopt_adjustpath 0
+instopt_adjustrepo 1
+instopt_letter 0
+instopt_portable 0
+instopt_write18_restricted 1
+tlpdbopt_autobackup 1
+tlpdbopt_backupdir tlpkg/backups
+tlpdbopt_create_formats 1
+tlpdbopt_desktop_integration 0
+tlpdbopt_file_assocs 0
+tlpdbopt_generate_updmap 0
+tlpdbopt_install_docfiles 0
+tlpdbopt_install_srcfiles 0
+tlpdbopt_post_code 1
+tlpdbopt_sys_bin $PREFIX/bin
+tlpdbopt_sys_info $PREFIX/share/info
+tlpdbopt_sys_man $PREFIX/share/man
+tlpdbopt_w32_multi_user 0
 XXHEREXX
 
 #start installer with a profile and premade binaries

--- a/packages/texlive/termux-install-tl.sh
+++ b/packages/texlive/termux-install-tl.sh
@@ -41,8 +41,8 @@ option_path 0
 option_post_code 1
 option_src 0
 option_sys_bin $PREFIX/bin
-option_sys_info $PREFIX/local/share/info
-option_sys_man $PREFIX/local/share/man
+option_sys_info $PREFIX/share/info
+option_sys_man $PREFIX/share/man
 option_w32_multi_user 0
 option_write18_restricted 1
 portable 0


### PR DESCRIPTION
Also various improvements: split package into texlive and texlive-dev, remove most of the files in the texlive tree on uninstall. 