### PR TITLE
libpulseaudio: set alternate sample rate in aaudio sink data

### DIFF
--- a/packages/libpulseaudio/build.sh
+++ b/packages/libpulseaudio/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://www.freedesktop.org/wiki/Software/PulseAudio
 TERMUX_PKG_DESCRIPTION="A featureful, general-purpose sound server - shared libraries"
 TERMUX_PKG_VERSION=12.2
-TERMUX_PKG_REVISION=6
+TERMUX_PKG_REVISION=7
 TERMUX_PKG_SHA256=809668ffc296043779c984f53461c2b3987a45b7a25eb2f0a1d11d9f23ba4055
 TERMUX_PKG_SRCURL=https://www.freedesktop.org/software/pulseaudio/releases/pulseaudio-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_DEPENDS="libltdl, libsndfile, libandroid-glob, libsoxr"

--- a/packages/libpulseaudio/module-aaudio-sink.c
+++ b/packages/libpulseaudio/module-aaudio-sink.c
@@ -311,6 +311,7 @@ int pa__init(pa_module*m) {
     data.module = m;
     pa_sink_new_data_set_name(&data, pa_modargs_get_value(ma, "sink_name", DEFAULT_SINK_NAME));
     pa_sink_new_data_set_sample_spec(&data, &u->ss);
+    pa_sink_new_data_set_alternate_sample_rate(&data, u->ss.rate);
     pa_sink_new_data_set_channel_map(&data, &map);
     pa_proplist_sets(data.proplist, PA_PROP_DEVICE_DESCRIPTION, _("AAudio Output"));
     pa_proplist_sets(data.proplist, PA_PROP_DEVICE_CLASS, "abstract");


### PR DESCRIPTION
The "core" alternate sample rate must not kick in with our sink.
The sample rate of the sink must be locked onto that of the AAudio
stream.