### PR TITLE
Use -Os instead of -Oz for 32-bit arm

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -574,8 +574,14 @@ termux_step_setup_toolchain() {
 		if [ "$TERMUX_PKG_CLANG" = "no" ]; then
 			CFLAGS+=" -Os"
 		else
-			# -Oz seems good for clang, see https://github.com/android-ndk/ndk/issues/133
-			CFLAGS+=" -Oz"
+			# -Oz seems good for clang, see https://github.com/android-ndk/ndk/issues/133.
+			# However, on arm it has a lot of issues such as #1520, #1680, #1765 and
+			# https://bugs.llvm.org/show_bug.cgi?id=35379, so use so use -Os there for now:
+			if [ $TERMUX_ARCH = arm ]; then
+				CFLAGS+=" -Os"
+			else
+				CFLAGS+=" -Oz"
+			fi
 		fi
 	fi
 

--- a/packages/espeak/build.sh
+++ b/packages/espeak/build.sh
@@ -27,11 +27,6 @@ termux_step_host_build() {
 	make install
 }
 
-termux_step_pre_configure() {
-	# Oz flag causes problems. See https://github.com/termux/termux-packages/issues/1680:
-	CFLAGS=${CFLAGS/Oz/O2}
-}
-
 termux_step_make() {
 	# Prevent caching of host build:
 	rm -Rf $TERMUX_PKG_HOSTBUILD_DIR

--- a/packages/ruby/build.sh
+++ b/packages/ruby/build.sh
@@ -17,14 +17,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" rb_cv_type_deprecated=x"
 # getresuid(2) does not work on ChromeOS - https://github.com/termux/termux-app/issues/147:
 # TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_func_getresuid=no"
 
-termux_step_pre_configure() {
-	# This exception is to avoid a broken ruby on 32-bit arm
-	# with NDK r15c and ruby 2.4.2 - see #1520.
-	if [ "$TERMUX_ARCH" = arm ]; then
-		CFLAGS=${CFLAGS/Oz/O1}
-	fi
-}
-
 termux_step_make_install () {
 	make install
 	make uninstall # remove possible remains to get fresh timestamps

--- a/packages/texlive-bin/build.sh
+++ b/packages/texlive-bin/build.sh
@@ -123,8 +123,6 @@ opt/texlive/${TERMUX_PKG_VERSION:0:4}/texmf-dist/scripts/checkcites/checkcites.l
 termux_step_pre_configure() {
 	# When building against libicu 59.1 or later we need c++11:
 	CXXFLAGS+=" -std=c++11"
-	# Oz flag causes problems. See https://github.com/termux/termux-packages/issues/1765:
-	CFLAGS=${CFLAGS/Oz/O3}
 }
 
 termux_step_post_make_install () {


### PR DESCRIPTION
What do you think about this?

@Grimler91 The problems in #1680 and #1765 were for 32-bit arm only, and -Os should work there, right?

@its-pointless You mentioned a problem with libgc on 32-bit arm with -Oz (so we should revision-bump that package after this change)?