### PR TITLE
lftp: fix hardcoded paths

### DIFF
--- a/packages/lftp/build.sh
+++ b/packages/lftp/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://lftp.tech/
 TERMUX_PKG_DESCRIPTION="FTP/HTTP client and file transfer program"
 TERMUX_PKG_VERSION=4.8.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=de7aee451afaa1aa391f7076b5f602922c2da0e05524a8d8fea413eda83cc78b
 TERMUX_PKG_SRCURL=https://lftp.tech/ftp/lftp-${TERMUX_PKG_VERSION}.tar.xz
 # (1) Android has dn_expand, but lftp assumes that dn_skipname then exists, which it does not on android.

--- a/packages/lftp/lftp_ssl.cc.patch
+++ b/packages/lftp/lftp_ssl.cc.patch
@@ -1,0 +1,12 @@
+diff -uNr lftp-4.8.3/src/lftp_ssl.cc lftp-4.8.3.mod/src/lftp_ssl.cc
+--- lftp-4.8.3/src/lftp_ssl.cc	2017-08-10 12:57:37.000000000 +0300
++++ lftp-4.8.3.mod/src/lftp_ssl.cc	2017-12-19 17:06:58.526580533 +0200
+@@ -214,6 +214,8 @@
+       "/usr/local/ssl/certs/ca-bundle.crt",
+       "/etc/apache/ssl.crt/ca-bundle.crt",
+       "/usr/share/curl/curl-ca-bundle.crt",
++      "@TERMUX_PREFIX@/etc/tls/cert.pem",
++      "@TERMUX_PREFIX@/etc/tls/ca-bundle.crt",
+       0};
+    for(int i=0; ca_file_location[i]; i++)
+    {

--- a/packages/lftp/src-commands.cc.patch
+++ b/packages/lftp/src-commands.cc.patch
@@ -1,0 +1,12 @@
+diff -uNr lftp-4.8.3/src/commands.cc lftp-4.8.3.mod/src/commands.cc
+--- lftp-4.8.3/src/commands.cc	2017-08-10 13:17:10.000000000 +0300
++++ lftp-4.8.3.mod/src/commands.cc	2017-12-19 16:59:50.095958249 +0200
+@@ -3006,7 +3006,7 @@
+ 
+       xstring cmd0("exec ${EDITOR:-vi} ");
+       cmd0.append(shell_encode(lftp_bookmarks.GetFilePath()));
+-      xstring cmd1("/bin/sh -c ");
++      xstring cmd1("@TERMUX_PREFIX@/bin/sh -c ");
+       cmd1.append(shell_encode(cmd0));
+ 
+       parent->PrependCmd(xstring::get_tmp("shell ").append_quoted(cmd1));


### PR DESCRIPTION
Fix error 'no such file or directory: /bin/sh' when doing `bookmark edit` and add correct path to CA cert bundle.