### PR TITLE
redis: use TCSANOW instead of TCSAFLUSH

### DIFF
--- a/packages/redis/no-tcsaflush.patch
+++ b/packages/redis/no-tcsaflush.patch
@@ -1,0 +1,12 @@
+diff -uNr redis-4.0.11/deps/linenoise/linenoise.c redis-4.0.11.mod/deps/linenoise/linenoise.c
+--- redis-4.0.11/deps/linenoise/linenoise.c	2018-08-04 01:44:56.000000000 +0300
++++ redis-4.0.11.mod/deps/linenoise/linenoise.c	2018-08-28 18:05:27.440652876 +0300
+@@ -241,7 +241,7 @@
+     raw.c_cc[VMIN] = 1; raw.c_cc[VTIME] = 0; /* 1 byte, no timer */
+ 
+     /* put terminal in raw mode after flushing */
+-    if (tcsetattr(fd,TCSAFLUSH,&raw) < 0) goto fatal;
++    if (tcsetattr(fd,TCSANOW,&raw) < 0) goto fatal;
+     rawmode = 1;
+     return 0;
+ 


### PR DESCRIPTION
Quick fix for https://github.com/termux/termux-packages/issues/2783.

However cli looks like too bad anyway:
![screenshot_20180828-182333_termux](https://user-images.githubusercontent.com/25881154/44733124-8f20d780-aaef-11e8-8a97-d214da51d546.jpg)

Seems that tcsaflush cannot be replaced here.