### PR TITLE
ocaml opam

### DIFF
--- a/packages/ocaml/arm.S.patch
+++ b/packages/ocaml/arm.S.patch
@@ -1,0 +1,11 @@
+--- ocaml-4.02.3/asmrun/arm.S	2014-08-21 10:06:19.000000000 +0000
++++ ocaml-4.02.3.patched/asmrun/arm.S	2017-10-10 06:27:21.271748503 +0000
+@@ -27,7 +27,7 @@
+         cmp     \reg, #0
+         beq     \lbl
+         .endm
+-#elif defined(SYS_linux_eabihf)
++#elif defined(SYS_linux_eabihf) || defined(SYS_android_eabi)
+         .arch   armv7-a
+         .fpu    vfpv3-d16
+         .thumb

--- a/packages/ocaml/build.sh
+++ b/packages/ocaml/build.sh
@@ -1,0 +1,25 @@
+local OCAML_MAJORVERSION=4.05
+local OCAML_MINORVERSION=0
+TERMUX_PKG_VERSION=$OCAML_MAJORVERSION.$OCAML_MINORVERSION
+TERMUX_PKG_HOMEPAGE=https://ocaml.org
+local TARNAME=ocaml-$TERMUX_PKG_VERSION.tar.xz
+TERMUX_PKG_DESCRIPTION="OCaml is an industrial strength programming language supporting functional, imperative and object-oriented styles"
+TERMUX_PKG_VERSION=$OCAML_MAJORVERSION.$OCAML_MINORVERSION
+TERMUX_PKG_SRCURL="SRCURL=http://caml.inria.fr/pub/distrib/ocaml-${OCAML_MAJORVERSION}/${TARNAME}"
+TERMUX_PKG_SHA256=04a527ba14b4d7d1b2ea7b2ae21aefecfa8d304399db94f35a96df1459e02ef9
+TERMUX_PKG_BUILD_IN_SRC=yes
+TERMUX_PKG_KEEP_STATIC_LIBRARIES=true
+TERMUX_PKG_DEPENDS=opam
+termux_step_configure() {
+	termux_setup_ocaml
+	./configure -fPIC -cc "$TERMUX_HOST_PLATFORM-clang" -aspp "$CC -no-integrated-as -c"  --prefix "$TERMUX_PREFIX" \
+	          -target-bindir $TERMUX_PREFIX/bin --target "$TERMUX_HOST_PLATFORM"
+
+}
+termux_step_make() {
+
+	sed -i "s/-O2/${CFLAGS}/g" config/Makefile
+       
+	make world.opt -j $TERMUX_MAKE_PROCESSES  || true
+	make world.opt
+}

--- a/packages/ocaml/disable-RTLD_NODELETE.patch
+++ b/packages/ocaml/disable-RTLD_NODELETE.patch
@@ -1,0 +1,32 @@
+From 4ac705ce49fbfca762575458e7b893d3ba0f6e80 Mon Sep 17 00:00:00 2001
+From: Max Mouratov <mmouratov@gmail.com>
+Date: Sat, 31 May 2014 06:33:48 +0600
+Subject: [PATCH] runtime: disabled the RTLD_NODELETE option in the call to
+ dlopen in unix.c
+
+Because of this option it was impossible to unload shared libraries on Unix.
+The reason why it was there in the first place is shrouded in mystery.
+---
+ byterun/unix.c | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/byterun/unix.c b/byterun/unix.c
+index f131e1e4de..5d59779599 100644
+--- a/byterun/unix.c
++++ b/byterun/unix.c
+@@ -263,14 +263,10 @@ char * caml_dlerror(void)
+ #ifndef RTLD_LOCAL
+ #define RTLD_LOCAL 0
+ #endif
+-#ifndef RTLD_NODELETE
+-#define RTLD_NODELETE 0
+-#endif
+ 
+ void * caml_dlopen(char * libname, int for_execution, int global)
+ {
+-  return dlopen(libname, RTLD_NOW | (global ? RTLD_GLOBAL : RTLD_LOCAL)
+-                         | RTLD_NODELETE);
++  return dlopen(libname, RTLD_NOW | (global ? RTLD_GLOBAL : RTLD_LOCAL));
+   /* Could use RTLD_LAZY if for_execution == 0, but needs testing */
+ }
+ 

