### PR TITLE
openssh: SendEnv LANG by default

### DIFF
--- a/packages/openssh/build.sh
+++ b/packages/openssh/build.sh
@@ -62,7 +62,7 @@ termux_step_post_make_install () {
 	# "PrintMotd no" is due to our login program already showing it.
 	# OpenSSH 7.0 disabled ssh-dss by default, keep it for a while in Termux:
 	echo -e "PrintMotd no\nPasswordAuthentication no\nPubkeyAcceptedKeyTypes +ssh-dss\nSubsystem sftp $TERMUX_PREFIX/libexec/sftp-server" > $TERMUX_PREFIX/etc/ssh/sshd_config
-	echo "PubkeyAcceptedKeyTypes +ssh-dss" > $TERMUX_PREFIX/etc/ssh/ssh_config
+	printf "PubkeyAcceptedKeyTypes +ssh-dss\nSendEnv LANG\n" > $TERMUX_PREFIX/etc/ssh/ssh_config
 	cp $TERMUX_PKG_BUILDER_DIR/source-ssh-agent.sh $TERMUX_PREFIX/bin/source-ssh-agent
 	cp $TERMUX_PKG_BUILDER_DIR/ssh-with-agent.sh $TERMUX_PREFIX/bin/ssha
 


### PR DESCRIPTION
many distributions use "AcceptEnv LANG LC_*" by default for sshd. this
fixes UTF-8 output from such servers that do not happen to set LANG or
LC_CTYPE to UTF-8 by default server-side (termux env already sets
LANG=en_US.UTF-8)

I did not actually build-test this (sorry), but it's quite a trivial change.