### PR TITLE
Add root check to pkg

### DIFF
--- a/packages/termux-tools/pkg
+++ b/packages/termux-tools/pkg
@@ -18,6 +18,14 @@ show_help() {
 	exit 1
 }
 
+assert_not_root() {
+  if [ $(id -u) -eq 0 ]
+  then
+    echo "This must NOT be run as root as it will break your environment (root will be required for nearly everything due to changed file permissions)"
+    exit 1
+  fi
+}
+
 if [ $# = 0 ]; then show_help; fi
 CMD="$1"
 shift 1
@@ -25,14 +33,14 @@ shift 1
 case "$CMD" in
 	f*) dpkg -L $@;;
 	h*) show_help;;
-	add|i*) apt update; apt install $@;;
+	add|i*) assert_not_root; apt update; apt install $@;;
 	list-a*) apt list $@;;
 	list-i*) apt list --installed $@;;
-	re*) apt install --reinstall $@;;
-	se*) apt update; apt search $@;;
+	re*) assert_not_root; apt install --reinstall $@;;
+	se*) assert_not_root; apt update; apt search $@;;
 	sh*) apt show $@;;
-	un*|rem*|rm|del*) apt remove $@;;
-	up*) apt update; apt full-upgrade;;
+	un*|rem*|rm|del*) assert_not_root; apt remove $@;;
+	up*) assert_not_root; apt update; apt full-upgrade;;
 	*) echo "Unknown command: '$CMD' (run 'pkg help' for usage information)";;
 esac
 


### PR DESCRIPTION
This prevents users from using "su pkg ..." which breaks permissions. This prevents things like https://github.com/termux/termux-app/issues/542.