### PR TITLE
Fast build fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
     - unset BINTRAY_GPG_PASSPHRASE
     - |
       for package in $(./scripts/build/ci/determine_git_changes.sh); do
-          ./build-package.sh -q -i -a "$TERMUX_ARCH" "$package" || exit 1
+          ./build-package.sh -q -I -a "$TERMUX_ARCH" "$package" || exit 1
       done
   retry:
     max: 2

--- a/scripts/build/termux_get_repo_files.sh
+++ b/scripts/build/termux_get_repo_files.sh
@@ -21,7 +21,10 @@ termux_get_repo_files() {
 			local TERMUX_REPO_NAME=$(echo ${TERMUX_REPO_URL[$idx-1]} | sed -e 's%https://%%g' -e 's%http://%%g' -e 's%/%-%g')
 			local RELEASE_FILE=${TERMUX_COMMON_CACHEDIR}/${TERMUX_REPO_NAME}-${TERMUX_REPO_DISTRIBUTION[$idx-1]}-Release
 
-			termux_download "${TERMUX_REPO_URL[$idx-1]}/dists/${TERMUX_REPO_DISTRIBUTION[$idx-1]}/Release" $RELEASE_FILE "SKIP_CHECKSUM"
+			if [ ! -e "$RELEASE_FILE" ]; then
+				termux_download "${TERMUX_REPO_URL[$idx-1]}/dists/${TERMUX_REPO_DISTRIBUTION[$idx-1]}/Release" \
+					"$RELEASE_FILE" SKIP_CHECKSUM
+			fi
 
 			for arch in all $TERMUX_ARCH; do
 				local PACKAGES_HASH=$(./scripts/get_hash_from_file.py ${RELEASE_FILE} $arch ${TERMUX_REPO_COMPONENT[$idx-1]})

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -55,6 +55,13 @@ termux_step_start_build() {
 			if [ ! "$TERMUX_QUIET_BUILD" = true ]; then
 				echo "Downloading dependency $PKG@$DEP_VERSION if necessary..."
 			fi
+
+			if [ -e "/data/data/.built-packages/$PKG" ]; then
+				if [ "$(cat "/data/data/.built-packages/$PKG")" = "$DEP_VERSION" ]; then
+					continue
+				fi
+			fi
+
 			if ! termux_download_deb $PKG $DEP_ARCH $DEP_VERSION; then
 				echo "Download of $PKG@$DEP_VERSION from $TERMUX_REPO_URL failed, building instead"
 				TERMUX_BUILD_IGNORE_LOCK=true ./build-package.sh -a $TERMUX_ARCH -I "${PKG_DIR}"


### PR DESCRIPTION
* Do not re=download release files.

* Efficiently handle dependencies: do not try to download \*.deb files when they already downloaded, do not try to extract them more than one time.

These 2 changes can significantly speed up fast-builds, especially when packages have large amount of dependencies.