### PR TITLE
libgrpc: update to 1.17.2 and avoid using libprotobuf's host-build

### DIFF
--- a/packages/libgrpc/build.sh
+++ b/packages/libgrpc/build.sh
@@ -1,8 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://grpc.io/
 TERMUX_PKG_DESCRIPTION="High performance, open source, general RPC framework that puts mobile and HTTP/2 first"
 TERMUX_PKG_MAINTAINER="Vishal Biswas @vishalbiswas"
-TERMUX_PKG_VERSION=1.16.1
+TERMUX_PKG_VERSION=1.17.2
 TERMUX_PKG_DEPENDS="openssl, protobuf, c-ares"
+TERMUX_PKG_BUILD_DEPENDS="libprotobuf"
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_BUILD_IN_SRC=yes
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
@@ -13,11 +14,15 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DgRPC_PROTOBUF_PROVIDER=package
 -DgRPC_SSL_PROVIDER=package
 -DgRPC_ZLIB_PROVIDER=package
--DProtobuf_PROTOC_EXECUTABLE=$TERMUX_TOPDIR/libprotobuf/host-build/src/protoc
 -DRUN_HAVE_POSIX_REGEX=0
 -DRUN_HAVE_STD_REGEX=0
 -DRUN_HAVE_STEADY_CLOCK=0
+-DProtobuf_PROTOC_EXECUTABLE=$TERMUX_PKG_HOSTBUILD_DIR/protoc/bin/protoc
+-DProtobuf_PROTOC_LIBRARY=$TERMUX_PREFIX/lib/libprotoc.so
 "
+
+_protoc_version=3.6.1
+_protoc_sha256=6003de742ea3fcf703cfec1cd4a3380fd143081a2eb0e559065563496af27807
 
 termux_step_extract_package() {
 	local CHECKED_OUT_FOLDER=$TERMUX_PKG_CACHEDIR/checkout-$TERMUX_PKG_VERSION
@@ -42,7 +47,12 @@ termux_step_extract_package() {
 
 termux_step_host_build () {
 	termux_setup_cmake
-	local protoinstall=$TERMUX_TOPDIR/libprotobuf/host-build/install
+	termux_download https://github.com/protocolbuffers/protobuf/releases/download/v${_protoc_version}/protoc-${_protoc_version}-linux-x86_64.zip \
+			protoc-${_protoc_version}-linux-x86_64.zip \
+			${_protoc_sha256}
+	mkdir protoc && cd protoc
+	unzip ../protoc-${_protoc_version}-linux-x86_64.zip
+
 	cd $TERMUX_PKG_SRCDIR
 	export LD=gcc
 	export LDXX=g++


### PR DESCRIPTION
Needed for #1169