### PR TITLE
Qemu: add new package (system emulation only)

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -759,12 +759,12 @@ termux_step_setup_toolchain() {
 		fi
 	fi
 
-	export PKG_CONFIG_LIBDIR="$TERMUX_PKG_CONFIG_LIBDIR"
+	export PKG_CONFIG_LIBDIR="$TERMUX_PKG_CONFIG_LIBDIR:$TERMUX_PREFIX/share/pkgconfig"
 	# Create a pkg-config wrapper. We use path to host pkg-config to
 	# avoid picking up a cross-compiled pkg-config later on.
 	local _HOST_PKGCONFIG
 	_HOST_PKGCONFIG=$(which pkg-config)
-	mkdir -p $TERMUX_STANDALONE_TOOLCHAIN/bin "$PKG_CONFIG_LIBDIR"
+	mkdir -p $TERMUX_STANDALONE_TOOLCHAIN/bin "$TERMUX_PKG_CONFIG_LIBDIR"
 	cat > "$PKG_CONFIG" <<-HERE
 		#!/bin/sh
 		export PKG_CONFIG_DIR=

--- a/packages/libgnutls/build.sh
+++ b/packages/libgnutls/build.sh
@@ -14,4 +14,5 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --with-system-priority-file=${TERMUX_PREFIX}/etc/gnutls/default-priorities
 --with-included-libtasn1
 --without-p11-kit
+--enable-local-libopts
 "

--- a/packages/libspice-protocol/build.sh
+++ b/packages/libspice-protocol/build.sh
@@ -1,0 +1,5 @@
+TERMUX_PKG_HOMEPAGE=https://www.spice-space.org/
+TERMUX_PKG_DESCRIPTION="Remote access to virtual machines, protocol definitions"
+TERMUX_PKG_VERSION=0.12.13
+TERMUX_PKG_SRCURL=https://www.spice-space.org/download/releases/spice-protocol-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_SHA256=89ee11b202d2268e061788e6ace114e1ff18c7620ae64d1ca3aba252ee7c9933

--- a/packages/libspice-server/build.sh
+++ b/packages/libspice-server/build.sh
@@ -1,0 +1,8 @@
+TERMUX_PKG_HOMEPAGE=https://www.spice-space.org/
+TERMUX_PKG_DESCRIPTION="Remote access to virtual machines, server part"
+TERMUX_PKG_VERSION=0.12.8
+TERMUX_PKG_SRCURL=https://www.spice-space.org/download/releases/spice-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_SHA256=f901a5c5873d61acac84642f9eea5c4d6386fc3e525c2b68792322794e1c407d
+TERMUX_PKG_DEPENDS="libspice-protocol, libpixman, libsasl, glib, openssl, libjpeg-turbo"
+# Unfortunately we have to disable CEL, OpenGL, smartcard and LZ4 for now
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-celt051 --disable-opengl --disable-smartcard --disable-lz4 --enable-manual --enable-sasl"

--- a/packages/libspice-server/disable_red_statistics.patch
+++ b/packages/libspice-server/disable_red_statistics.patch
@@ -1,0 +1,49 @@
+Red statistice requires shm_open that we don't have.
+
+We have no use for them, so just disable.
+
+diff -ur spice-orig/server/Makefile.am spice/server/Makefile.am
+--- spice-orig/server/Makefile.am	2017-07-31 21:10:22.743215770 +0200
++++ spice/server/Makefile.am	2017-07-31 21:11:26.450979462 +0200
+@@ -3,7 +3,6 @@
+ 
+ AM_CPPFLAGS =					\
+ 	-DSPICE_SERVER_INTERNAL			\
+-	-DRED_STATISTICS			\
+ 	$(COMMON_CFLAGS)			\
+ 	$(GLIB2_CFLAGS)				\
+ 	$(LZ4_CFLAGS)				\
+diff -ur spice-orig/server/Makefile.in spice/server/Makefile.in
+--- spice-orig/server/Makefile.in	2017-07-31 21:10:22.747216004 +0200
++++ spice/server/Makefile.in	2017-07-31 21:11:33.555402767 +0200
+@@ -475,7 +475,6 @@
+ SUBDIRS = . tests
+ AM_CPPFLAGS = \
+ 	-DSPICE_SERVER_INTERNAL			\
+-	-DRED_STATISTICS			\
+ 	$(COMMON_CFLAGS)			\
+ 	$(GLIB2_CFLAGS)				\
+ 	$(LZ4_CFLAGS)				\
+diff -ur spice-orig/server/red_channel.c spice/server/red_channel.c
+--- spice-orig/server/red_channel.c	2017-07-31 21:10:22.743215770 +0200
++++ spice/server/red_channel.c	2017-07-31 21:13:55.887999209 +0200
+@@ -1067,7 +1067,9 @@
+ 
+     channel->thread_id = pthread_self();
+ 
++#ifdef RED_STATISTICS
+     channel->out_bytes_counter = 0;
++#endif
+ 
+     spice_debug("channel type %d id %d thread_id 0x%lx",
+                 channel->type, channel->id, channel->thread_id);
+@@ -1118,7 +1120,9 @@
+     spice_debug("channel type %d id %d thread_id 0x%lx",
+                 channel->type, channel->id, channel->thread_id);
+ 
++#ifdef RED_STATISTICS
+     channel->out_bytes_counter = 0;
++#endif
+ 
+     return channel;
+ }

