### PR TITLE
Only C++

### DIFF
--- a/packages/libgrpc/build.sh
+++ b/packages/libgrpc/build.sh
@@ -62,7 +62,7 @@ termux_step_host_build () {
 	# src/core/lib/security/credentials/oauth2/oauth2_credentials.cc:336:61: error: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct grpc_oauth2_token_fetcher_credentials’; use assignment or value-initialization instead [-Werror=class-memaccess]
 	# memset(c, 0, sizeof(grpc_oauth2_token_fetcher_credentials));
 	# when building version 1.17.2:
-	CPPFLAGS="-Wno-error=class-memaccess" \
+	CXXFLAGS="-Wno-error=class-memaccess" \
 		CFLAGS="-Wno-implicit-fallthrough" \
 		make -j $TERMUX_MAKE_PROCESSES \
 		HAS_SYSTEM_PROTOBUF=false \


### PR DESCRIPTION
Fixes #3317 

Successful [build](https://cirrus-ci.com/build/5720193415249920) with `CXXFLAGS` rather than `CPPFLAGS`.

Failed [build](https://cirrus-ci.com/task/6213371692056576) with `CPPFLAGS`.