### PR TITLE
create argp

### DIFF
--- a/packages/argp/build.sh
+++ b/packages/argp/build.sh
@@ -8,10 +8,6 @@ TERMUX_PKG_KEEP_STATIC_LIBRARIES="true"
 TERMUX_PKG_DEPENDS="libandroid-support, liblzma, libbz2"
 TERMUX_PKG_CLANG=no
 TERMUX_PKG_BUILD_IN_SRC=yes
-# Use "eu-" as program prefix to avoid conflict with binutils programs.
-# This is what several linux distributions do.
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS=""
-# The ar.c file is patched away for now:
 
 termux_step_pre_configure() {
         CFLAGS+=" -Wno-error=unused-value -Wno-error=format-nonliteral -Wno-error"

--- a/packages/argp/build.sh
+++ b/packages/argp/build.sh
@@ -15,8 +15,6 @@ termux_step_pre_configure() {
         # Exposes ACCESSPERMS in <sys/stat.h> which elfutils uses:
         CFLAGS+=" -D__USE_BSD"
 
-        # Install argp lib.
-
         CFLAGS+=" -std=gnu89"
 }
 

--- a/packages/argp/build.sh
+++ b/packages/argp/build.sh
@@ -1,0 +1,31 @@
+TERMUX_PKG_HOMEPAGE=https://www.lysator.liu.se/~nisse/misc/
+TERMUX_PKG_DESCRIPTION="Standalone version of arguments parsing functions from GLIBC"
+TERMUX_PKG_VERSION=1.3
+TERMUX_PKG_SRCURL=http://www.lysator.liu.se/~nisse/archive/argp-standalone-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=dec79694da1319acd2238ce95df57f3680fea2482096e483323fddf3d818d8be
+TERMUX_PKG_KEEP_STATIC_LIBRARIES="true"
+# libandroid-support for langinfo.
+TERMUX_PKG_DEPENDS="libandroid-support, liblzma, libbz2"
+TERMUX_PKG_CLANG=no
+TERMUX_PKG_BUILD_IN_SRC=yes
+# Use "eu-" as program prefix to avoid conflict with binutils programs.
+# This is what several linux distributions do.
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS=""
+# The ar.c file is patched away for now:
+
+termux_step_pre_configure() {
+        CFLAGS+=" -Wno-error=unused-value -Wno-error=format-nonliteral -Wno-error"
+
+        # Exposes ACCESSPERMS in <sys/stat.h> which elfutils uses:
+        CFLAGS+=" -D__USE_BSD"
+
+        # Install argp lib.
+
+        CFLAGS+=" -std=gnu89"
+}
+
+termux_step_make_install() {
+        make install
+        cp libargp.a $TERMUX_PREFIX/lib
+        cp argp.h $TERMUX_PREFIX/include
+}


### PR DESCRIPTION
separate from `elfutils`

trying to build `mingw-w64`, needed for gcc build