### PR TITLE
libmpdclient: Update from 2.11 to 2.13

### DIFF
--- a/packages/libmpdclient/build.sh
+++ b/packages/libmpdclient/build.sh
@@ -2,9 +2,8 @@ TERMUX_PKG_HOMEPAGE=https://www.musicpd.org/libs/libmpdclient/
 TERMUX_PKG_DESCRIPTION="Asynchronous API library for interfacing MPD in the C, C++ & Objective C languages"
 TERMUX_PKG_MAINTAINER="Matthew Klein @mklein994"
 _MAIN_VERSION=2
-_PATCH_VERSION=11
+_PATCH_VERSION=13
 TERMUX_PKG_VERSION=${_MAIN_VERSION}.${_PATCH_VERSION}
+TERMUX_PKG_SHA256=5115bd52bc20a707c1ecc7587e6389c17305348e2132a66cf767c62fc55ed45d
 TERMUX_PKG_SRCURL=https://www.musicpd.org/download/libmpdclient/${_MAIN_VERSION}/libmpdclient-${_MAIN_VERSION}.${_PATCH_VERSION}.tar.xz
-TERMUX_PKG_SHA256=15fe693893c0d7ea3f4c35c4016fbd0332836164178b20983eec9b470846baf6
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-documentation"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-default-socket=${TERMUX_PREFIX}/var/run/mpd/socket"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" -D default_socket==${TERMUX_PREFIX}/var/run/mpd/socket"


### PR DESCRIPTION
This is the first package to be built using [the meson build system](http://mesonbuild.com/) (using new support for it in `build-package.sh`), which makes it interesting, as it seems that this build system is being adopted in multiple projects.

Any `ncmpcpp`, `mpc` or `mpd` users wanting to try out this libmpdclient and see if it works? @mklein994 or @Neo-Oli perhaps?

```
# 64-bit aarch64 devices:
wget http://fornwall.net/libmpdclient_2.13_aarch64.deb
apt install ./libmpdclient_2.13_aarch64.deb

# 32-bit arm devices:
wget http://fornwall.net/libmpdclient_2.13_arm.deb
apt install ./libmpdclient_2.13_arm.deb
```