### PR TITLE
setup-ubuntu.sh: add xxd which is required for ttyd build

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -36,6 +36,7 @@ PACKAGES+=" xutils-dev" # Provides 'makedepend' which the openssl build uses.
 PACKAGES+=" libexpat1-dev" # Needed by ghostscript
 PACKAGES+=" libjpeg-dev" # Needed by ghostscript
 PACKAGES+=" gawk" # Needed by apr-util
+PACKAGES+=" xxd" # Needed by ttyd
 
 sudo DEBIAN_FRONTEND=noninteractive \
 	apt-get install -yq --no-install-recommends $PACKAGES


### PR DESCRIPTION
If xxd is missing then `./build-package.sh ttyd` fails with error 1, without any error message whatsoever