### PR TITLE
Add patch for Fossil to use correct shell when emulating popen()

### DIFF
--- a/packages/fossil/fossil-2.3-termux-sh.patch
+++ b/packages/fossil/fossil-2.3-termux-sh.patch
@@ -1,7 +1,7 @@
 Index: src/popen.c
 ==================================================================
---- src/popen.c
-+++ src/popen.c
+--- a/src/popen.c
++++ b/src/popen.c
 @@ -189,11 +189,11 @@
      close(1);
      fd = dup(pin[1]);

--- a/packages/fossil/fossil-2.3-termux-sh.patch
+++ b/packages/fossil/fossil-2.3-termux-sh.patch
@@ -1,0 +1,18 @@
+Index: src/popen.c
+==================================================================
+--- src/popen.c
++++ src/popen.c
+@@ -189,11 +189,11 @@
+     close(1);
+     fd = dup(pin[1]);
+     if( fd!=1 ) nErr++;
+     close(pin[0]);
+     close(pin[1]);
+-    execl("/bin/sh", "/bin/sh", "-c", zCmd, (char*)0);
++    execl("/data/data/com.termux/files/usr/bin/sh", "/data/data/com.termux/files/usr/bin/sh", "-c", zCmd, (char*)0);
+     return 1;
+   }else{
+     /* This is the parent process */
+     close(pin[1]);
+     *pfdIn = pin[0];
+


### PR DESCRIPTION
Currently Fossil uses /bin/sh for calling out, change this to a Termux-ified path.