### PR TITLE
proot: Update for setgid() checking euid==0

### DIFF
--- a/packages/proot/build.sh
+++ b/packages/proot/build.sh
@@ -1,11 +1,11 @@
 TERMUX_PKG_HOMEPAGE=https://proot-me.github.io/
 TERMUX_PKG_DESCRIPTION="Emulate chroot, bind mount and binfmt_misc for non-root users"
 # Just bump commit and version when needed:
-_COMMIT=b4afbd31d93ab7050303bdd749a97f65709439eb
+_COMMIT=d349cb68a5374d625f4d984d56c5c6c3300386a7
 TERMUX_PKG_VERSION=5.1.107
-TERMUX_PKG_REVISION=13
+TERMUX_PKG_REVISION=14
 TERMUX_PKG_SRCURL=https://github.com/termux/proot/archive/${_COMMIT}.zip
-TERMUX_PKG_SHA256=46587d33ecebb08bccc077f1a9336de84579d3f2e8a6a923814060fd7c06013c
+TERMUX_PKG_SHA256=351fac8ad13b9ddba1be4491168b5b659abed31ce6a160474659081272d8ef87
 TERMUX_PKG_DEPENDS="libtalloc"
 
 termux_step_pre_configure() {


### PR DESCRIPTION
termux/proot#26 by @tomty89: For fake_id0 emulated `setgid` check if `euid==0`.