### PR TITLE
proot: Update to skip link2symlink rmdir handling

### DIFF
--- a/packages/proot/build.sh
+++ b/packages/proot/build.sh
@@ -1,11 +1,11 @@
 TERMUX_PKG_HOMEPAGE=https://proot-me.github.io/
 TERMUX_PKG_DESCRIPTION="Emulate chroot, bind mount and binfmt_misc for non-root users"
 # Just bump commit and version when needed:
-_COMMIT=02bc8d1fbad330c6ea3b9a57125b29fe0e17c19e
+_COMMIT=3bc06868508b858e9dc290e29815ecd690e9cb0c
 TERMUX_PKG_VERSION=5.1.107
-TERMUX_PKG_REVISION=10
+TERMUX_PKG_REVISION=11
 TERMUX_PKG_SRCURL=https://github.com/termux/proot/archive/${_COMMIT}.zip
-TERMUX_PKG_SHA256=18006cdd6d1059c939cf4d12a47968aa1d38badbe1be72bb5c40c56d0709136f
+TERMUX_PKG_SHA256=6214cc47d468c04503fd004a2c44f77986ad110857446525087389524e32b86e
 TERMUX_PKG_DEPENDS="libtalloc"
 
 termux_step_pre_configure() {


### PR DESCRIPTION
Fixes termux/termux-packages#2307 (aka. termux/proot#18); note however that while this fix prevents creation of broken hardlinks by `dpkg`, existing broken links needs to be removed manually (while running outside `proot`)