### PR TITLE
build-package.sh: fix gcc/g++ relative paths

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -728,6 +728,9 @@ termux_step_setup_toolchain() {
 		unset file
 		cd $_TERMUX_TOOLCHAIN_TMPDIR/include/c++/4.9.x
                 sed "s%\@TERMUX_HOST_PLATFORM\@%${TERMUX_HOST_PLATFORM}%g" $TERMUX_SCRIPTDIR/ndk-patches/*.cpppatch | patch -p1
+		# Fix relative path in gcc/g++ script:
+		sed -i "s%\`dirname \$0\`/../../../../%$NDK/toolchains/%g" $_TERMUX_TOOLCHAIN_TMPDIR/bin/${TERMUX_HOST_PLATFORM}-gcc
+		sed -i "s%\`dirname \$0\`/../../../../%$NDK/toolchains/%g" $_TERMUX_TOOLCHAIN_TMPDIR/bin/${TERMUX_HOST_PLATFORM}-g++
 		mv $_TERMUX_TOOLCHAIN_TMPDIR $TERMUX_STANDALONE_TOOLCHAIN
 	fi
 


### PR DESCRIPTION
`${TERMUX_HOST_PLATFORM}-{gcc.g++}` was removed and replaced with a script that assumed the llvm toolchain is in the ../../../../ folder, which isn't true for us after the toolchain has been copied to `~/.termux-build/_cache`. So replace with correct path in termux_step_setup_toolchain.