### PR TITLE
switch from /home to ${HOME}

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -26,11 +26,11 @@ RUN apt-get update && \
     # Removed unused parts to make a smaller Docker image:
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    cd /home/builder/lib/android-ndk/ && \
+    cd ${HOME}/lib/android-ndk/ && \
     rm -Rf sources/cxx-stl/system && \
-    cd /home/builder/lib/android-sdk/tools && \
+    cd ${HOME}/lib/android-sdk/tools && \
     rm -Rf emulator* lib* proguard templates
 
 # We expect this to be mounted with '-v $PWD:/home/builder/termux-packages':
-WORKDIR /home/builder/termux-packages
+WORKDIR ${HOME}/builder/termux-packages
 


### PR DESCRIPTION
Actually, the `${HOME}` directory is never specified to be equal to `/home`. Once an aboslute path of `/home` is specified, the directory may not exist.

Therefore, it is the best to use the `${HOME}` variable rather than `/home`.