### PR TITLE
asciinema: don't use TCSAFLUSH

### DIFF
--- a/packages/asciinema/build.sh
+++ b/packages/asciinema/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://asciinema.org/
 TERMUX_PKG_DESCRIPTION="Record and share your terminal sessions, the right way"
 TERMUX_PKG_VERSION=2.0.1
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SHA256=7087b247dae36d04821197bc14ebd4248049592b299c9878d8953c025ac802e4
 TERMUX_PKG_SRCURL=https://github.com/asciinema/asciinema/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_BUILD_IN_SRC=yes

--- a/packages/asciinema/no-tcsaflush.patch
+++ b/packages/asciinema/no-tcsaflush.patch
@@ -1,0 +1,12 @@
+diff -uNr asciinema-2.0.1/asciinema/term.py asciinema-2.0.1.mod/asciinema/term.py
+--- asciinema-2.0.1/asciinema/term.py	2018-04-04 10:05:41.000000000 +0300
++++ asciinema-2.0.1.mod/asciinema/term.py	2019-01-15 19:08:03.539657566 +0200
+@@ -18,7 +18,7 @@
+ 
+     def __exit__(self, type, value, traceback):
+         if self.restore:
+-            tty.tcsetattr(self.fd, tty.TCSAFLUSH, self.mode)
++            tty.tcsetattr(self.fd, tty.TCSANOW, self.mode)
+ 
+ 
+ def read_blocking(fd, timeout):


### PR DESCRIPTION
Now asciinema works as expected: no hang or permission denial when pressing "ctrl-d" to stop recording.

**Requires merging of https://github.com/termux/termux-packages/pull/3222**.