### PR TITLE
specify CONFFILES for bash, nano, resolv-conf, tmux

### DIFF
--- a/packages/bash/build.sh
+++ b/packages/bash/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_DEPENDS="ncurses, readline, libandroid-support, termux-tools, command-not-found"
 _MAIN_VERSION=4.4
 _PATCH_VERSION=23
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SHA256=d86b3392c1202e8ff5a423b302e6284db7f8f435ea9f39b5b1b20fd3ac36dfcb
 TERMUX_PKG_VERSION=${_MAIN_VERSION}.${_PATCH_VERSION}
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/bash/bash-${_MAIN_VERSION}.tar.gz
@@ -24,6 +24,8 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" bash_cv_dev_fd=whacky"
 # - http://permalink.gmane.org/gmane.linux.embedded.yocto.general/25204
 # - https://github.com/termux/termux-app/issues/200
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" bash_cv_getcwd_malloc=yes"
+
+TERMUX_PKG_CONFFILES="etc/bash.bashrc etc/profile"
 
 TERMUX_PKG_RM_AFTER_INSTALL="share/man/man1/bashbug.1 bin/bashbug"
 

--- a/packages/nano/build.sh
+++ b/packages/nano/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://www.nano-editor.org/
 TERMUX_PKG_DESCRIPTION="Small, free and friendly text editor"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=3.2
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SHA256=d12773af3589994b2e4982c5792b07c6240da5b86c5aef2103ab13b401fe6349
 TERMUX_PKG_SRCURL=https://nano-editor.org/dist/latest/nano-$TERMUX_PKG_VERSION.tar.xz
 TERMUX_PKG_DEPENDS="libandroid-support, libandroid-glob, ncurses"
@@ -12,6 +12,7 @@ ac_cv_header_pwd_h=no
 --enable-utf8
 --with-wordbounds
 "
+TERMUX_PKG_CONFFILES="etc/nanorc"
 TERMUX_PKG_RM_AFTER_INSTALL="bin/rnano share/man/man1/rnano.1 share/nano/man-html"
 
 termux_step_pre_configure() {

--- a/packages/resolv-conf/build.sh
+++ b/packages/resolv-conf/build.sh
@@ -1,7 +1,8 @@
 TERMUX_PKG_HOMEPAGE=http://man7.org/linux/man-pages/man5/resolv.conf.5.html
 TERMUX_PKG_DESCRIPTION="Resolver configuration file"
 TERMUX_PKG_LICENSE="Public Domain"
-TERMUX_PKG_VERSION=1.1
+TERMUX_PKG_VERSION=1.2
+TERMUX_PKG_CONFFILES="etc/resolv.conf"
 
 termux_step_make_install() {
 	_RESOLV_CONF=$TERMUX_PREFIX/etc/resolv.conf

--- a/packages/tmux/build.sh
+++ b/packages/tmux/build.sh
@@ -4,10 +4,12 @@ TERMUX_PKG_LICENSE="BSD"
 # Link against libandroid-support for wcwidth(), see https://github.com/termux/termux-packages/issues/224
 TERMUX_PKG_DEPENDS="ncurses, libevent, libutil, libandroid-support, libandroid-glob"
 TERMUX_PKG_VERSION=2.8
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SHA256=7f6bf335634fafecff878d78de389562ea7f73a7367f268b66d37ea13617a2ba
 TERMUX_PKG_SRCURL=https://github.com/tmux/tmux/releases/download/${TERMUX_PKG_VERSION}/tmux-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_BUILD_IN_SRC=yes
+
+TERMUX_PKG_CONFFILES="etc/tmux.conf"
 
 termux_step_pre_configure() {
 	LDFLAGS+=" -landroid-glob"


### PR DESCRIPTION
Some packages have configuration files not specified in TERMUX_PKG_CONFFILES. This makes user's configuration overwritten on package upgrade.