### PR TITLE
espeak: fix floating point exception on arm

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -574,14 +574,8 @@ termux_step_setup_toolchain() {
 		if [ "$TERMUX_PKG_CLANG" = "no" ]; then
 			CFLAGS+=" -Os"
 		else
-			if [ "$TERMUX_PKG_NAME" = "ruby" -a "$TERMUX_ARCH" = arm ]; then
-				# This exception is to avoid a broken ruby on 32-bit arm
-				# with NDK r15c and ruby 2.4.2 - see #1520.
-				CFLAGS+=" -O1"
-			else
-				# -Oz seems good for clang, see https://github.com/android-ndk/ndk/issues/133
-				CFLAGS+=" -Oz"
-			fi
+			# -Oz seems good for clang, see https://github.com/android-ndk/ndk/issues/133
+			CFLAGS+=" -Oz"
 		fi
 	fi
 

--- a/packages/espeak/build.sh
+++ b/packages/espeak/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_DESCRIPTION="Compact software speech synthesizer"
 # See https://github.com/espeak-ng/espeak-ng/issues/180
 # about cross compilation of espeak-ng.
 TERMUX_PKG_VERSION=1.49.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=cf7ed86850b99bafe819548c73a6651a74300980dd15f319ff22e2bd72ea20b4
 TERMUX_PKG_SRCURL=https://github.com/espeak-ng/espeak-ng/releases/download/${TERMUX_PKG_VERSION}/espeak-ng-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_BUILD_IN_SRC=yes
@@ -24,6 +25,11 @@ termux_step_host_build() {
 	#(cd $TERMUX_PREFIX/share/man/man1 && ln -s -f espeak-ng.1 espeak.1)
 
 	make install
+}
+
+termux_step_pre_configure() {
+	# Oz flag causes problems. See https://github.com/termux/termux-packages/issues/1680:
+	CFLAGS=${CFLAGS/Oz/O2}
 }
 
 termux_step_make() {

--- a/packages/ruby/build.sh
+++ b/packages/ruby/build.sh
@@ -18,6 +18,14 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" rb_cv_type_deprecated=x"
 # getresuid(2) does not work on ChromeOS - https://github.com/termux/termux-app/issues/147:
 # TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_func_getresuid=no"
 
+termux_step_pre_configure() {
+	# This exception is to avoid a broken ruby on 32-bit arm
+	# with NDK r15c and ruby 2.4.2 - see #1520.
+	if [ "$TERMUX_ARCH" = arm ]; then
+		CFLAGS=${CFLAGS/Oz/O1}
+	fi
+}
+
 termux_step_make_install () {
 	make install
 	make uninstall # remove possible remains to get fresh timestamps


### PR DESCRIPTION
Fixes #1680. 

Also move similar fix for ruby from build-package.sh to build.sh. 
Let me know if you disagree about this movement. 