### PR TITLE
ldc-beta: add package

### DIFF
--- a/packages/ldc-beta/build.sh
+++ b/packages/ldc-beta/build.sh
@@ -1,0 +1,153 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/ldc-developers/ldc
+TERMUX_PKG_DESCRIPTION="D programming language beta compiler, built with LLVM"
+_PKG_MAJOR_VERSION=1.5
+_PKG_BETA_VERSION=1
+TERMUX_PKG_VERSION=${_PKG_MAJOR_VERSION}.0
+TERMUX_PKG_SRCURL=https://github.com/ldc-developers/ldc/releases/download/v${TERMUX_PKG_VERSION}-beta${_PKG_BETA_VERSION}/ldc-${TERMUX_PKG_VERSION}-beta${_PKG_BETA_VERSION}-src.tar.gz
+TERMUX_PKG_SHA256=fd7fd23dbdad3a0c3b688956743afb461115e4b4f3a2e78fdfec32bc04d5a129
+TERMUX_PKG_DEPENDS="clang"
+TERMUX_PKG_HOSTBUILD=true
+TERMUX_PKG_BLACKLISTED_ARCHES="aarch64,i686,x86_64"
+TERMUX_PKG_FORCE_CMAKE=yes
+#These CMake args are only used to configure a patched LLVM
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DLLVM_ENABLE_PIC=ON
+-DLLVM_BUILD_TOOLS=OFF
+-DLLVM_BUILD_UTILS=OFF
+-DLLVM_TABLEGEN=$TERMUX_PKG_HOSTBUILD_DIR/bin/llvm-tblgen
+-DPYTHON_EXECUTABLE=`which python`
+"
+TERMUX_PKG_KEEP_STATIC_LIBRARIES=true
+TERMUX_PKG_NO_DEVELSPLIT=yes
+TERMUX_PKG_MAINTAINER="Joakim @joakim-noah"
+
+termux_step_post_extract_package () {
+	local LLVM_SRC_VERSION=5.0.0
+	termux_download \
+		https://github.com/ldc-developers/llvm/releases/download/ldc-v${LLVM_SRC_VERSION}/llvm-${LLVM_SRC_VERSION}.src.tar.xz \
+		$TERMUX_PKG_CACHEDIR/llvm-${LLVM_SRC_VERSION}.src.tar.xz \
+		5955d441566b6f86a98ad5a9b4a9ad5c393789d402bb0eeda563e8b7bfbd283c
+
+	tar xf $TERMUX_PKG_CACHEDIR/llvm-${LLVM_SRC_VERSION}.src.tar.xz
+	mv llvm-${LLVM_SRC_VERSION}.src llvm
+
+	DMD_COMPILER_VERSION=2.076.1
+	termux_download \
+		http://downloads.dlang.org/releases/2.x/${DMD_COMPILER_VERSION}/dmd.${DMD_COMPILER_VERSION}.linux.tar.xz \
+		$TERMUX_PKG_CACHEDIR/dmd.${DMD_COMPILER_VERSION}.linux.tar.xz \
+		1d0b8fb6aadc80f6c5dfe7acf46fc17d2b3de24a0bf46e947352094bb21fef04
+
+	sed "s#\@TERMUX_C_COMPILER\@#$TERMUX_STANDALONE_TOOLCHAIN/bin/$TERMUX_HOST_PLATFORM-clang#" \
+		$TERMUX_PKG_BUILDER_DIR/ldc-config-stdlib.patch.beforehostbuild.in > \
+		$TERMUX_PKG_BUILDER_DIR/ldc-config-stdlib.patch.beforehostbuild
+
+	sed "s#\@TERMUX_PKG_HOSTBUILD\@#$TERMUX_PKG_HOSTBUILD_DIR#" $TERMUX_PKG_BUILDER_DIR/ldc-linker-flags.patch.in > \
+		$TERMUX_PKG_BUILDER_DIR/ldc-linker-flags.patch
+
+	sed $TERMUX_PKG_BUILDER_DIR/llvm-config.in \
+		-e "s|@LLVM_VERSION@|$LLVM_SRC_VERSION|g" \
+		-e "s|@LLVM_BUILD_DIR@|$TERMUX_PKG_BUILDDIR/llvm|g" \
+		-e "s|@TERMUX_PKG_SRCDIR@|$TERMUX_PKG_SRCDIR|g" \
+		-e "s|@LLVM_TARGETS@|ARM AArch64 X86|g" \
+		-e "s|@LLVM_DEFAULT_TARGET_TRIPLE@|armv7-none-linux-android|g" \
+		-e "s|@TERMUX_ARCH@|$TERMUX_ARCH|g" > $TERMUX_PKG_BUILDDIR/llvm-config
+	chmod 755 $TERMUX_PKG_BUILDDIR/llvm-config
+}
+
+termux_step_host_build () {
+	tar xf $TERMUX_PKG_CACHEDIR/dmd.${DMD_COMPILER_VERSION}.linux.tar.xz
+
+	termux_setup_cmake
+	termux_setup_ninja
+	cmake -GNinja $TERMUX_PKG_SRCDIR/llvm \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DLLVM_TARGETS_TO_BUILD=ARM \
+		-DLLVM_DEFAULT_TARGET_TRIPLE=armv7-none-linux-android \
+		-DLLVM_BUILD_TOOLS=OFF \
+		-DLLVM_BUILD_UTILS=OFF
+	ninja -j $TERMUX_MAKE_PROCESSES all llvm-config
+
+	mkdir ldc-bootstrap
+	cd ldc-bootstrap
+	export DMD="$TERMUX_PKG_HOSTBUILD_DIR/dmd2/linux/bin64/dmd"
+
+	cmake -GNinja $TERMUX_PKG_SRCDIR \
+		-DD_FLAGS="-w;-mcpu=cortex-a8" \
+		-DRT_CFLAGS="-march=armv7-a -mfpu=neon -mfloat-abi=softfp -mthumb -Oz -I$TERMUX_PREFIX/include" \
+		-DLLVM_CONFIG="$TERMUX_PKG_HOSTBUILD_DIR/bin/llvm-config"
+	ninja -j $TERMUX_MAKE_PROCESSES druntime-ldc phobos2-ldc \
+		druntime-ldc-debug phobos2-ldc-debug ldmd2
+	cd ..
+}
+
+termux_step_pre_configure () {
+	rm $TERMUX_PKG_BUILDER_DIR/ldc-config-stdlib.patch.beforehostbuild
+	rm $TERMUX_PKG_BUILDER_DIR/ldc-linker-flags.patch
+
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DLLVM_DEFAULT_TARGET_TRIPLE=armv7a-linux-androideabi"
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DLLVM_TARGET_ARCH=ARM -DLLVM_TARGETS_TO_BUILD=AArch64;ARM;X86"
+
+	# CPPFLAGS adds the system llvm to the include path, which causes
+	# conflicts with the local patched llvm when compiling ldc
+	CPPFLAGS=""
+
+	OLD_TERMUX_PKG_SRCDIR=$TERMUX_PKG_SRCDIR
+	TERMUX_PKG_SRCDIR=$TERMUX_PKG_SRCDIR/llvm
+
+	OLD_TERMUX_PKG_BUILDDIR=$TERMUX_PKG_BUILDDIR
+	TERMUX_PKG_BUILDDIR=$TERMUX_PKG_BUILDDIR/llvm
+	mkdir "$TERMUX_PKG_BUILDDIR"
+}
+
+termux_step_post_configure () {
+	TERMUX_PKG_SRCDIR=$OLD_TERMUX_PKG_SRCDIR
+	TERMUX_PKG_BUILDDIR=$OLD_TERMUX_PKG_BUILDDIR
+	cd "$TERMUX_PKG_BUILDDIR"
+
+	mv llvm-config llvm/bin
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DLLVM_CONFIG=$TERMUX_PKG_BUILDDIR/llvm/bin/llvm-config"
+	export DMD="$TERMUX_PKG_HOSTBUILD_DIR/ldc-bootstrap/bin/ldmd2"
+	termux_step_configure_cmake
+
+	cp $TERMUX_PKG_HOSTBUILD_DIR/ldc-bootstrap/ddmd/id.d $TERMUX_PKG_BUILDDIR/ddmd
+	cp $TERMUX_PKG_HOSTBUILD_DIR/ldc-bootstrap/ddmd/id.h $TERMUX_PKG_BUILDDIR/ddmd
+}
+
+termux_step_make () {
+	cd llvm
+	if ls ./*akefile &> /dev/null; then
+		make -j $TERMUX_MAKE_PROCESSES
+	fi
+
+	cd ..
+	if ls ./*akefile &> /dev/null; then
+		make -j $TERMUX_MAKE_PROCESSES ldc2 ldmd2
+	fi
+}
+
+termux_step_make_install () {
+	cp bin/ldc2 $TERMUX_PREFIX/bin/ldc2-beta
+	cp bin/ldmd2 $TERMUX_PREFIX/bin/ldmd2-beta
+	cp $TERMUX_PKG_HOSTBUILD_DIR/ldc-bootstrap/lib/libdruntime-ldc.a $TERMUX_PREFIX/lib/libdruntime-ldc-beta.a
+	cp $TERMUX_PKG_HOSTBUILD_DIR/ldc-bootstrap/lib/libdruntime-ldc-debug.a $TERMUX_PREFIX/lib/libdruntime-ldc-beta-debug.a
+	cp $TERMUX_PKG_HOSTBUILD_DIR/ldc-bootstrap/lib/libphobos2-ldc.a $TERMUX_PREFIX/lib/libphobos2-ldc-beta.a
+	cp $TERMUX_PKG_HOSTBUILD_DIR/ldc-bootstrap/lib/libphobos2-ldc-debug.a $TERMUX_PREFIX/lib/libphobos2-ldc-beta-debug.a
+	sed -i "/runtime\/druntime\/src/d" bin/ldc2.conf
+	sed -i "/runtime\/profile-rt\/d/d" bin/ldc2.conf
+	sed -i "s|$TERMUX_PKG_SRCDIR/runtime/phobos|%%ldcbinarypath%%/../include/d-beta|" bin/ldc2.conf
+	sed -i "s|-ldc|-ldc-beta|g" bin/ldc2.conf
+	sed "s|$TERMUX_PKG_BUILDDIR/lib|%%ldcbinarypath%%/../lib|" bin/ldc2.conf > $TERMUX_PREFIX/etc/ldc2-beta.conf
+
+	rm -Rf $TERMUX_PREFIX/include/d-beta
+	mkdir $TERMUX_PREFIX/include/d-beta
+	cp -r $TERMUX_PKG_SRCDIR/runtime/druntime/src/{core,etc,ldc,object.d} $TERMUX_PREFIX/include/d-beta
+	cp $TERMUX_PKG_HOSTBUILD_DIR/ldc-bootstrap/runtime/gccbuiltins_arm.di $TERMUX_PREFIX/include/d-beta/ldc
+	cp -r $TERMUX_PKG_SRCDIR/runtime/phobos/etc/c $TERMUX_PREFIX/include/d-beta/etc
+	rm -Rf $TERMUX_PREFIX/include/d-beta/etc/c/zlib
+	find $TERMUX_PKG_SRCDIR/runtime/phobos/std -name "*.orig" -delete
+	cp -r $TERMUX_PKG_SRCDIR/runtime/phobos/std $TERMUX_PREFIX/include/d-beta
+
+	rm -Rf $TERMUX_PREFIX/share/ldc-beta
+	mkdir $TERMUX_PREFIX/share/ldc-beta
+	cp -r $TERMUX_PKG_SRCDIR/{LICENSE,README,bash_completion.d} $TERMUX_PREFIX/share/ldc-beta
+}

--- a/packages/ldc-beta/ldc-config-beta.patch
+++ b/packages/ldc-beta/ldc-config-beta.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c89cb228..415c5cf4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -691,7 +691,7 @@ endif()
+ 
+ set_source_files_properties(driver/exe_path.cpp driver/ldmd.cpp driver/response.cpp PROPERTIES
+     COMPILE_FLAGS "${LDC_CXXFLAGS} ${LLVM_CXXFLAGS}"
+-    COMPILE_DEFINITIONS LDC_EXE_NAME="${LDC_EXE_NAME}"
++    COMPILE_DEFINITIONS LDC_EXE_NAME="${LDC_EXE_NAME}-beta"
+ )
+ 
+ add_library(LDMD_CXX_LIB ${LDC_LIB_TYPE} driver/exe_path.cpp driver/ldmd.cpp driver/response.cpp driver/exe_path.h)
+diff --git a/driver/configfile.cpp b/driver/configfile.cpp
+index 96363888..2950817e 100644
+--- a/driver/configfile.cpp
++++ b/driver/configfile.cpp
+@@ -90,7 +90,7 @@ bool ConfigFile::locate(std::string &pathstr) {
+   // temporary configuration
+ 
+   llvm::SmallString<128> p;
+-  const char *filename = "ldc2.conf";
++  const char *filename = "ldc2-beta.conf";
+ 
+ #define APPEND_FILENAME_AND_RETURN_IF_EXISTS                                   \
+   {                                                                            \

--- a/packages/ldc-beta/ldc-config-stdlib.patch.beforehostbuild.in
+++ b/packages/ldc-beta/ldc-config-stdlib.patch.beforehostbuild.in
@@ -1,0 +1,14 @@
+diff --git a/runtime/CMakeLists.txt b/runtime/CMakeLists.txt
+index 32795da6..091d344b 100644
+--- a/runtime/CMakeLists.txt
++++ b/runtime/CMakeLists.txt
+@@ -551,6 +551,9 @@ include(profile-rt/DefineBuildProfileRT.cmake)
+ #
+ # Set up build and install targets
+ #
++
++set(CMAKE_C_COMPILER @TERMUX_C_COMPILER@)
++set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+ 
+ if(MULTILIB AND "${TARGET_SYSTEM}" MATCHES "APPLE")
+     # On OS X, build "fat" libraries containing code for both architectures.

--- a/packages/ldc-beta/ldc-disable-idgen.patch
+++ b/packages/ldc-beta/ldc-disable-idgen.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c89cb228..cc507c22 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -269,7 +269,7 @@ endmacro()
+ #
+ # Build idgen.
+ #
+-build_idgen(${DDMDFE_PATH}/idgen.d ${PROJECT_BINARY_DIR}/idgen${CMAKE_EXECUTABLE_SUFFIX}  ${DDMD_DFLAGS} "" "")
++#build_idgen(${DDMDFE_PATH}/idgen.d ${PROJECT_BINARY_DIR}/idgen${CMAKE_EXECUTABLE_SUFFIX}  ${DDMD_DFLAGS} "" "")
+ # Run idgen.
+ add_custom_command(
+     OUTPUT
+@@ -277,7 +277,7 @@ add_custom_command(
+         ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/id.h
+     COMMAND ${PROJECT_BINARY_DIR}/idgen  #provide full path to avoid clash with idgen on path
+     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+-    DEPENDS ${PROJECT_BINARY_DIR}/idgen${CMAKE_EXECUTABLE_SUFFIX}
++    #    DEPENDS ${PROJECT_BINARY_DIR}/idgen${CMAKE_EXECUTABLE_SUFFIX}
+ )
+ set(LDC_CXX_GENERATED
+     ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/id.h

--- a/packages/ldc-beta/ldc-linker-flags.patch.in
+++ b/packages/ldc-beta/ldc-linker-flags.patch.in
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 336bbdbc..4b9e8c88 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -591,7 +591,8 @@ if(UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR (${CMAKE_CXX_COMPILER_ID} STREQUAL "Cla
+         message(FATAL_ERROR "GDMD currently not supported due to http://bugzilla.gdcproject.org/show_bug.cgi?id=232.")
+     endif()
+ 
+-    include(ExtractDMDSystemLinker)
++    #include(ExtractDMDSystemLinker)
++    set(D_LINKER_ARGS "-fuse-ld=bfd;-L@TERMUX_PKG_HOSTBUILD@/ldc-bootstrap/lib;-lphobos2-ldc;-ldruntime-ldc;-Wl,--gc-sections")
+     message(STATUS "Host D compiler linker program: ${D_LINKER_COMMAND}")
+     message(STATUS "Host D compiler linker flags: ${D_LINKER_ARGS}")
+     list(APPEND LDC_LINKERFLAG_LIST ${D_LINKER_ARGS})

--- a/packages/ldc-beta/ldc-phobos.patch.beforehostbuild
+++ b/packages/ldc-beta/ldc-phobos.patch.beforehostbuild
@@ -1,0 +1,62 @@
+diff --git a/std/stdio.d b/std/stdio.d
+index 0c315026..8b1860d0 100644
+--- a/std/stdio.d
++++ b/runtime/phobos/std/stdio.d
+@@ -310,6 +310,45 @@ else version (GENERIC_IO)
+         void funlockfile(FILE*);
+     }
+ 
++    version(CRuntime_Bionic)
++    {
++        import core.stdc.wchar_ : mbstate_t;
++        import core.sys.posix.sys.types : pthread_mutex_t;
++
++        extern(C) struct wchar_io_data
++        {
++            mbstate_t  wcio_mbstate_in;
++            mbstate_t  wcio_mbstate_out;
++            wchar_t[1] wcio_ungetwc_buf;
++            size_t     wcio_ungetwc_inbuf;
++            int        wcio_mode;
++        }
++
++        extern(C) struct __sfileext
++        {
++            __sbuf          _ub;
++            wchar_io_data   _wcio;
++            pthread_mutex_t _lock;
++        }
++
++        void bionic_lock(FILE* foo)
++        {
++            if( foo == stdout._p.handle || foo == stdin._p.handle || foo == stderr._p.handle)
++            {
++                auto ext = cast(__sfileext*) foo._ext._base;
++                if (ext._lock.value == 0)
++                {
++                    // A bionic regression in Android 5.0 leaves
++                    // the mutex for stdout/err/in uninitialized,
++                    // so check for that and initialize it.
++                    printf("lock is zero, initializing...\n");
++                    ext._lock.value = 0x4000;
++                }
++            }
++            flockfile(foo);
++        }
++    }
++
+     int fputc_unlocked(int c, _iobuf* fp) { return fputc(c, cast(shared) fp); }
+     int fputwc_unlocked(wchar_t c, _iobuf* fp)
+     {
+@@ -328,7 +367,10 @@ else version (GENERIC_IO)
+     alias FGETC = fgetc_unlocked;
+     alias FGETWC = fgetwc_unlocked;
+ 
+-    alias FLOCK = flockfile;
++    version(CRuntime_Bionic)
++        alias FLOCK = bionic_lock;
++    else
++        alias FLOCK = flockfile;
+     alias FUNLOCK = funlockfile;
+ }
+ else

--- a/packages/ldc-beta/ldc-readme.patch
+++ b/packages/ldc-beta/ldc-readme.patch
@@ -1,0 +1,24 @@
+diff --git a/README b/README
+new file mode 100644
+index 00000000..cd578cb7
+--- /dev/null
++++ b/README
+@@ -0,0 +1,18 @@
++This is the beta version of LDC, the LLVM-based D compiler.
++It will natively compile D on Android/ARM devices.
++
++The compiler configuration file is etc/ldc2-beta.conf, and by
++default only include/d-beta is on the module search path.
++
++To develop for Android, you will find the D headers and
++sample apps at this github repository useful:
++
++https://github.com/joakim-noah/android
++
++You can find instructions on building Android apps at the
++D wiki:
++
++http://wiki.dlang.org/Build_D_for_Android
++
++For further information, including how to report bugs,
++please refer to the LDC wiki: http://wiki.dlang.org/LDC.

--- a/packages/ldc-beta/ldc-tools-utils-bugs.patch
+++ b/packages/ldc-beta/ldc-tools-utils-bugs.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 336bbdbc..4b9e8c88 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -736,12 +737,12 @@ endif()
+ #
+ # Auxiliary build and test utils.
+ #
+-add_subdirectory(utils)
++#add_subdirectory(utils)
+ 
+ #
+ # Auxiliary tools.
+ #
+-add_subdirectory(tools)
++#add_subdirectory(tools)
+ 
+ #
+ # Test and runtime targets. Note that enable_testing() is order-sensitive!

--- a/packages/ldc-beta/llvm-config.in
+++ b/packages/ldc-beta/llvm-config.in
@@ -1,0 +1,106 @@
+#!/bin/sh
+show_help () {
+echo "usage: llvm-config <OPTION>... [<COMPONENT>...]
+
+Get various configuration information needed to compile programs which use
+LLVM.  Typically called from 'configure' scripts.  Examples:
+  llvm-config --cxxflags
+  llvm-config --ldflags
+  llvm-config --libs engine bcreader scalaropts
+
+Options:
+  --version         Print LLVM version.
+  --prefix          Print the installation prefix.
+  --src-root        Print the source root LLVM was built from.
+  --obj-root        Print the object root used to build LLVM.
+  --bindir          Directory containing LLVM executables.
+  --includedir      Directory containing LLVM headers.
+  --libdir          Directory containing LLVM libraries.
+  --cppflags        C preprocessor flags for files that include LLVM headers.
+  --cflags          C compiler flags for files that include LLVM headers.
+  --cxxflags        C++ compiler flags for files that include LLVM headers.
+  --ldflags         Print Linker flags.
+  --system-libs     System Libraries needed to link against LLVM components.
+  --libs            Libraries needed to link against LLVM components.
+  --libnames        Bare library names for in-tree builds.
+  --libfiles        Fully qualified library filenames for makefile depends.
+  --components      List of all possible components.
+  --targets-built   List of all targets currently built.
+  --host-target     Target triple used to configure LLVM.
+  --build-mode      Print build mode of LLVM tree (e.g. Debug or Release).
+  --assertion-mode  Print assertion mode of LLVM tree (ON or OFF).
+  --build-system    Print the build system used to build LLVM (always cmake).
+  --has-rtti        Print whether or not LLVM was built with rtti (YES or NO).
+  --has-global-isel Print whether or not LLVM was built with global-isel support (YES or NO).
+  --shared-mode     Print how the provided components can be collectively linked (\`shared\` or \`static\`).
+  --link-shared     Link the components as shared libraries.
+  --link-static     Link the component libraries statically.                                                                                                                                 
+Typical components:                                                                                                                                                                          
+  all               All LLVM libraries (default).                                                                                                                                            
+  engine            Either a native JIT or a bitcode interpreter."
+}
+
+arch=@TERMUX_ARCH@
+version=@LLVM_VERSION@
+prefix=@LLVM_BUILD_DIR@
+has_rtti=NO
+CPPFLAGS="-I@TERMUX_PKG_SRCDIR@/llvm/include -I${prefix}/include -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS"
+CFLAGS="${CPPFLAGS} -Os -fPIC -Wall -W -Wno-unused-parameter -Wwrite-strings -Wmissing-field-initializers"
+CFLAGS="${CFLAGS} -pedantic -Wno-long-long -Wdelete-non-virtual-dtor -Werror=date-time -ffunction-sections"
+CFLAGS="${CFLAGS} -fdata-sections -DNDEBUG"
+CXXFLAGS="${CFLAGS} -fvisibility-inlines-hidden -Wcast-qual -Wnon-virtual-dtor -std=c++11 -fno-exceptions"
+if [ "$has_rtti" != "YES" ]; then CXXFLAGS="$CXXFLAGS -fno-rtti"; fi
+LDFLAGS="-L${prefix}/lib"
+LIBFILE="${prefix}/lib/libLLVM-$version.so"
+LLVM_LIBRARIES="-lLLVMTableGen -lLLVMLibDriver -lLLVMOption -lLLVMSymbolize -lLLVMDebugInfoPDB -lLLVMDebugInfoDWARF -lLLVMTestingSupport -lLLVMAArch64Disassembler -lLLVMAArch64CodeGen -lLLVMAArch64AsmParser -lLLVMAArch64Desc -lLLVMAArch64Info -lLLVMAArch64AsmPrinter -lLLVMAArch64Utils -lLLVMARMDisassembler -lLLVMARMCodeGen -lLLVMARMAsmParser -lLLVMARMDesc -lLLVMARMInfo -lLLVMARMAsmPrinter -lLLVMLineEditor -lLLVMMIRParser -lLLVMLTO -lLLVMPasses -lLLVMObjCARCOpts -lLLVMOrcJIT -lLLVMInterpreter -lLLVMObjectYAML -lLLVMX86Disassembler -lLLVMX86AsmParser -lLLVMX86CodeGen -lLLVMGlobalISel -lLLVMSelectionDAG -lLLVMAsmPrinter -lLLVMDebugInfoCodeView -lLLVMDebugInfoMSF -lLLVMCodeGen -lLLVMX86Desc -lLLVMMCDisassembler -lLLVMX86Info -lLLVMX86AsmPrinter -lLLVMX86Utils -lLLVMMCJIT -lLLVMExecutionEngine -lLLVMTarget -lLLVMRuntimeDyld -lgtest_main -lgtest -lLLVMCoroutines -lLLVMipo -lLLVMInstrumentation -lLLVMVectorize -lLLVMScalarOpts -lLLVMLinker -lLLVMIRReader -lLLVMAsmParser -lLLVMDlltoolDriver -lLLVMInstCombine -lLLVMTransformUtils -lLLVMBitWriter -lLLVMAnalysis -lLLVMCoverage -lLLVMProfileData -lLLVMObject -lLLVMMCParser -lLLVMMC -lLLVMBitReader -lLLVMCore -lLLVMBinaryFormat -lLLVMSupport -lLLVMDemangle"
+
+show_components () {
+if [ "$arch" == "x86_64" -o "$arch" == "i686" ]; then arch="x86"; fi
+components="all all-targets analysis $arch ${arch}asmparser ${arch}asmprinter ${arch}codegen ${arch}desc"
+components="$components ${arch}disassembler ${arch}info asmparser asmprinter bitreader bitwriter codegen"
+components="$components core coroutines coverage debuginfocodeview debuginfodwarf debuginfomsf debuginfopdb"
+components="$components demangle engine executionengine globalisel instcombine instrumentation interpreter"
+components="$components ipo irreader libdriver lineeditor linker lto mc mcdisassembler mcjit mcparser"
+components="$components mirparser native nativecodegen objcarcopts object objectyaml option orcjit passes"
+components="$components profiledata runtimedyld scalaropts selectiondag support symbolize tablegen target"
+components="$components transformutils vectorize"
+if [ "$arch" != "arm" ]; then components="$components ${arch}utils"; fi
+echo "$components"
+}
+
+handle_args () {
+	case "${1##--}" in
+		version) echo "$version";;
+		prefix) echo "$prefix";;
+		src-root) echo "@TERMUX_PKG_SRCDIR@";;
+		obj-root) echo "$prefix";;
+		bindir) echo "$prefix/bin";;
+		includedir) echo "@TERMUX_PKG_SRCDIR@/llvm/include";;
+		libdir) echo "$prefix/lib";;
+		cppflags) echo "$CPPFLAGS";;
+		cflags) echo "$CFLAGS";;
+		cxxflags) echo "$CXXFLAGS";;
+		ldflags) echo "$LDFLAGS";;
+		system-libs) echo "-lc -ldl -lncurses -lz -lm";;
+		libs) echo "$LLVM_LIBRARIES";;
+		libnames) echo "libLLVM-$version.so";;
+		libfiles) echo "$LIBFILE";;
+		components) show_components;;
+		targets-built) echo "@LLVM_TARGETS@";;
+		host-target) echo "@LLVM_DEFAULT_TARGET_TRIPLE@";;
+		build-mode) echo "Release";;
+		assertion-mode) echo "OFF";;
+		build-system) echo "cmake";;
+		has-rtti) echo "$has_rtti";;
+		has-global-isel) echo "OFF";;
+		shared-mode) echo "shared";;
+		cmakedir) echo "$prefix/lib/cmake/llvm";;
+		# don't know what these do
+		link-shared) ;;
+		link-static) ;;
+		*) show_help >&2;;
+	esac
+}
+
+for arg in $@; do handle_args $arg; done
+


### PR DESCRIPTION
This is an updated version of the ldc package, built from the recently released ldc 1.4 beta1.  I want to use it alongside the ldc package, so I added the `-beta` designation to executables, directories, libraries, and the config file.  If you diff it against the latest version of ldc in #1311, that's basically all that changed.