### PR TITLE
debug build fixes

### DIFF
--- a/packages/binutils/build.sh
+++ b/packages/binutils/build.sh
@@ -10,6 +10,17 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-gold --enable-plugins --disable-werror
 TERMUX_PKG_EXTRA_MAKE_ARGS="tooldir=$TERMUX_PREFIX"
 TERMUX_PKG_RM_AFTER_INSTALL="share/man/man1/windmc.1 share/man/man1/windres.1 bin/ld.bfd"
 TERMUX_PKG_KEEP_STATIC_LIBRARIES=true
+TERMUX_PKG_HAS_DEBUG=no
+# Debug build fails with:
+# ~/termux-build/binutils/src/binutils/readelf.c:19060:81: error: in call to 'fread', size * count is too large for the given buffer
+#     if (fread (ehdr32.e_type, sizeof (ehdr32) - EI_NIDENT, 1, filedata->handle) != 1)
+#                                                                               ^
+# ~/termux-build/_cache/19b-aarch64-24-v5/bin/../sysroot/usr/include/bits/fortify/stdio.h:107:9: note: from 'diagnose_if' attribute on 'fread':
+#        __clang_error_if(__bos(buf) != __BIONIC_FORTIFY_UNKNOWN_SIZE && size * count > __bos(buf),
+#        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~/termux-build/_cache/19b-aarch64-24-v5/bin/../sysroot/usr/include/sys/cdefs.h:163:52: note: expanded from macro '__clang_error_if'
+# #define __clang_error_if(cond, msg) __attribute__((diagnose_if(cond, msg, "error")))
+#                                                    ^           ~~~~
 
 # Avoid linking against libfl.so from flex if available:
 export LEXLIB=

--- a/packages/datamash/build.sh
+++ b/packages/datamash/build.sh
@@ -5,3 +5,16 @@ TERMUX_PKG_VERSION=1.4
 TERMUX_PKG_SHA256=fa44dd2d5456bcb94ef49dfc6cfe62c83fd53ac435119a85d34e6812f6e6472a
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/datamash/datamash-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_BUILD_IN_SRC=yes
+
+termux_step_pre_configure() {
+	if [ "$TERMUX_DEBUG" == "true" ]; then
+		# When doing debug build, -D_FORTIFY_SOURCE=2 gives this error:
+		# /home/builder/.termux-build/_cache/19b-aarch64-24-v5/bin/../sysroot/usr/include/bits/fortify/stdio.h:51:53: error: use of undeclared identifier '__USE_FORTIFY_LEVEL'
+		# return __builtin___vsnprintf_chk(dest, size, 0, __bos(dest), format, ap);
+		#                                                 ^
+		# lib/cdefs.h:123:48: note: expanded from macro '__bos'
+		# #define __bos(ptr) __builtin_object_size (ptr, __USE_FORTIFY_LEVEL > 1)
+		#                                                ^
+		export CFLAGS=${CFLAGS/-D_FORTIFY_SOURCE=2/}
+	fi
+}

--- a/packages/diffutils/build.sh
+++ b/packages/diffutils/build.sh
@@ -7,3 +7,11 @@ TERMUX_PKG_SHA256=b3a7a6221c3dc916085f0d205abf6b8e1ba443d4dd965118da364a1dc1cb3a
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/diffutils/diffutils-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_DEPENDS="libiconv"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="ac_cv_path_PR_PROGRAM=${TERMUX_PREFIX}/bin/pr"
+
+termux_step_pre_configure() {
+	if [ "$TERMUX_DEBUG" == "true" ]; then
+		# When doing debug build, -D_FORTIFY_SOURCE=2 gives an
+		# error: use of undeclared identifier '__USE_FORTIFY_LEVEL'
+		export CFLAGS=${CFLAGS/-D_FORTIFY_SOURCE=2/}
+	fi
+}

--- a/packages/exiv2/exiv2json.cpp.patch
+++ b/packages/exiv2/exiv2json.cpp.patch
@@ -1,0 +1,11 @@
+--- ../exiv2json.cpp.orig	2019-05-31 21:32:41.319959442 +0200
++++ ./samples/exiv2json.cpp	2019-05-31 21:33:11.399959231 +0200
+@@ -236,7 +236,7 @@
+ {
+     Jzon::Object& fs = (Jzon::Object&) nfs;
+     fs.Add("path",path);
+-    char resolved_path[2000]; // PATH_MAX];
++    char resolved_path[PATH_MAX];
+     fs.Add("realpath",realpath(path,resolved_path));
+ 
+     struct stat buf;

--- a/packages/grep/build.sh
+++ b/packages/grep/build.sh
@@ -6,3 +6,16 @@ TERMUX_PKG_VERSION=3.3
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/grep/grep-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=b960541c499619efd6afe1fa795402e4733c8e11ebf9fafccc0bb4bccdc5b514
+
+termux_step_pre_configure() {
+	if [ "$TERMUX_DEBUG" == "true" ]; then
+		# When doing debug build, -D_FORTIFY_SOURCE=2 gives this error:
+		# /home/builder/.termux-build/_cache/19b-aarch64-24-v5/bin/../sysroot/usr/include/bits/fortify/stdio.h:51:53: error: use of undeclared identifier '__USE_FORTIFY_LEVEL'
+		# return __builtin___vsnprintf_chk(dest, size, 0, __bos(dest), format, ap);
+		#                                                 ^
+		# lib/cdefs.h:123:48: note: expanded from macro '__bos'
+		# #define __bos(ptr) __builtin_object_size (ptr, __USE_FORTIFY_LEVEL > 1)
+		#                                                ^
+		export CFLAGS=${CFLAGS/-D_FORTIFY_SOURCE=2/}
+	fi
+}

--- a/packages/indent/code_io.c.patch
+++ b/packages/indent/code_io.c.patch
@@ -1,0 +1,11 @@
+--- ../code_io.c.orig	2019-05-30 20:55:54.216630725 +0200
++++ ./src/code_io.c	2019-05-30 20:55:57.723297366 +0200
+@@ -210,7 +210,7 @@
+ #endif
+ 
+     unsigned int namelen = strlen(filename);
+-    int          fd      = open(filename, O_RDONLY, 0777);
++    int          fd      = open(filename, O_RDONLY);
+ 
+     if (fd < 0)
+     {

--- a/packages/libllvm/build.sh
+++ b/packages/libllvm/build.sh
@@ -53,6 +53,9 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 TERMUX_PKG_FORCE_CMAKE=yes
 TERMUX_PKG_KEEP_STATIC_LIBRARIES=true
 TERMUX_PKG_HAS_DEBUG=no
+# Debug build succeeds but make install with:
+# cp: cannot stat '../src/projects/openmp/runtime/exports/common.min.50.ompt.optional/include/omp.h': No such file or directory
+# common.min.50.ompt.optional should be common.deb.50.ompt.optional when doing debug build
 
 termux_step_post_extract_package() {
 	mv cfe-${TERMUX_PKG_VERSION}.src tools/clang


### PR DESCRIPTION
With this `./build-all -d -i` succeeds for all packages.

Several builds fail with `error: use of undeclared identifier '__USE_FORTIFY_LEVEL'`, maybe it's possible to solve this in some other way (rather than not using `__FORTIFY_SOURCE=2`).

The binutils error might be trivial to fix as well, but I've disabled the debug build for now. 

libllvm builds but the make install step fails so it's still disabled.