### PR TITLE
build-package.sh: don't set TERMUX_PKG_REPLACES for debug builds

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -411,8 +411,6 @@ termux_step_start_build() {
 			echo "$TERMUX_PKG_NAME@$TERMUX_PKG_FULLVERSION built - skipping (rm /data/data/.built-packages/$TERMUX_PKG_NAME to force rebuild)"
 			exit 0
 		fi
-	else
-		export TERMUX_PKG_REPLACES=${TERMUX_PKG_NAME}
 	fi
 
 	# Cleanup old state:


### PR DESCRIPTION
It was introduced in c18051e78118966e4a4d77cb1638d767822eca66. It didn't work as expected.