--- a/packages/ocaml/filename.ml.patch
+++ b/packages/ocaml/filename.ml.patch
@@ -1,0 +1,11 @@
+--- ../cache/ocaml-4.05.0/stdlib/filename.ml	2017-07-13 08:56:45.000000000 +0000
++++ ./stdlib/filename.ml	2017-11-03 07:26:50.205671425 +0000
+@@ -84,7 +84,7 @@
+     String.sub name (String.length name - String.length suff)
+                     (String.length suff) = suff
+   let temp_dir_name =
+-    try Sys.getenv "TMPDIR" with Not_found -> "/tmp"
++    try Sys.getenv "TMPDIR" with Not_found -> "@TERMUX_PREFIX@/tmp"
+   let quote = generic_quote "'\\''"
+   let basename = generic_basename is_dir_sep current_dir_name
+   let dirname = generic_dirname is_dir_sep current_dir_name

--- a/packages/ocaml/ocaml-arch.ml.patch
+++ b/packages/ocaml/ocaml-arch.ml.patch
@@ -1,0 +1,11 @@
+--- ../cache/ocaml-4.05.0/asmcomp/arm/arch.ml	2017-07-13 08:56:44.000000000 +0000
++++ ./asmcomp/arm/arch.ml	2017-10-14 21:57:33.401669000 +0000
+@@ -24,7 +24,7 @@
+ 
+ let abi =
+   match Config.system with
+-    "linux_eabi" | "freebsd" -> EABI
++    "linux_eabi" | "freebsd" | "android_eabi" -> EABI
+   | "linux_eabihf" | "netbsd" -> EABI_HF
+   | _ -> assert false
+ 

