### PR TITLE
remove zeroed escape time

### DIFF
--- a/packages/tmux/tmux.conf
+++ b/packages/tmux/tmux.conf
@@ -1,2 +1,1 @@
 set -g mouse on
-set -s escape-time 0


### PR DESCRIPTION
an escape time of zero breaks tmux core functionality... you cannot have an escape time of 0, then it's impossible to use most custom key bindings, or to do things like resize panes effectively, etc...