### PR TITLE
Revert non-sensical OpenMP commits

### DIFF
--- a/packages/libllvm/build.sh
+++ b/packages/libllvm/build.sh
@@ -105,16 +105,6 @@ termux_step_post_make_install () {
 	for tool in clang clang++ cc c++ cpp gcc g++ ${TERMUX_HOST_PLATFORM}-{clang,clang++,gcc,g++,cpp}; do
 		ln -f -s clang-${_PKG_MAJOR_VERSION} $tool
 	done
-
-	local OPENMP_ARCH
-	if [ $TERMUX_ARCH = "i686" ]; then
-		OPENMP_ARCH="i386"
-	else
-		OPENMP_ARCH=$TERMUX_ARCH
-	fi
-
-	local OPENMP_PATH=lib64/clang/5.0/lib/linux/$OPENMP_ARCH/libomp.a
-	cp $TERMUX_STANDALONE_TOOLCHAIN/$OPENMP_PATH $TERMUX_PREFIX/lib
 }
 
 termux_step_post_massage () {

--- a/packages/libllvm/clang.subpackage.sh
+++ b/packages/libllvm/clang.subpackage.sh
@@ -7,7 +7,6 @@ bin/*g++
 bin/*gcc
 bin/scan-build
 lib/clang
-lib/libomp.a
 libexec/
 share/clang
 "

--- a/packages/ndk-sysroot/build.sh
+++ b/packages/ndk-sysroot/build.sh
@@ -16,8 +16,6 @@ termux_step_extract_into_massagedir () {
 
 	cp -Rf $TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/include/* \
 		$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include
-	cp $TERMUX_STANDALONE_TOOLCHAIN/lib64/clang/5.0/include/omp.h \
-		$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include
 
 	local _LIBDIR=lib
 	if [ "$TERMUX_ARCH" = "x86_64" ]; then


### PR DESCRIPTION
If we want to add OpenMP support to our clang we should have it built and shipped properly as package, not brutally copy files from the NDK.

Also see #2139.