### PR TITLE
readline: Add inputrc

### DIFF
--- a/packages/readline/build.sh
+++ b/packages/readline/build.sh
@@ -4,11 +4,12 @@ TERMUX_PKG_DEPENDS="libandroid-support, ncurses"
 _MAIN_VERSION=7.0
 _PATCH_VERSION=3
 TERMUX_PKG_VERSION=${_MAIN_VERSION}.${_PATCH_VERSION}
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/readline/readline-${_MAIN_VERSION}.tar.gz
 TERMUX_PKG_SHA256=750d437185286f40a369e1e4f4764eda932b9459b5ec9a731628393dd3d32334
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-curses --enable-multibyte bash_cv_wcwidth_broken=no"
 TERMUX_PKG_EXTRA_MAKE_ARGS="SHLIB_LIBS=-lncursesw"
+TERMUX_PKG_CONFFILES="etc/inputrc"
 
 termux_step_pre_configure () {
 	local PATCH_CHECKSUMS
@@ -28,4 +29,7 @@ termux_step_pre_configure () {
 termux_step_post_make_install() {
 	mkdir -p $TERMUX_PREFIX/lib/pkgconfig
 	cp readline.pc $TERMUX_PREFIX/lib/pkgconfig/
+
+	mkdir -p $TERMUX_PREFIX/etc
+	cp $TERMUX_PKG_BUILDER_DIR/inputrc $TERMUX_PREFIX/etc/
 }

--- a/packages/readline/inputrc
+++ b/packages/readline/inputrc
@@ -1,0 +1,24 @@
+# Be 8 bit clean.
+set input-meta on
+set output-meta on
+
+# some defaults / modifications for the emacs mode
+$if mode=emacs
+
+# allow the use of the Home/End keys
+"\e[1~": beginning-of-line
+"\e[2~": quoted-insert
+
+# allow the use of the Delete/Insert keys
+"\e[3~": delete-char
+"\e[4~": end-of-line
+
+# mappings for Ctrl-left-arrow and Ctrl-right-arrow for word moving 
+"\e[1;5C": forward-word
+"\e[1;5D": backward-word
+"\e[5C": forward-word
+"\e[5D": backward-word
+
+"\e[8~": end-of-line
+
+$endif


### PR DESCRIPTION
This makes Home/End keys working over SSH when connected from some clients like PuTTY on Windows.

Basically all Linux distributions provide some default /etc/inputrc configuration:
- Debian based distros in package readline-common (both Debian 9 and Ubuntu 17.10 share same config)
- Red Hat based distros in package setup (both CentOS 7 and Fedora 27 share same config)
- Arch Linux in package readline
- openSUSE in package aaa_base
- OpenWRT etc.

The proposed inputrc configuration is a intersection of default mappings used in Debian 9, CentOS 7 and Arch Linux. That should provide safe and expected mappings.