### PR TITLE
Enable Omemo support in Profanity

### DIFF
--- a/packages/libsignal-protocol-c/build.sh
+++ b/packages/libsignal-protocol-c/build.sh
@@ -1,0 +1,13 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/signalapp/libsignal-protocol-c
+TERMUX_PKG_DESCRIPTION="Signal Protocol C Library"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_VERSION=2.3.2
+TERMUX_PKG_MAINTAINER="Oliver Schmidhauser @Neo-Oli"
+TERMUX_PKG_SRCURL=https://github.com/signalapp/libsignal-protocol-c/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=f3826f3045352e14027611c95449bfcfe39bfd3d093d578c70f70eee0c85000d
+TERMUX_PKG_DEPENDS="openssl"
+
+termux_step_pre_configure() {
+    TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DBUILD_SHARED_LIBS=ON"
+    TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DM_LIB=$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib/$TERMUX_HOST_PLATFORM/$TERMUX_PKG_API_LEVEL/libm.so"
+}

--- a/packages/profanity/build.sh
+++ b/packages/profanity/build.sh
@@ -3,9 +3,10 @@ TERMUX_PKG_DESCRIPTION="Profanity is a console based XMPP client written in C us
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="Oliver Schmidhauser @Neo-Oli"
 TERMUX_PKG_VERSION=0.7.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=f1eb99be01683d41b891b0f997f4c873c9bb87b0b6b8400b7fccb8e553d514bb
 TERMUX_PKG_SRCURL=https://github.com/profanity-im/profanity/releases/download/$TERMUX_PKG_VERSION/profanity-$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_DEPENDS="libandroid-support, libffi, ncurses, glib, libmesode, libcurl, readline, libuuid, libotr, gpgme, python, libassuan, libgpg-error, zlib"
+TERMUX_PKG_DEPENDS="libandroid-support, libffi, ncurses, glib, libmesode, libcurl, readline, libuuid, libotr, gpgme, python, libassuan, libgpg-error, zlib, libsignal-protocol-c"
 TERMUX_PKG_BREAKS="profanity-dev"
 TERMUX_PKG_REPLACES="profanity-dev"
 # openssl, libexpat needed by libmesode, pcre needed by glib:


### PR DESCRIPTION
Omemo is the hot new end-to-end encryption scheme that is now available in the latest profanity version