### PR TITLE
hugo: Update from 0.55.6 to 0.57.2

### DIFF
--- a/packages/hugo/build.sh
+++ b/packages/hugo/build.sh
@@ -1,10 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://gohugo.io/
 TERMUX_PKG_DESCRIPTION="A fast and flexible static site generator"
 TERMUX_PKG_LICENSE="Apache-2.0"
-TERMUX_PKG_VERSION=0.55.6
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION=0.57.2
 TERMUX_PKG_SRCURL=https://github.com/gohugoio/hugo/archive/v$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_SHA256=2b585e1919e2643e5bb4226eb64d7cd523bbf85be266f43bf3a132fa924949e4
+TERMUX_PKG_SHA256=435267c639ce58daea14c1f7d1f64bdd9176d20bd5719457e11051b88a6fffe6
 TERMUX_PKG_DEPENDS="libc++"
 
 termux_step_make() {
@@ -14,8 +13,10 @@ termux_step_make() {
 	cd $TERMUX_PKG_SRCDIR
 	go build \
 		-o "$TERMUX_PREFIX/bin/hugo" \
-		-tags extended \
+		-tags "linux extended" \
 		main.go
+		# "linux" tag should not be necessary
+		# try removing when golang version is upgraded
 
 	# Building for host to generate manpages and completion.
 	chmod 700 -R $GOPATH/pkg && rm -rf $GOPATH/pkg
@@ -23,8 +24,10 @@ termux_step_make() {
 	unset CC CXX CFLAGS CXXFLAGS LDFLAGS
 	go build \
 		-o "$TERMUX_PKG_BUILDDIR/hugo" \
-		-tags extended \
+		-tags "linux extended" \
 		main.go
+		# "linux" tag should not be necessary
+		# try removing when golang version is upgraded
 }
 
 termux_step_make_install() {


### PR DESCRIPTION
Update hugo package from 0.55.6 to 0.57.2.

This is my first contribution to termux-packages so please tell me if I am forgetting something in the contribution guidelines.

TODO
- [x] Follow-up on CI status
- [ ] Manual test with hugo 0.57.2 (using my blog https://alarencontredumonde.gitlab.io)