### PR TITLE
 Don't disable SIGWINCH in ncmpcpp

### DIFF
--- a/packages/ncmpcpp/build.sh
+++ b/packages/ncmpcpp/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://rybczak.net/ncmpcpp/
 TERMUX_PKG_DESCRIPTION="NCurses Music Player Client (Plus Plus)"
 TERMUX_PKG_VERSION=0.8
-TERMUX_PKG_REVISION=4
+TERMUX_PKG_REVISION=5
 TERMUX_PKG_SRCURL=https://rybczak.net/ncmpcpp/stable/ncmpcpp-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=2f0f2a1c0816119430880be6932e5eb356b7875dfa140e2453a5a802909f465a
 TERMUX_PKG_DEPENDS="fftw, boost, readline, libcurl, libmpdclient"

--- a/packages/ncmpcpp/ncmpcpp.cpp.patch
+++ b/packages/ncmpcpp/ncmpcpp.cpp.patch
@@ -5,9 +5,8 @@
  	std::cerr.rdbuf(errorlog.rdbuf());
  	
 -	sigignore(SIGPIPE);
--	signal(SIGWINCH, sighandler);
 +	// sigignore(SIGPIPE);
-+	// signal(SIGWINCH, sighandler);
+	signal(SIGWINCH, sighandler);
  
  	Mpd.setNoidleCallback(Status::update);
  


### PR DESCRIPTION
It makes ncmpcpp resize itself when the window size has changed.
Not sure why this was ever added, but according to @its-pointless it can
be removed