--- a/packages/ocaml/ocaml-cross-compile.configure.patch
+++ b/packages/ocaml/ocaml-cross-compile.configure.patch
@@ -1,0 +1,134 @@
+--- ../cache/ocaml-4.05.0/configure	2017-07-13 08:56:44.000000000 +0000
++++ ./configure	2017-10-15 01:40:57.185067140 +0000
+@@ -555,6 +555,7 @@
+           "sources ($ocaml_source_version)."
+     else
+       echo "CAMLRUN=`./searchpath -p ocamlrun`" >> Makefile
++      echo "OCAMLDOC_RUN=`./searchpath -p ocamldoc`" >> Makefile
+     fi
+   fi
+ 
+@@ -609,11 +610,24 @@
+                    echo "#undef ARCH_SIXTYFOUR" >> m.h
+                    set 4 4 4 2 8
+                    arch64=false;;
++    i686-*android) inf "OK, this is a regular 32 bit architecture."
++	    echo "#undef ARCH_SIXTYFOUR" >> m.h
++	           set 4 4 4 2 8
++		   arch64=false;;
++	   arm*-android*)
++		   inf "OK, this is a regular 32 bit architecture."
++		   echo "#undef ARCH_SIXTYFOUR" >> m.h
++		   set 4 4 4 2 8
++		   arch64=false;;
+     x86_64-*-mingw*) inf "Wow! A 64 bit architecture!"
+                      echo "#define ARCH_SIXTYFOUR" >> m.h
+                      set 4 4 8 2 8
+                      arch64=true;;
+-    *) err "Since datatype sizes cannot be guessed when cross-compiling,\n" \
++	     *64-*-android) inf "Wow! A 64 bit architecture!"
++		      echo "#define ARCH_SIXTYFOUR" >> m.h
++		      set 4 8 8 2 8
++		      arch64=true;;
++	   *) err "Since datatype sizes cannot be guessed when cross-compiling,\n" \
+            "a hardcoded list is used but your architecture isn't known yet.\n" \
+            "You need to determine the sizes yourself.\n" \
+            "Please submit a bug report in order to expand the list." ;;
+@@ -699,7 +713,7 @@
+ 
+ case "$target" in
+   # PR#5088: autodetection is unreliable on ARM.  PR#5280: also on MIPS.
+-  sparc*-*-*|hppa*-*-*|arm*-*-*|mips*-*-*)
++  sparc*-*-*|hppa*-*-*|arm*-*-*|mips*-*-*|aarch64-*-*|i686-*-*-android)
+     if test $2 = 8; then
+       inf "64-bit integers can be word-aligned."
+       echo "#undef ARCH_ALIGN_INT64" >> m.h
+@@ -812,6 +826,14 @@
+       mksharedlibrpath="-Wl,-rpath,"
+       natdynlinkopts="-Wl,-E"
+       shared_libraries_supported=true;;
++    *-android*)
++      sharedcccompopts="-fPIC"
++      mksharedlib="$bytecc -shared"
++      bytecclinkopts="$bytecclinkopts -Wl,-E"
++      byteccrpath=""
++      mksharedlibrpath=""
++      natdynlinkopts="-Wl,-E"
++      shared_libraries_supported=true;;
+   esac
+ fi
+ 
+@@ -854,6 +876,7 @@
+     arm*-*-freebsd*)              natdynlink=true;;
+     earm*-*-netbsd*)              natdynlink=true;;
+     aarch64-*-linux*)             natdynlink=true;;
++    *-android*)                   natdynlink=true;;
+   esac
+ fi
+ 
+@@ -907,6 +930,7 @@
+                                 else
+                                   arch=i386; system=solaris
+                                 fi;;
++  i686-*android)                arch=i386; system=linux_elf;;
+   i[3456]86-*-haiku*)           arch=i386; system=beos;;
+   i[3456]86-*-beos*)            arch=i386; system=beos;;
+   i[3456]86-*-cygwin*)          arch=i386; system=cygwin;;
+@@ -934,7 +958,8 @@
+   earmv7*-*-netbsd*)            arch=arm; model=armv7; system=netbsd;;
+   armv5te*-*-linux-gnueabi)     arch=arm; model=armv5te; system=linux_eabi;;
+   armv5*-*-linux-gnueabi)       arch=arm; model=armv5; system=linux_eabi;;
+-  arm*-*-linux-gnueabi)         arch=arm; system=linux_eabi;;
++  arm*-*-androideabi)		arch=arm; model=armv7; system=android_eabi;;
++  arm*-*-linux-gnueabi)         arch=arm; system=android;;
+   arm*-*-openbsd*)              arch=arm; system=bsd;;
+   zaurus*-*-openbsd*)           arch=arm; system=bsd;;
+   x86_64-*-linux*)              arch=amd64; system=linux;;
+@@ -947,6 +972,8 @@
+   x86_64-*-mingw*)              arch=amd64; system=mingw;;
+   aarch64-*-linux*)             arch=arm64; system=linux;;
+   x86_64-*-cygwin*)             arch=amd64; system=cygwin;;
++  aarch64-*-android)            arch=arm64; system=android;;
++  x86_64-*-android)             arch=amd64; system=android;;
+ esac
+ 
+ # Some platforms exist both in 32-bit and 64-bit variants, not distinguished
+@@ -1378,17 +1405,17 @@
+   has_wait=yes
+ fi
+ 
+-if sh ./hasgot -i limits.h && sh ./runtest getgroups.c; then
++if sh ./hasgot -i limits.h && sh ./trycompile getgroups.c; then
+   inf "getgroups() found."
+   echo "#define HAS_GETGROUPS" >> s.h
+ fi
+ 
+-if sh ./hasgot -i limits.h -i grp.h && sh ./runtest setgroups.c; then
++if sh ./hasgot -i limits.h -i grp.h && sh ./trycompile setgroups.c; then
+   inf "setgroups() found."
+   echo "#define HAS_SETGROUPS" >> s.h
+ fi
+ 
+-if sh ./hasgot -i limits.h -i grp.h && sh ./runtest initgroups.c; then
++if sh ./hasgot -i limits.h -i grp.h && sh ./trycompile initgroups.c; then
+   inf "initgroups() found."
+   echo "#define HAS_INITGROUPS" >> s.h
+ fi
+@@ -1598,6 +1625,8 @@
+                    pthread_caml_link="-cclib -pthread";;
+     *-*-haiku*)    pthread_link=""
+                    pthread_caml_link="";;
++    *-*-android*)  pthread_link="-pthread"
++	    	   pthread_caml_link="-cclib -pthread";;
+     *)             pthread_link="-lpthread"
+                    pthread_caml_link="-cclib -lpthread";;
+   esac
+@@ -1845,7 +1874,7 @@
+ 
+ # Check whether assembler supports CFI directives
+ 
+-asm_cfi_supported=false
++asm_cfi_supported=true
+ 
+ export as aspp
+ 

