### PR TITLE
fossil: working without api 23?

### DIFF
--- a/packages/fossil/build.sh
+++ b/packages/fossil/build.sh
@@ -1,7 +1,6 @@
 TERMUX_PKG_HOMEPAGE=https://www.fossil-scm.org
 TERMUX_PKG_DESCRIPTION="DSCM with built-in wiki, http interface and server, tickets database"
 TERMUX_PKG_LICENSE="BSD 2-Clause"
-TERMUX_PKG_API_LEVEL=23
 TERMUX_PKG_MAINTAINER="Vishal Biswas @vishalbiswas"
 TERMUX_PKG_VERSION=2.8
 TERMUX_PKG_SHA256=6a32bec73de26ff5cc8bbb0b7b45360f4e4145931fd215ed91414ed190b3715d


### PR DESCRIPTION
it appears to be working without api level 23 on android 5 anyway ?
