### PR TITLE
[android-5] some packages should be rebuilt due to fixes

### DIFF
--- a/packages/finch/build.sh
+++ b/packages/finch/build.sh
@@ -2,6 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://pidgin.im/
 TERMUX_PKG_DESCRIPTION="Text-based multi-protocol instant messaging client"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=2.13.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=2747150c6f711146bddd333c496870bfd55058bab22ffb7e4eb784018ec46d8f
 TERMUX_PKG_SRCURL=http://downloads.sourceforge.net/project/pidgin/Pidgin/${TERMUX_PKG_VERSION}/pidgin-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_DEPENDS="libgnutls, libxml2, ncurses-ui-libs, glib"
@@ -43,7 +44,7 @@ termux_step_post_configure() {
 
 termux_step_post_make_install() {
 	cd $TERMUX_PREFIX/lib
-	for lib in jabber oscar ymsg; do
+	for lib in jabber oscar; do
 		ln -f -s purple-2/lib${lib}.so .
 	done
 }

--- a/packages/notmuch/build.sh
+++ b/packages/notmuch/build.sh
@@ -2,6 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://notmuchmail.org
 TERMUX_PKG_DESCRIPTION="Thread-based email index, search and tagging system"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_VERSION=0.28.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=4e212d8b4ae30da04edb05d836dcdb569488ff6760706cecb882488eb1710eec
 TERMUX_PKG_SRCURL=https://notmuchmail.org/releases/notmuch-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_BUILD_IN_SRC=yes


### PR DESCRIPTION
* notmuch: should be rebuilt after manpage gzipping fix in 3832f16c0fd092aa443ec293c37315e143283d5b.

* finch: remove unneeded symlink which is broken anyway.