### PR TITLE
binutils: build with -Wno-c++11-narrowing

### DIFF
--- a/packages/binutils/build.sh
+++ b/packages/binutils/build.sh
@@ -12,6 +12,10 @@ TERMUX_PKG_KEEP_STATIC_LIBRARIES=true
 # Avoid linking against libfl.so from flex if available:
 export LEXLIB=
 
+termux_step_pre_configure () {
+	export CPPFLAGS="$CPPFLAGS -Wno-c++11-narrowing"
+}
+
 termux_step_post_make_install () {
 	cp $TERMUX_PKG_BUILDER_DIR/ldd $TERMUX_PREFIX/bin/ldd
 	cd $TERMUX_PREFIX/bin


### PR DESCRIPTION
Disable warning for now:
```
/home/builder/.termux-build/binutils/src/gold/x86_64.cc:1592:10: error: case value evaluates to 3221225474, which cannot be narrowed to type 'int' [-Wc++11-narrowing]
    case elfcpp::GNU_PROPERTY_X86_FEATURE_1_AND:
```