### PR TITLE
Update tsu to v2.1. Use git clone to checkout tags.

### DIFF
--- a/packages/tsu/build.sh
+++ b/packages/tsu/build.sh
@@ -1,11 +1,32 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/cswl/tsu
 TERMUX_PKG_DESCRIPTION="A su wrapper for Termux"
 TERMUX_PKG_LICENSE="ISC"
-TERMUX_PKG_VERSION=2.0
+TERMUX_PKG_VERSION=2.1
 TERMUX_PKG_PLATFORM_INDEPENDENT=yes
-TERMUX_PKG_SRCURL=https://github.com/cswl/tsu/archive/ce32547e7ca441ed449b12447539da959b889e95.zip
-TERMUX_PKG_SHA256=11c0b0c0b1c9acb64d354ce9b0348d3d950e06e274d567498b1b46e8fd51fb9e
+TERMUX_PKG_SKIP_SRC_EXTRACT=1
 TERMUX_PKG_BUILD_IN_SRC=yes
+
+termux_step_extract_package() {
+	local CHECKED_OUT_FOLDER=$TERMUX_PKG_CACHEDIR/tsu-checkout-$TERMUX_PKG_VERSION
+	if [ ! -d $CHECKED_OUT_FOLDER ]; then
+		local TMP_CHECKOUT=$TERMUX_PKG_TMPDIR/tmp-checkout
+		rm -Rf $TMP_CHECKOUT
+		mkdir -p $TMP_CHECKOUT
+
+		git clone --depth 1 \
+			--branch master \
+			https://github.com/cswl/tsu.git \
+			$TMP_CHECKOUT
+		cd $TMP_CHECKOUT
+		git fetch --all --tags --prune
+		git checkout "tags/v$TERMUX_PKG_VERSION" -b "$TERMUX_PKG_VERSION"
+		mv $TMP_CHECKOUT $CHECKED_OUT_FOLDER
+	fi
+
+	mkdir $TERMUX_PKG_SRCDIR
+	cd $TERMUX_PKG_SRCDIR
+	cp -Rf $CHECKED_OUT_FOLDER/* .
+}
 
 termux_step_make() {
 	:


### PR DESCRIPTION
Minor release since Magisk fixed 64bit support.