### PR TITLE
cmus: fix cue sheet input plugin

### DIFF
--- a/packages/cmus/build.sh
+++ b/packages/cmus/build.sh
@@ -10,7 +10,7 @@ TERMUX_PKG_BUILD_IN_SRC=yes
 
 termux_step_pre_configure() {
 	LD=$CC
-	LDFLAGS+=" -lm"
+	export CUE_LIBS=" -lm"
 	export CONFIG_OSS=n
 }
 

--- a/packages/cmus/build.sh
+++ b/packages/cmus/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://cmus.github.io/
 TERMUX_PKG_DESCRIPTION="Small, fast and powerful console music player"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=2.8.0
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_DEPENDS="libandroid-support, libiconv, ncurses, pulseaudio, ffmpeg, libmad, opusfile, libflac, libvorbis"
 TERMUX_PKG_SRCURL=https://github.com/cmus/cmus/archive/2748d40bb670558b523d5b47b4af442e82c7ffd2.tar.gz
 TERMUX_PKG_SHA256=37b5a1889a97cdfd319880bc5925c179119330163315dc3f408145c66d352f6b
@@ -10,6 +10,7 @@ TERMUX_PKG_BUILD_IN_SRC=yes
 
 termux_step_pre_configure() {
 	LD=$CC
+	LDFLAGS+=" -lm"
 	export CONFIG_OSS=n
 }
 


