### PR TITLE
proot: Update with tmpdir canonicalization

### DIFF
--- a/packages/proot/build.sh
+++ b/packages/proot/build.sh
@@ -1,12 +1,15 @@
 TERMUX_PKG_HOMEPAGE=https://proot-me.github.io/
 TERMUX_PKG_DESCRIPTION="Emulate chroot, bind mount and binfmt_misc for non-root users"
 # Just bump commit and version when needed:
-_COMMIT=bb145259590c13c4992fb34d128218f560daf0fc
+_COMMIT=d9f15817f8e06e41f8c2d37f1433005c8323631e
 TERMUX_PKG_VERSION=5.1.107
-TERMUX_PKG_REVISION=16
+TERMUX_PKG_REVISION=17
 TERMUX_PKG_SRCURL=https://github.com/termux/proot/archive/${_COMMIT}.zip
-TERMUX_PKG_SHA256=aa0c5b18fbf615847cd186babf6c89c73fe4308032c50c2db9b7e6bb2220a515
+TERMUX_PKG_SHA256=565fe3e0e49c1510fe1697649def917692ac6a2ec3282b2421d68a845bec26aa
 TERMUX_PKG_DEPENDS="libtalloc"
+
+# Install loader in libexec instead of extracting it every time
+export PROOT_UNBUNDLE_LOADER=$TERMUX_PREFIX/libexec/proot
 
 termux_step_pre_configure() {
 	export LD=$CC


### PR DESCRIPTION
* Canonicalize tmp dir (termux/proot#40 by @tomty89)
* Merge changes from UserLAnd (althrough most are off by default, termux/proot#39 by @corbinlc)
* Puting loader in libexec instead of extracting it on every run