### PR TITLE
MPV. Fix for #1127 and disable video output.

### DIFF
--- a/packages/mpv/build.sh
+++ b/packages/mpv/build.sh
@@ -33,7 +33,7 @@ termux_step_make_install () {
 
 	# Use opensles audio out be default:
 	mkdir -p $TERMUX_PREFIX/etc/mpv
-	echo "ao=opensles" > $TERMUX_PREFIX/etc/mpv/mpv.conf
+	cp $TERMUX_PKG_BUILDER_DIR/mpv.conf $TERMUX_PREFIX/etc/mpv/mpv.conf
 
 	# Try to work around OpenSL ES library clashes:
 	# Linking against libOpenSLES causes indirect linkage against

--- a/packages/mpv/mpv.conf
+++ b/packages/mpv/mpv.conf
@@ -6,3 +6,5 @@ ao=opensles
 # Increase audio buffer to help with stuttering with bluetooth devices. See #1127.
 audio-buffer=0.5
 
+# Disable Video Output. Termux doesn't support video output (with the exception of "tct").
+vo=null

--- a/packages/mpv/mpv.conf
+++ b/packages/mpv/mpv.conf
@@ -3,3 +3,6 @@
 # Enable OpenSL ES output, since this should work on all Android devices
 ao=opensles
 
+# Increase audio buffer to help with stuttering with bluetooth devices. See #1127.
+audio-buffer=0.5
+

--- a/packages/mpv/mpv.conf
+++ b/packages/mpv/mpv.conf
@@ -1,0 +1,5 @@
+# Default configuration for mpv
+
+# Enable OpenSL ES output, since this should work on all Android devices
+ao=opensles
+


### PR DESCRIPTION
1. I changed the way we add settings to the default mpv config.
2. Increase the audio-buffer, to prevent stuttering with bluetooth devices (#1127)
3. Added setting to disable video output of mpv, as mpv would fail if any video information is found in a file (even just album art in an mp3). It can still be overridden with `--vo=tct` (or another vo, should one become available).

I didn't bump the version number of mpv, because as of yet. 0.26.0 isn't in the repository yet. 