### PR TITLE
Add tergent

### DIFF
--- a/packages/tergent/build.sh
+++ b/packages/tergent/build.sh
@@ -1,0 +1,19 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/aeolwyr/tergent
+TERMUX_PKG_DESCRIPTION="An ssh-agent implementation for Termux that uses Android Keystore as its backend"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_VERSION=0.1.1
+TERMUX_PKG_SHA256=b16e5ba1a9333d6e14b94d8cf3f5ad27d3af124f6f2bbebb0eca62ac95783281
+TERMUX_PKG_SRCURL=https://github.com/aeolwyr/tergent/archive/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_DEPENDS="termux-api"
+
+termux_step_pre_configure() {
+	termux_setup_rust
+}
+
+termux_step_make_install() {
+	cd $TERMUX_PKG_SRCDIR
+
+	cargo build --target=$CARGO_TARGET_NAME --release
+
+	cp target/$CARGO_TARGET_NAME/release/tergent $TERMUX_PREFIX/bin/tergent
+}

--- a/packages/tergent/build.sh
+++ b/packages/tergent/build.sh
@@ -2,18 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://github.com/aeolwyr/tergent
 TERMUX_PKG_DESCRIPTION="An ssh-agent implementation for Termux that uses Android Keystore as its backend"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_VERSION=0.1.1
-TERMUX_PKG_SHA256=b16e5ba1a9333d6e14b94d8cf3f5ad27d3af124f6f2bbebb0eca62ac95783281
 TERMUX_PKG_SRCURL=https://github.com/aeolwyr/tergent/archive/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=b16e5ba1a9333d6e14b94d8cf3f5ad27d3af124f6f2bbebb0eca62ac95783281
 TERMUX_PKG_DEPENDS="termux-api"
-
-termux_step_pre_configure() {
-	termux_setup_rust
-}
-
-termux_step_make_install() {
-	cd $TERMUX_PKG_SRCDIR
-
-	cargo build --target=$CARGO_TARGET_NAME --release
-
-	cp target/$CARGO_TARGET_NAME/release/tergent $TERMUX_PREFIX/bin/tergent
-}
+TERMUX_PKG_BUILD_IN_SRC=true


### PR DESCRIPTION
> An ssh-agent implementation for Termux that uses Android Keystore as its backend.

The author of tergent provides [AArch64 deb](https://github.com/aeolwyr/tergent/releases). I'd like to make the installation even easier by including it in official Termux packages.