### PR TITLE
unstable-repo: use per-API repository URL

### DIFF
--- a/packages/unstable-repo/build.sh
+++ b/packages/unstable-repo/build.sh
@@ -2,13 +2,13 @@ TERMUX_PKG_HOMEPAGE=https://github.com/termux/unstable-packages
 TERMUX_PKG_DESCRIPTION="Package repository containing new/unstable programs and libraries."
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
-TERMUX_PKG_VERSION=1.0
+TERMUX_PKG_VERSION=1.1
 TERMUX_PKG_DEPENDS="termux-keyring"
 TERMUX_PKG_PLATFORM_INDEPENDENT=yes
 
 termux_step_make_install() {
 	mkdir -p $TERMUX_PREFIX/etc/apt/sources.list.d
-	echo "deb https://dl.bintray.com/xeffyr/unstable-packages unstable main" > $TERMUX_PREFIX/etc/apt/sources.list.d/unstable.list
+	echo "deb https://dl.bintray.com/xeffyr/unstable-packages-21 unstable main" > $TERMUX_PREFIX/etc/apt/sources.list.d/unstable.list
 }
 
 termux_step_create_debscripts() {


### PR DESCRIPTION
Since we are going to use Android 7 (API 24) as target, I'm splitting my repositories into API 21/24 to avoid potential problems.