### PR TITLE
Add package: Opam

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -199,8 +199,9 @@ termux_setup_ocaml() {
 		tar xf "$TAR_FILE" -C "$TERMUX_PKG_TMPDIR"
 		(
 				cd "$OCAML_SRC_FOLDER" &&
-			 	patch -p1 < "$TERMUX_SCRIPTDIR/scripts/ocaml-cross-compile.patch" &&
-			 	patch -p1 < "$TERMUX_SCRIPTDIR/scripts/ocaml-group-passwd.patch"
+				patch -p1 < "$TERMUX_SCRIPTDIR/scripts/ocaml-cross-compile.patch" &&
+				patch -p1 < "$TERMUX_SCRIPTDIR/scripts/ocaml-group-passwd.patch" &&
+				patch -p1 < "$TERMUX_SCRIPTDIR/scripts/ocaml-arm-pic.patch"
 		)
 
 		# The ocaml cross compiler build scripts require a native version of ocaml

--- a/packages/opam/build.sh
+++ b/packages/opam/build.sh
@@ -1,0 +1,28 @@
+TERMUX_PKG_HOMEPAGE=http://www.ocaml.org
+TERMUX_PKG_DESCRIPTION="OPAM is a source-based package manager for OCaml."
+TERMUX_PKG_DEPENDS="wget, curl, git, patch, tar, gzip, bzip2, xz-utils, rsync"
+_MAIN_VERSION=1.2.2
+_PATCH_VERSION=1
+TERMUX_PKG_VERSION=${_MAIN_VERSION}.${_PATCH_VERSION}
+TERMUX_PKG_SRCURL=https://github.com/ocaml/opam/releases/download/${_MAIN_VERSION}/opam-full-${_MAIN_VERSION}.tar.gz
+TERMUX_PKG_SHA256=15e617179251041f4bf3910257bbb8398db987d863dd3cfc288bdd958de58f00
+TERMUX_PKG_BUILD_IN_SRC=yes
+
+termux_step_pre_configure() {
+	termux_setup_ocaml
+
+  # One of the patches edited the configure.ac file, so the configure file
+  # needs to be regenerated.
+  autoreconf -i
+}
+
+termux_step_make() {
+  # opam's dependencies seem to be broken. So the -j 1 option is given to only
+  # build one rule at a time.
+
+  # Build the dependencies from the included source instead of using them from
+  # the system.
+  make -j 1 lib-ext
+  # Now build opam.
+  make -j 1
+}

--- a/packages/opam/cross.patch
+++ b/packages/opam/cross.patch
@@ -1,0 +1,103 @@
+diff -r -u src.orig/Makefile src/Makefile
+--- src.orig/Makefile	2017-08-29 16:37:11.860642704 +0000
++++ src/Makefile	2017-08-29 16:42:38.114253040 +0000
+@@ -1,6 +1,6 @@
+ -include Makefile.config
+ 
+-all: opam-lib opam opam-admin opam-installer
++all: opam-lib opam opam-admin opam-installer opam-installer.byte
+ 	@
+ 
+ ALWAYS:
+@@ -55,16 +55,16 @@
+ 
+ libinstall:
+ 	$(if $(wildcard src_ext/lib/*),$(error Installing the opam libraries is incompatible with embedding the dependencies. Run 'make clean-ext' and try again))
+-	src/opam-installer $(OPAMINSTALLER_FLAGS) opam-lib.install
++	src/opam-installer.byte $(OPAMINSTALLER_FLAGS) opam-lib.install
+ 
+ install:
+-	src/opam-installer $(OPAMINSTALLER_FLAGS) opam.install
++	$(OCAMLRUN) src/opam-installer.byte $(OPAMINSTALLER_FLAGS) opam.install
+ 
+ libuninstall:
+-	src/opam-installer -u $(OPAMINSTALLER_FLAGS) opam-lib.install
++	$(OCAMLRUN) src/opam-installer.byte -u $(OPAMINSTALLER_FLAGS) opam-lib.install
+ 
+ uninstall:
+-	src/opam-installer -u $(OPAMINSTALLER_FLAGS) opam.install
++	$(OCAMLRUN) src/opam-installer.byte -u $(OPAMINSTALLER_FLAGS) opam.install
+ 
+ .PHONY: tests tests-local tests-git
+ tests: opam opam-admin opam-check
+diff -r -u src.orig/Makefile.config.in src/Makefile.config.in
+--- src.orig/Makefile.config.in	2017-08-29 15:04:04.643629165 +0000
++++ src/Makefile.config.in	2017-08-29 16:42:38.115252993 +0000
+@@ -20,5 +20,7 @@
+ OCAMLYACC = @OCAMLYACC@
+ OCAMLMKLIB = @OCAMLMKLIB@
+ OCAMLDOC = @OCAMLDOC@
++OCAMLMKTOP = @OCAMLMKTOP@
++OCAMLRUN = @OCAMLRUN@
+ 
+-export OCAMLVERSION OCAMLFIND OCAML OCAMLC OCAMLOPT OCAMLDEP OCAMLLEX OCAMLYACC OCAMLMKLIB OCAMLDOC
++export OCAMLVERSION OCAMLFIND OCAML OCAMLC OCAMLOPT OCAMLDEP OCAMLLEX OCAMLYACC OCAMLMKLIB OCAMLDOC OCAMLMKTOP OCAMLRUN
+diff -r -u src.orig/OCamlMakefile src/OCamlMakefile
+--- src.orig/OCamlMakefile	2017-08-29 16:38:42.884349037 +0000
++++ src/OCamlMakefile	2017-08-29 16:42:38.115252993 +0000
+@@ -112,7 +112,7 @@
+ 
+ ####################  variables depending on your OCaml-installation
+ 
+-SYSTEM := $(shell ocamlc -config 2>/dev/null | grep system | sed 's/system: //')
++SYSTEM := $(shell $(OCAMLC) -config 2>/dev/null | grep system | sed 's/system: //')
+     # This may be
+     # - mingw
+     # - mingw64
+diff -r -u src.orig/configure.ac src/configure.ac
+--- src.orig/configure.ac	2017-08-29 15:04:04.642629214 +0000
++++ src/configure.ac	2017-08-29 16:42:38.115252993 +0000
+@@ -31,6 +31,8 @@
+ AC_PROG_OCAMLLEX
+ AC_PROG_OCAMLYACC
+ AC_PROG_FINDLIB
++AC_CHECK_TOOL([OCAMLRUN],[ocamlrun],[no])
++AC_SUBST([OCAMLRUN])
+ 
+ AC_ARG_ENABLE([certificate_check],
+   AS_HELP_STRING([--disable-certificate-check],
+diff -r -u src.orig/src/Makefile src/src/Makefile
+--- src.orig/src/Makefile	2017-08-29 16:50:05.154165783 +0000
++++ src/src/Makefile	2017-08-29 16:47:33.236331878 +0000
+@@ -10,6 +10,7 @@
+ 	$(MAKE) opam-check
+ 	$(MAKE) opam-admin
+ 	$(MAKE) opam-installer
++	$(MAKE) opam-installer.byte
+ 	$(MAKE) opamlfind
+ 	$(MAKE) opam-admin.top
+ 
+@@ -216,6 +217,9 @@
+ $(TOOLS): opam ALWAYS
+ 	$(MAKE) -f $(OCAMLMAKEFILE) subprojs SUBPROJS=$@ SUBTARGET=$(BINTARGET)
+ 
++opam-installer.byte: opam opam-lib.byte ALWAYS
++	$(MAKE) -f $(OCAMLMAKEFILE) subprojs SUBPROJS=opam-installer-byte SUBTARGET=byte-code
++
+ define PROJ_opam-check
+   SOURCES = tools/opam_check.ml
+   RESULT = opam-check
+@@ -246,6 +250,13 @@
+ endef
+ export PROJ_opam-installer
+ 
++define PROJ_opam-installer-byte
++  SOURCES = tools/opam_installer.ml
++  RESULT = opam-installer.byte
++  LIBS = $(LIBS) $(OPAMLIB)
++endef
++export PROJ_opam-installer-byte
++
+ define PROJ_opamlfind
+   SOURCES = tools/opamlfind.ml
+   RESULT = opamlfind

--- a/packages/opam/sh-path.patch
+++ b/packages/opam/sh-path.patch
@@ -1,0 +1,23 @@
+diff -r -u src.orig/src/core/opamSystem.ml src/src/core/opamSystem.ml
+--- src.orig/src/core/opamSystem.ml	2017-08-29 15:04:04.634629601 +0000
++++ src/src/core/opamSystem.ml	2017-08-29 19:11:59.323852294 +0000
+@@ -302,10 +302,10 @@
+ let command_exists =
+   let is_external_cmd name = Filename.basename name <> name in
+   let check_existence ?dir env name =
+-    let cmd, args = "/bin/sh", ["-c"; Printf.sprintf "command -v %s" name] in
++    let cmd, args = "/data/data/com.termux/files/usr/bin/sh", ["-c"; Printf.sprintf "command -v %s" name] in
+     let r =
+       OpamProcess.run
+         (OpamProcess.command ~env ?dir ~name:(temp_file "command") ~verbose:false
+            cmd args)
+     in
+     OpamProcess.cleanup ~force:true r;
+diff -r -u opam-full-1.2.2.orig/AUTHORS opam-full-1.2.2/AUTHORS
+--- opam-full-1.2.2.orig/AUTHORS	2015-04-27 01:51:22.000000000 -0700
++++ opam-full-1.2.2/AUTHORS	2017-08-29 15:35:46.144809688 -0700
+@@ -6,3 +6,4 @@
+ Guillem Rieu        <guillem.rieu@ocamlpro.com>
+ Vincent Bernardoff  <vb@luminar.eu.org>
+ Roberto Di Cosmo    <roberto@dicosmo.org>
++Kyle Stemen         <kstemen@google.com>

--- a/scripts/ocaml-arm-pic.patch
+++ b/scripts/ocaml-arm-pic.patch
@@ -1,0 +1,394 @@
+diff -ru ocaml-4.02.3/asmcomp/arm/arch.ml ocaml-4.02.3.patched/asmcomp/arm/arch.ml
+--- ocaml-4.02.3/asmcomp/arm/arch.ml	2017-10-09 00:49:16.174443075 +0000
++++ ocaml-4.02.3.patched/asmcomp/arm/arch.ml	2017-10-09 00:53:18.818877148 +0000
+@@ -21,7 +21,7 @@
+ 
+ let abi =
+   match Config.system with
+-    "linux_eabi" | "freebsd" -> EABI
++    "linux_eabi" | "freebsd" | "android_eabi" -> EABI
+   | "linux_eabihf" -> EABI_HF
+   | _ -> assert false
+ 
+@@ -56,7 +56,9 @@
+     end in
+   (ref def_arch, ref def_fpu, ref def_thumb)
+ 
+-let pic_code = ref false
++let pic_code = ref (match Config.system with
++                    | "android_eabi" -> true
++                    | _              -> false)
+ 
+ let farch spec =
+   arch := (match spec with
+--- ocaml-4.02.3/asmrun/arm.S	2014-08-21 10:06:19.000000000 +0000
++++ ocaml-4.02.3.patched/asmrun/arm.S	2017-10-10 06:27:21.271748503 +0000
+@@ -27,7 +27,7 @@
+         cmp     \reg, #0
+         beq     \lbl
+         .endm
+-#elif defined(SYS_linux_eabihf)
++#elif defined(SYS_linux_eabihf) || defined(SYS_android_eabi)
+         .arch   armv7-a
+         .fpu    vfpv3-d16
+         .thumb
+@@ -81,6 +81,70 @@
+ #define PROFILE
+ #endif
+ 
++#if defined(__PIC__)
++
++/* This assembly code goes in the .text section. The .text section holds
++ * read-only, executable code. Android complains when .text sections have
++ * relocations. A relocation is inserted whenever an instruction is used that
++ * has to be altered depending on where the code is loaded in memory.
++ *
++ * An example is:
++ *     ldr      r1, =caml_last_return_address
++ *
++ * caml_last_return_address is a dynamic symbol. Its location relative to this
++ * file can change (since the symbol can be overridden with an LD_PRELOAD). So
++ * the above ldr pseudo instruction example would actually stick the absolute
++ * address of caml_last_return_address somewhere inside this section as a data
++ * word. The ldr pseudo instruction would turn into an ldr instruction that
++ * reads that data word. That data word would need a relocation so that at load
++ * time, the data word would have to get changed depending on where
++ * caml_last_return_address is. Since the data word is part of this .text
++ * section, that would be a relocation in a .text section.
++ *
++ * The alternative is to use a global offset table (GOT), which is essentially
++ * a big array of all the pointers to dynamic symbols. The GOT is stored in a
++ * different section, but the location of the GOT relative to this section is
++ * fixed. So this section can use addresses relative to the pc register to
++ * access the GOT.
++ *
++ * The ldr can only directly use relative addresses that are within +4KB of
++ * the pc register. The GOT is likely farther away than that. So instead the
++ * GOT relative address can be stored in a data word in this section
++ * (.Lgot_caml_last_return_address in the previous example), because data words
++ * are 32 bit. Then the code can use an ldr instruction to access the data
++ * word, and then readjust the loaded data word based on the pc.
++ *
++ * caml_last_return_address(GOT_PREL) means the address of the
++ * caml_last_return_address in the GOT. The address to the GOT is relative to
++ * where the data word is defined. So translating it involves:
++ * 1. Load the data word using a relative address.
++ * 2. The relative address is relative to the data word's address. Adding the
++ *    PC from around where the data word was loaded gets close to the absolute
++ *    address of the GOT entry.
++ * 3. Fix the absolute address by subtracting the difference between the data
++ *    word's location and the instruction address of where it was loaded (the
++ *    pc value from the previous step). Now the correct absolute address of the
++ *    GOT entry is in the register.
++ * 4. Read the GOT entry to get the absolute address of the symbol.
++ */
++
++#define ADDRGLOBAL(reg, sym) \
++        ldr     reg, .Lgot_##sym; \
++        8: \
++        add     reg, pc, reg; \
++        9: \
++        /* On ARM the pc register's value actually points to 2             */ \
++        /* instructions after the current instruction. The 8b 9b is        */ \
++        /* adjusting for that. */ \
++        ldr     reg, [reg, #(.Lgot_##sym - 8b - 2 * (9b - 8b))]
++
++#else
++
++#define ADDRGLOBAL(reg, sym) \
++        ldr     reg, =sym
++
++#endif
++
+ /* Allocation functions and GC interface */
+ 
+         .globl  caml_system__code_begin
+@@ -92,11 +156,11 @@
+         CFI_STARTPROC
+         PROFILE
+     /* Record return address */
+-        ldr     r12, =caml_last_return_address
++        ADDRGLOBAL(r12, caml_last_return_address)
+         str     lr, [r12]
+ .Lcaml_call_gc:
+     /* Record lowest stack address */
+-        ldr     r12, =caml_bottom_of_stack
++        ADDRGLOBAL(r12, caml_bottom_of_stack)
+         str     sp, [r12]
+ #if defined(SYS_linux_eabihf)
+     /* Save caller floating-point registers on the stack */
+@@ -105,13 +169,13 @@
+     /* Save integer registers and return address on the stack */
+         push    {r0-r7,r12,lr}; CFI_ADJUST(40)
+     /* Store pointer to saved integer registers in caml_gc_regs */
+-        ldr     r12, =caml_gc_regs
++        ADDRGLOBAL(r12, caml_gc_regs)
+         str     sp, [r12]
+     /* Save current allocation pointer for debugging purposes */
+-        ldr     alloc_limit, =caml_young_ptr
++        ADDRGLOBAL(alloc_limit, caml_young_ptr)
+         str     alloc_ptr, [alloc_limit]
+     /* Save trap pointer in case an exception is raised during GC */
+-        ldr     r12, =caml_exception_pointer
++        ADDRGLOBAL(r12, caml_exception_pointer)
+         str     trap_ptr, [r12]
+     /* Call the garbage collector */
+         bl      caml_garbage_collection
+@@ -123,7 +187,7 @@
+ #endif
+     /* Reload new allocation pointer and limit */
+     /* alloc_limit still points to caml_young_ptr */
+-        ldr     r12, =caml_young_limit
++        ADDRGLOBAL(r12, caml_young_limit)
+         ldr     alloc_ptr, [alloc_limit]
+         ldr     alloc_limit, [r12]
+     /* Return to caller */
+@@ -143,7 +207,7 @@
+         bcc     1f
+         bx      lr
+ 1:  /* Record return address */
+-        ldr     r7, =caml_last_return_address
++        ADDRGLOBAL(r7, caml_last_return_address)
+         str     lr, [r7]
+     /* Call GC (preserves r7) */
+         bl      .Lcaml_call_gc
+@@ -166,7 +230,7 @@
+         bcc     1f
+         bx      lr
+ 1:  /* Record return address */
+-        ldr     r7, =caml_last_return_address
++        ADDRGLOBAL(r7, caml_last_return_address)
+         str     lr, [r7]
+     /* Call GC (preserves r7) */
+         bl      .Lcaml_call_gc
+@@ -190,7 +254,7 @@
+         bcc     1f
+         bx      lr
+ 1:  /* Record return address */
+-        ldr     r7, =caml_last_return_address
++        ADDRGLOBAL(r7, caml_last_return_address)
+         str     lr, [r7]
+     /* Call GC (preserves r7) */
+         bl      .Lcaml_call_gc
+@@ -213,12 +277,12 @@
+         bcc     1f
+         bx      lr
+ 1:  /* Record return address */
+-        ldr     r12, =caml_last_return_address
++        ADDRGLOBAL(r12, caml_last_return_address)
+         str     lr, [r12]
+     /* Call GC (preserves r7) */
+         bl      .Lcaml_call_gc
+     /* Restore return address */
+-        ldr     r12, =caml_last_return_address
++        ADDRGLOBAL(r12, caml_last_return_address)
+         ldr     lr, [r12]
+     /* Try again */
+         b       .Lcaml_allocN
+@@ -235,21 +299,21 @@
+         CFI_STARTPROC
+         PROFILE
+     /* Record lowest stack address and return address */
+-        ldr     r5, =caml_last_return_address
+-        ldr     r6, =caml_bottom_of_stack
++        ADDRGLOBAL(r5, caml_last_return_address)
++        ADDRGLOBAL(r6, caml_bottom_of_stack)
+         str     lr, [r5]
+         str     sp, [r6]
+     /* Preserve return address in callee-save register r4 */
+         mov     r4, lr
+     /* Make the exception handler alloc ptr available to the C code */
+-        ldr     r5, =caml_young_ptr
+-        ldr     r6, =caml_exception_pointer
++        ADDRGLOBAL(r5, caml_young_ptr)
++        ADDRGLOBAL(r6, caml_exception_pointer)
+         str     alloc_ptr, [r5]
+         str     trap_ptr, [r6]
+     /* Call the function */
+         blx     r7
+     /* Reload alloc ptr and alloc limit */
+-        ldr     r6, =caml_young_limit
++        ADDRGLOBAL(r6, caml_young_limit)
+         ldr     alloc_ptr, [r5]         /* r5 still points to caml_young_ptr */
+         ldr     alloc_limit, [r6]
+     /* Return */
+@@ -265,7 +329,7 @@
+ caml_start_program:
+         CFI_STARTPROC
+         PROFILE
+-        ldr     r12, =caml_program
++        ADDRGLOBAL(r12, caml_program)
+ 
+ /* Code shared with caml_callback* */
+ /* Address of OCaml code to call is in r12 */
+@@ -280,9 +344,9 @@
+         push    {r4-r8,r10,r11,lr}; CFI_ADJUST(32)      /* 8-byte alignment */
+     /* Setup a callback link on the stack */
+         sub     sp, sp, 16; CFI_ADJUST(16)              /* 8-byte alignment */
+-        ldr     r4, =caml_bottom_of_stack
+-        ldr     r5, =caml_last_return_address
+-        ldr     r6, =caml_gc_regs
++        ADDRGLOBAL(r4, caml_bottom_of_stack)
++        ADDRGLOBAL(r5, caml_last_return_address)
++        ADDRGLOBAL(r6, caml_gc_regs)
+         ldr     r4, [r4]
+         ldr     r5, [r5]
+         ldr     r6, [r6]
+@@ -291,39 +355,39 @@
+         str     r6, [sp, 8]
+     /* Setup a trap frame to catch exceptions escaping the OCaml code */
+         sub     sp, sp, 8; CFI_ADJUST(8)
+-        ldr     r6, =caml_exception_pointer
+-        ldr     r5, =.Ltrap_handler
++        ADDRGLOBAL(r6, caml_exception_pointer)
++        adr     r5, .Ltrap_handler
+         ldr     r4, [r6]
+         str     r4, [sp, 0]
+         str     r5, [sp, 4]
+         mov     trap_ptr, sp
+     /* Reload allocation pointers */
+-        ldr     r4, =caml_young_ptr
++        ADDRGLOBAL(r4, caml_young_ptr)
+         ldr     alloc_ptr, [r4]
+-        ldr     r4, =caml_young_limit
++        ADDRGLOBAL(r4, caml_young_limit)
+         ldr     alloc_limit, [r4]
+     /* Call the OCaml code */
+         blx     r12
+ .Lcaml_retaddr:
+     /* Pop the trap frame, restoring caml_exception_pointer */
+-        ldr     r4, =caml_exception_pointer
++        ADDRGLOBAL(r4, caml_exception_pointer)
+         ldr     r5, [sp, 0]
+         str     r5, [r4]
+         add     sp, sp, 8; CFI_ADJUST(-8)
+     /* Pop the callback link, restoring the global variables */
+ .Lreturn_result:
+-        ldr     r4, =caml_bottom_of_stack
++        ADDRGLOBAL(r4, caml_bottom_of_stack)
+         ldr     r5, [sp, 0]
+         str     r5, [r4]
+-        ldr     r4, =caml_last_return_address
++        ADDRGLOBAL(r4, caml_last_return_address)
+         ldr     r5, [sp, 4]
+         str     r5, [r4]
+-        ldr     r4, =caml_gc_regs
++        ADDRGLOBAL(r4, caml_gc_regs)
+         ldr     r5, [sp, 8]
+         str     r5, [r4]
+         add     sp, sp, 16; CFI_ADJUST(-16)
+     /* Update allocation pointer */
+-        ldr     r4, =caml_young_ptr
++        ADDRGLOBAL(r4, caml_young_ptr)
+         str     alloc_ptr, [r4]
+     /* Reload callee-save registers and return address */
+         pop     {r4-r8,r10,r11,lr}; CFI_ADJUST(-32)
+@@ -344,7 +408,7 @@
+ .Ltrap_handler:
+         CFI_STARTPROC
+     /* Save exception pointer */
+-        ldr     r12, =caml_exception_pointer
++        ADDRGLOBAL(r12, caml_exception_pointer)
+         str     trap_ptr, [r12]
+     /* Encode exception bucket as an exception result */
+         orr     r0, r0, 2
+@@ -362,7 +426,7 @@
+         CFI_STARTPROC
+         PROFILE
+     /* Test if backtrace is active */
+-        ldr     r1, =caml_backtrace_active
++        ADDRGLOBAL(r1, caml_backtrace_active)
+         ldr     r1, [r1]
+         cbz     r1, 1f
+     /* Preserve exception bucket in callee-save register r4 */
+@@ -390,21 +454,21 @@
+         CFI_STARTPROC
+         PROFILE
+     /* Reload trap ptr, alloc ptr and alloc limit */
+-        ldr     trap_ptr, =caml_exception_pointer
+-        ldr     alloc_ptr, =caml_young_ptr
+-        ldr     alloc_limit, =caml_young_limit
++        ADDRGLOBAL(trap_ptr, caml_exception_pointer)
++        ADDRGLOBAL(alloc_ptr, caml_young_ptr)
++        ADDRGLOBAL(alloc_limit, caml_young_limit)
+         ldr     trap_ptr, [trap_ptr]
+         ldr     alloc_ptr, [alloc_ptr]
+         ldr     alloc_limit, [alloc_limit]
+     /* Test if backtrace is active */
+-        ldr     r1, =caml_backtrace_active
++        ADDRGLOBAL(r1, caml_backtrace_active)
+         ldr     r1, [r1]
+         cbz     r1, 1f
+     /* Preserve exception bucket in callee-save register r4 */
+         mov     r4, r0
+-        ldr     r1, =caml_last_return_address   /* arg2: pc of raise */
++        ADDRGLOBAL(r1, caml_last_return_address)/* arg2: pc of raise */
+         ldr     r1, [r1]
+-        ldr     r2, =caml_bottom_of_stack       /* arg3: sp of raise */
++        ADDRGLOBAL(r2, caml_bottom_of_stack)    /* arg3: sp of raise */
+         ldr     r2, [r2]
+         mov     r3, trap_ptr                    /* arg4: sp of handler */
+         bl      caml_stash_backtrace
+@@ -445,7 +509,7 @@
+         mov     r0, r1          /* r0 = first arg */
+         mov     r1, r2          /* r1 = second arg */
+         mov     r2, r12         /* r2 = closure environment */
+-        ldr     r12, =caml_apply2
++        ADDRGLOBAL(r12, caml_apply2)
+         b       .Ljump_to_caml
+         CFI_ENDPROC
+         .type   caml_callback2_exn, %function
+@@ -463,7 +527,7 @@
+         mov     r1, r2          /* r1 = second arg */
+         mov     r2, r3          /* r2 = third arg */
+         mov     r3, r12         /* r3 = closure environment */
+-        ldr     r12, =caml_apply3
++        ADDRGLOBAL(r12, caml_apply3)
+         b       .Ljump_to_caml
+         CFI_ENDPROC
+         .type   caml_callback3_exn, %function
+@@ -475,7 +539,7 @@
+         CFI_STARTPROC
+         PROFILE
+     /* Load address of [caml_array_bound_error] in r7 */
+-        ldr     r7, =caml_array_bound_error
++        ADDRGLOBAL(r7, caml_array_bound_error)
+     /* Call that function */
+         b       caml_c_call
+         CFI_ENDPROC
+@@ -485,6 +549,35 @@
+         .globl  caml_system__code_end
+ caml_system__code_end:
+ 
++#if defined(__PIC__)
++
++/* Data words that contain the relative addresses of GOT entries. */
++
++        .align  2
++.Lgot_caml_program:
++        .word   caml_program(GOT_PREL)
++.Lgot_caml_bottom_of_stack:
++        .word   caml_bottom_of_stack(GOT_PREL)
++.Lgot_caml_gc_regs:
++        .word   caml_gc_regs(GOT_PREL)
++.Lgot_caml_exception_pointer:
++        .word   caml_exception_pointer(GOT_PREL)
++.Lgot_caml_young_ptr:
++        .word   caml_young_ptr(GOT_PREL)
++.Lgot_caml_young_limit:
++        .word   caml_young_limit(GOT_PREL)
++.Lgot_caml_backtrace_active:
++        .word   caml_backtrace_active(GOT_PREL)
++.Lgot_caml_last_return_address:
++        .word   caml_last_return_address(GOT_PREL)
++.Lgot_caml_apply2:
++        .word   caml_apply2(GOT_PREL)
++.Lgot_caml_array_bound_error:
++        .word   caml_array_bound_error(GOT_PREL)
++.Lgot_caml_apply3:
++        .word   caml_apply3(GOT_PREL)
++#endif
++
+ /* GC roots for callback */
+ 
+         .data

--- a/scripts/ocaml-cross-compile.patch
+++ b/scripts/ocaml-cross-compile.patch
@@ -1,0 +1,161 @@
+diff -r -u ocaml-4.02.3/Makefile ocaml-4.02.3.patched/Makefile
+--- ocaml-4.02.3/Makefile	2015-07-20 14:10:11.000000000 +0000
++++ ocaml-4.02.3.patched/Makefile	2017-08-29 19:27:39.174505147 +0000
+@@ -265,7 +265,7 @@
+ 
+ # Native-code versions of the tools
+ opt.opt:
+-	$(MAKE) checkstack
++	#$(MAKE) checkstack
+ 	$(MAKE) runtime
+ 	$(MAKE) core
+ 	$(MAKE) ocaml
+diff -r -u ocaml-4.02.3/configure ocaml-4.02.3.patched/configure
+--- ocaml-4.02.3/configure	2015-05-12 14:46:37.000000000 +0000
++++ ocaml-4.02.3.patched/configure	2017-08-29 19:37:56.029656081 +0000
+@@ -433,6 +433,10 @@
+     TOOLCHAIN="mingw"
+     SO="dll"
+     ;;
++  aarch64-*-android)
++    mkexe="$mkexe -pie"
++    partialld="${TOOLPREF}ld -r"
++    ;;
+   *gcc*,x86_64-*-linux*)
+     bytecccompopts="-fno-defer-pop $gcc_warnings"
+     # Tell gcc that we can use 32-bit code addresses for threaded code
+@@ -483,6 +487,7 @@
+           "($ocaml_source_version)."
+     else
+       echo "CAMLRUN=`./searchpath -p ocamlrun`" >> Makefile
++      echo "OCAMLDOC_RUN=`./searchpath -p ocamldoc`" >> Makefile
+     fi
+   fi
+ 
+@@ -540,6 +545,10 @@
+                      echo "#define ARCH_SIXTYFOUR" >> m.h
+                      set 4 4 8 2 8
+                      arch64=true;;
++    aarch64-*-android) inf "Wow! A 64 bit architecture!"
++                     echo "#define ARCH_SIXTYFOUR" >> m.h
++                     set 4 8 8 2 8
++                     arch64=true;;
+     *) err "Since datatype sizes cannot be guessed when cross-compiling,\n" \
+            "a hardcoded list is used but your architecture isn't known yet.\n" \
+            "You need to determine the sizes yourself.\n" \
+@@ -573,8 +582,12 @@
+      echo "#define ARCH_BIG_ENDIAN" >> m.h;;
+   1) inf "This is a little-endian architecture."
+      echo "#undef ARCH_BIG_ENDIAN" >> m.h;;
+-  2) err "This architecture seems to be neither big endian nor little endian.\n" \
+-         "OCaml won't run on this architecture.";;
++  2) case $target in
++       aarch64-*-android) inf "This is a little-endian architecture."
++                          echo "#undef ARCH_BIG_ENDIAN" >> m.h;;
++       *) err "This architecture seems to be neither big endian nor little endian.\n" \
++              "OCaml won't run on this architecture.";;
++     esac;;
+   *) case $target in
+        *-*-mingw*) inf "This is a little-endian architecture."
+                    echo "#undef ARCH_BIG_ENDIAN" >> m.h;;
+@@ -612,6 +625,8 @@
+       *) case "$target" in
+            *-*-mingw*) inf "Doubles can be word-aligned."
+                        echo "#undef ARCH_ALIGN_DOUBLE" >> m.h;;
++           aarch64-*-android) inf "Doubles can be word-aligned."
++                             echo "#undef ARCH_ALIGN_DOUBLE" >> m.h;;
+            *) wrn "Something went wrong during alignment determination for doubles.\n" \
+                   "We will assume alignment constraints over doubles.\n" \
+                   "That's a safe bet: OCaml will work even if\n" \
+@@ -623,7 +638,7 @@
+ 
+ case "$target" in
+   # PR#5088: autodetection is unreliable on ARM.  PR#5280: also on MIPS.
+-  sparc*-*-*|hppa*-*-*|arm*-*-*|mips*-*-*)
++  sparc*-*-*|hppa*-*-*|arm*-*-*|aarch64-*-*|mips*-*-*)
+     if test $2 = 8; then
+       inf "64-bit integers can be word-aligned."
+       echo "#undef ARCH_ALIGN_INT64" >> m.h
+@@ -662,6 +677,9 @@
+        *-*-mingw*) inf "Native division and modulus have round-towards-zero" \
+                        "semantics, will use them."
+                    echo "#undef NONSTANDARD_DIV_MOD" >> m.h;;
++       aarch64-*-android) inf "Native division and modulus have round-towards-zero" \
++                              "semantics, will use them."
++                          echo "#undef NONSTANDARD_DIV_MOD" >> m.h;;
+        *) wrn "Something went wrong while checking native division and modulus"\
+               "please report it at http://http://caml.inria.fr/mantis/"
+           echo "#define NONSTANDARD_DIV_MOD" >> m.h;;
+@@ -765,6 +783,14 @@
+       byteccrpath="-Wl,-rpath,"
+       mksharedlibrpath="-Wl,-rpath,"
+       shared_libraries_supported=true;;
++    aarch64-*-android)
++      sharedcccompopts="-fPIC"
++      mksharedlib="$bytecc -shared"
++      bytecclinkopts="$bytecclinkopts -Wl,-E"
++      byteccrpath="-Wl,-rpath,"
++      mksharedlibrpath="-Wl,-rpath,"
++      natdynlinkopts="-Wl,-E"
++      shared_libraries_supported=true;;
+   esac
+ fi
+ 
+@@ -804,6 +830,7 @@
+     arm*-*-linux*)                natdynlink=true;;
+     arm*-*-freebsd*)              natdynlink=true;;
+     aarch64-*-linux*)             natdynlink=true;;
++    aarch64-linux-android)        natdynlink=true;;
+   esac
+ fi
+ 
+@@ -868,6 +895,7 @@
+   x86_64-*-darwin*)             arch=amd64; system=macosx;;
+   x86_64-*-mingw*)              arch=amd64; system=mingw;;
+   aarch64-*-linux*)             arch=arm64; system=linux;;
++  aarch64-*-android)            arch=arm64; system=android;;
+   x86_64-*-cygwin*)             arch=amd64; system=cygwin;;
+ esac
+ 
+@@ -1226,17 +1254,17 @@
+   has_wait=yes
+ fi
+ 
+-if sh ./hasgot -i limits.h && sh ./runtest getgroups.c; then
++if sh ./hasgot -i limits.h && sh ./trycompile getgroups.c; then
+   inf "getgroups() found."
+   echo "#define HAS_GETGROUPS" >> s.h
+ fi
+ 
+-if sh ./hasgot -i limits.h -i grp.h && sh ./runtest setgroups.c; then
++if sh ./hasgot -i limits.h -i grp.h && sh ./trycompile setgroups.c; then
+   inf "setgroups() found."
+   echo "#define HAS_SETGROUPS" >> s.h
+ fi
+ 
+-if sh ./hasgot -i limits.h -i grp.h && sh ./runtest initgroups.c; then
++if sh ./hasgot -i limits.h -i grp.h && sh ./trycompile initgroups.c; then
+   inf "initgroups() found."
+   echo "#define HAS_INITGROUPS" >> s.h
+ fi
+@@ -1421,6 +1449,8 @@
+                    pthread_caml_link="-cclib -pthread";;
+     *-*-haiku*)    pthread_link=""
+                    pthread_caml_link="";;
++    *-*-android)   pthread_link="-pthread"
++                   pthread_caml_link="-cclib -pthread";;
+     *)             pthread_link="-lpthread"
+                    pthread_caml_link="-cclib -lpthread";;
+   esac
+diff -r -u ocaml-4.02.3/ocamldoc/Makefile ocaml-4.02.3.patched/ocamldoc/Makefile
+--- ocaml-4.02.3/ocamldoc/Makefile	2015-05-12 14:46:37.000000000 +0000
++++ ocaml-4.02.3.patched/ocamldoc/Makefile	2017-08-29 19:27:39.174505147 +0000
+@@ -31,7 +31,7 @@
+ MKDIR=mkdir -p
+ CP=cp -f
+ OCAMLDOC=ocamldoc
+-OCAMLDOC_RUN=sh ./runocamldoc $(SUPPORTS_SHARED_LIBRARIES)
++OCAMLDOC_RUN ?= sh ./runocamldoc $(SUPPORTS_SHARED_LIBRARIES)
+ OCAMLDOC_OPT=$(OCAMLDOC).opt
+ OCAMLDOC_LIBCMA=odoc_info.cma
+ OCAMLDOC_LIBCMI=odoc_info.cmi

--- a/scripts/ocaml-group-passwd.patch
+++ b/scripts/ocaml-group-passwd.patch
@@ -1,0 +1,12 @@
+diff -r -u ocaml-4.02.3.orig/otherlibs/unix/getgr.c ocaml-4.02.3/otherlibs/unix/getgr.c
+--- ocaml-4.02.3.orig/otherlibs/unix/getgr.c	2017-08-29 20:58:58.647250193 +0000
++++ ocaml-4.02.3/otherlibs/unix/getgr.c	2017-08-29 21:00:24.088257776 +0000
+@@ -26,7 +26,7 @@
+ 
+   Begin_roots3 (name, pass, mem);
+     name = copy_string(entry->gr_name);
+-    pass = copy_string(entry->gr_passwd);
++    pass = copy_string(entry->gr_passwd ? entry->gr_passwd : "");
+     mem = copy_string_array((const char**)entry->gr_mem);
+     res = alloc_small(4, 0);
+     Field(res,0) = name;


### PR DESCRIPTION
This commit sets up an ocaml cross compiler and uses it to build opam, the
package manager for ocaml.

The packages in the default repository still try to use /bin/sh. So the
alternative repository described at http://ygrek.org.ua/p/ocaml-termux.html
must be used.