### PR TITLE
add iconv dependency to ctags

### DIFF
--- a/packages/ctags/build.sh
+++ b/packages/ctags/build.sh
@@ -6,6 +6,7 @@ TERMUX_PKG_SHA256=33bd6ada4889d4d023fb44f44d440a5bcf82606c99a378a694f2a001cb6d1a
 TERMUX_PKG_SRCURL=https://github.com/universal-ctags/ctags/archive/${_COMMIT}.zip
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-tmpdir=$TERMUX_PREFIX/tmp"
 TERMUX_PKG_FOLDERNAME=ctags-$_COMMIT
+TERMUX_PKG_DEPENDS="iconv"
 TERMUX_PKG_BUILD_IN_SRC="yes"
 
 termux_step_pre_configure() {


### PR DESCRIPTION
#1169

show up in configure script

```
+ env ac_cv_func_calloc_0_nonnull=yes ac_cv_func_chown_works=yes ac_cv_func_getgroups_works=yes ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes am_cv_func_working_getline=yes gl_cv_func_dup2_works=yes gl_cv_func_fcntl_f_dupfd_cloexec=yes gl_cv_func_fcntl_f_dupfd_works=yes gl_cv_func_fnmatch_posix=yes gl_cv_func_getcwd_abort_bug=no gl_cv_func_getcwd_null=yes gl_cv_func_getcwd_path_max=yes gl_cv_func_getcwd_posix_signature=yes gl_cv_func_gettimeofday_clobber=no gl_cv_func_gettimeofday_posix_signature=yes gl_cv_func_link_works=yes gl_cv_func_lstat_dereferences_slashed_symlink=yes gl_cv_func_malloc_0_nonnull=yes gl_cv_func_memchr_works=yes gl_cv_func_mkdir_trailing_dot_works=yes gl_cv_func_mkdir_trailing_slash_works=yes gl_cv_func_mkfifo_works=yes gl_cv_func_realpath_works=yes gl_cv_func_select_detects_ebadf=yes gl_cv_func_snprintf_posix=yes gl_cv_func_snprintf_retval_c99=yes gl_cv_func_snprintf_truncation_c99=yes gl_cv_func_stat_dir_slash=yes gl_cv_func_stat_file_slash=yes gl_cv_func_strerror_0_works=yes gl_cv_func_symlink_works=yes gl_cv_func_tzset_clobber=no gl_cv_func_unlink_honors_slashes=yes gl_cv_func_unlink_honors_slashes=yes gl_cv_func_vsnprintf_posix=yes gl_cv_func_vsnprintf_zerosize_c99=yes gl_cv_func_wcwidth_works=yes gl_cv_func_working_getdelim=yes gl_cv_func_working_mkstemp=yes gl_cv_func_working_mktime=yes gl_cv_func_working_strerror=yes gl_cv_header_working_fcntl_h=yes gl_cv_C_locale_sans_EILSEQ=yes /home/builder/.termux-build/ctags/src/configure --disable-dependency-tracking --prefix=/data/data/com.termux/files/usr --disable-rpath --disable-rpath-hack --host=aarch64-linux-android --enable-tmpdir=/data/data/com.termux/files/usr/tmp --disable-nls --enable-shared --disable-static --libexecdir=/data/data/com.termux/files/usr/libexec
configure: WARNING: unrecognized options: --disable-rpath, --disable-rpath-hack, --disable-nls, --enable-shared, --disable-static
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for aarch64-linux-android-strip... aarch64-linux-android-strip
checking for a thread-safe mkdir -p... /bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether UID '1000' is supported by ustar format... yes
checking whether GID '1000' is supported by ustar format... yes
checking how to create a ustar tar archive... gnutar
checking whether make supports nested variables... (cached) yes
checking build system type... x86_64-pc-linux-gnu
checking host system type... aarch64-unknown-linux-android
Universal Ctags, version 0.0.0
Linux 4.9.41-moby #1 SMP Wed Sep 6 00:05:16 UTC 2017 x86_64
checking for aarch64-linux-android-gcc... aarch64-linux-android-clang
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... yes
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether aarch64-linux-android-clang accepts -g... yes
checking for aarch64-linux-android-clang option to accept ISO C89... none needed
checking whether aarch64-linux-android-clang understands -c and -o together... yes
checking for style of include used by make... GNU
checking dependency style of aarch64-linux-android-clang... none
checking for aarch64-linux-android-clang option to accept ISO C99... none needed
checking whether ln -s works... yes
checking for strip... (cached) aarch64-linux-android-strip
checking for special C compiler options needed for large files... no
checking for _FILE_OFFSET_BITS value needed for large files... no
checking for perl... no
checking for rst2man... /usr/bin/rst2man
checking building in a git repository... no
checking for git... git
checking directory to use for temporary files... /data/data/com.termux/files/usr/tmp
checking for case-insensitive filenames... no
checking selected sort method... external sort utility
checking for sort... yes
checking if sort accepts our command line... yes
checking how to run the C preprocessor... aarch64-linux-android-cpp
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking dirent.h usability... yes
checking dirent.h presence... yes
checking for dirent.h... yes
checking errno.h usability... yes
checking errno.h presence... yes
checking for errno.h... yes
checking fcntl.h usability... yes
checking fcntl.h presence... yes
checking for fcntl.h... yes
checking io.h usability... no
checking io.h presence... no
checking for io.h... no
checking limits.h usability... yes
checking limits.h presence... yes
checking for limits.h... yes
checking stat.h usability... no
checking stat.h presence... no
checking for stat.h... no
checking for stdlib.h... (cached) yes
checking for string.h... (cached) yes
checking time.h usability... yes
checking time.h presence... yes
checking for time.h... yes
checking types.h usability... no
checking types.h presence... no
checking for types.h... no
checking for unistd.h... (cached) yes
checking sys/dir.h usability... no
checking sys/dir.h presence... no
checking for sys/dir.h... no
checking for sys/stat.h... (cached) yes
checking sys/times.h usability... yes
checking sys/times.h presence... yes
checking for sys/times.h... yes
checking for sys/types.h... (cached) yes
checking sys/wait.h usability... yes
checking sys/wait.h presence... yes
checking for sys/wait.h... yes
checking if L_tmpnam is defined in stdio.h... yes
checking if INT_MAX is defined in limits.h... yes
checking for size_t... yes
checking for off_t... yes
checking for fpos_t... yes
checking for clock_t... yes
checking stdbool.h usability... yes
checking stdbool.h presence... yes
checking for stdbool.h... yes
checking for an ANSI C-conforming const... yes
checking if struct stat contains st_ino... yes
checking for fnmatch... yes
checking fnmatch.h usability... yes
checking fnmatch.h presence... yes
checking for fnmatch.h... yes
checking for strstr... yes
checking for strcasecmp... yes
checking for strncasecmp... yes
checking for fgetpos... yes
checking for mkstemp... yes
checking for opendir... yes
checking for strerror... yes
checking for clock... yes
checking for remove... yes
checking for truncate... yes
checking for setenv... yes
checking for regcomp... yes
checking if regcomp works... yes
checking for scandir... yes
checking pkg-config is at least version 0.9.0... yes
checking for JANSSON... no
checking for SECCOMP... no
checking for LIBYAML... no
checking for ASPELL... no
configure: checking for new missing prototypes
checking for iconv_open with -liconv... no
checking for iconv_open... no
configure: error: Could not find libiconv. Please install libiconv and libiconv-devel.
```