### PR TITLE
Travis CI for all architectures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,8 @@ sudo: required
 cache: bundler
 services: docker
 before_script: mkdir debs && chmod 777 debs
+env:
+    - TRAVIS_ARCH=aarch64
+    - TRAVIS_ARCH=arm
+    - TRAVIS_ARCH=i686
+    - TRAVIS_ARCH=x86_64

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ task :build do
     puts "Building #{pkg}"
     begin
       # Start blocking build loop
-      PTY.spawn("./scripts/run-docker.sh ./build-package.sh #{pkg}") do |stdout, stdin, pid|
+      PTY.spawn("./scripts/run-docker.sh ./build-package.sh -a $TRAVIS_ARCH #{pkg}") do |stdout, stdin, pid|
         begin
           stdout.each { |line| print line }
         rescue Errno::EIO


### PR DESCRIPTION
This script can trigger builds for all architectures in parallel.

I am not very sure if this works as I am banned from Travis CI. Thanks.