### PR TITLE
Add scripts/setup-archlinux.sh similar to setup-ubuntu.sh

### DIFF
--- a/scripts/setup-archlinux.sh
+++ b/scripts/setup-archlinux.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e -u
+
+PACKAGES=""
+PACKAGES+=" apache-ant" # Used by apksigner.
+PACKAGES+=" asciidoc"
+PACKAGES+=" automake"
+PACKAGES+=" bison"
+PACKAGES+=" clang" # Used by golang, useful to have same compiler building.
+PACKAGES+=" curl" # Used for fetching sources.
+PACKAGES+=" ed" # Used by bc
+PACKAGES+=" flex"
+PACKAGES+=" gettext" # Provides 'msgfmt' which the apt build uses.
+PACKAGES+=" git" # Used by the neovim build.
+PACKAGES+=" help2man"
+PACKAGES+=" intltool" # Used by qalc build.
+PACKAGES+=" glib2" # Provides 'glib-genmarshal' which the glib build uses.
+PACKAGES+=" libtool"
+#PACKAGES+=" ncurses5-compat-libs" # Used by mariadb for host build part. - only available in aur
+PACKAGES+=" lzip"
+PACKAGES+=" python"
+PACKAGES+=" tar"
+PACKAGES+=" unzip"
+PACKAGES+=" m4"
+PACKAGES+=" jre8-openjdk-headless" # Used for android-sdk.
+PACKAGES+=" pkg-config"
+PACKAGES+=" python-docutils" # For rst2man, used by mpv.
+PACKAGES+=" python-setuptools" # Needed by at least asciinema.
+PACKAGES+=" scons"
+PACKAGES+=" texinfo"
+PACKAGES+=" xmlto"
+#PACKAGES+=" xutils-dev" # Provides 'makedepend' which the openssl build uses.
+
+sudo pacman -Syq --noconfirm $PACKAGES
+
+sudo mkdir -p /data/data/com.termux/files/usr
+sudo chown -R `whoami` /data
+
+echo "Please also install ncurses5-compat-libs and makedepend packages from the AUR before continuing"


### PR DESCRIPTION
The other day when tinkering with pulseaudio as per the #821 I wanted to build it my-self. I am not very much into docker, and I am running arch linux rather than ubuntu so partially just for fun and partially because I wanted to build pulseaudio I have taken setup-ubuntu.sh and turned it into setup-archlinux.sh .
Perhaps there are more crazy guys out there who might find this usefull.
I took building more packages for a test drive not just pulseaudio, for example openssl and mariadb build fine on arch linux as host OS after running both the setup scripts setup-archlinux.sh followed by the setup-android-sdk.sh .
I might hopefully revisit #104 in the foreseeable future.