### PR TITLE
[android-5] Move some packages from "unstable-packages" repository

### DIFF
--- a/packages/capstone/build.sh
+++ b/packages/capstone/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE=http://www.capstone-engine.org/
+TERMUX_PKG_DESCRIPTION="Lightweight multi-platform, multi-architecture disassembly framework"
+TERMUX_PKG_LICENSE="BSD"
+TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
+TERMUX_PKG_VERSION=4.0.1
+TERMUX_PKG_REVISION=2
+TERMUX_PKG_SRCURL=https://github.com/aquynh/capstone/archive/$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=79bbea8dbe466bd7d051e037db5961fdb34f67c9fac5c3471dd105cfb1e05dc7
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DINSTALL_LIB_DIR=$TERMUX_PREFIX/lib"

--- a/packages/dtc/build.sh
+++ b/packages/dtc/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE=https://git.kernel.org/pub/scm/utils/dtc/dtc
+TERMUX_PKG_DESCRIPTION="Device Tree Compiler"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
+TERMUX_PKG_VERSION=1.5.0
+TERMUX_PKG_SRCURL=https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/dtc-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=3416f10ca69b0b911f027a9cb96471485dd8705705fc4813283f963299eaae0a
+TERMUX_PKG_EXTRA_MAKE_ARGS="PREFIX=$TERMUX_PREFIX"
+TERMUX_PKG_BUILD_IN_SRC=true

--- a/packages/e2fsprogs/build.sh
+++ b/packages/e2fsprogs/build.sh
@@ -1,0 +1,39 @@
+TERMUX_PKG_HOMEPAGE=http://e2fsprogs.sourceforge.net
+TERMUX_PKG_DESCRIPTION="EXT 2/3/4 filesystem utilities"
+TERMUX_PKG_LICENSE="GPL-2.0, LGPL-2.0, MIT"
+TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
+TERMUX_PKG_VERSION=1.44.5
+TERMUX_PKG_REVISION=2
+TERMUX_PKG_SRCURL=https://www.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v$TERMUX_PKG_VERSION/e2fsprogs-$TERMUX_PKG_VERSION.tar.xz
+TERMUX_PKG_SHA256=ba5eb3069d69160d96818bb9700de9ab5a8458d9add1fd85d427c0000d34c5b9
+TERMUX_PKG_KEEP_STATIC_LIBRARIES=true
+TERMUX_PKG_INCLUDE_IN_DEVPACKAGE="lib/*.a"
+TERMUX_PKG_CONFFILES="etc/mke2fs.conf"
+
+## util-linux provides libblkid
+TERMUX_PKG_DEPENDS="libuuid, util-linux"
+
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--sbindir=${TERMUX_PREFIX}/bin
+--enable-symlink-install
+--enable-relative-symlinks
+--disable-defrag
+--disable-e2initrd-helper
+--disable-libuuid
+--disable-libblkid
+--disable-uuidd"
+
+TERMUX_PKG_RM_AFTER_INSTALL="
+bin/compile_et
+bin/mk_cmds
+share/et
+share/ss
+share/man/man1/compile_et.1
+share/man/man1/mk_cmds.1"
+
+termux_step_make_install() {
+	make install install-libs
+	install -Dm600 \
+		"$TERMUX_PKG_SRCDIR"/misc/mke2fs.conf.in \
+		"$TERMUX_PREFIX"/etc/mke2fs.conf
+}

