### PR TITLE
termux-elf-cleaner: update to v1.4

### DIFF
--- a/packages/termux-elf-cleaner/build.sh
+++ b/packages/termux-elf-cleaner/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="GPL-3.0"
 # NOTE: The termux-elf-cleaner.cpp file is used by build-package.sh
 #       to create a native binary. Bumping this version will need
 #       updating the checksum used there.
-TERMUX_PKG_VERSION=1.3
+TERMUX_PKG_VERSION=1.4
 TERMUX_PKG_SRCURL=https://github.com/termux/termux-elf-cleaner/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=972e768d6e5b780415190bda966f76401d95e5da66fef01ba0dbd63a1ea106cf
+TERMUX_PKG_SHA256=a88829b74bef2830fddd5b83eb6569db46dd8045c3eeb3670ab43382cfb7ab3c
 TERMUX_PKG_BUILD_IN_SRC=yes

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -121,7 +121,7 @@ termux_step_start_build() {
 	termux_download \
 		"https://raw.githubusercontent.com/termux/termux-elf-cleaner/v$TERMUX_ELF_CLEANER_VERSION/termux-elf-cleaner.cpp" \
 		"$TERMUX_ELF_CLEANER_SRC" \
-		690991371101cd1dadf73f07f73d1db72fe1cd646dcccf11cd252e194bd5de76
+		ad66652e26ae2379b4b3137b6fca16241cf0247b9fbdaeb0974b000cd87e1a1a
 	if [ "$TERMUX_ELF_CLEANER_SRC" -nt "$TERMUX_ELF_CLEANER" ]; then
 		g++ -std=c++11 -Wall -Wextra -pedantic -Os -D__ANDROID_API__=$TERMUX_PKG_API_LEVEL \
 			"$TERMUX_ELF_CLEANER_SRC" -o "$TERMUX_ELF_CLEANER"


### PR DESCRIPTION
Provides fix for Android 5.
Closes https://github.com/termux/termux-packages/issues/2846.