### PR TITLE
debootstrap: update to 1.0.106

### DIFF
--- a/packages/debootstrap/Makefile.patch
+++ b/packages/debootstrap/Makefile.patch
@@ -1,21 +1,20 @@
-diff --git a/Makefile b/Makefile
-index 8516803..0c61852 100644
---- a/Makefile
-+++ b/Makefile
-@@ -5,14 +5,12 @@ all:
-
+diff -uNr debootstrap-1.0.106/Makefile debootstrap-1.0.106.mod/Makefile
+--- debootstrap-1.0.106/Makefile	2018-07-05 11:48:22.000000000 +0300
++++ debootstrap-1.0.106.mod/Makefile	2018-07-10 15:33:41.289906934 +0300
+@@ -5,14 +5,12 @@
+ 
  clean:
-
+ 
 -DSDIR=$(DESTDIR)/usr/share/debootstrap
 +DSDIR=$(DESTDIR)$(PREFIX)/share/debootstrap
  install:
  	mkdir -p $(DSDIR)/scripts
 -	mkdir -p $(DESTDIR)/usr/sbin
-
+ 
  	cp -a scripts/* $(DSDIR)/scripts/
 -	install -o root -g root -m 0644 functions $(DSDIR)/
 +	install -m 0644 functions $(DSDIR)/
-
+ 
 -	sed 's/@VERSION@/$(VERSION)/g' debootstrap >$(DESTDIR)/usr/sbin/debootstrap
 -	chown root:root $(DESTDIR)/usr/sbin/debootstrap
 -	chmod 0755 $(DESTDIR)/usr/sbin/debootstrap

--- a/packages/debootstrap/build.sh
+++ b/packages/debootstrap/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://wiki.debian.org/Debootstrap
 TERMUX_PKG_DESCRIPTION="Bootstrap a basic Debian system"
-TERMUX_PKG_VERSION=1.0.102
-TERMUX_PKG_SHA256=09675c7338ff0a328a1d67d84af93af46716a618d6c8cdb8c76d1ce07cb70ec5
+TERMUX_PKG_VERSION=1.0.106
+TERMUX_PKG_SHA256=4ffcd12477540cbccdbed7c254f77797b886228ca94e749414d0380eab62c26e
 TERMUX_PKG_SRCURL=http://http.debian.net/debian/pool/main/d/debootstrap/debootstrap_${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_BUILD_IN_SRC=yes
 TERMUX_PKG_DEPENDS="wget, proot, perl"

--- a/packages/debootstrap/debootstrap.patch
+++ b/packages/debootstrap/debootstrap.patch
@@ -1,6 +1,15 @@
-diff -u -r ../debootstrap-1.0.97/debootstrap ./debootstrap
---- ../debootstrap-1.0.97/debootstrap	2018-04-17 04:06:32.000000000 +0200
-+++ ./debootstrap	2018-04-30 03:14:32.764728670 +0200
+diff -uNr debootstrap-1.0.106/debootstrap debootstrap-1.0.106.mod/debootstrap
+--- debootstrap-1.0.106/debootstrap	2018-07-05 11:48:22.000000000 +0300
++++ debootstrap-1.0.106.mod/debootstrap	2018-07-10 17:32:34.599933159 +0300
+@@ -3,7 +3,7 @@
+ 
+ VERSION='@VERSION@'
+ 
+-unset TMP TEMP TMPDIR || true
++unset LD_PRELOAD TMP TEMP TMPDIR || true
+ 
+ # might not be exported if we're running from init=/bin/sh or similar
+ export PATH
 @@ -14,7 +14,7 @@
  	if [ -x /debootstrap/debootstrap ]; then
  		DEBOOTSTRAP_DIR=/debootstrap
@@ -10,7 +19,7 @@ diff -u -r ../debootstrap-1.0.97/debootstrap ./debootstrap
  	fi
  fi
  
-@@ -468,10 +468,10 @@
+@@ -483,10 +483,10 @@
  
  if in_path dpkg && \
       dpkg --print-architecture >/dev/null 2>&1; then
@@ -23,17 +32,22 @@ diff -u -r ../debootstrap-1.0.97/debootstrap ./debootstrap
  elif [ -e "$DEBOOTSTRAP_DIR/arch" ]; then
  	HOST_ARCH=$(cat "$DEBOOTSTRAP_DIR/arch")
  fi
-@@ -512,7 +512,8 @@
+@@ -527,12 +527,8 @@
  if [ "$TARGET" = "/" ]; then
  	CHROOT_CMD=""
  else
 -	CHROOT_CMD="chroot \"$TARGET\""
+-fi
+-
+-# fakeroot cannot check /proc/1/environ
+-if [ "$HOST_OS" = Linux ] && ! doing_variant fakechroot && [ "$CONTAINER" = "lxc-libvirt" ]; then
+-       CHROOT_CMD="unshare --net $CHROOT_CMD"
 +	PATH=$PATH:/usr/bin:/bin:/usr/sbin:/sbin
 +	CHROOT_CMD="proot -w /home -b /dev -b /proc --link2symlink -0 -r $TARGET"
  fi
  
- # fakeroot cannot check /proc/1/environ
-@@ -532,16 +533,6 @@
+ if [ -z "$SHA_SIZE" ]; then
+@@ -546,16 +542,6 @@
  
  export ARCH SUITE TARGET CHROOT_CMD SHA_SIZE DEBOOTSTRAP_CHECKSUM_FIELD
  

--- a/packages/debootstrap/functions.patch
+++ b/packages/debootstrap/functions.patch
@@ -1,7 +1,26 @@
-diff -u -r ../debootstrap-1.0.102/functions ./functions
---- ../debootstrap-1.0.102/functions	2018-06-13 13:00:11.000000000 +0000
-+++ ./functions	2018-06-21 20:30:41.301533374 +0000
-@@ -910,7 +910,7 @@
+diff -uNr debootstrap-1.0.106/functions debootstrap-1.0.106.mod/functions
+--- debootstrap-1.0.106/functions	2018-07-05 11:48:22.000000000 +0300
++++ debootstrap-1.0.106.mod/functions	2018-07-10 17:20:18.985640585 +0300
+@@ -220,17 +220,7 @@
+ }
+ 
+ detect_container () {
+-	if [ "$container" = lxc ]; then
+-		CONTAINER="lxc"
+-	elif grep -qs container=lxc-libvirt /proc/1/environ; then
+-		CONTAINER="lxc-libvirt"
+-	elif grep -qs ^systemd-nspawn$ /run/systemd/container || [ "$container" = "systemd-nspawn" ]; then
+-		CONTAINER="systemd-nspawn"
+-	elif grep -qs '[[:space:]]/docker/.*/sys/fs/cgroup' /proc/1/mountinfo; then
+-		CONTAINER="docker"
+-	else
+-		CONTAINER=""
+-	fi
++	CONTAINER=""
+ }
+ 
+ ########################################################## variant handling
+@@ -924,7 +914,7 @@
  extract_dpkg_deb_data () {
  	local pkg="$1"
  
@@ -10,7 +29,7 @@ diff -u -r ../debootstrap-1.0.102/functions ./functions
  }
  
  # Raw .deb extractors
