### PR TITLE
add ncurses-dev to lftp build dependencies

### DIFF
--- a/packages/lftp/build.sh
+++ b/packages/lftp/build.sh
@@ -13,6 +13,7 @@ ac_cv_func_dn_expand=no
 --with-readline=$TERMUX_PREFIX
 "
 TERMUX_PKG_DEPENDS="libexpat, openssl, readline, libutil, libidn"
+TERMUX_PKG_BUILD_DEPENDS="ncurses-dev"
 
 termux_step_pre_configure () {
 	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-zlib=$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr"


### PR DESCRIPTION
#1169 

could also be made a normal depends since it shows a missing header file and obviously uses the library during the compilation phase, even before linking