### PR TITLE
scrypt: fix crash on AArch64

### DIFF
--- a/packages/scrypt/build.sh
+++ b/packages/scrypt/build.sh
@@ -2,7 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://www.tarsnap.com/scrypt.html
 TERMUX_PKG_DESCRIPTION="scrypt KDF library and file encryption tool"
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_VERSION=1.2.1
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://www.tarsnap.com/scrypt/scrypt-1.2.1.tgz
 TERMUX_PKG_SHA256=4621f5e7da2f802e20850436219370092e9fcda93bd598f6d4236cce33f4c577
 TERMUX_PKG_DEPENDS="openssl"
+
+termux_step_pre_configure() {
+	export CFLAGS=${CFLAGS/-Oz/-Os}
+}


### PR DESCRIPTION
Fixes https://github.com/termux/termux-packages/issues/3260.