### PR TITLE
Silent make too

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -939,11 +939,15 @@ termux_step_post_configure () {
 }
 
 termux_step_make() {
+	if [ ! -z ${TERMUX_QUIET_BUILD+x} ]; then
+		QUIET_BUILD="-s"
+	fi
+
 	if ls ./*akefile &> /dev/null; then
 		if [ -z "$TERMUX_PKG_EXTRA_MAKE_ARGS" ]; then
-			make -j $TERMUX_MAKE_PROCESSES
+			make -j $TERMUX_MAKE_PROCESSES $QUIET_BUILD
 		else
-			make -j $TERMUX_MAKE_PROCESSES ${TERMUX_PKG_EXTRA_MAKE_ARGS}
+			make -j $TERMUX_MAKE_PROCESSES $QUIET_BUILD ${TERMUX_PKG_EXTRA_MAKE_ARGS}
 		fi
 	fi
 }

--- a/build-package.sh
+++ b/build-package.sh
@@ -801,7 +801,7 @@ termux_step_configure_autotools () {
         fi
 	QUIET_BUILD=
 	if [ ! -z ${TERMUX_QUIET_BUILD+x} ]; then
-		QUIET_BUILD="--enable-silent-rules"
+		QUIET_BUILD="--enable-silent-rules --silent"
 	fi
 
 	# Some packages provides a $PKG-config script which some configure scripts pickup instead of pkg-config:


### PR DESCRIPTION
`make` echos all commands, which makes logs like [this](https://api.travis-ci.org/v3/job/343233352/log.txt) less readable. Therefore, echoing of commands should also be suppressed.

( It is not tested because my Travis CI account has been suspended. )