### PR TITLE
[WIP] termux_create_subpackages: avoid include dir test for develsplit

### DIFF
--- a/scripts/build/termux_create_subpackages.sh
+++ b/scripts/build/termux_create_subpackages.sh
@@ -1,7 +1,7 @@
 termux_create_subpackages() {
 	# Sub packages:
-	if [ -d include ] && [ -z "${TERMUX_PKG_NO_DEVELSPLIT}" ]; then
-		# Add virtual -dev sub package if there are include files:
+	if [ -z "${TERMUX_PKG_NO_DEVELSPLIT}" ]; then
+		# Add virtual -dev sub package for development files:
 		local _DEVEL_SUBPACKAGE_FILE=$TERMUX_PKG_TMPDIR/${TERMUX_PKG_NAME}-dev.subpackage.sh
 		echo TERMUX_SUBPKG_INCLUDE=\"include share/vala share/man/man3 lib/pkgconfig share/aclocal lib/cmake $TERMUX_PKG_INCLUDE_IN_DEVPACKAGE\" > "$_DEVEL_SUBPACKAGE_FILE"
 		echo "TERMUX_SUBPKG_DESCRIPTION=\"Development files for ${TERMUX_PKG_NAME}\"" >> "$_DEVEL_SUBPACKAGE_FILE"


### PR DESCRIPTION
Supplement to #3537.

I don't really know if it's necessary, as I don't know what would actually happen when
https://github.com/termux/termux-packages/blob/087ecd0416af1df81d56f354187dd9f969a9d4ad/scripts/build/termux_step_start_build.sh#L32-L35
works on e.g.
```
libc++-dev                     packages/libc++
```
when e.g. apt is being fast built.

I am also not sure, if it's necessary, how you would want to apply it. I mean, do you want merge this first and then fix packages *when* you bump into the failure? Or, do you think we *have to* identify all packages that needs to be fixed first and then we merge them all together? (Assuming there's a way)