### PR TITLE
texlive-bin: host-build tools and rm texlive-binaries from setup-ubuntu.sh

### DIFF
--- a/packages/texlive-bin/build.sh
+++ b/packages/texlive-bin/build.sh
@@ -11,6 +11,7 @@ TERMUX_PKG_BREAKS="texlive (<< 20180414)"
 TERMUX_PKG_REPLACES="texlive (<< 20170524-3)"
 TERMUX_PKG_RECOMMENDS="texlive"
 TERMUX_PKG_NO_DEVELSPLIT=yes
+TERMUX_PKG_HOSTBUILD=true
 
 TL_ROOT=$TERMUX_PREFIX/share/texlive
 TL_BINDIR=$TERMUX_PREFIX/bin
@@ -122,9 +123,37 @@ share/texlive/texmf-dist/scripts/lua2dox/lua2dox_filter
 share/texlive/texmf-dist/scripts/context/perl/mptopdf.pl
 share/texlive/texmf-dist/scripts/checkcites/checkcites.lua"
 
+termux_step_host_build () {
+	mkdir -p auxdir/auxsub
+	mkdir -p texk/kpathsea
+	mkdir -p texk/web2c
+
+	cd $TERMUX_PKG_HOSTBUILD_DIR/auxdir/auxsub
+	$TERMUX_PKG_SRCDIR/auxdir/auxsub/configure
+	make
+
+	cd $TERMUX_PKG_HOSTBUILD_DIR/texk/kpathsea
+	$TERMUX_PKG_SRCDIR/texk/kpathsea/configure
+
+	cd $TERMUX_PKG_HOSTBUILD_DIR/texk/web2c
+	$TERMUX_PKG_SRCDIR/texk/web2c/configure --without-x
+	make tangle
+	make ctangle
+	make tie
+	make otangle
+}
+
 termux_step_pre_configure() {
 	# When building against libicu 59.1 or later we need c++11:
 	CXXFLAGS+=" -std=c++11"
+	export TANGLE=$TERMUX_PKG_HOSTBUILD_DIR/texk/web2c/tangle
+	export TANGLEBOOT=$TERMUX_PKG_HOSTBUILD_DIR/texk/web2c/tangleboot
+	export CTANGLE=$TERMUX_PKG_HOSTBUILD_DIR/texk/web2c/ctangle
+	export CTANGLEBOOT=$TERMUX_PKG_HOSTBUILD_DIR/texk/web2c/ctangleboot
+	export TIE=$TERMUX_PKG_HOSTBUILD_DIR/texk/web2c/tie
+	export OTANGLE=$TERMUX_PKG_HOSTBUILD_DIR/texk/web2c/.libs/otangle
+	# otangle is linked against libkpathsea but can't find it, so we use LD_LIBRARY_PATH
+	export LD_LIBRARY_PATH=$TERMUX_PKG_HOSTBUILD_DIR/texk/kpathsea/.libs
 }
 
 termux_step_create_debscripts () {

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -31,7 +31,6 @@ PACKAGES+=" python3-sphinx" # Needed by notmuch man page generation.
 PACKAGES+=" ruby" # Needed to build ruby.
 PACKAGES+=" scons"
 PACKAGES+=" texinfo"
-PACKAGES+=" texlive-binaries" # Needed by texlive build.
 PACKAGES+=" xmlto"
 PACKAGES+=" xutils-dev" # Provides 'makedepend' which the openssl build uses.
 PACKAGES+=" libexpat1-dev" # Needed by ghostscript


### PR DESCRIPTION
Saves about 300 mb from docker image.