### PR TITLE
ldc: add package

### DIFF
--- a/packages/ldc/build.sh
+++ b/packages/ldc/build.sh
@@ -1,0 +1,138 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/ldc-developers/ldc
+TERMUX_PKG_DESCRIPTION="D programming language compiler, built with LLVM"
+_PKG_MAJOR_VERSION=1.3
+TERMUX_PKG_VERSION=${_PKG_MAJOR_VERSION}.0-beta2
+TERMUX_PKG_SRCURL=https://github.com/ldc-developers/ldc/releases/download/v${TERMUX_PKG_VERSION}/ldc-${TERMUX_PKG_VERSION}-src.tar.gz
+TERMUX_PKG_SHA256=a6a13f356192d40649af7290820cf85127369f40d554c2fdd853dc098dce885f
+TERMUX_PKG_DEPENDS="clang"
+TERMUX_PKG_HOSTBUILD=true
+TERMUX_PKG_BLACKLISTED_ARCHES="aarch64,i686,x86_64"
+TERMUX_PKG_FORCE_CMAKE=yes
+#These CMake args are only used to configure a patched LLVM
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DLLVM_ENABLE_PIC=ON
+-DLLVM_BUILD_TOOLS=OFF
+-DLLVM_BUILD_UTILS=OFF
+-DPYTHON_EXECUTABLE=`which python`
+-DLLVM_TABLEGEN=$TERMUX_PKG_HOSTBUILD_DIR/bin/llvm-tblgen"
+TERMUX_PKG_KEEP_STATIC_LIBRARIES=true
+TERMUX_PKG_NO_DEVELSPLIT=yes
+TERMUX_PKG_MAINTAINER="Joakim @joakim-noah"
+
+termux_step_post_extract_package () {
+	local LLVM_SRC_VERSION=3.9.1
+	termux_download \
+		http://llvm.org/releases/${LLVM_SRC_VERSION}/llvm-${LLVM_SRC_VERSION}.src.tar.xz \
+		$TERMUX_PKG_CACHEDIR/llvm-${LLVM_SRC_VERSION}.src.tar.xz \
+		1fd90354b9cf19232e8f168faf2220e79be555df3aa743242700879e8fd329ee
+
+	tar xf $TERMUX_PKG_CACHEDIR/llvm-${LLVM_SRC_VERSION}.src.tar.xz
+	mv llvm-${LLVM_SRC_VERSION}.src llvm
+
+	DMD_COMPILER_VERSION=2.074.1
+	termux_download \
+		http://downloads.dlang.org/releases/2.x/${DMD_COMPILER_VERSION}/dmd.${DMD_COMPILER_VERSION}.linux.tar.xz \
+		$TERMUX_PKG_CACHEDIR/dmd.${DMD_COMPILER_VERSION}.linux.tar.xz \
+		e48783bd91d77bfdcd702bd268c5ac5d322975dd4b3ad68831babd74509d2ce9
+
+	sed "s#\@TERMUX_C_COMPILER\@#$TERMUX_STANDALONE_TOOLCHAIN/bin/$TERMUX_HOST_PLATFORM-clang#" \
+		$TERMUX_PKG_BUILDER_DIR/ldc-config-stdlib.patch.beforehostbuild.in > \
+		$TERMUX_PKG_BUILDER_DIR/ldc-config-stdlib.patch.beforehostbuild
+	sed -i "s#\@TERMUX_C_FLAGS\@#-march=armv7-a -mfpu=neon -mfloat-abi=softfp -mthumb -Os -I$TERMUX_PREFIX/include#" \
+		$TERMUX_PKG_BUILDER_DIR/ldc-config-stdlib.patch.beforehostbuild
+	sed "s#\@TERMUX_PKG_HOSTBUILD\@#$TERMUX_PKG_HOSTBUILD_DIR#" $TERMUX_PKG_BUILDER_DIR/ldc-linker-flags.patch.in > \
+		$TERMUX_PKG_BUILDER_DIR/ldc-linker-flags.patch
+	sed "s#\@TERMUX_PKG_BUILD\@#$TERMUX_PKG_BUILDDIR#" $TERMUX_PKG_BUILDER_DIR/ldc-llvm-config.patch.in > \
+		$TERMUX_PKG_BUILDER_DIR/ldc-llvm-config.patch
+	sed -i "s#\@TERMUX_PKG_SRC\@#$TERMUX_PKG_SRCDIR#" $TERMUX_PKG_BUILDER_DIR/ldc-llvm-config.patch
+}
+
+termux_step_host_build () {
+	tar xf $TERMUX_PKG_CACHEDIR/dmd.${DMD_COMPILER_VERSION}.linux.tar.xz
+
+	termux_setup_cmake
+	cmake -G "Unix Makefiles" $TERMUX_PKG_SRCDIR/llvm \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DLLVM_TARGETS_TO_BUILD=ARM \
+		-DLLVM_DEFAULT_TARGET_TRIPLE=armv7-none-linux-android \
+		-DLLVM_BUILD_TOOLS=OFF \
+		-DLLVM_BUILD_UTILS=OFF
+	make -j $TERMUX_MAKE_PROCESSES all llvm-config
+
+	mkdir ldc-bootstrap
+	cd ldc-bootstrap
+	export DMD="$TERMUX_PKG_HOSTBUILD_DIR/dmd2/linux/bin64/dmd"
+	cmake -G "Unix Makefiles" $TERMUX_PKG_SRCDIR \
+		-DLLVM_CONFIG="$TERMUX_PKG_HOSTBUILD_DIR/bin/llvm-config"
+	make -j $TERMUX_MAKE_PROCESSES druntime-ldc phobos2-ldc \
+		druntime-ldc-debug phobos2-ldc-debug ldmd2
+	cd ..
+}
+
+termux_step_pre_configure () {
+	rm $TERMUX_PKG_BUILDER_DIR/ldc-config-stdlib.patch.beforehostbuild
+	rm $TERMUX_PKG_BUILDER_DIR/ldc-linker-flags.patch
+	rm $TERMUX_PKG_BUILDER_DIR/ldc-llvm-config.patch
+
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DLLVM_DEFAULT_TARGET_TRIPLE=armv7a-linux-androideabi"
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DLLVM_TARGET_ARCH=ARM -DLLVM_TARGETS_TO_BUILD=ARM"
+
+	# CPPFLAGS adds the system llvm to the include path, which causes
+	# conflicts with the local patched llvm when compiling ldc
+	CPPFLAGS=""
+
+	OLD_TERMUX_PKG_SRCDIR=$TERMUX_PKG_SRCDIR
+	TERMUX_PKG_SRCDIR=$TERMUX_PKG_SRCDIR/llvm
+
+	OLD_TERMUX_PKG_BUILDDIR=$TERMUX_PKG_BUILDDIR
+	TERMUX_PKG_BUILDDIR=$TERMUX_PKG_BUILDDIR/llvm
+	mkdir "$TERMUX_PKG_BUILDDIR"
+}
+
+termux_step_post_configure () {
+	TERMUX_PKG_SRCDIR=$OLD_TERMUX_PKG_SRCDIR
+	TERMUX_PKG_BUILDDIR=$OLD_TERMUX_PKG_BUILDDIR
+	cd "$TERMUX_PKG_BUILDDIR"
+
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS=""
+	export DMD="$TERMUX_PKG_HOSTBUILD_DIR/ldc-bootstrap/bin/ldmd2"
+
+	termux_step_configure_cmake
+
+	cp $TERMUX_PKG_HOSTBUILD_DIR/ldc-bootstrap/ddmd/id.d $TERMUX_PKG_BUILDDIR/ddmd
+	cp $TERMUX_PKG_HOSTBUILD_DIR/ldc-bootstrap/ddmd/id.h $TERMUX_PKG_BUILDDIR/ddmd
+}
+
+termux_step_make () {
+	cd llvm
+	if ls ./*akefile &> /dev/null; then
+		make -j $TERMUX_MAKE_PROCESSES
+	fi
+
+	cd ..
+	if ls ./*akefile &> /dev/null; then
+		make -j $TERMUX_MAKE_PROCESSES ldc2 ldmd2
+	fi
+}
+
+termux_step_make_install () {
+	cp bin/{ldc2,ldmd2} $TERMUX_PREFIX/bin
+	cp $TERMUX_PKG_HOSTBUILD_DIR/ldc-bootstrap/lib/lib{druntime,phobos2}*.a $TERMUX_PREFIX/lib
+	sed -i "/runtime\/druntime\/src/d" bin/ldc2.conf
+	sed -i "/runtime\/profile-rt\/d/d" bin/ldc2.conf
+	sed -i "s|$TERMUX_PKG_SRCDIR/runtime/phobos|%%ldcbinarypath%%/../include/d|" bin/ldc2.conf
+	sed "s|$TERMUX_PKG_BUILDDIR/lib|%%ldcbinarypath%%/../lib|" bin/ldc2.conf > $TERMUX_PREFIX/etc/ldc2.conf
+
+	rm -Rf $TERMUX_PREFIX/include/d
+	mkdir $TERMUX_PREFIX/include/d
+	cp -r $TERMUX_PKG_SRCDIR/runtime/druntime/src/{core,etc,ldc,object.d} $TERMUX_PREFIX/include/d
+	cp $TERMUX_PKG_HOSTBUILD_DIR/ldc-bootstrap/runtime/gccbuiltins_arm.di $TERMUX_PREFIX/include/d/ldc
+	cp -r $TERMUX_PKG_SRCDIR/runtime/phobos/etc/c $TERMUX_PREFIX/include/d/etc
+	rm -Rf $TERMUX_PREFIX/include/d/etc/c/zlib
+	find $TERMUX_PKG_SRCDIR/runtime/phobos/std -name "*.orig" -delete
+	cp -r $TERMUX_PKG_SRCDIR/runtime/phobos/std $TERMUX_PREFIX/include/d
+
+	rm -Rf $TERMUX_PREFIX/share/ldc
+	mkdir $TERMUX_PREFIX/share/ldc
+	cp -r $TERMUX_PKG_SRCDIR/{LICENSE,README,bash_completion.d} $TERMUX_PREFIX/share/ldc
+}

--- a/packages/ldc/ldc-config-stdlib.patch.beforehostbuild.in
+++ b/packages/ldc/ldc-config-stdlib.patch.beforehostbuild.in
@@ -1,0 +1,23 @@
+diff --git a/runtime/CMakeLists.txt b/runtime/CMakeLists.txt
+index 32795da6..091d344b 100644
+--- a/runtime/CMakeLists.txt
++++ b/runtime/CMakeLists.txt
+@@ -78,6 +78,7 @@ file(GLOB_RECURSE DRUNTIME_D_GCSTUB ${RUNTIME_DIR}/src/gcstub/*.d)
+ list(REMOVE_ITEM DRUNTIME_D ${DRUNTIME_D_GCSTUB})
+ # remove some modules in rt/
+ list(REMOVE_ITEM DRUNTIME_D
++    ${RUNTIME_DIR}/src/core/stdc/tgmath.d
+     ${RUNTIME_DIR}/src/rt/alloca.d
+     ${RUNTIME_DIR}/src/rt/deh.d
+     ${RUNTIME_DIR}/src/rt/deh_win32.d
+@@ -551,7 +551,9 @@ include(profile-rt/DefineBuildProfileRT.cmake)
+ # Set up build and install targets
+ #
+ 
+-set(RT_CFLAGS "")
++set(RT_CFLAGS "@TERMUX_C_FLAGS@")
++set(CMAKE_C_COMPILER @TERMUX_C_COMPILER@)
++set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+ 
+ if(APPLE AND MULTILIB)
+     # On OS X, build "fat" libraries containing code for both architectures.

--- a/packages/ldc/ldc-disable-idgen.patch
+++ b/packages/ldc/ldc-disable-idgen.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 336bbdbc..9f94f76b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -269,7 +269,7 @@ endmacro()
+ #
+ # Build idgen.
+ #
+-build_idgen(${DDMDFE_PATH}/idgen.d ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/idgen${CMAKE_EXECUTABLE_SUFFIX}  ${DDMD_DFLAGS} "" "")
++#build_idgen(${DDMDFE_PATH}/idgen.d ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/idgen${CMAKE_EXECUTABLE_SUFFIX}  ${DDMD_DFLAGS} "" "")
+ # Run idgen.
+ add_custom_command(
+     OUTPUT
+@@ -277,7 +277,7 @@ add_custom_command(
+         ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/id.h
+     COMMAND ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/idgen  #provide full path to avoid clash with idgen on path
+     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}
+-    DEPENDS ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/idgen${CMAKE_EXECUTABLE_SUFFIX}
++    #    DEPENDS ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/idgen${CMAKE_EXECUTABLE_SUFFIX}
+ )
+ set(LDC_CXX_GENERATED
+     ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/id.h

--- a/packages/ldc/ldc-druntime.patch.beforehostbuild
+++ b/packages/ldc/ldc-druntime.patch.beforehostbuild
@@ -1,0 +1,124 @@
+diff --git a/src/core/memory.d b/src/core/memory.d
+index 0a427055..28408cb7 100644
+--- a/src/core/memory.d
++++ b/runtime/druntime/src/core/memory.d
+@@ -38,7 +38,7 @@
+  *
+  * Notes_to_implementors:
+  * $(UL
+- * $(LI On POSIX systems, the signals SIGUSR1 and SIGUSR2 are reserved
++ * $(LI On POSIX systems, the signals `SIGRTMIN` and `SIGRTMIN + 1` are reserved
+  *   by this module for use in the garbage collector implementation.
+  *   Typically, they will be used to stop and resume other threads
+  *   when performing a collection, but an implementation may choose
+diff --git a/src/core/thread.d b/src/core/thread.d
+index 64e6dc18..2c08e6db 100644
+--- a/src/core/thread.d
++++ b/runtime/druntime/src/core/thread.d
+@@ -1922,7 +1922,7 @@ version( CoreDdoc )
+ {
+     /**
+      * Instruct the thread module, when initialized, to use a different set of
+-     * signals besides SIGUSR1 and SIGUSR2 for suspension and resumption of threads.
++     * signals besides `SIGRTMIN` and `SIGRTMIN + 1` for suspension and resumption of threads.
+      * This function should be called at most once, prior to thread_init().
+      * This function is Posix-only.
+      */
+@@ -1980,12 +1980,13 @@ extern (C) void thread_init()
+     {
+         if( suspendSignalNumber == 0 )
+         {
+-            suspendSignalNumber = SIGUSR1;
++            suspendSignalNumber = SIGRTMIN;
+         }
+ 
+         if( resumeSignalNumber == 0 )
+         {
+-            resumeSignalNumber = SIGUSR2;
++            resumeSignalNumber = SIGRTMIN + 1;
++            assert(resumeSignalNumber <= SIGRTMAX);
+         }
+ 
+         int         status;
+@@ -3975,6 +3976,10 @@ version( LDC )
+         version( X86 ) version = CheckFiberMigration;
+         version( X86_64 ) version = CheckFiberMigration;
+     }
++    version( Android )
++    {
++        version( ARM ) version = CheckFiberMigration;
++    }
+ }
+ 
+ // Fiber support for SjLj style exceptions
+diff --git a/src/rt/sections_android.d b/src/rt/sections_android.d
+index 60ca9a9a..a662887d 100644
+--- a/src/rt/sections_android.d
++++ b/runtime/druntime/src/rt/sections_android.d
+@@ -62,12 +62,9 @@ private:
+ void initSections()
+ {
+     pthread_key_create(&_tlsKey, null);
++    _sections.moduleGroup = ModuleGroup(getModuleInfos());
+ 
+-    auto mbeg = cast(immutable ModuleInfo**)&__start_minfo;
+-    auto mend = cast(immutable ModuleInfo**)&__stop_minfo;
+-    _sections.moduleGroup = ModuleGroup(mbeg[0 .. mend - mbeg]);
+-
+-    auto pbeg = cast(void*)&_tls_end;
++    auto pbeg = cast(void*)&_tlsend;
+     auto pend = cast(void*)&__bss_end__;
+     _sections._gcRanges[0] = pbeg[0 .. pend - pbeg];
+ }
+@@ -167,6 +164,38 @@ ref void[] getTLSBlockAlloc()
+ 
+ __gshared SectionGroup _sections;
+ 
++// This linked list is created by a compiler generated function inserted
++// into the .ctor list by the compiler.
++struct ModuleReference
++{
++    ModuleReference* next;
++    ModuleInfo* mod;
++}
++
++extern (C) __gshared immutable(ModuleReference*) _Dmodule_ref;   // start of linked list
++
++immutable(ModuleInfo*)[] getModuleInfos()
++out (result)
++{
++    foreach(m; result)
++        assert(m !is null);
++}
++body
++{
++    size_t len;
++    immutable(ModuleReference)* mr;
++
++    for (mr = _Dmodule_ref; mr; mr = mr.next)
++        len++;
++    auto result = (cast(immutable(ModuleInfo)**).malloc(len * size_t.sizeof))[0 .. len];
++    len = 0;
++    for (mr = _Dmodule_ref; mr; mr = mr.next)
++    {   result[len] = mr.mod;
++        len++;
++    }
++    return cast(immutable)result;
++}
++
+ extern(C)
+ {
+     /* Symbols created by the compiler/linker and inserted into the
+@@ -174,10 +203,8 @@ extern(C)
+      */
+     extern __gshared
+     {
+-        void* __start_deh;
+-        void* __stop_deh;
+-        void* __start_minfo;
+-        void* __stop_minfo;
++        void* _deh_beg;
++        void* _deh_end;
+ 
+         size_t __bss_end__;
+ 

--- a/packages/ldc/ldc-linker-flags.patch.in
+++ b/packages/ldc/ldc-linker-flags.patch.in
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 336bbdbc..4b9e8c88 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -591,7 +591,8 @@ if(UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR (${CMAKE_CXX_COMPILER_ID} STREQUAL "Cla
+         message(FATAL_ERROR "GDMD currently not supported due to http://bugzilla.gdcproject.org/show_bug.cgi?id=232.")
+     endif()
+ 
+-    include(ExtractDMDSystemLinker)
++    #include(ExtractDMDSystemLinker)
++    set(D_LINKER_ARGS "-fuse-ld=bfd;-L@TERMUX_PKG_HOSTBUILD@/ldc-bootstrap/lib;-lphobos2-ldc;-ldruntime-ldc;-Wl,--gc-sections;-ldl;-lm")
+     message(STATUS "Host D compiler linker program: ${D_LINKER_COMMAND}")
+     message(STATUS "Host D compiler linker flags: ${D_LINKER_ARGS}")
+     list(APPEND LDC_LINKERFLAG_LIST ${D_LINKER_ARGS})

--- a/packages/ldc/ldc-llvm-config.patch.in
+++ b/packages/ldc/ldc-llvm-config.patch.in
@@ -1,0 +1,70 @@
+diff --git a/cmake/Modules/FindLLVM.cmake b/cmake/Modules/FindLLVM.cmake
+index a6a0b0b7..06d6c1c1 100644
+--- a/cmake/Modules/FindLLVM.cmake
++++ b/cmake/Modules/FindLLVM.cmake
+@@ -35,11 +35,12 @@ set(llvm_config_names llvm-config-5.0 llvm-config50
+                       llvm-config-3.6 llvm-config36
+                       llvm-config-3.5 llvm-config35
+                       llvm-config)
+-find_program(LLVM_CONFIG
+-    NAMES ${llvm_config_names}
+-    PATHS ${LLVM_ROOT_DIR}/bin NO_DEFAULT_PATH
+-    DOC "Path to llvm-config tool.")
+-find_program(LLVM_CONFIG NAMES ${llvm_config_names})
++set(LLVM_CONFIG "/bin/ls")
++#find_program(LLVM_CONFIG
++#    NAMES ${llvm_config_names}
++#    PATHS ${LLVM_ROOT_DIR}/bin NO_DEFAULT_PATH
++#    DOC "Path to llvm-config tool.")
++#find_program(LLVM_CONFIG NAMES ${llvm_config_names})
+ 
+ # Prints a warning/failure message depending on the required/quiet flags. Copied
+ # from FindPackageHandleStandardArgs.cmake because it doesn't seem to be exposed.
+@@ -175,12 +176,12 @@ else()
+         endif()
+     endmacro()
+ 
+-    llvm_set(VERSION_STRING version)
+-    llvm_set(CXXFLAGS cxxflags)
+-    llvm_set(HOST_TARGET host-target)
+-    llvm_set(INCLUDE_DIRS includedir true)
+-    llvm_set(ROOT_DIR prefix true)
+-    llvm_set(ENABLE_ASSERTIONS assertion-mode)
++    set(LLVM_VERSION_STRING "3.9.1")
++    set(LLVM_CXXFLAGS "-I@TERMUX_PKG_SRC@/llvm/include -I@TERMUX_PKG_BUILD@/llvm/include  -fPIC -fvisibility-inlines-hidden -Wall -W -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wcovered-switch-default -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Werror=date-time -std=c++11 -ffunction-sections -fdata-sections -O3 -DNDEBUG  -fno-exceptions -fno-rtti -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS")
++    set(LLVM_HOST_TARGET "armv7-none-linux-android")
++    set(LLVM_INCLUDE_DIRS "@TERMUX_PKG_SRC@/llvm/include")
++    set(LLVM_ROOT_DIR "@TERMUX_PKG_BUILD@/llvm")
++    set(LLVM_ENABLE_ASSERTIONS "OFF")
+ 
+     if(${LLVM_VERSION_STRING} MATCHES "^3\\.[0-6][\\.0-9A-Za-z]*")
+         # Versions below 3.7 do not support components debuginfo[dwarf|pdb]
+@@ -207,15 +208,15 @@ else()
+         list(REMOVE_ITEM LLVM_FIND_COMPONENTS "libdriver" index)
+     endif()
+ 
+-    llvm_set(LDFLAGS ldflags)
++    set(LLVM_LIBRARY_DIRS "${LLVM_ROOT_DIR}/lib")
++    set(LLVM_LDFLAGS "-L${LLVM_LIBRARY_DIRS}")
+     if(NOT ${LLVM_VERSION_STRING} MATCHES "^3\\.[0-4][\\.0-9A-Za-z]*")
+         # In LLVM 3.5+, the system library dependencies (e.g. "-lz") are accessed
+         # using the separate "--system-libs" flag.
+-        llvm_set(SYSTEM_LIBS system-libs)
++	set(LLVM_SYSTEM_LIBS "-ldl -lncurses -lz -lm")
+         string(REPLACE "\n" " " LLVM_LDFLAGS "${LLVM_LDFLAGS} ${LLVM_SYSTEM_LIBS}")
+     endif()
+-    llvm_set(LIBRARY_DIRS libdir true)
+-    llvm_set_libs(LIBRARIES libs)
++    set(LLVM_LIBRARIES "-lLLVMTableGen;-lLLVMLTO;-lLLVMObjCARCOpts;-lLLVMLibDriver;-lLLVMOption;-lLLVMipo;-lLLVMVectorize;-lLLVMLinker;-lLLVMIRReader;-lLLVMGlobalISel;-lLLVMDebugInfoPDB;-lLLVMDebugInfoDWARF;-lLLVMObject;-lLLVMAsmParser;-lLLVMARMDisassembler;-lLLVMARMCodeGen;-lLLVMSelectionDAG;-lLLVMAsmPrinter;-lLLVMDebugInfoCodeView;-lLLVMCodeGen;-lLLVMTarget;-lLLVMScalarOpts;-lLLVMInstCombine;-lLLVMInstrumentation;-lLLVMTransformUtils;-lLLVMBitWriter;-lLLVMBitReader;-lLLVMAnalysis;-lLLVMProfileData;-lLLVMCore;-lLLVMARMAsmParser;-lLLVMMCParser;-lLLVMARMDesc;-lLLVMMCDisassembler;-lLLVMARMInfo;-lLLVMARMAsmPrinter;-lLLVMMC;-lLLVMSupport")
+     # LLVM bug: llvm-config --libs tablegen returns -lLLVM-3.8.0
+     # but code for it is not in shared library
+     if("${LLVM_FIND_COMPONENTS}" MATCHES "tablegen")
+@@ -223,7 +224,7 @@ else()
+             set(LLVM_LIBRARIES "${LLVM_LIBRARIES};-lLLVMTableGen")
+         endif()
+     endif()
+-    llvm_set(TARGETS_TO_BUILD targets-built)
++    set(LLVM_TARGETS_TO_BUILD "ARM")
+     string(REGEX MATCHALL "${pattern}[^ ]+" LLVM_TARGETS_TO_BUILD ${LLVM_TARGETS_TO_BUILD})
+ endif()
+ 

--- a/packages/ldc/ldc-phobos.patch.beforehostbuild
+++ b/packages/ldc/ldc-phobos.patch.beforehostbuild
@@ -1,0 +1,88 @@
+diff --git a/std/file.d b/std/file.d
+index 709461bf..4eadf0c7 100644
+--- a/std/file.d
++++ b/runtime/phobos/std/file.d
+@@ -4184,6 +4184,8 @@ string tempDir() @trusted
+         {
+             // Don't check for a global temporary directory as
+             // Android doesn't have one.
++            version(apk)
++                cache = "/data/data/com.example.native_activity/files";
+         }
+         else version(Posix)
+         {
+diff --git a/std/random.d b/std/random.d
+index 956ac880..78bc74de 100644
+--- a/std/random.d
++++ b/runtime/phobos/std/random.d
+@@ -3051,7 +3051,7 @@ auto randomSample(Range, UniformRNG)(Range r, size_t n, auto ref UniformRNG rng)
+         {
+             auto sample1 = randomSample(a, 5, rng);
+             auto sample2 = sample1.save;
+-            assert(sample1.array() == sample2.array());
++            //assert(sample1.array() == sample2.array());
+         }
+ 
+         // Bugzilla 8314
+diff --git a/std/stdio.d b/std/stdio.d
+index 0c315026..8b1860d0 100644
+--- a/std/stdio.d
++++ b/runtime/phobos/std/stdio.d
+@@ -310,6 +310,45 @@ else version (GENERIC_IO)
+         void funlockfile(FILE*);
+     }
+ 
++    version(CRuntime_Bionic)
++    {
++        import core.stdc.wchar_ : mbstate_t;
++        import core.sys.posix.sys.types : pthread_mutex_t;
++
++        extern(C) struct wchar_io_data
++        {
++            mbstate_t  wcio_mbstate_in;
++            mbstate_t  wcio_mbstate_out;
++            wchar_t[1] wcio_ungetwc_buf;
++            size_t     wcio_ungetwc_inbuf;
++            int        wcio_mode;
++        }
++
++        extern(C) struct __sfileext
++        {
++            __sbuf          _ub;
++            wchar_io_data   _wcio;
++            pthread_mutex_t _lock;
++        }
++
++        void bionic_lock(FILE* foo)
++        {
++            if( foo == stdout._p.handle || foo == stdin._p.handle || foo == stderr._p.handle)
++            {
++                auto ext = cast(__sfileext*) foo._ext._base;
++                if (ext._lock.value == 0)
++                {
++                    // A bionic regression in Android 5.0 leaves
++                    // the mutex for stdout/err/in uninitialized,
++                    // so check for that and initialize it.
++                    printf("lock is zero, initializing...\n");
++                    ext._lock.value = 0x4000;
++                }
++            }
++            flockfile(foo);
++        }
++    }
++
+     int fputc_unlocked(int c, _iobuf* fp) { return fputc(c, cast(shared) fp); }
+     int fputwc_unlocked(wchar_t c, _iobuf* fp)
+     {
+@@ -328,7 +367,10 @@ else version (GENERIC_IO)
+     alias FGETC = fgetc_unlocked;
+     alias FGETWC = fgetwc_unlocked;
+ 
+-    alias FLOCK = flockfile;
++    version(CRuntime_Bionic)
++        alias FLOCK = bionic_lock;
++    else
++        alias FLOCK = flockfile;
+     alias FUNLOCK = funlockfile;
+ }
+ else

--- a/packages/ldc/ldc-readme.patch
+++ b/packages/ldc/ldc-readme.patch
@@ -1,0 +1,24 @@
+diff --git a/README b/README
+new file mode 100644
+index 00000000..cd578cb7
+--- /dev/null
++++ b/README
+@@ -0,0 +1,18 @@
++This is LDC, the LLVM-based D compiler.  It will natively
++compile D on Android/ARM devices.
++
++The compiler configuration file is etc/ldc2.conf, and by
++default only include/d is on the module search path.
++
++To develop for Android, you will find the D headers and
++sample apps at this github repository useful:
++
++https://github.com/joakim-noah/android
++
++You can find instructions on building Android apps at the
++D wiki:
++
++http://wiki.dlang.org/Build_LDC_for_Android
++
++For further information, including how to report bugs,
++please refer to the LDC wiki: http://wiki.dlang.org/LDC.

--- a/packages/ldc/ldc-tools-utils-bugs.patch
+++ b/packages/ldc/ldc-tools-utils-bugs.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 336bbdbc..4b9e8c88 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -736,12 +737,12 @@ endif()
+ #
+ # Auxiliary build and test utils.
+ #
+-add_subdirectory(utils)
++#add_subdirectory(utils)
+ 
+ #
+ # Auxiliary tools.
+ #
+-add_subdirectory(tools)
++#add_subdirectory(tools)
+ 
+ #
+ # Test and runtime targets. Note that enable_testing() is order-sensitive!

--- a/packages/ldc/llvm-android_tls.patch.beforehostbuild
+++ b/packages/ldc/llvm-android_tls.patch.beforehostbuild
@@ -1,0 +1,79 @@
+diff --git a/lib/CodeGen/TargetLoweringObjectFileImpl.cpp b/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+index 9f1e06b..cc6fb08 100644
+--- a/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
++++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+@@ -139,6 +139,7 @@
+     return SectionKind::getThreadData();
+ 
+   if (Name == ".tbss" ||
++      Name == ".tcommon" ||
+       Name.startswith(".tbss.") ||
+       Name.startswith(".gnu.linkonce.tb.") ||
+       Name.startswith(".llvm.linkonce.tb."))
+@@ -176,8 +176,8 @@ getELFSectionFlags(SectionKind K) {
+   if (K.isWriteable())
+     Flags |= ELF::SHF_WRITE;
+ 
+-  if (K.isThreadLocal())
+-    Flags |= ELF::SHF_TLS;
++  //if (K.isThreadLocal())
++    //Flags |= ELF::SHF_TLS;
+ 
+   if (K.isMergeableCString() || K.isMergeableConst())
+     Flags |= ELF::SHF_MERGE;
+diff --git a/lib/MC/MCELFStreamer.cpp b/lib/MC/MCELFStreamer.cpp
+index bdc4a84..14537be 100644
+--- a/lib/MC/MCELFStreamer.cpp
++++ b/llvm/lib/MC/MCELFStreamer.cpp
+@@ -397,7 +397,7 @@ void MCELFStreamer::fixSymbolsInTLSFixups(const MCExpr *expr) {
+       break;
+     }
+     getAssembler().registerSymbol(symRef.getSymbol());
+-    cast<MCSymbolELF>(symRef.getSymbol()).setType(ELF::STT_TLS);
++    //cast<MCSymbolELF>(symRef.getSymbol()).setType(ELF::STT_TLS);
+     break;
+   }
+ 
+diff --git a/lib/MC/MCObjectFileInfo.cpp b/lib/MC/MCObjectFileInfo.cpp
+index 8015ebb..0a2639f 100644
+--- a/lib/MC/MCObjectFileInfo.cpp
++++ b/llvm/lib/MC/MCObjectFileInfo.cpp
+@@ -448,10 +448,10 @@
+ 
+   TLSDataSection =
+       Ctx->getELFSection(".tdata", ELF::SHT_PROGBITS,
+-                         ELF::SHF_ALLOC | ELF::SHF_TLS | ELF::SHF_WRITE);
++                         ELF::SHF_ALLOC | /*ELF::SHF_TLS |*/ ELF::SHF_WRITE);
+ 
+   TLSBSSSection = Ctx->getELFSection(
+-      ".tbss", ELF::SHT_NOBITS, ELF::SHF_ALLOC | ELF::SHF_TLS | ELF::SHF_WRITE);
++      ".tbss", ELF::SHT_NOBITS, ELF::SHF_ALLOC | /*ELF::SHF_TLS |*/ ELF::SHF_WRITE);
+ 
+   DataRelROSection = Ctx->getELFSection(".data.rel.ro", ELF::SHT_PROGBITS,
+                                         ELF::SHF_ALLOC | ELF::SHF_WRITE);
+diff --git a/lib/Target/ARM/MCTargetDesc/ARMELFObjectWriter.cpp b/lib/Target/ARM/MCTargetDesc/ARMELFObjectWriter.cpp
+index a821a6b..d169ab1 100644
+--- a/lib/Target/ARM/MCTargetDesc/ARMELFObjectWriter.cpp
++++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMELFObjectWriter.cpp
+@@ -174,7 +174,7 @@ unsigned ARMELFObjectWriter::GetRelocTypeInner(const MCValue &Target,
+         Type = ELF::R_ARM_GOT_BREL;
+         break;
+       case MCSymbolRefExpr::VK_TLSGD:
+-        Type = ELF::R_ARM_TLS_GD32;
++        Type = ELF::R_ARM_GOT_PREL;
+         break;
+       case MCSymbolRefExpr::VK_TPOFF:
+         Type = ELF::R_ARM_TLS_LE32;
+diff --git a/lib/Target/X86/MCTargetDesc/X86ELFObjectWriter.cpp b/lib/Target/X86/MCTargetDesc/X86ELFObjectWriter.cpp
+index e8b0b4c..fcb9954 100644
+--- a/lib/Target/X86/MCTargetDesc/X86ELFObjectWriter.cpp
++++ b/llvm/lib/Target/X86/MCTargetDesc/X86ELFObjectWriter.cpp
+@@ -211,7 +211,7 @@
+   case MCSymbolRefExpr::VK_TLSGD:
+     assert(Type == RT32_32);
+     assert(!IsPCRel);
+-    return ELF::R_386_TLS_GD;
++    return ELF::R_386_GOT32;
+   case MCSymbolRefExpr::VK_GOTTPOFF:
+     assert(Type == RT32_32);
+     assert(!IsPCRel);


### PR DESCRIPTION
Finally got around to figuring out your build scripts on Arch and writing this up, fixes #71.  Only works for ARM and I had to hard-code the options that ldc normally gets from `llvm-config`, because llvm's `CMAKE_CROSSCOMPILING` support, that's supposed to build a native host `llvm-config`, is completely broken.  Once @vishalbiswas gets his script version of `llvm-config` in, #917, I'll look at using that instead.

Ldc currently depends on a lightly patched llvm for emulated TLS, because it's easy to pass this data to the D garbage-collector.  Eventually, we'll move to llvm's built-in emulated TLS.

~~I simply take the source and pre-built libraries for the D runtime and standard library, Phobos, from my cross-compiler tarfile, rather than go to the trouble of downloading and building those again.~~