### PR TITLE
emacs: add patch to make hunspell 1.7.0 work

### DIFF
--- a/packages/emacs/build.sh
+++ b/packages/emacs/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/emacs/
 TERMUX_PKG_DESCRIPTION="Extensible, customizable text editor-and more"
 TERMUX_PKG_VERSION=26.1
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SHA256=1cf4fc240cd77c25309d15e18593789c8dbfba5c2b44d8f77c886542300fd32c
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/emacs/emacs-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_DEPENDS="ncurses, gnutls, libxml2"

--- a/packages/emacs/hunspell_1.7.0.patch.beforehostbuild
+++ b/packages/emacs/hunspell_1.7.0.patch.beforehostbuild
@@ -1,0 +1,16 @@
+--- ../ispell.el.orig	2018-12-14 21:01:30.659947236 +0100
++++ ./lisp/textmodes/ispell.el	2018-12-14 21:05:18.803278916 +0100
+@@ -1111,7 +1111,12 @@
+ 				 null-device
+ 				 t
+ 				 nil
+-				 "-D")
++                                 ;; Hunspell 1.7.0 (and later?) won't
++                                 ;; show LOADED DICTIONARY unless
++                                 ;; there's at least one file argument
++                                 ;; on the command line.  So we feed
++                                 ;; it with the null device.
++				 "-D" null-device)
+ 	    (buffer-string))
+ 	  "[\n\r]+"
+ 	  t))

--- a/packages/emacs/lisp-textmodes-ispell.el.patch.beforehostbuild
+++ b/packages/emacs/lisp-textmodes-ispell.el.patch.beforehostbuild
@@ -1,0 +1,34 @@
+--- ../ispell.el.orig	2018-12-14 21:01:30.659947236 +0100
++++ ./lisp/textmodes/ispell.el	2018-12-14 21:05:18.803278916 +0100
+@@ -213,13 +213,13 @@
+   :group 'ispell)
+ 
+ (defcustom ispell-alternate-dictionary
+-  (cond ((file-readable-p "/usr/dict/web2") "/usr/dict/web2")
+-	((file-readable-p "/usr/share/dict/web2") "/usr/share/dict/web2")
+-	((file-readable-p "/usr/dict/words") "/usr/dict/words")
+-	((file-readable-p "/usr/lib/dict/words") "/usr/lib/dict/words")
+-	((file-readable-p "/usr/share/dict/words") "/usr/share/dict/words")
+-	((file-readable-p "/usr/share/lib/dict/words")
+-	 "/usr/share/lib/dict/words")
++  (cond ((file-readable-p "@TERMUX_PREFIX@/dict/web2") "@TERMUX_PREFIX@/dict/web2")
++	((file-readable-p "@TERMUX_PREFIX@/share/dict/web2") "@TERMUX_PREFIX@/share/dict/web2")
++	((file-readable-p "@TERMUX_PREFIX@/dict/words") "@TERMUX_PREFIX@/dict/words")
++	((file-readable-p "@TERMUX_PREFIX@/lib/dict/words") "@TERMUX_PREFIX@/lib/dict/words")
++	((file-readable-p "@TERMUX_PREFIX@/share/dict/words") "@TERMUX_PREFIX@/share/dict/words")
++	((file-readable-p "@TERMUX_PREFIX@/share/lib/dict/words")
++	 "@TERMUX_PREFIX@/share/lib/dict/words")
+ 	((file-readable-p "/sys/dict") "/sys/dict"))
+   "Alternate plain word-list dictionary for spelling help."
+   :type '(choice file (const :tag "None" nil))
+@@ -265,8 +265,8 @@
+ 
+ (defcustom ispell-look-command
+   (cond ((file-exists-p "/bin/look") "/bin/look")
+-	((file-exists-p "/usr/local/bin/look") "/usr/local/bin/look")
+-	((file-exists-p "/usr/bin/look") "/usr/bin/look")
++	((file-exists-p "@TERMUX_PREFIX@/local/bin/look") "@TERMUX_PREFIX@/local/bin/look")
++	((file-exists-p "@TERMUX_PREFIX@/bin/look") "@TERMUX_PREFIX@/bin/look")
+ 	(t "look"))
+   "Name of the look command for search processes.
+ This must be an absolute file name."


### PR DESCRIPTION
hunspell_1.7.0.patch can perhaps be removed when emacs 26.2 is released.

Solves #3140.