### PR TITLE
termux-elf-cleaner: update to v1.3

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -671,9 +671,10 @@ termux_step_start_build() {
 	termux_download \
 		"https://raw.githubusercontent.com/termux/termux-elf-cleaner/v$TERMUX_ELF_CLEANER_VERSION/termux-elf-cleaner.cpp" \
 		"$TERMUX_ELF_CLEANER_SRC" \
-		62c3cf9813756a1b262108fbc39684c5cfd3f9a69b376276bb1ac6af138f5fa2
+		690991371101cd1dadf73f07f73d1db72fe1cd646dcccf11cd252e194bd5de76
 	if [ "$TERMUX_ELF_CLEANER_SRC" -nt "$TERMUX_ELF_CLEANER" ]; then
-		g++ -std=c++11 -Wall -Wextra -pedantic -Os "$TERMUX_ELF_CLEANER_SRC" -o "$TERMUX_ELF_CLEANER"
+		g++ -std=c++11 -Wall -Wextra -pedantic -Os -D__ANDROID_API__=$TERMUX_PKG_API_LEVEL \
+			"$TERMUX_ELF_CLEANER_SRC" -o "$TERMUX_ELF_CLEANER"
 	fi
 
 	if [ -n "$TERMUX_PKG_BUILD_IN_SRC" ]; then
@@ -787,7 +788,7 @@ termux_step_setup_toolchain() {
 	export AS=${TERMUX_HOST_PLATFORM}-clang
 	export CC=$TERMUX_HOST_PLATFORM-clang
 	export CXX=$TERMUX_HOST_PLATFORM-clang++
-	
+
 	export CCTERMUX_HOST_PLATFORM=$TERMUX_HOST_PLATFORM$TERMUX_PKG_API_LEVEL
 	if [ $TERMUX_ARCH = arm ]; then
 	       CCTERMUX_HOST_PLATFORM=armv7a-linux-androideabi$TERMUX_PKG_API_LEVEL

--- a/packages/termux-elf-cleaner/build.sh
+++ b/packages/termux-elf-cleaner/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="GPL-3.0"
 # NOTE: The termux-elf-cleaner.cpp file is used by build-package.sh
 #       to create a native binary. Bumping this version will need
 #       updating the checksum used there.
-TERMUX_PKG_VERSION=1.2
+TERMUX_PKG_VERSION=1.3
 TERMUX_PKG_SRCURL=https://github.com/termux/termux-elf-cleaner/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=956d35778bf40523543a98ecec79d7d895a08ac69da1018acb84658a1c94e82b
+TERMUX_PKG_SHA256=972e768d6e5b780415190bda966f76401d95e5da66fef01ba0dbd63a1ea106cf
 TERMUX_PKG_BUILD_IN_SRC=yes


### PR DESCRIPTION
I released new version of `termux-elf-cleaner`. It can be targeted at specific API level, for example if `__ANDROID_API__` is set to 24, it will keep DT_RUNPATH.

More information about changes can be found in https://github.com/termux/termux-elf-cleaner/commit/623f314cee94e5344588c40b7eb72a492f4e9b02.