### PR TITLE
debug packages: rename package to package-dbg and add debug option to build-all.sh

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -7,16 +7,20 @@ set -e -u -o pipefail
 test -f $HOME/.termuxrc && . $HOME/.termuxrc
 : ${TERMUX_TOPDIR:="$HOME/.termux-build"}
 : ${TERMUX_ARCH:="aarch64"}
+: ${TERMUX_DEBUG:=""}
 
 _show_usage () {
-	echo "Usage: ./build-all.sh [-a ARCH]"
-	echo "Build all packages. ARCH is one of aarch64 (default), arm, i686 or x86_64."
+	echo "Usage: ./build-all.sh [-a ARCH] [-d]"
+	echo "Build all packages."
+	echo "  -a The architecture to build for: aarch64(default), arm, i686, x86_64 or all."
+	echo "  -d Build with debug symbols."
 	exit 1
 }
 
 while getopts :a:hdDs option; do
 case "$option" in
 	a) TERMUX_ARCH="$OPTARG";;
+	d) TERMUX_DEBUG='-d';;
 	h) _show_usage;;
 esac
 done
@@ -57,7 +61,7 @@ for package_path in `cat $BUILDORDER_FILE`; do
 
 	echo -n "Building $package... "
 	BUILD_START=`date "+%s"`
-	bash -x $BUILDSCRIPT -a $TERMUX_ARCH -s $package \
+	bash -x $BUILDSCRIPT -a $TERMUX_ARCH -s $TERMUX_DEBUG $package \
 	        > $BUILDALL_DIR/${package}.out 2> $BUILDALL_DIR/${package}.err
 	BUILD_END=`date "+%s"`
 	BUILD_SECONDS=$(( $BUILD_END - $BUILD_START ))

--- a/build-package.sh
+++ b/build-package.sh
@@ -393,6 +393,12 @@ termux_step_start_build() {
 		TERMUX_PKG_FULLVERSION+="-$TERMUX_PKG_REVISION"
 	fi
 
+	if [ "$TERMUX_DEBUG" == "true" ]; then
+		DEBUG="-dbg"
+	else
+		DEBUG=""
+	fi
+
 	if [ -z "$TERMUX_DEBUG" ] &&
 	   [ -z "${TERMUX_FORCE_BUILD+x}" ] &&
 	   [ -e "/data/data/.built-packages/$TERMUX_PKG_NAME" ]; then
@@ -1103,7 +1109,7 @@ termux_step_massage() {
 		mkdir -p DEBIAN
 		cd DEBIAN
 		cat > control <<-HERE
-			Package: $SUB_PKG_NAME
+			Package: $SUB_PKG_NAME$DEBUG
 			Architecture: ${SUB_PKG_ARCH}
 			Installed-Size: ${SUB_PKG_INSTALLSIZE}
 			Maintainer: $TERMUX_PKG_MAINTAINER
@@ -1119,7 +1125,7 @@ termux_step_massage() {
 		for f in $TERMUX_SUBPKG_CONFFILES; do echo "$TERMUX_PREFIX/$f" >> conffiles; done
 
 		# Create the actual .deb file:
-		TERMUX_SUBPKG_DEBFILE=$TERMUX_DEBDIR/${SUB_PKG_NAME}_${TERMUX_PKG_FULLVERSION}_${SUB_PKG_ARCH}.deb
+		TERMUX_SUBPKG_DEBFILE=$TERMUX_DEBDIR/${SUB_PKG_NAME}${DEBUG}_${TERMUX_PKG_FULLVERSION}_${SUB_PKG_ARCH}.deb
 		test ! -f "$TERMUX_COMMON_CACHEDIR/debian-binary" && echo "2.0" > "$TERMUX_COMMON_CACHEDIR/debian-binary"
 		ar cr "$TERMUX_SUBPKG_DEBFILE" \
 				   "$TERMUX_COMMON_CACHEDIR/debian-binary" \
@@ -1171,7 +1177,7 @@ termux_step_create_debfile() {
 
 	mkdir -p DEBIAN
 	cat > DEBIAN/control <<-HERE
-		Package: $TERMUX_PKG_NAME
+		Package: $TERMUX_PKG_NAME$DEBUG
 		Architecture: ${TERMUX_ARCH}
 		Installed-Size: ${TERMUX_PKG_INSTALLSIZE}
 		Maintainer: $TERMUX_PKG_MAINTAINER
@@ -1198,7 +1204,7 @@ termux_step_create_debfile() {
 	tar -cJf "$TERMUX_PKG_PACKAGEDIR/control.tar.xz" .
 
 	test ! -f "$TERMUX_COMMON_CACHEDIR/debian-binary" && echo "2.0" > "$TERMUX_COMMON_CACHEDIR/debian-binary"
-	TERMUX_PKG_DEBFILE=$TERMUX_DEBDIR/${TERMUX_PKG_NAME}_${TERMUX_PKG_FULLVERSION}_${TERMUX_ARCH}.deb
+	TERMUX_PKG_DEBFILE=$TERMUX_DEBDIR/${TERMUX_PKG_NAME}${DEBUG}_${TERMUX_PKG_FULLVERSION}_${TERMUX_ARCH}.deb
 	# Create the actual .deb file:
 	ar cr "$TERMUX_PKG_DEBFILE" \
 	       "$TERMUX_COMMON_CACHEDIR/debian-binary" \


### PR DESCRIPTION
Quite some packages require additional patching to build with debug symbols, I'm looking into that.