### PR TITLE
proot: Update package

### DIFF
--- a/packages/proot/build.sh
+++ b/packages/proot/build.sh
@@ -2,11 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://proot-me.github.io/
 TERMUX_PKG_DESCRIPTION="Emulate chroot, bind mount and binfmt_misc for non-root users"
 TERMUX_PKG_LICENSE="GPL-2.0"
 # Just bump commit and version when needed:
-_COMMIT=0717de26d1394fec3acf90efdc1d172e01bc932b
+_COMMIT=3ea655b1ae40bfa2ee612d45bf1e7ad97c4559f8
 TERMUX_PKG_VERSION=5.1.107
-TERMUX_PKG_REVISION=21
+TERMUX_PKG_REVISION=22
 TERMUX_PKG_SRCURL=https://github.com/termux/proot/archive/${_COMMIT}.zip
-TERMUX_PKG_SHA256=0ff540373197cab850f33de9b35818bcf0b098596adeee36d44e6f68c50eb7ee
+TERMUX_PKG_SHA256=4b649d88e6953b8f127fa79d078f7a773d84aba97211696d53a7d0cced810151
 TERMUX_PKG_DEPENDS="libtalloc"
 
 # Install loader in libexec instead of extracting it every time


### PR DESCRIPTION
* Added SIGSYS handler for waitpid (Required for bash on Android 10)
* Added SIGSYS handler for sendmmsg on x86 (for DNS when using emulator)
* Fixed void syscall handling on 32 bit ARM
* Prevent tracees from setting SUID_DUMP_DISABLE