### PR TITLE
fontconfig: don't use link(2) for locking

### DIFF
--- a/packages/fontconfig/build.sh
+++ b/packages/fontconfig/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://www.freedesktop.org/wiki/Software/fontconfig/
 TERMUX_PKG_DESCRIPTION="Library for configuring and customizing font access"
 TERMUX_PKG_VERSION=2.13.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=f655dd2a986d7aa97e052261b36aa67b0a64989496361eca8d604e6414006741
 TERMUX_PKG_SRCURL=https://www.freedesktop.org/software/fontconfig/release/fontconfig-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_DEPENDS="freetype, libxml2, libpng, libuuid"

--- a/packages/fontconfig/fcatomic.c.patch
+++ b/packages/fontconfig/fcatomic.c.patch
@@ -1,0 +1,20 @@
+diff -uNr fontconfig-2.13.1/src/fcatomic.c fontconfig-2.13.1.mod/src/fcatomic.c
+--- fontconfig-2.13.1/src/fcatomic.c	2018-03-15 10:44:44.000000000 +0200
++++ fontconfig-2.13.1.mod/src/fcatomic.c	2018-10-03 02:20:37.073426762 +0300
+@@ -130,15 +130,12 @@
+ 	unlink ((char *) atomic->tmp);
+ 	return FcFalse;
+     }
+-    ret = link ((char *) atomic->tmp, (char *) atomic->lck);
+-    if (ret < 0 && (errno == EPERM || errno == ENOTSUP || errno == EACCES))
+-    {
++
+ 	/* the filesystem where atomic->lck points to may not supports
+ 	 * the hard link. so better try to fallback
+ 	 */
+ 	ret = mkdir ((char *) atomic->lck, 0600);
+ 	no_link = FcTrue;
+-    }
+     (void) unlink ((char *) atomic->tmp);
+ #else
+     ret = mkdir ((char *) atomic->lck, 0600);


### PR DESCRIPTION
By default, fontconfig tries to use link(2) when performing locking, but it fails due to SELinux. So it is better to disable it and directly use provided fallback.

```
<36>[13150.308510] type=1400 audit(1538522946.183:206): avc: denied { link } for pid=13109 comm="fluxbox" name="3336a65c52528c9c368e942d3dd307f8-le32d4.cache-7.TMP-b0gZma" dev="dm-0" ino=133296 scontext=u:r:untrusted_app_27:s0:c512,c768 tcontext=u:object_r:app_data_file:s0:c512,c768 tclass=file permissive=0
```