### PR TITLE
add termux module to nodejs-current

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -247,7 +247,7 @@ termux_step_handle_arguments() {
 termux_step_setup_variables() {
 	: "${ANDROID_HOME:="${HOME}/lib/android-sdk"}"
 	: "${NDK:="${HOME}/lib/android-ndk"}"
-	: "${TERMUX_MAKE_PROCESSES:="$(nproc)"}"
+	: "${TERMUX_MAKE_PROCESSES:="$(sysctl -n hw.ncpu)"}"
 	: "${TERMUX_TOPDIR:="$HOME/.termux-build"}"
 	: "${TERMUX_ARCH:="aarch64"}" # arm, aarch64, i686 or x86_64.
 	: "${TERMUX_PREFIX:="/data/data/com.termux/files/usr"}"

--- a/packages/nodejs-current/build.sh
+++ b/packages/nodejs-current/build.sh
@@ -13,6 +13,9 @@ TERMUX_PKG_BUILD_IN_SRC=yes
 TERMUX_PKG_CONFLICTS="nodejs"
 
 termux_step_configure () {
+	# install termux module
+	cp $TERMUX_PKG_BUILDER_DIR/termux-module.js ./lib/termux.js
+
 	# See https://github.com/nodejs/build/issues/266 about enabling snapshots
 	# when cross compiling. We use {CC,CXX}_host for compilation of code to
 	# be run on the build maching (snapshots when cross compiling are

--- a/packages/nodejs-current/termux-module.js
+++ b/packages/nodejs-current/termux-module.js
@@ -1,0 +1,77 @@
+const util = require('util');
+const child_process = require('child_process');
+const pexec = util.promisify(child_process.exec);
+
+
+function bind(command, { json = false } = {}) {
+  return function run(argv, options) {
+    if (!options && argv && !Array.isArray(argv) && typeof argv !== 'string') {
+      options = argv;
+      argv = [];
+    }
+    const args = Object.entries(options).reduce((a, [k, v]) => {
+      const key = k[0];
+      if (v === true) a.push(`-${key}`);
+      else a.push(`-${key} ${v}`);
+      return a;
+    }, []).join(' ');
+    argv = Array.isArray(argv) ? argv.length ? ` ${argv.join(' ')}` : '' : ` ${argv}`.trim();
+    pexec(`${command}${argv} ${args}`.trim())
+      .then((ret) => {
+        if (json) return { stdout: JSON.parse(ret.stdout), stderr: JSON.parse(ret.stderr) };
+        return ret;
+      });
+  };
+}
+
+const API_COMMANDS = [
+  'battery-status',
+  'camera-info',
+  'camera-photo',
+  'clipboard-get',
+  'clipboard-set',
+  'contact-list',
+  'dialog',
+  'download',
+  'infrared-frequencies',
+  'infrared-transmit',
+  'location',
+  'notification',
+  'share',
+  'sms-inbox',
+  'sms-send',
+  'storage-get',
+  'telephony-call',
+  'telephony-cellinfo',
+  'telephony-deviceinfo',
+  'toast',
+  'tts-engines',
+  'tts-speak',
+  'vibrate',
+  'wifi-connectioninfo',
+  'wifi-scaninfo',
+];
+
+module.exports.api = {};
+for (const command of API_COMMANDS) {
+  const props = command.split('-');
+  const last = props.pop();
+  let value = module.exports.api;
+  for (const prop of props) {
+    if (!value[prop]) value[prop] = {};
+    value = value[prop];
+  }
+  value[last] = bind(`termux-${command}`, { json: true });
+}
+
+module.exports.wake = {
+  lock: bind('termux-wake-lock'),
+  unlock: bind('termux-wake-unlock'),
+};
+
+module.exports.open = bind('termux-open');
+module.exports.open.url = bind('termux-open-url');
+
+module.exports.fixShebang = bind('termux-fix-shebang');
+
+module.exports.playAudio = bind('play-audio');

--- a/packages/nodejs-current/termux-module.patch
+++ b/packages/nodejs-current/termux-module.patch
@@ -1,0 +1,12 @@
+--- ./lib/internal/module.js    2017-07-30 10:32:26.000000000 -0500
++++ ./node-v8.3.0/lib/internal/module.js        2017-07-30 10:32:50.000000000 -0500
+@@ -80,7 +80,8 @@
+   'assert', 'async_hooks', 'buffer', 'child_process', 'cluster', 'crypto',
+   'dgram', 'dns', 'domain', 'events', 'fs', 'http', 'https', 'net', 'os',
+   'path', 'punycode', 'querystring', 'readline', 'repl', 'stream',
+-  'string_decoder', 'tls', 'tty', 'url', 'util', 'v8', 'vm', 'zlib'
++  'string_decoder', 'tls', 'tty', 'url', 'util', 'v8', 'vm', 'zlib',
++  'termux'
+ ];
+
+ function addBuiltinLibsToObject(object) {


### PR DESCRIPTION
allows usage such as
```js
require('termux').battery.status().then(console.log)
```