### PR TITLE
Add package: proxychains-ng

### DIFF
--- a/packages/proxychains-ng/Makefile.patch
+++ b/packages/proxychains-ng/Makefile.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 28169ab..9bd0088 100644
+--- a/Makefile
++++ b/Makefile
+@@ -25,7 +25,7 @@ GENH = src/version.h
+ CFLAGS  += -Wall -O0 -g -std=c99 -D_GNU_SOURCE -pipe
+ NO_AS_NEEDED = -Wl,--no-as-needed
+ LIBDL   = -ldl
+-LDFLAGS = -fPIC $(NO_AS_NEEDED) $(LIBDL) -lpthread
++LDFLAGS = -fPIC $(NO_AS_NEEDED) $(LIBDL)
+ INC     = 
+ PIC     = -fPIC
+ AR      = $(CROSS_COMPILE)ar

--- a/packages/proxychains-ng/build.sh
+++ b/packages/proxychains-ng/build.sh
@@ -4,7 +4,6 @@ TERMUX_PKG_VERSION=4.12
 TERMUX_PKG_MAINTAINER="Oliver Schmidhauser @Neo-Oli"
 TERMUX_PKG_SRCURL=https://github.com/rofl0r/proxychains-ng/releases/download/v${TERMUX_PKG_VERSION}/proxychains-ng-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=482a549935060417b629f32ddadd14f9c04df8249d9588f7f78a3303e3d03a4e
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" --prefix=${TERMUX_PREFIX}"
 TERMUX_PKG_BUILD_IN_SRC=yes
 termux_step_post_make_install(){
     # Remove conf file from previous build, otherwise nothing will be done and it won't be included in the package

--- a/packages/proxychains-ng/build.sh
+++ b/packages/proxychains-ng/build.sh
@@ -1,0 +1,15 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/dgoulet/torsocks
+TERMUX_PKG_DESCRIPTION="Wrapper to safely torify applications"
+TERMUX_PKG_VERSION=4.12
+TERMUX_PKG_MAINTAINER="Oliver Schmidhauser @Neo-Oli"
+TERMUX_PKG_SRCURL=https://github.com/rofl0r/proxychains-ng/releases/download/v${TERMUX_PKG_VERSION}/proxychains-ng-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=482a549935060417b629f32ddadd14f9c04df8249d9588f7f78a3303e3d03a4e
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" --prefix=${TERMUX_PREFIX}"
+TERMUX_PKG_BUILD_IN_SRC=yes
+termux_step_post_make_install(){
+    # Remove conf file from previous build, otherwise nothing will be done and it won't be included in the package
+    rm -f $TERMUX_PREFIX/etc/proxychains.conf
+    make install-config
+}
+
+

--- a/packages/proxychains-ng/build.sh
+++ b/packages/proxychains-ng/build.sh
@@ -1,5 +1,5 @@
-TERMUX_PKG_HOMEPAGE=https://github.com/dgoulet/torsocks
-TERMUX_PKG_DESCRIPTION="Wrapper to safely torify applications"
+TERMUX_PKG_HOMEPAGE=https://github.com/rofl0r/proxychains-ng
+TERMUX_PKG_DESCRIPTION="a preloader which hooks calls to sockets in dynamically linked programs and redirects it through one or more socks/http proxies. It is a kind of proxifier."
 TERMUX_PKG_VERSION=4.12
 TERMUX_PKG_MAINTAINER="Oliver Schmidhauser @Neo-Oli"
 TERMUX_PKG_SRCURL=https://github.com/rofl0r/proxychains-ng/releases/download/v${TERMUX_PKG_VERSION}/proxychains-ng-${TERMUX_PKG_VERSION}.tar.xz

--- a/packages/proxychains-ng/core.c.patch
+++ b/packages/proxychains-ng/core.c.patch
@@ -1,0 +1,20 @@
+diff --git a/src/core.c b/src/core.c
+index 827ee54..a360fe8 100644
+--- a/src/core.c
++++ b/src/core.c
+@@ -787,7 +787,6 @@ void proxy_freeaddrinfo(struct addrinfo *res) {
+ 	free(res);
+ }
+ 
+-#if defined(IS_MAC) || defined(IS_OPENBSD)
+ #ifdef IS_OPENBSD /* OpenBSD has its own incompatible getservbyname_r */
+ #define getservbyname_r mygetservbyname_r
+ #endif
+@@ -810,7 +809,6 @@ static int getservbyname_r(const char* name, const char* proto, struct servent*
+ 	}
+ 	return ret;
+ }
+-#endif
+ 
+ int proxy_getaddrinfo(const char *node, const char *service, const struct addrinfo *hints, struct addrinfo **res) {
+ 	struct gethostbyname_data ghdata;

--- a/packages/proxychains-ng/libproxychains.c.patch
+++ b/packages/proxychains-ng/libproxychains.c.patch
@@ -1,0 +1,13 @@
+diff --git a/src/libproxychains.c b/src/libproxychains.c
+index 7373d55..20bf993 100644
+--- a/src/libproxychains.c
++++ b/src/libproxychains.c
+@@ -332,7 +332,7 @@ static int is_v4inv6(const struct in6_addr *a) {
+ 	return a->s6_addr32[0] == 0 && a->s6_addr32[1] == 0 &&
+ 	       a->s6_addr16[4] == 0 && a->s6_addr16[5] == 0xffff;
+ }
+-int connect(int sock, const struct sockaddr *addr, unsigned int len) {
++int connect(int sock, const struct sockaddr *addr, socklen_t len) {
+ 	INIT();
+ 	PFUNC();
+ 


### PR DESCRIPTION
Closes #330 (#395)

I've tested it with a simple ssh tunnel and it seems to work really
well. It works better than tsocks because I was able use python
programs (getmail) with this. I hope it holds up when more experienced
users put it through it's paces.