### PR TITLE
termux-api: depend on 'bash'

### DIFF
--- a/packages/termux-api/build.sh
+++ b/packages/termux-api/build.sh
@@ -1,6 +1,8 @@
 TERMUX_PKG_HOMEPAGE=https://termux.com/add-on-api.html
 TERMUX_PKG_DESCRIPTION="Termux API commands (install also the Termux:API app)"
 TERMUX_PKG_VERSION=0.35
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=dec8f73233a6c6401acdcca1ffd9e4ddcc51bfc71bfb89678c8b11479abb4bb4
 TERMUX_PKG_SRCURL=https://github.com/termux/termux-api-package/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_BUILD_IN_SRC=yes
+TERMUX_PKG_DEPENDS="bash"


### PR DESCRIPTION
Fixes https://github.com/termux/termux-packages/issues/2967.