### PR TITLE
Update tsu to v1.1 fixes copyright derp

### DIFF
--- a/packages/tsu/build.sh
+++ b/packages/tsu/build.sh
@@ -1,12 +1,12 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/cswl/tsu
 TERMUX_PKG_DESCRIPTION="A su wrapper for Termux"
-TERMUX_PKG_VERSION=0.4
+TERMUX_PKG_VERSION=1.1
 TERMUX_PKG_PLATFORM_INDEPENDENT=yes
 
 termux_step_make_install () {
-	termux_download https://raw.githubusercontent.com/cswl/tsu/88a8cb09d6fea8e8ed47bd874b5df8ea647302c0/tsu \
+	termux_download https://raw.githubusercontent.com/cswl/tsu/7d60aa3479cd2f66c97cc441f022a43371b60523/tsu \
 	                $TERMUX_PREFIX/bin/tsu \
-	                7a71ada4caff54b04e342da74fc211e4bd7dfdf68e7c289673887bcdebcc0b71
+	                7d1d4c00b4bbc0f964e8488e9ae964f049665b108cbb3568212e530dbb659c54
 	touch $TERMUX_PREFIX/bin/tsu
 	chmod +x $TERMUX_PREFIX/bin/tsu
 }


### PR DESCRIPTION
tsu shell script didn't had the copyright header.
hence  installations wouldnt preserve the license of tsu

i've fixed the issue in upstream tsu
and bumped the version to 1.1 as it is much stable now.