### PR TITLE
Update sys-utils-ipcutils.h.patch

### DIFF
--- a/packages/util-linux/sys-utils-ipcutils.h.patch
+++ b/packages/util-linux/sys-utils-ipcutils.h.patch
@@ -1,11 +1,11 @@
 diff -u -r ../util-linux-2.29.2/sys-utils/ipcutils.h ./sys-utils/ipcutils.h
 --- ../util-linux-2.29.2/sys-utils/ipcutils.h	2016-11-02 13:57:31.661167155 +0100
 +++ ./sys-utils/ipcutils.h	2017-03-06 03:13:00.055879319 +0100
-@@ -5,7 +5,6 @@
+@@ -5,8 +5,6 @@
  #include <stdlib.h>
  #include <sys/ipc.h>
  #include <sys/msg.h>
 -#include <sys/sem.h>
- #include <sys/shm.h>
+-#include <sys/shm.h>
  #include <sys/types.h>
  #include <time.h>


### PR DESCRIPTION
`sys/shm.h` is no longer included, should be removed

#1169 