### PR TITLE
new package: fakeroot

### DIFF
--- a/packages/fakeroot/build.sh
+++ b/packages/fakeroot/build.sh
@@ -1,0 +1,8 @@
+TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
+
+TERMUX_PKG_HOMEPAGE=http://packages.debian.org/fakeroot
+TERMUX_PKG_DESCRIPTION="Tool for simulating superuser privileges (with tcp ipc)"
+TERMUX_PKG_VERSION=1.23
+TERMUX_PKG_SRCURL=http://ftp.debian.org/debian/pool/main/f/fakeroot/fakeroot_${TERMUX_PKG_VERSION}.orig.tar.xz
+TERMUX_PKG_SHA256=009cd6696a931562cf1c212bb57ca441a4a2d45cd32c3190a35c7ae98506f4f6
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-ipc=tcp"

--- a/packages/fakeroot/fakeroot-1.23_faked.c.patch
+++ b/packages/fakeroot/fakeroot-1.23_faked.c.patch
@@ -1,6 +1,6 @@
 diff -uNr fakeroot-1.23/faked.c fakeroot-1.23.mod/faked.c
 --- fakeroot-1.23/faked.c	2018-07-01 22:01:34.000000000 +0300
-+++ fakeroot-1.23.mod/faked.c	2018-10-01 17:11:53.263620010 +0300
++++ fakeroot-1.23.mod/faked.c	2018-10-01 17:31:45.172555748 +0300
 @@ -1487,7 +1487,7 @@
      /* literally copied from the linux klogd code, go to background */
      if ((pid=fork()) == 0){

--- a/packages/fakeroot/fakeroot-1.23_faked.c.patch
+++ b/packages/fakeroot/fakeroot-1.23_faked.c.patch
@@ -1,0 +1,12 @@
+diff -uNr fakeroot-1.23/faked.c fakeroot-1.23.mod/faked.c
+--- fakeroot-1.23/faked.c	2018-07-01 22:01:34.000000000 +0300
++++ fakeroot-1.23.mod/faked.c	2018-10-01 17:11:53.263620010 +0300
+@@ -1487,7 +1487,7 @@
+     /* literally copied from the linux klogd code, go to background */
+     if ((pid=fork()) == 0){
+       int fl;
+-      int num_fds = getdtablesize();
++      int num_fds = sysconf(_SC_OPEN_MAX);
+ 
+       fflush(stdout);
+ 

--- a/packages/fakeroot/fakeroot-1.23_libfakeroot.c.patch
+++ b/packages/fakeroot/fakeroot-1.23_libfakeroot.c.patch
@@ -1,6 +1,6 @@
 diff -uNr fakeroot-1.23/libfakeroot.c fakeroot-1.23.mod/libfakeroot.c
 --- fakeroot-1.23/libfakeroot.c	2018-07-01 22:01:34.000000000 +0300
-+++ fakeroot-1.23.mod/libfakeroot.c	2018-10-01 17:09:21.633620119 +0300
++++ fakeroot-1.23.mod/libfakeroot.c	2018-10-01 17:31:45.175889099 +0300
 @@ -81,12 +81,14 @@
  #define SEND_STAT64(a,b,c) send_stat64(a,b,c)
  #define SEND_GET_STAT(a,b) send_get_stat(a,b)

--- a/packages/fakeroot/fakeroot-1.23_libfakeroot.c.patch
+++ b/packages/fakeroot/fakeroot-1.23_libfakeroot.c.patch
@@ -1,0 +1,18 @@
+diff -uNr fakeroot-1.23/libfakeroot.c fakeroot-1.23.mod/libfakeroot.c
+--- fakeroot-1.23/libfakeroot.c	2018-07-01 22:01:34.000000000 +0300
++++ fakeroot-1.23.mod/libfakeroot.c	2018-10-01 17:09:21.633620119 +0300
+@@ -81,12 +81,14 @@
+ #define SEND_STAT64(a,b,c) send_stat64(a,b,c)
+ #define SEND_GET_STAT(a,b) send_get_stat(a,b)
+ #define SEND_GET_STAT64(a,b) send_get_stat64(a,b)
++#define SEND_GET_XATTR(a,b,c) send_get_xattr(a,b,c)
+ #define SEND_GET_XATTR64(a,b,c) send_get_xattr64(a,b,c)
+ #else
+ #define SEND_STAT(a,b,c) send_stat(a,b)
+ #define SEND_STAT64(a,b,c) send_stat64(a,b)
+ #define SEND_GET_STAT(a,b) send_get_stat(a)
+ #define SEND_GET_STAT64(a,b) send_get_stat64(a)
++#define SEND_GET_XATTR(a,b,c) send_get_xattr(a,b)
+ #define SEND_GET_XATTR64(a,b,c) send_get_xattr64(a,b)
+ #endif
+ 

--- a/packages/fakeroot/fakeroot-1.23_scripts_fakeroot.in.patch
+++ b/packages/fakeroot/fakeroot-1.23_scripts_fakeroot.in.patch
@@ -1,0 +1,25 @@
+diff -uNr fakeroot-1.23/scripts/fakeroot.in fakeroot-1.23.mod/scripts/fakeroot.in
+--- fakeroot-1.23/scripts/fakeroot.in	2018-07-01 22:01:34.000000000 +0300
++++ fakeroot-1.23.mod/scripts/fakeroot.in	2018-10-01 17:32:47.566222406 +0300
+@@ -145,8 +145,8 @@
+ if [ "$WAITINTRAP" -eq 0 ]; then
+   trap "kill -s @signal@ $PID" EXIT INT
+ else
+-  @MACOSX_FALSE@trap 'FAKEROOTKEY=$FAKEROOTKEY @LDLIBPATHVAR@="$PATHS" @LDPRELOADVAR@="$LIB" /bin/ls -l / >/dev/null 2>&1; while kill -s @signal@ $PID 2>/dev/null; do sleep 0.1; done' EXIT INT
+-  @MACOSX_TRUE@trap 'FAKEROOTKEY=$FAKEROOTKEY @LDPRELOADVAR@="$LIB" /bin/ls -l / >/dev/null 2>&1; while kill -s @signal@ $PID 2>/dev/null; do sleep 0.1; done' EXIT INT
++  @MACOSX_FALSE@trap 'FAKEROOTKEY=$FAKEROOTKEY @LDLIBPATHVAR@="$PATHS" @LDPRELOADVAR@="$LIB" ls -l / >/dev/null 2>&1; while kill -s @signal@ $PID 2>/dev/null; do sleep 0.1; done' EXIT INT
++  @MACOSX_TRUE@trap 'FAKEROOTKEY=$FAKEROOTKEY @LDPRELOADVAR@="$LIB" ls -l / >/dev/null 2>&1; while kill -s @signal@ $PID 2>/dev/null; do sleep 0.1; done' EXIT INT
+ fi
+ 
+ if test -z "$FAKEROOTKEY" || test -z "$PID"; then
+@@ -168,8 +168,8 @@
+ export FAKEROOT_FD_BASE
+ 
+ if test -z "$*"; then
+-  @MACOSX_FALSE@FAKEROOTKEY=$FAKEROOTKEY @LDLIBPATHVAR@="$PATHS" @LDEXTRAVAR@ @LDPRELOADVAR@="$LIB" ${SHELL:-/bin/sh}
+-  @MACOSX_TRUE@FAKEROOTKEY=$FAKEROOTKEY @LDEXTRAVAR@ @LDPRELOADVAR@="$LIB" ${SHELL:-/bin/sh}
++  @MACOSX_FALSE@FAKEROOTKEY=$FAKEROOTKEY @LDLIBPATHVAR@="$PATHS" @LDEXTRAVAR@ @LDPRELOADVAR@="$LIB" ${SHELL:-@TERMUX_PREFIX@/bin/sh}
++  @MACOSX_TRUE@FAKEROOTKEY=$FAKEROOTKEY @LDEXTRAVAR@ @LDPRELOADVAR@="$LIB" ${SHELL:-@TERMUX_PREFIX@/bin/sh}
+   RESULT=$?
+ else
+   @MACOSX_FALSE@FAKEROOTKEY=$FAKEROOTKEY @LDLIBPATHVAR@="$PATHS" @LDEXTRAVAR@ @LDPRELOADVAR@="$LIB" "$@"


### PR DESCRIPTION
Uses tcp ipc since SysV ipc is not available on most devices.
Requested in: https://github.com/termux/termux-packages/issues/2915