--- a/packages/libspice-server/sun_len.patch
+++ b/packages/libspice-server/sun_len.patch
@@ -1,0 +1,17 @@
+Define SUN_LEN.
+
+It's missing in our headers, so add it here.
+
+diff -ur spice-orig/server/reds.c spice/server/reds.c
+--- spice-orig/server/reds.c	2017-07-31 21:10:22.747216004 +0200
++++ spice/server/reds.c	2017-07-31 21:17:50.342461769 +0200
+@@ -93,6 +93,9 @@
+ 
+ static TicketAuthentication taTicket;
+ 
++#define SUN_LEN(ptr) ((size_t) (((struct sockaddr_un *) 0)->sun_path)	      \
++		      + strlen ((ptr)->sun_path))
++
+ static int spice_port = -1;
+ static int spice_secure_port = -1;
+ static int spice_listen_socket_fd = -1;

--- a/packages/qemu-common/build.sh
+++ b/packages/qemu-common/build.sh
@@ -1,0 +1,96 @@
+TERMUX_PKG_HOMEPAGE=http://www.qemu.org
+TERMUX_PKG_DESCRIPTION="Qemu fast processor emulator - common files"
+TERMUX_PKG_VERSION=2.12.0
+TERMUX_PKG_SRCURL=http://download.qemu-project.org/qemu-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=e69301f361ff65bf5dabd8a19196aeaa5613c1b5ae1678f0823bdf50e7d5c6fc
+TERMUX_PKG_DEPENDS="glib, libutil, liblzo, libbz2, libnettle, ncurses, libjpeg-turbo, libcurl, libandroid-shmem, libpulseaudio, libsasl, libgnutls, libspice-server, libspice-protocol, libpixman, libpng"
+TERMUX_PKG_RM_AFTER_INSTALL="share/man/man8/qemu-nbd.8"
+
+termux_step_configure () {
+	# Unfortunately for now we have to disable sound-oss, sound-alsa,
+	# sound-sdl, KVM, seccomp, snappy, sparse, gtk, vte, sdl, vde,
+	# netmap, cap-ng, brlapi, bluez, rbd, libssh2, AIO, OpenGL, iSCSI,
+	# smartcard, libusb, usb-redir, nfs, VirtFS, guest-agent-msi,
+	# hax, virglrenderer
+	"$TERMUX_PKG_SRCDIR/configure" \
+	    --prefix=$TERMUX_PREFIX \
+	    --cross-prefix=${TERMUX_HOST_PLATFORM}- \
+	    --audio-drv-list="pa" \
+	    --disable-kvm \
+	    --disable-seccomp \
+	    --disable-snappy \
+	    --disable-sparse \
+	    --disable-gtk \
+	    --disable-sdl \
+	    --disable-vde \
+	    --disable-netmap \
+	    --disable-bluez \
+	    --disable-rbd \
+	    --disable-libssh2 \
+	    --disable-linux-aio \
+	    --disable-opengl \
+	    --disable-glusterfs \
+	    --disable-libiscsi \
+	    --disable-smartcard \
+	    --disable-libusb \
+	    --disable-usb-redir \
+	    --disable-virglrenderer \
+	    --disable-libnfs \
+	    --disable-virtfs \
+	    --disable-guest-agent-msi \
+	    --disable-hax \
+	    --enable-lzo \
+	    --enable-vnc-jpeg \
+	    --smbd=$TERMUX_PREFIX/usr/sbin/smbd \
+	    --enable-system \
+	    --disable-user \
+	    --disable-linux-user \
+	    --disable-bsd-user \
+	    --enable-docs \
+	    --enable-guest-agent \
+	    --enable-pie \
+	    --enable-gnutls \
+	    --enable-modules \
+	    --enable-nettle \
+	    --enable-curses \
+	    --disable-gcrypt \
+	    --enable-spice \
+	    --enable-vnc \
+	    --enable-vnc-jpeg \
+	    --enable-vnc-png \
+	    --enable-vnc-sasl \
+	    --disable-cocoa \
+	    --disable-xen \
+	    --disable-xen-pci-passthrough \
+	    --enable-curl \
+	    --enable-fdt \
+	    --disable-rdma \
+	    --enable-attr \
+	    --enable-vhost-net \
+	    --enable-lzo \
+	    --enable-bzip2 \
+	    --enable-coroutine-pool \
+	    --enable-tpm \
+	    --disable-numa \
+	    --enable-replication \
+	    --enable-vhost-vsock \
+	    --enable-qom-cast-debug \
+	    --disable-xfsctl \
+	    --enable-tools
+}
+
+termux_step_make () {
+	QEMU_ARCH=${TERMUX_ARCH}
+	case ${TERMUX_ARCH} in
+		i?86)
+			QEMU_ARCH=i386;;
+		*)
+			QEMU_ARCH="${TERMUX_ARCH}";;
+	esac
+	make ARCH=${QEMU_ARCH} CROSS_COMPILE=${TERMUX_HOST_PLATFORM}- -j $TERMUX_MAKE_PROCESSES
+}
+
+termux_step_pre_configure() {
+    LDFLAGS+=" -llog -landroid-shmem"
+    LDFLAGS+=" $CPPFLAGS"
+}

