### PR TITLE
add tclsqlite3.c to libsqlite dev package

### DIFF
--- a/packages/libsqlite/build.sh
+++ b/packages/libsqlite/build.sh
@@ -13,7 +13,13 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 ac_cv_func_strerror_r=no
 --enable-readline
 "
+TERMUX_PKG_INCLUDE_IN_DEVPACKAGE="src/libsqlite/tclsqlite3.c"
 
 termux_step_pre_configure() {
 	CPPFLAGS+=" -Werror"
+}
+
+termux_step_post_make_install () {
+	mkdir -p $TERMUX_PREFIX/src/libsqlite
+	cp $TERMUX_PKG_SRCDIR/tea/generic/tclsqlite3.c $TERMUX_PREFIX/src/libsqlite/tclsqlite3.c
 }


### PR DESCRIPTION
fixes issues that arose from building tcl with #1169 and avoids a circular dependency