### PR TITLE
command-not-found: remove 'w' from suggestions

### DIFF
--- a/packages/command-not-found/build.sh
+++ b/packages/command-not-found/build.sh
@@ -1,6 +1,6 @@
 TERMUX_PKG_HOMEPAGE=https://termux.com
 TERMUX_PKG_DESCRIPTION="Suggest installation of packages in interactive shell sessions"
-TERMUX_PKG_VERSION=1.33
+TERMUX_PKG_VERSION=1.34
 
 termux_step_make_install () {
 	TERMUX_LIBEXEC_DIR=$TERMUX_PREFIX/libexec/termux

--- a/packages/command-not-found/commands.h
+++ b/packages/command-not-found/commands.h
@@ -1937,7 +1937,6 @@ char const* const commands[] = {
 " top",
 " uptime",
 " vmstat",
-" w",
 " watch",
 "profanity",
 " profanity",


### PR DESCRIPTION
Command 'w' from procps is not available so it should be removed from command-not-found suggestions.