### PR TITLE
bash: /etc/profile should not source ~/.bashrc

### DIFF
--- a/packages/bash/etc-profile
+++ b/packages/bash/etc-profile
@@ -5,14 +5,11 @@ for i in @TERMUX_PREFIX@/etc/profile.d/*.sh; do
 done
 unset i
 
-# Source etc/bash.bashrc and ~/.bashrc also for interactive bash login shells:
+# Source etc/bash.bashrc also for interactive bash login shells:
 if [ "$BASH" ]; then
         if [[ "$-" == *"i"* ]]; then
-                if [ -r /data/data/com.termux/files/usr/etc/bash.bashrc ]; then
-                        . /data/data/com.termux/files/usr/etc/bash.bashrc
-                fi
-                if [ -r /data/data/com.termux/files/home/.bashrc ]; then
-                        . /data/data/com.termux/files/home/.bashrc
+                if [ -r @TERMUX_PREFIX@/etc/bash.bashrc ]; then
+                        . @TERMUX_PREFIX@/etc/bash.bashrc
                 fi
         fi
 fi


### PR DESCRIPTION
As stated in the title, `/etc/profile` should probably not be sourcing `~/.bashrc` (`/etc/bash.bashrc` is good, though). Generally, I believe, it should be the responsibility of `~/.bash_profile` to source `~/.bashrc` for interactive login shells. This is the behavior recommended by [the Bash manual](https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Bash-Startup-Files) and, based on a quick look, followed by Ubuntu, Arch Linux, and macOS.

I'm not sure if there are any files in the home directory for a brand-new termux install, but it might make sense to add a default `~/.bash_profile` with the line
```bash
if [ -f ~/.bashrc ]; then . ~/.bashrc; fi
```