### PR TITLE
New package: lhasa.

### DIFF
--- a/packages/lhasa/build.sh
+++ b/packages/lhasa/build.sh
@@ -1,0 +1,6 @@
+TERMUX_PKG_HOMEPAGE=https://fragglet.github.io/lhasa/
+TERMUX_PKG_DESCRIPTION="LHA compressor/decompressor"
+TERMUX_PKG_VERSION=0.3.1
+TERMUX_PKG_SRCURL=https://soulsphere.org/projects/lhasa/lhasa-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=3fb08e5f85a9b9dd023922896be9157d5fb5c0448424681810aaa2b0558a5f24
+TERMUX_PKG_BUILD_IN_SRC=yes


### PR DESCRIPTION
lhasa is an implementation of lha which is an archiver popular with amiga
fans. This is a nice addition to Amiga forever and third-party Amiga emulators
for android.