### PR TITLE
ldc: update to 1.4 release

### DIFF
--- a/packages/ldc/build.sh
+++ b/packages/ldc/build.sh
@@ -1,10 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/ldc-developers/ldc
 TERMUX_PKG_DESCRIPTION="D programming language compiler, built with LLVM"
-_PKG_MAJOR_VERSION=1.3
+_PKG_MAJOR_VERSION=1.4
 TERMUX_PKG_VERSION=${_PKG_MAJOR_VERSION}.0
-TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/ldc-developers/ldc/releases/download/v${TERMUX_PKG_VERSION}/ldc-${TERMUX_PKG_VERSION}-src.tar.gz
-TERMUX_PKG_SHA256=efe31a639bcb44e1f5b752da21713376d9410a01279fecc8aab8572065a3050b
+TERMUX_PKG_SHA256=dd29a5833ae02307c387e87d861d5de588b9b16ea3574ef96f8da1f81bbd7c5c
 TERMUX_PKG_DEPENDS="clang"
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_BLACKLISTED_ARCHES="aarch64,i686,x86_64"
@@ -55,7 +54,7 @@ termux_step_post_extract_package () {
 	sed "s#\@TERMUX_C_COMPILER\@#$TERMUX_STANDALONE_TOOLCHAIN/bin/$TERMUX_HOST_PLATFORM-clang#" \
 		$TERMUX_PKG_BUILDER_DIR/ldc-config-stdlib.patch.beforehostbuild.in > \
 		$TERMUX_PKG_BUILDER_DIR/ldc-config-stdlib.patch.beforehostbuild
-	sed -i "s#\@TERMUX_C_FLAGS\@#-march=armv7-a -mfpu=neon -mfloat-abi=softfp -mthumb -Os -I$TERMUX_PREFIX/include#" \
+	sed -i "s#\@TERMUX_C_FLAGS\@#-march=armv7-a -mfpu=neon -mfloat-abi=softfp -mthumb -Oz -I$TERMUX_PREFIX/include#" \
 		$TERMUX_PKG_BUILDER_DIR/ldc-config-stdlib.patch.beforehostbuild
 	sed "s#\@TERMUX_PKG_HOSTBUILD\@#$TERMUX_PKG_HOSTBUILD_DIR#" $TERMUX_PKG_BUILDER_DIR/ldc-linker-flags.patch.in > \
 		$TERMUX_PKG_BUILDER_DIR/ldc-linker-flags.patch
@@ -128,11 +127,11 @@ termux_step_make () {
 
 	cd ..
 	if ls ./*akefile &> /dev/null; then
-		make -j $TERMUX_MAKE_PROCESSES ldc2 ldmd2
+		make -j $TERMUX_MAKE_PROCESSES ldc2 ldmd2 ldc-build-runtime
 	fi
 
 	# Build the rdmd scripting wrapper and the dub package manager
-	D_FLAGS="-w -de -O -inline -release"
+	D_FLAGS="-w -dw -O -inline -release"
 	$DMD $D_FLAGS -c $TERMUX_PKG_SRCDIR/rdmd/rdmd.d -of=$TERMUX_PKG_BUILDDIR/bin/rdmd.o
 	D_LDFLAGS="-fuse-ld=bfd -L${TERMUX_PKG_HOSTBUILD_DIR}/ldc-bootstrap/lib -lphobos2-ldc -ldruntime-ldc -Wl,--gc-sections -ldl -lm -Wl,--fix-cortex-a8 -fPIE -pie -Wl,-z,nocopyreloc ${LDFLAGS}"
 	$CC $TERMUX_PKG_BUILDDIR/bin/rdmd.o $D_LDFLAGS -o $TERMUX_PKG_BUILDDIR/bin/rdmd
@@ -144,7 +143,7 @@ termux_step_make () {
 }
 
 termux_step_make_install () {
-	cp bin/{dub,ldc2,ldmd2,rdmd} $TERMUX_PREFIX/bin
+	cp bin/{dub,ldc-build-runtime,ldc2,ldmd2,rdmd} $TERMUX_PREFIX/bin
 	cp $TERMUX_PKG_HOSTBUILD_DIR/ldc-bootstrap/lib/lib{druntime,phobos2}*.a $TERMUX_PREFIX/lib
 	sed -i "/runtime\/druntime\/src/d" bin/ldc2.conf
 	sed -i "/runtime\/profile-rt\/d/d" bin/ldc2.conf

--- a/packages/ldc/ldc-config-stdlib.patch.beforehostbuild.in
+++ b/packages/ldc/ldc-config-stdlib.patch.beforehostbuild.in
@@ -10,14 +10,14 @@ index 32795da6..091d344b 100644
      ${RUNTIME_DIR}/src/rt/alloca.d
      ${RUNTIME_DIR}/src/rt/deh.d
      ${RUNTIME_DIR}/src/rt/deh_win32.d
-@@ -551,7 +551,9 @@ include(profile-rt/DefineBuildProfileRT.cmake)
+@@ -551,6 +551,10 @@ include(profile-rt/DefineBuildProfileRT.cmake)
+ #
  # Set up build and install targets
  #
- 
--set(RT_CFLAGS "")
++
 +set(RT_CFLAGS "@TERMUX_C_FLAGS@")
 +set(CMAKE_C_COMPILER @TERMUX_C_COMPILER@)
 +set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
  
- if(APPLE AND MULTILIB)
+ if(MULTILIB AND "${TARGET_SYSTEM}" MATCHES "APPLE")
      # On OS X, build "fat" libraries containing code for both architectures.

--- a/packages/ldc/ldc-disable-idgen.patch
+++ b/packages/ldc/ldc-disable-idgen.patch
@@ -1,22 +1,22 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 336bbdbc..9f94f76b 100644
+index c89cb228..cc507c22 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -269,7 +269,7 @@ endmacro()
  #
  # Build idgen.
  #
--build_idgen(${DDMDFE_PATH}/idgen.d ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/idgen${CMAKE_EXECUTABLE_SUFFIX}  ${DDMD_DFLAGS} "" "")
-+#build_idgen(${DDMDFE_PATH}/idgen.d ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/idgen${CMAKE_EXECUTABLE_SUFFIX}  ${DDMD_DFLAGS} "" "")
+-build_idgen(${DDMDFE_PATH}/idgen.d ${PROJECT_BINARY_DIR}/idgen${CMAKE_EXECUTABLE_SUFFIX}  ${DDMD_DFLAGS} "" "")
++#build_idgen(${DDMDFE_PATH}/idgen.d ${PROJECT_BINARY_DIR}/idgen${CMAKE_EXECUTABLE_SUFFIX}  ${DDMD_DFLAGS} "" "")
  # Run idgen.
  add_custom_command(
      OUTPUT
 @@ -277,7 +277,7 @@ add_custom_command(
          ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/id.h
-     COMMAND ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/idgen  #provide full path to avoid clash with idgen on path
-     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}
--    DEPENDS ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/idgen${CMAKE_EXECUTABLE_SUFFIX}
-+    #    DEPENDS ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/idgen${CMAKE_EXECUTABLE_SUFFIX}
+     COMMAND ${PROJECT_BINARY_DIR}/idgen  #provide full path to avoid clash with idgen on path
+     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+-    DEPENDS ${PROJECT_BINARY_DIR}/idgen${CMAKE_EXECUTABLE_SUFFIX}
++    #    DEPENDS ${PROJECT_BINARY_DIR}/idgen${CMAKE_EXECUTABLE_SUFFIX}
  )
  set(LDC_CXX_GENERATED
      ${PROJECT_BINARY_DIR}/${DDMDFE_PATH}/id.h

--- a/packages/ldc/ldc-llvm-config.patch.in
+++ b/packages/ldc/ldc-llvm-config.patch.in
@@ -3,8 +3,8 @@ index a6a0b0b7..06d6c1c1 100644
 --- a/cmake/Modules/FindLLVM.cmake
 +++ b/cmake/Modules/FindLLVM.cmake
 @@ -35,11 +35,12 @@ set(llvm_config_names llvm-config-5.0 llvm-config50
-                       llvm-config-3.6 llvm-config36
-                       llvm-config-3.5 llvm-config35
+                       llvm-config-3.8 llvm-config38
+                       llvm-config-3.7 llvm-config37
                        llvm-config)
 -find_program(LLVM_CONFIG
 -    NAMES ${llvm_config_names}
@@ -37,22 +37,20 @@ index a6a0b0b7..06d6c1c1 100644
 +    set(LLVM_ROOT_DIR "@TERMUX_PKG_BUILD@/llvm")
 +    set(LLVM_ENABLE_ASSERTIONS "OFF")
  
-     if(${LLVM_VERSION_STRING} MATCHES "^3\\.[0-6][\\.0-9A-Za-z]*")
-         # Versions below 3.7 do not support components debuginfo[dwarf|pdb]
-@@ -207,15 +208,15 @@ else()
-         list(REMOVE_ITEM LLVM_FIND_COMPONENTS "libdriver" index)
+     if(${LLVM_VERSION_STRING} MATCHES "^3\\.[0-8][\\.0-9A-Za-z]*")
+         # Versions below 3.9 do not support components debuginfocodeview, globalisel
+@@ -207,13 +208,13 @@ else()
+         list(REMOVE_ITEM LLVM_FIND_COMPONENTS "debuginfomsf" index)
      endif()
  
 -    llvm_set(LDFLAGS ldflags)
 +    set(LLVM_LIBRARY_DIRS "${LLVM_ROOT_DIR}/lib")
 +    set(LLVM_LDFLAGS "-L${LLVM_LIBRARY_DIRS}")
-     if(NOT ${LLVM_VERSION_STRING} MATCHES "^3\\.[0-4][\\.0-9A-Za-z]*")
-         # In LLVM 3.5+, the system library dependencies (e.g. "-lz") are accessed
-         # using the separate "--system-libs" flag.
--        llvm_set(SYSTEM_LIBS system-libs)
-+	set(LLVM_SYSTEM_LIBS "-ldl -lncurses -lz -lm")
-         string(REPLACE "\n" " " LLVM_LDFLAGS "${LLVM_LDFLAGS} ${LLVM_SYSTEM_LIBS}")
-     endif()
+     # In LLVM 3.5+, the system library dependencies (e.g. "-lz") are accessed
+     # using the separate "--system-libs" flag.
+-    llvm_set(SYSTEM_LIBS system-libs)
++    set(LLVM_SYSTEM_LIBS "-ldl -lncurses -lz -lm")
+     string(REPLACE "\n" " " LLVM_LDFLAGS "${LLVM_LDFLAGS} ${LLVM_SYSTEM_LIBS}")
 -    llvm_set(LIBRARY_DIRS libdir true)
 -    llvm_set_libs(LIBRARIES libs)
 +    set(LLVM_LIBRARIES "-lLLVMTableGen;-lLLVMLibDriver;-lLLVMOption;-lLLVMSymbolize;-lLLVMDebugInfoPDB;-lLLVMDebugInfoDWARF;-lLLVMAArch64Disassembler;-lLLVMAArch64CodeGen;-lLLVMAArch64AsmParser;-lLLVMAArch64Desc;-lLLVMAArch64Info;-lLLVMAArch64AsmPrinter;-lLLVMAArch64Utils;-lLLVMARMDisassembler;-lLLVMARMCodeGen;-lLLVMARMAsmParser;-lLLVMARMDesc;-lLLVMARMInfo;-lLLVMARMAsmPrinter;-lLLVMLineEditor;-lLLVMMIRParser;-lLLVMLTO;-lLLVMPasses;-lLLVMObjCARCOpts;-lLLVMOrcJIT;-lLLVMInterpreter;-lLLVMObjectYAML;-lLLVMX86Disassembler;-lLLVMX86AsmParser;-lLLVMX86CodeGen;-lLLVMGlobalISel;-lLLVMSelectionDAG;-lLLVMAsmPrinter;-lLLVMDebugInfoCodeView;-lLLVMDebugInfoMSF;-lLLVMCodeGen;-lLLVMX86Desc;-lLLVMMCDisassembler;-lLLVMX86Info;-lLLVMX86AsmPrinter;-lLLVMX86Utils;-lLLVMMCJIT;-lLLVMExecutionEngine;-lLLVMTarget;-lLLVMRuntimeDyld;-lgtest_main;-lgtest;-lLLVMCoroutines;-lLLVMipo;-lLLVMInstrumentation;-lLLVMVectorize;-lLLVMScalarOpts;-lLLVMLinker;-lLLVMIRReader;-lLLVMAsmParser;-lLLVMInstCombine;-lLLVMTransformUtils;-lLLVMBitWriter;-lLLVMAnalysis;-lLLVMCoverage;-lLLVMProfileData;-lLLVMObject;-lLLVMMCParser;-lLLVMMC;-lLLVMBitReader;-lLLVMCore;-lLLVMSupport;-lLLVMDemangle")


### PR DESCRIPTION
Simply pulled in my changes from #1323, which is now obsolete, will update that PR to the upcoming 1.5 beta instead.