### PR TITLE
build-package: use libc++.so linker script as fake libstdc++.so

### DIFF
--- a/packages/ddrescue/build.sh
+++ b/packages/ddrescue/build.sh
@@ -2,5 +2,6 @@ TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/ddrescue/
 TERMUX_PKG_DESCRIPTION="GNU data recovery tool"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_VERSION=1.24
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=4b5d3feede70e3657ca6b3c7844f23131851cbb6af0cecc9721500f7d7021087
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/ddrescue/ddrescue-${TERMUX_PKG_VERSION}.tar.lz

--- a/packages/unrar/build.sh
+++ b/packages/unrar/build.sh
@@ -2,6 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://www.rarlab.com/
 TERMUX_PKG_DESCRIPTION="Tool for extracting files from .rar archives"
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_VERSION=5.7.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=40e856b78374f258d8a1f5f02c02f828c5392a0118c9300fd169a300b520a444
 TERMUX_PKG_SRCURL=https://www.rarlab.com/rar/unrarsrc-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_DEPENDS="libandroid-support"

--- a/scripts/build/termux_step_setup_toolchain.sh
+++ b/scripts/build/termux_step_setup_toolchain.sh
@@ -169,17 +169,13 @@ termux_step_setup_toolchain() {
 		mkdir -p "$TERMUX_PREFIX/lib"
 		cd "$TERMUX_PREFIX/lib"
 
-		local _STL_LIBFILE=$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib/${TERMUX_HOST_PLATFORM}/$_STL_LIBFILE_NAME
+		local _STL_LIBFILE="$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib/${TERMUX_HOST_PLATFORM}/$_STL_LIBFILE_NAME"
+		local _STL_LINKERSCRIPT="$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib/${TERMUX_HOST_PLATFORM}/$TERMUX_PKG_API_LEVEL/libc++.so"
 
 		cp "$_STL_LIBFILE" .
 		$STRIP --strip-unneeded $_STL_LIBFILE_NAME
 		$TERMUX_ELF_CLEANER $_STL_LIBFILE_NAME
-		if [ $TERMUX_ARCH = "arm" ]; then
-			# Use a linker script to get libunwind.a.
-			echo 'INPUT(-lunwind -lc++_shared)' > libstdc++.so
-		else
-			ln -f $_STL_LIBFILE_NAME libstdc++.so
-		fi
+		cp --remove-destination "$_STL_LINKERSCRIPT" libstdc++.so
 	fi
 
 	export PKG_CONFIG_LIBDIR="$TERMUX_PKG_CONFIG_LIBDIR"

--- a/scripts/build/termux_step_setup_toolchain.sh
+++ b/scripts/build/termux_step_setup_toolchain.sh
@@ -168,6 +168,7 @@ termux_step_setup_toolchain() {
 	# fake a libstdc++.so in $PREFIX/lib with the libc++ linker script
 	rm -f libstdc++.so
 	echo 'INPUT(-lmeh)' > libstdc++.so
+        cp libstdc++.so libc++.so
 
 	export PKG_CONFIG_LIBDIR="$TERMUX_PKG_CONFIG_LIBDIR"
 	# Create a pkg-config wrapper. We use path to host pkg-config to

--- a/scripts/build/termux_step_setup_toolchain.sh
+++ b/scripts/build/termux_step_setup_toolchain.sh
@@ -166,8 +166,8 @@ termux_step_setup_toolchain() {
 	$TERMUX_ELF_CLEANER $_STL_LIBFILE_NAME
 
 	# fake a libstdc++.so in $PREFIX/lib with the libc++ linker script
-	local _STL_LINKERSCRIPT="$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib/${TERMUX_HOST_PLATFORM}/$TERMUX_PKG_API_LEVEL/libc++.so"
-	cp --remove-destination "$_STL_LINKERSCRIPT" libstdc++.so
+	rm -f libstdc++.so
+	echo 'INPUT(-lmeh)' > libstdc++.so
 
 	export PKG_CONFIG_LIBDIR="$TERMUX_PKG_CONFIG_LIBDIR"
 	# Create a pkg-config wrapper. We use path to host pkg-config to


### PR DESCRIPTION
With ndk 19, NDK/libllvm's libunwind is linked via the libgcc.a
linker script for arm. A linker script named libc++.so is also
provided for each supported API level for libc++_shared.so linking.
We should use it as our fake libstdc++.so for all architectures.