### PR TITLE
nzbget: Update from 19.1 to 20.0

### DIFF
--- a/packages/nzbget/build.sh
+++ b/packages/nzbget/build.sh
@@ -1,16 +1,18 @@
 TERMUX_PKG_HOMEPAGE=https://nzbget.net/
 TERMUX_PKG_DESCRIPTION="The most efficient usenet downloader"
-TERMUX_PKG_VERSION=19.1
+TERMUX_PKG_VERSION=20.0
 TERMUX_PKG_SRCURL=https://github.com/nzbget/nzbget/releases/download/v${TERMUX_PKG_VERSION}/nzbget-${TERMUX_PKG_VERSION}-src.tar.gz
-TERMUX_PKG_SHA256=06df42356ac2d63bbc9f7861abe9c3216df56fa06802e09e8a50b05f4ad95ce6
+TERMUX_PKG_SHA256=04dc36d432549c33d55145ecd95cc4309b3ab4a7731a1a03d954de389eacd06f
 TERMUX_PKG_DEPENDS="libxml2, ncurses, openssl, unrar, p7zip"
 TERMUX_PKG_BUILD_IN_SRC=yes
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="ac_cv_c_bigendian=no"
 
 termux_step_create_debscripts () {
 	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo "if [ -z \"\$2\" ]; then" >> postinst # Run only on fresh install, not on upgrade
 	echo "sed -e 's|^\(CertStore=\).*|\1$TERMUX_PREFIX/etc/tls/cert.pem|g" >> postinst
-	echo "s|^\(ControlPassword=\).*|\1|g' $TERMUX_PREFIX/share/nzbget/nzbget.conf > ~/.nzbget" >> postinst
+	echo "s|^\(ControlPassword=\).*|\1|g' $TERMUX_PREFIX/share/nzbget/nzbget.conf > $TERMUX_PREFIX/etc/nzbget.conf" >> postinst
+	echo "fi" >> postinst
 	echo "exit 0" >> postinst
 	chmod 0755 postinst
 }

--- a/packages/nzbget/nzbget.cpp.patch
+++ b/packages/nzbget/nzbget.cpp.patch
@@ -1,5 +1,5 @@
 diff --git a/daemon/main/nzbget.cpp b/daemon/main/nzbget.cpp
-index 1cfa105..b5cee58 100644
+index c4f27721..aabf69cc 100644
 --- a/daemon/main/nzbget.cpp
 +++ b/daemon/main/nzbget.cpp
 @@ -19,6 +19,8 @@
@@ -11,7 +11,7 @@ index 1cfa105..b5cee58 100644
  #include "nzbget.h"
  #include "ServerPool.h"
  #include "Log.h"
-@@ -913,7 +915,7 @@ void NZBGet::Daemonize()
+@@ -932,7 +934,7 @@ void NZBGet::Daemonize()
  			error("Starting daemon failed: could not create lock-file %s", m_options->GetLockFile());
  			exit(1);
  		}

--- a/packages/nzbget/nzbget.h.patch
+++ b/packages/nzbget/nzbget.h.patch
@@ -1,0 +1,14 @@
+diff --git a/daemon/main/nzbget.h b/daemon/main/nzbget.h
+index bfaf03b9..eeb4445c 100644
+--- a/daemon/main/nzbget.h
++++ b/daemon/main/nzbget.h
+@@ -254,7 +254,9 @@ typedef int pid_t;
+ #include <openssl/sha.h>
+ #include <openssl/pem.h>
+ #include <openssl/x509v3.h>
++#ifndef OPENSSL_NO_COMP
+ #include <openssl/comp.h>
++#endif
+ #endif /* HAVE_OPENSSL */
+ 
+ #ifdef HAVE_REGEX_H

--- a/packages/nzbget/options.cpp.patch
+++ b/packages/nzbget/options.cpp.patch
@@ -1,5 +1,5 @@
 diff --git a/daemon/main/Options.cpp b/daemon/main/Options.cpp
-index f41bd82..6a3dc0e 100644
+index f41bd824..50fa8dd9 100644
 --- a/daemon/main/Options.cpp
 +++ b/daemon/main/Options.cpp
 @@ -182,10 +182,7 @@ const int BoolCount = 12;

--- a/packages/nzbget/thread.cpp.patch
+++ b/packages/nzbget/thread.cpp.patch
@@ -1,17 +1,16 @@
 diff --git a/daemon/util/Thread.cpp b/daemon/util/Thread.cpp
-index 199005f..61b5bcb 100644
+index 199005ff..e922c402 100644
 --- a/daemon/util/Thread.cpp
 +++ b/daemon/util/Thread.cpp
-@@ -111,7 +111,7 @@ void Thread::Start()
+@@ -111,7 +111,6 @@ void Thread::Start()
  	pthread_attr_t m_attr;
  	pthread_attr_init(&m_attr);
  	pthread_attr_setdetachstate(&m_attr, PTHREAD_CREATE_DETACHED);
 -	pthread_attr_setinheritsched(&m_attr, PTHREAD_INHERIT_SCHED);
-+	//pthread_attr_setinheritsched(&m_attr, PTHREAD_INHERIT_SCHED);
  	m_running = !pthread_create(&m_threadObj, &m_attr, Thread::thread_handler, (void *) this);
  	pthread_attr_destroy(&m_attr);
  #endif
-@@ -140,7 +140,7 @@ bool Thread::Kill()
+@@ -140,7 +139,7 @@ bool Thread::Kill()
  #ifdef WIN32
  	bool terminated = TerminateThread(m_threadObj, 0) != 0;
  #else

--- a/packages/nzbget/tlssocket.cpp.patch
+++ b/packages/nzbget/tlssocket.cpp.patch
@@ -1,0 +1,14 @@
+diff --git a/daemon/connect/TlsSocket.cpp b/daemon/connect/TlsSocket.cpp
+index 158101e4..2d426f22 100644
+--- a/daemon/connect/TlsSocket.cpp
++++ b/daemon/connect/TlsSocket.cpp
+@@ -214,7 +214,9 @@ void TlsSocket::Final()
+ 	//ENGINE_cleanup();
+ 	CONF_modules_free();
+ 	CONF_modules_unload(1);
++#ifndef OPENSSL_NO_COMP
+ 	COMP_zlib_cleanup();
++#endif
+ 	ERR_free_strings();
+ 	EVP_cleanup();
+ 	CRYPTO_cleanup_all_ex_data();


### PR DESCRIPTION
Also fixes overwriting of config file during package upgrade. Use config in etc
as default instead (leaves config in users home to allow overriding).