### PR TITLE
Update imagemagick to version 7.0.7.32

### DIFF
--- a/packages/imagemagick/build.sh
+++ b/packages/imagemagick/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://www.imagemagick.org/
 TERMUX_PKG_DESCRIPTION="Suite to create, edit, compose, or convert images in a variety of formats"
-TERMUX_PKG_VERSION=7.0.7.31
-TERMUX_PKG_SHA256=2208eb6b9355fda4279ed1861523830aec1f9b0a39bf8c20718d1c8f5ad42710
+TERMUX_PKG_VERSION=7.0.7.32
+TERMUX_PKG_SHA256=f1785adf8bbf378b47e789c74c2fd9ebdd5ec1c4de12e53306f8f6eb5b55d656
 local _download_version=`echo $TERMUX_PKG_VERSION | sed 's/\(.*\)\./\1-/'`
 TERMUX_PKG_SRCURL=https://github.com/ImageMagick/ImageMagick/archive/${_download_version}.tar.gz
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="

--- a/packages/imagemagick/build.sh
+++ b/packages/imagemagick/build.sh
@@ -8,7 +8,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-largefile
 --without-x
 --without-gvc
---without-ltdl
 --with-magick-plus-plus=no
 --with-bzlib=no
 --with-xml=yes

--- a/packages/imagemagick/build.sh
+++ b/packages/imagemagick/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://www.imagemagick.org/
 TERMUX_PKG_DESCRIPTION="Suite to create, edit, compose, or convert images in a variety of formats"
-TERMUX_PKG_VERSION=7.0.7.29
-TERMUX_PKG_SHA256=be171d13e58bb19685b36080edf9d36b9b95633b0331fbf7e70b5997a3501d65
+TERMUX_PKG_VERSION=7.0.7.31
+TERMUX_PKG_SHA256=2208eb6b9355fda4279ed1861523830aec1f9b0a39bf8c20718d1c8f5ad42710
 local _download_version=`echo $TERMUX_PKG_VERSION | sed 's/\(.*\)\./\1-/'`
 TERMUX_PKG_SRCURL=https://github.com/ImageMagick/ImageMagick/archive/${_download_version}.tar.gz
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="


### PR DESCRIPTION
I was checking if it might fix the segfault problems, as the changelog
indicated that several memory overflows have been fixed, but they still
happen for me.
But at least it fixes the compliance bug present in version .29, that has been annoying me.