### PR TITLE
htop: fix segfault which may occur in some cases

### DIFF
--- a/packages/htop/build.sh
+++ b/packages/htop/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Interactive process viewer for Linux"
 # htop checks setlocale() return value for UTF-8 support, so use libandroid-support.
 TERMUX_PKG_DEPENDS="ncurses, libandroid-support"
 TERMUX_PKG_VERSION=2.0.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=http://hisham.hm/htop/releases/${TERMUX_PKG_VERSION}/htop-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=179be9dccb80cee0c5e1a1f58c8f72ce7b2328ede30fb71dcdf336539be2f487
 TERMUX_PKG_BUILD_IN_SRC="yes"

--- a/packages/htop/fix-sigsegv.patch
+++ b/packages/htop/fix-sigsegv.patch
@@ -1,0 +1,14 @@
+diff -uNr htop-2.0.2/StringUtils.c htop-2.0.2.mod/StringUtils.c
+--- htop-2.0.2/StringUtils.c	2016-06-20 18:11:13.000000000 +0300
++++ htop-2.0.2.mod/StringUtils.c	2017-09-26 13:33:10.596064441 +0300
+@@ -88,6 +88,10 @@
+ }
+ 
+ void String_freeArray(char** s) {
++   if (!s) {
++      return;
++   }
++
+    for (int i = 0; s[i] != NULL; i++) {
+       free(s[i]);
+    }


### PR DESCRIPTION
In some configurations of htop we may receive the following error:
```
htop 2.0.2 aborting. Please report bug at http://hisham.hm/htop
zsh: abort      htop
```

This bug already fixed in htop's repo at commit [cceab15b9dbdc2f0914c8d479cefa429d1c0daaf](https://github.com/hishamhm/htop/commit/cceab15b9dbdc2f0914c8d479cefa429d1c0daaf).

