### PR TITLE
libmnl: change to https url

### DIFF
--- a/packages/libmnl/build.sh
+++ b/packages/libmnl/build.sh
@@ -3,4 +3,3 @@ TERMUX_PKG_DESCRIPTION="a minimalistic user-space library oriented to Netlink de
 TERMUX_PKG_VERSION=1.0.4
 TERMUX_PKG_SRCURL=https://netfilter.org/projects/libmnl/files/libmnl-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=171f89699f286a5854b72b91d06e8f8e3683064c5901fb09d954a9ab6f551f81
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" LIBDIR=$TERMUX_PREFIX/lib"

--- a/packages/libmnl/build.sh
+++ b/packages/libmnl/build.sh
@@ -1,5 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://www.netfilter.org/projects/libmnl/
 TERMUX_PKG_DESCRIPTION="a minimalistic user-space library oriented to Netlink developers"
 TERMUX_PKG_VERSION=1.0.4
-TERMUX_PKG_SRCURL=http://ftp.netfilter.org/pub/libmnl/libmnl-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=https://netfilter.org/projects/libmnl/files/libmnl-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=171f89699f286a5854b72b91d06e8f8e3683064c5901fb09d954a9ab6f551f81
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" LIBDIR=$TERMUX_PREFIX/lib"

--- a/packages/libmnl/build.sh
+++ b/packages/libmnl/build.sh
@@ -1,7 +1,6 @@
 TERMUX_PKG_HOMEPAGE=https://www.netfilter.org/projects/libmnl/
 TERMUX_PKG_DESCRIPTION="a minimalistic user-space library oriented to Netlink developers"
 TERMUX_PKG_VERSION=1.0.4
-TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://netfilter.org/projects/libmnl/files/libmnl-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=171f89699f286a5854b72b91d06e8f8e3683064c5901fb09d954a9ab6f551f81
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" LIBDIR=$TERMUX_PREFIX/lib"


### PR DESCRIPTION
LIBDIR defaults to $PREFIX/lib64 for x86_64 these days. Maybe something that started at r17 upgrade?

Maybe other packages have the same issue.