### PR TITLE
fix readline homepage

### DIFF
--- a/packages/readline/build.sh
+++ b/packages/readline/build.sh
@@ -1,4 +1,4 @@
-TERMUX_PKG_HOMEPAGE=http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html
+TERMUX_PKG_HOMEPAGE=https://tiswww.case.edu/php/chet/readline/rltop.html
 TERMUX_PKG_DESCRIPTION="Library that allow users to edit command lines as they are typed in"
 TERMUX_PKG_DEPENDS="libandroid-support, ncurses"
 _MAIN_VERSION=7.0


### PR DESCRIPTION
The old site seems to be down.

See also: https://en.wikipedia.org/w/index.php?title=GNU_Readline&type=revision&diff=815079915&oldid=815079783