### PR TITLE
texlive: fix postinst, prerm, preinst scripts

### DIFF
--- a/packages/texlive-bin/build.sh
+++ b/packages/texlive-bin/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="TeX Live is a distribution of the TeX typesetting system
 TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
 _MAJOR_VERSION=20170524
 _MINOR_VERSION=
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_VERSION=${_MAJOR_VERSION}${_MINOR_VERSION}
 TERMUX_PKG_SRCURL=ftp://tug.org/historic/systems/texlive/${TERMUX_PKG_VERSION:0:4}/texlive-${TERMUX_PKG_VERSION}-source.tar.xz
 TERMUX_PKG_SHA256="0161695304e941334dc0b3b5dabcf8edf46c09b7bc33eea8229b5ead7ccfb2aa"
@@ -145,7 +145,7 @@ termux_step_post_make_install () {
 
 termux_step_create_debscripts () {
 	# Clean texlive's folder if needed (run on fresh install)
-	echo "#!$TERMUX_PREFIX/bin/sh" > preinst
+	echo "#!$TERMUX_PREFIX/bin/bash" > preinst
 	echo "if [ ! -f $TERMUX_PREFIX/opt/texlive/2016/install-tl -a ! -f $TERMUX_PREFIX/opt/texlive/2017/install-tl ]; then exit 0; else echo 'Removing residual files from old version of TeX Live for Termux'; fi" >> preinst
 	echo "rm -rf $TERMUX_PREFIX/etc/profile.d/texlive.sh" >> preinst
 	echo "rm -rf $TERMUX_PREFIX/opt/texlive/2016" >> preinst

--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
 _MAJOR_VERSION=20170524
 _MINOR_VERSION=
 TERMUX_PKG_VERSION=${_MAJOR_VERSION}${_MINOR_VERSION}
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=("ftp://ftp.tug.org/texlive/historic/${TERMUX_PKG_VERSION:0:4}/"\
 {"texlive-$_MAJOR_VERSION-texmf.tar.xz",\
 "texlive-$_MAJOR_VERSION-extra.tar.xz",\
@@ -56,7 +56,7 @@ termux_step_make() {
 
 termux_step_create_debscripts () {
 	# Clean texlive's folder if needed (run on upgrade)
-	echo "#!$TERMUX_PREFIX/bin/sh" > preinst
+	echo "#!$TERMUX_PREFIX/bin/bash" > preinst
 	echo "if [ ! -f $TERMUX_PREFIX/opt/texlive/2016/install-tl -a ! -f $TERMUX_PREFIX/opt/texlive/2017/install-tl ]; then exit 0; else echo 'Removing residual files from old version of TeX Live for Termux'; fi" >> preinst
 	echo "rm -rf $TERMUX_PREFIX/etc/profile.d/texlive.sh" >> preinst
 	echo "rm -rf $TERMUX_PREFIX/opt/texlive/2016" >> preinst

--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -67,7 +67,7 @@ termux_step_create_debscripts () {
 	echo "exit 0" >> preinst
 	chmod 0755 preinst
 	
-	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo "#!$TERMUX_PREFIX/bin/bash" > postinst
 	echo "mkdir -p $TL_ROOT/{tlpkg/{backups,tlpobj},texmf-var/{web2c,tex/generic/config}}" >> postinst
 	echo "export PATH=\$PATH:$TL_BINDIR" >> postinst
 	echo "echo Updating tlmgr" >> postinst
@@ -88,7 +88,7 @@ termux_step_create_debscripts () {
 	chmod 0755 postinst
 
 	# Remove all files installed through tlmgr on removal
-	echo "#!$TERMUX_PREFIX/bin/sh" > prerm
+	echo "#!$TERMUX_PREFIX/bin/bash" > prerm
 	echo 'if [ $1 != "remove" ]; then exit 0; fi' >> prerm
 	echo "echo Running texlinks --unlink" >> prerm
 	echo "texlinks --unlink" >> prerm

--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -90,7 +90,6 @@ termux_step_create_debscripts () {
 	# Remove all files installed through tlmgr on removal
 	echo "#!$TERMUX_PREFIX/bin/sh" > prerm
 	echo 'if [ $1 != "remove" ]; then exit 0; fi' >> prerm
-	#echo "tlmgr remove --dry-run "
 	echo "echo Running texlinks --unlink" >> prerm
 	echo "texlinks --unlink" >> prerm
 	echo "echo Removing texmf-dist" >> prerm

--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -70,6 +70,7 @@ termux_step_create_debscripts () {
 	echo "#!$TERMUX_PREFIX/bin/bash" > postinst
 	echo "mkdir -p $TL_ROOT/{tlpkg/{backups,tlpobj},texmf-var/{web2c,tex/generic/config}}" >> postinst
 	echo "export PATH=\$PATH:$TL_BINDIR" >> postinst
+	echo "export TMPDIR=$TERMUX_PREFIX/tmp" >> postinst
 	echo "echo Updating tlmgr" >> postinst
 	echo "tlmgr update --self" >> postinst
 	echo "echo Generating language files and setting up symlinks" >> postinst


### PR DESCRIPTION
This seem to work for all test cases I can think of (fresh install, update, install/update when TMPDIR isn't set...). 

Should solve #1639, finally. 

Sorry for the mess.