### PR TITLE
build-package.sh: set TERMUX_NO_CLEAN to false per default

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -324,7 +324,7 @@ termux_step_setup_variables() {
 	: "${TERMUX_ANDROID_HOME:="/data/data/com.termux/files/home"}"
 	: "${TERMUX_DEBUG:=""}"
 	: "${TERMUX_PKG_API_LEVEL:="21"}"
-	: "${TERMUX_NO_CLEAN:="true"}"
+	: "${TERMUX_NO_CLEAN:="false"}"
 	: "${TERMUX_QUIET_BUILD:="false"}"
 	: "${TERMUX_DEBDIR:="${TERMUX_SCRIPTDIR}/debs"}"
 	: "${TERMUX_SKIP_DEPCHECK:="false"}"


### PR DESCRIPTION
Ensures -i builds are run in fresh environments