### PR TITLE
texlive-bin: fix build failure for i686 and x86_64 (due to NDK r16?)

### DIFF
--- a/packages/texlive-bin/texk-web2c-luatexdir-luaffi-ffi.h.patch
+++ b/packages/texlive-bin/texk-web2c-luatexdir-luaffi-ffi.h.patch
@@ -1,0 +1,11 @@
+--- ./texk/web2c/luatexdir/luaffi/ffi.h	2017-11-17 14:32:47.517562104 +0000
++++ ../ffi.h	2017-11-17 14:32:26.333562953 +0000
+@@ -42,7 +42,7 @@
+ #include <sys/mman.h>
+ #endif
+ 
+-#if ( defined( _WIN32) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__bsdi__) || defined(__DragonFly__))
++#if ( defined( _WIN32) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__bsdi__) || defined(__DragonFly__) || defined(__ANDROID__))
+ /* We should include something equivalent to */
+ /* complex.h                                 */
+ #else


### PR DESCRIPTION
Fixes build error: 
```
libluaffi.a(libluaffi_a-ffi.o):/home/builder/.termux-build/texlive-bin/src/texk/web2c/luatexdir/luaffi/ffi.c:function cdata_pow: error: undefined reference to 'cpow'
clang50++: error: linker command failed with exit code 1 (use -v to see invocation)
Makefile:4995: recipe for target 'luatex' failed
```

Bumping the revision shouldn't be necessary in this case I guess.