### PR TITLE
cmake: fix typo that broke exec_program

### DIFF
--- a/packages/cmake/Source-cmExecProgramCommand.cxx.patch
+++ b/packages/cmake/Source-cmExecProgramCommand.cxx.patch
@@ -6,7 +6,7 @@ diff -u -r ../cmake-3.15.2/Source/cmExecProgramCommand.cxx ./Source/cmExecProgra
    fflush(stdout);
    fflush(stderr);
 -  const char* cmd[] = { "/bin/sh", "-c", command.c_str(), nullptr };
-+  const char* cmd[] = { "@TERMUX_PREFIX/bin/sh", "-c", command.c_str(), nullptr };
++  const char* cmd[] = { "@TERMUX_PREFIX@/bin/sh", "-c", command.c_str(), nullptr };
    cmsysProcess_SetCommand(cp, cmd);
  #endif
  

--- a/packages/cmake/build.sh
+++ b/packages/cmake/build.sh
@@ -2,6 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://cmake.org/
 TERMUX_PKG_DESCRIPTION="Family of tools designed to build, test and package software"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_VERSION=3.15.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.cmake.org/files/v${TERMUX_PKG_VERSION:0:4}/cmake-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=539088cb29a68e6d6a8fba5c00951e5e5b1a92c68fa38a83e1ed2f355933f768
 TERMUX_PKG_DEPENDS="libarchive, libc++, libcurl, libexpat, jsoncpp, libuv, rhash, make, clang, zlib"


### PR DESCRIPTION
CMake modules that ran uname and other programs broke a couple days ago.