### PR TITLE
Add Android SDK 26 for termux-am

### DIFF
--- a/scripts/setup-android-sdk.sh
+++ b/scripts/setup-android-sdk.sh
@@ -42,5 +42,6 @@ fi
 
 yes | $ANDROID_HOME/tools/bin/sdkmanager --licenses
 
+# The android-26 platform and build tools are used in the termux-am package:
 # The android-21 platform is used in the ecj package:
-yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;${TERMUX_ANDROID_BUILD_TOOLS_VERSION}" "platforms;android-27" "platforms;android-21"
+yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;${TERMUX_ANDROID_BUILD_TOOLS_VERSION}" "platforms;android-27" "platforms;android-21" "platforms;android-26" "build-tools;android-26"

--- a/scripts/setup-android-sdk.sh
+++ b/scripts/setup-android-sdk.sh
@@ -44,4 +44,4 @@ yes | $ANDROID_HOME/tools/bin/sdkmanager --licenses
 
 # The android-26 platform and build tools are used in the termux-am package:
 # The android-21 platform is used in the ecj package:
-yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;${TERMUX_ANDROID_BUILD_TOOLS_VERSION}" "platforms;android-27" "platforms;android-21" "platforms;android-26" "build-tools;android-26"
+yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;${TERMUX_ANDROID_BUILD_TOOLS_VERSION}" "platforms;android-27" "build-tools;android-26" "platforms;android-26" "platforms;android-21"

--- a/scripts/setup-android-sdk.sh
+++ b/scripts/setup-android-sdk.sh
@@ -44,4 +44,4 @@ yes | $ANDROID_HOME/tools/bin/sdkmanager --licenses
 
 # The android-26 platform and build tools are used in the termux-am package:
 # The android-21 platform is used in the ecj package:
-yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;${TERMUX_ANDROID_BUILD_TOOLS_VERSION}" "platforms;android-27" "build-tools;android-26.0.2" "platforms;android-26" "platforms;android-21"
+yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;${TERMUX_ANDROID_BUILD_TOOLS_VERSION}" "platforms;android-27" "build-tools;26.0.2" "platforms;android-26" "platforms;android-21"

--- a/scripts/setup-android-sdk.sh
+++ b/scripts/setup-android-sdk.sh
@@ -44,4 +44,4 @@ yes | $ANDROID_HOME/tools/bin/sdkmanager --licenses
 
 # The android-26 platform and build tools are used in the termux-am package:
 # The android-21 platform is used in the ecj package:
-yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;${TERMUX_ANDROID_BUILD_TOOLS_VERSION}" "platforms;android-27" "build-tools;android-26" "platforms;android-26" "platforms;android-21"
+yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;${TERMUX_ANDROID_BUILD_TOOLS_VERSION}" "platforms;android-27" "build-tools;android-26.0.2" "platforms;android-26" "platforms;android-21"


### PR DESCRIPTION
Currently, Android SDK 26 is not pre-installed. Therefore, `gradle` automatically downloads it if needed.

However, `gradle` does not allow anyone to accept licenses non-interactively. Therefore, there will be an error message in Travis CI, reporting an error.

Hope that this commit will fix the error and get `termux-am` builds working.

Build failure examples here:
https://travis-ci.org/termux/termux-packages/jobs/484159311
https://travis-ci.org/termux/termux-packages/jobs/484150688