### PR TITLE
libutil: bump revision due to tcsaflush patch

### DIFF
--- a/packages/libutil/build.sh
+++ b/packages/libutil/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://refspecs.linuxbase.org/LSB_2.1.0/LSB-generic/LSB-generic/libutil.html
 TERMUX_PKG_DESCRIPTION="Library with terminal functions"
 TERMUX_PKG_VERSION=0.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_BUILD_IN_SRC=yes
 
 termux_step_make_install () {


### PR DESCRIPTION
Libutil requires rebuild because it uses TCSAFLUSH.