### PR TITLE
Add option to build-{package,all}.sh to set TERMUX_DEBDIR

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -10,17 +10,19 @@ test -f $HOME/.termuxrc && . $HOME/.termuxrc
 : ${TERMUX_DEBUG:=""}
 
 _show_usage () {
-	echo "Usage: ./build-all.sh [-a ARCH] [-d]"
+	echo "Usage: ./build-all.sh [-a ARCH] [-d] [-o DIR]"
 	echo "Build all packages."
 	echo "  -a The architecture to build for: aarch64(default), arm, i686, x86_64 or all."
 	echo "  -d Build with debug symbols."
+	echo "  -o Specify deb directory. Default: debs/."
 	exit 1
 }
 
-while getopts :a:hdDs option; do
+while getopts :a:hdDso: option; do
 case "$option" in
 	a) TERMUX_ARCH="$OPTARG";;
 	d) TERMUX_DEBUG='-d';;
+	o) TERMUX_DEBDIR="$(realpath -m $OPTARG)";;
 	h) _show_usage;;
 esac
 done
@@ -61,7 +63,8 @@ for package_path in `cat $BUILDORDER_FILE`; do
 
 	echo -n "Building $package... "
 	BUILD_START=`date "+%s"`
-	bash -x $BUILDSCRIPT -a $TERMUX_ARCH -s $TERMUX_DEBUG $package \
+	bash -x $BUILDSCRIPT -a $TERMUX_ARCH -s \
+	        $TERMUX_DEBUG ${TERMUX_DEBDIR+-o $TERMUX_DEBDIR} $package \
 	        > $BUILDALL_DIR/${package}.out 2> $BUILDALL_DIR/${package}.err
 	BUILD_END=`date "+%s"`
 	BUILD_SECONDS=$(( $BUILD_END - $BUILD_START ))

--- a/build-package.sh
+++ b/build-package.sh
@@ -227,7 +227,7 @@ termux_step_handle_arguments() {
 		case "$option" in
 		a) TERMUX_ARCH="$OPTARG";;
 		h) _show_usage;;
-		d) TERMUX_DEBUG=true;;
+		d) export TERMUX_DEBUG=true;;
 		D) local TERMUX_IS_DISABLED=true;;
 		f) TERMUX_FORCE_BUILD=true;;
 		q) export TERMUX_QUIET_BUILD=true;;
@@ -244,11 +244,8 @@ termux_step_handle_arguments() {
 	# Handle 'all' arch:
 	if [ -n "${TERMUX_ARCH+x}" ] && [ "${TERMUX_ARCH}" = 'all' ]; then
 		for arch in 'aarch64' 'arm' 'i686' 'x86_64'; do
-			if [ -n "${TERMUX_DEBDIR+x}" ]; then
-				./build-package.sh ${TERMUX_FORCE_BUILD+-f} -a $arch -o $TERMUX_DEBDIR "$1"
-			else
-				./build-package.sh ${TERMUX_FORCE_BUILD+-f} -a $arch "$1"
-			fi
+			./build-package.sh ${TERMUX_FORCE_BUILD+-f} -a $arch \
+				${TERMUX_DEBUG+-d} ${TERMUX_DEBDIR+-o $TERMUX_DEBDIR} "$1"
 		done
 		exit
 	fi


### PR DESCRIPTION
Accompanies 806de439b4926d590ed90eca790b532c9e461ce5. Makes it possible to, for example, build all root packages, debug packages and all normal packages and separate them into different folders easily. 

The -o option works with both relative paths (to the termux-packages folder) and absolute paths.
Also fix so that a build-package.sh -a all -d works as intended.