### PR DESCRIPTION
The cue sheet input plugin, which provides support for `.cue` files in cmus, makes use of the `lround` function found in the mathematical library `libm`. The linker doesn't link against `libm` by default, rendering the resulting `cue.so` library unloadable by cmus. This PR fixes this issue by appending ` -lm` to the linker flags.
Build log:
```
unprivileged@ubuntu-termux:~/gdr/termux-packages$ ./build-package.sh cmus
Building dependency libc++ if necessary...
libc++@19b built - skipping (rm /data/data/.built-packages/libc++ to force rebuild)
Building dependency libbz2 if necessary...
libbz2@1.0.6-3 built - skipping (rm /data/data/.built-packages/libbz2 to force rebuild)
Building dependency zlib if necessary...
zlib@1.2.11-3 built - skipping (rm /data/data/.built-packages/zlib to force rebuild)
Building dependency libpng if necessary...
libpng@1.6.37-1 built - skipping (rm /data/data/.built-packages/libpng to force rebuild)
Building dependency freetype if necessary...
freetype@2.10.0-1 built - skipping (rm /data/data/.built-packages/freetype to force rebuild)
Building dependency libandroid-glob if necessary...
libandroid-glob@0.4 built - skipping (rm /data/data/.built-packages/libandroid-glob to force rebuild)
Building dependency ca-certificates if necessary...
ca-certificates@20190515 built - skipping (rm /data/data/.built-packages/ca-certificates to force rebuild)
Building dependency libgmp if necessary...
libgmp@6.1.2-2 built - skipping (rm /data/data/.built-packages/libgmp to force rebuild)
Building dependency libandroid-support if necessary...
libandroid-support@24-6 built - skipping (rm /data/data/.built-packages/libandroid-support to force rebuild)
Building dependency libiconv if necessary...
libiconv@1.16 built - skipping (rm /data/data/.built-packages/libiconv to force rebuild)
Building dependency libunistring if necessary...
libunistring@0.9.10-2 built - skipping (rm /data/data/.built-packages/libunistring to force rebuild)
Building dependency libidn2 if necessary...
libidn2@2.1.1a built - skipping (rm /data/data/.built-packages/libidn2 to force rebuild)
Building dependency libnettle if necessary...
libnettle@3.4.1-1 built - skipping (rm /data/data/.built-packages/libnettle to force rebuild)
Building dependency libgnutls if necessary...
libgnutls@3.6.7-1 built - skipping (rm /data/data/.built-packages/libgnutls to force rebuild)
Building dependency liblzma if necessary...
liblzma@5.2.4-2 built - skipping (rm /data/data/.built-packages/liblzma to force rebuild)
Building dependency libmp3lame if necessary...
libmp3lame@3.100 built - skipping (rm /data/data/.built-packages/libmp3lame to force rebuild)
Building dependency libopus if necessary...
libopus@1.3.1 built - skipping (rm /data/data/.built-packages/libopus to force rebuild)
Building dependency libsoxr if necessary...
libsoxr@0.1.3 built - skipping (rm /data/data/.built-packages/libsoxr to force rebuild)
Building dependency libogg if necessary...
libogg@1.3.3 built - skipping (rm /data/data/.built-packages/libogg to force rebuild)
Building dependency libvorbis if necessary...
libvorbis@1.3.6 built - skipping (rm /data/data/.built-packages/libvorbis to force rebuild)
Building dependency libvpx if necessary...
libvpx@1.8.0-1 built - skipping (rm /data/data/.built-packages/libvpx to force rebuild)
Building dependency libx264 if necessary...
libx264@20190215 built - skipping (rm /data/data/.built-packages/libx264 to force rebuild)
Building dependency libx265 if necessary...
libx265@3.0-2 built - skipping (rm /data/data/.built-packages/libx265 to force rebuild)
Building dependency xvidcore if necessary...
xvidcore@1.3.5 built - skipping (rm /data/data/.built-packages/xvidcore to force rebuild)
Building dependency ffmpeg if necessary...
ffmpeg@4.1.3-3 built - skipping (rm /data/data/.built-packages/ffmpeg to force rebuild)
Building dependency libflac if necessary...
libflac@1.3.2-7 built - skipping (rm /data/data/.built-packages/libflac to force rebuild)
Building dependency libmad if necessary...
libmad@0.15.1b-1 built - skipping (rm /data/data/.built-packages/libmad to force rebuild)
Building dependency ncurses if necessary...
ncurses@6.1.20181117-5 built - skipping (rm /data/data/.built-packages/ncurses to force rebuild)
Building dependency opusfile if necessary...
opusfile@0.11-1 built - skipping (rm /data/data/.built-packages/opusfile to force rebuild)
Building dependency command-not-found if necessary...
command-not-found@1.38 built - skipping (rm /data/data/.built-packages/command-not-found to force rebuild)
Building dependency readline if necessary...
readline@8.0-2 built - skipping (rm /data/data/.built-packages/readline to force rebuild)
Building dependency termux-am if necessary...
termux-am@0.2 built - skipping (rm /data/data/.built-packages/termux-am to force rebuild)
Building dependency termux-tools if necessary...
termux-tools@0.66 built - skipping (rm /data/data/.built-packages/termux-tools to force rebuild)
Building dependency bash if necessary...
bash@5.0.7-1 built - skipping (rm /data/data/.built-packages/bash to force rebuild)
Building dependency pcre if necessary...
pcre@8.43-3 built - skipping (rm /data/data/.built-packages/pcre to force rebuild)
Building dependency grep if necessary...
grep@3.3-1 built - skipping (rm /data/data/.built-packages/grep to force rebuild)
Building dependency sed if necessary...
sed@4.7 built - skipping (rm /data/data/.built-packages/sed to force rebuild)
Building dependency libtool if necessary...
libtool@2.4.6-6 built - skipping (rm /data/data/.built-packages/libtool to force rebuild)
Building dependency libsndfile if necessary...
libsndfile@1.0.29~pre1-2 built - skipping (rm /data/data/.built-packages/libsndfile to force rebuild)
Building dependency speexdsp if necessary...
speexdsp@1.2rc3 built - skipping (rm /data/data/.built-packages/speexdsp to force rebuild)
Building dependency libpulseaudio if necessary...
libpulseaudio@12.2-17 built - skipping (rm /data/data/.built-packages/libpulseaudio to force rebuild)
termux - building cmus for arch aarch64...
checking for program aarch64-linux-android-clang... /home/unprivileged/.termux-build/_cache/19b-aarch64-24-v5/bin/aarch64-linux-android-clang
checking for program gcc... /usr/bin/gcc
checking for C11 (with atomics support)... yes
checking for CFLAGS -pipe -Wall -Wshadow -Wcast-align -Wpointer-arith -Wwrite-strings -Wundef -Wmissing-prototypes -Wredundant-decls -Wextra -Wno-sign-compare -Wformat-security... yes
checking for CFLAGS -Wold-style-definition... yes
checking for CFLAGS -Wno-pointer-sign... yes
checking for CFLAGS -Werror-implicit-function-declaration... yes
checking for CFLAGS -Wno-unused-parameter... yes
checking for CFLAGS -Wno-missing-field-initializers... yes
checking if CC can generate dependency information... yes
checking byte order... ./configure: 528: ./configure: ./.tmp-1-prog: Exec format error
little-endian
checking for DL_LIBS (-ldl -Wl,--export-dynamic)... yes
checking for PTHREAD_LIBS (-lpthread)... no
checking for PTHREAD_LIBS (-lc_r)... no
checking for PTHREAD_LIBS (-lkse)... no
using -pthread gcc option
checking for realtime scheduling... yes
checking for NCURSES_LIBS (pkg-config)... -L/data/data/com.termux/files/usr/lib -lncursesw
checking for NCURSES_CFLAGS (pkg-config)... -D_XOPEN_SOURCE=600 -I/data/data/com.termux/files/usr/include
checking for working ncurses setup... yes
checking for function resizeterm... yes
checking for function use_default_colors... yes
checking for ICONV_LIBS (-liconv)... yes
taking iconv from libiconv
checking for working iconv... yes
checking for header <byteswap.h>... yes
checking for function strdup... yes
checking for function strndup... yes
checking for CDDB_LIBS (pkg-config)... no
checking for CDDB_LIBS (-lcddb)... no
checking for CDIO_LIBS (pkg-config)... no
checking for CDIO_LIBS (-lcdio_cdio -lcdio -lm)... no
checking for FLAC_LIBS (pkg-config)... -L/data/data/com.termux/files/usr/lib -lFLAC
checking for FLAC_CFLAGS (pkg-config)... -I/data/data/com.termux/files/usr/include
checking for MAD_LIBS (pkg-config)... no
checking for MAD_LIBS (-lmad -lm)... yes
checking for MODPLUG_LIBS (pkg-config)... no
checking for MODPLUG_LIBS (-lmodplug -lstdc++ -lm)... no
checking for header <mpc/mpcdec.h>... no
checking for header <mpcdec/mpcdec.h>... no
checking for VORBIS_LIBS (pkg-config)... -L/data/data/com.termux/files/usr/lib -lvorbisfile
checking for VORBIS_CFLAGS (pkg-config)... -I/data/data/com.termux/files/usr/include
checking for OPUS_LIBS (pkg-config)... -L/data/data/com.termux/files/usr/lib -lopusfile
checking for OPUS_CFLAGS (pkg-config)... -I/data/data/com.termux/files/usr/include/opus -I/data/data/com.termux/files/usr/include -I/data/data/com.termux/files/usr/include/opus
checking for LIBSYSTEMD_LIBS (pkg-config)... no
*** Package libsystemd was not found in the pkg-config search path.
*** Perhaps you should add the directory containing `libsystemd.pc'
*** to the PKG_CONFIG_PATH environment variable
*** No package 'libsystemd' found
checking for LIBSYSTEMD_LIBS (pkg-config)... no
*** Package libelogind was not found in the pkg-config search path.
*** Perhaps you should add the directory containing `libelogind.pc'
*** to the PKG_CONFIG_PATH environment variable
*** No package 'libelogind' found
checking for WAVPACK_LIBS (pkg-config)... no
checking for WAVPACK_LIBS (-lwavpack)... no
checking for header <mp4v2/mp4v2.h>... no
checking for header <mp4.h>... no
checking for header <neaacdec.h>... no
checking for FFMPEG_LIBS (pkg-config)... -L/data/data/com.termux/files/usr/lib -lavformat -lavcodec
checking for FFMPEG_CFLAGS (pkg-config)... -I/data/data/com.termux/files/usr/include
checking for header <libavcodec/avcodec.h>... yes
checking for successful build of ffmpeg.c... yes
checking for header <ayemu.h>... no
checking for PULSE_LIBS (pkg-config)... -L/data/data/com.termux/files/usr/lib -lpulse
checking for PULSE_CFLAGS (pkg-config)... -D_REENTRANT -I/data/data/com.termux/files/usr/include
checking for ALSA_LIBS (pkg-config)... no
*** Package alsa was not found in the pkg-config search path.
*** Perhaps you should add the directory containing `alsa.pc'
*** to the PKG_CONFIG_PATH environment variable
*** No package 'alsa' found
checking for JACK_LIBS (pkg-config)... no
*** Package jack was not found in the pkg-config search path.
*** Perhaps you should add the directory containing `jack.pc'
*** to the PKG_CONFIG_PATH environment variable
*** No package 'jack' found
checking for SAMPLERATE_LIBS (pkg-config)... no
*** Package samplerate was not found in the pkg-config search path.
*** Perhaps you should add the directory containing `samplerate.pc'
*** to the PKG_CONFIG_PATH environment variable
*** No package 'samplerate' found
checking for AO_LIBS (pkg-config)... no
checking for AO_LIBS (-lao)... no
checking for program artsc-config... no
checking for SNDIO_LIBS (-lsndio)... no
checking for header <sys/audioio.h>... no
checking for ROAR_LIBS (pkg-config)... no
*** Package libroar was not found in the pkg-config search path.
*** Perhaps you should add the directory containing `libroar.pc'
*** to the PKG_CONFIG_PATH environment variable
*** No package 'libroar' found
creating config/cdio.h
creating config/mpris.h
creating config/datadir.h
creating config/libdir.h
creating config/debug.h
creating config/tremor.h
creating config/modplug.h
creating config/mpc.h
creating config/mp4.h
creating config/curses.h
creating config/ffmpeg.h
creating config/utils.h
creating config/iconv.h
creating config/samplerate.h
creating config/xmalloc.h
creating config.mk
   CC     ape.o
   CC     browser.o
   CC     buffer.o
   CC     cache.o
   CC     channelmap.o
   CC     cmdline.o
   CC     cmus.o
   GEN    .version
   CC     comment.o
   CC     convert.lo
   CC     cue.o
   CC     cue_utils.o
   CC     debug.o
   CC     discid.o
   CC     editable.o
   CC     expr.o
   CC     filters.o
   CC     format_print.o
   CC     gbuf.o
   CC     glob.o
   CC     help.o
   CC     history.o
   CC     http.o
   CC     id3.o
   CC     input.o
   CC     job.o
   CC     keys.o
   CC     keyval.o
   CC     lib.o
   CC     load_dir.o
   CC     locking.o
   CC     mergesort.o
   CC     misc.o
   CC     options.o
   CC     output.o
   CC     pcm.o
   CC     player.o
   CC     play_queue.o
   CC     pl.o
   CC     rbtree.o
   CC     read_wrapper.o
   CC     search_mode.o
   CC     search.o
   CC     server.o
   CC     spawn.o
   CC     tabexp_file.o
   CC     tabexp.o
   CC     track_info.o
   CC     track.o
   CC     tree.o
   CC     uchar.o
   CC     u_collate.o
   CC     ui_curses.o
   CC     window.o
   CC     worker.o
   CC     xstrjoin.o
   CC     file.o
   CC     path.o
   CC     prog.o
   CC     xmalloc.o
   CC     main.o
   CC     ip/flac.lo
   CC     ip/mad.lo
   CC     ip/nomad.lo
   CC     ip/vorbis.lo
   CC     ip/opus.lo
   CC     ip/wav.lo
   CC     ip/ffmpeg.lo
   CC     ip/cue.lo
   CC     op/pulse.lo
   HOSTCC     Doc/ttman.o
   CC     command_mode.o
   LD     cmus-remote
   LD     ip/flac.so
   LD     ip/mad.so
   LD     ip/vorbis.so
   LD     ip/opus.so
   LD     ip/wav.so
   LD     ip/ffmpeg.so
   LD     ip/cue.so
   LD     op/pulse.so
   HOSTLD     Doc/ttman
   MAN    Doc/cmus.1
   MAN    Doc/cmus-remote.1
   MAN    Doc/cmus-tutorial.7
   LD     cmus
INSTALL /data/data/com.termux/files/usr/bin/cmus
INSTALL /data/data/com.termux/files/usr/bin/cmus-remote
INSTALL /data/data/com.termux/files/usr/lib/cmus/ip/flac.so
INSTALL /data/data/com.termux/files/usr/lib/cmus/ip/mad.so
INSTALL /data/data/com.termux/files/usr/lib/cmus/ip/vorbis.so
INSTALL /data/data/com.termux/files/usr/lib/cmus/ip/opus.so
INSTALL /data/data/com.termux/files/usr/lib/cmus/ip/wav.so
INSTALL /data/data/com.termux/files/usr/lib/cmus/ip/ffmpeg.so
INSTALL /data/data/com.termux/files/usr/lib/cmus/ip/cue.so
INSTALL /data/data/com.termux/files/usr/lib/cmus/op/pulse.so
INSTALL /data/data/com.termux/files/usr/share/cmus/green-mono-88.theme
INSTALL /data/data/com.termux/files/usr/share/cmus/gruvbox-alt.theme
INSTALL /data/data/com.termux/files/usr/share/cmus/zenburn.theme
INSTALL /data/data/com.termux/files/usr/share/cmus/solarized-dark.theme
INSTALL /data/data/com.termux/files/usr/share/cmus/rc
INSTALL /data/data/com.termux/files/usr/share/cmus/gray-88.theme
INSTALL /data/data/com.termux/files/usr/share/cmus/green.theme
INSTALL /data/data/com.termux/files/usr/share/cmus/gruvbox.theme
INSTALL /data/data/com.termux/files/usr/share/cmus/cyan.theme
INSTALL /data/data/com.termux/files/usr/share/cmus/default.theme
INSTALL /data/data/com.termux/files/usr/share/cmus/solarized-light.theme
INSTALL /data/data/com.termux/files/usr/share/cmus/night.theme
INSTALL /data/data/com.termux/files/usr/share/cmus/dracula.theme
INSTALL /data/data/com.termux/files/usr/share/cmus/xterm-white.theme
INSTALL /data/data/com.termux/files/usr/share/cmus/jellybeans.theme
INSTALL /data/data/com.termux/files/usr/share/man/man1/cmus.1
INSTALL /data/data/com.termux/files/usr/share/man/man1/cmus-remote.1
INSTALL /data/data/com.termux/files/usr/share/man/man7/cmus-tutorial.7
INSTALL /data/data/com.termux/files/usr/share/doc/cmus/examples/cmus-status-display
termux - build of 'cmus' done
```