### PR TITLE
Changed shells were not being recognized

### DIFF
--- a/packages/proot/termux-chroot
+++ b/packages/proot/termux-chroot
@@ -69,13 +69,14 @@ ARGS="$ARGS --cwd=/home"
 # Root of the file system:
 ARGS="$ARGS -r $PREFIX/.."
 
-export HOME=/home
-
 # Shell to execute:
 PROGRAM=/bin/bash
 if [ -x $HOME/.termux/shell ]; then
 	PROGRAM=`readlink -f $HOME/.termux/shell`
 fi
+
+export HOME=/home
+
 # Execute shell if no command has been supplied
 if [ -z "$1" ];then
 	ARGS="$ARGS $PROGRAM -l"


### PR DESCRIPTION
The check for a changed shell (e.g. by chsh) was correctly using $HOME/.termux/shell, but $HOME was being hardcoded to "/home" prior to the check.

Since most likely, $HOME is not yet "/home" (since the user is invoking termux-chroot) this test was failing to recognize changed shells (e.g. this failed with zsh).

Moving the assignment of HOME to /home after the shell has been read fixes this.