### PR TITLE
new package: ncurses-termcap

### DIFF
--- a/packages/ncurses-termcap/build.sh
+++ b/packages/ncurses-termcap/build.sh
@@ -1,0 +1,98 @@
+TERMUX_PKG_HOMEPAGE=https://invisible-island.net/ncurses/
+TERMUX_PKG_DESCRIPTION="Ncurses package with termcap and libtinfo"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_VERSION=(6.1.20190511
+		    9.22
+		    15)
+TERMUX_PKG_SHA256=(fdbd39234fc7e7f8e5fd08d2329014e085fa5c8d0a9cc9a919e94bbc9d411c0e
+		   e94628e9bcfa0adb1115d83649f898d6edb4baced44f5d5b769c2eeb8b95addd
+		   3ae9ebef28aad081c6c11351f086776e2fd9547563b2f900732b41c376bec05a)
+TERMUX_PKG_SRCURL=(https://dl.bintray.com/termux/upstream/ncurses-${TERMUX_PKG_VERSION:0:3}-${TERMUX_PKG_VERSION:4}.tgz
+		   https://fossies.org/linux/misc/rxvt-unicode-${TERMUX_PKG_VERSION[1]}.tar.bz2
+		   https://github.com/thestinger/termite/archive/v${TERMUX_PKG_VERSION[2]}.tar.gz)
+
+TERMUX_PKG_BREAKS="ncurses, ncurses-ui-libs, ncurses-utils"
+TERMUX_PKG_REPLACES="ncurses, ncurses-ui-libs, ncurses-utils"
+TERMUX_PKG_PROVIDES="ncurses, ncurses-ui-libs, ncurses-utils"
+TERMUX_PKG_DEVPACKAGE_BREAKS="ncurses-dev"
+TERMUX_PKG_DEVPACKAGE_REPLACES="ncurses-dev"
+
+# --without-normal disables static libraries:
+# --disable-stripping to disable -s argument to install which does not work when cross compiling:
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+ac_cv_header_locale_h=no
+--disable-stripping
+--enable-const
+--enable-ext-colors
+--enable-ext-mouse
+--enable-overwrite
+--enable-pc-files
+--enable-termcap
+--enable-widec
+--mandir=$TERMUX_PREFIX/share/man
+--without-ada
+--without-cxx-binding
+--without-debug
+--without-normal
+--without-static
+--without-tests
+--with-shared
+--with-termlib
+"
+TERMUX_PKG_INCLUDE_IN_DEVPACKAGE="
+share/man/man1/ncursesw6-config.1*
+bin/ncursesw6-config
+"
+TERMUX_PKG_RM_AFTER_INSTALL="
+share/man/man5
+share/man/man7
+"
+
+termux_step_pre_configure() {
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-pkg-config-libdir=$PKG_CONFIG_LIBDIR"
+}
+
+termux_step_post_make_install() {
+	cd $TERMUX_PREFIX/lib
+	# we need the rm as we create(d) symlinks for the versioned so as well
+	for lib in form menu ncurses panel tinfo; do
+		rm -f lib${lib}.so*
+		for file in lib${lib}w.so*; do
+			ln -s $file ${file/w./.}
+		done
+		(cd pkgconfig; ln -sf ${lib}w.pc $lib.pc)
+	done
+	# some packages want libcurses while building/compiling
+	rm -f libcurses.so*
+	for file in libncurses.so*; do
+		ln -s $file ${file/libn/lib}
+	done
+
+	# Some packages want these:
+	cd $TERMUX_PREFIX/include/
+	rm -Rf ncurses{,w}
+	mkdir ncurses{,w}
+	ln -s ../{ncurses.h,termcap.h,panel.h,unctrl.h,menu.h,form.h,tic.h,nc_tparm.h,term.h,eti.h,term_entry.h,ncurses_dll.h,curses.h} ncurses
+	ln -s ../{ncurses.h,termcap.h,panel.h,unctrl.h,menu.h,form.h,tic.h,nc_tparm.h,term.h,eti.h,term_entry.h,ncurses_dll.h,curses.h} ncursesw
+}
+
+termux_step_post_massage() {
+	# Strip away 30 years of cruft to decrease size.
+	local TI=$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/share/terminfo
+	mv $TI $TERMUX_PKG_TMPDIR/full-terminfo
+	mkdir -p $TI/{a,d,e,n,l,p,r,s,t,v,x}
+	cp $TERMUX_PKG_TMPDIR/full-terminfo/a/ansi $TI/a/
+	cp $TERMUX_PKG_TMPDIR/full-terminfo/d/{dtterm,dumb} $TI/d/
+	cp $TERMUX_PKG_TMPDIR/full-terminfo/e/eterm-color $TI/e/
+	cp $TERMUX_PKG_TMPDIR/full-terminfo/n/nsterm $TI/n/
+	cp $TERMUX_PKG_TMPDIR/full-terminfo/l/linux $TI/l/
+	cp $TERMUX_PKG_TMPDIR/full-terminfo/p/putty{,-256color} $TI/p/
+	cp $TERMUX_PKG_TMPDIR/full-terminfo/r/rxvt{,-256color} $TI/r/
+	cp $TERMUX_PKG_TMPDIR/full-terminfo/s/{screen{,2,-256color},st{,-256color}} $TI/s/
+	cp $TERMUX_PKG_TMPDIR/full-terminfo/t/tmux{,-256color} $TI/t/
+	cp $TERMUX_PKG_TMPDIR/full-terminfo/v/{vt52,vt100,vt102} $TI/v/
+	cp $TERMUX_PKG_TMPDIR/full-terminfo/x/xterm{,-color,-new,-16color,-256color,+256color} $TI/x/
+
+	tic -x -o $TI $TERMUX_PKG_SRCDIR/rxvt-unicode-${TERMUX_PKG_VERSION[1]}/doc/etc/rxvt-unicode.terminfo
+	tic -x -o $TI $TERMUX_PKG_SRCDIR/termite-${TERMUX_PKG_VERSION[2]}/termite.terminfo
+}

--- a/packages/ncurses-termcap/fix-paths.patch
+++ b/packages/ncurses-termcap/fix-paths.patch
@@ -1,0 +1,35 @@
+diff -uNr ncurses-6.1-20181117/progs/tic.c ncurses-6.1-20181117.mod/progs/tic.c
+--- ncurses-6.1-20181117/progs/tic.c	2018-03-18 02:05:10.000000000 +0200
++++ ncurses-6.1-20181117.mod/progs/tic.c	2019-03-01 20:40:56.193173489 +0200
+@@ -386,7 +386,7 @@
+ {
+     FILE *result = 0;
+ 
+-    _nc_STRCPY(filename, "/tmp/XXXXXX", PATH_MAX);
++    _nc_STRCPY(filename, "@TERMUX_PREFIX@/tmp/XXXXXX", PATH_MAX);
+ #if HAVE_MKSTEMP
+     {
+ 	int oldmask = (int) umask(077);
+@@ -900,7 +900,7 @@
+     } else {
+ 	if (infodump == TRUE) {
+ 	    /* captoinfo's no-argument case */
+-	    source_file = "/etc/termcap";
++	    source_file = "@TERMUX_PREFIX@/etc/termcap";
+ 	    if ((termcap = getenv("TERMCAP")) != 0
+ 		&& (namelst = make_namelist(getenv("TERM"))) != 0) {
+ 		if (access(termcap, F_OK) == 0) {
+diff -uNr ncurses-6.1-20181117/progs/tset.c ncurses-6.1-20181117.mod/progs/tset.c
+--- ncurses-6.1-20181117/progs/tset.c	2017-10-08 03:01:29.000000000 +0300
++++ ncurses-6.1-20181117.mod/progs/tset.c	2019-03-01 20:40:15.049476720 +0200
+@@ -566,8 +566,8 @@
+ 	    goto map;
+ 	}
+ #else
+-	if ((fp = fopen("/etc/ttytype", "r")) != 0
+-	    || (fp = fopen("/etc/ttys", "r")) != 0) {
++	if ((fp = fopen("@TERMUX_PREFIX@/etc/ttytype", "r")) != 0
++	    || (fp = fopen("@TERMUX_PREFIX@/etc/ttys", "r")) != 0) {
+ 	    char buffer[BUFSIZ];
+ 	    char *s, *t, *d;
+ 

--- a/packages/ncurses-termcap/ncurses-tinfo-lib_setup.c.patch
+++ b/packages/ncurses-termcap/ncurses-tinfo-lib_setup.c.patch
@@ -1,0 +1,25 @@
+diff -u -r ../src-patched/ncurses/tinfo/lib_setup.c ./ncurses/tinfo/lib_setup.c
+--- ../src-patched/ncurses/tinfo/lib_setup.c	2015-07-11 10:03:50.340357853 -0400
++++ ./ncurses/tinfo/lib_setup.c	2015-07-11 14:42:01.049867165 -0400
+@@ -352,21 +352,6 @@
+ 		    _nc_setenv_num("COLUMNS", *colp);
+ 		}
+ 	    }
+-
+-	    /*
+-	     * Finally, look for environment variables.
+-	     *
+-	     * Solaris lets users override either dimension with an environment
+-	     * variable.
+-	     */
+-	    if ((value = _nc_getenv_num("LINES")) > 0) {
+-		*linep = value;
+-		T(("screen size: environment LINES = %d", *linep));
+-	    }
+-	    if ((value = _nc_getenv_num("COLUMNS")) > 0) {
+-		*colp = value;
+-		T(("screen size: environment COLUMNS = %d", *colp));
+-	    }
+ 	}
+ 
+ 	/* if we can't get dynamic info about the size, use static */

--- a/packages/ncurses-termcap/ncurses-tinfo-tinfo_driver.c.patch
+++ b/packages/ncurses-termcap/ncurses-tinfo-tinfo_driver.c.patch
@@ -1,0 +1,25 @@
+diff -u -r ../src-patched/ncurses/tinfo/tinfo_driver.c ./ncurses/tinfo/tinfo_driver.c
+--- ../src-patched/ncurses/tinfo/tinfo_driver.c	2015-07-11 10:03:50.340357853 -0400
++++ ./ncurses/tinfo/tinfo_driver.c	2015-07-11 10:04:02.836153796 -0400
+@@ -417,21 +417,6 @@
+ 		    _nc_setenv_num("COLUMNS", *colp);
+ 		}
+ 	    }
+-
+-	    /*
+-	     * Finally, look for environment variables.
+-	     *
+-	     * Solaris lets users override either dimension with an environment
+-	     * variable.
+-	     */
+-	    if ((value = _nc_getenv_num("LINES")) > 0) {
+-		*linep = value;
+-		T(("screen size: environment LINES = %d", *linep));
+-	    }
+-	    if ((value = _nc_getenv_num("COLUMNS")) > 0) {
+-		*colp = value;
+-		T(("screen size: environment COLUMNS = %d", *colp));
+-	    }
+ 	}
+ 
+ 	/* if we can't get dynamic info about the size, use static */


### PR DESCRIPTION
Ncurses with termcap support and libtinfo. Implements https://github.com/termux/termux-packages/pull/4101.

Seems to be compatible with already installed ncurses-based applications, but should not be used for compiling official Termux packages.