### PR TITLE
syncthing: fix crash on Android 8 (#2391)

### DIFF
--- a/packages/syncthing/build.sh
+++ b/packages/syncthing/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://syncthing.net/
 TERMUX_PKG_DESCRIPTION="Decentralized file synchronization"
 TERMUX_PKG_VERSION=0.14.45
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=3236a12b3698f6eaef785348a26fea59f87398b2753c414d18844e5f7d7a655b
 TERMUX_PKG_SRCURL=https://github.com/syncthing/syncthing/releases/download/v${TERMUX_PKG_VERSION}/syncthing-source-v${TERMUX_PKG_VERSION}.tar.gz
 

--- a/packages/syncthing/no_ioprioSet.patch
+++ b/packages/syncthing/no_ioprioSet.patch
@@ -1,0 +1,19 @@
+diff -uNr syncthing/lib/osutil/lowprio_linux.go syncthing.mod/lib/osutil/lowprio_linux.go
+--- syncthing/lib/osutil/lowprio_linux.go	2018-03-06 08:19:07.000000000 +0200
++++ syncthing.mod/lib/osutil/lowprio_linux.go	2018-05-02 13:03:12.463566932 +0300
+@@ -30,13 +30,8 @@
+ )
+ 
+ func ioprioSet(class ioprioClass, value int) error {
+-	res, _, err := syscall.Syscall(syscall.SYS_IOPRIO_SET,
+-		uintptr(ioprioWhoProcess), 0,
+-		uintptr(class)<<ioprioClassShift|uintptr(value))
+-	if res == 0 {
+-		return nil
+-	}
+-	return err
++    // Android 8 does not allow syscall SYS_IOPRIO_SET
++    return nil
+ }
+ 
+ // SetLowPriority lowers the process CPU scheduling priority, and possibly


### PR DESCRIPTION
Disable use of syscall sys_ioprio_set() which is blocked
by seccomp.