### PR TITLE
Set some settings in w3m to be termux-friendly

### DIFF
--- a/packages/w3m/build.sh
+++ b/packages/w3m/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Text based Web browser and pager"
 _MAJOR_VERSION=0.5.3
 _MINOR_VERSION=20170102
 TERMUX_PKG_VERSION=0.5.3.$_MINOR_VERSION
+TERMUX_PKG_REVISION=1
 # The upstream w3m project is dead, but every linux distribution uses
 # this maintained fork in debian:
 TERMUX_PKG_SRCURL=https://github.com/tats/w3m/archive/v${_MAJOR_VERSION}+git${_MINOR_VERSION}.tar.gz
@@ -13,6 +14,11 @@ TERMUX_PKG_DEPENDS="libgc, ncurses, openssl"
 # ac_cv_func_bcopy=yes to avoid w3m defining it's own bcopy function, which
 # breaks 64-bit builds where NDK headers define bcopy as a macro:
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="ac_cv_func_setpgrp_void=yes ac_cv_func_bcopy=yes"
+
+#Overwrite the default /usr/bin/firefox with termux-open-url as default external browser. That way, pressing "M" on a URL will open a link in Androids default Browser.
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-browser=termux-open-url"
+#Overwrite the default editor to just vi, as the default was /usr/bin/vi.
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-editor=vi"
 
 # For Makefile.in.patch:
 export TERMUX_PKG_BUILDER_DIR


### PR DESCRIPTION
The default browser and editor in w3m where /usr/bin/firefox and
/usr/bin/vi respectively. I change that to termux-open-url and vi.
If you now press "M" on a link in w3m it will open it with Androids
default browser. If you press "E" while viewing a local file it will
open vi. Previously this has just printed error messages. Obviously
these settings can still be overwritten in the options of w3m to set it
to whatever you want.