### PR TITLE
procps: Ignore Permission denied in several places.

### DIFF
--- a/packages/procps/z01_eaccess.patch
+++ b/packages/procps/z01_eaccess.patch
@@ -1,0 +1,92 @@
+Ignore Permission denied in several places.
+
+On some Androids many of proc files can't actually be opened. So ignore
+when opening fails and go on.
+
+diff '--exclude=config.log' -ur src-orig/proc/sysinfo.c src/proc/sysinfo.c
+--- src-orig/proc/sysinfo.c	2017-08-26 23:22:50.704748922 +0200
++++ src/proc/sysinfo.c	2017-08-27 00:08:52.482479053 +0200
+@@ -97,6 +97,10 @@
+     char *savelocale;
+ #endif
+ 
++    if (uptime_fd == -1 && (uptime_fd = open(UPTIME_FILE, O_RDONLY)) == -1) {
++	return 0;
++    }
++
+     FILE_TO_BUF(UPTIME_FILE,uptime_fd);
+ #ifndef __ANDROID__
+     savelocale = strdup(setlocale(LC_NUMERIC, NULL));
+@@ -130,6 +136,7 @@
+     /* /proc/stat can get very large on multi-CPU systems so we
+        can't use FILE_TO_BUF */
+     if (!(f = fopen(STAT_FILE, "r"))) {
++	return 0;
+ 	fputs(BAD_OPEN_MESSAGE, stderr);
+ 	fflush(NULL);
+ 	_exit(102);
+@@ -389,6 +401,10 @@
+     char *savelocale;
+ #endif
+ 
++    if (loadavg_fd == -1 && (loadavg_fd = open(LOADAVG_FILE, O_RDONLY)) == -1) {
++	return;
++    }
++
+     FILE_TO_BUF(LOADAVG_FILE,loadavg_fd);
+ #ifndef __ANDROID__
+     savelocale = strdup(setlocale(LC_NUMERIC, NULL));
+diff '--exclude=config.log' -ur src-orig/top/top.c src/top/top.c
+--- src-orig/top/top.c	2017-08-26 23:22:50.708748956 +0200
++++ src/top/top.c	2017-08-27 00:13:34.416643298 +0200
+@@ -2379,7 +2379,7 @@
+       (sorry Linux, but you'll have to close it for us) */
+    if (!fp) {
+       if (!(fp = fopen("/proc/stat", "r")))
+-         error_exit(fmtmk(N_fmt(FAIL_statopn_fmt), strerror(errno)));
++         return NULL;
+       /* note: we allocate one more CPU_t via totSLOT than 'cpus' so that a
+                slot can hold tics representing the /proc/stat cpu summary */
+       cpus = alloc_c(totSLOT * sizeof(CPU_t));
+@@ -3814,7 +3814,7 @@
+       tmptty.c_cc[VERASE] = *key_backspace;
+ #ifdef TERMIOS_ONLY
+    if (-1 == tcsetattr(STDIN_FILENO, TCSAFLUSH, &tmptty))
+-      error_exit(fmtmk(N_fmt(FAIL_tty_set_fmt), strerror(errno)));
++      {}
+    tcgetattr(STDIN_FILENO, &Tty_tweaked);
+ #endif
+    // lastly, a nearly raw mode for unsolicited single keystrokes
+@@ -3822,7 +3822,7 @@
+    tmptty.c_cc[VMIN] = 1;
+    tmptty.c_cc[VTIME] = 0;
+    if (-1 == tcsetattr(STDIN_FILENO, TCSAFLUSH, &tmptty))
+-      error_exit(fmtmk(N_fmt(FAIL_tty_set_fmt), strerror(errno)));
++      {}
+    tcgetattr(STDIN_FILENO, &Tty_raw);
+ 
+ #ifndef OFF_STDIOLBF
+@@ -5155,7 +5155,7 @@
+ #ifndef NUMA_DISABLE
+       if (!Numa_node_tot) goto numa_nope;
+ 
+-      if (CHKw(w, View_CPUNOD)) {
++      if (smpcpu && CHKw(w, View_CPUNOD)) {
+          if (Numa_node_sel < 0) {
+             // display the 1st /proc/stat line, then the nodes (if room)
+             summary_hlp(&smpcpu[smp_num_cpus], N_txt(WORD_allcpus_txt));
+@@ -5191,12 +5191,12 @@
+       } else
+ numa_nope:
+ #endif
+-      if (CHKw(w, View_CPUSUM)) {
++      if (smpcpu && CHKw(w, View_CPUSUM)) {
+          // display just the 1st /proc/stat line
+          summary_hlp(&smpcpu[Cpu_faux_tot], N_txt(WORD_allcpus_txt));
+          Msg_row += 1;
+ 
+-      } else {
++      } else if (smpcpu) {
+          // display each cpu's states separately, screen height permitting...
+          for (i = 0; i < Cpu_faux_tot; i++) {
+             snprintf(tmp, sizeof(tmp), N_fmt(WORD_eachcpu_fmt), smpcpu[i].id);


### PR DESCRIPTION
On some Androids many of proc files can't actually be opened. So ignore
when opening fails and go on.