### PR TITLE
Vagrantfile tweaks

### DIFF
--- a/scripts/Vagrantfile
+++ b/scripts/Vagrantfile
@@ -5,6 +5,9 @@ Vagrant.configure("2") do |config|
 
   config.vm.box = "ubuntu/artful64"
 
+  # use vagrant-disksize plugin to resize partition - https://github.com/sprotheroe/vagrant-disksize
+  config.disksize.size = '50GB'
+  
   config.vm.provider "virtualbox" do |vb|
     # Customize the amount of memory on the VM
     vb.memory = "2048"
@@ -15,14 +18,19 @@ Vagrant.configure("2") do |config|
   # Disable the default /vagrant share directory, as it shares the directory with the Vagrantfile in it, not the repo root
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
+  # filesystem needs to be resized
+  config.vm.provision "shell", inline: "sudo resize2fs /dev/sda1"
+  
+  # helpful before setup-ubuntu.sh is run
+  config.vm.provision "shell", inline: "sudo apt-get update"
 
   # Run provisioning scripts
   config.vm.provision "shell", path: "./setup-ubuntu.sh", privileged: false
   config.vm.provision "shell", path: "./setup-android-sdk.sh", privileged: false
 
-  # Fix permissions on the /data directory in order to allow the "ubuntu" user to write to it
+  # Fix permissions on the /data directory in order to allow the "vagrant" user to write to it
   config.vm.provision "shell",
-    inline: "sudo chown -R ubuntu /data"
+    inline: "sudo chown -R vagrant /data"
 
   # Tell the user how to use the VM
   config.vm.post_up_message = "Box has been provisioned! Use 'vagrant ssh' to enter the box. The repository root is available under '/termux-packages'."


### PR DESCRIPTION
Existing Vagrantfile lead to some problems here during provisioning:

  1. setup-ubuntu.sh would fail

and after:

  2. build-all.sh would run out of disk space
  3. build-all.sh would exit due to permission issues

Issue 1 can be addressed by running sudo apt-get update before setup-ubuntu.sh in the Vagrantfile.

One way to address issue 2 is to use the vagrant-disksize plugin:

  https://github.com/sprotheroe/vagrant-disksize

It can be installed by:

  vagrant plugin install vagrant-disksize

Then modifying Vagrantfile to contain a line like:

  config.disksize.size = '50GB'

causes the first partition to be enlarged to 50GB during provisioning.  Combined with an appropriate invocation of resize2fs:

  sudo resize2fs /dev/sda1

so that the filesystem in the partition is resized, the disk space issue seems alleviated.

Issue 3 can be addressed by changing the user from 'ubuntu' to 'vagrant' in the Vagrantfile -- at least that's what worked here.