### PR TITLE
nodejs-current: Removing link() breaking npm package installation

### DIFF
--- a/packages/nodejs-current/npm-link-patch.patch
+++ b/packages/nodejs-current/npm-link-patch.patch
@@ -1,0 +1,29 @@
+--- ../node/deps/npm/node_modules/cacache/lib/util/move-file.js	2017-10-22 19:30:25.778456404 +0200
++++ ./deps/npm/node_modules/cacache/lib/util/move-file.js	2017-10-22 20:41:18.021337095 +0200
+@@ -4,6 +4,7 @@
+ const BB = require('bluebird')
+ const chmod = BB.promisify(fs.chmod)
+ const unlink = BB.promisify(fs.unlink)
++const access = BB.promisify(fs.access)
+ let move
+ let pinflight
+ 
+@@ -18,6 +19,18 @@
+   // content their own way.
+   //
+   // Note that, as the name suggests, this strictly only supports file moves.
++
++
++  // Calling link() on android is not allowed, we get a SELinux security exception
++  if(process.platform === 'android') {
++    return access(dest, fs.constants.F_OK)
++      .catch(err => {
++        if (!move) { move = require('move-concurrently') }
++        return move(src, dest, { BB, fs })
++          .then(() => chmod(dest, '0444'))
++      })
++  }
++
+   return BB.fromNode(cb => {
+     fs.link(src, dest, err => {
+       if (err) {


### PR DESCRIPTION
As it turns out, npm's dependency `cacache` does an "optimization" by instead of doing a simple `rename()`, it `link()`s the source file to its destination, and `unlink()`s the source file. Since `link()` is disallowed on Android, we don't want that behavior.

Fixes #1192. This makes it possible to correctly do an `npm install` again.