### PR TITLE
poppler: avoid trying to use qt5 stuff

### DIFF
--- a/packages/poppler/build.sh
+++ b/packages/poppler/build.sh
@@ -9,5 +9,6 @@ TERMUX_PKG_DEPENDS="fontconfig, libcairo, libpng, libjpeg-turbo, libtiff, little
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DENABLE_GLIB=OFF
 -DENABLE_XPDF_HEADERS=ON
+-DENABLE_QT5=OFF
 -DFONT_CONFIGURATION=fontconfig
 "


### PR DESCRIPTION
Ran into errors when building outside the docker container.