### PR TITLE
wireguard-tools: remove part of patch

### DIFF
--- a/packages/wireguard-tools/android.c.patch
+++ b/packages/wireguard-tools/android.c.patch
@@ -1,23 +1,6 @@
 diff -u -r ../WireGuard-0.0.20180802/src/tools/wg-quick/android.c ./src/tools/wg-quick/android.c
 --- ../WireGuard-0.0.20180802/src/tools/wg-quick/android.c	2018-08-03 03:19:55.000000000 +0000
 +++ ./src/tools/wg-quick/android.c	2018-08-05 23:42:23.137024693 +0000
-@@ -38,6 +38,16 @@
- 
- static bool is_exiting = false;
- 
-+#if defined(__ANDROID_API__) && __ANDROID_API__ < 24
-+static char *strchrnul(const char *s, int c)
-+{
-+	char *x = strchr(s, c);
-+	if (!x)
-+		return (char *)s + strlen(s);
-+	return x;
-+}
-+#endif
-+
- static void *xmalloc(size_t size)
- {
- 	void *ret = malloc(size);
 @@ -242,17 +252,17 @@
  	if (!getuid())
  		return;


### PR DESCRIPTION
Not needed for ANDROID_API >= 24