### PR TITLE
python(2): dev package requires libcrypto-dev

### DIFF
--- a/packages/python/build.sh
+++ b/packages/python/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://python.org/
 TERMUX_PKG_DESCRIPTION="Python 3 programming language intended to enable clear programs"
 TERMUX_PKG_DEPENDS="libandroid-support, ncurses, readline, libffi, openssl, libutil, libbz2, libsqlite, gdbm, ncurses-ui-libs, libcrypt, liblzma"
+TERMUX_PKG_DEVPACKAGE_DEPENDS="libcrypt-dev"
 _MAJOR_VERSION=3.6
 TERMUX_PKG_VERSION=${_MAJOR_VERSION}.6
 TERMUX_PKG_REVISION=1

--- a/packages/python2/build.sh
+++ b/packages/python2/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_DESCRIPTION="Python 2 programming language intended to enable clear p
 # libbz2 for the bz2 module.
 # ncurses-ui-libs for the curses.panel module.
 TERMUX_PKG_DEPENDS="libandroid-support, ncurses, readline, libffi, openssl, libutil, libbz2, libsqlite, gdbm, ncurses-ui-libs, libcrypt"
+TERMUX_PKG_DEVPACKAGE_DEPENDS="libcrypt-dev"
 TERMUX_PKG_HOSTBUILD=true
 
 _MAJOR_VERSION=2.7


### PR DESCRIPTION
Header file 'Python.h' requires 'crypt.h' from libcrypto-dev.