### PR TITLE
make PS1 dynamic and shell-specific

### DIFF
--- a/packages/bash/etc-bash.bashrc
+++ b/packages/bash/etc-bash.bashrc
@@ -1,3 +1,5 @@
 command_not_found_handle() {
 	@TERMUX_PREFIX@/libexec/termux/command-not-found "$1"
 }
+
+PS1='\$ '

--- a/packages/openssh/session.c.patch
+++ b/packages/openssh/session.c.patch
@@ -1,5 +1,5 @@
 diff --git a/session.c.orig b/session.c
-index 58826db..c251ee9 100644
+index 58826db..890e452 100644
 --- a/session.c.orig
 +++ b/session.c
 @@ -199,7 +199,7 @@ auth_input_request_forwarding(struct ssh *ssh, struct passwd * pw)
@@ -36,7 +36,7 @@ index 58826db..c251ee9 100644
  		child_set_env(&env, &envsize, "TZ", getenv("TZ"));
  
 +#ifdef __ANDROID__
-+	char const* envs_to_keep[] = {"LD_LIBRARY_PATH", "PATH", "ANDROID_ROOT", "ANDROID_DATA", "EXTERNAL_STORAGE", "LANG", "PREFIX", "TMPDIR", "PS1"};
++	char const* envs_to_keep[] = {"LD_LIBRARY_PATH", "PATH", "ANDROID_ROOT", "ANDROID_DATA", "EXTERNAL_STORAGE", "LANG", "PREFIX", "TMPDIR"};
 +	for (i = 0; i < (sizeof(envs_to_keep) / sizeof(envs_to_keep[0])); i++) {
 +		char const* env_to_keep_name = envs_to_keep[i];
 +		char const* env_to_keep_value = getenv(env_to_keep_name);

--- a/packages/zsh/etc-zshrc
+++ b/packages/zsh/etc-zshrc
@@ -2,3 +2,5 @@ command_not_found_handler() {
 	@TERMUX_PREFIX@/libexec/termux/command-not-found $1
 	return 0
 }
+
+PS1='%# '


### PR DESCRIPTION
PS1 is not supposed to be an environment variable (i.e. will not
be listed in `printenv` but only in `set`). Its value should also
be shell-specific.

With this commit we can stop exporting a static PS1 as env var on
the java side.

The prompt would now indicate whether the current user is root.