### PR TITLE
Use ln -sf in dash rather than rm

### DIFF
--- a/packages/dash/build.sh
+++ b/packages/dash/build.sh
@@ -9,9 +9,8 @@ TERMUX_PKG_SRCURL=http://gondor.apana.org.au/~herbert/dash/files/dash-${TERMUX_P
 
 termux_step_post_make_install () {
 	# Symlink sh -> dash
-	rm -f $TERMUX_PREFIX/bin/sh $TERMUX_PREFIX/share/man/man1/sh.1
 	cd $TERMUX_PREFIX/bin
-	ln -s dash sh
+	ln -sf dash sh
 	cd $TERMUX_PREFIX/share/man/man1
-	ln -s dash.1 sh.1
+	ln -sf dash.1 sh.1
 }


### PR DESCRIPTION
There is no need to separate `rm` and `ln -s`, right? Only `ln -sf` will already remove the original files, so that the code is less clumsy. How do you think?