### PR TITLE
Dropbear & OpenSSH password authentication

### DIFF
--- a/packages/dropbear/build.sh
+++ b/packages/dropbear/build.sh
@@ -12,8 +12,8 @@ TERMUX_PKG_BUILD_IN_SRC="yes"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-syslog --disable-utmp --disable-utmpx --disable-wtmp"
 # Avoid linking to libcrypt for server password authentication:
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_lib_crypt_crypt=no"
-# build a multi-call binary
-TERMUX_PKG_EXTRA_MAKE_ARGS="MULTI=1"
+# build a multi-call binary & enable progress info in 'scp'
+TERMUX_PKG_EXTRA_MAKE_ARGS="MULTI=1 SCPPROGRESS=1"
 
 termux_step_pre_configure() {
     export LIBS="-ltermux-auth"

--- a/packages/dropbear/build.sh
+++ b/packages/dropbear/build.sh
@@ -3,15 +3,21 @@ TERMUX_PKG_DESCRIPTION="Small SSH server and client"
 TERMUX_PKG_DEPENDS="libutil"
 TERMUX_PKG_CONFLICTS="openssh"
 TERMUX_PKG_VERSION=2018.76
-TERMUX_PKG_REVISION=4
+TERMUX_PKG_REVISION=5
 TERMUX_PKG_SRCURL=https://matt.ucc.asn.au/dropbear/releases/dropbear-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=f2fb9167eca8cf93456a5fc1d4faf709902a3ab70dd44e352f3acbc3ffdaea65
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-syslog --disable-utmp --disable-utmpx --disable-wtmp"
+TERMUX_PKG_DEPENDS="termux-auth"
 TERMUX_PKG_BUILD_IN_SRC="yes"
+
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-syslog --disable-utmp --disable-utmpx --disable-wtmp"
 # Avoid linking to libcrypt for server password authentication:
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_lib_crypt_crypt=no"
 # build a multi-call binary
 TERMUX_PKG_EXTRA_MAKE_ARGS="MULTI=1"
+
+termux_step_pre_configure() {
+    export LIBS="-ltermux-auth"
+}
 
 termux_step_post_make_install() {
     ln -sf "dropbearmulti" "${TERMUX_PREFIX}/bin/ssh"

--- a/packages/dropbear/default_options.h.patch
+++ b/packages/dropbear/default_options.h.patch
@@ -1,6 +1,6 @@
 diff -uNr dropbear-2018.76/default_options.h dropbear-2018.76.mod/default_options.h
 --- dropbear-2018.76/default_options.h	2018-02-27 16:25:10.000000000 +0200
-+++ dropbear-2018.76.mod/default_options.h	2018-04-21 13:44:59.120396918 +0300
++++ dropbear-2018.76.mod/default_options.h	2018-10-21 14:11:01.838918022 +0300
 @@ -13,15 +13,15 @@
  
  IMPORTANT: Some options will require "make clean" after changes */
@@ -30,7 +30,7 @@ diff -uNr dropbear-2018.76/default_options.h dropbear-2018.76.mod/default_option
  
  /* Enable X11 Forwarding - server only */
  #define DROPBEAR_X11FWD 1
-@@ -175,11 +175,11 @@
+@@ -175,7 +175,7 @@
  
  /* Whether to print the message of the day (MOTD). */
  #define DO_MOTD 0
@@ -39,11 +39,6 @@ diff -uNr dropbear-2018.76/default_options.h dropbear-2018.76.mod/default_option
  
  /* Authentication Types - at least one required.
     RFC Draft requires pubkey auth, and recommends password */
--#define DROPBEAR_SVR_PASSWORD_AUTH 1
-+#undef DROPBEAR_SVR_PASSWORD_AUTH
- 
- /* Note: PAM auth is quite simple and only works for PAM modules which just do
-  * a simple "Login: " "Password: " (you can edit the strings in svr-authpam.c).
 @@ -222,7 +222,7 @@
  
  /* Set this to use PRNGD or EGD instead of /dev/urandom */

--- a/packages/dropbear/svr-authpasswd.c.patch
+++ b/packages/dropbear/svr-authpasswd.c.patch
@@ -1,0 +1,93 @@
+diff -uNr dropbear-2018.76/svr-authpasswd.c dropbear-2018.76.mod/svr-authpasswd.c
+--- dropbear-2018.76/svr-authpasswd.c	2018-02-27 16:25:12.000000000 +0200
++++ dropbear-2018.76.mod/svr-authpasswd.c	2018-10-21 14:05:37.774231619 +0300
+@@ -33,36 +33,13 @@
+ 
+ #if DROPBEAR_SVR_PASSWORD_AUTH
+ 
+-/* not constant time when strings are differing lengths. 
+- string content isn't leaked, and crypt hashes are predictable length. */
+-static int constant_time_strcmp(const char* a, const char* b) {
+-	size_t la = strlen(a);
+-	size_t lb = strlen(b);
+-
+-	if (la != lb) {
+-		return 1;
+-	}
+-
+-	return constant_time_memcmp(a, b, la);
+-}
++#include <termux-auth.h>
+ 
+ /* Process a password auth request, sending success or failure messages as
+  * appropriate */
+ void svr_auth_password() {
+-	
+-	char * passwdcrypt = NULL; /* the crypt from /etc/passwd or /etc/shadow */
+-	char * testcrypt = NULL; /* crypt generated from the user's password sent */
+-	char * password;
+-	unsigned int passwordlen;
+-
+-	unsigned int changepw;
+-
+-	passwdcrypt = ses.authstate.pw_passwd;
+-
+-#ifdef DEBUG_HACKCRYPT
+-	/* debugging crypt for non-root testing with shadows */
+-	passwdcrypt = DEBUG_HACKCRYPT;
+-#endif
++    char *password;
++    unsigned int changepw, passwordlen;
+ 
+ 	/* check if client wants to change password */
+ 	changepw = buf_getbool(ses.payload);
+@@ -72,43 +49,23 @@
+ 		return;
+ 	}
+ 
+-	password = buf_getstring(ses.payload, &passwordlen);
+-
+-	/* the first bytes of passwdcrypt are the salt */
+-	testcrypt = crypt(password, passwdcrypt);
+-	m_burn(password, passwordlen);
+-	m_free(password);
+-
+-	if (testcrypt == NULL) {
+-		/* crypt() with an invalid salt like "!!" */
+-		dropbear_log(LOG_WARNING, "User account '%s' is locked",
+-				ses.authstate.pw_name);
+-		send_msg_userauth_failure(0, 1);
+-		return;
+-	}
+-
+-	/* check for empty password */
+-	if (passwdcrypt[0] == '\0') {
+-		dropbear_log(LOG_WARNING, "User '%s' has blank password, rejected",
+-				ses.authstate.pw_name);
+-		send_msg_userauth_failure(0, 1);
+-		return;
+-	}
++    password = buf_getstring(ses.payload, &passwordlen);
+ 
+-	if (constant_time_strcmp(testcrypt, passwdcrypt) == 0) {
++    /* check if password is valid */
++    if (termux_auth(ses.authstate.pw_name, password)) {
+ 		/* successful authentication */
+-		dropbear_log(LOG_NOTICE, 
++		dropbear_log(LOG_NOTICE,
+ 				"Password auth succeeded for '%s' from %s",
+ 				ses.authstate.pw_name,
+ 				svr_ses.addrstring);
+ 		send_msg_userauth_success();
+-	} else {
++    } else {
+ 		dropbear_log(LOG_WARNING,
+ 				"Bad password attempt for '%s' from %s",
+ 				ses.authstate.pw_name,
+ 				svr_ses.addrstring);
+ 		send_msg_userauth_failure(0, 1);
+-	}
++    }
+ }
+ 
+ #endif

--- a/packages/dropbear/sysoptions.h.patch
+++ b/packages/dropbear/sysoptions.h.patch
@@ -1,6 +1,6 @@
 diff -uNr dropbear-2018.76/sysoptions.h dropbear-2018.76.mod/sysoptions.h
 --- dropbear-2018.76/sysoptions.h	2018-02-27 16:25:12.000000000 +0200
-+++ dropbear-2018.76.mod/sysoptions.h	2018-04-21 13:48:41.227075019 +0300
++++ dropbear-2018.76.mod/sysoptions.h	2018-10-21 13:49:10.558094478 +0300
 @@ -71,7 +71,7 @@
  
  #define _PATH_TTY "/dev/tty"
@@ -10,3 +10,14 @@ diff -uNr dropbear-2018.76/sysoptions.h dropbear-2018.76.mod/sysoptions.h
  
  #define DROPBEAR_ESCAPE_CHAR '~'
  
+@@ -233,10 +233,6 @@
+ #error "DROPBEAR_SVR_PATM_AUTH requires PAM headers. Perhaps ./configure --enable-pam ?"
+ #endif
+ 
+-#if DROPBEAR_SVR_PASSWORD_AUTH && !HAVE_CRYPT
+-	#error "DROPBEAR_SVR_PASSWORD_AUTH requires `crypt()'."
+-#endif
+-
+ #if !(DROPBEAR_SVR_PASSWORD_AUTH || DROPBEAR_SVR_PAM_AUTH || DROPBEAR_SVR_PUBKEY_AUTH)
+ 	#error "At least one server authentication type must be enabled. DROPBEAR_SVR_PUBKEY_AUTH and DROPBEAR_SVR_PASSWORD_AUTH are recommended."
+ #endif

--- a/packages/openssh/auth2-passwd.c.patch
+++ b/packages/openssh/auth2-passwd.c.patch
@@ -1,0 +1,21 @@
+diff -uNr openssh-7.9p1/auth2-passwd.c openssh-7.9p1.mod/auth2-passwd.c
+--- openssh-7.9p1/auth2-passwd.c	2018-10-17 03:01:20.000000000 +0300
++++ openssh-7.9p1.mod/auth2-passwd.c	2018-10-21 14:30:10.208918070 +0300
+@@ -30,6 +30,8 @@
+ #include <string.h>
+ #include <stdarg.h>
+ 
++#include <termux-auth.h>
++
+ #include "packet.h"
+ #include "ssherr.h"
+ #include "log.h"
+@@ -62,7 +64,7 @@
+ 
+ 	if (change)
+ 		logit("password change not supported");
+-	else if (PRIVSEP(auth_password(ssh, password)) == 1)
++	else if (termux_auth(((Authctxt *)ssh->authctxt)->user, password))
+ 		authenticated = 1;
+ 	explicit_bzero(password, len);
+ 	free(password);

--- a/packages/openssh/build.sh
+++ b/packages/openssh/build.sh
@@ -1,9 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://www.openssh.com/
 TERMUX_PKG_DESCRIPTION="Secure shell for logging into a remote machine"
 TERMUX_PKG_VERSION=7.9p1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=6b4b3ba2253d84ed3771c8050728d597c91cfce898713beb7b64a305b6f11aad
 TERMUX_PKG_SRCURL=https://fastly.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_DEPENDS="libandroid-support, ldns, openssl, libedit, libutil"
+TERMUX_PKG_DEPENDS="libandroid-support, ldns, openssl, libedit, libutil, termux-auth"
 TERMUX_PKG_CONFLICTS="dropbear"
 # --disable-strip to prevent host "install" command to use "-s", which won't work for target binaries:
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
@@ -50,6 +51,7 @@ termux_step_pre_configure() {
 	CPPFLAGS+=" -DHAVE_ATTRIBUTE__SENTINEL__=1 -DBROKEN_SETRESGID"
 	LD=$CC # Needed to link the binaries
 	LDFLAGS+=" -llog" # liblog for android logging in syslog hack
+	LDFLAGS+=" -ltermux-auth" # libtermux-auth for password auth
 }
 
 termux_step_post_configure() {
@@ -61,7 +63,7 @@ termux_step_post_configure() {
 termux_step_post_make_install () {
 	# "PrintMotd no" is due to our login program already showing it.
 	# OpenSSH 7.0 disabled ssh-dss by default, keep it for a while in Termux:
-	echo -e "PrintMotd no\nPasswordAuthentication no\nPubkeyAcceptedKeyTypes +ssh-dss\nSubsystem sftp $TERMUX_PREFIX/libexec/sftp-server" > $TERMUX_PREFIX/etc/ssh/sshd_config
+	echo -e "PrintMotd no\nPasswordAuthentication yes\nPubkeyAcceptedKeyTypes +ssh-dss\nSubsystem sftp $TERMUX_PREFIX/libexec/sftp-server" > $TERMUX_PREFIX/etc/ssh/sshd_config
 	printf "PubkeyAcceptedKeyTypes +ssh-dss\nSendEnv LANG\n" > $TERMUX_PREFIX/etc/ssh/ssh_config
 	cp $TERMUX_PKG_BUILDER_DIR/source-ssh-agent.sh $TERMUX_PREFIX/bin/source-ssh-agent
 	cp $TERMUX_PKG_BUILDER_DIR/ssh-with-agent.sh $TERMUX_PREFIX/bin/ssha

--- a/packages/termux-auth/build.sh
+++ b/packages/termux-auth/build.sh
@@ -1,0 +1,7 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/xeffyr/termux-auth
+TERMUX_PKG_DESCRIPTION="Password authentication library and utility for Termux"
+TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
+TERMUX_PKG_VERSION=1.0
+TERMUX_PKG_SRCURL=https://github.com/xeffyr/termux-auth/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=37a1ccebc73caced72a1baead20d50ebfc630dce97f68aa35fb30a1133b7206e
+TERMUX_PKG_DEPENDS="openssl"

--- a/packages/termux-auth/build.sh
+++ b/packages/termux-auth/build.sh
@@ -1,4 +1,4 @@
-TERMUX_PKG_HOMEPAGE=https://github.com/xeffyr/termux-auth
+TERMUX_PKG_HOMEPAGE=https://github.com/termux/termux-auth
 TERMUX_PKG_DESCRIPTION="Password authentication library and utility for Termux"
 TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
 TERMUX_PKG_VERSION=1.1

--- a/packages/termux-auth/build.sh
+++ b/packages/termux-auth/build.sh
@@ -2,6 +2,6 @@ TERMUX_PKG_HOMEPAGE=https://github.com/xeffyr/termux-auth
 TERMUX_PKG_DESCRIPTION="Password authentication library and utility for Termux"
 TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
 TERMUX_PKG_VERSION=1.1
-TERMUX_PKG_SRCURL=https://github.com/xeffyr/termux-auth/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SRCURL=https://github.com/termux/termux-auth/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=fd6fab1808b1e98dc865c47db8b4719f887273f95fe0f4dad26af016c28fa915
 TERMUX_PKG_DEPENDS="openssl"

--- a/packages/termux-auth/build.sh
+++ b/packages/termux-auth/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/xeffyr/termux-auth
 TERMUX_PKG_DESCRIPTION="Password authentication library and utility for Termux"
 TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
-TERMUX_PKG_VERSION=1.0
+TERMUX_PKG_VERSION=1.1
 TERMUX_PKG_SRCURL=https://github.com/xeffyr/termux-auth/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=37a1ccebc73caced72a1baead20d50ebfc630dce97f68aa35fb30a1133b7206e
+TERMUX_PKG_SHA256=fd6fab1808b1e98dc865c47db8b4719f887273f95fe0f4dad26af016c28fa915
 TERMUX_PKG_DEPENDS="openssl"


### PR DESCRIPTION
Password authentication for OpenSSH and Dropbear.

This PR provides:

* libtermux-auth.so - library with password hashing & authentication method
* Password is hashed by using PBKDF from OpenSSL
* Password can be set by `passwd` command (like in normal Linux distributions)
* Necessary patches for OpenSSH & Dropbear