### PR TITLE
stow: update from 2.3.0 to 2.3.1

### DIFF
--- a/packages/stow/build.sh
+++ b/packages/stow/build.sh
@@ -1,9 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/stow/
 TERMUX_PKG_DESCRIPTION="Tool for managing the installation of multiple software packages into a single directory"
 TERMUX_PKG_LICENSE="GPL-2.0"
-TERMUX_PKG_VERSION=2.3.0
+TERMUX_PKG_VERSION=2.3.1
 TERMUX_PKG_SRCURL=https://fossies.org/linux/misc/stow-$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_SHA256=0524eaa0d4485d1bffb78b5cdf5b6fc13e39444666ca2e51336f66ddb3c81841
+TERMUX_PKG_SHA256=09d5d99671b78537fd9b2c0b39a5e9761a7a0e979f6fdb7eabfa58ee45f03d4b
 TERMUX_PKG_DEPENDS="perl"
 TERMUX_PKG_BUILD_IN_SRC=yes
 TERMUX_PKG_PLATFORM_INDEPENDENT=yes


### PR DESCRIPTION
Fix #4114 by bumping stow to the version that removes unnecessary dependency