### PR TITLE
emacs: remove ctags.1.gz after building

### DIFF
--- a/packages/emacs/build.sh
+++ b/packages/emacs/build.sh
@@ -37,7 +37,7 @@ TERMUX_PKG_RM_AFTER_INSTALL="share/icons share/emacs/${TERMUX_PKG_VERSION}/etc/i
 # Remove ctags from the emacs package to prevent conflicting with
 # the Universal Ctags from the 'ctags' package (the bin/etags
 # program still remain in the emacs package):
-TERMUX_PKG_RM_AFTER_INSTALL+=" bin/ctags share/man/man1/ctags.1"
+TERMUX_PKG_RM_AFTER_INSTALL+=" bin/ctags share/man/man1/ctags.1 share/man/man1/ctags.1.gz"
 
 termux_step_post_extract_package () {
 	# XXX: We have to start with new host build each time


### PR DESCRIPTION
This man page conflicts with the one included with Universal Ctags (just
like the ungziped one), so exclude it as well.