### PR TITLE
apt: restores apt-mark

### DIFF
--- a/disabled-packages/apt-updated/build.sh
+++ b/disabled-packages/apt-updated/build.sh
@@ -19,7 +19,6 @@ TERMUX_PKG_REPLACES=apt-transport-https
 TERMUX_PKG_RM_AFTER_INSTALL="
 bin/apt-cdrom
 bin/apt-extracttemplates
-bin/apt-mark
 bin/apt-sortpkgs
 etc/apt/apt.conf.d
 lib/apt/apt-helper

--- a/packages/apt/build.sh
+++ b/packages/apt/build.sh
@@ -19,7 +19,6 @@ TERMUX_PKG_REPLACES=apt-transport-https
 TERMUX_PKG_RM_AFTER_INSTALL="
 bin/apt-cdrom
 bin/apt-extracttemplates
-bin/apt-mark
 bin/apt-sortpkgs
 etc/apt/apt.conf.d
 lib/apt/apt-helper


### PR DESCRIPTION
apt-mark is missing from Termux and I find it quite useful to figure out which packages are manually installed, it's even detailed as the only method which is listed to do so in ```man apt```.

On my Debian buster machine with apt 1.6~alpha5 apt-mark is 43168 bytes large.

Resolves #1635 