### PR TITLE
ncurses: fix versioned library symlinking

### DIFF
--- a/packages/ncurses/build.sh
+++ b/packages/ncurses/build.sh
@@ -42,14 +42,19 @@ termux_step_pre_configure() {
 
 termux_step_post_make_install () {
 	cd $TERMUX_PREFIX/lib
+	# we need the rm as we create(d) symlinks for the versioned so as well
 	for lib in form menu ncurses panel; do
+		rm -f lib${lib}.so*
 		for file in lib${lib}w.so*; do
-			ln -s -f $file `echo $file | sed 's/w//'`
+			ln -s $file ${file/w./.}
 		done
-		(cd pkgconfig && ln -s -f ${lib}w.pc `echo $lib | sed 's/w//'`.pc)
+		(cd pkgconfig; ln -sf ${lib}w.pc $lib.pc)
 	done
 	# some packages want libcurses while building/compiling
-	ln -sf libncurses.so libcurses.so
+	rm -f libcurses.so*
+	for file in libncurses.so*; do
+		ln -s $file ${file/libn/lib}
+	done
 
 	# Some packages want these:
 	cd $TERMUX_PREFIX/include/


### PR DESCRIPTION
Symlinks of 6.0 has remained as we had been using `ln -sf` but not `rm -f` + `ln -s`:
```
$ dpkg -L ncurses ncurses-ui-libs | grep .so | sort
/data/data/com.termux/files/usr/lib/libcurses.so
/data/data/com.termux/files/usr/lib/libform.so
/data/data/com.termux/files/usr/lib/libform.so.6
/data/data/com.termux/files/usr/lib/libform.so.6.0
/data/data/com.termux/files/usr/lib/libform.so.6.1
/data/data/com.termux/files/usr/lib/libformw.so
/data/data/com.termux/files/usr/lib/libformw.so.6
/data/data/com.termux/files/usr/lib/libformw.so.6.1
/data/data/com.termux/files/usr/lib/libmenu.so
/data/data/com.termux/files/usr/lib/libmenu.so.6
/data/data/com.termux/files/usr/lib/libmenu.so.6.0
/data/data/com.termux/files/usr/lib/libmenu.so.6.1
/data/data/com.termux/files/usr/lib/libmenuw.so
/data/data/com.termux/files/usr/lib/libmenuw.so.6
/data/data/com.termux/files/usr/lib/libmenuw.so.6.1
/data/data/com.termux/files/usr/lib/libncurses.so
/data/data/com.termux/files/usr/lib/libncurses.so.6
/data/data/com.termux/files/usr/lib/libncurses.so.6.0
/data/data/com.termux/files/usr/lib/libncurses.so.6.1
/data/data/com.termux/files/usr/lib/libncursesw.so
/data/data/com.termux/files/usr/lib/libncursesw.so.6
/data/data/com.termux/files/usr/lib/libncursesw.so.6.1
/data/data/com.termux/files/usr/lib/libpanel.so
/data/data/com.termux/files/usr/lib/libpanel.so.6
/data/data/com.termux/files/usr/lib/libpanel.so.6.0
/data/data/com.termux/files/usr/lib/libpanel.so.6.1
/data/data/com.termux/files/usr/lib/libpanelw.so
/data/data/com.termux/files/usr/lib/libpanelw.so.6
/data/data/com.termux/files/usr/lib/libpanelw.so.6.1
$
```

Use bash string manipulation instead of silly `echo` + `sed`.
Use more precise search patterns.
No manipulation was ever needed in the pkgconfig line.

Also create versioned libcurses symlinks.