### PR TITLE
include libcurl as dependency for apt

### DIFF
--- a/packages/apt/build.sh
+++ b/packages/apt/build.sh
@@ -1,6 +1,6 @@
 TERMUX_PKG_HOMEPAGE=https://packages.debian.org/apt
 TERMUX_PKG_DESCRIPTION="Front-end for the dpkg package manager"
-TERMUX_PKG_DEPENDS="liblzma, dpkg, gpgv, libc++"
+TERMUX_PKG_DEPENDS="liblzma, dpkg, gpgv, libcurl"
 # Wait with updating to later version until the NDK supports std::to_string() and other
 # functions (hopefully in r15, https://github.com/android-ndk/ndk/issues/82).
 # Updating to apt 1.4 will also get rid of the build hacks used as apt has transitioned


### PR DESCRIPTION
libc++ is an essential package, always included, libcurl is a hard dependency that should be listed

#1169