### PR TITLE
emacs: ac_cv_func_setrlimit=no to make termux-am work within emacs

### DIFF
--- a/packages/emacs/build.sh
+++ b/packages/emacs/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/emacs/
 TERMUX_PKG_DESCRIPTION="Extensible, customizable text editor-and more"
 TERMUX_PKG_VERSION=25.3
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SHA256=253ac5e7075e594549b83fd9ec116a9dc37294d415e2f21f8ee109829307c00b
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/emacs/emacs-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_DEPENDS="ncurses, gnutls, libxml2"
@@ -16,6 +16,8 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" emacs_cv_prog_cc_nopie=no"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_lib_elf_elf_begin=no"
 # implemented using dup3(), which fails if oldfd == newfd
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" gl_cv_func_dup2_works=no"
+# disable setrlimit function to make termux-am work from within emacs
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_func_setrlimit=no"
 TERMUX_PKG_HOSTBUILD=yes
 TERMUX_PKG_KEEP_INFOPAGES=yes
 


### PR DESCRIPTION
Solves https://github.com/termux/termux-app/issues/608. @michalbednarski found the solution.
Not sure if this will have any other side effects.

I also tried patching src/emacs.c by adding `&& !defined __ANDROID__` to [this line](https://github.com/emacs-mirror/emacs/blob/0965d94ca426765382f366bf48f88ba5f9500afd/src/emacs.c#L830) and it worked as well, adding this configure option felt cleaner though.