### PR TITLE
Shrink docker image

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -10,7 +10,7 @@ FROM ubuntu:19.04
 ENV LANG C.UTF-8
 
 # Needed for setup:
-COPY ./setup-ubuntu.sh ./setup-android-sdk.sh ./properties.sh /tmp/
+COPY ./docker-cleanup.sh ./setup-ubuntu.sh ./setup-android-sdk.sh ./properties.sh /tmp/
 
 # Setup needed packages and the Android SDK and NDK:
 RUN apt-get update && \
@@ -22,17 +22,7 @@ RUN apt-get update && \
 	su - builder -c /tmp/setup-ubuntu.sh && \
 	su - builder -c /tmp/setup-android-sdk.sh && \
 	# Removed unused parts to make a smaller Docker image:
-	apt-get clean && \
-	rm -rf /var/lib/apt/lists/* && \
-	cd /home/builder/lib/android-ndk/sources && \
-	rm -Rf cxx-stl/system third_party/shaderc third_party/vulkan && \
-	cd /home/builder/lib/android-ndk/platforms && \
-	rm -Rf android-16 android-17 android-18 android-19 && \
-	cd /home/builder/lib/android-ndk && \
-	rm -Rf shader-tools && \
-	fdupes -r -1 path | while read line; do master=""; for file in ${line[*]}; do if [ "x${master}" == "x" ]; then master=$file; else ln -f "${master}" "${file}"; fi; done; done && \
-	cd /home/builder/lib/android-sdk/tools && \
-	rm -Rf emulator* lib* proguard templates
+	su - builder -c /tmp/docker-cleanup.sh
 
 # Switch User
 USER builder:builder

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -24,8 +24,12 @@ RUN apt-get update && \
 	# Removed unused parts to make a smaller Docker image:
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/* && \
-	cd /home/builder/lib/android-ndk/ && \
-	rm -Rf sources/cxx-stl/system platforms/android-16 platforms/android-17 platforms/android-18 platforms/android-19 && \
+	cd /home/builder/lib/android-ndk/sources && \
+	rm -Rf cxx-stl/system third_party/shaderc third_party/vulkan && \
+	cd /home/builder/lib/android-ndk/platforms && \
+	rm -Rf android-16 android-17 android-18 android-19 && \
+	cd /home/builder/lib/android-ndk && \
+	rm -Rf shader-tools && \
 	cd /home/builder/lib/android-sdk/tools && \
 	rm -Rf emulator* lib* proguard templates
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/* && \
 	cd /home/builder/lib/android-ndk/ && \
-	rm -Rf sources/cxx-stl/system && \
+	rm -Rf sources/cxx-stl/system platforms/android-16 platforms/android-17 platforms/android-18 platforms/android-19 && \
 	cd /home/builder/lib/android-sdk/tools && \
 	rm -Rf emulator* lib* proguard templates
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -15,7 +15,7 @@ COPY ./setup-ubuntu.sh ./setup-android-sdk.sh ./properties.sh /tmp/
 # Setup needed packages and the Android SDK and NDK:
 RUN apt-get update && \
 	apt-get -yq upgrade && \
-	apt-get install -yq sudo && \
+	apt-get install -yq --no-install-recommends sudo fdupes && \
 	adduser --disabled-password --shell /bin/bash --gecos "" builder && \
 	echo "builder ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/builder && \
 	chmod 0440 /etc/sudoers.d/builder && \
@@ -30,6 +30,7 @@ RUN apt-get update && \
 	rm -Rf android-16 android-17 android-18 android-19 && \
 	cd /home/builder/lib/android-ndk && \
 	rm -Rf shader-tools && \
+	fdupes -r -1 path | while read line; do master=""; for file in ${line[*]}; do if [ "x${master}" == "x" ]; then master=$file; else ln -f "${master}" "${file}"; fi; done; done && \
 	cd /home/builder/lib/android-sdk/tools && \
 	rm -Rf emulator* lib* proguard templates
 

--- a/scripts/docker-cleanup.sh
+++ b/scripts/docker-cleanup.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e -u
 
+. $(cd "$(dirname "$0")"; pwd)/properties.sh
+
 echo "Cleaning APT"
 sudo apt-get clean
 sudo rm -rf /var/lib/apt/lists/*
@@ -28,7 +30,7 @@ echo "Zipping notices"
 cd /home/builder/lib/android-ndk
 bzip2 NOTICE NOTICE.toolchain sysroot/NOTICE
 cd /home/builder/lib/android-sdk
-bzip2 tools/NOTICE.txt build-tools/28.0.3/NOTICE.txt platform-tools/NOTICE.txt
+bzip2 tools/NOTICE.txt build-tools/${TERMUX_ANDROID_BUILD_TOOLS_VERSION}/NOTICE.txt platform-tools/NOTICE.txt
 cd /home/builder/lib/android-sdk/platforms
 
 echo "Removing duplicate files"

--- a/scripts/docker-cleanup.sh
+++ b/scripts/docker-cleanup.sh
@@ -15,7 +15,10 @@ rm -Rf shader-tools
 
 echo "Cleaning unneeded SDK modules"
 cd /home/builder/lib/android-sdk/tools
-rm -Rf emulator* lib* proguard template support/*.txt
+mkdir -p lib2
+cp $(grep "CLASSPATH=" bin/sdkmanager | head -n 1 | cut -d '=' -f 2 | tr ':' ' ' | sed 's%\$APP_HOME/%%g') lib2
+rm -Rf emulator* lib proguard template support/*.txt
+mv lib2 lib
 cd /home/builder/lib/android-sdk/platforms
 rm -Rf android-21/templates android-28/templates
 

--- a/scripts/docker-cleanup.sh
+++ b/scripts/docker-cleanup.sh
@@ -19,8 +19,10 @@ mkdir -p lib2
 cp $(grep "CLASSPATH=" bin/sdkmanager | head -n 1 | cut -d '=' -f 2 | tr ':' ' ' | sed 's%\$APP_HOME/%%g') lib2
 rm -Rf emulator* lib proguard template support/*.txt
 mv lib2 lib
-cd /home/builder/lib/android-sdk/platforms
-rm -Rf android-21/templates android-28/templates
+cd /home/builder/lib/android-sdk/platforms/android-21
+rm -Rf data templates skins
+cd /home/builder/lib/android-sdk/platforms/android-28
+rm -Rf data templates skins
 
 echo "Zipping notices"
 cd /home/builder/lib/android-ndk
@@ -28,7 +30,6 @@ bzip2 NOTICE NOTICE.toolchain sysroot/NOTICE
 cd /home/builder/lib/android-sdk
 bzip2 tools/NOTICE.txt build-tools/28.0.3/NOTICE.txt platform-tools/NOTICE.txt
 cd /home/builder/lib/android-sdk/platforms
-bzip2 android-21/skins/NOTICE.txt android-21/data/NOTICE.txt android-28/skins/NOTICE.txt android-28/data/NOTICE.txt
 
 echo "Removing duplicate files"
 fdupes -r -1 /home/builder/lib/android-ndk /home/builder/lib/android-sdk | \

--- a/scripts/docker-cleanup.sh
+++ b/scripts/docker-cleanup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e -u
+
+echo "Cleaning APT"
+sudo apt-get clean
+sudo rm -rf /var/lib/apt/lists/*
+
+echo "Cleaning unneeded NDK modules"
+cd /home/builder/lib/android-ndk/sources
+rm -Rf cxx-stl/system third_party/shaderc third_party/vulkan
+cd /home/builder/lib/android-ndk/platforms
+rm -Rf android-16 android-17 android-18 android-19
+cd /home/builder/lib/android-ndk
+rm -Rf shader-tools
+
+echo "Cleaning unneeded SDK modules"
+cd /home/builder/lib/android-sdk/tools
+rm -Rf emulator* lib* proguard template support/*.txt
+
+echo "Removing duplicate files"
+fdupes -r -1 /home/builder/lib/android-ndk /home/builder/lib/android-sdk | \
+	while read line; do
+		master=""
+		for file in ${line[*]}; do
+			if [ "x${master}" == "x" ]; then
+				master=$file
+			else
+				ln -f "${master}" "${file}"
+			fi
+		done
+	done
+
+echo "Cleaning done"

--- a/scripts/docker-cleanup.sh
+++ b/scripts/docker-cleanup.sh
@@ -16,6 +16,8 @@ rm -Rf shader-tools
 echo "Cleaning unneeded SDK modules"
 cd /home/builder/lib/android-sdk/tools
 rm -Rf emulator* lib* proguard template support/*.txt
+cd /home/builder/lib/android-sdk/platforms
+rm -Rf android-21/templates android-28/templates
 
 echo "Removing duplicate files"
 fdupes -r -1 /home/builder/lib/android-ndk /home/builder/lib/android-sdk | \

--- a/scripts/docker-cleanup.sh
+++ b/scripts/docker-cleanup.sh
@@ -35,7 +35,7 @@ fdupes -r -1 /home/builder/lib/android-ndk /home/builder/lib/android-sdk | \
 			if [ "x${master}" == "x" ]; then
 				master=$file
 			else
-				ln -f "${master}" "${file}"
+				ln -sf "${master}" "${file}"
 			fi
 		done
 	done

--- a/scripts/docker-cleanup.sh
+++ b/scripts/docker-cleanup.sh
@@ -19,6 +19,14 @@ rm -Rf emulator* lib* proguard template support/*.txt
 cd /home/builder/lib/android-sdk/platforms
 rm -Rf android-21/templates android-28/templates
 
+echo "Zipping notices"
+cd /home/builder/lib/android-ndk
+bzip2 NOTICE NOTICE.toolchain sysroot/NOTICE
+cd /home/builder/lib/android-sdk
+bzip2 tools/NOTICE.txt build-tools/28.0.3/NOTICE.txt platform-tools/NOTICE.txt
+cd /home/builder/lib/android-sdk/platforms
+bzip2 android-21/skins/NOTICE.txt android-21/data/NOTICE.txt android-28/skins/NOTICE.txt android-28/data/NOTICE.txt
+
 echo "Removing duplicate files"
 fdupes -r -1 /home/builder/lib/android-ndk /home/builder/lib/android-sdk | \
 	while read line; do


### PR DESCRIPTION
As seen from [test builds](https://cirrus-ci.com/task/5661580147556352), the current uncompressed docker image size is 3.25GB...

Actually, there is a lot of work we can do that can cut down the size of the image.

1. Remove the NDK support for Android 16-19. Currently, the minimum Termux API Level is already Level 21, as seen in the `build.gradle` file of the [termux-app repository](https://github.com/termux/termux-app/blob/master/app/build.gradle). The Android NDK, however, also contains platforms for Android 16-19. These are totally unnecessary and can be removed. This yields a reduction of [80MB](https://cirrus-ci.com/task/6203545897402368). Although not significant, I think it is totally unnecessary to include it in Docker image.

2. Remove the [Vulkan API](https://developer.android.com/ndk/guides/graphics/) and the shaderc API. As the UI of any Termux package is expected to be command-line rather than displaying some 3D graphics, the Vulkan API can be safely deleted. The reduction is more significant, around [110MB](https://cirrus-ci.com/task/5753145964625920) in size.

3. This is the largest reduction in size. Actually, there are a lot of duplicate files in the Android NDK and the Android SDK. For example, the `libm.a` files are the same in all Android NDK versions. However, the Android NDK package just stores them in separate copies.
Therefore, by using `fdupes` and hard link all files which are the same, the duplicate files can be removed. There is a drop in [800MB](https://cirrus-ci.com/task/5853625852100608) due to symlinking all identical files.

Actually, the image size drops from 3.25GB to 2.25GB just by these 3 small moves! Even the compressed size also dropped from 1GB to 770MB.

If there are any essential directories removed, please don't hesitate to push any changes.