### PR TITLE
Git: include contrib projects

### DIFF
--- a/packages/git/build.sh
+++ b/packages/git/build.sh
@@ -50,9 +50,26 @@ termux_step_post_make_install () {
 	make -j $TERMUX_MAKE_PROCESSES man
 	make install-man
 
+	# Build contrib projects
+	make -C $TERMUX_PKG_SRCDIR/contrib/diff-highlight ${TERMUX_PKG_EXTRA_MAKE_ARGS}
+	make -C $TERMUX_PKG_SRCDIR/contrib/emacs ${TERMUX_PKG_EXTRA_MAKE_ARGS}
+	make -C $TERMUX_PKG_SRCDIR/contrib/subtree ${TERMUX_PKG_EXTRA_MAKE_ARGS}
+
+	termux_setup_golang
+	make -C $TERMUX_PKG_SRCDIR/contrib/persistent-https
+
+	# Install contrib projects
+	make -C $TERMUX_PKG_SRCDIR/contrib/subtree ${TERMUX_PKG_EXTRA_MAKE_ARGS} install install-doc
+	make -C $TERMUX_PKG_SRCDIR/contrib/emacs ${TERMUX_PKG_EXTRA_MAKE_ARGS} install
+
+	mv $TERMUX_PKG_SRCDIR/contrib/persistent-https/git-remote-persistent-http* $TERMUX_PREFIX/bin
+
+	find $TERMUX_PKG_SRCDIR/contrib/ -name '.gitignore' -delete
+	cp -r $TERMUX_PKG_SRCDIR/contrib $TERMUX_PREFIX/share/git-core/
+
 	mkdir -p $TERMUX_PREFIX/etc/bash_completion.d/
-	cp $TERMUX_PKG_SRCDIR/contrib/completion/git-completion.bash \
-	   $TERMUX_PREFIX/etc/bash_completion.d/
+	ln -s -f $TERMUX_PREFIX/share/git-core/contrib/completion/git-completion.bash \
+	   $TERMUX_PREFIX/etc/bash_completion.d/git-completion.bash
 
 	# Remove the build machine perl setup in termux_step_pre_configure to avoid it being packaged:
 	rm $TERMUX_PREFIX/bin/perl

--- a/packages/git/build.sh
+++ b/packages/git/build.sh
@@ -47,6 +47,7 @@ termux_step_pre_configure () {
 
 termux_step_post_make_install () {
 	# Installing man requires asciidoc and xmlto, so git uses separate make targets for man pages
+	make -j $TERMUX_MAKE_PROCESSES man
 	make install-man
 
 	mkdir -p $TERMUX_PREFIX/etc/bash_completion.d/

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -9,6 +9,7 @@ PACKAGES+=" bison"
 PACKAGES+=" clang" # Used by golang, useful to have same compiler building.
 PACKAGES+=" curl" # Used for fetching sources.
 PACKAGES+=" ed" # Used by bc
+PACKAGES+=" emacs-nox" # Used by the git build to compile emacs files
 PACKAGES+=" flex"
 PACKAGES+=" g++-multilib" # For building nodejs-current mkpeephole for 32-bit arm and i686.
 PACKAGES+=" gettext" # Provides 'msgfmt' which the apt build uses.


### PR DESCRIPTION
* Package the git `contrib/` directory, and build some associated files.
* Build the regular man files in parallel.

I'm not an emacs user, so I'm not sure if that `make` step (and the new dependency) are really necessary.