--- a/packages/qemu-common/curses.patch
+++ b/packages/qemu-common/curses.patch
@@ -1,0 +1,10 @@
+--- orig/configure	2017-08-27 00:52:48.028239171 +0200
++++ mod/configure	2017-08-27 00:53:21.868545043 +0200
+@@ -2986,6 +2986,7 @@
+   fi
+   curses_found=no
+   cat > $TMPC << EOF
++#define _XOPEN_SOURCE 500
+ #include <locale.h>
+ #include <curses.h>
+ #include <wchar.h>

--- a/packages/qemu-common/disable_ivshmem_and_nbd.patch
+++ b/packages/qemu-common/disable_ivshmem_and_nbd.patch
@@ -1,0 +1,20 @@
+qemu-nbd is pretty useless without root
+ivshmem needs shm_open that we don't have.
+
+Disable those components.
+
+--- src-orig/configure	2018-04-24 18:30:46.000000000 +0200
++++ src/configure	2018-06-21 15:18:19.778624056 +0200
+@@ -5496,12 +5496,6 @@
+ tools=""
+ if test "$want_tools" = "yes" ; then
+   tools="qemu-img\$(EXESUF) qemu-io\$(EXESUF) $tools"
+-  if [ "$linux" = "yes" -o "$bsd" = "yes" -o "$solaris" = "yes" ] ; then
+-    tools="qemu-nbd\$(EXESUF) $tools"
+-  fi
+-  if [ "$ivshmem" = "yes" ]; then
+-    tools="ivshmem-client\$(EXESUF) ivshmem-server\$(EXESUF) $tools"
+-  fi
+ fi
+ if test "$softmmu" = yes ; then
+   if test "$linux" = yes; then

