### PR TITLE
mpd: avoid seccomp-filtered ioprio_set

### DIFF
--- a/packages/mpd/build.sh
+++ b/packages/mpd/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://www.musicpd.org
 TERMUX_PKG_DESCRIPTION="Music player daemon"
 TERMUX_PKG_VERSION=0.20.20
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SHA256=d804b47a981b0398f119e9f398775706422c3d4d887dd7c0f5460904df89bbf2
 TERMUX_PKG_SRCURL=https://github.com/MusicPlayerDaemon/MPD/archive/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_DEPENDS="libcurl, libid3tag, libopus, libevent, fftw, libpulseaudio, libmpdclient, boost, openal-soft, libvorbis, libsqlite, ffmpeg, libmp3lame, libbz2"

--- a/packages/mpd/thread-Util.cxx.patch
+++ b/packages/mpd/thread-Util.cxx.patch
@@ -1,0 +1,31 @@
+diff --git a/src/thread/Util.cxx~ b/src/thread/Util.cxx
+index 0dbf818..671eb6a 100644
+--- a/src/thread/Util.cxx~
++++ b/src/thread/Util.cxx
+@@ -40,7 +40,7 @@
+ 
+ #ifdef __linux__
+ 
+-#ifndef ANDROID
++#if !defined(ANDROID) && !defined(TERMUX)
+ 
+ static int
+ linux_ioprio_set(int which, int who, int ioprio)
+@@ -60,7 +60,7 @@ ioprio_set_idle()
+ 	linux_ioprio_set(_IOPRIO_WHO_PROCESS, 0, _IOPRIO_IDLE);
+ }
+ 
+-#endif /* !ANDROID */
++#endif /* !ANDROID && !TERMUX */
+ 
+ /**
+  * Wrapper for the "sched_setscheduler" system call.  We don't use the
+@@ -84,7 +84,7 @@ SetThreadIdlePriority()
+ 	linux_sched_setscheduler(0, SCHED_IDLE, &sched_param);
+ #endif
+ 
+-#ifndef ANDROID
++#if !defined(ANDROID) && !defined(TERMUX)
+ 	/* this system call is forbidden via seccomp on Android 8 and
+ 	   leads to crash (SIGSYS) */
+ 	ioprio_set_idle();


### PR DESCRIPTION
Causes SIGSYS (SYS_SECCOMP) on arm. mpd will fail to start if no database exists.