### PR TITLE
pass-otp: add package

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -318,6 +318,7 @@ termux_step_setup_variables() {
 	TERMUX_PKG_ESSENTIAL=""
 	TERMUX_PKG_CONFLICTS="" # https://www.debian.org/doc/debian-policy/ch-relationships.html#s-conflicts
 	TERMUX_PKG_RECOMMENDS="" # https://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps
+	TERMUX_PKG_SUGGESTS=""
 	TERMUX_PKG_REPLACES=""
 	TERMUX_PKG_CONFFILES=""
 	TERMUX_PKG_INCLUDE_IN_DEVPACKAGE=""
@@ -1192,6 +1193,7 @@ termux_step_create_debfile() {
 	test ! -z "$TERMUX_PKG_CONFLICTS" && echo "Conflicts: $TERMUX_PKG_CONFLICTS" >> DEBIAN/control
 	test ! -z "$TERMUX_PKG_RECOMMENDS" && echo "Recommends: $TERMUX_PKG_RECOMMENDS" >> DEBIAN/control
 	test ! -z "$TERMUX_PKG_REPLACES" && echo "Replaces: $TERMUX_PKG_REPLACES" >> DEBIAN/control
+	test ! -z "$TERMUX_PKG_SUGGESTS" && echo "Suggests: $TERMUX_PKG_SUGGESTS" >> DEBIAN/control
 
 	# Create DEBIAN/conffiles (see https://www.debian.org/doc/debian-policy/ap-pkg-conffiles.html):
 	for f in $TERMUX_PKG_CONFFILES; do echo "$TERMUX_PREFIX/$f" >> DEBIAN/conffiles; done

--- a/packages/libqrencode/build.sh
+++ b/packages/libqrencode/build.sh
@@ -1,0 +1,7 @@
+TERMUX_PKG_HOMEPAGE=https://fukuchi.org/works/qrencode/
+TERMUX_PKG_DESCRIPTION="Libqrencode is a fast and compact library for encoding data in a QR Code symbol, a 2D symbology that can be scanned by handy terminals"
+TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
+TERMUX_PKG_VERSION=4.0.0
+TERMUX_PKG_SRCURL=https://github.com/fukuchi/libqrencode/archive/v$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=c2c8a8110354463a3332cb48abf8581c8d94136af4dc1418f891cc9c7719e3c1
+TERMUX_PKG_DEPENDS="libandroid-support, libpng"

--- a/packages/pass-otp/build.sh
+++ b/packages/pass-otp/build.sh
@@ -1,0 +1,10 @@
+TERMUX_PKG_HOMEPAGE=htts://github.com/tadfisher/pass-otp
+TERMUX_PKG_DESCRIPTION="A pass extension for managing one-time-password (OTP) tokens"
+TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
+TERMUX_PKG_VERSION=1.1.0
+TERMUX_PKG_SRCURL=https://github.com/tadfisher/pass-otp/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=3971467475f8ed573eb860c7a44bd268d464d169dddbc0a4da89232d5beee144
+TERMUX_PKG_BUILD_IN_SRC=yes
+TERMUX_PKG_PLATFORM_INDEPENDENT=yes
+TERMUX_PKG_DEPENDS="pass, oathtool"
+TERMUX_PKG_SUGGESTS="libqrencode"

--- a/packages/pass/build.sh
+++ b/packages/pass/build.sh
@@ -1,12 +1,14 @@
 TERMUX_PKG_HOMEPAGE=https://www.passwordstore.org/
 TERMUX_PKG_DESCRIPTION="Lightweight directory-based password manager"
 TERMUX_PKG_VERSION=1.7.1
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=https://git.zx2c4.com/password-store/snapshot/password-store-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_BUILD_IN_SRC=yes
 # Depend on coreutils as pass uses [:graph:] when calling tr, which
 # busybox tr does not support:
 TERMUX_PKG_DEPENDS="bash, gnupg2, tree, coreutils"
+TERMUX_PKG_RECOMMENDS="git"
+TERMUX_PKG_SUGGESTS="pass-otp"
 TERMUX_PKG_PLATFORM_INDEPENDENT=yes
 TERMUX_PKG_EXTRA_MAKE_ARGS="PREFIX=$TERMUX_PREFIX"
 TERMUX_PKG_SHA256=f6d2199593398aaefeaa55e21daddfb7f1073e9e096af6d887126141e99d9869


### PR DESCRIPTION
Useful package now that more companies/services implement two factor authorization following GDPR. 
Also add libqrencode to be able to generate qr codes. 

Add a TERMUX_PKG_SUGGESTS field to build-package.sh and suggest pass-otp for pass as well as libqrencode for pass-otp. 

Maybe pass-otp should be RECOMMENDS rather than SUGGESTS, any thoughts on the matter?