### PR TITLE
coreutils: force usage of renameat() instead of renameat2()

### DIFF
--- a/packages/coreutils/build.sh
+++ b/packages/coreutils/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/coreutils/
 TERMUX_PKG_DESCRIPTION="Basic file, shell and text manipulation utilities from the GNU project"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_VERSION=8.30
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SHA256=e831b3a86091496cdba720411f9748de81507798f6130adeaef872d206e1b057
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/coreutils/coreutils-${TERMUX_PKG_VERSION}.tar.xz
 # pinky has no usage on Android.

--- a/packages/coreutils/mv-renameat.patch
+++ b/packages/coreutils/mv-renameat.patch
@@ -1,0 +1,23 @@
+See https://github.com/termux/termux-packages/issues/2869.
+
+diff -uNr coreutils-8.30/src/mv.c coreutils-8.30.mod/src/mv.c
+--- coreutils-8.30/src/mv.c	2018-06-24 05:12:51.000000000 +0300
++++ coreutils-8.30.mod/src/mv.c	2019-01-28 22:37:18.322329162 +0200
+@@ -31,7 +31,6 @@
+ #include "error.h"
+ #include "filenamecat.h"
+ #include "remove.h"
+-#include "renameat2.h"
+ #include "root-dev-ino.h"
+ #include "priv-set.h"
+ 
+@@ -456,8 +455,7 @@
+     {
+       assert (2 <= n_files);
+       if (n_files == 2)
+-        x.rename_errno = (renameat2 (AT_FDCWD, file[0], AT_FDCWD, file[1],
+-                                     RENAME_NOREPLACE)
++        x.rename_errno = (renameat(AT_FDCWD, file[0], AT_FDCWD, file[1])
+                           ? errno : 0);
+       if (x.rename_errno != 0 && target_directory_operand (file[n_files - 1]))
+         {


### PR DESCRIPTION
Attempt to fix https://github.com/termux/termux-packages/issues/2869.
Just replace renameat2() with renameat() (like in busybox).