### PR TITLE
add quiet build option for ci builds

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -796,7 +796,7 @@ termux_step_configure_autotools () {
                 LIBEXEC_FLAG=""
         fi
 	QUIET_BUILD=
-	if [ -n ${TERMUX_QUIET_BUILD} ]; then
+	if [ ! -z ${TERMUX_QUIET_BUILD+x} ]; then
 		QUIET_BUILD="--enable-silent-rules"
 	fi
 

--- a/build-package.sh
+++ b/build-package.sh
@@ -202,7 +202,7 @@ termux_step_handle_arguments() {
 		d) TERMUX_DEBUG=true;;
 		D) local TERMUX_IS_DISABLED=true;;
 		f) TERMUX_FORCE_BUILD=true;;
-		q) TERMUX_QUIET_BUILD=true;;
+		q) export TERMUX_QUIET_BUILD=true;;
 		s) export TERMUX_SKIP_DEPCHECK=true;;
 		?) termux_error_exit "./build-package.sh: illegal option -$OPTARG";;
 		esac


### PR DESCRIPTION
need to find ways to reduce length of log output

```
$ ./scripts/run-docker.sh ./build-package.sh iconv | wc
    2836   15651  197322
$ ./scripts/run-docker.sh ./build-package.sh -q iconv | wc
    2177   13021  162608
```