### PR TITLE
poppler: disable multithreading. Fixes #1657.

### DIFF
--- a/packages/poppler/CMakeLists.txt.patch
+++ b/packages/poppler/CMakeLists.txt.patch
@@ -1,0 +1,19 @@
+--- ./CMakeLists.txt	2017-11-12 18:14:32.000000000 +0000
++++ ../CMakeLists.txt	2017-11-18 19:48:53.494691943 +0000
+@@ -60,6 +60,7 @@
+ option(USE_FIXEDPOINT "Use fixed point arithmetic in the Splash backend" OFF)
+ option(USE_FLOAT "Use single precision arithmetic in the Splash backend" OFF)
+ option(BUILD_SHARED_LIBS "Build poppler as a shared library" ON)
++option(ENABLE_MULTITHREAD "Build with multithread support" ON)
+ if(WIN32)
+   option(ENABLE_RELOCATABLE "Do not hardcode the poppler library location (on Windows)." ON)
+ else()
+@@ -105,7 +106,7 @@
+   message(FATAL_ERROR "Invalid font configuration setting: ${FONT_CONFIGURATION}")
+ endif()
+ 
+-if(CMAKE_USE_PTHREADS_INIT OR WIN32)
++if((CMAKE_USE_PTHREADS_INIT OR WIN32) AND ENABLE_MULTITHREAD)
+   set(MULTITHREADED ON)
+ endif()
+ 

--- a/packages/poppler/build.sh
+++ b/packages/poppler/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://poppler.freedesktop.org/
 TERMUX_PKG_DESCRIPTION="PDF rendering library"
 TERMUX_PKG_VERSION=0.61.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=1266096343f5163c1a585124e9a6d44474e1345de5cdfe55dc7b47357bcfcda9
 TERMUX_PKG_SRCURL=https://poppler.freedesktop.org/poppler-${TERMUX_PKG_VERSION}.tar.xz
 # libcairo and littlecms is used by pdftocairo:
@@ -9,4 +10,5 @@ TERMUX_PKG_DEPENDS="fontconfig, libcairo, libpng, libjpeg-turbo, libtiff, little
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DENABLE_GLIB=OFF
 -DENABLE_XPDF_HEADERS=ON
+-DENABLE_MULTITHREAD=OFF
 "


### PR DESCRIPTION
Valgrind still complains about invalid read & writes of size 4 but this also happens when building texlive on x86_64 desktop linux with the texlive-poppler-0.59.patch so it's not a problem isolated to us. 

There's probably a small error in the patch, I can try to contact the upstream author of the patch. 