### PR TITLE
proot: update package (with fix for utime and sendmsg)

### DIFF
--- a/packages/proot/build.sh
+++ b/packages/proot/build.sh
@@ -1,11 +1,11 @@
 TERMUX_PKG_HOMEPAGE=https://proot-me.github.io/
 TERMUX_PKG_DESCRIPTION="Emulate chroot, bind mount and binfmt_misc for non-root users"
 # Just bump commit and version when needed:
-_COMMIT=d349cb68a5374d625f4d984d56c5c6c3300386a7
+_COMMIT=e0569ad9f64a4eb79117759c73d02251746631a0
 TERMUX_PKG_VERSION=5.1.107
-TERMUX_PKG_REVISION=14
+TERMUX_PKG_REVISION=15
 TERMUX_PKG_SRCURL=https://github.com/termux/proot/archive/${_COMMIT}.zip
-TERMUX_PKG_SHA256=351fac8ad13b9ddba1be4491168b5b659abed31ce6a160474659081272d8ef87
+TERMUX_PKG_SHA256=4c646c27e177857e592a0e63979ac14dab95b1a2975a8b25fd3339b8375e1e2d
 TERMUX_PKG_DEPENDS="libtalloc"
 
 termux_step_pre_configure() {


### PR DESCRIPTION
* Fix `utime` not available on Chromebook (termux/proot#28)
* Fix for running on Oreo on i386 and x86_64
* Fix `sendmsg` `SCM_CREDENTAILS` message when `getuid` was faked and application couldn't send message with own uid (termux/proot#30)