### PR TITLE
Add check for root and root command to pkg

### DIFF
--- a/packages/termux-tools/pkg
+++ b/packages/termux-tools/pkg
@@ -22,6 +22,15 @@ if [ $# = 0 ]; then show_help; fi
 CMD="$1"
 shift 1
 
+rootMsg='You are running pkg with root privileges. If this is intentional run: pkg root command [arguments]';
+
+if [ "$(id -u)" = 0 ]; then
+	if [ $# = 0 ]; then echo "$rootMsg"; exit 1; fi
+	if [ "$CMD" != root ]; then echo "$rootMsg"; exit 1; fi
+	CMD="$1"
+	shift 1;
+fi
+
 case "$CMD" in
 	f*) dpkg -L $@;;
 	h*) show_help;;


### PR DESCRIPTION
(In reference to https://github.com/termux/termux-app/issues/542)
Currently running pkg as root will make the apt cache files owned by root, and is often accidental (for example running termux-info in a root shell).
The proposed change checks whether the user is root, and if they are, checks if and additional "root" command is given. Only if both (or neither) is the case apt will be run.