### PR TITLE
mpv: remove irrelevant/reverted part of a patch

### DIFF
--- a/packages/mpv/sles_float.patch
+++ b/packages/mpv/sles_float.patch
@@ -1,26 +1,3 @@
-diff --git a/audio/format.c b/audio/format.c
-index 8a13698ff7..7004409d10 100644
---- a/audio/format.c
-+++ b/audio/format.c
-@@ -95,14 +95,16 @@ int af_fmt_to_planar(int format)
- 
- // Return the interleaved format corresponding to the given format.
- // If the format is already interleaved, return it.
--// Always succeeds if format is actually planar; otherwise return 0.
-+// Return 0 if there's no equivalent.
- int af_fmt_from_planar(int format)
- {
-     for (int n = 0; n < MP_ARRAY_SIZE(planar_formats); n++) {
-         if (planar_formats[n][0] == format)
-             return planar_formats[n][1];
-+        if (planar_formats[n][1] == format)
-+            return format;
-     }
--    return format;
-+    return 0;
- }
- 
- bool af_fmt_is_valid(int format)
 diff --git a/audio/out/ao_opensles.c b/audio/out/ao_opensles.c
 index ea48de892e..f3082a9aa6 100644
 --- a/audio/out/ao_opensles.c


### PR DESCRIPTION
The patch that introduced s32/float support included a fix/change
in audio/format.c which is practically irrelevant and now reverted
in upstream. Removing the part to avoid confusion in the future.

No rebuild necessary, as it works in our case either way.