### PR TITLE
ca-certificates: fix version typo

### DIFF
--- a/packages/ca-certificates/build.sh
+++ b/packages/ca-certificates/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://curl.haxx.se/docs/caextract.html
 TERMUX_PKG_DESCRIPTION="Common CA certificates"
 TERMUX_PKG_LICENSE="GPL-2.0"
-TERMUX_PKG_VERSION=20180124
+TERMUX_PKG_VERSION=20190124
 TERMUX_PKG_SRCURL=https://curl.haxx.se/ca/cacert.pem
 # If the checksum has changed, it may be time to update the package version:
 TERMUX_PKG_SHA256=c1fd9b235896b1094ee97bfb7e042f93530b5e300781f59b45edf84ee8c75000


### PR DESCRIPTION
ca-certificates at termux.net is still version 20181205