--- a/packages/e2fsprogs/clang-compat.patch
+++ b/packages/e2fsprogs/clang-compat.patch
@@ -1,0 +1,191 @@
+diff -uNr e2fsprogs-1.44.4/debugfs/set_fields.c e2fsprogs-1.44.4.mod/debugfs/set_fields.c
+--- e2fsprogs-1.44.4/debugfs/set_fields.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/debugfs/set_fields.c	2018-09-22 15:23:46.532924119 +0300
+@@ -291,9 +293,11 @@
+ 	{ "checksum", &set_mmp.mmp_checksum, NULL, 4, parse_uint },
+ 	{ 0, 0, 0, 0 }
+ };
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 6)
+ #pragma GCC diagnostic pop
+ #endif
++#endif
+ 
+ #ifdef UNITTEST
+ 
+diff -uNr e2fsprogs-1.44.4/e2fsck/problem.c e2fsprogs-1.44.4.mod/e2fsck/problem.c
+--- e2fsprogs-1.44.4/e2fsck/problem.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/e2fsck/problem.c	2018-09-22 15:24:53.636504023 +0300
+@@ -99,10 +99,12 @@
+ 	"",			/* 20 */
+ };
+ 
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 6)
+ #pragma GCC diagnostic push
+ #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+ #endif
++#endif
+ 
+ static struct e2fsck_problem problem_table[] = {
+ 
+@@ -2094,9 +2096,11 @@
+ 	{ PR_LATCH_OPTIMIZE_EXT, PR_1E_OPTIMIZE_EXT_HEADER, PR_1E_OPTIMIZE_EXT_END },
+ 	{ -1, 0, 0 },
+ };
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 6)
+ #pragma GCC diagnostic pop
+ #endif
++#endif
+ 
+ static struct e2fsck_problem *find_problem(problem_t code)
+ {
+diff -uNr e2fsprogs-1.44.4/lib/ext2fs/ext4_acl.h e2fsprogs-1.44.4.mod/lib/ext2fs/ext4_acl.h
+--- e2fsprogs-1.44.4/lib/ext2fs/ext4_acl.h	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/lib/ext2fs/ext4_acl.h	2018-09-22 15:25:22.019941241 +0300
+@@ -50,13 +50,17 @@
+ 
+ typedef struct {
+         __le32                  a_version;
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 8)
+ #pragma GCC diagnostic push
+ #pragma GCC diagnostic ignored "-Wpedantic"
+ #endif
++#endif
+         posix_acl_xattr_entry   a_entries[0];
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 8)
+ #pragma GCC diagnostic pop
+ #endif
++#endif
+ } posix_acl_xattr_header;
+ 
+diff -uNr e2fsprogs-1.44.4/lib/ext2fs/fiemap.h e2fsprogs-1.44.4.mod/lib/ext2fs/fiemap.h
+--- e2fsprogs-1.44.4/lib/ext2fs/fiemap.h	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/lib/ext2fs/fiemap.h	2018-09-22 15:25:50.213377543 +0300
+@@ -31,14 +31,18 @@
+ 	__u32 fm_mapped_extents;/* number of extents that were mapped (out) */
+ 	__u32 fm_extent_count;  /* size of fm_extents array (in) */
+ 	__u32 fm_reserved;
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 8)
+ #pragma GCC diagnostic push
+ #pragma GCC diagnostic ignored "-Wpedantic"
+ #endif
++#endif
+ 	struct fiemap_extent fm_extents[0]; /* array of mapped extents (out) */
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 8)
+ #pragma GCC diagnostic pop
+ #endif
++#endif
+ };
+ 
+ #if defined(__linux__) && !defined(FS_IOC_FIEMAP)
+diff -uNr e2fsprogs-1.44.4/lib/ext2fs/hashmap.h e2fsprogs-1.44.4.mod/lib/ext2fs/hashmap.h
+--- e2fsprogs-1.44.4/lib/ext2fs/hashmap.h	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/lib/ext2fs/hashmap.h	2018-09-22 15:26:16.196805586 +0300
+@@ -17,14 +17,18 @@
+ 		struct ext2fs_hashmap_entry *next;
+ 		struct ext2fs_hashmap_entry *list_next;
+ 		struct ext2fs_hashmap_entry *list_prev;
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 8)
+ #pragma GCC diagnostic push
+ #pragma GCC diagnostic ignored "-Wpedantic"
+ #endif
++#endif
+ 	} *entries[0];
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 8)
+ #pragma GCC diagnostic pop
+ #endif
++#endif
+ };
+ 
+ struct ext2fs_hashmap *ext2fs_hashmap_create(
+diff -uNr e2fsprogs-1.44.4/lib/ext2fs/mmp.c e2fsprogs-1.44.4.mod/lib/ext2fs/mmp.c
+--- e2fsprogs-1.44.4/lib/ext2fs/mmp.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/lib/ext2fs/mmp.c	2018-09-22 15:26:44.660242476 +0300
+@@ -34,12 +34,14 @@
+ #define O_DIRECT 0
+ #endif
+ 
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 6)
+ #pragma GCC diagnostic push
+ #ifndef CONFIG_MMP
+ #pragma GCC diagnostic ignored "-Wunused-parameter"
+ #endif
+ #endif
++#endif
+ 
+ errcode_t ext2fs_mmp_read(ext2_filsys fs, blk64_t mmp_blk, void *buf)
+ {
+@@ -467,6 +469,8 @@
+ 	return EXT2_ET_OP_NOT_SUPPORTED;
+ #endif
+ }
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 6)
+ #pragma GCC diagnostic pop
+ #endif
++#endif
+diff -uNr e2fsprogs-1.44.4/lib/ext2fs/unix_io.c e2fsprogs-1.44.4.mod/lib/ext2fs/unix_io.c
+--- e2fsprogs-1.44.4/lib/ext2fs/unix_io.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/lib/ext2fs/unix_io.c	2018-09-22 15:27:09.206998294 +0300
+@@ -1127,10 +1127,12 @@
+ }
+ 
+ /* parameters might not be used if OS doesn't support zeroout */
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 6)
+ #pragma GCC diagnostic push
+ #pragma GCC diagnostic ignored "-Wunused-parameter"
+ #endif
++#endif
+ static errcode_t unix_zeroout(io_channel channel, unsigned long long block,
+ 			      unsigned long long count)
+ {
+@@ -1197,9 +1199,11 @@
+ unimplemented:
+ 	return EXT2_ET_UNIMPLEMENTED;
+ }
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 6)
+ #pragma GCC diagnostic pop
+ #endif
++#endif
+ 
+ static struct struct_io_manager struct_unix_manager = {
+ 	.magic		= EXT2_ET_MAGIC_IO_MANAGER,
+diff -uNr e2fsprogs-1.44.4/misc/filefrag.c e2fsprogs-1.44.4.mod/misc/filefrag.c
+--- e2fsprogs-1.44.4/misc/filefrag.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/misc/filefrag.c	2018-09-22 15:27:56.437169454 +0300
+@@ -535,10 +535,12 @@
+ 				char *end;
+ 				blocksize = strtoul(optarg, &end, 0);
+ 				if (end) {
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (7, 0)
+ #pragma GCC diagnostic push
+ #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+ #endif
++#endif
+ 					switch (end[0]) {
+ 					case 'g':
+ 					case 'G':
+@@ -555,9 +557,11 @@
+ 					default:
+ 						break;
+ 					}
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (7, 0)
+ #pragma GCC diagnostic pop
+ #endif
++#endif
+ 				}
+ 			} else { /* Allow -b without argument for compat. Remove
+ 				  * this eventually so "-b {blocksize}" works */

--- a/packages/e2fsprogs/doc-Makefile.in.patch
+++ b/packages/e2fsprogs/doc-Makefile.in.patch
@@ -1,0 +1,12 @@
+diff -uNr e2fsprogs-1.44.4/doc/Makefile.in e2fsprogs-1.44.4.mod/doc/Makefile.in
+--- e2fsprogs-1.44.4/doc/Makefile.in	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/doc/Makefile.in	2018-09-22 15:22:14.779251149 +0300
+@@ -17,7 +17,7 @@
+ HTML=makeinfo --html --no-split
+ PS2PDF=ps2pdf
+ 
+-all:: libext2fs.info libext2fs.dvi libext2fs.html
++all:: libext2fs.info
+ 
+ install-doc-libs: libext2fs.info libext2fs.dvi
+ 	$(Q) $(RM) -rf $(DESTDIR)$(infodir)/libext2fs.info*

--- a/packages/e2fsprogs/fix-hardcoded-paths.patch
+++ b/packages/e2fsprogs/fix-hardcoded-paths.patch
@@ -1,0 +1,404 @@
+diff -uNr e2fsprogs-1.44.4/debugfs/debugfs.c e2fsprogs-1.44.4.mod/debugfs/debugfs.c
+--- e2fsprogs-1.44.4/debugfs/debugfs.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/debugfs/debugfs.c	2018-09-22 15:22:14.775917803 +0300
+@@ -87,7 +87,7 @@
+ 	 */
+ 	tdb_dir = ss_safe_getenv("E2FSPROGS_UNDO_DIR");
+ 	if (!tdb_dir)
+-		tdb_dir = "/var/lib/e2fsprogs";
++		tdb_dir = "@TERMUX_PREFIX@/var/lib/e2fsprogs";
+ 
+ 	if (!strcmp(tdb_dir, "none") || (tdb_dir[0] == 0) ||
+ 	    access(tdb_dir, W_OK))
+diff -uNr e2fsprogs-1.44.4/debugfs/util.c e2fsprogs-1.44.4.mod/debugfs/util.c
+--- e2fsprogs-1.44.4/debugfs/util.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/debugfs/util.c	2018-09-22 15:22:14.779251149 +0300
+@@ -61,7 +61,7 @@
+ }
+ 
+ static const char *pager_search_list[] = { "pager", "more", "less", 0 };
+-static const char *pager_dir_list[] = { "/usr/bin", "/bin", 0 };
++static const char *pager_dir_list[] = { "@TERMUX_PREFIX@/bin", "@TERMUX_PREFIX@/bin/applets", 0 };
+ 
+ static const char *find_pager(char *buf)
+ {
+diff -uNr e2fsprogs-1.44.4/e2fsck/e2fsck.h e2fsprogs-1.44.4.mod/e2fsck/e2fsck.h
+--- e2fsprogs-1.44.4/e2fsck/e2fsck.h	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/e2fsck/e2fsck.h	2018-09-22 15:22:14.779251149 +0300
+@@ -53,7 +53,7 @@
+ #define NLS_CAT_NAME "e2fsprogs"
+ #endif
+ #ifndef LOCALEDIR
+-#define LOCALEDIR "/usr/share/locale"
++#define LOCALEDIR "@TERMUX_PREFIX@/share/locale"
+ #endif
+ #else
+ #define _(a) (a)
+diff -uNr e2fsprogs-1.44.4/e2fsck/unix.c e2fsprogs-1.44.4.mod/e2fsck/unix.c
+--- e2fsprogs-1.44.4/e2fsck/unix.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/e2fsck/unix.c	2018-09-22 15:22:14.782584494 +0300
+@@ -601,7 +601,7 @@
+ 	return 0;
+ }
+ 
+-#define PATH_SET "PATH=/sbin"
++#define PATH_SET "PATH=@TERMUX_PREFIX@/bin"
+ 
+ /*
+  * Make sure 0,1,2 file descriptors are open, so that we don't open
+@@ -1306,7 +1306,7 @@
+ 	tdb_dir = getenv("E2FSPROGS_UNDO_DIR");
+ 	if (!tdb_dir) {
+ 		profile_get_string(ctx->profile, "defaults",
+-				   "undo_dir", 0, "/var/lib/e2fsprogs",
++				   "undo_dir", 0, "@TERMUX_PREFIX@/var/lib/e2fsprogs",
+ 				   &tdb_dir);
+ 		free_tdb_dir = 1;
+ 	}
+diff -uNr e2fsprogs-1.44.4/ext2ed/init.c e2fsprogs-1.44.4.mod/ext2ed/init.c
+--- e2fsprogs-1.44.4/ext2ed/init.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/ext2ed/init.c	2018-09-22 15:22:14.789251186 +0300
+@@ -613,8 +613,8 @@
+ 
+ 	mounted=0;
+ 
+-	if ( (fp=fopen ("/etc/mtab","rt"))==NULL) {
+-		wprintw (command_win,"Error - Failed to open /etc/mtab. Assuming filesystem is mounted.\n");
++	if ( (fp=fopen ("@TERMUX_PREFIX@/etc/mtab","rt"))==NULL) {
++		wprintw (command_win,"Error - Failed to open @TERMUX_PREFIX@/etc/mtab. Assuming filesystem is mounted.\n");
+ 		refresh_command_win ();mounted=1;return;
+ 	};
+ 
+diff -uNr e2fsprogs-1.44.4/lib/blkid/blkidP.h e2fsprogs-1.44.4.mod/lib/blkid/blkidP.h
+--- e2fsprogs-1.44.4/lib/blkid/blkidP.h	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/lib/blkid/blkidP.h	2018-09-22 15:22:14.795917878 +0300
+@@ -110,7 +110,7 @@
+ extern char *blkid_strdup(const char *s);
+ extern char *blkid_strndup(const char *s, const int length);
+ 
+-#define BLKID_CACHE_FILE "/etc/blkid.tab"
++#define BLKID_CACHE_FILE "@TERMUX_PREFIX@/etc/blkid.tab"
+ 
+ #define BLKID_ERR_IO	 5
+ #define BLKID_ERR_PROC	 9
+diff -uNr e2fsprogs-1.44.4/lib/support/nls-enable.h e2fsprogs-1.44.4.mod/lib/support/nls-enable.h
+--- e2fsprogs-1.44.4/lib/support/nls-enable.h	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/lib/support/nls-enable.h	2018-09-22 15:22:14.799251223 +0300
+@@ -12,7 +12,7 @@
+ #define NLS_CAT_NAME "e2fsprogs"
+ #endif
+ #ifndef LOCALEDIR
+-#define LOCALEDIR "/usr/share/locale"
++#define LOCALEDIR "@TERMUX_PREFIX@/share/locale"
+ #endif
+ #else
+ #define _(a) (a)
+diff -uNr e2fsprogs-1.44.4/lib/uuid/gen_uuid.c e2fsprogs-1.44.4.mod/lib/uuid/gen_uuid.c
+--- e2fsprogs-1.44.4/lib/uuid/gen_uuid.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/lib/uuid/gen_uuid.c	2018-09-22 15:27:30.643742706 +0300
+@@ -325,7 +325,7 @@
+ 
+ 	if (state_fd == -2) {
+ 		save_umask = umask(0);
+-		state_fd = open("/var/lib/libuuid/clock.txt",
++		state_fd = open("@TERMUX_PREFIX@/var/lib/libuuid/clock.txt",
+ 				O_RDWR|O_CREAT, 0660);
+ 		(void) umask(save_umask);
+ 		if (state_fd >= 0) {
+@@ -484,12 +484,14 @@
+ }
+ #endif /* defined(USE_UUIDD) && defined(HAVE_SYS_UN_H) */
+ 
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 6)
+ #pragma GCC diagnostic push
+ #if !defined(USE_UUIDD) || !defined(HAVE_SYS_UN_H)
+ #pragma GCC diagnostic ignored "-Wunused-parameter"
+ #endif
+ #endif
++#endif
+ /*
+  * Try using the uuidd daemon to generate the UUID
+  *
+@@ -572,9 +574,11 @@
+ #endif
+ 	return -1;
+ }
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 6)
+ #pragma GCC diagnostic pop
+ #endif
++#endif
+ 
+ void uuid__generate_time(uuid_t out, int *num)
+ {
+diff -uNr e2fsprogs-1.44.4/lib/uuid/uuidd.h e2fsprogs-1.44.4.mod/lib/uuid/uuidd.h
+--- e2fsprogs-1.44.4/lib/uuid/uuidd.h	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/lib/uuid/uuidd.h	2018-09-22 15:22:14.802584569 +0300
+@@ -35,10 +35,10 @@
+ #ifndef _UUID_UUIDD_H
+ #define _UUID_UUIDD_H
+ 
+-#define UUIDD_DIR		"/var/lib/libuuid"
++#define UUIDD_DIR		"@TERMUX_PREFIX@/var/lib/libuuid"
+ #define UUIDD_SOCKET_PATH	UUIDD_DIR "/request"
+ #define UUIDD_PIDFILE_PATH	UUIDD_DIR "/uuidd.pid"
+-#define UUIDD_PATH		"/usr/sbin/uuidd"
++#define UUIDD_PATH		"@TERMUX_PREFIX@/bin/uuidd"
+ 
+ #define UUIDD_OP_GETPID			0
+ #define UUIDD_OP_GET_MAXOP		1
+diff -uNr e2fsprogs-1.44.4/misc/badblocks.c e2fsprogs-1.44.4.mod/misc/badblocks.c
+--- e2fsprogs-1.44.4/misc/badblocks.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/misc/badblocks.c	2018-09-22 15:22:14.802584569 +0300
+@@ -1007,7 +1007,7 @@
+ 		fprintf(stderr, _("%s is mounted; "), device_name);
+ 		if (force) {
+ 			fputs(_("badblocks forced anyway.  "
+-				"Hope /etc/mtab is incorrect.\n"), stderr);
++				"Hope @TERMUX_PREFIX@/etc/mtab is incorrect.\n"), stderr);
+ 			return;
+ 		}
+ 	abort_badblocks:
+diff -uNr e2fsprogs-1.44.4/misc/blkid.c e2fsprogs-1.44.4.mod/misc/blkid.c
+--- e2fsprogs-1.44.4/misc/blkid.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/misc/blkid.c	2018-09-22 15:22:14.805917914 +0300
+@@ -53,7 +53,7 @@
+ 	fprintf(out,
+ 		"usage:\t%s [-c <file>] [-ghlLv] [-o format] "
+ 		"[-s <tag>] [-t <token>]\n    [-w <file>] [dev ...]\n"
+-		"\t-c\tcache file (default: /etc/blkid.tab, /dev/null = none)\n"
++		"\t-c\tcache file (default: @TERMUX_PREFIX@/etc/blkid.tab, /dev/null = none)\n"
+ 		"\t-h\tprint this usage message and exit\n"
+ 		"\t-g\tgarbage collect the blkid cache\n"
+ 		"\t-s\tshow specified tag(s) (default show all tags)\n"
+diff -uNr e2fsprogs-1.44.4/misc/e2undo.c e2fsprogs-1.44.4.mod/misc/e2undo.c
+--- e2fsprogs-1.44.4/misc/e2undo.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/misc/e2undo.c	2018-09-22 15:28:19.140584897 +0300
+@@ -81,14 +81,18 @@
+ 	__le32 magic;		/* KEYBLOCK_MAGIC number */
+ 	__le32 crc;		/* block checksum */
+ 	__le64 reserved;	/* zero */
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 8)
+ #pragma GCC diagnostic push
+ #pragma GCC diagnostic ignored "-Wpedantic"
+ #endif
++#endif
+ 	struct undo_key keys[0];	/* keys, which come immediately after */
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 8)
+ #pragma GCC diagnostic pop
+ #endif
++#endif
+ };
+ 
+ struct undo_key_info {
+@@ -246,7 +250,7 @@
+ 	 */
+ 	tdb_dir = getenv("E2FSPROGS_UNDO_DIR");
+ 	if (!tdb_dir)
+-		tdb_dir = "/var/lib/e2fsprogs";
++		tdb_dir = "@TERMUX_PREFIX@/var/lib/e2fsprogs";
+ 
+ 	if (!strcmp(tdb_dir, "none") || (tdb_dir[0] == 0) ||
+ 	    access(tdb_dir, W_OK))
+diff -uNr e2fsprogs-1.44.4/misc/e4crypt.c e2fsprogs-1.44.4.mod/misc/e4crypt.c
+--- e2fsprogs-1.44.4/misc/e4crypt.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/misc/e4crypt.c	2018-09-22 15:22:14.812584606 +0300
+@@ -613,7 +613,7 @@
+ 
+ static void get_default_salts(void)
+ {
+-	FILE	*f = setmntent("/etc/mtab", "r");
++	FILE	*f = setmntent("@TERMUX_PREFIX@/etc/mtab", "r");
+ 	struct mntent *mnt;
+ 
+ 	while (f && ((mnt = getmntent(f)) != NULL)) {
+diff -uNr e2fsprogs-1.44.4/misc/e4defrag.c e2fsprogs-1.44.4.mod/misc/e4defrag.c
+--- e2fsprogs-1.44.4/misc/e4defrag.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/misc/e4defrag.c	2018-09-22 15:22:14.812584606 +0300
+@@ -223,7 +223,7 @@
+ 
+ 	fp = setmntent(mtab, "r");
+ 	if (fp == NULL) {
+-		perror("Couldn't access /etc/mtab");
++		perror("Couldn't access @TERMUX_PREFIX@/etc/mtab");
+ 		return -1;
+ 	}
+ 
+@@ -290,7 +290,7 @@
+ 
+ 	fp = setmntent(mtab, "r");
+ 	if (fp == NULL) {
+-		perror("Couldn't access /etc/mtab");
++		perror("Couldn't access @TERMUX_PREFIX@/etc/mtab");
+ 		return -1;
+ 	}
+ 
+diff -uNr e2fsprogs-1.44.4/misc/fsck.c e2fsprogs-1.44.4.mod/misc/fsck.c
+--- e2fsprogs-1.44.4/misc/fsck.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/misc/fsck.c	2018-09-22 15:22:14.815917952 +0300
+@@ -64,7 +64,7 @@
+ #include "blkid/blkid.h"
+ 
+ #ifndef _PATH_MNTTAB
+-#define	_PATH_MNTTAB	"/etc/fstab"
++#define	_PATH_MNTTAB	"@TERMUX_PREFIX@/etc/fstab"
+ #endif
+ 
+ static const char *ignored_types[] = {
+@@ -120,7 +120,7 @@
+ static char *fstype = NULL;
+ static struct fs_info *filesys_info = NULL, *filesys_last = NULL;
+ static struct fsck_instance *instance_list;
+-static const char *fsck_prefix_path = "/sbin:/sbin/fs.d:/sbin/fs:/etc/fs:/etc";
++static const char *fsck_prefix_path = "@TERMUX_PREFIX@/bin:@TERMUX_PREFIX@/bin/applets";
+ static char *fsck_path = 0;
+ static blkid_cache cache = NULL;
+ 
+@@ -367,9 +367,9 @@
+ 	if (old_fstab && filesys_info) {
+ 		fputs("\007\007\007", stderr);
+ 		fputs(_(
+-		"WARNING: Your /etc/fstab does not contain the fsck passno\n"
++		"WARNING: Your @TERMUX_PREFIX@/etc/fstab does not contain the fsck passno\n"
+ 		"	field.  I will kludge around things for you, but you\n"
+-		"	should fix your /etc/fstab file as soon as you can.\n\n"), stderr);
++		"	should fix your @TERMUX_PREFIX@/etc/fstab file as soon as you can.\n\n"), stderr);
+ 
+ 		for (fs = filesys_info; fs; fs = fs->next) {
+ 			fs->passno = 1;
+@@ -888,7 +888,7 @@
+ 	 */
+ 	if (opt_in_list("bind", fs->opts)) {
+ 		fprintf(stderr,
+-			_("%s: skipping bad line in /etc/fstab: bind mount with nonzero fsck pass number\n"),
++			_("%s: skipping bad line in @TERMUX_PREFIX@/etc/fstab: bind mount with nonzero fsck pass number\n"),
+ 			fs->mountpt);
+ 		return 1;
+ 	}
+diff -uNr e2fsprogs-1.44.4/misc/fuse2fs.c e2fsprogs-1.44.4.mod/misc/fuse2fs.c
+--- e2fsprogs-1.44.4/misc/fuse2fs.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/misc/fuse2fs.c	2018-09-22 15:28:50.517364876 +0300
+@@ -52,7 +52,7 @@
+ #define NLS_CAT_NAME "e2fsprogs"
+ #endif
+ #ifndef LOCALEDIR
+-#define LOCALEDIR "/usr/share/locale"
++#define LOCALEDIR "@TERMUX_PREFIX@/share/locale"
+ #endif
+ #else
+ #define _(a) (a)
+@@ -118,14 +118,18 @@
+ 
+ typedef struct {
+ 	u_int32_t	a_version;
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 8)
+ #pragma GCC diagnostic push
+ #pragma GCC diagnostic ignored "-Wpedantic"
+ #endif
++#endif
+ 	acl_ea_entry	a_entries[0];
++#ifndef __ANDROID__
+ #if __GNUC_PREREQ (4, 8)
+ #pragma GCC diagnostic pop
+ #endif
++#endif
+ } acl_ea_header;
+ 
+ static inline size_t acl_ea_size(int count)
+diff -uNr e2fsprogs-1.44.4/misc/ismounted.c e2fsprogs-1.44.4.mod/misc/ismounted.c
+--- e2fsprogs-1.44.4/misc/ismounted.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/misc/ismounted.c	2018-09-22 15:22:14.822584643 +0300
+@@ -197,7 +197,7 @@
+ 	if (mount_flags)
+ 		return 1;
+ #endif /* __linux__ */
+-	retval = check_mntent_file("/etc/mtab", file, &mount_flags);
++	retval = check_mntent_file("@TERMUX_PREFIX@/etc/mtab", file, &mount_flags);
+ 	if (retval)
+ 		return 0;
+ 	return (mount_flags);
+diff -uNr e2fsprogs-1.44.4/misc/mke2fs.c e2fsprogs-1.44.4.mod/misc/mke2fs.c
+--- e2fsprogs-1.44.4/misc/mke2fs.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/misc/mke2fs.c	2018-09-22 15:22:14.825917989 +0300
+@@ -781,7 +781,7 @@
+ 	return 1;
+ }
+ 
+-#define PATH_SET "PATH=/sbin"
++#define PATH_SET "PATH=@TERMUX_PREFIX@/bin"
+ 
+ static void parse_extended_opts(struct ext2_super_block *param,
+ 				const char *opts)
+@@ -2623,7 +2623,7 @@
+ 	tdb_dir = getenv("E2FSPROGS_UNDO_DIR");
+ 	if (!tdb_dir) {
+ 		profile_get_string(profile, "defaults",
+-				   "undo_dir", 0, "/var/lib/e2fsprogs",
++				   "undo_dir", 0, "@TERMUX_PREFIX@/var/lib/e2fsprogs",
+ 				   &tdb_dir);
+ 		free_tdb_dir = 1;
+ 	}
+diff -uNr e2fsprogs-1.44.4/misc/tune2fs.c e2fsprogs-1.44.4.mod/misc/tune2fs.c
+--- e2fsprogs-1.44.4/misc/tune2fs.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/misc/tune2fs.c	2018-09-22 15:22:14.829251334 +0300
+@@ -2764,7 +2764,7 @@
+ 	 */
+ 	tdb_dir = getenv("E2FSPROGS_UNDO_DIR");
+ 	if (!tdb_dir)
+-		tdb_dir = "/var/lib/e2fsprogs";
++		tdb_dir = "@TERMUX_PREFIX@/var/lib/e2fsprogs";
+ 
+ 	if (!strcmp(tdb_dir, "none") || (tdb_dir[0] == 0) ||
+ 	    access(tdb_dir, W_OK))
+diff -uNr e2fsprogs-1.44.4/misc/util.c e2fsprogs-1.44.4.mod/misc/util.c
+--- e2fsprogs-1.44.4/misc/util.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/misc/util.c	2018-09-22 15:22:14.832584681 +0300
+@@ -130,7 +130,7 @@
+ 	if (mount_flags & EXT2_MF_MOUNTED) {
+ 		fprintf(stderr, _("%s is mounted; "), device);
+ 		if (force >= 2) {
+-			fputs(_("mke2fs forced anyway.  Hope /etc/mtab is "
++			fputs(_("mke2fs forced anyway.  Hope @TERMUX_PREFIX@/etc/mtab is "
+ 				"incorrect.\n"), stderr);
+ 			return;
+ 		}
+diff -uNr e2fsprogs-1.44.4/resize/main.c e2fsprogs-1.44.4.mod/resize/main.c
+--- e2fsprogs-1.44.4/resize/main.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/resize/main.c	2018-09-22 15:22:14.842584717 +0300
+@@ -198,7 +198,7 @@
+ 	 */
+ 	tdb_dir = getenv("E2FSPROGS_UNDO_DIR");
+ 	if (!tdb_dir)
+-		tdb_dir = "/var/lib/e2fsprogs";
++		tdb_dir = "@TERMUX_PREFIX@/var/lib/e2fsprogs";
+ 
+ 	if (!strcmp(tdb_dir, "none") || (tdb_dir[0] == 0) ||
+ 	    access(tdb_dir, W_OK))
+diff -uNr e2fsprogs-1.44.4/resize/resize2fs.h e2fsprogs-1.44.4.mod/resize/resize2fs.h
+--- e2fsprogs-1.44.4/resize/resize2fs.h	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/resize/resize2fs.h	2018-09-22 15:22:14.842584717 +0300
+@@ -51,7 +51,7 @@
+ #define NLS_CAT_NAME "e2fsprogs"
+ #endif
+ #ifndef LOCALEDIR
+-#define LOCALEDIR "/usr/share/locale"
++#define LOCALEDIR "@TERMUX_PREFIX@/share/locale"
+ #endif
+ #else
+ #define _(a) (a)
+diff -uNr e2fsprogs-1.44.4/util/android_config.h e2fsprogs-1.44.4.mod/util/android_config.h
+--- e2fsprogs-1.44.4/util/android_config.h	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/util/android_config.h	2018-09-22 15:22:14.845918064 +0300
+@@ -2,7 +2,7 @@
+ #define HAVE_MALLOC_H 1
+ #endif
+ 
+-#define ROOT_SYSCONFDIR "/etc"
++#define ROOT_SYSCONFDIR "@TERMUX_PREFIX@/etc"
+ 
+ #define ENABLE_LIBSPARSE 1
+ 

--- a/packages/e2fsprogs/fsmap.h.patch
+++ b/packages/e2fsprogs/fsmap.h.patch
@@ -1,0 +1,30 @@
+diff -uNr e2fsprogs-1.44.4/misc/fsmap.h e2fsprogs-1.44.4.mod/misc/fsmap.h
+--- e2fsprogs-1.44.4/misc/fsmap.h	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/misc/fsmap.h	2018-09-22 15:22:14.819251297 +0300
+@@ -84,6 +84,26 @@
+ #define FMR_OWN_METADATA	FMR_OWNER(0, 3) /* metadata */
+ 
+ #define FS_IOC_GETFSMAP		_IOWR('X', 59, struct fsmap_head)
++#else
++
++#ifdef __ANDROID__
++/* Size of an fsmap_head with room for nr records. */
++static inline size_t
++fsmap_sizeof(
++	unsigned int	nr)
++{
++	return sizeof(struct fsmap_head) + nr * sizeof(struct fsmap);
++}
++
++/* Start the next fsmap query at the end of the current query results. */
++static inline void
++fsmap_advance(
++	struct fsmap_head	*head)
++{
++	head->fmh_keys[0] = head->fmh_recs[head->fmh_entries - 1];
++}
++#endif
++
+ #endif /* FS_IOC_GETFSMAP */
+ 
+ #endif

--- a/packages/e2fsprogs/hasmntopt.patch
+++ b/packages/e2fsprogs/hasmntopt.patch
@@ -1,0 +1,39 @@
+diff -uNr e2fsprogs-1.44.4/lib/ext2fs/ismounted.c e2fsprogs-1.44.4.mod/lib/ext2fs/ismounted.c
+--- e2fsprogs-1.44.4/lib/ext2fs/ismounted.c	2018-08-19 05:26:58.000000000 +0300
++++ e2fsprogs-1.44.4.mod/lib/ext2fs/ismounted.c	2018-09-22 15:22:14.795917878 +0300
+@@ -57,6 +57,26 @@
+ #include "ext2fs.h"
+ #include "ext2fsP.h"
+ 
++char *hasmntopt(const struct mntent *mnt, const char *opt)
++{
++	char *cp = mnt->mnt_opts;
++	int	len = strlen(opt);
++
++	if (!mnt->mnt_opts)
++		return 0;
++
++	while (1) {
++		if (!(cp = strstr(cp, opt)))
++			break;
++		if ((cp == mnt->mnt_opts || cp[-1]==',') &&
++		    (cp[len] == 0 || cp[len] == ',' || cp[len] == '='))
++			return cp;
++		cp += (len + 1);
++	}
++
++	return 0;
++}
++
+ #ifdef HAVE_SETMNTENT
+ /*
+  * Check to see if a regular file is mounted.
+@@ -234,7 +254,7 @@
+ 	errcode_t	retval;
+ 
+ #ifdef DEBUG
+-	retval = check_mntent_file("/tmp/mtab", file, mount_flags,
++	retval = check_mntent_file("@TERMUX_PREFIX@/tmp/mtab", file, mount_flags,
+ 				   mtpt, mtlen);
+ 	if (retval == 0)
+ 		return 0;

--- a/packages/geoip2-database/build.sh
+++ b/packages/geoip2-database/build.sh
@@ -1,0 +1,22 @@
+TERMUX_PKG_HOMEPAGE=https://dev.maxmind.com/geoip/geoip2/geolite2/
+TERMUX_PKG_DESCRIPTION="GeoLite2 IP geolocation databases compiled by MaxMind"
+TERMUX_PKG_LICENSE="CC0-1.0"
+TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_VERSION=20190307
+
+TERMUX_PKG_SRCURL=('https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz'
+				   'https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz'
+				   'https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz')
+
+## If these checksums becomes invalid - it's time to update package.
+TERMUX_PKG_SHA256=('6e32212ef0cd240bc6eeaa891beb2398e5d285f5b4c4972ee7afe2b5cad13957'
+				   'b1e6d664aeb00ab4c3c25b75f103425f96e747dbac59da21f3bbfc5bbafa9877'
+				   '6676658f47ac8d958bcf84348d06e67634f114ca160133b86658f23848e980ed')
+
+termux_step_make_install() {
+	install -Dm600 \
+		-t "$TERMUX_PREFIX"/share/GeoIP/ \
+		$(find "$TERMUX_PKG_SRCDIR" -type f -iname \*.mmdb)
+}

--- a/packages/geoip2-database/build.sh
+++ b/packages/geoip2-database/build.sh
@@ -4,16 +4,16 @@ TERMUX_PKG_LICENSE="CC0-1.0"
 TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_BUILD_IN_SRC=true
-TERMUX_PKG_VERSION=20190307
+TERMUX_PKG_VERSION=20190320
 
 TERMUX_PKG_SRCURL=('https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz'
 				   'https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz'
 				   'https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz')
 
 ## If these checksums becomes invalid - it's time to update package.
-TERMUX_PKG_SHA256=('6e32212ef0cd240bc6eeaa891beb2398e5d285f5b4c4972ee7afe2b5cad13957'
-				   'b1e6d664aeb00ab4c3c25b75f103425f96e747dbac59da21f3bbfc5bbafa9877'
-				   '6676658f47ac8d958bcf84348d06e67634f114ca160133b86658f23848e980ed')
+TERMUX_PKG_SHA256=('b3f844774b6a0423872b92c8ebab0990387c1e8fbf57122621963d6b357240c2'
+				   'b173951d63301c1c5817985525f836d80bf5f21574cf3fe3bdaf84632e4cf423'
+				   'dfb0d18db0f04765bc7738d3ccc342e7ba6baba775de48a716aa7cf42596608c')
 
 termux_step_make_install() {
 	install -Dm600 \

--- a/packages/giflib/build.sh
+++ b/packages/giflib/build.sh
@@ -1,0 +1,8 @@
+TERMUX_PKG_HOMEPAGE=https://sourceforge.net/projects/giflib/
+TERMUX_PKG_DESCRIPTION="A library for reading and writing gif images"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
+TERMUX_PKG_VERSION=5.1.4
+TERMUX_PKG_REVISION=6
+TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/giflib/giflib-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=34a7377ba834397db019e8eb122e551a49c98f49df75ec3fcc92b9a794a4f6d1

--- a/packages/giflib/egif_lib.c.patch
+++ b/packages/giflib/egif_lib.c.patch
@@ -1,0 +1,17 @@
+--- src/lib/egif_lib.c.orig	2017-12-09 15:46:41.761228962 +0000
++++ src/lib/egif_lib.c	2017-12-09 15:47:16.631668749 +0000
+@@ -25,6 +25,14 @@
+ #include "gif_lib.h"
+ #include "gif_lib_private.h"
+ 
++#ifndef S_IREAD
++#define S_IREAD  00400
++#endif
++
++#ifndef S_IWRITE
++#define S_IWRITE 00200
++#endif
++
+ /* Masks given codes to BitsPerPixel, to make sure all codes are in range: */
+ /*@+charint@*/
+ static const GifPixelType CodeMask[] = {

--- a/packages/giflib/giflib-utils.subpackage.sh
+++ b/packages/giflib/giflib-utils.subpackage.sh
@@ -1,0 +1,7 @@
+TERMUX_SUBPKG_DESCRIPTION="A set of utilities that comes with giflib package"
+TERMUX_SUBPKG_DEPENDS="giflib"
+TERMUX_SUBPKG_CONFLICTS="giflib (<< 5.1.4-4)"
+
+TERMUX_SUBPKG_INCLUDE="
+bin/
+share/man/"

--- a/packages/libcap/build.sh
+++ b/packages/libcap/build.sh
@@ -1,0 +1,18 @@
+TERMUX_PKG_HOMEPAGE=https://sites.google.com/site/fullycapable/
+TERMUX_PKG_DESCRIPTION="POSIX 1003.1e capabilities"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
+TERMUX_PKG_VERSION=2.26
+TERMUX_PKG_REVISION=3
+TERMUX_PKG_SRCURL=https://kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=b630b7c484271b3ba867680d6a14b10a86cfa67247a14631b14c06731d5a458b
+TERMUX_PKG_DEPENDS="attr"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make() {
+	make CC="$CC" PREFIX="$TERMUX_PREFIX"
+}
+
+termux_step_make_install() {
+	make CC="$CC" prefix="$TERMUX_PREFIX" RAISE_SETFCAP=no lib=/lib install
+}

--- a/packages/libcap/libcap-makefile.patch
+++ b/packages/libcap/libcap-makefile.patch
@@ -1,0 +1,12 @@
+diff -uNr libcap-2.26/libcap/Makefile libcap-2.26.mod/libcap/Makefile
+--- libcap-2.26/libcap/Makefile	2018-09-11 06:02:10.000000000 +0300
++++ libcap-2.26.mod/libcap/Makefile	2019-03-18 21:53:27.413691421 +0200
+@@ -35,7 +35,7 @@
+ 		$< >$@
+ 
+ _makenames: _makenames.c cap_names.list.h
+-	$(BUILD_CC) $(BUILD_CFLAGS) $< -o $@
++	gcc $(BUILD_CFLAGS) $< -o $@
+ 
+ cap_names.h: _makenames
+ 	./_makenames > cap_names.h

--- a/packages/libcap/progs-capsh.patch
+++ b/packages/libcap/progs-capsh.patch
@@ -1,0 +1,25 @@
+diff -uNr libcap-2.26/progs/capsh.c libcap-2.26.mod/progs/capsh.c
+--- libcap-2.26/progs/capsh.c	2018-09-08 23:07:52.000000000 +0300
++++ libcap-2.26.mod/progs/capsh.c	2019-03-05 19:42:47.917246690 +0200
+@@ -692,10 +692,10 @@
+ 	} else if (!strcmp("--print", argv[i])) {
+ 	    arg_print();
+ 	} else if ((!strcmp("--", argv[i])) || (!strcmp("==", argv[i]))) {
+-	    argv[i] = strdup(argv[i][0] == '-' ? "/bin/bash" : argv[0]);
++	    argv[i] = strdup(argv[i][0] == '-' ? "@TERMUX_PREFIX@/bin/bash" : argv[0]);
+ 	    argv[argc] = NULL;
+ 	    execve(argv[i], argv+i, envp);
+-	    fprintf(stderr, "execve /bin/bash failed!\n");
++	    fprintf(stderr, "execve @TERMUX_PREFIX@/bin/bash failed!\n");
+ 	    exit(1);
+ 	} else {
+ 	usage:
+@@ -720,7 +720,7 @@
+ 		   "  --killit=<n>   send signal(n) to child\n"
+ 		   "  --forkfor=<n>  fork and make child sleep for <n> sec\n"
+ 		   "  ==             re-exec(capsh) with args as for --\n"
+-		   "  --             remaing arguments are for /bin/bash\n"
++		   "  --             remaing arguments are for $PREFIX/bin/bash\n"
+ 		   "                 (without -- [%s] will simply exit(0))\n",
+ 		   argv[0], argv[0]);
+ 

--- a/packages/liblua52/build.sh
+++ b/packages/liblua52/build.sh
@@ -1,0 +1,40 @@
+TERMUX_PKG_HOMEPAGE=https://www.lua.org
+TERMUX_PKG_DESCRIPTION="Shared library for the Lua interpreter (v5.2.x)"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
+TERMUX_PKG_VERSION=5.2.4
+TERMUX_PKG_REVISION=3
+TERMUX_PKG_SRCURL=https://www.lua.org/ftp/lua-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=b9e2e4aad6789b3b63a056d442f7b39f0ecfca3ae0f1fc0ae4e9614401b69f4b
+TERMUX_PKG_BUILD_DEPENDS="readline"
+TERMUX_PKG_BUILD_IN_SRC=yes
+
+termux_step_configure() {
+	sed \
+		"s/%VER%/${TERMUX_PKG_VERSION%.*}/g;s/%REL%/${TERMUX_PKG_VERSION}/g" \
+		"$TERMUX_PKG_BUILDER_DIR"/lua.pc > lua.pc
+}
+
+termux_step_make() {
+	make -j $TERMUX_MAKE_PROCESSES \
+		MYCFLAGS="$CFLAGS -fPIC" \
+		MYLDFLAGS="$LDFLAGS" \
+		CC="$CC" \
+		CXX="$CXX" \
+		linux
+}
+
+termux_step_make_install() {
+	make \
+		TO_BIN="lua5.2 luac5.2" \
+		TO_LIB="liblua5.2.so liblua5.2.so.5.2 liblua5.2.so.${TERMUX_PKG_VERSION}" \
+		INSTALL_DATA="cp -d" \
+		INSTALL_TOP="$TERMUX_PREFIX" \
+		INSTALL_INC="$TERMUX_PREFIX/include/lua5.2" \
+		INSTALL_MAN="$TERMUX_PREFIX/share/man/man1" \
+		install
+	install -Dm644 lua.pc "$TERMUX_PREFIX"/lib/pkgconfig/lua52.pc
+
+	mv -f "$TERMUX_PREFIX"/share/man/man1/lua.1 "$TERMUX_PREFIX"/share/man/man1/lua5.2.1
+	mv -f "$TERMUX_PREFIX"/share/man/man1/luac.1 "$TERMUX_PREFIX"/share/man/man1/luac5.2.1
+}

--- a/packages/liblua52/lua-5.2.4_Makefile.patch
+++ b/packages/liblua52/lua-5.2.4_Makefile.patch
@@ -1,0 +1,21 @@
+diff -uNr lua-5.2.4/Makefile lua-5.2.4.mod/Makefile
+--- lua-5.2.4/Makefile	2015-02-24 03:28:54.000000000 +0200
++++ lua-5.2.4.mod/Makefile	2018-06-26 16:12:33.817832374 +0300
+@@ -10,7 +10,7 @@
+ # so take care if INSTALL_TOP is not an absolute path. See the local target.
+ # You may want to make INSTALL_LMOD and INSTALL_CMOD consistent with
+ # LUA_ROOT, LUA_LDIR, and LUA_CDIR in luaconf.h.
+-INSTALL_TOP= /usr/local
++INSTALL_TOP= @TERMUX_PREFIX@
+ INSTALL_BIN= $(INSTALL_TOP)/bin
+ INSTALL_INC= $(INSTALL_TOP)/include
+ INSTALL_LIB= $(INSTALL_TOP)/lib
+@@ -52,7 +52,7 @@
+ all:	$(PLAT)
+ 
+ $(PLATS) clean:
+-	cd src && $(MAKE) $@
++	cd src && $(MAKE) $@ V=$(V) R=$(R)
+ 
+ test:	dummy
+ 	src/lua -v

--- a/packages/liblua52/lua-5.2.4_src_Makefile.patch
+++ b/packages/liblua52/lua-5.2.4_src_Makefile.patch
@@ -1,0 +1,44 @@
+diff -uNr lua-5.2.4/src/Makefile lua-5.2.4.mod/src/Makefile
+--- lua-5.2.4/src/Makefile	2013-11-11 13:45:49.000000000 +0200
++++ lua-5.2.4.mod/src/Makefile	2018-06-26 16:14:09.981170535 +0300
+@@ -28,7 +28,8 @@
+ 
+ PLATS= aix ansi bsd freebsd generic linux macosx mingw posix solaris
+ 
+-LUA_A=	liblua.a
++LUA_A=	liblua5.2.a
++LUA_SO= liblua5.2.so
+ CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o \
+ 	lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o \
+ 	ltm.o lundump.o lvm.o lzio.o
+@@ -36,14 +37,14 @@
+ 	lmathlib.o loslib.o lstrlib.o ltablib.o loadlib.o linit.o
+ BASE_O= $(CORE_O) $(LIB_O) $(MYOBJS)
+ 
+-LUA_T=	lua
++LUA_T=	lua5.2
+ LUA_O=	lua.o
+ 
+-LUAC_T=	luac
++LUAC_T=	luac5.2
+ LUAC_O=	luac.o
+ 
+ ALL_O= $(BASE_O) $(LUA_O) $(LUAC_O)
+-ALL_T= $(LUA_A) $(LUA_T) $(LUAC_T)
++ALL_T= $(LUA_A) $(LUA_T) $(LUAC_T) $(LUA_SO)
+ ALL_A= $(LUA_A)
+ 
+ # Targets start here.
+@@ -59,6 +60,12 @@
+ 	$(AR) $@ $(BASE_O)
+ 	$(RANLIB) $@
+ 
++$(LUA_SO): $(CORE_O) $(LIB_O)
++	$(CC) -shared -ldl -Wl,-soname,$(LUA_SO).$(V) -o $@.$(R) $? -lm $(MYLDFLAGS)
++	ln -sf $(LUA_SO).$(R) $(LUA_SO).$(V)
++	ln -sf $(LUA_SO).$(R) $(LUA_SO)
++
++
+ $(LUA_T): $(LUA_O) $(LUA_A)
+ 	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
+ 

--- a/packages/liblua52/lua-5.2.4_src_loslib.c.patch
+++ b/packages/liblua52/lua-5.2.4_src_loslib.c.patch
@@ -1,0 +1,15 @@
+diff -uNr lua-5.2.4/src/loslib.c lua-5.2.4.mod/src/loslib.c
+--- lua-5.2.4/src/loslib.c	2013-04-12 21:48:47.000000000 +0300
++++ lua-5.2.4.mod/src/loslib.c	2018-06-26 16:13:07.191167382 +0300
+@@ -44,9 +44,9 @@
+ */
+ #if defined(LUA_USE_MKSTEMP)
+ #include <unistd.h>
+-#define LUA_TMPNAMBUFSIZE	32
++#define LUA_TMPNAMBUFSIZE	256
+ #define lua_tmpnam(b,e) { \
+-        strcpy(b, "/tmp/lua_XXXXXX"); \
++        strcpy(b, "@TERMUX_PREFIX@/tmp/lua_XXXXXX"); \
+         e = mkstemp(b); \
+         if (e != -1) close(e); \
+         e = (e == -1); }

--- a/packages/liblua52/lua-5.2.4_src_luaconf.h.patch
+++ b/packages/liblua52/lua-5.2.4_src_luaconf.h.patch
@@ -1,0 +1,12 @@
+diff -uNr lua-5.2.4/src/luaconf.h lua-5.2.4.mod/src/luaconf.h
+--- lua-5.2.4/src/luaconf.h	2013-11-21 19:26:16.000000000 +0200
++++ lua-5.2.4.mod/src/luaconf.h	2018-06-26 16:12:33.824499040 +0300
+@@ -100,7 +100,7 @@
+ #else			/* }{ */
+ 
+ #define LUA_VDIR	LUA_VERSION_MAJOR "." LUA_VERSION_MINOR "/"
+-#define LUA_ROOT	"/usr/local/"
++#define LUA_ROOT	"@TERMUX_PREFIX@/"
+ #define LUA_LDIR	LUA_ROOT "share/lua/" LUA_VDIR
+ #define LUA_CDIR	LUA_ROOT "lib/lua/" LUA_VDIR
+ #define LUA_PATH_DEFAULT  \

--- a/packages/liblua52/lua.pc
+++ b/packages/liblua52/lua.pc
@@ -1,0 +1,20 @@
+V=%VER%
+R=%REL%
+
+prefix=/data/data/com.termux/files/usr
+INSTALL_BIN=${prefix}/bin
+INSTALL_INC=${prefix}/include/lua5.2
+INSTALL_LIB=${prefix}/lib
+INSTALL_MAN=${prefix}/man/man1
+INSTALL_LMOD=${prefix}/share/lua/${V}
+INSTALL_CMOD=${prefix}/lib/lua/${V}
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include/lua5.2
+
+Name: Lua
+Description: An Extensible Extension Language
+Version: ${R}
+Requires: 
+Libs: -L${libdir} -llua5.2 -lm
+Cflags: -I${includedir}

--- a/packages/liblua52/lua52.subpackage.sh
+++ b/packages/liblua52/lua52.subpackage.sh
@@ -1,0 +1,3 @@
+TERMUX_SUBPKG_DESCRIPTION="Simple, extensible, embeddable programming language"
+TERMUX_SUBPKG_DEPENDS="readline"
+TERMUX_SUBPKG_INCLUDE="bin/ share/man/man1/"

--- a/packages/libmaxminddb/build.sh
+++ b/packages/libmaxminddb/build.sh
@@ -1,0 +1,14 @@
+TERMUX_PKG_HOMEPAGE=https://dev.maxmind.com/geoip/geoip2/
+TERMUX_PKG_DESCRIPTION="MaxMind GeoIP2 database - library and utilities"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
+TERMUX_PKG_VERSION=1.3.2
+TERMUX_PKG_REVISION=5
+TERMUX_PKG_SRCURL=https://github.com/maxmind/libmaxminddb/archive/$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=c0785521c7e5515f1169db90ed6e51bc2a5a000377d0fbad87e4d5a791a6e364
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-tests"
+
+termux_step_pre_configure() {
+	./bootstrap
+}

--- a/packages/libmaxminddb/libmaxminddb-tools.subpackage.sh
+++ b/packages/libmaxminddb/libmaxminddb-tools.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="A geoip lookup utility for MaxMind DB"
+TERMUX_SUBPKG_DEPENDS="geoip2-database, libmaxminddb"
+
+TERMUX_SUBPKG_INCLUDE="
+bin/mmdblookup
+share/man/man1/mmdblookup.1"

--- a/packages/libnfs/add-timeh.patch
+++ b/packages/libnfs/add-timeh.patch
@@ -1,0 +1,12 @@
+diff -uNr libnfs-libnfs-3.0.0/lib/libnfs.c libnfs-libnfs-3.0.0.mod/lib/libnfs.c
+--- libnfs-libnfs-3.0.0/lib/libnfs.c	2018-06-24 01:53:52.000000000 +0300
++++ libnfs-libnfs-3.0.0.mod/lib/libnfs.c	2019-01-30 19:06:40.638282264 +0200
+@@ -66,6 +66,8 @@
+ #include <sys/sysmacros.h>
+ #endif
+ 
++#include <time.h>
++
+ #include <errno.h>
+ #include <stdarg.h>
+ #include <stdlib.h>

--- a/packages/libnfs/build.sh
+++ b/packages/libnfs/build.sh
@@ -1,0 +1,11 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/sahlberg/libnfs
+TERMUX_PKG_DESCRIPTION="NFS client library"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
+TERMUX_PKG_VERSION=4.0.0
+TERMUX_PKG_SRCURL=https://github.com/sahlberg/libnfs/archive/libnfs-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=6ee77e9fe220e2d3e3b1f53cfea04fb319828cc7dbb97dd9df09e46e901d797d
+
+termux_step_pre_configure() {
+	autoreconf -fi
+}

--- a/packages/mpv/build.sh
+++ b/packages/mpv/build.sh
@@ -2,10 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://mpv.io/
 TERMUX_PKG_DESCRIPTION="Command-line media player"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_VERSION=0.29.1
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SHA256=f9f9d461d1990f9728660b4ccb0e8cb5dce29ccaa6af567bec481b79291ca623
 TERMUX_PKG_SRCURL=https://github.com/mpv-player/mpv/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_DEPENDS="ffmpeg, openal-soft, libandroid-support, libandroid-glob, libpulseaudio"
+TERMUX_PKG_DEPENDS="ffmpeg, openal-soft, libandroid-support, libandroid-glob, liblua52, libpulseaudio"
 TERMUX_PKG_RM_AFTER_INSTALL="share/icons share/applications"
 
 termux_step_pre_configure() {
@@ -24,7 +24,7 @@ termux_step_make_install() {
 		--disable-lcms2 \
 		--disable-libarchive \
 		--disable-libass \
-		--disable-lua \
+		--enable-lua \
 		--enable-pulse \
 		--enable-openal \
 		--disable-caca \

--- a/packages/proxychains-ng/Makefile.patch
+++ b/packages/proxychains-ng/Makefile.patch
@@ -1,0 +1,21 @@
+diff -uNr proxychains-ng-4.13/Makefile proxychains-ng-4.13.mod/Makefile
+--- proxychains-ng-4.13/Makefile	2018-06-25 02:26:05.000000000 +0300
++++ proxychains-ng-4.13.mod/Makefile	2019-03-05 19:35:28.924332422 +0200
+@@ -8,7 +8,7 @@
+ exec_prefix = /usr/local
+ bindir = $(exec_prefix)/bin
+ 
+-prefix = /usr/local/
++prefix = @TERMUX_PREFIX@
+ includedir = $(prefix)/include
+ libdir = $(prefix)/lib
+ sysconfdir=$(prefix)/etc
+@@ -25,7 +25,7 @@
+ CFLAGS  += -Wall -O0 -g -std=c99 -D_GNU_SOURCE -pipe
+ NO_AS_NEEDED = -Wl,--no-as-needed
+ LIBDL   = -ldl
+-LDFLAGS = -fPIC $(NO_AS_NEEDED) $(LIBDL) -lpthread
++LDFLAGS = -fPIC $(NO_AS_NEEDED) $(LIBDL)
+ INC     = 
+ PIC     = -fPIC
+ AR      = $(CROSS_COMPILE)ar

--- a/packages/proxychains-ng/build.sh
+++ b/packages/proxychains-ng/build.sh
@@ -1,0 +1,14 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/rofl0r/proxychains-ng
+TERMUX_PKG_DESCRIPTION="A hook preloader that allows to redirect TCP traffic of existing dynamically linked programs through one or more SOCKS or HTTP proxies"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
+TERMUX_PKG_VERSION=4.14
+TERMUX_PKG_SRCURL=https://github.com/rofl0r/proxychains-ng/archive/v$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=ab31626af7177cc2669433bb244b99a8f98c08031498233bb3df3bcc9711a9cc
+TERMUX_PKG_BUILD_IN_SRC=yes
+
+termux_step_post_make_install() {
+	# Remove conf file from previous build, otherwise nothing will be done and it won't be included in the package
+	rm -f "$TERMUX_PREFIX"/etc/proxychains.conf
+	make install-config
+}

--- a/packages/proxychains-ng/hostreader.c.patch
+++ b/packages/proxychains-ng/hostreader.c.patch
@@ -1,0 +1,16 @@
+diff -uNr proxychains-ng-4.13/src/hostsreader.c proxychains-ng-4.13.mod/src/hostsreader.c
+--- proxychains-ng-4.13/src/hostsreader.c	2018-06-25 02:26:05.000000000 +0300
++++ proxychains-ng-4.13.mod/src/hostsreader.c	2019-03-05 19:34:06.360468021 +0200
+@@ -16,7 +16,11 @@
+ };
+ 
+ int hostsreader_open(struct hostsreader *ctx) {
+-	if(!(ctx->f = fopen("/etc/hosts", "r"))) return 0;
++	if(!(ctx->f = fopen("@TERMUX_PREFIX@/etc/hosts", "r"))) {
++		if(!(ctx->f = fopen("/etc/hosts", "r"))) {
++			return 0;
++		}
++	}
+ 	return 1;
+ }
+ 

--- a/packages/proxychains-ng/libproxychains.c.patch
+++ b/packages/proxychains-ng/libproxychains.c.patch
@@ -1,0 +1,13 @@
+diff --git a/src/libproxychains.c b/src/libproxychains.c
+index 7373d55..20bf993 100644
+--- a/src/libproxychains.c
++++ b/src/libproxychains.c
+@@ -332,7 +332,7 @@ static int is_v4inv6(const struct in6_addr *a) {
+ 	return a->s6_addr32[0] == 0 && a->s6_addr32[1] == 0 &&
+ 	       a->s6_addr16[4] == 0 && a->s6_addr16[5] == 0xffff;
+ }
+-int connect(int sock, const struct sockaddr *addr, unsigned int len) {
++int connect(int sock, const struct sockaddr *addr, socklen_t len) {
+ 	INIT();
+ 	PFUNC();
+ 

--- a/packages/restic/build.sh
+++ b/packages/restic/build.sh
@@ -1,0 +1,28 @@
+TERMUX_PKG_HOMEPAGE=https://restic.net/
+TERMUX_PKG_DESCRIPTION="Fast, secure, efficient backup program"
+TERMUX_PKG_LICENSE="BSD"
+TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
+TERMUX_PKG_VERSION=0.9.4
+TERMUX_PKG_REVISION=2
+TERMUX_PKG_SRCURL=https://github.com/restic/restic/archive/v$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=c7dca90fb6fd83cee8b9f6a2776f5839794341af1953d251bf06a91870be7a8e
+TERMUX_PKG_SUGGESTS="openssh, rclone"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make() {
+	termux_setup_golang
+	_GOARCH=${GOARCH}
+	unset GOOS GOARCH
+
+	## build for host and regenerate manpages
+	go run build.go --goos linux --goarch "amd64"
+	./restic generate --man doc/man && rm -f ./restic
+
+	## finally build for target
+	go run build.go --enable-cgo --goos android --goarch "${_GOARCH}"
+}
+
+termux_step_make_install() {
+	install -Dm700 restic "$TERMUX_PREFIX"/bin/restic
+	install -Dm600 -t "$TERMUX_PREFIX/share/man/man1/" doc/man/*.1
+}

--- a/packages/yajl/build.sh
+++ b/packages/yajl/build.sh
@@ -1,0 +1,17 @@
+TERMUX_PKG_HOMEPAGE=https://lloyd.github.io/yajl/
+TERMUX_PKG_DESCRIPTION="Yet Another JSON Library"
+TERMUX_PKG_LICENSE="ISC"
+TERMUX_PKG_MAINTAINER="Leonid Plyushch <leonid.plyushch@gmail.com> @xeffyr"
+TERMUX_PKG_VERSION=2.1.0
+TERMUX_PKG_REVISION=3
+TERMUX_PKG_SRCURL=https://github.com/lloyd/yajl/archive/$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=3fb73364a5a30efe615046d07e6db9d09fd2b41c763c5f7d3bfb121cd5c5ac5a
+TERMUX_PKG_FORCE_CMAKE=true
+
+termux_step_post_make_install() {
+	# Fix location of 'yajl.pc'.
+	mkdir -p "${TERMUX_PREFIX}"/lib/pkgconfig
+	mv -f \
+		"${TERMUX_PREFIX}"/share/pkgconfig/yajl.pc \
+		"${TERMUX_PREFIX}"/lib/pkgconfig/yajl.pc
+}


### PR DESCRIPTION
Mostly they are dependencies for x11-packages and unstable-packages. Some packages, like `restic` or `proxychains-ng` may be useful too.

Also, I have enabled Lua support for MPV since liblua52 is added.