### PR TITLE
grep: depends on libandroid-support

### DIFF
--- a/packages/grep/build.sh
+++ b/packages/grep/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/grep/
 TERMUX_PKG_DESCRIPTION="Command which searches one or more input files for lines containing a match to a specified pattern"
-TERMUX_PKG_DEPENDS="pcre"
+TERMUX_PKG_DEPENDS="libandroid-support, pcre"
 TERMUX_PKG_VERSION=3.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/grep/grep-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=db625c7ab3bb3ee757b3926a5cfa8d9e1c3991ad24707a83dde8a5ef2bf7a07e


### PR DESCRIPTION
Attempt to fix https://github.com/termux/termux-packages/issues/3010. It seems that grep is not properly linked with libandroid-support if it is not added to dependencies.

Before:
![screenshot_1542460683](https://user-images.githubusercontent.com/25881154/48661549-1b51f380-ea7c-11e8-9f6e-cedde61b7c4a.png)

After:
![screenshot_1542460692](https://user-images.githubusercontent.com/25881154/48661550-2016a780-ea7c-11e8-951d-0e85e4c8545a.png)
