### PR TITLE
libpulseaudio/mpv: set numBuffers to 8 for SLES

### DIFF
--- a/packages/libpulseaudio/build.sh
+++ b/packages/libpulseaudio/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://www.freedesktop.org/wiki/Software/PulseAudio
 TERMUX_PKG_DESCRIPTION="A featureful, general-purpose sound server - shared libraries"
 TERMUX_PKG_VERSION=12.2
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SHA256=809668ffc296043779c984f53461c2b3987a45b7a25eb2f0a1d11d9f23ba4055
 TERMUX_PKG_SRCURL=https://www.freedesktop.org/software/pulseaudio/releases/pulseaudio-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_DEPENDS="libltdl, libsndfile, libandroid-glob, libsoxr"

--- a/packages/libpulseaudio/module-sles-sink.c
+++ b/packages/libpulseaudio/module-sles-sink.c
@@ -144,7 +144,7 @@ static int pa_init_sles_player(struct userdata *u, SLint32 sl_rate)
 
     SLDataLocator_BufferQueue locator_bufferqueue;
     locator_bufferqueue.locatorType = SL_DATALOCATOR_BUFFERQUEUE;
-    locator_bufferqueue.numBuffers = 1;
+    locator_bufferqueue.numBuffers = 8;
 
     if (sl_rate < 8000 || sl_rate > 192000) {
         pa_log("Incompatible sample rate");

--- a/packages/mpv/build.sh
+++ b/packages/mpv/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://mpv.io/
 TERMUX_PKG_DESCRIPTION="Command-line media player"
 TERMUX_PKG_VERSION=0.29.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=772af878cee5495dcd342788a6d120b90c5b1e677e225c7198f1e76506427319
 TERMUX_PKG_SRCURL=https://github.com/mpv-player/mpv/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_DEPENDS="ffmpeg, openal-soft, libandroid-glob"

--- a/packages/mpv/sles_numbuffers.patch
+++ b/packages/mpv/sles_numbuffers.patch
@@ -1,0 +1,13 @@
+diff --git a/audio/out/ao_opensles.c b/audio/out/ao_opensles.c
+index ea48de892e..2e637adf82 100644
+--- a/audio/out/ao_opensles.c
++++ b/audio/out/ao_opensles.c
+@@ -129,7 +129,7 @@ static int init(struct ao *ao)
+     CHK((*p->output_mix)->Realize(p->output_mix, SL_BOOLEAN_FALSE));
+ 
+     locator_buffer_queue.locatorType = SL_DATALOCATOR_BUFFERQUEUE;
+-    locator_buffer_queue.numBuffers = 1;
++    locator_buffer_queue.numBuffers = 8;
+ 
+     pcm.formatType = SL_DATAFORMAT_PCM;
+     pcm.numChannels = 2;


### PR DESCRIPTION
Apparently some Android builds/forks need it for Bluetooth audio.
It's a hardcoded default in the upstream AAudio implementation
anyway.

See the following for reference:
https://android.googlesource.com/platform/frameworks/av/+/android-8.0.0_r1/media/libaaudio/src/legacy/AudioStreamTrack.cpp#109
https://android.googlesource.com/platform/frameworks/wilhelm/+/android-8.0.0_r1/src/android/AudioPlayer_to_android.cpp#1680
https://android.googlesource.com/platform/frameworks/av/+/android-8.0.0_r1/media/libaudioclient/AudioTrack.cpp#488

Fixes #2703.