### PR TITLE
socat: don't use O_APPEND

### DIFF
--- a/packages/socat/build.sh
+++ b/packages/socat/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=http://www.dest-unreach.org/socat/
 TERMUX_PKG_DESCRIPTION="Relay for bidirectional data transfer between two independent data channels"
 TERMUX_PKG_DEPENDS="openssl, readline, libutil"
 TERMUX_PKG_VERSION=1.7.3.2
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=http://www.dest-unreach.org/socat/download/socat-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=ce3efc17e3e544876ebce7cd6c85b3c279fda057b2857fcaaf67b9ab8bdaf034
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="ac_header_resolv_h=no ac_cv_c_compiler_gnu=yes ac_compiler_gnu=yes" # sc_cv_sys_crdly_shift=9 sc_cv_sys_csize_shift=4 sc_cv_sys_tabdly_shift=11"

--- a/packages/socat/no-o_append.patch
+++ b/packages/socat/no-o_append.patch
@@ -1,0 +1,17 @@
+diff -uNr socat-1.7.3.2/xio-gopen.c socat-1.7.3.2.mod/xio-gopen.c
+--- socat-1.7.3.2/xio-gopen.c	2017-01-06 23:51:24.000000000 +0200
++++ socat-1.7.3.2.mod/xio-gopen.c	2018-12-31 14:22:34.046949870 +0200
+@@ -33,12 +33,7 @@
+    }
+    st_mode = result;
+ 
+-   if (exists) {
+-      /* file (or at least named entry) exists */
+-      if ((xioflags&XIO_ACCMODE) != XIO_RDONLY) {
+-	 openflags |= O_APPEND;
+-      }
+-   } else {
++   if (!exists) {
+       openflags |= O_CREAT;
+    }
+ 


### PR DESCRIPTION
Now socat can open PTYs on Android 8 or newer.