### PR TITLE
libpulseaudio: fix "shared memfd open() failed: Function not implemented"

### DIFF
--- a/packages/libpulseaudio/build.sh
+++ b/packages/libpulseaudio/build.sh
@@ -1,12 +1,13 @@
 TERMUX_PKG_HOMEPAGE=https://www.freedesktop.org/wiki/Software/PulseAudio
 TERMUX_PKG_DESCRIPTION="A featureful, general-purpose sound server - shared libraries"
 TERMUX_PKG_VERSION=11.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=f2521c525a77166189e3cb9169f75c2ee2b82fa3fcf9476024fbc2c3a6c9cd9e
 TERMUX_PKG_SRCURL=https://www.freedesktop.org/software/pulseaudio/releases/pulseaudio-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_DEPENDS="libltdl, libsndfile, libandroid-glob"
 TERMUX_PKG_BUILD_DEPENDS="libtool"
 TERMUX_PKG_INCLUDE_IN_DEVPACKAGE="share/vala"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-neon-opt --disable-alsa --disable-esound --disable-glib2 --disable-openssl --without-caps --with-database=simple"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-neon-opt --disable-alsa --disable-esound --disable-glib2 --disable-openssl --without-caps --with-database=simple --disable-memfd"
 TERMUX_PKG_CONFFILES="etc/pulse/client.conf etc/pulse/daemon.conf etc/pulse/dafault.pa etc/pulse/system.pa"
 
 termux_step_pre_configure () {

--- a/packages/libpulseaudio/build.sh
+++ b/packages/libpulseaudio/build.sh
@@ -7,7 +7,14 @@ TERMUX_PKG_SRCURL=https://www.freedesktop.org/software/pulseaudio/releases/pulse
 TERMUX_PKG_DEPENDS="libltdl, libsndfile, libandroid-glob"
 TERMUX_PKG_BUILD_DEPENDS="libtool"
 TERMUX_PKG_INCLUDE_IN_DEVPACKAGE="share/vala"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-neon-opt --disable-alsa --disable-esound --disable-glib2 --disable-openssl --without-caps --with-database=simple --disable-memfd"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-neon-opt
+--disable-alsa
+--disable-esound
+--disable-glib2
+--disable-openssl
+--without-caps
+--with-database=simple
+--disable-memfd"
 TERMUX_PKG_CONFFILES="etc/pulse/client.conf etc/pulse/daemon.conf etc/pulse/dafault.pa etc/pulse/system.pa"
 
 termux_step_pre_configure () {


### PR DESCRIPTION
Occured on arm when trying to play music through cmus. 
Rebuilding the package wasn't enough. 

pulseaudio worked a couple of weeks ago, I'm not sure what changed between then and now. 
This fixes it anyways.