### PR TITLE
buildorder.py: remove libandroid-support from always_deps

### DIFF
--- a/scripts/buildorder.py
+++ b/scripts/buildorder.py
@@ -70,7 +70,7 @@ class TermuxPackage(object):
             raise Exception("build.sh not found for package '" + self.name + "'")
 
         self.deps = parse_build_file_dependencies(build_sh_path)
-        always_deps = ['libandroid-support', 'libc++']
+        always_deps = ['libc++']
         for dependency_name in always_deps:
             if dependency_name not in self.deps and self.name not in always_deps:
                 self.deps.add(dependency_name)


### PR DESCRIPTION
as libiconv is no longer a symlink of it