### PR TITLE
Simplify libc++ setup (android-5)

### DIFF
--- a/packages/libc++/build.sh
+++ b/packages/libc++/build.sh
@@ -2,14 +2,8 @@ TERMUX_PKG_HOMEPAGE=https://libcxx.llvm.org/
 TERMUX_PKG_DESCRIPTION="C++ Standard Library"
 TERMUX_PKG_LICENSE="NCSA"
 TERMUX_PKG_VERSION=$TERMUX_NDK_VERSION
-# Since every C++ package links against this by default (due
-# to the libstdc++.so -> libc++_shared.so setup in
-# build-package.sh) this package is considered essential,
-# and other packages does not need to declare explicit
-# dependency on it.
 TERMUX_PKG_ESSENTIAL=yes
 
-termux_step_post_massage() {
-	mkdir lib
-	cp $TERMUX_PREFIX/lib/libc++_shared.so lib/
+termux_step_post_make_install() {
+	cp "$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib/${TERMUX_HOST_PLATFORM}/libc++_shared.so" $TERMUX_PREFIX/lib
 }

--- a/scripts/build/termux_step_extract_into_massagedir.sh
+++ b/scripts/build/termux_step_extract_into_massagedir.sh
@@ -3,9 +3,7 @@ termux_step_extract_into_massagedir() {
 
 	# Build diff tar with what has changed during the build:
 	cd $TERMUX_PREFIX
-	tar -N "$TERMUX_BUILD_TS_FILE" \
-		--exclude='lib/libc++_shared.so' --exclude='lib/libstdc++.so' \
-		-czf "$TARBALL_ORIG" .
+	tar -N "$TERMUX_BUILD_TS_FILE" -czf "$TARBALL_ORIG" .
 
 	# Extract tar in order to massage it
 	mkdir -p "$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX"

--- a/scripts/build/termux_step_setup_toolchain.sh
+++ b/scripts/build/termux_step_setup_toolchain.sh
@@ -156,32 +156,6 @@ termux_step_setup_toolchain() {
 		mv $_TERMUX_TOOLCHAIN_TMPDIR $TERMUX_STANDALONE_TOOLCHAIN
 	fi
 
-	local _STL_LIBFILE_NAME=libc++_shared.so
-	if [ ! -f $TERMUX_PREFIX/lib/libstdc++.so ]; then
-		# Setup libc++_shared.so in $PREFIX/lib and libstdc++.so as a link to it,
-		# so that other C++ using packages links to it instead of the default android
-		# C++ library which does not support exceptions or STL:
-		# https://developer.android.com/ndk/guides/cpp-support.html
-		# We do however want to avoid installing this, to avoid problems where e.g.
-		# libm.so on some i686 devices links against libstdc++.so.
-		# The libc++_shared.so library will be packaged in the libc++ package
-		# which is part of the base Termux installation.
-		mkdir -p "$TERMUX_PREFIX/lib"
-		cd "$TERMUX_PREFIX/lib"
-
-		local _STL_LIBFILE=$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib/${TERMUX_HOST_PLATFORM}/$_STL_LIBFILE_NAME
-
-		cp "$_STL_LIBFILE" .
-		$STRIP --strip-unneeded $_STL_LIBFILE_NAME
-		$TERMUX_ELF_CLEANER $_STL_LIBFILE_NAME
-		if [ $TERMUX_ARCH = "arm" ]; then
-			# Use a linker script to get libunwind.a.
-			echo 'INPUT(-lunwind -lc++_shared)' > libstdc++.so
-		else
-			ln -f $_STL_LIBFILE_NAME libstdc++.so
-		fi
-	fi
-
 	export PKG_CONFIG_LIBDIR="$TERMUX_PKG_CONFIG_LIBDIR"
 	# Create a pkg-config wrapper. We use path to host pkg-config to
 	# avoid picking up a cross-compiled pkg-config later on.

--- a/scripts/buildorder.py
+++ b/scripts/buildorder.py
@@ -64,9 +64,10 @@ class TermuxPackage(object):
             raise Exception("build.sh not found for package '" + self.name + "'")
 
         self.deps = parse_build_file_dependencies(build_sh_path)
-        if 'libandroid-support' not in self.deps and self.name != 'libandroid-support':
-            # Every package may depend on libandroid-support without declaring it:
-            self.deps.add('libandroid-support')
+        always_deps = ['libandroid-support', 'libc++']
+        for dependency_name in always_deps:
+            if dependency_name not in self.deps and self.name not in always_deps:
+                self.deps.add(dependency_name)
 
         # search subpackages
         self.subpkgs = []


### PR DESCRIPTION
As clang++ in the NDK defaults to libc++ since r17, we no longer
need to fake a libstdc++.so at build time (and omit it from the
libc++ package we ship).