### PR TITLE
Allow TERMUX_PKG_SRCURL and TERMUX_PKG_SHA256 to be arrays

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -473,23 +473,36 @@ termux_step_extract_package() {
 		return
 	fi
 	cd "$TERMUX_PKG_TMPDIR"
-	local filename
-	filename=$(basename "$TERMUX_PKG_SRCURL")
-	local file="$TERMUX_PKG_CACHEDIR/$filename"
-	termux_download "$TERMUX_PKG_SRCURL" "$file" "$TERMUX_PKG_SHA256"
-
-	local folder
-	set +o pipefail
-	if [ "${file##*.}" = zip ]; then
-		folder=`unzip -qql "$file" | head -n1 | tr -s ' ' | cut -d' ' -f5-`
-		rm -Rf $folder
-		unzip -q "$file"
-		mv $folder "$TERMUX_PKG_SRCDIR"
-	else
-		mkdir "$TERMUX_PKG_SRCDIR"
-		tar xf "$file" -C "$TERMUX_PKG_SRCDIR" --strip-components=1
+	local PKG_SRCURL=(${TERMUX_PKG_SRCURL[@]})
+	local PKG_SHA256=(${TERMUX_PKG_SHA256[@]})
+	if  [ ! ${#PKG_SRCURL[@]} == ${#PKG_SHA256[@]} ] && [ ! ${#PKG_SHA256[@]} == 0 ]; then
+		termux_error_exit "Error: length of TERMUX_PKG_SRCURL isn't equal to length of TERMUX_PKG_SHA256."
 	fi
-	set -o pipefail
+	# STRIP=1 extracts archives straight into TERMUX_PKG_SRCDIR while STRIP=0 puts them in subfolders. zip has same behaviour per default
+	# If this isn't desired then this can be fixed in termux_step_post_extract.
+	local STRIP=1
+	for i in $(seq 0 $(( ${#PKG_SRCURL[@]}-1 ))); do
+		test $i -gt 0 && STRIP=0
+		local filename=$(basename "${PKG_SRCURL[$i]}")
+		local file="$TERMUX_PKG_CACHEDIR/$filename"
+		# Allow TERMUX_PKG_SHA256 to be empty:
+		set +u
+		termux_download "${PKG_SRCURL[$i]}" "$file" "${PKG_SHA256[$i]}"
+		set -u
+
+		local folder
+		set +o pipefail
+		if [ "${file##*.}" = zip ]; then
+			folder=`unzip -qql "$file" | head -n1 | tr -s ' ' | cut -d' ' -f5-`
+			rm -Rf $folder
+			unzip -q "$file"
+			mv $folder "$TERMUX_PKG_SRCDIR"
+		else
+			mkdir -p "$TERMUX_PKG_SRCDIR"
+			tar xf "$file" -C "$TERMUX_PKG_SRCDIR" --strip-components=$STRIP
+		fi
+		set -o pipefail
+	done
 }
 
 # Hook for packages to act just after the package has been extracted.

--- a/packages/bash/build.sh
+++ b/packages/bash/build.sh
@@ -16,7 +16,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" bash_cv_unusable_rtsigs=no"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" bash_cv_dev_fd=whacky"
 # Bash assumes that getcwd is broken and provides a wrapper which
 # does not work when not all parent directories up to root are
-# accessible, which they are no under Android (/data). See
+# accessible, which they are not under Android (/data). See
 # - http://permalink.gmane.org/gmane.linux.embedded.yocto.general/25204
 # - https://github.com/termux/termux-app/issues/200
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" bash_cv_getcwd_malloc=yes"

--- a/packages/ecj/build.sh
+++ b/packages/ecj/build.sh
@@ -1,8 +1,10 @@
 TERMUX_PKG_HOMEPAGE=http://www.eclipse.org/jdt/core/
 TERMUX_PKG_DESCRIPTION="Eclipse Compiler for Java"
 TERMUX_PKG_VERSION=4.6.2
+_date=201611241400
 TERMUX_PKG_REVISION=3
-TERMUX_PKG_SRCURL=http://eclipse.mirror.wearetriple.com/eclipse/downloads/drops4/R-4.6.2-201611241400/ecj-4.6.2.jar
+TERMUX_PKG_SRCURL=http://eclipse.mirror.wearetriple.com/eclipse/downloads/drops${TERMUX_PKG_VERSION:0:1}/R-${TERMUX_PKG_VERSION}-${_date}/ecj-${TERMUX_PKG_VERSION}.jar
+TERMUX_PKG_SHA256=9953dc2be829732e1b939106a71de018f660891220dbca559a5c7bff84883e51
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 
 termux_step_extract_package () {
@@ -13,7 +15,7 @@ termux_step_make () {
 	RAW_JAR=$TERMUX_PKG_CACHEDIR/ecj-${TERMUX_PKG_VERSION}.jar
 	if [ ! -f $RAW_JAR ]; then
 		termux_download $TERMUX_PKG_SRCURL $RAW_JAR \
-			9953dc2be829732e1b939106a71de018f660891220dbca559a5c7bff84883e51
+			$TERMUX_PKG_SHA256
 	fi
 
         mkdir -p $TERMUX_PREFIX/share/{dex,java}

--- a/packages/elfutils/build.sh
+++ b/packages/elfutils/build.sh
@@ -1,8 +1,11 @@
 TERMUX_PKG_HOMEPAGE=https://sourceware.org/elfutils/
 TERMUX_PKG_DESCRIPTION="ELF object file access library"
-TERMUX_PKG_VERSION=0.170
-TERMUX_PKG_SHA256=1f844775576b79bdc9f9c717a50058d08620323c1e935458223a12f249c9e066
-TERMUX_PKG_SRCURL=ftp://sourceware.org/pub/elfutils/${TERMUX_PKG_VERSION}/elfutils-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_VERSION=(0.170
+		    1.3)
+TERMUX_PKG_SHA256=(1f844775576b79bdc9f9c717a50058d08620323c1e935458223a12f249c9e066
+		   dec79694da1319acd2238ce95df57f3680fea2482096e483323fddf3d818d8be)
+TERMUX_PKG_SRCURL=(ftp://sourceware.org/pub/elfutils/${TERMUX_PKG_VERSION}/elfutils-${TERMUX_PKG_VERSION}.tar.bz2
+		   http://www.lysator.liu.se/~nisse/archive/argp-standalone-${TERMUX_PKG_VERSION[1]}.tar.gz)
 # libandroid-support for langinfo.
 TERMUX_PKG_DEPENDS="libandroid-support, liblzma, libbz2"
 TERMUX_PKG_CLANG=no
@@ -21,15 +24,7 @@ termux_step_pre_configure() {
 
 	CFLAGS+=" -DFNM_EXTMATCH=0"
 
-	# Install argp lib.
-	ARGP_FILE=$TERMUX_PKG_CACHEDIR/argp-standalone.1.3.tar.gz
-	termux_download http://www.lysator.liu.se/~nisse/archive/argp-standalone-1.3.tar.gz \
-	                $ARGP_FILE \
-	                dec79694da1319acd2238ce95df57f3680fea2482096e483323fddf3d818d8be
-
-	cd $TERMUX_PKG_TMPDIR
-	tar xf $ARGP_FILE
-	cd argp-standalone-1.3
+	cd argp-standalone-${TERMUX_PKG_VERSION[1]}
 	ORIG_CFLAGS="$CFLAGS"
 	CFLAGS+=" -std=gnu89"
 	./configure --host=$TERMUX_HOST_PLATFORM
@@ -41,6 +36,6 @@ termux_step_pre_configure() {
 	cp $TERMUX_PKG_BUILDER_DIR/obstack.h .
 	cp $TERMUX_PKG_BUILDER_DIR/qsort_r.h .
 
-	LDFLAGS+=" -L$TERMUX_PKG_TMPDIR/argp-standalone-1.3"
-	CPPFLAGS+=" -isystem $TERMUX_PKG_TMPDIR/argp-standalone-1.3"
+	LDFLAGS+=" -L$TERMUX_PKG_SRCDIR/argp-standalone-${TERMUX_PKG_VERSION[1]}"
+	CPPFLAGS+=" -isystem $TERMUX_PKG_SRCDIR/argp-standalone-${TERMUX_PKG_VERSION[1]}"
 }

--- a/packages/libgc/build.sh
+++ b/packages/libgc/build.sh
@@ -1,18 +1,14 @@
 TERMUX_PKG_HOMEPAGE=http://www.hboehm.info/gc/
 TERMUX_PKG_DESCRIPTION="Library providing the Boehm-Demers-Weiser conservative garbage collector"
-TERMUX_PKG_VERSION=7.6.4
-TERMUX_PKG_SHA256=b94c1f2535f98354811ee644dccab6e84a0cf73e477ca03fb5a3758fb1fecd1c
-TERMUX_PKG_SRCURL=https://github.com/ivmai/bdwgc/releases/download/v$TERMUX_PKG_VERSION/gc-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_VERSION=(7.6.4
+		    7.6.4)
+TERMUX_PKG_SHA256=(b94c1f2535f98354811ee644dccab6e84a0cf73e477ca03fb5a3758fb1fecd1c
+		   5b823d5a685dd70caeef8fc50da7d763ba7f6167fe746abca7762e2835b3dd4e)
+TERMUX_PKG_SRCURL=(https://github.com/ivmai/bdwgc/releases/download/v$TERMUX_PKG_VERSION/gc-$TERMUX_PKG_VERSION.tar.gz
+		   https://github.com/ivmai/libatomic_ops/releases/download/v${TERMUX_PKG_VERSION[1]}/libatomic_ops-${TERMUX_PKG_VERSION[1]}.tar.gz)
 TERMUX_PKG_RM_AFTER_INSTALL="share/gc"
 
 termux_step_post_extract_package () {
-	LIBATOMIC_VERSION=7.6.4
-	LIBATOMIC_FILE=libatomic_ops-${LIBATOMIC_VERSION}.tar.gz
-	termux_download \
-		https://github.com/ivmai/libatomic_ops/releases/download/v${LIBATOMIC_VERSION}/libatomic_ops-${LIBATOMIC_VERSION}.tar.gz \
-		$TERMUX_PKG_CACHEDIR/$LIBATOMIC_FILE \
-		5b823d5a685dd70caeef8fc50da7d763ba7f6167fe746abca7762e2835b3dd4e
-	tar xf $TERMUX_PKG_CACHEDIR/$LIBATOMIC_FILE
-	mv libatomic_ops-${LIBATOMIC_VERSION} libatomic_ops
+	mv libatomic_ops-${TERMUX_PKG_VERSION[1]} libatomic_ops
 	./autogen.sh
 }

--- a/packages/libllvm/build.sh
+++ b/packages/libllvm/build.sh
@@ -3,8 +3,14 @@ TERMUX_PKG_DESCRIPTION="Modular compiler and toolchain technologies library"
 _PKG_MAJOR_VERSION=6.0
 TERMUX_PKG_VERSION=${_PKG_MAJOR_VERSION}.0
 TERMUX_PKG_REVISION=2
-TERMUX_PKG_SHA256=1ff53c915b4e761ef400b803f07261ade637b0c269d99569f18040f3dcee4408
-TERMUX_PKG_SRCURL=https://releases.llvm.org/${TERMUX_PKG_VERSION}/llvm-${TERMUX_PKG_VERSION}.src.tar.xz
+TERMUX_PKG_SHA256=(1ff53c915b4e761ef400b803f07261ade637b0c269d99569f18040f3dcee4408
+		   e07d6dd8d9ef196cfc8e8bb131cbd6a2ed0b1caf1715f9d05b0f0eeaddb6df32
+		   6b8c4a833cf30230c0213d78dbac01af21387b298225de90ab56032ca79c0e0b
+		   7c0e050d5f7da3b057579fb3ea79ed7dc657c765011b402eb5bbe5663a7c38fc)
+TERMUX_PKG_SRCURL=(https://releases.llvm.org/${TERMUX_PKG_VERSION}/llvm-${TERMUX_PKG_VERSION}.src.tar.xz
+		   https://releases.llvm.org/${TERMUX_PKG_VERSION}/cfe-${TERMUX_PKG_VERSION}.src.tar.xz
+		   https://llvm.org/releases/${TERMUX_PKG_VERSION}/lld-${TERMUX_PKG_VERSION}.src.tar.xz
+		   https://releases.llvm.org/${TERMUX_PKG_VERSION}/openmp-${TERMUX_PKG_VERSION}.src.tar.xz)
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_RM_AFTER_INSTALL="
 bin/clang-check
@@ -47,30 +53,9 @@ TERMUX_PKG_FORCE_CMAKE=yes
 TERMUX_PKG_KEEP_STATIC_LIBRARIES=true
 
 termux_step_post_extract_package () {
-	local CLANG_SRC_TAR=cfe-${TERMUX_PKG_VERSION}.src.tar.xz
-	termux_download \
-		https://releases.llvm.org/${TERMUX_PKG_VERSION}/$CLANG_SRC_TAR \
-		$TERMUX_PKG_CACHEDIR/$CLANG_SRC_TAR \
-		e07d6dd8d9ef196cfc8e8bb131cbd6a2ed0b1caf1715f9d05b0f0eeaddb6df32
-
-	tar -xf $TERMUX_PKG_CACHEDIR/$CLANG_SRC_TAR -C tools
-	mv tools/cfe-${TERMUX_PKG_VERSION}.src tools/clang
-
-	local LLD_SRC_TAR=lld-${TERMUX_PKG_VERSION}.src.tar.xz
-	termux_download \
-		https://llvm.org/releases/${TERMUX_PKG_VERSION}/$LLD_SRC_TAR \
-		$TERMUX_PKG_CACHEDIR/$LLD_SRC_TAR \
-		6b8c4a833cf30230c0213d78dbac01af21387b298225de90ab56032ca79c0e0b
-
-	tar -xf $TERMUX_PKG_CACHEDIR/$LLD_SRC_TAR -C tools
-	mv tools/lld-${TERMUX_PKG_VERSION}.src tools/lld
-	local OPENMP_SRC_TAR=openmp-${TERMUX_PKG_VERSION}.src.tar.xz
-	termux_download \
-		http://releases.llvm.org/${TERMUX_PKG_VERSION}/$OPENMP_SRC_TAR \
-		$TERMUX_PKG_CACHEDIR/$OPENMP_SRC_TAR \
-		7c0e050d5f7da3b057579fb3ea79ed7dc657c765011b402eb5bbe5663a7c38fc
-	tar -xf $TERMUX_PKG_CACHEDIR/$OPENMP_SRC_TAR -C projects
-	mv projects/openmp-${TERMUX_PKG_VERSION}.src projects/openmp
+	mv cfe-${TERMUX_PKG_VERSION}.src tools/clang
+	mv lld-${TERMUX_PKG_VERSION}.src tools/lld
+	mv openmp-${TERMUX_PKG_VERSION}.src projects/openmp
 }
 
 termux_step_host_build () {

--- a/packages/linux-man-pages/build.sh
+++ b/packages/linux-man-pages/build.sh
@@ -1,8 +1,11 @@
 TERMUX_PKG_HOMEPAGE=https://www.kernel.org/doc/man-pages/
 TERMUX_PKG_DESCRIPTION="Man pages for linux kernel and C library interfaces"
-TERMUX_PKG_VERSION=4.16
-TERMUX_PKG_SHA256=47ffcc0d27d50e497e290b27e8d76dbed4550db14c881f25b771bcaf28354db4
-TERMUX_PKG_SRCURL=https://www.kernel.org/pub/linux/docs/man-pages/man-pages-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_VERSION=(4.16
+		    2013)
+TERMUX_PKG_SHA256=(47ffcc0d27d50e497e290b27e8d76dbed4550db14c881f25b771bcaf28354db4
+		   19633a5c75ff7deab35b1d2c3d5b7748e7bd4ef4ab598b647bb7e7f60b90a808)
+TERMUX_PKG_SRCURL=(https://www.kernel.org/pub/linux/docs/man-pages/man-pages-${TERMUX_PKG_VERSION}.tar.xz
+		   https://www.kernel.org/pub/linux/docs/man-pages/man-pages-posix/man-pages-posix-${TERMUX_PKG_VERSION[1]}-a.tar.xz)
 TERMUX_PKG_DEPENDS="man"
 TERMUX_PKG_EXTRA_MAKE_ARGS="prefix=$TERMUX_PREFIX"
 # man.7 and mdoc.7 is included with mandoc:
@@ -15,17 +18,6 @@ TERMUX_MAKE_PROCESSSES=1
 
 termux_step_pre_configure() {
 	# Bundle posix man pages in same package:
-	local _POSIX_TARFILE=man-pages-posix-2013-a.tar.xz
-	if [ ! -f $TERMUX_PKG_CACHEDIR/$_POSIX_TARFILE ]; then
-		termux_download \
-			https://www.kernel.org/pub/linux/docs/man-pages/man-pages-posix/$_POSIX_TARFILE \
-			$TERMUX_PKG_CACHEDIR/$_POSIX_TARFILE \
-			19633a5c75ff7deab35b1d2c3d5b7748e7bd4ef4ab598b647bb7e7f60b90a808
-
-	fi
-	mkdir -p $TERMUX_PKG_TMPDIR/man-pages-posix
-	cd $TERMUX_PKG_TMPDIR/man-pages-posix
-	tar xf $TERMUX_PKG_CACHEDIR/$_POSIX_TARFILE
 	cd man-pages-posix-2013-a
 	make install
 }

--- a/packages/ncurses/build.sh
+++ b/packages/ncurses/build.sh
@@ -1,8 +1,11 @@
 TERMUX_PKG_HOMEPAGE=http://invisible-island.net/ncurses/
 TERMUX_PKG_DESCRIPTION="Library for text-based user interfaces in a terminal-independent manner"
-TERMUX_PKG_VERSION=6.1.20180512
-TERMUX_PKG_SHA256=a0c7b776702f504200f2beb78c6f798532a8c345506aa634a57e67094316610d
-TERMUX_PKG_SRCURL=https://dl.bintray.com/termux/upstream/ncurses-${TERMUX_PKG_VERSION:0:3}-${TERMUX_PKG_VERSION:4}.tgz
+TERMUX_PKG_VERSION=(6.1.20180512
+		    9.22)
+TERMUX_PKG_SHA256=(a0c7b776702f504200f2beb78c6f798532a8c345506aa634a57e67094316610d
+		   e94628e9bcfa0adb1115d83649f898d6edb4baced44f5d5b769c2eeb8b95addd)
+TERMUX_PKG_SRCURL=(https://dl.bintray.com/termux/upstream/ncurses-${TERMUX_PKG_VERSION:0:3}-${TERMUX_PKG_VERSION:4}.tgz
+		   https://fossies.org/linux/misc/rxvt-unicode-${TERMUX_PKG_VERSION[1]}.tar.bz2)
 # --without-normal disables static libraries:
 # --disable-stripping to disable -s argument to install which does not work when cross compiling:
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
@@ -76,12 +79,5 @@ termux_step_post_massage () {
 	cp $TERMUX_PKG_TMPDIR/full-terminfo/v/{vt52,vt100,vt102} $TI/v/
 	cp $TERMUX_PKG_TMPDIR/full-terminfo/x/xterm{,-color,-new,-16color,-256color,+256color} $TI/x/
 
-	local RXVT_TAR=$TERMUX_PKG_CACHEDIR/rxvt-unicode-9.22.tar.bz2
-	termux_download https://fossies.org/linux/misc/rxvt-unicode-9.22.tar.bz2 \
-		$RXVT_TAR \
-		e94628e9bcfa0adb1115d83649f898d6edb4baced44f5d5b769c2eeb8b95addd
-	cd $TERMUX_PKG_TMPDIR
-	local TI_FILE=rxvt-unicode-9.22/doc/etc/rxvt-unicode.terminfo
-	tar xf $RXVT_TAR $TI_FILE
-	tic -x -o $TI $TI_FILE
+	tic -x -o $TI $TERMUX_PKG_SRCDIR/rxvt-unicode-${TERMUX_PKG_VERSION[1]}/doc/etc/rxvt-unicode.terminfo
 }

--- a/packages/perl/build.sh
+++ b/packages/perl/build.sh
@@ -17,9 +17,8 @@ termux_step_post_extract_package () {
 
 	# Remove old installation to force fresh:
 	rm -rf $TERMUX_PREFIX/lib/perl5
-
-	# Export variable used by Kid.pm.patch:
-	export TERMUX_PKG_SRCDIR
+	rm -f $TERMUX_PREFIX/lib/libperl.so
+	rm -f $TERMUX_PREFIX/include/perl
 }
 
 termux_step_configure () {

--- a/packages/perl/build.sh
+++ b/packages/perl/build.sh
@@ -1,8 +1,11 @@
 TERMUX_PKG_HOMEPAGE=https://www.perl.org/
 TERMUX_PKG_DESCRIPTION="Capable, feature-rich programming language"
-TERMUX_PKG_VERSION=5.26.2
-TERMUX_PKG_SHA256=572f9cea625d6062f8a63b5cee9d3ee840800a001d2bb201a41b9a177ab7f70d
-TERMUX_PKG_SRCURL=http://www.cpan.org/src/5.0/perl-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_VERSION=(5.26.2
+		    1.1.9)
+TERMUX_PKG_SHA256=(572f9cea625d6062f8a63b5cee9d3ee840800a001d2bb201a41b9a177ab7f70d
+		   0bbb450e48d07e7fdf867d578b1780ac8f0e8dc284d52301dac4d763b42f6041)
+TERMUX_PKG_SRCURL=(http://www.cpan.org/src/5.0/perl-${TERMUX_PKG_VERSION}.tar.gz
+		   https://github.com/arsv/perl-cross/releases/download/${TERMUX_PKG_VERSION[1]}/perl-cross-${TERMUX_PKG_VERSION[1]}.tar.gz)
 TERMUX_PKG_BUILD_IN_SRC="yes"
 TERMUX_MAKE_PROCESSES=1
 TERMUX_PKG_RM_AFTER_INSTALL="bin/perl${TERMUX_PKG_VERSION}"
@@ -10,18 +13,7 @@ TERMUX_PKG_NO_DEVELSPLIT=yes
 
 termux_step_post_extract_package () {
 	# This port uses perl-cross: http://arsv.github.io/perl-cross/
-	local PERLCROSS_VERSION=1.1.9
-	local PERLCROSS_SHA256=0bbb450e48d07e7fdf867d578b1780ac8f0e8dc284d52301dac4d763b42f6041
-	local PERLCROSS_FILE=perl-cross-${PERLCROSS_VERSION}.tar.gz
-	local PERLCROSS_TAR=$TERMUX_PKG_CACHEDIR/$PERLCROSS_FILE
-	if [ ! -f $PERLCROSS_TAR ]; then
-		termux_download https://github.com/arsv/perl-cross/releases/download/$PERLCROSS_VERSION/$PERLCROSS_FILE \
-		                $PERLCROSS_TAR \
-		                $PERLCROSS_SHA256
-	fi
-	tar xf $PERLCROSS_TAR
-	cd perl-cross-${PERLCROSS_VERSION}
-	cp -Rf * ../
+	cp -rf perl-cross-${TERMUX_PKG_VERSION[1]}/* .
 
 	# Remove old installation to force fresh:
 	rm -rf $TERMUX_PREFIX/lib/perl5

--- a/packages/pngquant/build.sh
+++ b/packages/pngquant/build.sh
@@ -1,21 +1,17 @@
 TERMUX_PKG_HOMEPAGE=https://pngquant.org
 TERMUX_PKG_DESCRIPTION="PNG image optimising utility"
 TERMUX_PKG_VERSION=2.11.7
-TERMUX_PKG_SHA256=0ca09a1f253b264e5aab8477b7f0e3cde51d9f88ed668b38ae057ced24076bda
-TERMUX_PKG_SRCURL=https://github.com/pornel/pngquant/archive/$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=(0ca09a1f253b264e5aab8477b7f0e3cde51d9f88ed668b38ae057ced24076bda
+		   6b912616cfb60c5ff49f316649e1279bd7a1d797d6ace0bdbb532ebdf778a8bd)
+# If both archives are .tar.gz then they overwrite eachother since they are the same version and hence the same name.
+# Work around this by using .zip for one of them...
+TERMUX_PKG_SRCURL=(https://github.com/pornel/pngquant/archive/$TERMUX_PKG_VERSION.tar.gz
+		   https://github.com/ImageOptim/libimagequant/archive/$TERMUX_PKG_VERSION.zip)
 TERMUX_PKG_DEPENDS="libpng"
 TERMUX_PKG_MAINTAINER="Vishal Biswas @vishalbiswas"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-sse"
 
 termux_step_post_extract_package () {
-	local LIBIMAGEQUANT_SRC_FOLDER=libimagequant-$TERMUX_PKG_VERSION
-	termux_download \
-		https://github.com/ImageOptim/libimagequant/archive/$TERMUX_PKG_VERSION.tar.gz \
-		$TERMUX_PKG_CACHEDIR/$LIBIMAGEQUANT_SRC_FOLDER.tar.gz \
-		aa5c9ae93f245f6703ca3f15c0ffe1ba647f66aac87bbfea0b58ebae9a4e37b5
-
-	tar -xf $TERMUX_PKG_CACHEDIR/$LIBIMAGEQUANT_SRC_FOLDER.tar.gz -C $TERMUX_PKG_SRCDIR
-	rmdir $TERMUX_PKG_SRCDIR/lib
-	mv $TERMUX_PKG_SRCDIR/$LIBIMAGEQUANT_SRC_FOLDER $TERMUX_PKG_SRCDIR/lib
+	mv $TERMUX_PKG_SRCDIR/libimagequant-$TERMUX_PKG_VERSION/* $TERMUX_PKG_SRCDIR/lib/
 }


### PR DESCRIPTION
Packages that require several source archives can then specify these in the same variables instead of downloading them in termux_step_post_extract. 

I've verified that all the packages with changes here generate the same file tree by comparing massage folders with `diff -q -r`. 