### PR TITLE
mpdscribble: add package

### DIFF
--- a/packages/mpdscribble/build.sh
+++ b/packages/mpdscribble/build.sh
@@ -1,0 +1,23 @@
+TERMUX_PKG_HOMEPAGE=https://www.musicpd.org/clients/mpdscribble/
+TERMUX_PKG_DESCRIPTION="A Music Player Daemon (MPD) client which submits information about tracks being played to a scrobbler"
+TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
+TERMUX_PKG_VERSION=0.22
+TERMUX_PKG_SHA256=9f6d73e1d0d44bf782c199732acc91bb07efc1c02ae04d037d711860dd8e4012
+TERMUX_PKG_SRCURL=https://github.com/MusicPlayerDaemon/mpdscribble/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_DEPENDS="libcurl, mpd, libmpdclient, glib"
+TERMUX_PKG_CONFFILES="$TERMUX_PREFIX/etc/mpdscribble.conf"
+
+termux_step_pre_configure () {
+	NOCONFIGURE=1 ./autogen.sh
+	export LDFLAGS=" -llog"
+}
+
+termux_step_post_make_install () {
+	install $TERMUX_PKG_SRCDIR/doc/mpdscribble.conf $TERMUX_PREFIX/etc/
+}
+termux_step_create_debscripts () {
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo "mkdir -p ~/.mpdscribble" >> postinst
+	echo "exit 0" >> postinst
+	chmod 0755 postinst
+}

--- a/packages/mpdscribble/build.sh
+++ b/packages/mpdscribble/build.sh
@@ -1,9 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://www.musicpd.org/clients/mpdscribble/
 TERMUX_PKG_DESCRIPTION="A Music Player Daemon (MPD) client which submits information about tracks being played to a scrobbler"
+TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
 TERMUX_PKG_VERSION=0.22
-TERMUX_PKG_SHA256=9f6d73e1d0d44bf782c199732acc91bb07efc1c02ae04d037d711860dd8e4012
 TERMUX_PKG_SRCURL=https://github.com/MusicPlayerDaemon/mpdscribble/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=9f6d73e1d0d44bf782c199732acc91bb07efc1c02ae04d037d711860dd8e4012
 TERMUX_PKG_DEPENDS="libcurl, mpd, libmpdclient, glib"
 TERMUX_PKG_CONFFILES="$TERMUX_PREFIX/etc/mpdscribble.conf"
 

--- a/packages/mpdscribble/file.c.patch
+++ b/packages/mpdscribble/file.c.patch
@@ -1,0 +1,11 @@
+--- ../file.c.orig	2018-11-23 13:05:51.749928637 +0100
++++ ./src/file.c	2018-11-23 13:07:24.143261299 +0100
+@@ -38,7 +38,7 @@
+ 
+ #ifndef G_OS_WIN32
+ 
+-#define FILE_CACHE "/var/cache/mpdscribble/mpdscribble.cache"
++#define FILE_CACHE "@TERMUX_PREFIX@/var/cache/mpdscribble/mpdscribble.cache"
+ #define FILE_HOME_CONF "~/.mpdscribble/mpdscribble.conf"
+ #define FILE_HOME_CACHE "~/.mpdscribble/mpdscribble.cache"
+ 

--- a/packages/mpdscribble/mpdscribble.conf.patch
+++ b/packages/mpdscribble/mpdscribble.conf.patch
@@ -1,0 +1,53 @@
+--- ../mpdscribble.conf.orig	2018-11-23 15:02:34.929996250 +0100
++++ ./doc/mpdscribble.conf	2018-11-23 15:07:03.259994317 +0100
+@@ -5,7 +5,7 @@
+ #proxy = http://the.proxy.server:3128
+ 
+ # The location of the pid file.  mpdscribble saves its process id there.
+-#pidfile = /var/run/mpdscribble.pid
++pidfile = @TERMUX_HOME@/.mpdscribble/pid
+ 
+ # Change to this system user after daemonization.
+ #daemon_user = mpdscribble
+@@ -14,7 +14,7 @@
+ # "syslog" makes mpdscribble use the local syslog daemon.  On most
+ # systems, log messages will appear in /var/log/daemon.log then.
+ # "-" means log to stderr (the current terminal).
+-log = syslog
++log = @TERMUX_HOME@/.mpdscribble/log
+ 
+ # How verbose mpdscribble's logging should be.  Default is 1.
+ verbose = 1
+@@ -24,7 +24,7 @@
+ 
+ # The host running MPD, possibly protected by a password
+ # ([PASSWORD@]HOSTNAME).  Defaults to $MPD_HOST or localhost.
+-#host = localhost
++host = @TERMUX_PREFIX@/tmp/mpd.socket
+ 
+ # The port that the MPD listens on and mpdscribble should try to
+ # connect to.  Defaults to $MPD_PORT or 6600.
+@@ -36,19 +36,19 @@
+ password =
+ # The file where mpdscribble should store its Last.fm journal in case
+ # you do not have a connection to the Last.fm server.
+-journal = /var/cache/mpdscribble/lastfm.journal
++journal = @TERMUX_HOME@/.mpdscribble/lastfm.journal
+ 
+ #[libre.fm]
+ #url = http://turtle.libre.fm/
+ #username = my_username
+ #password = my_password
+-#journal = /var/cache/mpdscribble/librefm.journal
++#journal = @TERMUX_HOME@/.mpdscribble/librefm.journal
+ 
+ #[jamendo]
+ #url = http://postaudioscrobbler.jamendo.com/
+ #username = my_username
+ #password = my_password
+-#journal = /var/cache/mpdscribble/jamendo.journal
++#journal = @TERMUX_HOME@/.mpdscribble/jamendo.journal
+ 
+ #[file]
+-#file = /var/log/mpdscribble/log
++#file = @TERMUX_HOME@/.mpdscribble/log


### PR DESCRIPTION
Default config paths for log and other stuff is ~/.mpdscribble/ so users probably want to `mkdir ~/.mpdscribble` and `cp $PREFIX/etc/mpdcribble.conf ~/.mpdscribble/` and then edit `~/.mpdscribble/mpdscribble.conf` with their settings