### PR TITLE
ld: set --enable-new-dtags by default

### DIFF
--- a/packages/binutils/build.sh
+++ b/packages/binutils/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Collection of binary tools, the main ones being ld, the 
 TERMUX_PKG_VERSION=2.30
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/binutils/binutils-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=8c3850195d1c093d290a716e20ebcaa72eda32abf5e3d8611154b39cff79e9ea
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-werror --with-system-zlib"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-werror --with-system-zlib --enable-new-dtags"
 TERMUX_PKG_EXTRA_MAKE_ARGS="tooldir=$TERMUX_PREFIX"
 TERMUX_PKG_RM_AFTER_INSTALL="share/man/man1/windmc.1 share/man/man1/windres.1 bin/ld.bfd"
 


### PR DESCRIPTION
The --enable-new-dtags option to ld causes it to emit a RUNPATH rather than RPATH entry in the elf header. Because the Android linker supports RUNPATH but not RPATH, this means many things can now Just Work. This should (eventually) eliminate the need to set LD_LIBRARY_PATH.

Prior art:

This [became the default for Linux in 2013](https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=commitdiff;h=822b8bf) but I think termux isn't getting it because it reports "Android" instead of "Linux"? Or maybe the way it works changed since then. Regardless, [Debian has been using RUNPATH by default since December 2016.](https://sources.debian.org/src/binutils/2.27.90.20161231-1/debian/patches/ld-new-dtags-by-default.diff/?hl=27#L27) Their [newest configuration](https://sources.debian.org/src/binutils/2.30-7/debian/rules/#L362) uses the newer configuration option seen in this patch. The [suse and gentoo](https://web.archive.org/web/20160101182307/http://comments.gmane.org/gmane.comp.gnu.binutils/57379) maintainers said they did the same in 2004 and 2005, respectively. So it seems well battle-tested, to me.

For the curious:
This came up because I'm working on [getting Homebrew working under Termux](https://github.com/Linuxbrew/brew/pull/621).