### PR TITLE
hugo: build extended version

### DIFF
--- a/packages/hugo/build.sh
+++ b/packages/hugo/build.sh
@@ -1,22 +1,40 @@
 TERMUX_PKG_HOMEPAGE=https://gohugo.io/
 TERMUX_PKG_DESCRIPTION="A fast and flexible static site generator"
 TERMUX_PKG_VERSION=0.53
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/gohugoio/hugo/archive/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=48e65a33d3b10527101d13c354538379d9df698e5c38f60f4660386f4232e65c
 
 termux_step_make() {
 	termux_setup_golang
 	export GOPATH=$TERMUX_PKG_BUILDDIR
+	export CGO_LDFLAGS="-L$TERMUX_PREFIX/lib"
 
 	cd $TERMUX_PKG_SRCDIR
-	go install
+	go build \
+		-o "$TERMUX_PREFIX/bin/hugo" \
+		-tags extended \
+		main.go
+
+	# Building for host to generate manpages and completion.
+	chmod 700 -R $GOPATH/pkg && rm -rf $GOPATH/pkg
+	unset GOOS GOARCH CGO_LDFLAGS
+	unset CC CXX CFLAGS CXXFLAGS LDFLAGS
+	go build \
+		-o "$TERMUX_PKG_BUILDDIR/hugo" \
+		-tags extended \
+		main.go
 }
 
 termux_step_make_install() {
-	install -Dm700 $GOPATH/bin/android_$GOARCH/hugo $TERMUX_PREFIX/bin/hugo
+	mkdir -p $TERMUX_PREFIX/share/{bash-completion/completions,man/man1}
+
+	$TERMUX_PKG_BUILDDIR/hugo gen autocomplete \
+		--completionfile=$TERMUX_PREFIX/share/bash-completion/completions/hugo
+	$TERMUX_PKG_BUILDDIR/hugo gen man \
+		--dir=$TERMUX_PREFIX/share/man/man1/
 
 	# Seems that some files became RO-only
 	# and should be manually removed.
-	chmod 700 -R $GOPATH/pkg
-	rm -rf $GOPATH/pkg
+	chmod 700 -R $GOPATH/pkg && rm -rf $GOPATH/pkg
 }


### PR DESCRIPTION
Comple package "hugo" with feature requested in https://github.com/termux/termux-packages/issues/3236.
Generate manpages and bash completion.