### PR TITLE
libcln: using integrated as fix

### DIFF
--- a/packages/libcln/build.sh
+++ b/packages/libcln/build.sh
@@ -14,6 +14,7 @@ termux_step_pre_configure() {
 		# "(*) On these platforms, problems with the assembler routines have been
 		# reported. It may be best to add "-DNO_ASM" to CPPFLAGS before configuring."
 		CPPFLAGS+=" -DNO_ASM"
+		CXXFLAGS+=" -fintegrated-as"
 	fi
 
 	sed -i -e 's%tests/Makefile %%' configure.ac


### PR DESCRIPTION
using no-integrated-as fails on this build. 