--- a/packages/qemu-common/getdtablesize.patch
+++ b/packages/qemu-common/getdtablesize.patch
@@ -1,0 +1,14 @@
+Android doesn't have getdtablesize. Use sysconf(_SC_OPEN_MAX) instead.
+
+diff -ur qemu-2.9.0-orig/slirp/misc.c qemu-2.9.0/slirp/misc.c
+--- qemu-2.9.0-orig/slirp/misc.c	2017-07-31 04:13:25.711190162 +0200
++++ qemu-2.9.0/slirp/misc.c	2017-07-31 05:24:42.082381735 +0200
+@@ -144,7 +144,7 @@
+ 		dup2(s, 0);
+ 		dup2(s, 1);
+ 		dup2(s, 2);
+-		for (s = getdtablesize() - 1; s >= 3; s--)
++		for (s = sysconf(_SC_OPEN_MAX) - 1; s >= 3; s--)
+ 		   close(s);
+ 
+ 		i = 0;

--- a/packages/qemu-common/lockf.patch
+++ b/packages/qemu-common/lockf.patch
@@ -1,0 +1,37 @@
+Android has no lockf. Use flock instead.
+
+diff -ur qemu-2.9.0-orig/os-posix.c qemu-2.9.0/os-posix.c
+--- qemu-2.9.0-orig/os-posix.c	2017-07-31 04:13:25.711190162 +0200
++++ qemu-2.9.0/os-posix.c	2017-07-31 04:39:02.628159936 +0200
+@@ -308,7 +308,7 @@
+     if (fd == -1) {
+         return -1;
+     }
+-    if (lockf(fd, F_TLOCK, 0) == -1) {
++    if (flock(fd, LOCK_EX | LOCK_NB) == -1) {
+         close(fd);
+         return -1;
+     }
+diff -ur qemu-2.9.0-orig/qga/main.c qemu-2.9.0/qga/main.c
+--- qemu-2.9.0-orig/qga/main.c	2017-07-31 04:13:25.703189667 +0200
++++ qemu-2.9.0/qga/main.c	2017-07-31 04:39:09.220149780 +0200
+@@ -320,7 +320,7 @@
+     char pidstr[32];
+ 
+     pidfd = qemu_open(pidfile, O_CREAT|O_WRONLY, S_IRUSR|S_IWUSR);
+-    if (pidfd == -1 || lockf(pidfd, F_TLOCK, 0)) {
++    if (pidfd == -1 || flock(pidfd, LOCK_EX | LOCK_NB)) {
+         g_critical("Cannot lock pid file, %s", strerror(errno));
+         if (pidfd != -1) {
+             close(pidfd);
+--- src-orig/scsi/qemu-pr-helper.c	2018-04-24 18:30:47.000000000 +0200
++++ src/scsi/qemu-pr-helper.c	2018-06-21 14:49:21.245887786 +0200
+@@ -122,7 +122,7 @@
+         exit(EXIT_FAILURE);
+     }
+ 
+-    if (lockf(pidfd, F_TLOCK, 0)) {
++    if (flock(pidfd, LOCK_EX | LOCK_NB)) {
+         error_report("Cannot lock pid file, %s", strerror(errno));
+         goto fail;
+     }

--- a/packages/qemu-common/qemu-guest-additions.subpackage.sh
+++ b/packages/qemu-common/qemu-guest-additions.subpackage.sh
@@ -1,0 +1,7 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-ga
+share/man/man7/qemu-ga-ref.7
+share/man/man8/qemu-ga.8
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - sparc and sparc64 system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-alpha.subpackage.sh
+++ b/packages/qemu-common/qemu-system-alpha.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-alpha
+share/qemu/palcode-clipper
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - alpha system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-arm.subpackage.sh
+++ b/packages/qemu-common/qemu-system-arm.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-aarch64
+bin/qemu-system-arm
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - arm and aarch64 system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-cris.subpackage.sh
+++ b/packages/qemu-common/qemu-system-cris.subpackage.sh
@@ -1,0 +1,5 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-cris
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - cris system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-lm32.subpackage.sh
+++ b/packages/qemu-common/qemu-system-lm32.subpackage.sh
@@ -1,0 +1,5 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-lm32
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - lm32 system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-m68k.subpackage.sh
+++ b/packages/qemu-common/qemu-system-m68k.subpackage.sh
@@ -1,0 +1,5 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-m68k
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - m68k system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-microblaze.subpackage.sh
+++ b/packages/qemu-common/qemu-system-microblaze.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-microblaze
+bin/qemu-system-microblazeel
+share/qemu/petalogix-ml605.dtb
+share/qemu/petalogix-s3adsp1800.dtb
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - microblaze and microblazeel system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-mips.subpackage.sh
+++ b/packages/qemu-common/qemu-system-mips.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-mips
+bin/qemu-system-mips64
+bin/qemu-system-mipsel
+bin/qemu-system-mips64el
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - mips, mips64, mipsel and mips64el system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-moxie.subpackage.sh
+++ b/packages/qemu-common/qemu-system-moxie.subpackage.sh
@@ -1,0 +1,5 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-moxie
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - moxie system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-nios2.subpackage.sh
+++ b/packages/qemu-common/qemu-system-nios2.subpackage.sh
@@ -1,0 +1,5 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-nios2
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - nios2 system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-or1k.subpackage.sh
+++ b/packages/qemu-common/qemu-system-or1k.subpackage.sh
@@ -1,0 +1,5 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-or1k
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - or1k system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-ppc.subpackage.sh
+++ b/packages/qemu-common/qemu-system-ppc.subpackage.sh
@@ -1,0 +1,14 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-ppc
+bin/qemu-system-ppc64
+bin/qemu-system-ppcemb
+share/qemu/bamboo.dtb
+share/qemu/openbios-ppc
+share/qemu/ppc_rom.bin
+share/qemu/skiboot.lid
+share/qemu/slof.bin
+share/qemu/spapr-rtas.bin
+share/qemu/u-boot.e500
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - ppc, ppc64 and ppcemb system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-s390x.subpackage.sh
+++ b/packages/qemu-common/qemu-system-s390x.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-s390x
+share/qemu/s390-ccw.img
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - s390x system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-sh4.subpackage.sh
+++ b/packages/qemu-common/qemu-system-sh4.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-sh4
+bin/qemu-system-sh4eb
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - sh4 and sh4eb system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-sparc.subpackage.sh
+++ b/packages/qemu-common/qemu-system-sparc.subpackage.sh
@@ -1,0 +1,10 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-sparc
+bin/qemu-system-sparc64
+share/qemu/openbios-sparc32
+share/qemu/openbios-sparc64
+share/qemu/QEMU,cgthree.bin
+share/qemu/QEMU,tcx.bin
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - sparc and sparc64 system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-tricore.subpackage.sh
+++ b/packages/qemu-common/qemu-system-tricore.subpackage.sh
@@ -1,0 +1,5 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-tricore
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - tricore system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-unicore32.subpackage.sh
+++ b/packages/qemu-common/qemu-system-unicore32.subpackage.sh
@@ -1,0 +1,5 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-unicore32
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - unicore32 system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-x86.subpackage.sh
+++ b/packages/qemu-common/qemu-system-x86.subpackage.sh
@@ -1,0 +1,17 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-i386
+bin/qemu-system-x86_64
+share/qemu/acpi-dsdt.aml
+share/qemu/bios.bin
+share/qemu/bios-256k.bin
+share/qemu/efi-*.rom
+share/qemu/kvmvapic.bin
+share/qemu/linuxboot.bin
+share/qemu/linuxboot_dma.bin
+share/qemu/multiboot.bin
+share/qemu/pxe-*.rom
+share/qemu/sgabios.bin
+share/qemu/vgabios*.bin
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - x86 and x86_64 system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-system-xtensa.subpackage.sh
+++ b/packages/qemu-common/qemu-system-xtensa.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-xtensa
+bin/qemu-system-xtensaeb
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - xtensa and xtensaeb system emulation"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/qemu-utils.subpackage.sh
+++ b/packages/qemu-common/qemu-utils.subpackage.sh
@@ -1,0 +1,7 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-img
+bin/qemu-io
+share/man/man1/qemu-img.1
+"
+TERMUX_SUBPKG_DESCRIPTION="Qemu emulator - utilities"
+TERMUX_SUBPKG_DEPENDS="qemu-common"

--- a/packages/qemu-common/resolv.patch
+++ b/packages/qemu-common/resolv.patch
@@ -1,0 +1,23 @@
+Change resolv.conf path for termux.
+
+diff -ur src-orig/slirp/slirp.c src/slirp/slirp.c
+--- src-orig/slirp/slirp.c	2017-08-27 12:39:07.563732554 +0200
++++ src/slirp/slirp.c	2017-08-27 12:39:58.124118908 +0200
+@@ -132,7 +132,7 @@
+         return 0;
+     }
+     old_stat = *cached_stat;
+-    if (stat("/etc/resolv.conf", cached_stat) != 0) {
++    if (stat("@TERMUX_PREFIX@/etc/resolv.conf", cached_stat) != 0) {
+         return -1;
+     }
+     if (cached_stat->st_dev == old_stat.st_dev
+@@ -156,7 +156,7 @@
+     void *tmp_addr = alloca(addrlen);
+     unsigned if_index;
+ 
+-    f = fopen("/etc/resolv.conf", "r");
++    f = fopen("@TERMUX_PREFIX@/etc/resolv.conf", "r");
+     if (!f)
+         return -1;
+ 

--- a/packages/qemu-common/sasl.patch
+++ b/packages/qemu-common/sasl.patch
@@ -1,0 +1,14 @@
+SASL check is problematic in qemu as sasl.h needs size_t already predefined
+
+So incluse sys/types.h in the check.
+
+--- qemu-2.9.0-orig/configure	2017-07-31 04:13:25.703189667 +0200
++++ qemu-2.9.0/configure	2017-07-31 14:41:42.017217510 +0200
+@@ -2695,6 +2695,7 @@
+ # VNC SASL detection
+ if test "$vnc" = "yes" -a "$vnc_sasl" != "no" ; then
+   cat > $TMPC <<EOF
++#include <sys/types.h>
+ #include <sasl/sasl.h>
+ #include <stdio.h>
+ int main(void) { sasl_server_init(NULL, "qemu"); return 0; }

--- a/packages/qemu-common/unused.patch
+++ b/packages/qemu-common/unused.patch
@@ -1,0 +1,14 @@
+__unused is a reserved keyword. Use __qemu_unused instead.
+
+diff -ur qemu-2.9.0-orig/linux-user/syscall_defs.h qemu-2.9.0/linux-user/syscall_defs.h
+--- qemu-2.9.0-orig/linux-user/syscall_defs.h   2017-07-31 04:13:25.535179284 +0200
++++ qemu-2.9.0/linux-user/syscall_defs.h        2017-07-31 05:46:49.349822521 +0200
+@@ -2048,7 +2048,7 @@
+     abi_ulong  target_st_mtime_nsec;
+     abi_long  target_st_ctime;
+     abi_ulong  target_st_ctime_nsec;
+-    unsigned int __unused[2];
++    unsigned int __qemu_unused[2];
+ };
+ #elif defined(TARGET_OPENRISC) || defined(TARGET_TILEGX) || \
+       defined(TARGET_NIOS2)


### PR DESCRIPTION
New set of packages: qemu. It doesn't have SDL support, but it works fine with serial output, VNC and Spice.