### PR TITLE
fix for radare2 on android 5

### DIFF
--- a/packages/radare2/build.sh
+++ b/packages/radare2/build.sh
@@ -10,6 +10,7 @@ termux_step_pre_configure() {
 	# Unset CPPFLAGS to avoid -I$TERMUX_PREFIX/include. This is because
 	# radare2 build will put it's own -I flags after ours, which causes
 	# problems due to name clashes (binutils header files).
+	cp libr/util/mem.c libr/hash/mem.c
 	unset CPPFLAGS
 
 	# If this variable is not set, then build will fail on linking with 'pthread'

--- a/packages/radare2/hash_makefile.patch
+++ b/packages/radare2/hash_makefile.patch
@@ -1,0 +1,11 @@
+--- ../cache/radare2-2.9.0/libr/hash/Makefile	2018-09-03 23:55:31.000000000 +0000
++++ ./libr/hash/Makefile	2018-10-05 07:11:48.816607605 +0000
+@@ -12,7 +12,7 @@
+ 
+ DEPS=r_util
+ OBJS=state.o hash.o hamdist.o crca.o
+-OBJS+=entropy.o calc.o adler32.o luhn.o
++OBJS+=entropy.o calc.o adler32.o luhn.o mem.o
+ 
+ ifeq ($(HAVE_LIB_SSL),1)
+ CFLAGS+=${SSL_CFLAGS}


### PR DESCRIPTION
for some reason linker isn't behaving on android 5.... haven't looked deeply just obvious fix. 