### PR TITLE
termux-tools: improve default motd

### DIFF
--- a/packages/termux-tools/motd
+++ b/packages/termux-tools/motd
@@ -11,7 +11,6 @@ Working with packages:
  * Search packages:   pkg search <query>
  * Install a package: pkg install <package>
  * Upgrade packages:  pkg upgrade
- * Learn more:        pkg help
 
 Subscribing to additional repositories:
 

--- a/packages/termux-tools/motd
+++ b/packages/termux-tools/motd
@@ -3,9 +3,8 @@ Welcome to Termux!
 
 Wiki:            https://wiki.termux.com
 Community forum: https://termux.com/community
-IRC channel:     #termux on freenode
 Gitter chat:     https://gitter.im/termux/termux
-Mailing list:    termux+subscribe@groups.io
+IRC channel:     #termux on freenode
 
 Working with packages:
 

--- a/packages/termux-tools/motd
+++ b/packages/termux-tools/motd
@@ -19,6 +19,5 @@ Subscribing to additional repositories:
  * Unstable: pkg install unstable-repo
  * X11:      pkg install x11-repo
 
-App issues:     https://github.com/termux/termux-app/issues
-Package issues: https://github.com/termux/termux-packages/issues
+Report issues at https://termux.com/issues
 

--- a/packages/termux-tools/motd
+++ b/packages/termux-tools/motd
@@ -1,3 +1,4 @@
+
 Welcome to Termux!
 
 Wiki:            https://wiki.termux.com
@@ -6,7 +7,19 @@ IRC channel:     #termux on freenode
 Gitter chat:     https://gitter.im/termux/termux
 Mailing list:    termux+subscribe@groups.io
 
-Search packages:   pkg search <query>
-Install a package: pkg install <package>
-Upgrade packages:  pkg upgrade
-Learn more:        pkg help
+Working with packages:
+
+ * Search packages:   pkg search <query>
+ * Install a package: pkg install <package>
+ * Upgrade packages:  pkg upgrade
+ * Learn more:        pkg help
+
+Subscribing to additional repositories:
+
+ * Root:     pkg install root-repo
+ * Unstable: pkg install unstable-repo
+ * X11:      pkg install x11-repo
+
+App issues: https://github.com/termux/termux-app/issues
+Package issues: https://github.com/termux/termux-packages/issues
+

--- a/packages/termux-tools/motd
+++ b/packages/termux-tools/motd
@@ -20,6 +20,6 @@ Subscribing to additional repositories:
  * Unstable: pkg install unstable-repo
  * X11:      pkg install x11-repo
 
-App issues: https://github.com/termux/termux-app/issues
+App issues:     https://github.com/termux/termux-app/issues
 Package issues: https://github.com/termux/termux-packages/issues
 


### PR DESCRIPTION
What is added:

* hints for enabling additional repositories. For now only root, unstable and x11 repos mentioned as science and game repositories enabled by default.

* links to issue tracker for application and termux-packages.

![Screenshot_20190414-145906_Termux](https://user-images.githubusercontent.com/25881154/56092547-1035af00-5ec6-11e9-8d3b-0ef9d4ca40c9.jpg)
