### PR TITLE
ruby: use -O3 instead of -Os for 32 bit arches

### DIFF
--- a/packages/ruby/build.sh
+++ b/packages/ruby/build.sh
@@ -22,6 +22,7 @@ termux_step_pre_configure() {
 	if [ "$TERMUX_ARCH_BITS" = 32 ]; then
 		# process.c:function timetick2integer: error: undefined reference to '__mulodi4'
 		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" rb_cv_builtin___builtin_mul_overflow=no"
+		export CFLAGS="${CFLAGS/-Os/} -O3"
 	fi
 }
 

--- a/packages/ruby/build.sh
+++ b/packages/ruby/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://www.ruby-lang.org/
 TERMUX_PKG_DESCRIPTION="Dynamic programming language with a focus on simplicity and productivity"
 _MAJOR_VERSION=2.5
 TERMUX_PKG_VERSION=${_MAJOR_VERSION}.1
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SHA256=886ac5eed41e3b5fc699be837b0087a6a5a3d10f464087560d2d21b3e71b754d
 TERMUX_PKG_SRCURL=https://cache.ruby-lang.org/pub/ruby/${_MAJOR_VERSION}/ruby-${TERMUX_PKG_VERSION}.tar.xz
 # libbffi is used by the fiddle extension module:


### PR DESCRIPTION
This changes it for i686 as well, even though we haven't gotten any bug reports from that arch, AFAIK.

Solves #2845.