### PR TITLE
ecj: provide android-21.jar instead of android-16.jar

### DIFF
--- a/packages/ecj/build.sh
+++ b/packages/ecj/build.sh
@@ -47,4 +47,6 @@ termux_step_make () {
 	rm -Rf $TERMUX_PREFIX/bin/javac
 	install $TERMUX_PKG_BUILDER_DIR/ecj $TERMUX_PREFIX/bin/ecj
 	perl -p -i -e "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" $TERMUX_PREFIX/bin/ecj
+	install $TERMUX_PKG_BUILDER_DIR/ecj-21 $TERMUX_PREFIX/bin/ecj-21
+	perl -p -i -e "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" $TERMUX_PREFIX/bin/ecj-21
 }

--- a/packages/ecj/build.sh
+++ b/packages/ecj/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=http://www.eclipse.org/jdt/core/
 TERMUX_PKG_DESCRIPTION="Eclipse Compiler for Java"
 TERMUX_PKG_VERSION=4.6.2
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=http://eclipse.mirror.wearetriple.com/eclipse/downloads/drops4/R-4.6.2-201611241400/ecj-4.6.2.jar
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 

--- a/packages/ecj/build.sh
+++ b/packages/ecj/build.sh
@@ -38,11 +38,11 @@ termux_step_make () {
 	# Bundle in an android.jar from an older API also, for those who want to
 	# build apps that run on older Android versions.
 	rm -Rf ./*
-	cp $ANDROID_HOME/platforms/android-16/android.jar android.jar
+	cp $ANDROID_HOME/platforms/android-21/android.jar android.jar
 	unzip -q android.jar
 	rm -Rf android.jar resources.arsc res assets
-	jar cfM android-16.jar .
-	cp $TERMUX_PKG_TMPDIR/android-jar/android-16.jar $TERMUX_PREFIX/share/java/
+	jar cfM android-21.jar .
+	cp $TERMUX_PKG_TMPDIR/android-jar/android-21.jar $TERMUX_PREFIX/share/java/
 
 	rm -Rf $TERMUX_PREFIX/bin/javac
 	install $TERMUX_PKG_BUILDER_DIR/ecj $TERMUX_PREFIX/bin/ecj

--- a/packages/ecj/ecj-21
+++ b/packages/ecj/ecj-21
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# -proc:none to disable annotation processing.
+# -7 for java 1.7 compatibility.
+dalvikvm -Xmx256m \
+         -cp @TERMUX_PREFIX@/share/dex/ecj.jar \
+         org.eclipse.jdt.internal.compiler.batch.Main \
+         -proc:none \
+         -7 \
+         -cp @TERMUX_PREFIX@/share/java/android-21.jar \
+         $@

--- a/scripts/setup-android-sdk.sh
+++ b/scripts/setup-android-sdk.sh
@@ -37,5 +37,5 @@ fi
 
 yes | $ANDROID_HOME/tools/bin/sdkmanager --licenses
 
-# The android-16 platform is used in the ecj package:
-$ANDROID_HOME/tools/bin/sdkmanager "build-tools;27.0.1" "platforms;android-27" "platforms;android-16"
+# The android-21 platform is used in the ecj package:
+$ANDROID_HOME/tools/bin/sdkmanager "build-tools;27.0.1" "platforms;android-27" "platforms;android-21"


### PR DESCRIPTION
Also add executable that compiles with the older android classes