### PR TITLE
Avoid no subpackage error

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -572,6 +572,7 @@ termux_step_start_build() {
 		_PKG_BUILD_DEPENDS=${TERMUX_PKG_BUILD_DEPENDS// /}
 		# Also download subpackages dependencies (except the mother package):
 		for SUBPKG in packages/$TERMUX_PKG_NAME/*.subpackage.sh; do
+			test -e $SUBPKG || continue
 			_SUBPKG_DEPENDS+=" $(. $SUBPKG; echo $TERMUX_SUBPKG_DEPENDS | sed s%$TERMUX_PKG_NAME%%g)"
 		done
 		for PKG in $(echo ${_PKG_DEPENDS//,/ } ${_SUBPKG_DEPENDS//,/ } ${_PKG_BUILD_DEPENDS//,/ } | tr ' ' '\n' | sort -u); do


### PR DESCRIPTION
[This commit](876a1e77d) assumes that there must be subpackage(s) for each package. As a result, [builds](https://cirrus-ci.com/build/5763728675962880) for `libandroid-support` or packages with no subpackages fail.

`find *.subpackage.sh` could [prevent](https://cirrus-ci.com/build/5714783631310848) such errors.