### PR TITLE
Enable the use of MagiskSU within proot (if installed)

### DIFF
--- a/packages/proot/termux-chroot
+++ b/packages/proot/termux-chroot
@@ -1,4 +1,4 @@
-#!/data/data/com.termux/files/usr/bin/sh
+#!/bin/sh
 
 SCRIPTNAME=termux-chroot
 show_usage () {

--- a/packages/proot/termux-chroot
+++ b/packages/proot/termux-chroot
@@ -31,8 +31,13 @@ ARGS="$ARGS -b /vendor:/vendor"
 # and $HOME so that Termux programs with hard-coded paths continue to work:
 ARGS="$ARGS -b /data:/data"
 
+
 # Bind Magisk binary directories so root works, closing per Issue #2100.
-ARGS="$ARGS -b /sbin:/sbin -b /root:/root"
+if [ -d /sbin ] && [ -d /root ]; then
+	# Both of these directories exist under Android even without Magisk installed,
+	# The existence check is to ensure that it doesn't break if this changes.
+	ARGS="$ARGS -b /sbin:/sbin -b /root:/root"
+fi
 
 if [ -f /property_contexts ]; then
 	# Used by getprop (see https://github.com/termux/termux-packages/issues/1076)

--- a/packages/proot/termux-chroot
+++ b/packages/proot/termux-chroot
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/data/data/com.termux/files/usr/bin/sh
 
 SCRIPTNAME=termux-chroot
 show_usage () {
@@ -30,6 +30,9 @@ ARGS="$ARGS -b /vendor:/vendor"
 # Bind /data to include system folders such as /data/misc. Also $PREFIX
 # and $HOME so that Termux programs with hard-coded paths continue to work:
 ARGS="$ARGS -b /data:/data"
+
+# Bind Magisk binary directories so root works, closing per Issue #2100.
+ARGS="$ARGS -b /sbin:/sbin -b /root:/root"
 
 if [ -f /property_contexts ]; then
 	# Used by getprop (see https://github.com/termux/termux-packages/issues/1076)


### PR DESCRIPTION
This change enables the use of MagiskSU from within proot while using termux-chroot. For use cases such as starting SSH via termux-chroot, and perhaps others. Will close issue #2100 