-@@ -950,7 +950,7 @@
+@@ -964,7 +954,7 @@
  	esac
  
  	if in_path "$cat_cmd"; then
@@ -19,7 +38,25 @@ diff -u -r ../debootstrap-1.0.102/functions ./functions
  	else
  		error 1 UNPACKCMDUNVL "Extracting %s requires the %s command, which is not available" "$pkg" "$cat_cmd"
  	fi
-@@ -1165,7 +1165,6 @@
+@@ -1020,7 +1010,7 @@
+ ); }
+ 
+ in_target_nofail () {
+-	if ! PATH=/sbin:/usr/sbin:/bin:/usr/bin eval "$CHROOT_CMD \"\$@\"" 2>/dev/null; then
++	if ! PATH=$PATH:/sbin:/usr/sbin:/bin:/usr/bin $CHROOT_CMD "$@" 2>/dev/null; then
+ 		true
+ 	fi
+ 	return 0
+@@ -1032,7 +1022,7 @@
+ 	msg="$2"
+ 	arg="$3"
+ 	shift; shift; shift
+-	if ! PATH=/sbin:/usr/sbin:/bin:/usr/bin eval "$CHROOT_CMD \"\$@\""; then
++	if ! PATH=$PATH:/sbin:/usr/sbin:/bin:/usr/bin $CHROOT_CMD "$@"; then
+ 		warning "$code" "$msg" "$arg"
+ 		# Try to point user at actual failing package.
+ 		msg="See %s for details"
+@@ -1184,7 +1174,6 @@
  			return 0
  		fi
  

--- a/packages/debootstrap/scripts-debian-common.patch
+++ b/packages/debootstrap/scripts-debian-common.patch
@@ -1,7 +1,7 @@
-diff -u -r ../debootstrap-1.0.99/scripts/debian-common ./scripts/debian-common
---- ../debootstrap-1.0.99/scripts/debian-common	2018-05-17 01:57:52.000000000 +0000
-+++ ./scripts/debian-common	2018-05-18 22:15:13.894769189 +0000
-@@ -52,7 +52,7 @@
+diff -uNr debootstrap-1.0.106/scripts/debian-common debootstrap-1.0.106.mod/scripts/debian-common
+--- debootstrap-1.0.106/scripts/debian-common	2018-07-05 11:48:22.000000000 +0300
++++ debootstrap-1.0.106.mod/scripts/debian-common	2018-07-10 15:33:41.289906934 +0300
+@@ -60,7 +60,7 @@
  	setup_etc
  	if [ ! -e "$TARGET/etc/fstab" ]; then
  		echo '# UNCONFIGURED FSTAB FOR BASE SYSTEM' > "$TARGET/etc/fstab"
@@ -10,7 +10,7 @@ diff -u -r ../debootstrap-1.0.99/scripts/debian-common ./scripts/debian-common
  	fi
  
  	setup_devices
-@@ -94,7 +94,6 @@
+@@ -102,7 +102,6 @@
  	}
  
  	if ! doing_variant fakechroot; then
