### PR TITLE
Remove @Neo-Oli (myself) as maintainer of bs1770gain

### DIFF
--- a/packages/bs1770gain/build.sh
+++ b/packages/bs1770gain/build.sh
@@ -2,7 +2,6 @@ TERMUX_PKG_HOMEPAGE=http://bs1770gain.sourceforge.net/
 TERMUX_PKG_DESCRIPTION="Tool to normalize the loudness of different audio files to the same level"
 TERMUX_PKG_VERSION=0.4.12
 TERMUX_PKG_REVISION=3
-TERMUX_PKG_MAINTAINER="Oliver Schmidhauser @Neo-Oli"
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/project/bs1770gain/bs1770gain/${TERMUX_PKG_VERSION}/bs1770gain-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=cafc5440cf4940939c675e98c8dbeb839f4965d60f74270a37d4ee70559b3a59
 TERMUX_PKG_DEPENDS="ffmpeg, sox"


### PR DESCRIPTION
Regrettably, I no longer wish to associate myself with this software. I do not want to have to read [changelogs](http://bs1770gain.sourceforge.net/#0.5.0-beta-4) where the author of a software chooses to inject his own political ideology, conspiracy theories and hate.