### PR TITLE
ndk-stl: include libstdc++ headers

### DIFF
--- a/packages/ndk-stl/build.sh
+++ b/packages/ndk-stl/build.sh
@@ -11,7 +11,3 @@ termux_step_extract_into_massagedir () {
 	cd $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include/c++/v1/
 	patch -p1 < $TERMUX_PKG_BUILDER_DIR/math-header.diff
 }
-
-termux_step_massage () {
-	echo "overriding termux_step_massage to avoid removing header files"
-}

--- a/packages/ndk-stl/build.sh
+++ b/packages/ndk-stl/build.sh
@@ -6,13 +6,10 @@ TERMUX_PKG_NO_DEVELSPLIT=yes
 
 termux_step_extract_into_massagedir () {
 	mkdir -p $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include/c++/v1/
-	cp -Rf $TERMUX_STANDALONE_TOOLCHAIN/include/c++/4.9.x/* $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include/c++/v1/
+	cp -Rf $NDK/sources/cxx-stl/llvm-libc++{,abi}/include/* $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include/c++/v1/
 
 	cd $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include/c++/v1/
 	patch -p1 < $TERMUX_PKG_BUILDER_DIR/math-header.diff
-	# Revert the patch for <cstddef> that's only used for using g++
-	# from the ndk (https://github.com/android-ndk/ndk/issues/215):
-	sed "s%\@TERMUX_HOST_PLATFORM\@%${TERMUX_HOST_PLATFORM}%g" $TERMUX_SCRIPTDIR/ndk-patches/cstddef.cpppatch | patch -p1 -R
 }
 
 termux_step_massage () {

--- a/packages/ndk-stl/build.sh
+++ b/packages/ndk-stl/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://developer.android.com/tools/sdk/ndk/index.html
-TERMUX_PKG_DESCRIPTION="Header files from the Android NDK needed for compiling C++ programs using STL"
+TERMUX_PKG_DESCRIPTION="Header files from the Android NDK needed for compiling C++ programs using LLVM STL"
 TERMUX_PKG_VERSION=$TERMUX_NDK_VERSION
-TERMUX_PKG_REVISION=4
+TERMUX_PKG_REVISION=5
 TERMUX_PKG_NO_DEVELSPLIT=yes
 
 termux_step_extract_into_massagedir () {
@@ -10,4 +10,18 @@ termux_step_extract_into_massagedir () {
 
 	cd $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include/c++/v1/
 	patch -p1 < $TERMUX_PKG_BUILDER_DIR/math-header.diff
+
+	local ARCH
+	if [ "$TERMUX_ARCH" = arm ]; then
+	    ARCH=armeabi-v7a
+	elif [ "$TERMUX_ARCH" = aarch64 ]; then
+	    ARCH=arm64-v8a
+	elif [ "$TERMUX_ARCH" = i686 ]; then
+	    ARCH=x86
+	elif [ "$TERMUX_ARCH" = x86_64 ]; then
+	    ARCH=x86_64
+	fi
+
+	mkdir -p $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include/c++/4.9/
+	cp -Rf $NDK/sources/cxx-stl/gnu-libstdc++/4.9{,/libs/$ARCH}/include/* $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include/c++/4.9/
 }

--- a/packages/ndk-stl/build.sh
+++ b/packages/ndk-stl/build.sh
@@ -8,11 +8,10 @@ termux_step_extract_into_massagedir () {
 	mkdir -p $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include/c++/v1/
 	cp -Rf $TERMUX_STANDALONE_TOOLCHAIN/include/c++/4.9.x/* $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include/c++/v1/
 
-	( cd  $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include/c++/v1/ && patch -p1 < $TERMUX_PKG_BUILDER_DIR/math-header.diff )
-
+	cd $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include/c++/v1/
+	patch -p1 < $TERMUX_PKG_BUILDER_DIR/math-header.diff
 	# Revert the patch for <cstddef> that's only used for using g++
 	# from the ndk (https://github.com/android-ndk/ndk/issues/215):
-	cd $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/include/c++/v1/
 	sed "s%\@TERMUX_HOST_PLATFORM\@%${TERMUX_HOST_PLATFORM}%g" $TERMUX_SCRIPTDIR/ndk-patches/cstddef.cpppatch | patch -p1 -R
 }
 

--- a/packages/ndk-stl/ndk-stl-gnu.subpackage.sh
+++ b/packages/ndk-stl/ndk-stl-gnu.subpackage.sh
@@ -1,0 +1,2 @@
+TERMUX_SUBPKG_INCLUDE="include/c++/4.9/"
+TERMUX_SUBPKG_DESCRIPTION="Header files from the Android NDK needed for compiling C++ programs using GNU STL"

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     cd /home/builder/lib/android-ndk/ && \
     rm -Rf toolchains/mips* && \
-    rm -Rf sources/cxx-stl/gabi++ sources/cxx-stl/system sources/cxx-stl/stlport sources/cxx-stl/gnu-libstdc++ && \
+    rm -Rf sources/cxx-stl/gabi++ sources/cxx-stl/system sources/cxx-stl/stlport && \
     cd /home/builder/lib/android-sdk/tools && rm -Rf emulator* lib* proguard templates
 
 # We expect this to be mounted with '-v $PWD:/home/builder/termux-packages':


### PR DESCRIPTION
Fixes #2273 