### PR TITLE
libomp x86_64 fix

### DIFF
--- a/packages/libllvm/openmp-config-ix-m32.patch
+++ b/packages/libllvm/openmp-config-ix-m32.patch
@@ -1,0 +1,10 @@
+--- projects/openmp/runtime/cmake/config-ix.cmake.orig	2019-04-04 21:32:58.195143957 +0000
++++ ./projects/openmp/runtime/cmake/config-ix.cmake	2019-04-04 21:33:43.999700683 +0000
+@@ -71,7 +71,6 @@
+ check_c_compiler_flag(-msse2 LIBOMP_HAVE_MSSE2_FLAG)
+ check_c_compiler_flag(-ftls-model=initial-exec LIBOMP_HAVE_FTLS_MODEL_FLAG)
+ libomp_check_architecture_flag(-mmic LIBOMP_HAVE_MMIC_FLAG)
+-libomp_check_architecture_flag(-m32 LIBOMP_HAVE_M32_FLAG)
+ if(WIN32)
+   if(MSVC)
+     # Check Windows MSVC style flags.


### PR DESCRIPTION
Currently builds 32 bit libomp for x86_64. 