### PR TITLE
global: fix path to 'echo' in globash

### DIFF
--- a/packages/global/build.sh
+++ b/packages/global/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/global/
 TERMUX_PKG_DESCRIPTION="Source code search and browse tools"
 TERMUX_PKG_VERSION=6.6.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=http://mirrors.kernel.org/gnu/global/global-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=943dc440382d82454786bfd92b86946961cb2196039eceffd7eb551ac83759e4
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="

--- a/packages/global/echo-path.patch
+++ b/packages/global/echo-path.patch
@@ -1,0 +1,12 @@
+diff -uNr global-6.6.1.orig/globash/globash.in global-6.6.1/globash/globash.in
+--- global-6.6.1.orig/globash/globash.in	2017-12-16 07:19:15.000000000 +0200
++++ global-6.6.1/globash/globash.in	2017-12-19 18:37:51.034558917 +0200
+@@ -36,7 +36,7 @@
+ # Use /bin/echo, because in some systems, built-in echo of /bin/sh
+ # does not accept -n option.
+ #
+-ECHO='/bin/echo'
++ECHO='@TERMUX_PREFIX@/bin/echo'
+ #
+ # global command name
+ #


### PR DESCRIPTION
Fixes error 'globash: line 47: /bin/echo: No such file or directory' which may occur when running `globash`.