### PR TITLE
Enable pulseaudio in cava

### DIFF
--- a/packages/cava/build.sh
+++ b/packages/cava/build.sh
@@ -2,14 +2,12 @@ TERMUX_PKG_HOMEPAGE=https://github.com/karlstav/cava
 TERMUX_PKG_DESCRIPTION="Console-based Audio Visualizer. Works with MPD."
 TERMUX_PKG_MAINTAINER="Oliver Schmidhauser @Neo-Oli"
 TERMUX_PKG_VERSION=0.6.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=98b880e7e704ed457863f379f31b488e06076bb34a5de02825096969b916a78d
 TERMUX_PKG_SRCURL=https://github.com/karlstav/cava/archive/${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_DEPENDS="ncurses,fftw"
+TERMUX_PKG_DEPENDS="ncurses,fftw,libpulseaudio"
 TERMUX_PKG_BUILD_DEPENDS="libtool"
 TERMUX_PKG_BUILD_IN_SRC=yes
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
-ac_cv_lib_pulse_simple_pa_simple_new=no
-"
 
 termux_step_pre_configure() {
 	./autogen.sh


### PR DESCRIPTION
The pulse method is the default of cava. Now that it is avalable and
works fairly well, I think we can enable it in cava. This way it can
also be used with cmus and other pulseaudio players.
The old method of fifo input (ncmpcpp visualizer output) can still be
enabled by adding the following to the config file
(`~/.config/cava/config`):

```
[input]
method = fifo
```