--- a/packages/ocaml/ocaml-cross-compile.makefile.patch
+++ b/packages/ocaml/ocaml-cross-compile.makefile.patch
@@ -1,0 +1,11 @@
+--- ./ocaml-4.05.0/Makefile	2017-07-13 08:56:44.000000000 +0000
++++ ./Makefile	2017-10-08 23:24:03.930684004 +0000
+@@ -454,7 +454,7 @@
+ .PHONY: opt.opt
+ ifeq "$(UNIX_OR_WIN32)" "unix"
+ opt.opt:
+-	$(MAKE) checkstack
++	#$(MAKE) checkstack
+ 	$(MAKE) runtime
+ 	$(MAKE) core
+ 	$(MAKE) ocaml

--- a/packages/ocaml/ocamldocmake.patch
+++ b/packages/ocaml/ocamldocmake.patch
@@ -1,0 +1,17 @@
+--- Makefile.orig	2017-11-04 00:29:07.818845724 +0000
++++ ./ocamldoc/Makefile	2017-11-04 00:34:51.697576708 +0000
+@@ -16,9 +16,13 @@
+ ROOTDIR = ..
+ 
+ include $(ROOTDIR)/config/Makefile
++ifndef CAMLRUN
+ OCAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
+ OCAMLYACC ?= $(ROOTDIR)/boot/ocamlyacc
+-
++else
++OCAMLRUN = $(CAMLRUN)
++OCAMLYACC = $(CAMLYACC)
++endif
+ STDLIBFLAGS = -nostdlib -I $(ROOTDIR)/stdlib
+ OCAMLC    = $(OCAMLRUN) $(ROOTDIR)/ocamlc $(STDLIBFLAGS)
+ ifeq "$(UNIX_OR_WIN32)" "unix"

--- a/packages/opam/build.sh
+++ b/packages/opam/build.sh
@@ -1,0 +1,28 @@
+TERMUX_PKG_HOMEPAGE=http://www.ocaml.org
+TERMUX_PKG_DESCRIPTION="OPAM is a source-based package manager for OCaml."
+TERMUX_PKG_DEPENDS="wget, curl, git, patch, tar, gzip, bzip2, xz-utils, rsync"
+_MAIN_VERSION=1.2.2
+_PATCH_VERSION=1
+TERMUX_PKG_VERSION=${_MAIN_VERSION}.${_PATCH_VERSION}
+TERMUX_PKG_SRCURL=https://github.com/ocaml/opam/releases/download/${_MAIN_VERSION}/opam-full-${_MAIN_VERSION}.tar.gz
+TERMUX_PKG_SHA256=15e617179251041f4bf3910257bbb8398db987d863dd3cfc288bdd958de58f00
+TERMUX_PKG_BUILD_IN_SRC=yes
+TERMUX_PKG_DEPENDS=termux-exec
+termux_step_pre_configure() {
+	termux_setup_ocaml
+
+  # One of the patches edited the configure.ac file, so the configure file
+  # needs to be regenerated.
+  autoreconf -i
+}
+
+termux_step_make() {
+  # opam's dependencies seem to be broken. So the -j 1 option is given to only
+  # build one rule at a time.
+  
+  # Build the dependencies from the included source instead of using them from
+  # the system.
+  make -j 1 lib-ext
+  # Now build opam.
+  make -j 1
+}

