### PR TITLE
build-package.sh: set --libdir=$PREFIX/lib

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -903,6 +903,7 @@ termux_step_configure_autotools () {
 	env $AVOID_GNULIB "$TERMUX_PKG_SRCDIR/configure" \
 		--disable-dependency-tracking \
 		--prefix=$TERMUX_PREFIX \
+		--libdir=$TERMUX_PREFIX/lib \
 		--disable-rpath --disable-rpath-hack \
 		$HOST_FLAG \
 		$TERMUX_PKG_EXTRA_CONFIGURE_ARGS \


### PR DESCRIPTION
x86_64 builds installs to $PREFIX/lib64 otherwise on some systems.

This explains https://github.com/termux/termux-packages/pull/2642, seems I built outside the docker container then.