### PR TITLE
nodejs: avoid using __NR_statx

### DIFF
--- a/packages/nodejs/build.sh
+++ b/packages/nodejs/build.sh
@@ -2,8 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://nodejs.org/
 TERMUX_PKG_DESCRIPTION="Platform built on Chrome's JavaScript runtime for easily building fast, scalable network applications"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_VERSION=11.13.0
-TERMUX_PKG_SHA256=7411952da11f6033d4ca5993d68f52b0d7eb90538099102c37d5221c445dc38a
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=7411952da11f6033d4ca5993d68f52b0d7eb90538099102c37d5221c445dc38a
 # Note that we do not use a shared libuv to avoid an issue with the Android
 # linker, which does not use symbols of linked shared libraries when resolving
 # symbols on dlopen(). See https://github.com/termux/termux-packages/issues/462.

--- a/packages/nodejs/deps-uv-src-unix-linux-syscalls.c.patch
+++ b/packages/nodejs/deps-uv-src-unix-linux-syscalls.c.patch
@@ -1,0 +1,20 @@
+--- ../linux-syscalls.c.orig	2019-04-01 12:59:57.770124746 +0000
++++ ./deps/uv/src/unix/linux-syscalls.c	2019-04-01 13:00:38.703457159 +0000
+@@ -187,7 +187,7 @@
+ # endif
+ #endif /* __NR_pwritev */
+ 
+-#ifndef __NR_statx
++#if !defined(__NR_statx) && !defined(__ANDROID__)
+ # if defined(__x86_64__)
+ #  define __NR_statx 332
+ # elif defined(__i386__)
+@@ -358,7 +358,7 @@
+               int flags,
+               unsigned int mask,
+               struct uv__statx* statxbuf) {
+-#if defined(__NR_statx)
++#if defined(__NR_statx) && !defined(__ANDROID__)
+   return syscall(__NR_statx, dirfd, path, flags, mask, statxbuf);
+ #else
+   return errno = ENOSYS, -1;


### PR DESCRIPTION
See https://github.com/termux/termux-packages/issues/3608

Depending on how soon we want to switch to the bintray repo it might or might not make sense to merge this PR.