--- a/packages/opam/cross.patch
+++ b/packages/opam/cross.patch
@@ -1,0 +1,103 @@
+diff -r -u src.orig/Makefile src/Makefile
+--- src.orig/Makefile	2017-08-29 16:37:11.860642704 +0000
++++ src/Makefile	2017-08-29 16:42:38.114253040 +0000
+@@ -1,6 +1,6 @@
+ -include Makefile.config
+ 
+-all: opam-lib opam opam-admin opam-installer
++all: opam-lib opam opam-admin opam-installer opam-installer.byte
+ 	@
+ 
+ ALWAYS:
+@@ -55,16 +55,16 @@
+ 
+ libinstall:
+ 	$(if $(wildcard src_ext/lib/*),$(error Installing the opam libraries is incompatible with embedding the dependencies. Run 'make clean-ext' and try again))
+-	src/opam-installer $(OPAMINSTALLER_FLAGS) opam-lib.install
++	src/opam-installer.byte $(OPAMINSTALLER_FLAGS) opam-lib.install
+ 
+ install:
+-	src/opam-installer $(OPAMINSTALLER_FLAGS) opam.install
++	$(OCAMLRUN) src/opam-installer.byte $(OPAMINSTALLER_FLAGS) opam.install
+ 
+ libuninstall:
+-	src/opam-installer -u $(OPAMINSTALLER_FLAGS) opam-lib.install
++	$(OCAMLRUN) src/opam-installer.byte -u $(OPAMINSTALLER_FLAGS) opam-lib.install
+ 
+ uninstall:
+-	src/opam-installer -u $(OPAMINSTALLER_FLAGS) opam.install
++	$(OCAMLRUN) src/opam-installer.byte -u $(OPAMINSTALLER_FLAGS) opam.install
+ 
+ .PHONY: tests tests-local tests-git
+ tests: opam opam-admin opam-check
+diff -r -u src.orig/Makefile.config.in src/Makefile.config.in
+--- src.orig/Makefile.config.in	2017-08-29 15:04:04.643629165 +0000
++++ src/Makefile.config.in	2017-08-29 16:42:38.115252993 +0000
+@@ -20,5 +20,7 @@
+ OCAMLYACC = @OCAMLYACC@
+ OCAMLMKLIB = @OCAMLMKLIB@
+ OCAMLDOC = @OCAMLDOC@
++OCAMLMKTOP = @OCAMLMKTOP@
++OCAMLRUN = @OCAMLRUN@
+ 
+-export OCAMLVERSION OCAMLFIND OCAML OCAMLC OCAMLOPT OCAMLDEP OCAMLLEX OCAMLYACC OCAMLMKLIB OCAMLDOC
++export OCAMLVERSION OCAMLFIND OCAML OCAMLC OCAMLOPT OCAMLDEP OCAMLLEX OCAMLYACC OCAMLMKLIB OCAMLDOC OCAMLMKTOP OCAMLRUN
+diff -r -u src.orig/OCamlMakefile src/OCamlMakefile
+--- src.orig/OCamlMakefile	2017-08-29 16:38:42.884349037 +0000
++++ src/OCamlMakefile	2017-08-29 16:42:38.115252993 +0000
+@@ -112,7 +112,7 @@
+ 
+ ####################  variables depending on your OCaml-installation
+ 
+-SYSTEM := $(shell ocamlc -config 2>/dev/null | grep system | sed 's/system: //')
++SYSTEM := $(shell $(OCAMLC) -config 2>/dev/null | grep system | sed 's/system: //')
+     # This may be
+     # - mingw
+     # - mingw64
+diff -r -u src.orig/configure.ac src/configure.ac
+--- src.orig/configure.ac	2017-08-29 15:04:04.642629214 +0000
++++ src/configure.ac	2017-08-29 16:42:38.115252993 +0000
+@@ -31,6 +31,8 @@
+ AC_PROG_OCAMLLEX
+ AC_PROG_OCAMLYACC
+ AC_PROG_FINDLIB
++AC_CHECK_TOOL([OCAMLRUN],[ocamlrun],[no])
++AC_SUBST([OCAMLRUN])
+ 
+ AC_ARG_ENABLE([certificate_check],
+   AS_HELP_STRING([--disable-certificate-check],
+diff -r -u src.orig/src/Makefile src/src/Makefile
+--- src.orig/src/Makefile	2017-08-29 16:50:05.154165783 +0000
++++ src/src/Makefile	2017-08-29 16:47:33.236331878 +0000
+@@ -10,6 +10,7 @@
+ 	$(MAKE) opam-check
+ 	$(MAKE) opam-admin
+ 	$(MAKE) opam-installer
++	$(MAKE) opam-installer.byte
+ 	$(MAKE) opamlfind
+ 	$(MAKE) opam-admin.top
+ 
+@@ -216,6 +217,9 @@
+ $(TOOLS): opam ALWAYS
+ 	$(MAKE) -f $(OCAMLMAKEFILE) subprojs SUBPROJS=$@ SUBTARGET=$(BINTARGET)
+ 
++opam-installer.byte: opam opam-lib.byte ALWAYS
++	$(MAKE) -f $(OCAMLMAKEFILE) subprojs SUBPROJS=opam-installer-byte SUBTARGET=byte-code
++
+ define PROJ_opam-check
+   SOURCES = tools/opam_check.ml
+   RESULT = opam-check
+@@ -246,6 +250,13 @@
+ endef
+ export PROJ_opam-installer
+ 
++define PROJ_opam-installer-byte
++  SOURCES = tools/opam_installer.ml
++  RESULT = opam-installer.byte
++  LIBS = $(LIBS) $(OPAMLIB)
++endef
++export PROJ_opam-installer-byte
++
+ define PROJ_opamlfind
+   SOURCES = tools/opamlfind.ml
+   RESULT = opamlfind

--- a/packages/opam/sh-path.patch
+++ b/packages/opam/sh-path.patch
@@ -1,0 +1,23 @@
+diff -r -u src.orig/src/core/opamSystem.ml src/src/core/opamSystem.ml
+--- src.orig/src/core/opamSystem.ml	2017-08-29 15:04:04.634629601 +0000
++++ src/src/core/opamSystem.ml	2017-08-29 19:11:59.323852294 +0000
+@@ -302,10 +302,10 @@
+ let command_exists =
+   let is_external_cmd name = Filename.basename name <> name in
+   let check_existence ?dir env name =
+-    let cmd, args = "/bin/sh", ["-c"; Printf.sprintf "command -v %s" name] in
++    let cmd, args = "/data/data/com.termux/files/usr/bin/sh", ["-c"; Printf.sprintf "command -v %s" name] in
+     let r =
+       OpamProcess.run
+         (OpamProcess.command ~env ?dir ~name:(temp_file "command") ~verbose:false
+            cmd args)
+     in
+     OpamProcess.cleanup ~force:true r;
+diff -r -u opam-full-1.2.2.orig/AUTHORS opam-full-1.2.2/AUTHORS
+--- opam-full-1.2.2.orig/AUTHORS	2015-04-27 01:51:22.000000000 -0700
++++ opam-full-1.2.2/AUTHORS	2017-08-29 15:35:46.144809688 -0700
+@@ -6,3 +6,4 @@
+ Guillem Rieu        <guillem.rieu@ocamlpro.com>
+ Vincent Bernardoff  <vb@luminar.eu.org>
+ Roberto Di Cosmo    <roberto@dicosmo.org>
++Kyle Stemen         <kstemen@google.com>


### PR DESCRIPTION
based on #1343 
by bluelightning32  
the assembly to get arm not to give text relocation errors doesn't work for 4.05 and asmrun/arm.S doesn't compile properly with clang so using -aspp "$CC-no-integrated-as -c " configure. 