### PR TITLE
alpine: use termux tmp dir for locks

### DIFF
--- a/packages/alpine/env_unix.c.patch
+++ b/packages/alpine/env_unix.c.patch
@@ -7,7 +7,7 @@ index 89e5092..f5a734e 100644
   */
  
 -static const char *tmpdir = "/tmp";
-+static const char *tmpdir = "/data/data/com.termux/files/usr/tmp";
++static const char *tmpdir = "@TERMUX_PREFIX@/tmp";
  
  /* Do not change shlock_mode.  Doing so can cause mailbox corruption and
   * denial of service.  It also defeats the entire purpose of the shared


### PR DESCRIPTION
I imagine people are using termux-exec, now, but this is for those who don't...