### PR TITLE
fix building vim after libvterm

### DIFF
--- a/packages/vim-python/vterm_internal.h.patch
+++ b/packages/vim-python/vterm_internal.h.patch
@@ -1,0 +1,11 @@
+--- ../cache/vim-8.0.0979/src/libvterm/src/vterm_internal.h	2017-08-20 18:21:23.000000000 +0000
++++ ./src/libvterm/src/vterm_internal.h	2017-08-21 03:25:48.637450794 +0000
+@@ -1,7 +1,7 @@
+ #ifndef __VTERM_INTERNAL_H__
+ #define __VTERM_INTERNAL_H__
+ 
+-#include "vterm.h"
++#include "../include/vterm.h"
+ 
+ #include <stdarg.h>
+ 

--- a/packages/vim/vterm_internal.h.patch
+++ b/packages/vim/vterm_internal.h.patch
@@ -1,0 +1,11 @@
+--- ../cache/vim-8.0.0979/src/libvterm/src/vterm_internal.h	2017-08-20 18:21:23.000000000 +0000
++++ ./src/libvterm/src/vterm_internal.h	2017-08-21 03:25:48.637450794 +0000
+@@ -1,7 +1,7 @@
+ #ifndef __VTERM_INTERNAL_H__
+ #define __VTERM_INTERNAL_H__
+ 
+-#include "vterm.h"
++#include "../include/vterm.h"
+ 
+ #include <stdarg.h>
+ 


### PR DESCRIPTION
after you add --enable-terminal to building vim if you had already built the package libvterm the internal vim libvterm fails. This fixes it so it uses local vim provided vterm.h 