### PR TITLE
add new bash.bashrc file to avoid segfault aarch64

### DIFF
--- a/packages/bash/aarch64-etc-bash.bashrc
+++ b/packages/bash/aarch64-etc-bash.bashrc
@@ -1,0 +1,7 @@
+command_not_found_handle() {
+	@TERMUX_PREFIX@/libexec/termux/command-not-found "$1"
+}
+
+{
+unset LD_PRELOAD
+}

--- a/packages/bash/build.sh
+++ b/packages/bash/build.sh
@@ -55,7 +55,15 @@ termux_step_post_make_install () {
 		sed "s|@TERMUX_HOME@|$TERMUX_ANDROID_HOME|" > \
 		$TERMUX_PREFIX/etc/profile
 	# /etc/bash.bashrc - System-wide .bashrc file for interactive shells. (config-top.h in bash source, patched to enable):
-	sed "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|" \
+	# avoid segfault on aarch64
+	# refference : https://github.com/termux/termux-packages/issues/2066
+	if [ $TERMUX_ARCH = "aarch64" ]; then
+		sed "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|" \
+		$TERMUX_PKG_BUILDER_DIR/aarch64-etc-bash.bashrc > \
+		$TERMUX_PREFIX/etc/bash.bashrc
+	else
+		sed "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|" \
 		$TERMUX_PKG_BUILDER_DIR/etc-bash.bashrc > \
 		$TERMUX_PREFIX/etc/bash.bashrc
+	fi
 }

--- a/packages/gifsicle/build.sh
+++ b/packages/gifsicle/build.sh
@@ -1,6 +1,6 @@
 TERMUX_PKG_HOMEPAGE=https://www.lcdf.org/gifsicle/
 TERMUX_PKG_DESCRIPTION="Tool for creating, editing, and getting information about GIF images and animations"
-TERMUX_PKG_VERSION=1.90
-TERMUX_PKG_SHA256=2d73b096752d58fa604cea559199aa6f55b45a3ec833898f94ff7997d22b834d
+TERMUX_PKG_VERSION=1.91
+TERMUX_PKG_SHA256=0a4ee602aa244cdcdd86a250a6b39c94d8343cf526b8fae862d8a0efc337a800
 TERMUX_PKG_SRCURL=http://www.lcdf.org/gifsicle/gifsicle-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-gifview"


### PR DESCRIPTION
almost of aarch64 architecture have segfault after upgrade, problem solved by @xeffyr [#2066](https://github.com/termux/termux-packages/issues/2066)