### PR TITLE
[REVIEW] Let packages depend on current dependency versions

### DIFF
--- a/packages/gnupg/dirmngr.subpackage.sh
+++ b/packages/gnupg/dirmngr.subpackage.sh
@@ -1,3 +1,3 @@
 TERMUX_SUBPKG_INCLUDE="bin/dirmngr bin/dirmngr-client share/man/man8/dirmngr.8 share/man/man1/dirmngr-client.1"
 TERMUX_SUBPKG_DESCRIPTION="Server for managing certificate revocation lists"
-TERMUX_SUBPKG_DEPENDS="gnupg (>= 2.2.9-1), libgnutls, resolv-conf"
+TERMUX_SUBPKG_DEPENDS="gnupg, libgnutls, resolv-conf"

--- a/packages/gpgme/build.sh
+++ b/packages/gpgme/build.sh
@@ -1,6 +1,6 @@
 TERMUX_PKG_HOMEPAGE=https://www.gnupg.org/related_software/gpgme/
 TERMUX_PKG_DESCRIPTION="Library designed to make access to GnuPG easier"
-TERMUX_PKG_DEPENDS="gnupg (>= 2.2.9-1), libassuan, libgpg-error"
+TERMUX_PKG_DEPENDS="gnupg, libassuan, libgpg-error"
 TERMUX_PKG_DEVPACKAGE_DEPENDS="libgpg-error-dev"
 TERMUX_PKG_VERSION=1.11.1
 TERMUX_PKG_REVISION=1

--- a/packages/pass/build.sh
+++ b/packages/pass/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_SHA256=2b6c65846ebace9a15a118503dcd31b6440949a30d3b5291dfb5b1615b99a3
 TERMUX_PKG_SRCURL=https://git.zx2c4.com/password-store/snapshot/password-store-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_BUILD_IN_SRC=yes
 # Depend on coreutils as pass uses [:graph:] when calling tr, which busybox tr does not support:
-TERMUX_PKG_DEPENDS="bash, gnupg (>= 2.2.9-1), tree, coreutils"
+TERMUX_PKG_DEPENDS="bash, gnupg, tree, coreutils"
 TERMUX_PKG_RECOMMENDS="git"
 TERMUX_PKG_SUGGESTS="pass-otp"
 TERMUX_PKG_PLATFORM_INDEPENDENT=yes

--- a/packages/texlive-tlmgr/build.sh
+++ b/packages/texlive-tlmgr/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_VERSION=20180414
 TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL="ftp://ftp.tug.org/texlive/historic/${TERMUX_PKG_VERSION:0:4}/install-tl-unx.tar.gz"
 TERMUX_PKG_SHA256="82c13110852af162c4c5ef1579fa2f4f51c2040850ec02fb7f97497da45eb446"
-TERMUX_PKG_DEPENDS="perl, wget, gnupg (>= 2.2.9-1), xz-utils, texlive"
+TERMUX_PKG_DEPENDS="perl, wget, gnupg, xz-utils, texlive"
 TERMUX_PKG_CONFFILES="share/texlive/tlpkg/texlive.tlpdb"
 TERMUX_PKG_CONFLICTS="texlive (<< 20180414-1)"
 TERMUX_PKG_PLATFORM_INDEPENDENT=yes

--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -6,7 +6,7 @@ TERMUX_PKG_VERSION=${_MAJOR_VERSION}
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="ftp://ftp.tug.org/texlive/historic/${TERMUX_PKG_VERSION:0:4}/texlive-$_MAJOR_VERSION-texmf.tar.xz"
 TERMUX_PKG_SHA256="bae2fa05ea1858b489f8138bea855c6d65829cf595c1fb219c5d65f4fe8b1fad"
-TERMUX_PKG_DEPENDS="perl, texlive-bin (>= 20180414)"
+TERMUX_PKG_DEPENDS="perl, texlive-bin"
 TERMUX_PKG_CONFLICTS="texlive (<< 20170524-5), texlive-bin (<< 20180414)"
 TERMUX_PKG_RECOMMENDS="texlive-tlmgr"
 TERMUX_PKG_FOLDERNAME="texlive-$_MAJOR_VERSION-texmf"

--- a/scripts/get-version.sh
+++ b/scripts/get-version.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# scripts/get-version.sh: A script to find out the current version of a package.
+# Usage: ./scripts/get-version.sh $package_name
+
+SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+cd $SCRIPT_DIR/..
+
+. scripts/properties.sh
+
+if [ -z "$1" ]; then
+	echo "get-version.sh: No package name specified"
+	exit 1
+fi
+
+pkg=$1
+path=packages/$1
+TERMUX_PKG_REVISION=0
+TERMUX_ARCH=aarch64
+
+if [ -f $path/build.sh ]; then
+	. $path/build.sh
+else
+	# Check for subpackage
+	subpackage_path=`find . -name ${pkg}.subpackage.sh`
+	if [ -z "$subpackage_path" ]; then
+		echo "get-version.sh: No package with name $pkg found"
+		exit 1
+	fi
+	. `dirname $subpackage_path`/build.sh
+fi
+
+if [ "$TERMUX_PKG_REVISION" != "0" ] || [ "$TERMUX_PKG_VERSION" != "${TERMUX_PKG_VERSION/-/}" ]; then
+	TERMUX_PKG_VERSION+="-$TERMUX_PKG_REVISION"
+fi
+
+echo "$TERMUX_PKG_VERSION"

--- a/scripts/get-version.sh
+++ b/scripts/get-version.sh
@@ -13,7 +13,10 @@ if [ -z "$1" ]; then
 fi
 
 pkg=$1
-path=packages/$1
+# Strip away -dev suffix if necessary:
+pkg=${pkg%%-dev}
+
+path=packages/$pkg
 TERMUX_PKG_REVISION=0
 TERMUX_ARCH=aarch64
 


### PR DESCRIPTION
Currently almost no dependency specify version requirements, which is bad as users may e.g. install a new package versions which doesn't work with old version of those dependencies that are installed, which has happened several times.

Having to manually version dependencies would be very tedious and error prone. Instead this change proposes to depend on the current dependency version at build time.

- Current behaviour: We're building libcurl, which has `TERMUX_PKG_DEPENDS="openssl, libnghttp2"`. This generates the control field `Depends: openssl, libnghttp2`.

- Proposed behaviour: We're building libcurl, which has `TERMUX_PKG_DEPENDS="openssl, libnghttp2"`. This generates the control field `Depends: openssl (>= 1.1.0), libnghttp2 (>= 7.61.0)` where the version numbers of the dependencies are taken at the time of building the libcurl package.

This is overly aggressive in that the built package may be compatible with older versions, but it's better than having no version dependency at all or having to manually keep track of all package versions. And having updated packages is never bad.
