### PR TITLE
qalc: update from 1.0.0 to 2.0.0

### DIFF
--- a/packages/qalc/build.sh
+++ b/packages/qalc/build.sh
@@ -1,8 +1,8 @@
 TERMUX_PKG_HOMEPAGE=https://qalculate.github.io/
 TERMUX_PKG_DESCRIPTION="Powerful and easy to use command line calculator"
-TERMUX_PKG_VERSION=1.0.0
+TERMUX_PKG_VERSION=2.0.0
 TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://github.com/Qalculate/libqalculate/releases/download/v${TERMUX_PKG_VERSION}a/libqalculate-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=7cc5a67356374d7f4fb20619dc4dd7976bbe9ae8d5bc3a40b44c46264de9549b
-TERMUX_PKG_DEPENDS="glib, gnuplot, libcln, ncurses"
+TERMUX_PKG_SRCURL=https://github.com/Qalculate/libqalculate/releases/download/v${TERMUX_PKG_VERSION}/libqalculate-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=86d04362f37aa5acbc78108e0044b96fbffbaa33c309c19c8c37ac4fb46c5485
+ERMUX_PKG_DEPENDS="gnuplot, libcurl, libgmp, libmpfr, libxml2, iconv, ncurses"
 TERMUX_PKG_BUILD_IN_SRC=yes

--- a/packages/qalc/util.cc.patch
+++ b/packages/qalc/util.cc.patch
@@ -1,6 +1,6 @@
---- ../libqalculate-1.0.0/libqalculate/util.cc	2017-07-16 12:48:15.000000000 +0200
-+++ ./libqalculate/util.cc	2017-08-08 23:15:29.000000000 +0200
-@@ -937,8 +937,8 @@
+--- ../libqalculate-2.0.0/libqalculate/util.cc	2017-08-27 20:37:20.000000000 +0200
++++ ./libqalculate/util.cc	2017-08-30 21:33:31.235484528 +0200
+@@ -771,8 +771,8 @@
  }
  
  void Thread::enableAsynchronousCancel() {
@@ -11,12 +11,13 @@
  }
  
  void *Thread::doRun(void *data) {
-@@ -960,7 +960,7 @@
- }
+@@ -795,7 +795,8 @@
  
  bool Thread::cancel() {
--	int ret = pthread_cancel(m_thread);
-+	int ret = pthread_kill(m_thread, 0);
- 	running = (ret != 0);
+ 	if(!running) return true;
+-	running = pthread_cancel(m_thread) != 0;
++	//running = pthread_cancel(m_thread) != 0;
++	running = pthread_kill(m_thread, 0) != 0;
  	return !running;
  }
+ 


### PR DESCRIPTION
[Version 2.0.0](https://github.com/Qalculate/libqalculate/releases/tag/v2.0.0) comes with dependency changes: forget glib and libcln to use libgmp and libmpfr instead, as well as libcurl and libiconv.