### PR TITLE
libcairo: don't use XCB if present

### DIFF
--- a/packages/libcairo/build.sh
+++ b/packages/libcairo/build.sh
@@ -8,5 +8,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 ac_cv_lib_lzo2_lzo2a_decompress=no
 --disable-gtk-doc-html
 --enable-xlib=no
+--enable-xcb=no
 "
 TERMUX_PKG_RM_AFTER_INSTALL="share/gtk-doc/html"


### PR DESCRIPTION
If libxcb is present (when building X-enabled packages), I'm getting errors:
```
/home/builder/.termux-build/libcairo/build/src/.libs/libcairo.so: error: undefined reference to 'shmat'
/home/builder/.termux-build/libcairo/build/src/.libs/libcairo.so: error: undefined reference to 'shmctl'
/home/builder/.termux-build/libcairo/build/src/.libs/libcairo.so: error: undefined reference to 'shmdt'
/home/builder/.termux-build/libcairo/build/src/.libs/libcairo.so: error: undefined reference to 'shmget'
```
because of XCB-SHM feature being enabled.

This patch disables all XCB-related stuff, it is not needed for official build anyway.