### PR TITLE
update ca-certificates

### DIFF
--- a/packages/ca-certificates/build.sh
+++ b/packages/ca-certificates/build.sh
@@ -1,9 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://curl.haxx.se/docs/caextract.html
 TERMUX_PKG_DESCRIPTION="Common CA certificates"
-TERMUX_PKG_VERSION=20181017
+TERMUX_PKG_VERSION=20181205
 TERMUX_PKG_SRCURL=https://curl.haxx.se/ca/cacert.pem
 # If the checksum has changed, it may be time to update the package version:
-TERMUX_PKG_SHA256=86695b1be9225c3cf882d283f05c944e3aabbc1df6428a4424269a93e997dc65
+TERMUX_PKG_SHA256=4d89992b90f3e177ab1d895c00e8cded6c9009bec9d56981ff4f0a59e9cc56d6
 TERMUX_PKG_SKIP_SRC_EXTRACT=yes
 TERMUX_PKG_PLATFORM_INDEPENDENT=yes
 


### PR DESCRIPTION
Looks like CA certificates should be updated:
```
termux - building ca-certificates for arch aarch64...
Downloading https://curl.haxx.se/ca/cacert.pem
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  203k  100  203k    0     0   376k      0 --:--:-- --:--:-- --:--:--  375k
Wrong checksum for https://curl.haxx.se/ca/cacert.pem:
Expected: 86695b1be9225c3cf882d283f05c944e3aabbc1df6428a4424269a93e997dc65
Actual:   4d89992b90f3e177ab1d895c00e8cded6c9009bec9d56981ff4f0a59e9cc56d6
```