### PR TITLE
ldc: add dub and rdmd, plus bump host dmd to latest version 2.076.0

### DIFF
--- a/packages/ldc/build.sh
+++ b/packages/ldc/build.sh
@@ -2,6 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://github.com/ldc-developers/ldc
 TERMUX_PKG_DESCRIPTION="D programming language compiler, built with LLVM"
 _PKG_MAJOR_VERSION=1.3
 TERMUX_PKG_VERSION=${_PKG_MAJOR_VERSION}.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/ldc-developers/ldc/releases/download/v${TERMUX_PKG_VERSION}/ldc-${TERMUX_PKG_VERSION}-src.tar.gz
 TERMUX_PKG_SHA256=efe31a639bcb44e1f5b752da21713376d9410a01279fecc8aab8572065a3050b
 TERMUX_PKG_DEPENDS="clang"
@@ -28,11 +29,28 @@ termux_step_post_extract_package () {
 	tar xf $TERMUX_PKG_CACHEDIR/llvm-${LLVM_SRC_VERSION}.src.tar.xz
 	mv llvm-${LLVM_SRC_VERSION}.src llvm
 
-	DMD_COMPILER_VERSION=2.075.1
+	DMD_COMPILER_VERSION=2.076.0
 	termux_download \
 		http://downloads.dlang.org/releases/2.x/${DMD_COMPILER_VERSION}/dmd.${DMD_COMPILER_VERSION}.linux.tar.xz \
 		$TERMUX_PKG_CACHEDIR/dmd.${DMD_COMPILER_VERSION}.linux.tar.xz \
-		6531c098020cf321b5e71c420a10db729566006b72e0af873b15b506a1583c57
+		3e3fc9fbdc61681edea837e9d095a341dda6c325ab4dbc437017239d576ba433
+
+	termux_download \
+		https://github.com/dlang/tools/archive/v${DMD_COMPILER_VERSION}.tar.gz \
+		$TERMUX_PKG_CACHEDIR/tools-v${DMD_COMPILER_VERSION}.tar.gz \
+		5f58dc6492e1abb539291a5fbf2bfb06eed818bd158912f090b55cd712c2a34a
+
+	tar xf $TERMUX_PKG_CACHEDIR/tools-v${DMD_COMPILER_VERSION}.tar.gz
+	mv tools-${DMD_COMPILER_VERSION} rdmd
+
+	local DUB_VERSION=1.5.0
+	termux_download \
+		https://github.com/dlang/dub/archive/v${DUB_VERSION}.tar.gz \
+		$TERMUX_PKG_CACHEDIR/dub-v${DUB_VERSION}.tar.gz \
+		3509f959cc5b34e44adaae586b62ded387ac10031f6c1aaf1cfbb4aae5af37dd
+
+	tar xf $TERMUX_PKG_CACHEDIR/dub-v${DUB_VERSION}.tar.gz
+	mv dub-${DUB_VERSION} dub
 
 	sed "s#\@TERMUX_C_COMPILER\@#$TERMUX_STANDALONE_TOOLCHAIN/bin/$TERMUX_HOST_PLATFORM-clang#" \
 		$TERMUX_PKG_BUILDER_DIR/ldc-config-stdlib.patch.beforehostbuild.in > \
@@ -112,10 +130,21 @@ termux_step_make () {
 	if ls ./*akefile &> /dev/null; then
 		make -j $TERMUX_MAKE_PROCESSES ldc2 ldmd2
 	fi
+
+	# Build the rdmd scripting wrapper and the dub package manager
+	D_FLAGS="-w -de -O -inline -release"
+	$DMD $D_FLAGS -c $TERMUX_PKG_SRCDIR/rdmd/rdmd.d -of=$TERMUX_PKG_BUILDDIR/bin/rdmd.o
+	D_LDFLAGS="-fuse-ld=bfd -L${TERMUX_PKG_HOSTBUILD_DIR}/ldc-bootstrap/lib -lphobos2-ldc -ldruntime-ldc -Wl,--gc-sections -ldl -lm -Wl,--fix-cortex-a8 -fPIE -pie -Wl,-z,nocopyreloc ${LDFLAGS}"
+	$CC $TERMUX_PKG_BUILDDIR/bin/rdmd.o $D_LDFLAGS -o $TERMUX_PKG_BUILDDIR/bin/rdmd
+
+	cd $TERMUX_PKG_SRCDIR/dub
+	$DMD $D_FLAGS -version=DubUseCurl -Isource -c @build-files.txt -of=$TERMUX_PKG_BUILDDIR/bin/dub.o
+	cd $TERMUX_PKG_BUILDDIR
+	$CC $TERMUX_PKG_BUILDDIR/bin/dub.o $D_LDFLAGS -o $TERMUX_PKG_BUILDDIR/bin/dub
 }
 
 termux_step_make_install () {
-	cp bin/{ldc2,ldmd2} $TERMUX_PREFIX/bin
+	cp bin/{dub,ldc2,ldmd2,rdmd} $TERMUX_PREFIX/bin
 	cp $TERMUX_PKG_HOSTBUILD_DIR/ldc-bootstrap/lib/lib{druntime,phobos2}*.a $TERMUX_PREFIX/lib
 	sed -i "/runtime\/druntime\/src/d" bin/ldc2.conf
 	sed -i "/runtime\/profile-rt\/d/d" bin/ldc2.conf

--- a/packages/ldc/rdmd-tempDir.patch
+++ b/packages/ldc/rdmd-tempDir.patch
@@ -1,0 +1,19 @@
+diff --git a/rdmd/rdmd.d b/rdmd/rdmd.d
+index 06f46d7..af22c35 100755
+--- a/rdmd/rdmd.d
++++ b/rdmd/rdmd.d
+@@ -386,7 +386,13 @@ bool inALibrary(string source, string object)
+ 
+ private @property string myOwnTmpDir()
+ {
+-    auto tmpRoot = userTempDir ? userTempDir : tempDir();
++    import std.file : empty, exists;
++    import std.process : environment;
++
++    string shellTemp = environment.get("TMPDIR");
++    string defaultTemp = !shellTemp.empty && shellTemp.exists ? shellTemp
++                                                              : tempDir();
++    auto tmpRoot = userTempDir ? userTempDir : defaultTemp;
+     version (Posix)
+     {
+         import core.sys.posix.unistd;


### PR DESCRIPTION
rdmd, a scripting wrapper that makes it easy to use D for scripting, and dub, the D package manager, normally ship with the D compiler.  I ran their tests and they mostly work fine on Android/ARM, so I'm including them in the ldc package.  I had to make a small modification to rdmd so that it found the temporary directory in Termux.  Also bumped dmd, the host D compiler used to bootstrap ldc, to the latest version that just came out.