### PR TITLE
ffmpeg: enable lavfi virtual input device

### DIFF
--- a/packages/ffmpeg/build.sh
+++ b/packages/ffmpeg/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Tools and libraries to manipulate a wide range of multim
 TERMUX_PKG_LICENSE="GPL-3.0"
 # NOTE: mpv has to be rebuilt and version bumped after updating ffmpeg.
 TERMUX_PKG_VERSION=4.1.3
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SHA256=0c3020452880581a8face91595b239198078645e7d7184273b8bcc7758beb63d
 TERMUX_PKG_SRCURL=https://www.ffmpeg.org/releases/ffmpeg-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_DEPENDS="libbz2, libiconv, libsoxr, libx264, libx265, xvidcore, libvorbis, libmp3lame, libopus, libvpx, libgnutls, libandroid-glob, freetype, zlib, liblzma"
@@ -39,7 +39,9 @@ termux_step_configure() {
 		--cc=$CC \
 		--cxx=$CXX \
 		--cross-prefix=${TERMUX_HOST_PLATFORM}- \
-		--disable-avdevice \
+		--disable-indevs \
+		--disable-outdevs \
+		--enable-indev=lavfi \
 		--disable-static \
 		--disable-symver \
 		--enable-cross-compile \


### PR DESCRIPTION
This PR enables the Libavfilter virtual input device. It allows for the usage of filterchains as input streams.
For example, `ffmpeg -f lavfi -i color=green -t 5.0 out.mkv` will generate a 5 seconds long video consisting solely of green pixels.
Build log: https://gist.github.com/gdrbyKo1/3e7343b66b85e0fc61d5277f3647f3bd