### PR TITLE
libunistring: fix locale_charset()

### DIFF
--- a/packages/libunistring/build.sh
+++ b/packages/libunistring/build.sh
@@ -1,6 +1,8 @@
 TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/libunistring/
 TERMUX_PKG_DESCRIPTION="Library providing functions for manipulating Unicode strings"
 TERMUX_PKG_VERSION=0.9.9
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=f5e90c08f9e5427ca3a2c0c53f19aa38b25c500913510ad25afef86448bea84a
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/libunistring/libunistring-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="ac_cv_func_uselocale=no"
+TERMUX_PKG_DEPENDS="libandroid-support"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="ac_cv_func_uselocale=no am_cv_langinfo_codeset=yes"


### PR DESCRIPTION
Make locale_charset() use nl_langinfo() so that it would work
properly. For example:

$ idn2 --debug ''
Charset: en_US.UTF-8
idn2: toAscii: could not convert string to UTF-8
$ LD_PRELOAD=$PREFIX/local/lib/libunistring.so idn2 --debug ''
Charset: UTF-8

$