### PR TITLE
pass: don't add newline to output. Fixes #3310

### DIFF
--- a/packages/pass/build.sh
+++ b/packages/pass/build.sh
@@ -2,6 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://www.passwordstore.org
 TERMUX_PKG_DESCRIPTION="Lightweight directory-based password manager"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=1.7.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=2b6c65846ebace9a15a118503dcd31b6440949a30d3b5291dfb5b1615b99a3f4
 TERMUX_PKG_SRCURL=https://git.zx2c4.com/password-store/snapshot/password-store-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_BUILD_IN_SRC=yes

--- a/packages/pass/src-password-store.sh.patch
+++ b/packages/pass/src-password-store.sh.patch
@@ -1,7 +1,8 @@
-diff -u -r ../password-store-1.7.3/src/password-store.sh ./src/password-store.sh
---- ../password-store-1.7.3/src/password-store.sh	2018-08-03 03:32:48.000000000 +0000
-+++ ./src/password-store.sh	2018-08-05 20:53:50.490883332 +0000
-@@ -11,7 +11,7 @@
+diff --git a/src/password-store.sh b/src/password-store.sh
+index 7264ffc..f924de3 100755
+--- a/src/password-store.sh
++++ b/src/password-store.sh
+@@ -11,7 +11,7 @@ GPG="gpg"
  export GPG_TTY="${GPG_TTY:-$(tty 2>/dev/null)}"
  which gpg2 &>/dev/null && GPG="gpg2"
  [[ -n $GPG_AGENT_INFO || $GPG == "gpg2" ]] && GPG_OPTS+=( "--batch" "--use-agent" )
@@ -10,7 +11,7 @@ diff -u -r ../password-store-1.7.3/src/password-store.sh ./src/password-store.sh
  PREFIX="${PASSWORD_STORE_DIR:-$HOME/.password-store}"
  EXTENSIONS="${PASSWORD_STORE_EXTENSIONS_DIR:-$PREFIX/.extensions}"
  X_SELECTION="${PASSWORD_STORE_X_SELECTION:-clipboard}"
-@@ -156,12 +156,13 @@
+@@ -156,11 +156,11 @@ clip() {
  	# trailing new lines.
  	local sleep_argv0="password store sleep on display $DISPLAY"
  	pkill -f "^$sleep_argv0" 2>/dev/null && sleep 0.5
@@ -21,14 +22,11 @@ diff -u -r ../password-store-1.7.3/src/password-store.sh ./src/password-store.sh
  	(
  		( exec -a "$sleep_argv0" bash <<<"trap 'kill %1' TERM; sleep '$CLIP_TIME' & wait" )
 -		local now="$(xclip -o -selection "$X_SELECTION" | $BASE64)"
--		[[ $now != $(echo -n "$1" | $BASE64) ]] && before="$now"
 +		local now="$(termux-clipboard-get | $BASE64)"
-+		#removing -n here, because termux-clipboard-get always returns a newline while xclip does not
-+		[[ $now != $(echo "$1" | $BASE64) ]] && before="$now"
+ 		[[ $now != $(echo -n "$1" | $BASE64) ]] && before="$now"
  
  		# It might be nice to programatically check to see if klipper exists,
- 		# as well as checking for other common clipboard managers. But for now,
-@@ -172,7 +173,7 @@
+@@ -172,7 +172,7 @@ clip() {
  		# so we axe it here:
  		qdbus org.kde.klipper /klipper org.kde.klipper.klipper.clearClipboardHistory &>/dev/null
  


### PR DESCRIPTION
Since https://github.com/termux/termux-api/commit/5b3f31bf14d8588b2f0fee02b5b70f9dc46be17d fixes the newline being added to termux-clipboard-get, this workaround is no longer required here and actually breaks the comparission.