@@ -18,7 +18,7 @@ diff -u -r ../debootstrap-1.0.99/scripts/debian-common ./scripts/debian-common
  		in_target /sbin/ldconfig
  	fi
  
-@@ -164,6 +163,20 @@
+@@ -172,6 +171,20 @@
  echo \"Warning: Fake start-stop-daemon called, doing nothing\"" > "$TARGET/sbin/start-stop-daemon"
  	chmod 755 "$TARGET/sbin/start-stop-daemon"
  


### PR DESCRIPTION
Update to v1.0.106 and fix these errors:
```
grep: /proc/1/environ: No such file or directory
/data/data/com.termux/files/usr/bin/debootstrap: 1: eval: proot: Permission denied
/data/data/com.termux/files/usr/bin/debootstrap: 1027: /data/data/com.termux/files/usr/bin/debootstrap: grep: Permission denied
/data/data/com.termux/files/usr/bin/debootstrap: 1027: /data/data/com.termux/files/usr/bin/debootstrap: head: Permission denied
/data/data/com.termux/files/usr/bin/debootstrap: 1027: /data/data/com.termux/files/usr/bin/debootstrap: sed: Permission denied
/data/data/com.termux/files/usr/bin/debootstrap: 1027: /data/data/com.termux/files/usr/bin/debootstrap: cut: Permission denied
```