### PR TITLE
tor: fix paths to /etc/hosts and /etc/resolv.conf

### DIFF
--- a/packages/tor/fix-hardcoded-paths.patch
+++ b/packages/tor/fix-hardcoded-paths.patch
@@ -1,0 +1,42 @@
+diff -uNr tor-0.3.1.8/src/or/dns.c tor-0.3.1.8.mod/src/or/dns.c
+--- tor-0.3.1.8/src/or/dns.c	2017-06-19 18:56:51.000000000 +0300
++++ tor-0.3.1.8.mod/src/or/dns.c	2017-11-10 18:05:46.220054396 +0200
+@@ -1349,7 +1349,7 @@
+   conf_fname = options->ServerDNSResolvConfFile;
+ #ifndef _WIN32
+   if (!conf_fname)
+-    conf_fname = "/etc/resolv.conf";
++    conf_fname = "/data/data/com.termux/files/usr/etc/resolv.conf";
+ #endif
+   flags = DNS_OPTIONS_ALL;
+ 
+diff -uNr tor-0.3.1.8/src/or/main.c tor-0.3.1.8.mod/src/or/main.c
+--- tor-0.3.1.8/src/or/main.c	2017-09-29 01:52:51.000000000 +0300
++++ tor-0.3.1.8.mod/src/or/main.c	2017-11-10 18:02:56.257471811 +0200
+@@ -3472,7 +3472,7 @@
+   OPEN("/dev/srandom");
+   OPEN("/dev/urandom");
+   OPEN("/dev/random");
+-  OPEN("/etc/hosts");
++  OPEN("/data/data/com.termux/files/usr/etc/hosts");
+   OPEN("/proc/meminfo");
+ 
+   if (options->BridgeAuthoritativeDir)
+@@ -3485,7 +3485,7 @@
+     sandbox_cfg_allow_open_filename(&cfg,
+                                 tor_strdup(options->ServerDNSResolvConfFile));
+   else
+-    sandbox_cfg_allow_open_filename(&cfg, tor_strdup("/etc/resolv.conf"));
++    sandbox_cfg_allow_open_filename(&cfg, tor_strdup("/data/data/com.termux/files/usr/etc/resolv.conf"));
+ 
+   for (i = 0; i < 2; ++i) {
+     if (get_torrc_fname(i)) {
+@@ -3631,7 +3631,7 @@
+     OPEN_DATADIR_SUFFIX("hashed-fingerprint", ".tmp");
+     OPEN_DATADIR_SUFFIX("router-stability", ".tmp");
+ 
+-    OPEN("/etc/resolv.conf");
++    OPEN("/data/data/com.termux/files/usr/etc/resolv.conf");
+ 
+     RENAME_SUFFIX("fingerprint", ".tmp");
+     RENAME_SUFFIX2("keys", "secret_onion_key_ntor", ".tmp");


### PR DESCRIPTION
Should fix warnings like this:
```
[warn] Unable to stat resolver configuration in '/etc/resolv.conf': No such file or directory
```