### PR TITLE
binutils: set correct /system/lib dir for 32bit arches

### DIFF
--- a/packages/binutils/build.sh
+++ b/packages/binutils/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/binutils/
 TERMUX_PKG_DESCRIPTION="Collection of binary tools, the main ones being ld, the GNU linker, and as, the GNU assembler"
 TERMUX_PKG_VERSION=2.31.1
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SHA256=e88f8d36bd0a75d3765a4ad088d819e35f8d7ac6288049780e2fefcad18dde88
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/binutils/binutils-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-gold --enable-plugins --disable-werror --with-system-zlib --enable-new-dtags"
@@ -15,7 +15,7 @@ export LEXLIB=
 termux_step_pre_configure () {
 	export CPPFLAGS="$CPPFLAGS -Wno-c++11-narrowing"
 
-	if [ TERMUX_ARCH_BITS = 32 ]; then
+	if [ $TERMUX_ARCH_BITS = 32 ]; then
 		export LIB_PATH="${TERMUX_PREFIX}/lib:/system/lib"
 	else
 		export LIB_PATH="${TERMUX_PREFIX}/lib:/system/lib64"


### PR DESCRIPTION
Linking against libm.so libdl.so and so on currently fails on 32 bit arches

(see https://github.com/termux/termux-packages/issues/3005#issuecomment-435034306)