### PR TITLE
Adding gbt package

### DIFF
--- a/packages/gbt/build.sh
+++ b/packages/gbt/build.sh
@@ -1,0 +1,22 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/jtyr/gbt
+TERMUX_PKG_DESCRIPTION="Highly configurable prompt builder for Bash and ZSH written in Go"
+TERMUX_PKG_VERSION=1.1.6
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=https://github.com/jtyr/gbt/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=809670ffaf9477e50dc3d9332acc15721e5203d0a0b0f26f07c20f9b5b25c7bb
+
+termux_step_make_install() {
+	cd $TERMUX_PKG_SRCDIR
+
+	termux_setup_golang
+
+	export GOPATH=$HOME/go
+	mkdir -p $GOPATH/{bin,pkg,src/github.com/jtyr}
+	ln -fs $TERMUX_PKG_SRCDIR $GOPATH/src/github.com/jtyr/gbt
+
+	go build -ldflags='-s -w' -o $TERMUX_PREFIX/bin/gbt github.com/jtyr/gbt/cmd/gbt
+
+	mkdir -p $TERMUX_PREFIX/{doc/gbt,share/gbt}
+	cp -r $TERMUX_PKG_SRCDIR/{sources,themes} $TERMUX_PREFIX/share/gbt/
+	cp -r $TERMUX_PKG_SRCDIR/{LICENSE,README.md} $TERMUX_PREFIX/doc/gbt/
+}


### PR DESCRIPTION
I have created a new package for application called [GBT](https://github.com/jtyr/gbt/). It's a highly configurable prompt builder for Bash and ZSH written in Go. When run in Termux, it looks like this:

![screenshot_20180114-235825](https://user-images.githubusercontent.com/3788909/34922400-4814980a-f987-11e7-9cbd-593aad9c045d.png)

I'm going to present GBT on the [DevOps Exchange meetup](https://www.meetup.com/DevOps-Exchange-London/events/246447551/) in London next week and it would be really great if I could show people how they can install it on their Android device via Termux without the need to download the package manually.