### PR TITLE
build-package.sh: partly undo 9b2f3b6

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -1111,7 +1111,7 @@ termux_step_massage() {
 		mkdir -p DEBIAN
 		cd DEBIAN
 		cat > control <<-HERE
-			Package: $SUB_PKG_NAME$DEBUG
+			Package: $SUB_PKG_NAME
 			Architecture: ${SUB_PKG_ARCH}
 			Installed-Size: ${SUB_PKG_INSTALLSIZE}
 			Maintainer: $TERMUX_PKG_MAINTAINER
@@ -1179,7 +1179,7 @@ termux_step_create_debfile() {
 
 	mkdir -p DEBIAN
 	cat > DEBIAN/control <<-HERE
-		Package: $TERMUX_PKG_NAME$DEBUG
+		Package: $TERMUX_PKG_NAME
 		Architecture: ${TERMUX_ARCH}
 		Installed-Size: ${TERMUX_PKG_INSTALLSIZE}
 		Maintainer: $TERMUX_PKG_MAINTAINER


### PR DESCRIPTION
We'll rename debug debs to ${PKG}-dbg but not the actual package name in
control. Debug versions of packages and normal packages can then replace each
other without complaints from apt.

We need to work a bit more on it to be able to setup a debug repo.