### PR TITLE
Rebuild aria2 because of dependencies

### DIFF
--- a/packages/aria2/build.sh
+++ b/packages/aria2/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://aria2.github.io
 TERMUX_PKG_DESCRIPTION="Download utility supporting HTTP/HTTPS, FTP, BitTorrent and Metalink"
 TERMUX_PKG_VERSION=1.32.0
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/aria2/aria2/releases/download/release-${TERMUX_PKG_VERSION}/aria2-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=546e9194a9135d665fce572cb93c88f30fb5601d113bfa19951107ced682dc50
 TERMUX_PKG_DEPENDS="c-ares, openssl, libxml2"


### PR DESCRIPTION
Aria2 needs to be rebuilt, because the 'arm' arch is getting segfaults because of some updated dependencies.