### PR TITLE
build-package.sh: add TERMUX_PKG_SUBPKG_ORDER to allow in which order  to split packages

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -322,6 +322,7 @@ termux_step_setup_variables() {
 	TERMUX_PKG_CONFFILES=""
 	TERMUX_PKG_INCLUDE_IN_DEVPACKAGE=""
 	TERMUX_PKG_DEVPACKAGE_DEPENDS=""
+	TERMUX_PKG_SUBPKG_ORDER=""
 	# Set if a host build should be done in TERMUX_PKG_HOSTBUILD_DIR:
 	TERMUX_PKG_HOSTBUILD=""
 	TERMUX_PKG_MAINTAINER="Fredrik Fornwall @fornwall"
@@ -1067,7 +1068,26 @@ termux_step_massage() {
 	fi
 	# Now build all sub packages
 	rm -Rf "$TERMUX_TOPDIR/$TERMUX_PKG_NAME/subpackages"
-	for subpackage in $TERMUX_PKG_BUILDER_DIR/*.subpackage.sh $TERMUX_PKG_TMPDIR/*subpackage.sh; do
+	# Copy .subpackage.sh files to tmpdir, to have all subpackages there
+	find $TERMUX_PKG_BUILDER_DIR -type f -name *.subpackage.sh -exec cp {} $TERMUX_PKG_TMPDIR \;
+	local SUBPACKAGES_ORDER=$(find $TERMUX_PKG_TMPDIR -maxdepth 1 -name "*subpackage.sh" -type f)
+	if [ ! -z "$TERMUX_PKG_SUBPKG_ORDER" ]; then
+		# We have a specified build order
+		# Check number of *subpackage.sh files and length of $TERMUX_PKG_SUBPKG_ORDER
+		if [ $(echo $TERMUX_PKG_SUBPKG_ORDER | wc -w) != $(echo $SUBPACKAGES_ORDER | wc -w) ]; then
+			termux_error_exit "Number of *subpackage.sh files differs from length of \$TERMUX_PKG_SUBPKG_ORDER"
+		fi
+		# Lets check so TERMUX_PKG_SUBPKG_ORDER subpackage files exists
+		SUBPACKAGES_ORDER=""
+		for subpkg_file in $TERMUX_PKG_SUBPKG_ORDER; do
+			if [ ! -f $TERMUX_PKG_TMPDIR/$subpkg_file.subpackage.sh ]; then
+				termux_error_exit "$subpkg_file.subpackage.sh (from TERMUX_PKG_SUBPKG_ORDER) does not exist"
+			fi
+			SUBPACKAGES_ORDER+=" $TERMUX_PKG_TMPDIR/$subpkg_file.subpackage.sh"
+		done
+	fi
+
+	for subpackage in $SUBPACKAGES_ORDER; do
 		test ! -f "$subpackage" && continue
 		local SUB_PKG_NAME
 		SUB_PKG_NAME=$(basename "$subpackage" .subpackage.sh)


### PR DESCRIPTION
Let's say that the package `foo` provides this folder:
```
/data/data/com.termux/files/usr/foo
├── Bashful
├── Doc
├── Dopey
├── Grumpy
├── Happy
├── Sleepy
├── Sneezy
└── baz
```
and that we want `foo` to have two subpackages, `bar` and `baz`. 
`bar` should contain `$PREFIX/{Bashful,Doc,Dopey,Grumpy,Happy,Sleepy,Sneezy}` and `baz` should contain `$PREFIX/foo/baz`.

We can currently achieve this by setting: 
```
TERMUX_SUBPKG_INCLUDE="foo/Bashful 
foo/Doc 
foo/Dopey
foo/Grumpy
foo/Happy
foo/Sleepy
foo/Sneezy"
```
for `bar` and:
```
TERMUX_SUBPKG_INCLUDE="foo/baz"
```
for `baz`.

build-package.sh currently packages subpackages in alphabetic order. If we could specify the order, and package `baz` before `bar`, we could achieve the same package split by setting 
`TERMUX_SUBPKG_INCLUDE="foo"` 
for `bar` and 
`TERMUX_SUBPKG_INCLUDE="foo/baz"` 
for `baz`. 
`baz` then grabs its file and `bar` afterwards grabs the rest of the files in `$PREFIX/foo`.

This introduced parameter `TERMUX_PKG_SUBPKG_ORDER` can save quite a lot of LoC for a package like Texlive, since we want to package it fully and split it up into several subpackages.