### PR TITLE
nodejs and nodejs-lts: Use included zlib instead of the one from the NDK.

### DIFF
--- a/packages/nodejs-lts/build.sh
+++ b/packages/nodejs-lts/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://nodejs.org/
 TERMUX_PKG_DESCRIPTION="Platform built on Chrome's JavaScript runtime for easily building fast, scalable network applications"
 TERMUX_PKG_VERSION=8.12.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=5a9dff58016c18fb4bf902d963b124ff058a550ebcd9840c677757387bce419a
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
 # Note that we do not use a shared libuv to avoid an issue with the Android
@@ -33,7 +34,6 @@ termux_step_configure () {
 		--dest-os=android \
 		--shared-cares \
 		--shared-openssl \
-		--shared-zlib \
 		--without-inspector \
 		--without-intl \
 		--without-snapshot \

--- a/packages/nodejs/build.sh
+++ b/packages/nodejs/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://nodejs.org/
 TERMUX_PKG_DESCRIPTION="Platform built on Chrome's JavaScript runtime for easily building fast, scalable network applications"
 TERMUX_PKG_VERSION=10.11.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=b91242c2599db23db9261673500969510fdc7e74426e8d80f1a679b12c7f8e9b
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
 # Note that we do not use a shared libuv to avoid an issue with the Android
@@ -38,7 +39,6 @@ termux_step_configure () {
 		--dest-os=android \
 		--shared-cares \
 		--shared-openssl \
-		--shared-zlib \
 		--without-inspector \
 		--with-intl=system-icu \
 		--without-snapshot \


### PR DESCRIPTION
This adds about 64kB to the installed package size, but makes it possible to install some NPM packages again, due to the old `zlib` not being able to unpack them.

Fixes #2922, so `create-react-app` runs successfully again.