### PR TITLE
fix for preprocessing assembly with -fno-integrated-as

### DIFF
--- a/packages/binutils/build.sh
+++ b/packages/binutils/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/binutils/
 TERMUX_PKG_DESCRIPTION="Collection of binary tools, the main ones being ld, the GNU linker, and as, the GNU assembler"
 TERMUX_PKG_VERSION=2.30
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/binutils/binutils-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-gold --enable-plugins --disable-werror --with-system-zlib --enable-new-dtags"
 TERMUX_PKG_SHA256=8c3850195d1c093d290a716e20ebcaa72eda32abf5e3d8611154b39cff79e9ea

--- a/packages/binutils/input-file.c.patch
+++ b/packages/binutils/input-file.c.patch
@@ -1,0 +1,14 @@
+--- ../cache/binutils-2.30/gas/input-file.c	2018-01-13 13:31:15.000000000 +0000
++++ ./gas/input-file.c	2018-06-13 02:20:54.522178962 +0000
+@@ -188,10 +188,8 @@
+ 	  else
+ 	    ungetc ('\n', f_in);
+ 	}
+-      else if (c == '\n')
++      else (fgets (buf, sizeof (buf), f_in));
+ 	ungetc ('\n', f_in);
+-      else
+-	ungetc ('#', f_in);
+     }
+   else
+     ungetc (c, f_in);


### PR DESCRIPTION
For things that require gnu as. 