### PR TITLE
Android Oreo-compatible am command reimplementation

### DIFF
--- a/packages/termux-am/build.sh
+++ b/packages/termux-am/build.sh
@@ -1,0 +1,20 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/michalbednarski/TermuxAm
+TERMUX_PKG_DESCRIPTION="Android Oreo-compatible am command reimplementation"
+TERMUX_PKG_MAINTAINER="Michal Bednarski @michalbednarski"
+TERMUX_PKG_SRCURL=https://github.com/michalbednarski/TermuxAm/archive/v0.1.zip
+TERMUX_PKG_SHA256=ed5dcb526d2cabb12754e471f1284822e052550c3206421e1bb889684b97c7b8
+TERMUX_PKG_VERSION=0.1
+TERMUX_PKG_PLATFORM_INDEPENDENT=yes
+TERMUX_PKG_BUILD_IN_SRC=yes
+TERMUX_PKG_CONFLICTS="termux-tools (<< 0.51)"
+
+termux_step_make () {
+	export ANDROID_HOME
+	./gradlew :app:assembleRelease
+}
+
+termux_step_make_install () {
+	cp $TERMUX_PKG_SRCDIR/am-libexec-packaged $TERMUX_PREFIX/bin/am
+	mkdir -p $TERMUX_PREFIX/libexec/termux-am
+	cp $TERMUX_PKG_SRCDIR/app/build/outputs/apk/release/app-release-unsigned.apk $TERMUX_PREFIX/libexec/termux-am/am.apk
+}

--- a/packages/termux-tools/build.sh
+++ b/packages/termux-tools/build.sh
@@ -1,21 +1,25 @@
 TERMUX_PKG_HOMEPAGE=https://termux.com/
 TERMUX_PKG_DESCRIPTION="Basic system tools for Termux"
-TERMUX_PKG_VERSION=0.50
+TERMUX_PKG_VERSION=0.51
 TERMUX_PKG_PLATFORM_INDEPENDENT=yes
 TERMUX_PKG_CONFFILES="etc/motd"
 
 termux_step_make_install () {
+	mkdir -p $TERMUX_PREFIX/bin/applets
 	# Remove LD_LIBRARY_PATH from environment to avoid conflicting
 	# with system libraries that system binaries may link against:
 	for tool in am df getprop logcat ping ping6 ip pm settings; do
 		WRAPPER_FILE=$TERMUX_PREFIX/bin/$tool
+		if [ $tool == am ] ; then
+			WRAPPER_FILE=$TERMUX_PREFIX/bin/applets/$tool
+		fi
 		echo '#!/bin/sh' > $WRAPPER_FILE
 		echo 'unset LD_LIBRARY_PATH LD_PRELOAD' >> $WRAPPER_FILE
 		# Some tools require having /system/bin/app_process in the PATH,
 		# at least am&pm on a Nexus 6p running Android 6.0:
 		echo -n 'PATH=$PATH:/system/bin ' >> $WRAPPER_FILE
 		echo "exec /system/bin/$tool \"\$@\"" >> $WRAPPER_FILE
-		chmod +x $TERMUX_PREFIX/bin/$tool
+		chmod +x $WRAPPER_FILE
 	done
 
 	cp -p $TERMUX_PKG_BUILDER_DIR/{dalvikvm,su,termux-fix-shebang,termux-reload-settings,termux-setup-storage,chsh,termux-open-url,termux-wake-lock,termux-wake-unlock,login,pkg,termux-open,termux-info} $TERMUX_PREFIX/bin/


### PR DESCRIPTION
`am` command reimplementation that works on Android Oreo

This pull request moves default `am` from `$PREFIX/bin/am` to `$PREFIX/bin/applets/am` and adds `$PERFIX/bin/am` reimplementation in separate package, so `am` refers to reimplementation if new package is installed and system `am` from `termux-tools` if it's not.

Mostly based on AOSP code

termux/termux-api#105