### PR TITLE
proot: Upgrade to skip syscalls blocked by seccomp

### DIFF
--- a/packages/proot/build.sh
+++ b/packages/proot/build.sh
@@ -1,11 +1,11 @@
 TERMUX_PKG_HOMEPAGE=http://proot.me/
 TERMUX_PKG_DESCRIPTION="Emulate chroot, bind mount and binfmt_misc for non-root users"
 # Just bump commit and version when needed:
-_COMMIT=6671bfed4ddcbd393d8ca7b2754d58e41ed9595b
+_COMMIT=454b0b121f03a662f53844a8865f518757e0a315
 TERMUX_PKG_VERSION=5.1.106
-TERMUX_PKG_REVISION=4
+TERMUX_PKG_REVISION=5
 TERMUX_PKG_SRCURL=https://github.com/termux/proot/archive/${_COMMIT}.zip
-TERMUX_PKG_SHA256=e3565bd6789659d86106d6e08eb204d8606af94664aebcb20dcf68a1852c4ba2
+TERMUX_PKG_SHA256=571a56af65969dbb26096893c32a5121e5cb3acd8d5fb6de8130765579bd2eb0
 TERMUX_PKG_DEPENDS="libtalloc"
 
 termux_step_pre_configure() {


### PR DESCRIPTION
termux/proot#5

Also includes fix termux/termux-packages#1679