### PR TITLE
librsync: fix segfault in 'rs_search_for_block'

### DIFF
--- a/packages/librsync/build.sh
+++ b/packages/librsync/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/librsync/librsync
 TERMUX_PKG_DESCRIPTION="Remote delta-compression library"
 TERMUX_PKG_VERSION=2.0.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/librsync/librsync/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=b5c4dd114289832039397789e42d4ff0d1108ada89ce74f1999398593fae2169
 TERMUX_PKG_DEPENDS="libbz2"

--- a/packages/librsync/fix-crash-in-rs_search_for_block.patch
+++ b/packages/librsync/fix-crash-in-rs_search_for_block.patch
@@ -1,0 +1,12 @@
+diff -uNr librsync-2.0.0/src/search.c librsync-2.0.0.mod/src/search.c
+--- librsync-2.0.0/src/search.c	2015-11-29 22:43:12.000000000 +0200
++++ librsync-2.0.0.mod/src/search.c	2017-12-23 15:06:05.684445933 +0200
+@@ -218,7 +218,7 @@
+ 	    r = m;
+     }
+ 
+-    if (l == r) {
++    if ((l == r) && (l <= bucket->r)) {
+ 	int i = sig->targets[l].i;
+ 	rs_block_sig_t *b = &(sig->block_sigs[i]);
+ 	if (weak_sum != b->weak_sum)


### PR DESCRIPTION
Fix for #1963.
For more info about segfault in 'rs_search_for_block' see https://github.com/librsync/librsync/issues/50.