### PR TITLE
hfsutils: Correct termux_step_post_configure mandir location

### DIFF
--- a/packages/hfsutils/build.sh
+++ b/packages/hfsutils/build.sh
@@ -9,6 +9,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--mandir=$TERMUX_PREFIX/share/man"
 TERMUX_PKG_BUILD_IN_SRC=yes
 
 termux_step_post_configure() {
-	mkdir -p ${TERMUX_PREFIX}/man/man1
+	mkdir -p ${TERMUX_PREFIX}/share/man/man1
 }
 


### PR DESCRIPTION
mandir is set to $TERMUX_PREFIX/share/man in TERMUX_PKG_EXTRA_CONFIGURE_ARGS yet mkdir location does not match, causing build-all.sh to fail.