### PR TITLE
ninja: add package

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -90,14 +90,14 @@ termux_setup_golang() {
 
 # Utility function for cmake-built packages to setup a current ninja.
 termux_setup_ninja() {
-	local NINJA_VERSION=1.7.2
+	local NINJA_VERSION=1.8.2
 	local NINJA_FOLDER=$TERMUX_COMMON_CACHEDIR/ninja-$NINJA_VERSION
 	if [ ! -x $NINJA_FOLDER/ninja ]; then
 		mkdir -p $NINJA_FOLDER
 		local NINJA_ZIP_FILE=$TERMUX_PKG_TMPDIR/ninja-$NINJA_VERSION.zip
 		termux_download https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-linux.zip \
 			$NINJA_ZIP_FILE \
-			38fa8cfb9c1632a5cdf7a32fe1a7c5aa89e96c1d492c28624f4cc018e68458b9
+			d2fea9ff33b3ef353161ed906f260d565ca55b8ca0568fa07b1d2cab90a84a07
 		unzip $NINJA_ZIP_FILE -d $NINJA_FOLDER
 	fi
 	export PATH=$NINJA_FOLDER:$PATH

--- a/packages/ninja/build.sh
+++ b/packages/ninja/build.sh
@@ -1,0 +1,20 @@
+TERMUX_PKG_HOMEPAGE=https://ninja-build.org
+TERMUX_PKG_DESCRIPTION="A small build system with a focus on speed"
+_MAJOR_VERSION=1.8
+TERMUX_PKG_VERSION=${_MAJOR_VERSION}.2
+TERMUX_PKG_SHA256=86b8700c3d0880c2b44c2ff67ce42774aaf8c28cbf57725cb881569288c1c6f4
+TERMUX_PKG_SRCURL=https://github.com/ninja-build/ninja/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_FOLDERNAME=ninja-${TERMUX_PKG_VERSION}
+
+termux_step_configure () {
+	$TERMUX_PKG_SRCDIR/configure.py
+}
+
+termux_step_make () {
+	termux_setup_ninja
+	ninja -j $TERMUX_MAKE_PROCESSES
+}
+
+termux_step_make_install () {
+	cp ninja $TERMUX_PREFIX/bin
+}

--- a/packages/ninja/configure.py.patch
+++ b/packages/ninja/configure.py.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.py b/configure.py
+index a443748..697a110 100755
+--- a/configure.py
++++ b/configure.py
+@@ -507,6 +507,7 @@ if platform.is_windows():
+         objs += cxx('minidump-win32')
+     objs += cc('getopt')
+ else:
++    objs += cc('posix_spawn')
+     objs += cxx('subprocess-posix')
+ if platform.is_aix():
+     objs += cc('getopt')

--- a/packages/ninja/src-posix_spawn.c.patch
+++ b/packages/ninja/src-posix_spawn.c.patch
@@ -1,0 +1,162 @@
+diff --git a/src/posix_spawn.c b/src/posix_spawn.c
+new file mode 100644
+index 0000000..18ceb06
+--- /dev/null
++++ b/src/posix_spawn.c
+@@ -0,0 +1,156 @@
++/*
++ * dhcpcd - DHCP client daemon
++ * Copyright (c) 2006-2012 Roy Marples <roy@marples.name>
++ * All rights reserved
++
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++/* This implementation of posix_spawn is only suitable for the needs of dhcpcd
++ * but it could easily be extended to other applications. */
++
++#include <sys/types.h>
++#include <sys/wait.h>
++
++#include <errno.h>
++#include <signal.h>
++#include <stdlib.h>
++#include <string.h>
++#include <unistd.h>
++
++#include "posix_spawn.h"
++
++#ifndef _NSIG
++#ifdef _SIG_MAXSIG
++#define _NSIG _SIG_MAXSIG + 1
++#else
++/* Guess */
++#define _NSIG SIGPWR + 1
++#endif
++#endif
++
++extern char **environ;
++
++static int
++posix_spawnattr_handle(const posix_spawnattr_t *attrp)
++{
++	struct sigaction sa;
++	int i;
++
++	if (attrp->posix_attr_flags & POSIX_SPAWN_SETSIGMASK)
++		sigprocmask(SIG_SETMASK, &attrp->posix_attr_sigmask, NULL);
++
++	if (attrp->posix_attr_flags & POSIX_SPAWN_SETSIGDEF) {
++		memset(&sa, 0, sizeof(sa));
++		sa.sa_handler = SIG_DFL;
++		for (i = 1; i < _NSIG; i++) {
++			if (sigismember(&attrp->posix_attr_sigdefault, i)) {
++				if (sigaction(i, &sa, NULL) == -1)
++					return -1;
++			}
++		}
++	}
++
++	return 0;
++}
++
++inline static int
++is_vfork_safe(short int flags)
++{
++	return !(flags & (POSIX_SPAWN_SETSIGDEF | POSIX_SPAWN_SETSIGMASK));
++}
++
++int
++posix_spawn(pid_t *pid, const char *path,
++	const posix_spawn_file_actions_t *file_actions,
++	const posix_spawnattr_t *attrp,
++	char *const argv[], char *const envp[])
++{
++	short int flags;
++	pid_t p;
++	volatile int error;
++
++	error = 0;
++	flags = attrp ? attrp->posix_attr_flags : 0;
++	if (file_actions == NULL && is_vfork_safe(flags))
++		p = vfork();
++	else
++#ifdef THERE_IS_NO_FORK
++		return ENOSYS;
++#else
++		p = fork();
++#endif
++	switch (p) {
++	case -1:
++		return errno;
++	case 0:
++		if (attrp) {
++			error = posix_spawnattr_handle(attrp);
++			if (error)
++				_exit(127);
++		}
++		execve(path, argv, envp);
++		error = errno;
++		_exit(127);
++	default:
++		if (error != 0)
++			waitpid(p, NULL, WNOHANG);
++		else if (pid != NULL)
++			*pid = p;
++		return error;
++	}
++}
++
++int
++posix_spawnattr_init(posix_spawnattr_t *attr)
++{
++
++	memset(attr, 0, sizeof(*attr));
++	attr->posix_attr_flags = 0;
++	sigprocmask(0, NULL, &attr->posix_attr_sigmask);
++	sigemptyset(&attr->posix_attr_sigdefault);
++	return 0;
++}
++
++int
++posix_spawnattr_setflags(posix_spawnattr_t *attr, short flags)
++{
++
++	attr->posix_attr_flags = flags;
++	return 0;
++}
++
++int
++posix_spawnattr_setsigmask(posix_spawnattr_t *attr, const sigset_t *sigmask)
++{
++
++	attr->posix_attr_sigmask = *sigmask;
++	return 0;
++}
++
++int
++posix_spawnattr_setsigdefault(posix_spawnattr_t *attr, const sigset_t *sigmask)
++{
++
++	attr->posix_attr_sigdefault = *sigmask;
++	return 0;
++}

--- a/packages/ninja/src-posix_spawn.h.patch
+++ b/packages/ninja/src-posix_spawn.h.patch
@@ -1,0 +1,59 @@
+diff --git a/src/posix_spawn.h b/src/posix_spawn.h
+new file mode 100644
+index 0000000..ccfb0f0
+--- /dev/null
++++ b/src/posix_spawn.h
+@@ -0,0 +1,53 @@
++/*
++ * dhcpcd - DHCP client daemon
++ * Copyright (c) 2006-2012 Roy Marples <roy@marples.name>
++ * All rights reserved
++
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++#ifndef POSIX_SPAWN_H
++#define POSIX_SPAWN_H
++
++#include <signal.h>
++
++typedef struct {
++	short posix_attr_flags;
++#define POSIX_SPAWN_SETSIGDEF		0x10
++#define POSIX_SPAWN_SETSIGMASK		0x20
++	sigset_t posix_attr_sigmask;
++	sigset_t posix_attr_sigdefault;
++} posix_spawnattr_t;
++
++typedef struct {
++//	int unused;
++} posix_spawn_file_actions_t;
++
++int posix_spawn(pid_t *, const char *,
++    const posix_spawn_file_actions_t *, const posix_spawnattr_t *,
++    char *const [], char *const []);
++int posix_spawnattr_init(posix_spawnattr_t *);
++int posix_spawnattr_setflags(posix_spawnattr_t *, short);
++int posix_spawnattr_setsigmask(posix_spawnattr_t *, const sigset_t *);
++int posix_spawnattr_setsigdefault(posix_spawnattr_t *, const sigset_t *);
++
++#endif

--- a/packages/ninja/src-subprocess-posix.cc.patch
+++ b/packages/ninja/src-subprocess-posix.cc.patch
@@ -1,0 +1,68 @@
+diff --git a/src/subprocess-posix.cc b/src/subprocess-posix.cc
+index 1de22c3..f988297 100644
+--- a/src/subprocess-posix.cc
++++ b/src/subprocess-posix.cc
+@@ -22,10 +22,10 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <sys/wait.h>
+-#include <spawn.h>
+ 
+ extern char** environ;
+ 
++#include "posix_spawn.h"
+ #include "util.h"
+ 
+ Subprocess::Subprocess(bool use_console) : fd_(-1), pid_(-1),
+@@ -54,11 +54,11 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
+   SetCloseOnExec(fd_);
+ 
+   posix_spawn_file_actions_t action;
+-  if (posix_spawn_file_actions_init(&action) != 0)
++  /*if (posix_spawn_file_actions_init(&action) != 0)
+     Fatal("posix_spawn_file_actions_init: %s", strerror(errno));
+ 
+   if (posix_spawn_file_actions_addclose(&action, output_pipe[0]) != 0)
+-    Fatal("posix_spawn_file_actions_addclose: %s", strerror(errno));
++    Fatal("posix_spawn_file_actions_addclose: %s", strerror(errno));*/
+ 
+   posix_spawnattr_t attr;
+   if (posix_spawnattr_init(&attr) != 0)
+@@ -73,7 +73,7 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
+   // default action in the new process image, so no explicit
+   // POSIX_SPAWN_SETSIGDEF parameter is needed.
+ 
+-  if (!use_console_) {
++  /*if (!use_console_) {
+     // Put the child in its own process group, so ctrl-c won't reach it.
+     flags |= POSIX_SPAWN_SETPGROUP;
+     // No need to posix_spawnattr_setpgroup(&attr, 0), it's the default.
+@@ -92,7 +92,7 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
+       Fatal("posix_spawn_file_actions_addclose: %s", strerror(errno));
+     // In the console case, output_pipe is still inherited by the child and
+     // closed when the subprocess finishes, which then notifies ninja.
+-  }
++  }*/
+ #ifdef POSIX_SPAWN_USEVFORK
+   flags |= POSIX_SPAWN_USEVFORK;
+ #endif
+@@ -100,15 +100,15 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
+   if (posix_spawnattr_setflags(&attr, flags) != 0)
+     Fatal("posix_spawnattr_setflags: %s", strerror(errno));
+ 
+-  const char* spawned_args[] = { "/bin/sh", "-c", command.c_str(), NULL };
+-  if (posix_spawn(&pid_, "/bin/sh", &action, &attr,
++  const char* spawned_args[] = { "/system/bin/sh", "-c", command.c_str(), NULL };
++  if (posix_spawn(&pid_, "/system/bin/sh", &action, &attr,
+                   const_cast<char**>(spawned_args), environ) != 0)
+     Fatal("posix_spawn: %s", strerror(errno));
+ 
+-  if (posix_spawnattr_destroy(&attr) != 0)
++  /*if (posix_spawnattr_destroy(&attr) != 0)
+     Fatal("posix_spawnattr_destroy: %s", strerror(errno));
+   if (posix_spawn_file_actions_destroy(&action) != 0)
+-    Fatal("posix_spawn_file_actions_destroy: %s", strerror(errno));
++    Fatal("posix_spawn_file_actions_destroy: %s", strerror(errno));*/
+ 
+   close(output_pipe[1]);
+   return true;

--- a/packages/ninja/src-util.cc.patch
+++ b/packages/ninja/src-util.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/src/util.cc b/src/util.cc
+index 84de879..0ac9ec7 100644
+--- a/src/util.cc
++++ b/src/util.cc
+@@ -585,7 +585,7 @@ double GetLoadAverage() {
+   // Calculation taken from comment in libperfstats.h
+   return double(cpu_stats.loadavg[0]) / double(1 << SBITS);
+ }
+-#elif defined(__UCLIBC__)
++#elif defined(__UCLIBC__) || defined(__ANDROID__)
+ double GetLoadAverage() {
+   struct sysinfo si;
+   if (sysinfo(&si) != 0)


### PR DESCRIPTION
Update the host version to latest and use it to cross-compile.

Ninja uses `posix_spawn` which isn't in bionic, but a google search found [this BSD-licensed `fork` wrapper in dhcpcd from the Android source repo](https://android.googlesource.com/platform/external/dhcpcd-6.8.2/+/master/compat/posix_spawn.c), so I copied it over.  However, it doesn't support `posix_spawn_file_actions*`, so I simply commented those out.  Ninja fails some of those subprocess tests on Android as a result, but in actual use to build a project like ldc, I haven't noticed a problem.

Also, bionic doesn't have `getloadavg`, so use `sysinfo` instead.