### PR TITLE
Bump tsu version so it actually gets installed.

### DIFF
--- a/packages/tsu/build.sh
+++ b/packages/tsu/build.sh
@@ -1,6 +1,6 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/cswl/tsu
 TERMUX_PKG_DESCRIPTION="A su wrapper for Termux"
-TERMUX_PKG_VERSION=0.1
+TERMUX_PKG_VERSION=0.2
 TERMUX_PKG_PLATFORM_INDEPENDENT=yes
 
 termux_step_make_install () {


### PR DESCRIPTION
https://github.com/termux/termux-packages/commit/db817da647bfea31e7965ca99fb35c64046eab99
updated the url of tsu download but didnt bump the package version

Which I guess caused apt to skip updating this package