### PR TITLE
Activate Kerberos5 authentication

### DIFF
--- a/packages/openssh/build.sh
+++ b/packages/openssh/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_VERSION=7.5p1
 TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=http://mirrors.evowise.com/pub/OpenBSD/OpenSSH/portable/openssh-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=9846e3c5fab9f0547400b4d2c017992f914222b3fd1f8eee6c7dc6bc5e59f9f0
-TERMUX_PKG_DEPENDS="libandroid-support, ldns, openssl, libedit, libutil"
+TERMUX_PKG_DEPENDS="libandroid-support, ldns, openssl, krb5, libedit, libutil"
 # --disable-strip to prevent host "install" command to use "-s", which won't work for target binaries:
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-etc-default-login
@@ -21,6 +21,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --with-cflags=-Dfd_mask=int
 --with-ldns
 --with-libedit
+--with-kerberos5
 --without-ssh1
 --without-stackprotect
 --with-pid-dir=$TERMUX_PREFIX/var/run


### PR DESCRIPTION
You added the krb5 package to the termux list of packages. That's great as one can now get kerberos tickets (I saw some problems mentioned in an issue, but it works perfectly fine for me). But once you get a ticket, you can't do anything with it because your openssh was not built with the --with-kerberos5 configure option. This pull request turns on that option. I can now successfully ssh into machines using my kerberos ticket. Awesome!

I know that lack of an ssh application with kerberos has been a problem for Android and IOS (at least for me). This patch solves it! 

Once this openssh is installed, one must add the following to `.ssh/config`
```
GSSAPIAuthentication yes
```

And then one can,

```
kinit myUser@MY.DOMAIN
ssh myUser@mymachine.my.domain
# It'll work!
```