### PR TITLE
Fix ghostscript for aarch64.

### DIFF
--- a/disabled-packages/ghostscript/arch-aarch64.h
+++ b/disabled-packages/ghostscript/arch-aarch64.h
@@ -1,0 +1,40 @@
+/* Parameters derived from machine and compiler architecture. */
+/* This file is generated mechanically by genarch.c. */
+
+	 /* ---------------- Scalar alignments ---------------- */
+
+#define ARCH_ALIGN_SHORT_MOD 2
+#define ARCH_ALIGN_INT_MOD 4
+#define ARCH_ALIGN_LONG_MOD 8
+#define ARCH_ALIGN_PTR_MOD 8
+#define ARCH_ALIGN_FLOAT_MOD 4
+#define ARCH_ALIGN_DOUBLE_MOD 8
+
+	 /* ---------------- Scalar sizes ---------------- */
+
+#define ARCH_LOG2_SIZEOF_CHAR 0
+#define ARCH_LOG2_SIZEOF_SHORT 1
+#define ARCH_LOG2_SIZEOF_INT 2
+#define ARCH_LOG2_SIZEOF_LONG 3
+#define ARCH_LOG2_SIZEOF_LONG_LONG 3
+#define ARCH_SIZEOF_GX_COLOR_INDEX 8
+#define ARCH_SIZEOF_PTR 8
+#define ARCH_SIZEOF_FLOAT 4
+#define ARCH_SIZEOF_DOUBLE 8
+#define ARCH_FLOAT_MANTISSA_BITS 24
+#define ARCH_DOUBLE_MANTISSA_BITS 53
+
+	 /* ---------------- Unsigned max values ---------------- */
+
+#define ARCH_MAX_UCHAR ((unsigned char)0xff + (unsigned char)0)
+#define ARCH_MAX_USHORT ((unsigned short)0xffff + (unsigned short)0)
+#define ARCH_MAX_UINT ((unsigned int)~0 + (unsigned int)0)
+#define ARCH_MAX_ULONG ((unsigned long)~0L + (unsigned long)0)
+
+	 /* ---------------- Miscellaneous ---------------- */
+
+#define ARCH_IS_BIG_ENDIAN 0
+#define ARCH_PTRS_ARE_SIGNED 0
+#define ARCH_FLOATS_ARE_IEEE 1
+#define ARCH_ARITH_RSHIFT 2
+#define ARCH_DIV_NEG_POS_TRUNCATES 1

--- a/disabled-packages/ghostscript/build.sh
+++ b/disabled-packages/ghostscript/build.sh
@@ -7,7 +7,7 @@ TERMUX_PKG_DEPENDS="libandroid-support, libtiff, libjpeg-turbo, libpng"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-system-libtiff \
 --enable-little-endian \
 --without-x \
---with-arch_h=$TERMUX_PKG_BUILDER_DIR/arch-arm.h \
+--with-arch_h=$TERMUX_PKG_BUILDER_DIR/arch-${TERMUX_ARCH}.h \
 CCAUX=gcc \
 --build=$TERMUX_BUILD_TUPLE \
 --without-pcl"
@@ -21,7 +21,8 @@ CCAUX=gcc \
 termux_step_post_extract_package () {
         rm -rdf $TERMUX_PKG_SRCDIR/jpeg
 	rm -rdf $TERMUX_PKG_SRCDIR/libpng
-	
+	rm -rdf $TERMUX_PKG_SRCDIR/expat $TERMUX_PKG_SRCDIR/jasper $TERMUX_PKG_SRCDIR/freetype $TERMUX_PKG_SRCDIR/lcms $TERMUX_PKG_SRCDIR/tiff
+
 	if [ -f $PREFIX/include/libandroid-support/time.h ]; then
 	    mv $PREFIX/include/libandroid-support/time.h $PREFIX/include/libandroid-support/time.h_
 	fi


### PR DESCRIPTION
Hi there,
this fix makes ghostscript run on aarch64. Please merge it! I think that the ghostscript package can be enabled now...

Bye,
Richard  

```
-bash-4.4$ gs
GPL Ghostscript 9.21 (2017-03-16)
Copyright (C) 2017 Artifex Software, Inc.  All rights reserved.
This software comes with NO WARRANTY: see the file PUBLIC for details.
GS>
```