### PR TITLE
llbuild: add package

### DIFF
--- a/packages/llbuild/CMakeLists.txt.patch
+++ b/packages/llbuild/CMakeLists.txt.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0c30c55..26336a1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -202,7 +202,8 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+ endif()
+ 
+ # On BSD and Linux, always build with PIC.
+-if(${CMAKE_SYSTEM_NAME} MATCHES ".*BSD" OR ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
++if(${CMAKE_SYSTEM_NAME} MATCHES ".*BSD" OR ${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR
++   CMAKE_SYSTEM_NAME STREQUAL Android)
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+ endif ()

--- a/packages/llbuild/build.sh
+++ b/packages/llbuild/build.sh
@@ -1,0 +1,7 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/apple/swift-llbuild
+TERMUX_PKG_DESCRIPTION="A low-level build system, used by the Swift Package Manager"
+TERMUX_PKG_LICENSE="Apache-2.0, NCSA"
+TERMUX_PKG_VERSION=0.1.1
+TERMUX_PKG_SRCURL=https://github.com/apple/swift-llbuild/archive/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=8f04c76dcc65bd47e197574998b30dfef1eab10a81aba704b605d12bd9c31b68
+TERMUX_PKG_DEPENDS="libc++, libandroid-spawn, libsqlite"

--- a/packages/llbuild/include-llbuild-BuildSystem-BuildSystemFrontend.h.patch
+++ b/packages/llbuild/include-llbuild-BuildSystem-BuildSystemFrontend.h.patch
@@ -1,0 +1,19 @@
+commit 111d9828e6422447321196b1826c0a666a0632d2
+Author: Igor Makarov <igormaka@gmail.com>
+Date:   Wed Aug 21 15:06:30 2019 +0300
+
+    change ProcessHandle int width so it complies with platform int width
+
+diff --git a/include/llbuild/BuildSystem/BuildSystemFrontend.h b/include/llbuild/BuildSystem/BuildSystemFrontend.h
+index b14e9c8..53bf570 100644
+--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
++++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
+@@ -116,7 +116,7 @@ public:
+   /// Handle used to communicate information about a launched process.
+   struct ProcessHandle {
+     /// Opaque ID.
+-    uintptr_t id;
++    uint64_t id;
+   };
+   
+ private:

--- a/packages/llbuild/include-llvm-Config-config.h.patch
+++ b/packages/llbuild/include-llvm-Config-config.h.patch
@@ -1,0 +1,36 @@
+diff --git a/include/llvm/Config/config.h b/include/llvm/Config/config.h
+index f1fe468..18a2bd6 100644
+--- a/include/llvm/Config/config.h
++++ b/include/llvm/Config/config.h
+@@ -23,7 +23,9 @@
+ #endif
+ 
+ /* Define to 1 if you have the `backtrace' function. */
++#if !defined(__ANDROID__)
+ #define HAVE_BACKTRACE 1
++#endif
+ 
+ /* Define to 1 if you have the <cxxabi.h> header file. */
+ #define HAVE_CXXABI_H 1
+@@ -53,7 +55,9 @@
+ #define HAVE_ERRNO_H 1
+ 
+ /* Define to 1 if you have the <execinfo.h> header file. */
++#if !defined(__ANDROID__)
+ #define HAVE_EXECINFO_H 1
++#endif
+ 
+ /* Define to 1 if you have the <fcntl.h> header file. */
+ #define HAVE_FCNTL_H 1
+@@ -62,7 +66,11 @@
+ #define HAVE_FUTIMES 1
+ 
+ /* Define to 1 if you have the `futimens' function */
++#if defined(__ANDROID__)
++#define HAVE_FUTIMENS 1
++#else
+ /* #undef HAVE_FUTIMENS */
++#endif
+ 
+ /* Define to 1 if you have the `getpagesize' function. */
+ #define HAVE_GETPAGESIZE 1

--- a/packages/llbuild/lib-Basic-PlatformUtility.cpp.patch
+++ b/packages/llbuild/lib-Basic-PlatformUtility.cpp.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/Basic/PlatformUtility.cpp b/lib/Basic/PlatformUtility.cpp
+index afbfa01..3a495b8 100644
+--- a/lib/Basic/PlatformUtility.cpp
++++ b/lib/Basic/PlatformUtility.cpp
+@@ -324,7 +324,7 @@ std::string sys::makeTmpDir() {
+   CreateDirectoryW((LPCWSTR)wPath.data(), NULL);
+   return std::string(path);
+ #else
+-  char tmpDirPathBuf[] = "/tmp/fileXXXXXX";
++  char tmpDirPathBuf[] = "@TERMUX_PREFIX@/tmp/fileXXXXXX";
+   return std::string(mkdtemp(tmpDirPathBuf));
+ #endif
+ }

--- a/packages/llbuild/lib-llvm-Support-CmakeLists.txt.patch
+++ b/packages/llbuild/lib-llvm-Support-CmakeLists.txt.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/llvm/Support/CMakeLists.txt b/lib/llvm/Support/CMakeLists.txt
+index 8e79e18..a844183 100644
+--- a/lib/llvm/Support/CMakeLists.txt
++++ b/lib/llvm/Support/CMakeLists.txt
+@@ -45,3 +45,7 @@ endif()
+ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+   target_link_libraries(llvmSupport pthread dl)
+ endif()
++
++if(${CMAKE_SYSTEM_NAME} MATCHES "Android")
++  target_link_libraries(llvmSupport PRIVATE android-spawn)
++endif()

--- a/packages/llbuild/products-llbuild-CMakeLists.txt.patch
+++ b/packages/llbuild/products-llbuild-CMakeLists.txt.patch
@@ -1,0 +1,12 @@
+diff --git a/products/llbuild/CMakeLists.txt b/products/llbuild/CMakeLists.txt
+index 6ec9d16..3d4b9dc 100644
+--- a/products/llbuild/CMakeLists.txt
++++ b/products/llbuild/CMakeLists.txt
+@@ -13,3 +13,7 @@ target_link_libraries(llbuild
+ if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+   target_link_libraries(llbuild curses)
+ endif()
++
++install(TARGETS llbuild
++        COMPONENT llbuild
++        DESTINATION bin)


### PR DESCRIPTION
llbuild is an interesting new build system and library that is now at the core of XCode and the Swift package manager. It includes a workalike to ninja, so you can replace the command `ninja test` with `llbuild ninja build test` (or more likely a shortcut).

I've been trying it out a bit lately and it seems to work well: all but one test in this package pass after adding the Termux prefix path to some tests. It also includes a swift-build-tool, which is useless right now, but won't be once I finally get the Swift compiler submitted here.

Strangely, this would be [the first llbuild package for a linux "distro"](https://pkgs.org/download/llbuild), as that site reports only a single outdated BSD package and my google searches turn up nothing else.