### PR TITLE
tar: fix segfault when extracting archive that contains device files

### DIFF
--- a/packages/tar/build.sh
+++ b/packages/tar/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=http://www.gnu.org/software/tar/
 TERMUX_PKG_DESCRIPTION="GNU tar for manipulating tar archives"
 TERMUX_PKG_VERSION=1.30
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/tar/tar-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=f1bf92dbb1e1ab27911a861ea8dde8208ee774866c46c0bb6ead41f4d1f4d2d3
 # Allow xz compression (busybox only provides xz decompression):
@@ -8,3 +9,7 @@ TERMUX_PKG_DEPENDS="xz-utils"
 # When cross-compiling configure guesses that d_ino in struct dirent only exists
 # if triplet matches linux*-gnu*, so we force set it explicitly:
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="gl_cv_struct_dirent_d_ino=yes"
+
+# this needed to disable tar's implementation of mkfifoat() so it is possible
+# to use own implementation (see patch 'mkfifoat.patch').
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_func_mkfifoat=yes"

--- a/packages/tar/mkfifoat.patch
+++ b/packages/tar/mkfifoat.patch
@@ -1,0 +1,30 @@
+mkfifoat() is available in Android only after API 23. We can't use tar's
+implementation of mkfifioat() since it will use tar's implementation of
+mknodat(). This will cause infinite recursion in file gnu/at-func.c and
+segfault.
+
+Snippet of backtrace:
+....
+#9  0x000000555559819c in mknodat (fd=-100, file=0x7fb7c90050 "sda", mode=25008, dev=2048) at /home/builder/.termux-build/tar/src/gnu/at-func.c:75
+#10 0x000000555559819c in mknodat (fd=-100, file=0x7fb7c90050 "sda", mode=25008, dev=2048) at /home/builder/.termux-build/tar/src/gnu/at-func.c:75
+#11 0x000000555559819c in mknodat (fd=-100, file=0x7fb7c90050 "sda", mode=25008, dev=2048) at /home/builder/.termux-build/tar/src/gnu/at-func.c:75
+#12 0x000000555559819c in mknodat (fd=-100, file=0x7fb7c90050 "sda", mode=25008, dev=2048) at /home/builder/.termux-build/tar/src/gnu/at-func.c:75
+#13 0x000000555556a9d4 in extract_node (file_name=0x7fb7c90050 "sda", typeflag=52) at /home/builder/.termux-build/tar/src/src/extract.c:1447
+#14 0x0000005555568f38 in extract_archive () at /home/builder/.termux-build/tar/src/src/extract.c:1709
+....
+
+diff -uNr tar-1.30/src/extract.c tar-1.30.mod/src/extract.c
+--- tar-1.30/src/extract.c	2017-12-16 23:23:12.000000000 +0200
++++ tar-1.30.mod/src/extract.c	2017-12-25 14:31:31.541886176 +0200
+@@ -42,6 +42,11 @@
+ # define fchown(fd, uid, gid) (errno = ENOSYS, -1)
+ #endif
+ 
++static int
++mkfifoat(int fd, const char* path, mode_t mode) {
++  return mknodat(fd, path, (mode & ~S_IFMT) | S_IFIFO, 0);
++}
++
+ /* Return true if an error number ERR means the system call is
+    supported in this case.  */
+ static bool


### PR DESCRIPTION
Should fix #1971.
Archive for testing: [devices.tar.gz](https://github.com/termux/termux-packages/files/1584815/devices.tar.gz)