### PR TITLE
proot: Update for accept and MagiskSU support

### DIFF
--- a/packages/proot/build.sh
+++ b/packages/proot/build.sh
@@ -1,11 +1,11 @@
 TERMUX_PKG_HOMEPAGE=https://proot-me.github.io/
 TERMUX_PKG_DESCRIPTION="Emulate chroot, bind mount and binfmt_misc for non-root users"
 # Just bump commit and version when needed:
-_COMMIT=9553bc6b65f705b26249cf70244bff9ab8e935e9
+_COMMIT=c24fa3a43af2336a93f63fe3fb3eac599f0e3592
 TERMUX_PKG_VERSION=5.1.107
-TERMUX_PKG_REVISION=5
+TERMUX_PKG_REVISION=6
 TERMUX_PKG_SRCURL=https://github.com/termux/proot/archive/${_COMMIT}.zip
-TERMUX_PKG_SHA256=8602a43aa0ce16e0f8248cde726eac11938cae78ad04b4ef75a9c62870db3cc5
+TERMUX_PKG_SHA256=185e01d02a0bbf93036d143500e747e06b95fa6056fc1b8c1a093764b467e5b8
 TERMUX_PKG_DEPENDS="libtalloc"
 
 termux_step_pre_configure() {

--- a/packages/proot/termux-chroot
+++ b/packages/proot/termux-chroot
@@ -31,6 +31,14 @@ ARGS="$ARGS -b /vendor:/vendor"
 # and $HOME so that Termux programs with hard-coded paths continue to work:
 ARGS="$ARGS -b /data:/data"
 
+
+# Bind Magisk binary directories so root works, closing per Issue #2100.
+if [ -d /sbin ] && [ -d /root ]; then
+	# Both of these directories exist under Android even without Magisk installed,
+	# The existence check is to ensure that it doesn't break if this changes.
+	ARGS="$ARGS -b /sbin:/sbin -b /root:/root"
+fi
+
 if [ -f /property_contexts ]; then
 	# Used by getprop (see https://github.com/termux/termux-packages/issues/1076)
 	# but does not exist on Android 8.


### PR DESCRIPTION
Update proot:
* MagiskSU support in `termux-chroot` (termux/termux-packages#2229, pull request by @ShadowEO)
* `accept(2)` seccomp workaround (termux/proot#11, pull request by @marksteward)