### PR TITLE
texlive-bin: fix compilation errors

### DIFF
--- a/packages/texlive-bin/build.sh
+++ b/packages/texlive-bin/build.sh
@@ -3,11 +3,11 @@ TERMUX_PKG_DESCRIPTION="TeX Live is a distribution of the TeX typesetting system
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
 TERMUX_PKG_VERSION=20180414
-TERMUX_PKG_REVISION=11
+TERMUX_PKG_REVISION=12
 TERMUX_PKG_SHA256=b6251e2edefb174ca402109d7f82df3cb98e45d367fada627a61de7ed2d4380d
 # FIXME: update version format and SRCURL when texlive 2019 is released
 TERMUX_PKG_SRCURL=https://github.com/TeX-Live/texlive-source/archive/texlive-2018.2.tar.gz
-TERMUX_PKG_DEPENDS="freetype, libpng, libgd, libgmp, libmpfr, libicu, liblua, poppler, libgraphite, harfbuzz, harfbuzz-icu, teckit, libpixman, libcairo, zlib"
+TERMUX_PKG_DEPENDS="freetype, libpng, libgd, libgmp, libmpfr, libicu, liblua52, poppler, libgraphite, harfbuzz, harfbuzz-icu, teckit, libpixman, libcairo, zlib"
 # libpcre, glib, fonconfig are dependencies to libcairo. pkg-config gives an error if they are missing
 # libuuid, libxml2 are needed by fontconfig
 TERMUX_PKG_BUILD_DEPENDS="icu-devtools, pcre-dev, glib-dev, fontconfig, libuuid-dev, libxml2-dev"


### PR DESCRIPTION
@Grimler91 Is it will be acceptable to use Lua 5.2 for texlive-bin package ?

With liblua 5.3.5 it fails at build time:
```
aarch64-linux-android-clang -DHAVE_CONFIG_H -I. -I/home/builder/.termux-build/texlive-bin/src/texk/web2c -I./w2c  -I/home/builder/.termux-build/texlive-bin/build/texk -I/home/builder/.termux-build/texlive-bin/src/texk  -I/data/data/com.termux/files/usr/include/libpng16 -I/data/data/com.termux/files/usr/include -DPOPPLER_VERSION=\"0.75.0\" -I/data/data/com.termux/files/usr/include/poppler -I/home/builder/.termux-build/texlive-bin/src/texk/web2c/libmd5 -DpdfTeX -I/home/builder/.termux-build/texlive-bin/src/texk/web2c/luatexdir -I/home/builder/.termux-build/texlive-bin/src/texk/web2c/luatexdir/unilib -I/home/builder/.termux-build/texlive-bin/src/texk/web2c/luatexdir/luafontloader/fontforge/inc -DLUA_FF_LIB=1 -I/home/builder/.termux-build/texlive-bin/src/texk/web2c/luatexdir/luafontloader/fontforge/fontforge -DSYNCTEX_ENGINE_H='<synctex-luatex.h>' -I/home/builder/.termux-build/texlive-bin/src/texk/web2c/synctexdir -I/home/builder/.termux-build/texlive-bin/build/libs/lua52/include -DLUA_COMPAT_MODULE -DLUAI_HASHLIMIT=6 -DLUA_USE_POSIX -DLUA_USE_DLOPEN -I/data/data/com.termux/files/usr/include -Wimplicit -Wreturn-type -Wdeclaration-after-statement -Wno-unknown-pragmas -Oz -c -o luatexdir/lua/libluatex_a-lstrlibext.o `test -f 'luatexdir/lua/lstrlibext.c' || echo '/home/builder/.termux-build/texlive-bin/src/texk/web2c/'`luatexdir/lua/lstrlibext.c
In file included from /home/builder/.termux-build/texlive-bin/src/texk/web2c/luatexdir/lua/lstrlibext.c:33:
In file included from /home/builder/.termux-build/texlive-bin/build/libs/lua52/include/lapi.h:11:
/home/builder/.termux-build/texlive-bin/build/libs/lua52/include/llimits.h:18:27: error: expected ';' after top level declarator
typedef unsigned LUA_INT32 lu_int32;
                          ^
                          ;
/home/builder/.termux-build/texlive-bin/build/libs/lua52/include/llimits.h:20:9: error: unknown type name 'LUAI_UMEM'
typedef LUAI_UMEM lu_mem;
        ^
/home/builder/.termux-build/texlive-bin/build/libs/lua52/include/llimits.h:22:9: error: unknown type name 'LUAI_MEM'
typedef LUAI_MEM l_mem;
        ^
/home/builder/.termux-build/texlive-bin/build/libs/lua52/include/llimits.h:133:9: error: unknown type name 'lu_int32'
typedef lu_int32 Instruction;
        ^
In file included from /home/builder/.termux-build/texlive-bin/src/texk/web2c/luatexdir/lua/lstrlibext.c:33:
In file included from /home/builder/.termux-build/texlive-bin/build/libs/lua52/include/lapi.h:12:
/home/builder/.termux-build/texlive-bin/build/libs/lua52/include/lstate.h:61:3: error: unknown type name 'lu_int32'
  lu_int32 nuse;  /* number of elements */
  ^
5 errors generated.
make[5]: *** [Makefile:11420: luatexdir/lua/libluatex_a-lstrlibext.o] Error 1
make[5]: *** Waiting for unfinished jobs....
```

Error appeared after switching zlib implementation. But if I replace liblua with liblua52 error disappears.