### PR TITLE
openjpeg: fix OpenJPEGConfig.cmake after relocation

### DIFF
--- a/packages/openjpeg/OpenJPEGConfig.cmake.patch
+++ b/packages/openjpeg/OpenJPEGConfig.cmake.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/OpenJPEGConfig.cmake.in b/cmake/OpenJPEGConfig.cmake.in
+index b20294ca..6a2f4baf 100644
+--- a/cmake/OpenJPEGConfig.cmake.in
++++ b/cmake/OpenJPEGConfig.cmake.in
+@@ -26,7 +26,7 @@ get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+ if(EXISTS ${SELF_DIR}/OpenJPEGTargets.cmake)
+   # This is an install tree
+   include(${SELF_DIR}/OpenJPEGTargets.cmake)
+-  get_filename_component(OPENJPEG_INCLUDE_ROOT "${SELF_DIR}/../../@OPENJPEG_INSTALL_INCLUDE_DIR@" ABSOLUTE)
++  get_filename_component(OPENJPEG_INCLUDE_ROOT "${SELF_DIR}/../../../@OPENJPEG_INSTALL_INCLUDE_DIR@" ABSOLUTE)
+   set(OPENJPEG_INCLUDE_DIRS ${OPENJPEG_INCLUDE_ROOT})
+ 
+ else()

--- a/packages/openjpeg/build.sh
+++ b/packages/openjpeg/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=http://www.openjpeg.org/
 TERMUX_PKG_DESCRIPTION="JPEG 2000 image compression library"
 TERMUX_PKG_VERSION=2.3.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=3dc787c1bb6023ba846c2a0d9b1f6e179f1cd255172bde9eb75b01f1e6c7d71a
 TERMUX_PKG_SRCURL=https://github.com/uclouvain/openjpeg/archive/v${TERMUX_PKG_VERSION}.tar.gz
 


### PR DESCRIPTION
Prerequisite for #3150 