### PR TITLE
fixes building cstddef include for g++

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -592,7 +592,8 @@ termux_step_setup_toolchain() {
 			        https://raw.githubusercontent.com/madler/zlib/v1.2.8/$file
 		done
 		unset file
-
+		cd $_TERMUX_TOOLCHAIN_TMPDIR/include/c++/4.9.x
+                sed "s%\@TERMUX_HOST_PLATFORM\@%${TERMUX_HOST_PLATFORM}%g" $TERMUX_SCRIPTDIR/ndk-patches/*.cpppatch | patch -p1
 		mv $_TERMUX_TOOLCHAIN_TMPDIR $TERMUX_STANDALONE_TOOLCHAIN
 	fi
 

--- a/ndk-patches/cstddef.cpppatch
+++ b/ndk-patches/cstddef.cpppatch
@@ -1,0 +1,14 @@
+--- /home/builder/cstddef.orig	2017-07-15 01:17:10.637496279 +0000
++++ ./cstddef	2017-07-15 10:28:28.526713523 +0000
+@@ -40,7 +40,11 @@
+ #endif
+ 
+ // Don't include our own <stddef.h>; we don't want to declare ::nullptr_t.
++#ifdef __clang__
+ #include_next <stddef.h>
++#else
++#include "../../../lib/gcc/@TERMUX_HOST_PLATFORM@/4.9.x/include/stddef.h"
++#endif
+ #include <__nullptr>
+ 
+ _LIBCPP_BEGIN_NAMESPACE_STD

--- a/packages/ndk-stl/build.sh
+++ b/packages/ndk-stl/build.sh
@@ -7,7 +7,8 @@ TERMUX_PKG_NO_DEVELSPLIT=yes
 termux_step_extract_into_massagedir () {
 	mkdir -p $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include/c++/v1/
 	cp -Rf $TERMUX_STANDALONE_TOOLCHAIN/include/c++/4.9.x/* $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include/c++/v1/
-
+	cd $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include/c++/v1/
+	sed "s%\@TERMUX_HOST_PLATFORM\@%${TERMUX_HOST_PLATFORM}%g" $TERMUX_SCRIPTDIR/ndk-patches/cstddef.cpppatch | patch -p1 -R
 	# fenv.h is a C++ compatibility header which should be included with the compiler
 	#rm -Rf $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include/{arm-linux-androideabi,tr1,tr2,fenv.h,complex.h,stdio.h,wctype.h}
 }


### PR DESCRIPTION
Allows cstddef include  so g++ with libc++_shared works. 