### PR TITLE
Docker: login as "builder" even if run-docker.sh is run as root.

### DIFF
--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -12,7 +12,7 @@ fi
 IMAGE_NAME=termux/package-builder
 CONTAINER_NAME=termux-package-builder
 
-[ $(id -u) -eq 0 ] && USER=root || USER=builder
+USER=builder
 
 echo "Running container '$CONTAINER_NAME' from image '$IMAGE_NAME'..."
 
@@ -25,7 +25,7 @@ docker start $CONTAINER_NAME > /dev/null 2> /dev/null || {
 	       --volume $REPOROOT:$HOME/termux-packages \
 	       --tty \
 	       $IMAGE_NAME
-	if [ $(id -u) -ne 1000 ]
+	if [ $(id -u) -ne 1000 -a $(id -u) -ne 0 ]
 	then
 		echo "Changed builder uid/gid... (this may take a while)"
 		docker exec --tty $CONTAINER_NAME chown -R $(id -u) $HOME


### PR DESCRIPTION
And don't {chmod,chown} if run as root. Running with sudo otherwise produces debs that normal users don't have permission to access.

There might still be a small change needed related to the group id of the builder. Currently, all files are given group id 1000, which my system isn't an existing group. 
I'm using 
`docker exec --interactive --tty --user $USER:100 $CONTAINER_NAME bash` 
instead of 
`docker exec --interactive --tty --user $USER $CONTAINER_NAME bash` 
but I guess group 100 doesn't exist on all systems either? 