### PR TITLE
libyaml: add package

### DIFF
--- a/packages/libyaml/build.sh
+++ b/packages/libyaml/build.sh
@@ -1,0 +1,5 @@
+TERMUX_PKG_HOMEPAGE=http://pyyaml.org/wiki/LibYAML
+TERMUX_PKG_DESCRIPTION="LibYAML is a YAML 1.1 parser and emitter written in C"
+TERMUX_PKG_VERSION=0.1.7
+TERMUX_PKG_SRCURL=http://pyyaml.org/download/libyaml/yaml-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256SUM=8088e457264a98ba451a90b8661fcb4f9d6f478f7265d48322a196cec2480729


### PR DESCRIPTION
We need [LibYAML](http://pyyaml.org/wiki/LibYAML) to compile [php-yml](http://bd808.com/pecl-file_formats-yaml/) and can be added as dependency for Ruby.