### PR TITLE
Fast build bug fix

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -131,7 +131,6 @@ source scripts/build/termux_step_finish_build.sh
 termux_step_handle_arguments "$@"
 termux_step_setup_variables
 termux_step_handle_buildarch
-termux_step_get_repo_files
 termux_step_start_build
 termux_step_extract_package
 cd "$TERMUX_PKG_SRCDIR"

--- a/scripts/build/termux_download_deb.sh
+++ b/scripts/build/termux_download_deb.sh
@@ -1,24 +1,27 @@
 termux_download_deb() {
-	local package=$1
-	local package_arch=$2
-	local version=$3
-	local deb_file=${package}_${version}_${package_arch}.deb
+	local PACKAGE=$1
+	local PACKAGE_ARCH=$2
+	local VERSION=$3
+	local DEB_FILE=${PACKAGE}_${VERSION}_${PACKAGE_ARCH}.deb
+	PKG_HASH=""
 	for idx in $(seq ${#TERMUX_REPO_URL[@]}); do
 		local TERMUX_REPO_NAME=$(echo ${TERMUX_REPO_URL[$idx-1]} | sed -e 's%https://%%g' -e 's%http://%%g' -e 's%/%-%g')
 		local PACKAGE_FILE_PATH="${TERMUX_REPO_NAME}-${TERMUX_REPO_DISTRIBUTION[$idx-1]}-${TERMUX_REPO_COMPONENT[$idx-1]}-Packages"
-		read -d "\n" PKG_PATH PKG_HASH <<<$(./scripts/get_hash_from_file.py "${TERMUX_COMMON_CACHEDIR}-$arch/$PACKAGE_FILE_PATH" $package $version)
-		if ! [ "$PKG_HASH" = "" ]; then
-			if [ ! "$TERMUX_QUIET_BUILD" = true ]; then
-				echo "Found $package in ${TERMUX_REPO_URL[$idx-1]}/dists/${TERMUX_REPO_DISTRIBUTION[$idx-1]}"
+		if [ -f "${TERMUX_COMMON_CACHEDIR}-${PACKAGE_ARCH}/${PACKAGE_FILE_PATH}" ]; then
+			read -d "\n" PKG_PATH PKG_HASH <<<$(./scripts/get_hash_from_file.py "${TERMUX_COMMON_CACHEDIR}-${PACKAGE_ARCH}/$PACKAGE_FILE_PATH" $PACKAGE $VERSION)
+			if [ ! -z "$PKG_HASH" ]; then
+				if [ ! "$TERMUX_QUIET_BUILD" = true ]; then
+					echo "Found $PACKAGE in ${TERMUX_REPO_URL[$idx-1]}/dists/${TERMUX_REPO_DISTRIBUTION[$idx-1]}"
+				fi
+				break
 			fi
-			break
 		fi
 	done
 	if [ "$PKG_HASH" = "" ]; then
 		return 1
 	else
 		termux_download ${TERMUX_REPO_URL[$idx-1]}/${PKG_PATH} \
-				$TERMUX_COMMON_CACHEDIR-$package_arch/${deb_file} \
+				$TERMUX_COMMON_CACHEDIR-$PACKAGE_ARCH/${DEB_FILE} \
 				$PKG_HASH
 		return 0
 	fi

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -19,6 +19,8 @@ termux_step_start_build() {
 		while read PKG PKG_DIR; do
 			if [ -z $PKG ]; then
 				continue
+			elif [ "$PKG" = "ERROR" ]; then
+				termux_error_exit "Obtaining buildorder failed"
 			fi
 			# llvm doesn't build if ndk-sysroot is installed:
 			if [ "$PKG" = "ndk-sysroot" ]; then continue; fi
@@ -51,17 +53,19 @@ termux_step_start_build() {
 			fi
 			mkdir -p /data/data/.built-packages
 			echo "$DEP_VERSION" > "/data/data/.built-packages/$PKG"
-		done<<<$(./scripts/buildorder.py -i "$TERMUX_PKG_BUILDER_DIR" $TERMUX_PACKAGES_DIRECTORIES)
+		done<<<$(./scripts/buildorder.py -i "$TERMUX_PKG_BUILDER_DIR" $TERMUX_PACKAGES_DIRECTORIES || echo "ERROR")
 	elif [ "$TERMUX_SKIP_DEPCHECK" = false ] && [ "$TERMUX_INSTALL_DEPS" = false ]; then
 		# Build dependencies
 		while read PKG PKG_DIR; do
 			if [ -z $PKG ]; then
 				continue
+			elif [ "$PKG" = "ERROR" ]; then
+				termux_error_exit "Obtaining buildorder failed"
 			fi
 			echo "Building dependency $PKG if necessary..."
 			# Built dependencies are put in the default TERMUX_DEBDIR instead of the specified one
 			./build-package.sh -a $TERMUX_ARCH -s "${PKG_DIR}"
-		done<<<$(./scripts/buildorder.py "$TERMUX_PKG_BUILDER_DIR" $TERMUX_PACKAGES_DIRECTORIES)
+		done<<<$(./scripts/buildorder.py "$TERMUX_PKG_BUILDER_DIR" $TERMUX_PACKAGES_DIRECTORIES || echo "ERROR")
 	fi
 
 	TERMUX_PKG_FULLVERSION=$TERMUX_PKG_VERSION

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -13,6 +13,8 @@ termux_step_start_build() {
 	fi
 
 	if [ "$TERMUX_SKIP_DEPCHECK" = false ] && [ "$TERMUX_INSTALL_DEPS" = true ]; then
+		# Download repo files
+		termux_get_repo_files
 		# Download dependencies
 		while read PKG PKG_DIR; do
 			if [ -z $PKG ]; then


### PR DESCRIPTION
- Stop build if buildorder.py script throws an error
- Fix typo that prevented some arch=all packages to be downloaded
- Call termux_get_repo_files in termux_step_start_build instead to prevent re-downloading repo files
