### PR TITLE
fix pulse audio linking to platform 26 #2750.

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -712,12 +712,11 @@ termux_step_setup_toolchain() {
 
 		local _LIBDIR=usr/lib
 		if [ $TERMUX_ARCH = x86_64 ]; then _LIBDIR+=64; fi
-		$TERMUX_ELF_CLEANER $_LIBDIR/*.so
 		# so we can use aaudio for devices that support it
 		if (( $TERMUX_PKG_API_LEVEL < 26 )); then
 		cp $NDK/platforms/android-26/arch-$_NDK_ARCHNAME/$_LIBDIR/libaaudio.so $_TERMUX_TOOLCHAIN_TMPDIR/sysroot/$_LIBDIR
 		fi
-	
+		$TERMUX_ELF_CLEANER $_LIBDIR/*.so	
 		# zlib is really version 1.2.8 in the Android platform (at least
 		# starting from Android 5), not older as the NDK headers claim.
 		for file in zconf.h zlib.h; do

--- a/build-package.sh
+++ b/build-package.sh
@@ -371,7 +371,7 @@ termux_step_start_build() {
 	TERMUX_STANDALONE_TOOLCHAIN="$TERMUX_COMMON_CACHEDIR/${TERMUX_NDK_VERSION}-${TERMUX_ARCH}-${TERMUX_PKG_API_LEVEL}"
 	# Bump the below version if a change is made in toolchain setup to ensure
 	# that everyone gets an updated toolchain:
-	TERMUX_STANDALONE_TOOLCHAIN+="-v1"
+	TERMUX_STANDALONE_TOOLCHAIN+="-v2"
 
 	if [ -n "${TERMUX_PKG_BLACKLISTED_ARCHES:=""}" ] && [ "$TERMUX_PKG_BLACKLISTED_ARCHES" != "${TERMUX_PKG_BLACKLISTED_ARCHES/$TERMUX_ARCH/}" ]; then
 		echo "Skipping building $TERMUX_PKG_NAME for arch $TERMUX_ARCH"
@@ -713,7 +713,11 @@ termux_step_setup_toolchain() {
 		local _LIBDIR=usr/lib
 		if [ $TERMUX_ARCH = x86_64 ]; then _LIBDIR+=64; fi
 		$TERMUX_ELF_CLEANER $_LIBDIR/*.so
-
+		# so we can use aaudio for devices that support it
+		if (( $TERMUX_PKG_API_LEVEL < 26 )); then
+		cp $NDK/platforms/android-26/arch-$_NDK_ARCHNAME/$_LIBDIR/libaaudio.so $_TERMUX_TOOLCHAIN_TMPDIR/sysroot/$_LIBDIR
+		fi
+	
 		# zlib is really version 1.2.8 in the Android platform (at least
 		# starting from Android 5), not older as the NDK headers claim.
 		for file in zconf.h zlib.h; do

--- a/packages/libpulseaudio/build.sh
+++ b/packages/libpulseaudio/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://www.freedesktop.org/wiki/Software/PulseAudio
 TERMUX_PKG_DESCRIPTION="A featureful, general-purpose sound server - shared libraries"
 TERMUX_PKG_VERSION=12.2
-TERMUX_PKG_REVISION=5
+TERMUX_PKG_REVISION=6
 TERMUX_PKG_SHA256=809668ffc296043779c984f53461c2b3987a45b7a25eb2f0a1d11d9f23ba4055
 TERMUX_PKG_SRCURL=https://www.freedesktop.org/software/pulseaudio/releases/pulseaudio-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_DEPENDS="libltdl, libsndfile, libandroid-glob, libsoxr"
@@ -20,7 +20,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-neon-opt
 ax_cv_PTHREAD_PRIO_INHERIT=no
 ac_cv_func_posix_madvise=no"
 TERMUX_PKG_CONFFILES="etc/pulse/client.conf etc/pulse/daemon.conf etc/pulse/default.pa etc/pulse/system.pa"
-TERMUX_PKG_API_LEVEL=26
 
 termux_step_pre_configure () {
 	mkdir $TERMUX_PKG_SRCDIR/src/modules/sles
@@ -28,7 +27,6 @@ termux_step_pre_configure () {
 	mkdir $TERMUX_PKG_SRCDIR/src/modules/aaudio
 	cp $TERMUX_PKG_BUILDER_DIR/module-aaudio-sink.c $TERMUX_PKG_SRCDIR/src/modules/aaudio
 	intltoolize --automake --copy --force
-	CFLAGS+=" -D__ANDROID_API__=21"
 	LDFLAGS+=" -llog -landroid-glob"
 }
 


### PR DESCRIPTION
Using platform 26 breaks things. This is hopefully better whilst still allowing to link to libaaudio.so