### PR TITLE
setup-ubuntu.sh: add jq and remove debdiff

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -38,7 +38,7 @@ PACKAGES+=" libjpeg-dev" # Needed by ghostscript
 PACKAGES+=" gawk" # Needed by apr-util
 PACKAGES+=" libssl-dev" # Needed to build Rust
 PACKAGES+=" gnupg" # Needed to verify downloaded .debs
-PACKAGES+=" devscripts" # Provides utility "debdiff".
+PACKAGES+=" jq" # Needed by bintray upload script.
 
 sudo DEBIAN_FRONTEND=noninteractive \
 	apt-get install -yq --no-install-recommends $PACKAGES


### PR DESCRIPTION
jq is needed by [bintray upload script](https://github.com/termux/termux-packages/blob/3f16a41efac3f364e00313ec7842a275606d08ad/scripts/package_uploader.sh#L103) and termux_step_compare_debs has been removed so debdiff is no longer needed in docker image