### PR TITLE
libdispatch: add package

### DIFF
--- a/packages/libdispatch/build.sh
+++ b/packages/libdispatch/build.sh
@@ -1,0 +1,8 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/apple/swift-corelibs-libdspatch
+TERMUX_PKG_DESCRIPTION="The libdispatch project, for concurrency on multicore hardware"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_VERSION=2019-09-04
+TERMUX_PKG_SRCURL=https://github.com/apple/swift-corelibs-libdispatch/archive/swift-DEVELOPMENT-SNAPSHOT-${TERMUX_PKG_VERSION}-a.tar.gz
+TERMUX_PKG_SHA256=fada9fc9f4c6fac1c8b11d4187deb67329744f412df656d1b77122765db06147
+TERMUX_PKG_DEPENDS="libc++"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DENABLE_TESTING=OFF"

--- a/packages/libdispatch/src-CMakeLists.txt.patch
+++ b/packages/libdispatch/src-CMakeLists.txt.patch
@@ -1,0 +1,14 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 2809c11..368d428 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -246,6 +246,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+                  "-Xlinker -dead_strip"
+                  "-Xlinker -alias_list -Xlinker ${PROJECT_SOURCE_DIR}/xcodeconfig/libdispatch.aliases")
+ endif()
++if(CMAKE_SYSTEM_NAME STREQUAL Android)
++  set_property(TARGET dispatch APPEND PROPERTY LINK_LIBRARIES "log")
++endif()
+ 
+ install(TARGETS
+           dispatch


### PR DESCRIPTION
Need this for the Swift stdlib but realized it can be its own library, for those who just want to use it alone. Everything else is mostly written in Swift, so it will come packaged with the compiler.  This package sticks a couple headers in $PREFIX/include/os, can change that if wanted.

Currently built off a recent snapshot, will update to the next official release whenever that's out.