### PR TITLE
postgresql: do not split postgresql-contrib

### DIFF
--- a/packages/postgresql/build.sh
+++ b/packages/postgresql/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://www.postgresql.org
 TERMUX_PKG_DESCRIPTION="Object-relational SQL database"
 TERMUX_PKG_MAINTAINER='Vishal Biswas @vishalbiswas'
 TERMUX_PKG_VERSION=10.3
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SHA256=6ea268780ee35e88c65cdb0af7955ad90b7d0ef34573867f223f14e43467931a
 TERMUX_PKG_SRCURL=https://ftp.postgresql.org/pub/source/v$TERMUX_PKG_VERSION/postgresql-$TERMUX_PKG_VERSION.tar.bz2
 TERMUX_PKG_DEPENDS="openssl, libcrypt, readline, libandroid-shmem"
@@ -23,6 +23,8 @@ ZIC=$TERMUX_PKG_HOSTBUILD_DIR/src/timezone/zic
 TERMUX_PKG_EXTRA_MAKE_ARGS=" -s"
 TERMUX_PKG_RM_AFTER_INSTALL="lib/libecpg* bin/ecpg share/man/man1/ecpg.1"
 TERMUX_PKG_HOSTBUILD=yes
+TERMUX_PKG_BREAKS="postgresql-contrib (<= 10.3-1)"
+TERMUX_PKG_REPLACES="postgresql-contrib (<= 10.3-1)"
 
 termux_step_host_build() {
 	# Build a native zic binary which we have patched to
@@ -35,7 +37,6 @@ termux_step_post_make_install() {
 	# Man pages are not installed by default:
 	make -C doc/src/sgml install-man
 
-	# Sync with postgresql-contrib.subpackage.sh:
 	for contrib in \
 		hstore \
 		pageinspect \

--- a/packages/postgresql/postgresql-contrib.subpackage.sh
+++ b/packages/postgresql/postgresql-contrib.subpackage.sh
@@ -1,9 +1,0 @@
-TERMUX_SUBPKG_INCLUDE="
-lib/postgresql/fuzzystrmatch.so
-lib/postgresql/hstore.so
-lib/postgresql/pgcrypto.so
-lib/postgresql/pg_stat_statements.so
-share/postgresql/extension/
-"
-TERMUX_SUBPKG_DESCRIPTION="Additional facilities for PostgreSQL"
-TERMUX_SUBPKG_DEPENDS="postgresql"


### PR DESCRIPTION
Three reasons:
1. build-package.sh doesn't have the facility to do this:

```
$ tar -xf /sdcard/Download/postgresql-9.6_9.6.7-0+deb9u1.debian.tar.xz
$ cd debian/
$ grep extension postgresql-9.6.install postgresql-contrib-9.6.install
postgresql-9.6.install:usr/share/postgresql/*/extension/plpgsql*
postgresql-contrib-9.6.install:usr/share/postgresql/*/extension/*
$
```

while `initdb` requires `extension/plpgsql*`.

2. postgresql-contrib takes up only 492kB out of 17.3MB

```
$ pkg unins postgresql
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following package was automatically installed and is no longer required:
  libandroid-shmem
Use 'apt autoremove' to remove it.
The following packages will be REMOVED:
  postgresql postgresql-contrib
0 upgraded, 0 newly installed, 2 to remove and 0 not upgraded.
After this operation, 17.3 MB disk space will be freed.
Do you want to continue? [Y/n] n
Abort.
$ pkg unins postgresql-contrib
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following packages will be REMOVED:
  postgresql-contrib
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
After this operation, 492 kB disk space will be freed.
Do you want to continue? [Y/n] n
Abort.
$
```

3. Both Ubuntu and Debian has stopped splitting postgresql-contrib.
It is now only a virtual package provided by postgresql in the 10
branch.

Fixes #2333 @aitva