### PR TITLE
Add package tshark (terminal wireshark)

### DIFF
--- a/packages/tshark/build.sh
+++ b/packages/tshark/build.sh
@@ -10,4 +10,5 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-qt=no --disable-wireshark"
 
 termux_step_pre_configure () {
 	./autogen.sh
+	LDFLAGS+=" -L$TERMUX_PKG_BUILDDIR/wsutil/.libs -L$TERMUX_PKG_BUILDDIR/epan/.libs" #A bit hacky.. 
 }

--- a/packages/tshark/build.sh
+++ b/packages/tshark/build.sh
@@ -1,0 +1,10 @@
+TERMUX_PKG_HOMEPAGE=https://www.aircrack-ng.org
+TERMUX_PKG_DESCRIPTION="network protocol analyzer and sniffer"
+TERMUX_PKG_VERSION=2.4.2
+TERMUX_PKG_SRCURL=https://github.com/wireshark/wireshark/archive/wireshark-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=b9b60b3a23e2f24f0f9a75d67364b8eef649960c9d1926697739825a3a7a9861
+TERMUX_PKG_MAINTAINER="Auxilus @Auxilus"
+TERMUX_PKG_DEPENDS="libnl, libnl-dev, openssl,openssl-dev " 
+# As GUI is not supported by termux we need to disable wireshark 
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--prefix=$PREFIX --with-qt=no --disable-wireshark" 
+TERMUX_PKG_BUILD_IN_SRC=yes

--- a/packages/tshark/build.sh
+++ b/packages/tshark/build.sh
@@ -6,5 +6,5 @@ TERMUX_PKG_SHA256=b9b60b3a23e2f24f0f9a75d67364b8eef649960c9d1926697739825a3a7a98
 TERMUX_PKG_MAINTAINER="Auxilus @Auxilus"
 TERMUX_PKG_DEPENDS="libnl, libnl-dev, openssl,openssl-dev " 
 # As GUI is not supported by termux we need to disable wireshark 
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--prefix=$PREFIX --with-qt=no --disable-wireshark" 
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-qt=no --disable-wireshark" 
 TERMUX_PKG_BUILD_IN_SRC=yes

--- a/packages/tshark/build.sh
+++ b/packages/tshark/build.sh
@@ -4,7 +4,10 @@ TERMUX_PKG_VERSION=2.4.2
 TERMUX_PKG_SRCURL=https://github.com/wireshark/wireshark/archive/wireshark-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=b9b60b3a23e2f24f0f9a75d67364b8eef649960c9d1926697739825a3a7a9861
 TERMUX_PKG_MAINTAINER="Auxilus @Auxilus"
-TERMUX_PKG_DEPENDS="libnl, libnl-dev, openssl,openssl-dev " 
-# As GUI is not supported by termux we need to disable wireshark 
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-qt=no --disable-wireshark" 
-TERMUX_PKG_BUILD_IN_SRC=yes
+TERMUX_PKG_DEPENDS="libnl, openssl, libpcap, libpcap-dev, libcrypt, libgcrypt-dev, glib"
+# As GUI is not supported by termux we need to disable wireshark
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-qt=no --disable-wireshark"
+
+termux_step_pre_configure () {
+	./autogen.sh
+}

--- a/packages/tshark/caputils-ws80211.c.patch
+++ b/packages/tshark/caputils-ws80211.c.patch
@@ -1,0 +1,11 @@
+--- ./caputils/ws80211_utils.c	2017-10-10 17:50:57.000000000 +0000
++++ ../ws80211_utils.c	2017-10-18 08:19:26.903580180 +0000
+@@ -671,7 +671,7 @@
+ 
+ 	/* Update names of user created monitor interfaces */
+ 	while(fgets(line, sizeof(line), fh)) {
+-		t = index(line, ':');
++		t = strchr(line, ':');
+ 		if (!t)
+ 			continue;
+ 		*t = 0;

--- a/packages/tshark/epan-dissectors-packet-gtp.c.patch
+++ b/packages/tshark/epan-dissectors-packet-gtp.c.patch
@@ -1,0 +1,11 @@
+--- ./epan/dissectors/packet-gtp.c	2017-10-10 17:50:57.000000000 +0000
++++ ../packet-gtp.c	2017-10-18 14:55:54.098432467 +0000
+@@ -2364,7 +2364,7 @@
+ /* Next definitions and function check_field_presence checks if given field
+  * in GTP packet is compliant with ETSI
+  */
+-typedef struct _header {
++typedef struct _hehethaerhyaader {
+     guint8 code;
+     guint8 presence;
+ } ext_header;

--- a/packages/tshark/plugins-Makefile.am.inc.patch
+++ b/packages/tshark/plugins-Makefile.am.inc.patch
@@ -1,0 +1,11 @@
+--- ./plugins/Makefile.am.inc	2017-10-10 17:50:57.000000000 +0000
++++ Makefile.am.inc	2017-10-18 13:00:13.821739287 +0000
+@@ -26,7 +26,7 @@
+ 
+ PLUGIN_CFLAGS =
+ 
+-PLUGIN_LDFLAGS = -module -avoid-version
++PLUGIN_LDFLAGS = -module -avoid-version -lwireshark -lglib-2.0 -lwsutil
+ 
+ #
+ # Source files are divided up along several axes:


### PR DESCRIPTION
Although it runs correctly, it gives some sort of warnings at the starting of the capture 
![screenshot_20171018-080536](https://user-images.githubusercontent.com/23075789/31698445-44473f80-b3db-11e7-81a3-13d8a4c4a21f.png)

BTW looks like it generates the `.so ` files during the build process so its not there when you unpack the tarball