### PR TITLE
ldc: Update from 1.11 to 1.12

### DIFF
--- a/packages/ldc/build.sh
+++ b/packages/ldc/build.sh
@@ -1,26 +1,25 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/ldc-developers/ldc
 TERMUX_PKG_DESCRIPTION="D programming language compiler, built with LLVM"
 TERMUX_PKG_VERSION=()
-TERMUX_PKG_VERSION+=(1.11.0)
-TERMUX_PKG_VERSION+=(6.0.1-2) # LLVM version
-TERMUX_PKG_VERSION+=(2.081.2) # TOOLS version
-TERMUX_PKG_VERSION+=(1.10.0)  # DUB version
+TERMUX_PKG_VERSION+=(1.12.0)
+TERMUX_PKG_VERSION+=(7.0.0)   # LLVM version
+TERMUX_PKG_VERSION+=(2.082.1) # TOOLS version
+TERMUX_PKG_VERSION+=(1.11.0)  # DUB version
 
 TERMUX_PKG_SRCURL=(https://github.com/ldc-developers/ldc/releases/download/v${TERMUX_PKG_VERSION}/ldc-${TERMUX_PKG_VERSION}-src.tar.gz
 		   https://github.com/ldc-developers/llvm/releases/download/ldc-v${TERMUX_PKG_VERSION[1]}/llvm-${TERMUX_PKG_VERSION[1]}.src.tar.xz
 		   https://github.com/dlang/tools/archive/v${TERMUX_PKG_VERSION[2]}.tar.gz
 		   https://github.com/dlang/dub/archive/v${TERMUX_PKG_VERSION[3]}.tar.gz
 		   https://github.com/ldc-developers/ldc/releases/download/v${TERMUX_PKG_VERSION}/ldc2-${TERMUX_PKG_VERSION}-linux-x86_64.tar.xz)
-TERMUX_PKG_SHA256=(85464fae47bc605308910afd6cfc6ddeafe95a8ad5b61e2c0c23caff82119f70
-		   768a78f5a6e918da7bd8180f9afad94182056fcf2f9b7d1d9bdb67953d7122d0
-		   d7dc67d258499e5ee401467f0570b4ca2547deb7720e7cd163b73fccb039a60e
-		   db6c3a9e45408d2431bc3d1138a31b561fb71665c1d89db4b0cb3725b2b12faa
-		   43b826ef2bd0c249115bc83dad12f3638fd6997fdc80a6a7db147f9ae0fa3fe8)
+TERMUX_PKG_SHA256=(952ba57a957079345333d3f6aaaac766cc49750859357c419efc0c897850b5b9
+		   cc4f6fd2ec9002a9c7f4ff731c81be5b50672dd6d359e901ce58030f82f7b38a
+		   19c02fba1cb270cda3d7101448f36974e623e09a696ce2310a742faf2f3dfdad
+		   ef3f7d6ce0b726530973d9348a94fd91f9d02d30851ef3257ff538af4af571b6
+		   eeb83d3356d6ba3f5892f629de466df79c02bac5fd1f0e1ecdf01fe6171d42ac)
 TERMUX_PKG_DEPENDS="clang"
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_BLACKLISTED_ARCHES="i686,x86_64"
 TERMUX_PKG_FORCE_CMAKE=yes
-TERMUX_CMAKE_BUILD="Ninja"
 #These CMake args are only used to configure a patched LLVM
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DLLVM_ENABLE_PIC=ON
@@ -38,7 +37,7 @@ termux_step_post_extract_package () {
 	mv tools-${TERMUX_PKG_VERSION[2]} rdmd
 	mv dub-${TERMUX_PKG_VERSION[3]} dub
 
-	export LLVM_TRIPLE=$TERMUX_HOST_PLATFORM
+	export LLVM_TRIPLE=${TERMUX_HOST_PLATFORM/-/--}
 	if [ $TERMUX_ARCH = arm ]; then LLVM_TRIPLE=${LLVM_TRIPLE/arm-/armv7a-}; fi
 	sed $TERMUX_PKG_BUILDER_DIR/llvm-config.in \
 		-e "s|@LLVM_VERSION@|${TERMUX_PKG_VERSION[1]}|g" \

--- a/packages/ldc/ldc-druntime-tls.patch
+++ b/packages/ldc/ldc-druntime-tls.patch
@@ -1,0 +1,80 @@
+diff --git a/src/rt/sections_android.d b/src/rt/sections_android.d
+index cd8d5535..6a7fcd11 100644
+--- a/runtime/druntime/src/rt/sections_android.d
++++ b/runtime/druntime/src/rt/sections_android.d
+@@ -76,7 +76,11 @@ void initSections() nothrow @nogc
+     _sections.moduleGroup = ModuleGroup(mbeg[0 .. mend - mbeg]);
+ 
+     auto pbeg = cast(void*)&_tlsend;
+-    auto pend = cast(void*)&__bss_end__;
++    version(X86) auto pend = cast(void*)&_end;
++    else version(X86_64) auto pend = cast(void*)& _end;
++    else version(ARM) auto pend = cast(void*)& __bss_end__;
++    else version(AArch64) auto pend = cast(void*)& __bss_end__;
++    else static assert( false, "Android architecture not supported." );
+     // _tlsend is a 32-bit int and may not be 64-bit void*-aligned, so align pbeg.
+     version(D_LP64) pbeg = cast(void*)(cast(size_t)(pbeg + 7) & ~cast(size_t)7);
+     _sections._gcRanges[0] = pbeg[0 .. pend - pbeg];
+@@ -115,43 +119,14 @@ void scanTLSRanges(void[]* rng, scope void delegate(void* pbeg, void* pend) noth
+  *       the corresponding address in the TLS dynamic per-thread data.
+  */
+ 
+-version(X86)
++extern(C) void* __tls_get_addr( void* p ) nothrow @nogc
+ {
+-    // NB: the compiler mangles this function as '___tls_get_addr'
+-    // even though it is extern(D)
+-    extern(D) void* ___tls_get_addr( void* p ) nothrow @nogc
+-    {
+-        debug(PRINTF) printf("  ___tls_get_addr input - %p\n", p);
+-        immutable offset = cast(size_t)(p - cast(void*)&_tlsstart);
+-        auto tls = getTLSBlockAlloc();
+-        assert(offset < tls.length);
+-        return tls.ptr + offset;
+-    }
+-}
+-else version(ARM)
+-{
+-    extern(C) void* __tls_get_addr( void** p ) nothrow @nogc
+-    {
+-        debug(PRINTF) printf("  __tls_get_addr input - %p\n", *p);
+-        immutable offset = cast(size_t)(*p - cast(void*)&_tlsstart);
+-        auto tls = getTLSBlockAlloc();
+-        assert(offset < tls.length);
+-        return tls.ptr + offset;
+-    }
+-}
+-else version(AArch64)
+-{
+-    extern(C) void* __tls_get_addr( void* p ) nothrow @nogc
+-    {
+-        debug(PRINTF) printf("  __tls_get_addr input - %p\n", p);
+-        immutable offset = cast(size_t)(p - cast(void*)&_tlsstart);
+-        auto tls = getTLSBlockAlloc();
+-        assert(offset < tls.length);
+-        return tls.ptr + offset;
+-    }
++    debug(PRINTF) printf("  __tls_get_addr input - %p\n", p);
++    immutable offset = cast(size_t)(p - cast(void*)&_tlsstart);
++    auto tls = getTLSBlockAlloc();
++    assert(offset < tls.length);
++    return tls.ptr + offset;
+ }
+-else
+-    static assert( false, "Android architecture not supported." );
+ 
+ private:
+ 
+@@ -209,7 +184,11 @@ extern(C)
+             void* __stop_minfo;
+         }
+ 
+-        size_t __bss_end__;
++        version(X86) size_t _end;
++        else version(X86_64) size_t _end;
++        else version(ARM) size_t __bss_end__;
++        else version(AArch64) size_t __bss_end__;
++        else static assert( false, "Android architecture not supported." );
+ 
+         int _tlsstart;
+         int _tlsend;

--- a/packages/ldc/llvm-config.in
+++ b/packages/ldc/llvm-config.in
@@ -72,7 +72,7 @@ transformutils vectorize webassembly webassemblyasmprinter webassemblycodegen we
 webassemblyinfo windowsmanifest x86 x86asmparser x86asmprinter x86codegen x86desc x86disassembler x86info x86utils xcore \
 xcoreasmprinter xcorecodegen xcoredesc xcoredisassembler xcoreinfo"
 static_libs="-lLLVMTableGen -lLLVMLTO -lLLVMPasses -lLLVMObjCARCOpts -lLLVMMIRParser -lLLVMSymbolize -lLLVMDebugInfoPDB -lLLVMDebugInfoDWARF \
--lLLVMCoverage -lLLVMDlltoolDriver -lLLVMOrcJIT -lLLVMARMDisassembler \
+-lLLVMCoverage -lLLVMDlltoolDriver -lLLVMOrcJIT -lLLVMARMDisassembler -lLLVMAggressiveInstCombine -lLLVMTestingSupport \
 -lLLVMARMCodeGen -lLLVMARMAsmParser -lLLVMARMDesc -lLLVMARMInfo -lLLVMARMAsmPrinter -lLLVMARMUtils \
 -lLLVMAArch64Disassembler -lLLVMAArch64CodeGen -lLLVMAArch64AsmParser -lLLVMAArch64Desc -lLLVMAArch64Info -lLLVMAArch64AsmPrinter \
 -lLLVMAArch64Utils -lLLVMObjectYAML -lLLVMLibDriver -lLLVMOption -lLLVMWindowsManifest -lLLVMFuzzMutate -lLLVMX86Disassembler \


### PR DESCRIPTION
`i686` is also working with one more small patch, but I need to clean it up. `x86_64` has problems when trying to link ldc, apparently because D doesn't expect the 128-bit `long double` type used. I'll work on both and submit another pull for those arches later.