### PR TITLE
busybox: fix #2488 and fix debug build

### DIFF
--- a/packages/busybox/build.sh
+++ b/packages/busybox/build.sh
@@ -2,6 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://busybox.net/
 TERMUX_PKG_DESCRIPTION="Tiny versions of many common UNIX utilities into a single small executable"
 TERMUX_PKG_ESSENTIAL=yes
 TERMUX_PKG_VERSION=1.28.4
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=e3c14a3699dc7e82fed397392957afc78e37bdf25398ac38ead6e84621b2ae6a
 TERMUX_PKG_SRCURL=https://busybox.net/downloads/busybox-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_BUILD_IN_SRC=yes
@@ -27,6 +28,9 @@ termux_step_configure () {
 }
 
 termux_step_post_make_install () {
+	if [ "$TERMUX_DEBUG" == "true" ]; then
+		install busybox_unstripped $PREFIX/bin/busybox
+	fi
 	# Create symlinks in $PREFIX/bin/applets to $PREFIX/bin/busybox
 	rm -Rf $TERMUX_PREFIX/bin/applets
 	mkdir -p $TERMUX_PREFIX/bin/applets

--- a/packages/busybox/svlogd.c.patch
+++ b/packages/busybox/svlogd.c.patch
@@ -1,0 +1,12 @@
+svlogd doesn't work with clang.
+Patch inspired by http://landley.net/mantis/mantis-2344.html
+--- ../svlogd.c.orig	2018-06-07 19:34:47.442867090 +0000
++++ ./runit/svlogd.c	2018-06-07 19:35:16.438776951 +0000
+@@ -244,6 +244,7 @@
+ #define INIT_G() do { \
+ 	setup_common_bufsiz(); \
+ 	SET_PTR_TO_GLOBALS(xzalloc(sizeof(G))); \
++	asm volatile("":::"memory"); \
+ 	linemax = 1000; \
+ 	/*buflen = 1024;*/ \
+ 	linecomplete = 1; \


### PR DESCRIPTION
Busybox builds "busybox" and "busybox_unstripped", where the latter contains
debug symbols.

(I see that I made a typo in the commit message issue number)