### PR TITLE
libboost_python not linked to python fix

### DIFF
--- a/packages/boost/build.sh
+++ b/packages/boost/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://boost.org
 TERMUX_PKG_DESCRIPTION="Free peer-reviewed portable C++ source libraries"
 TERMUX_PKG_VERSION=1.65.1
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SHA256=9807a5d16566c57fd74fb522764e0b134a8bbe6b6e8967b83afefd30dcd3be81
 TERMUX_PKG_SRCURL=https://sourceforge.net/projects/boost/files/boost/${TERMUX_PKG_VERSION}/boost_${TERMUX_PKG_VERSION//./_}.tar.bz2
 TERMUX_PKG_BUILD_IN_SRC=yes

--- a/packages/boost/python.jam.patch
+++ b/packages/boost/python.jam.patch
@@ -1,11 +1,11 @@
---- ../cache/boost_1_64_0/tools/build/src/tools/python.jam	2017-04-17 02:22:26.000000000 +0000
-+++ ./tools/build/src/tools/python.jam	2017-04-30 06:12:15.748537322 +0000
+--- ../cache/boost_1_65_1/tools/build/src/tools/python.jam	2017-09-02 09:56:19.000000000 +0000
++++ ./tools/build/src/tools/python.jam	2018-01-06 01:26:09.993772847 +0000
 @@ -651,7 +651,7 @@
  
          case aix : return  <library>pthread <library>dl ;
  
 -        case * : return  <library>pthread <library>dl
-+        case * : return  <library>dl
++        case * : return   <library>dl <linkflags>-lpython3.6m ;
              <toolset>gcc:<library>util <toolset-intel:platform>linux:<library>util ;
      }
  }


### PR DESCRIPTION
not being linked against libpython3.6 prevents loading module from python. This makes it work.