### PR TITLE
redis: use TCSANOW instead of TCSAFLUSH

### DIFF
--- a/packages/redis/no-tcsaflush.patch
+++ b/packages/redis/no-tcsaflush.patch
@@ -1,0 +1,21 @@
+diff -uNr redis-4.0.11/deps/linenoise/linenoise.c redis-4.0.11.mod/deps/linenoise/linenoise.c
+--- redis-4.0.11/deps/linenoise/linenoise.c	2018-08-04 01:44:56.000000000 +0300
++++ redis-4.0.11.mod/deps/linenoise/linenoise.c	2018-08-28 18:48:44.778320660 +0300
+@@ -241,7 +241,7 @@
+     raw.c_cc[VMIN] = 1; raw.c_cc[VTIME] = 0; /* 1 byte, no timer */
+ 
+     /* put terminal in raw mode after flushing */
+-    if (tcsetattr(fd,TCSAFLUSH,&raw) < 0) goto fatal;
++    if (tcsetattr(fd,TCSANOW,&raw) < 0) goto fatal;
+     rawmode = 1;
+     return 0;
+ 
+@@ -252,7 +252,7 @@
+ 
+ static void disableRawMode(int fd) {
+     /* Don't even check the return value as it's too late. */
+-    if (rawmode && tcsetattr(fd,TCSAFLUSH,&orig_termios) != -1)
++    if (rawmode && tcsetattr(fd,TCSANOW,&orig_termios) != -1)
+         rawmode = 0;
+ }
+ 


### PR DESCRIPTION
Fix for https://github.com/termux/termux-packages/issues/2783

![screenshot_20180828-185118_termux](https://user-images.githubusercontent.com/25881154/44734899-aa8de180-aaf3-11e8-8d99-554b6d2d3e4c.jpg)
