### PR TITLE
fixes gmic on arm by linking libz last not first

### DIFF
--- a/packages/gmic/makefile.patch
+++ b/packages/gmic/makefile.patch
@@ -1,7 +1,6 @@
-diff -u -r ../gmic-2.2.3/src/Makefile ./src/Makefile
---- ../gmic-2.2.3/src/Makefile	2018-05-16 13:18:08.000000000 +0000
-+++ ./src/Makefile	2018-05-18 22:44:33.038378433 +0000
-@@ -61,7 +61,7 @@
+--- ../cache/gmic-2.3.1/src/Makefile	2018-06-25 12:57:35.000000000 +0000
++++ ./src/Makefile	2018-06-27 05:33:59.637954036 +0000
+@@ -60,7 +60,7 @@
  
  # Try to auto-detect target OS.
  OS = $(shell uname)
@@ -10,18 +9,25 @@ diff -u -r ../gmic-2.2.3/src/Makefile ./src/Makefile
  LIB = lib
  BIN = bin
  INCLUDE = include
-@@ -136,9 +136,7 @@
- endif
+@@ -136,8 +136,6 @@
  
  ifdef NOSTRIP
--STRIP = echo skip strip
+ STRIP = echo skip strip
 -else
 -STRIP = strip
-+STRIP = echo skip stripe
  endif
  
  ifndef QMAKE
-@@ -190,7 +188,7 @@
+@@ -154,7 +152,7 @@
+ 
+ # Minimal set of flags mandatory to compile G'MIC.
+ MANDATORY_CFLAGS = -Dgmic_build -Dcimg_use_zlib `pkg-config --cflags zlib || echo -I$(USR)/$(INCLUDE)` $(PRERELEASE_CFLAGS) $(EXTRA_CFLAGS)
+-MANDATORY_LIBS = `pkg-config --libs zlib || echo -lz` $(EXTRA_LIBS)
++# MANDATORY_LIBS = `pkg-config --libs zlib || echo -lz` $(EXTRA_LIBS)
+ ifndef NO_SRIPDLIB
+ MANDATORY_CFLAGS += -std=c++11 -pedantic
+ endif
+@@ -189,7 +187,7 @@
  # Enable multi-threading support.
  PARALLEL_CFLAGS = -Dgmic_is_parallel
  ifneq ($(OS),Windows)
@@ -30,7 +36,25 @@ diff -u -r ../gmic-2.2.3/src/Makefile ./src/Makefile
  endif
  
  # Enable parallelization in CImg, using OpenMP.
-@@ -326,8 +324,8 @@
+@@ -238,7 +236,7 @@
+ # (http://www.libpng.org/pub/png/libpng.html)
+ ifneq ($(OS),Darwin)
+ PNG_CFLAGS = -Dcimg_use_png `pkg-config --cflags libpng`
+-PNG_LIBS = `pkg-config --libs libpng || echo -lpng -lz`
++PNG_LIBS = `echo -lpng`
+ else
+ ifeq (,$(wildcard /tmp/skl))
+ PNG_CFLAGS = -Dcimg_use_png `pkg-config --cflags libpng`
+@@ -277,7 +275,7 @@
+ # Enable support of most classical image file formats, using the GraphicsMagick++ library.
+ # (http://www.graphicsmagick.org/Magick++/)
+ MAGICK_CFLAGS = -Dcimg_use_magick `pkg-config --cflags GraphicsMagick++ || echo -I$(USR)/$(INCLUDE)/GraphicsMagick`
+-MAGICK_LIBS = `pkg-config --libs GraphicsMagick++ || echo -lGraphicsMagick++`
++MAGICK_LIBS = `echo -L/data/data/com.termux/files/usr/lib -lGraphicsMagick++ -lGraphicsMagick -lz`
+ 
+ # Enable native support of EXR image files, using the OpenEXR library.
+ # (http://www.openexr.com/)
+@@ -325,8 +323,8 @@
  GMIC_CLI_CFLAGS = $(MANDATORY_CFLAGS) $(ABORT_CFLAGS) $(PARALLEL_CFLAGS) $(FFTW_CFLAGS) $(CURL_CFLAGS) $(PNG_CFLAGS) $(JPEG_CFLAGS) $(TIFF_CFLAGS)
  GMIC_CLI_LIBS = $(MANDATORY_LIBS) $(PARALLEL_LIBS) $(FFTW_LIBS) $(CURL_LIBS) $(PNG_LIBS) $(JPEG_LIBS) $(TIFF_LIBS)
  ifeq ($(OS),Unix) # Unix.
@@ -41,7 +65,7 @@ diff -u -r ../gmic-2.2.3/src/Makefile ./src/Makefile
  else
  ifeq ($(OS),Darwin) # MacOSX.
  GMIC_CLI_CFLAGS += $(X11_CFLAGS) $(OPENEXR_CFLAGS) $(OPENCV_CFLAGS)
-@@ -339,8 +337,7 @@
+@@ -338,8 +336,7 @@
  endif
  
  cli:


### PR DESCRIPTION
this fixes gmic on arm breaking. You are meant to link the system libs last otherwise you get interfering unwind implementations and other weirdness. WIthout this gmic doesn't work on arm device. 