### PR TITLE
strace: fix crash on Android 9 (Pie)

### DIFF
--- a/packages/strace/build.sh
+++ b/packages/strace/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://strace.io/
 TERMUX_PKG_DESCRIPTION="Debugging utility to monitor system calls and signals received"
 TERMUX_PKG_VERSION=4.24
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=1f4e59fc1edfa2bfb4adf2a748623dc25b105ec79713dd84404199f91b0b0634
 TERMUX_PKG_SRCURL=https://strace.io/files/$TERMUX_PKG_VERSION/strace-$TERMUX_PKG_VERSION.tar.xz
 TERMUX_PKG_RM_AFTER_INSTALL=bin/strace-graph # This is a perl script

--- a/packages/strace/ipc_msgctl.c.patch
+++ b/packages/strace/ipc_msgctl.c.patch
@@ -1,7 +1,7 @@
-diff -u -r ../strace-4.11/ipc_msgctl.c ./ipc_msgctl.c
---- ../strace-4.11/ipc_msgctl.c	2015-11-25 20:36:58.000000000 -0500
-+++ ./ipc_msgctl.c	2015-12-25 22:20:18.904846632 -0500
-@@ -74,7 +74,9 @@
+diff -uNr strace-4.24/ipc_msgctl.c strace-4.24.mod/ipc_msgctl.c
+--- strace-4.24/ipc_msgctl.c	2017-05-22 20:33:51.000000000 +0300
++++ strace-4.24.mod/ipc_msgctl.c	2018-10-03 01:14:05.344818748 +0300
+@@ -75,7 +75,9 @@
  			break;
  		}
  

--- a/packages/strace/ipc_shmctl.c.patch
+++ b/packages/strace/ipc_shmctl.c.patch
@@ -1,7 +1,7 @@
-diff -u -r ../strace-4.11/ipc_shmctl.c ./ipc_shmctl.c
---- ../strace-4.11/ipc_shmctl.c	2015-11-25 20:36:58.000000000 -0500
-+++ ./ipc_shmctl.c	2015-12-25 22:21:12.944165532 -0500
-@@ -74,7 +74,9 @@
+diff -uNr strace-4.24/ipc_shmctl.c strace-4.24.mod/ipc_shmctl.c
+--- strace-4.24/ipc_shmctl.c	2017-05-22 20:33:51.000000000 +0300
++++ strace-4.24.mod/ipc_shmctl.c	2018-10-03 01:14:05.348152107 +0300
+@@ -75,7 +75,9 @@
  			break;
  		}
  

--- a/packages/strace/strace.c.patch
+++ b/packages/strace/strace.c.patch
@@ -1,0 +1,42 @@
+diff -uNr strace-4.24/strace.c strace-4.24.mod/strace.c
+--- strace-4.24/strace.c	2018-07-11 03:00:57.000000000 +0300
++++ strace-4.24.mod/strace.c	2018-10-03 01:15:15.105370170 +0300
+@@ -442,11 +442,7 @@
+ static void
+ swap_uid(void)
+ {
+-	int euid = geteuid(), uid = getuid();
+-
+-	if (euid != uid && setreuid(euid, uid) < 0) {
+-		perror_msg_and_die("setreuid");
+-	}
++    return;
+ }
+ 
+ static FILE *
+@@ -1182,25 +1178,6 @@
+ 		}
+ 	}
+ 
+-	if (username != NULL) {
+-		/*
+-		 * It is important to set groups before we
+-		 * lose privileges on setuid.
+-		 */
+-		if (initgroups(username, run_gid) < 0) {
+-			perror_msg_and_die("initgroups");
+-		}
+-		if (setregid(run_gid, params->run_egid) < 0) {
+-			perror_msg_and_die("setregid");
+-		}
+-		if (setreuid(run_uid, params->run_euid) < 0) {
+-			perror_msg_and_die("setreuid");
+-		}
+-	} else if (geteuid() != 0)
+-		if (setreuid(run_uid, run_uid) < 0) {
+-			perror_msg_and_die("setreuid");
+-		}
+-
+ 	if (!daemonized_tracer) {
+ 		/*
+ 		 * Induce a ptrace stop. Tracer (our parent)


### PR DESCRIPTION
Fixes error `Unexpected wait status 0x1f` and makes strace working on Android Pie.