### PR TITLE
termux-tools: make motd work well with emacs' tramp

### DIFF
--- a/packages/termux-tools/motd
+++ b/packages/termux-tools/motd
@@ -6,7 +6,7 @@ IRC channel:     #termux on freenode
 Gitter chat:     https://gitter.im/termux/termux
 Mailing list:    termux+subscribe@groups.io
 
-Search packages:   pkg search <query>
-Install a package: pkg install <package>
+Search packages:   pkg search QUERY
+Install a package: pkg install PACKAGE
 Upgrade packages:  pkg upgrade
 Learn more:        pkg help


### PR DESCRIPTION
The orig motd file has "<" and ">", which let tramp
ssh/plink method do not work.