### PR TITLE
NDK fixes for GCC and C++

### DIFF
--- a/ndk-patches/bits-ioctl.h.patch
+++ b/ndk-patches/bits-ioctl.h.patch
@@ -1,0 +1,11 @@
+--- sysroot.orig/usr/include/bits/ioctl.h	2019-07-30 14:11:49.196931147 -0400
++++ sysroot/usr/include/bits/ioctl.h	2019-07-30 14:12:44.446936650 -0400
+@@ -55,7 +55,7 @@
+  * - defining BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD, which will make the
+  *   overloading go away.
+  */
+-#if !defined(BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD)
++#if !defined(BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD) && defined(__clang__)
+ /* enable_if(1) just exists to break overloading ties. */
+ int ioctl(int __fd, unsigned __request, ...) __overloadable __enable_if(1, "") __RENAME(ioctl);
+ #endif

--- a/ndk-patches/langinfo.h
+++ b/ndk-patches/langinfo.h
@@ -143,7 +143,7 @@ static char *nl_langinfo_l(nl_item item, locale_t loc)
 	int idx = item & 65535;
 	const char *str;
 
-	if (item == CODESET) return "UTF-8";
+	if (item == CODESET) return (char *)"UTF-8";
 
 	switch (cat) {
 	case 0:

--- a/ndk-patches/pwd.h.patch
+++ b/ndk-patches/pwd.h.patch
@@ -1,7 +1,6 @@
-diff -uNr sysroot.orig/usr/include/pwd.h sysroot/usr/include/pwd.h
---- sysroot.orig/usr/include/pwd.h	2019-02-12 16:12:24.000000000 +0000
-+++ sysroot/usr/include/pwd.h	2019-03-20 13:26:24.283060011 +0000
-@@ -89,13 +89,58 @@
+--- sysroot.orig/usr/include/pwd.h	2019-07-30 14:15:53.170288784 -0400
++++ sysroot/usr/include/pwd.h	2019-07-30 14:12:44.446936650 -0400
+@@ -89,7 +89,6 @@
  struct passwd* getpwent(void) __INTRODUCED_IN(26);
  
  void setpwent(void) __INTRODUCED_IN(26);
@@ -9,22 +8,21 @@ diff -uNr sysroot.orig/usr/include/pwd.h sysroot/usr/include/pwd.h
  #endif /* __ANDROID_API__ >= 26 */
  
  
- int getpwnam_r(const char* __name, struct passwd* __pwd, char* __buf, size_t __n, struct passwd** __result) __INTRODUCED_IN(12);
- int getpwuid_r(uid_t __uid, struct passwd* __pwd, char* __buf, size_t __n, struct passwd** __result) __INTRODUCED_IN(12);
+@@ -98,6 +97,50 @@
  
-+int access(const char* __path, int __mode);
-+
+ int access(const char* __path, int __mode);
+ 
 +static void android_setup_pwd(struct passwd* pw) {
 +	char const* result = "@TERMUX_PREFIX@/bin/login";
 +	if (result == NULL || access(result, /*X_OK*/1) == -1) {
-+		pw->pw_shell = "@TERMUX_PREFIX@/bin/bash";
++		pw->pw_shell = (char *) "@TERMUX_PREFIX@/bin/bash";
 +	} else {
 +		pw->pw_shell = (char*) result;
 +	}
-+	pw->pw_dir = "@TERMUX_HOME@";
-+	pw->pw_passwd = "*";
++	pw->pw_dir = (char *) "@TERMUX_HOME@";
++	pw->pw_passwd = (char *) "*";
 +#ifdef __LP64__
-+	pw->pw_gecos = ""; /* Avoid NULL field. */
++	pw->pw_gecos = (char *) ""; /* Avoid NULL field. */
 +#endif
 +}
 +

--- a/ndk-patches/string.h.patch
+++ b/ndk-patches/string.h.patch
@@ -1,0 +1,11 @@
+--- sysroot.orig/usr/include/string.h	2019-07-30 14:11:49.196931147 -0400
++++ sysroot/usr/include/string.h	2019-07-30 14:12:44.446936650 -0400
+@@ -188,7 +188,7 @@
+ #endif
+ 
+ /* Const-correct overloads. Placed after FORTIFY so we call those functions, if possible. */
+-#if defined(__cplusplus)
++#if defined(__cplusplus) && defined(__clang__)
+ /*
+  * Use two enable_ifs so these overloads don't conflict with + are preferred over libcxx's. This can
+  * be reduced to 1 after libcxx recognizes that we have const-correct overloads.

--- a/ndk-patches/sys-cdefs.h.patch
+++ b/ndk-patches/sys-cdefs.h.patch
@@ -1,11 +1,29 @@
-diff -uNr sysroot.orig/usr/include/sys/cdefs.h sysroot/usr/include/sys/cdefs.h
---- sysroot.orig/usr/include/sys/cdefs.h	2019-02-12 16:12:24.000000000 +0000
-+++ sysroot/usr/include/sys/cdefs.h	2019-03-20 13:27:29.977876824 +0000
-@@ -206,7 +206,11 @@
+--- sysroot.orig/usr/include/sys/cdefs.h	2019-07-30 14:14:11.386945311 -0400
++++ sysroot/usr/include/sys/cdefs.h	2019-07-30 14:12:44.446936650 -0400
+@@ -46,6 +46,18 @@
+ #define __END_DECLS
+ #endif
+ 
++/* GCC keyword fixes */
++#ifndef __has_builtin
++#   define __has_builtin(x) 0
++#endif
++#ifndef __has_feature
++#   define __has_feature(x) 0
++#endif
++#ifndef __clang__
++#  define _Nullable
++#  define _Nonnull
++#endif
++
+ #define __strong_alias(alias, sym) \
+     __asm__(".global " #alias "\n" \
+             #alias " = " #sym);
+@@ -176,7 +188,11 @@
   * _FILE_OFFSET_BITS 64 support.
   * See https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md
   */
--#if !defined(__LP64__) && defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64
+-#if !defined(__LP64__) && defined(_FILE_OFFSET_BITS) && _FILE_OFFeSET_BITS == 64
 +/* Using _FILE_OFFSET_BITS=64 does not work well on Android
 + * and can cause problems when mixing libraries, which is why
 + * Termux hides away this unless TERMUX_EXPOSE_FILE_OFFSET64
@@ -14,3 +32,40 @@ diff -uNr sysroot.orig/usr/include/sys/cdefs.h sysroot/usr/include/sys/cdefs.h
  #  define __USE_FILE_OFFSET64 1
  /*
   * Note that __RENAME_IF_FILE_OFFSET64 is only valid if the off_t and off64_t
+@@ -243,6 +259,14 @@
+ #  endif
+ #endif
+ 
++/* GCC does not fare well with fortify headers. */
++#if !defined(__clang__) && (defined(__BIONIC_FORTIFY) || defined(__BIONIC_DECLARE_FORTIFY_HELPERS))
++#   warning "Disabling _FORTIFY_SOURCE, it requires Clang."
++#   undef _FORTIFY_SOURCE
++#   undef __BIONIC_FORTIFY
++#   undef __BIONIC_DECLARE_FORTIFY_HEADERS
++#endif
++
+ // As we move some FORTIFY checks to be always on, __bos needs to be
+ // always available.
+ #if defined(__BIONIC_FORTIFY)
+@@ -292,7 +316,11 @@
+ #  define __BIONIC_INCLUDE_FORTIFY_HEADERS 1
+ #endif
+ 
+-#define __overloadable __attribute__((overloadable))
++#ifdef __clang__
++#  define __overloadable __attribute__((overloadable))
++#else
++#  define __overloadable
++#endif
+ 
+ /* Used to tag non-static symbols that are private and never exposed by the shared library. */
+ #define __LIBC_HIDDEN__ __attribute__((visibility("hidden")))
+@@ -310,7 +338,7 @@
+ /* Used to rename functions so that the compiler emits a call to 'x' rather than the function this was applied to. */
+ #define __RENAME(x) __asm__(#x)
+ 
+-#if __has_builtin(__builtin_umul_overflow) || __GNUC__ >= 5
++#if __GNUC__ >= 5 || __has_builtin(__builtin_umul_overflow)
+ #if defined(__LP64__)
+ #define __size_mul_overflow(a, b, result) __builtin_umull_overflow(a, b, result)
+ #else

--- a/ndk-patches/sys-cdefs.h.patch
+++ b/ndk-patches/sys-cdefs.h.patch
@@ -23,7 +23,7 @@
   * _FILE_OFFSET_BITS 64 support.
   * See https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md
   */
--#if !defined(__LP64__) && defined(_FILE_OFFSET_BITS) && _FILE_OFFeSET_BITS == 64
+-#if !defined(__LP64__) && defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64
 +/* Using _FILE_OFFSET_BITS=64 does not work well on Android
 + * and can cause problems when mixing libraries, which is why
 + * Termux hides away this unless TERMUX_EXPOSE_FILE_OFFSET64


### PR DESCRIPTION
This patch hopefully makes it so that GCC can use the system headers,
and fixes a few C++ compiler issues.

Fixes made:
 - __has_xxx wrappers
 - Disable __overload__ attribute
 - Disable _FORTIFY_SOURCE, it relies on Clangisms.
 - Missing string literal cast

Hopefully, at least the main headers should work now.

Not tested. Based on my fiddling on-device.