### PR TITLE
libpng: update to 1.6.31

### DIFF
--- a/packages/libpng/build.sh
+++ b/packages/libpng/build.sh
@@ -1,6 +1,6 @@
 TERMUX_PKG_HOMEPAGE=http://www.libpng.org/pub/png/libpng.html
 TERMUX_PKG_DESCRIPTION="Official PNG reference library"
-TERMUX_PKG_VERSION=1.6.29
+TERMUX_PKG_VERSION=1.6.31
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/project/libpng/libpng16/${TERMUX_PKG_VERSION}/libpng-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=4245b684e8fe829ebb76186327bb37ce5a639938b219882b53d64bd3cfc5f239
+TERMUX_PKG_SHA256=232a602de04916b2b5ce6f901829caf419519e6a16cc9cd7c1c91187d3ee8b41
 TERMUX_PKG_RM_AFTER_INSTALL="bin/libpng-config bin/libpng16-config bin/png-fix-itxt bin/pngfix"


### PR DESCRIPTION
1.6.29 is no longer available at the previously used sourceforge url.