### PR TITLE
mpv: allow custom LD_LIBRARY_PATH

### DIFF
--- a/packages/mpv/build.sh
+++ b/packages/mpv/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://mpv.io/
 TERMUX_PKG_DESCRIPTION="Command-line media player"
 TERMUX_PKG_VERSION=0.29.0
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SHA256=772af878cee5495dcd342788a6d120b90c5b1e677e225c7198f1e76506427319
 TERMUX_PKG_SRCURL=https://github.com/mpv-player/mpv/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_DEPENDS="ffmpeg, openal-soft, libandroid-glob, libpulseaudio"
@@ -61,7 +61,7 @@ termux_step_make_install () {
 
 	# /system/vendor/lib(64) needed for libqc-opt.so on
 	# a xperia z5 c, reported by BrainDamage on #termux:
-	echo "LD_LIBRARY_PATH=/system/$SYSTEM_LIBFOLDER:/system/vendor/$SYSTEM_LIBFOLDER:$TERMUX_PREFIX/lib $TERMUX_PREFIX/libexec/mpv \"\$@\"" >> $TERMUX_PREFIX/bin/mpv
+	echo "LD_LIBRARY_PATH=/system/$SYSTEM_LIBFOLDER:/system/vendor/$SYSTEM_LIBFOLDER:\$LD_LIBRARY_PATH $TERMUX_PREFIX/libexec/mpv \"\$@\"" >> $TERMUX_PREFIX/bin/mpv
 
 	chmod +x $TERMUX_PREFIX/bin/mpv
 }


### PR DESCRIPTION
So that e.g. `LD_LIBRARY_PATH=$PREFIX/local/lib:$PREFIX/lib` would
work, allowing local builds of libraries to be picked up.