### PR TITLE
valgrind: build without -fstack-protector if debug

### DIFF
--- a/packages/valgrind/build.sh
+++ b/packages/valgrind/build.sh
@@ -19,4 +19,7 @@ termux_step_pre_configure() {
 		# "valgrind uses inline assembly that is not Thumb compatible":
 		CFLAGS=${CFLAGS/-mthumb/}
 	fi
+	if [ "$TERMUX_DEBUG" == "true" ]; then
+		CFLAGS=${CFLAGS/-fstack-protector/}
+	fi
 }


### PR DESCRIPTION
Can't use `-fstack-protector`, as discussed in https://github.com/termux/termux-packages/issues/2148. 