### PR TITLE
Update llbuild and libdispatch packages to latest 5.1 release

### DIFF
--- a/packages/libdispatch/build.sh
+++ b/packages/libdispatch/build.sh
@@ -1,8 +1,8 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/apple/swift-corelibs-libdspatch
 TERMUX_PKG_DESCRIPTION="The libdispatch project, for concurrency on multicore hardware"
 TERMUX_PKG_LICENSE="Apache-2.0"
-TERMUX_PKG_VERSION=2019-09-04
-TERMUX_PKG_SRCURL=https://github.com/apple/swift-corelibs-libdispatch/archive/swift-DEVELOPMENT-SNAPSHOT-${TERMUX_PKG_VERSION}-a.tar.gz
-TERMUX_PKG_SHA256=fada9fc9f4c6fac1c8b11d4187deb67329744f412df656d1b77122765db06147
+TERMUX_PKG_VERSION=5.1
+TERMUX_PKG_SRCURL=https://github.com/apple/swift-corelibs-libdispatch/archive/swift-${TERMUX_PKG_VERSION}-RELEASE.tar.gz
+TERMUX_PKG_SHA256=da24d299eecc10e7d4b40a24e0700ca2f73da622795ecf6f4a5da4d33c486662
 TERMUX_PKG_DEPENDS="libc++"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DENABLE_TESTING=OFF"

--- a/packages/libdispatch/src-CMakeLists.txt.patch
+++ b/packages/libdispatch/src-CMakeLists.txt.patch
@@ -3,9 +3,9 @@ index 2809c11..368d428 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -246,6 +246,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-                  "-Xlinker -dead_strip"
                   "-Xlinker -alias_list -Xlinker ${PROJECT_SOURCE_DIR}/xcodeconfig/libdispatch.aliases")
  endif()
+ dispatch_set_linker(dispatch)
 +if(CMAKE_SYSTEM_NAME STREQUAL Android)
 +  set_property(TARGET dispatch APPEND PROPERTY LINK_LIBRARIES "log")
 +endif()

--- a/packages/llbuild/build.sh
+++ b/packages/llbuild/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/apple/swift-llbuild
 TERMUX_PKG_DESCRIPTION="A low-level build system, used by the Swift Package Manager"
 TERMUX_PKG_LICENSE="Apache-2.0, NCSA"
-TERMUX_PKG_VERSION=0.1.1
-TERMUX_PKG_SRCURL=https://github.com/apple/swift-llbuild/archive/${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=8f04c76dcc65bd47e197574998b30dfef1eab10a81aba704b605d12bd9c31b68
+TERMUX_PKG_VERSION=5.1
+TERMUX_PKG_SRCURL=https://github.com/apple/swift-llbuild/archive/swift-${TERMUX_PKG_VERSION}-RELEASE.tar.gz
+TERMUX_PKG_SHA256=cbd228619d1172f7f6d38983f0419226baa1cfbecc6afac891856fcb46ba4920
 TERMUX_PKG_DEPENDS="libc++, libandroid-spawn, libsqlite"

--- a/packages/llbuild/include-llvm-Config-config.h.patch
+++ b/packages/llbuild/include-llvm-Config-config.h.patch
@@ -1,36 +1,36 @@
 diff --git a/include/llvm/Config/config.h b/include/llvm/Config/config.h
-index f1fe468..18a2bd6 100644
+index 9cf1c89..9af2945 100644
 --- a/include/llvm/Config/config.h
 +++ b/include/llvm/Config/config.h
-@@ -23,7 +23,9 @@
- #endif
+@@ -14,7 +14,9 @@
+ #define ENABLE_CRASH_OVERRIDES 1
  
  /* Define to 1 if you have the `backtrace' function. */
 +#if !defined(__ANDROID__)
- #define HAVE_BACKTRACE 1
+ #define HAVE_BACKTRACE TRUE
 +#endif
  
- /* Define to 1 if you have the <cxxabi.h> header file. */
- #define HAVE_CXXABI_H 1
-@@ -53,7 +55,9 @@
- #define HAVE_ERRNO_H 1
+ #define BACKTRACE_HEADER <execinfo.h>
  
- /* Define to 1 if you have the <execinfo.h> header file. */
-+#if !defined(__ANDROID__)
- #define HAVE_EXECINFO_H 1
-+#endif
+@@ -74,7 +76,11 @@
+ /* #undef HAVE_FFI_H */
  
- /* Define to 1 if you have the <fcntl.h> header file. */
- #define HAVE_FCNTL_H 1
-@@ -62,7 +66,11 @@
- #define HAVE_FUTIMES 1
- 
- /* Define to 1 if you have the `futimens' function */
+ /* Define to 1 if you have the `futimens' function. */
 +#if defined(__ANDROID__)
 +#define HAVE_FUTIMENS 1
 +#else
  /* #undef HAVE_FUTIMENS */
 +#endif
  
- /* Define to 1 if you have the `getpagesize' function. */
- #define HAVE_GETPAGESIZE 1
+ /* Define to 1 if you have the `futimes' function. */
+ #define HAVE_FUTIMES 1
+@@ -104,7 +110,9 @@
+ #define HAVE_LIBPTHREAD 1
+ 
+ /* Define to 1 if you have the `pthread_getname_np' function. */
++#if !defined(__ANDROID__)
+ #define HAVE_PTHREAD_GETNAME_NP 1
++#endif
+ 
+ /* Define to 1 if you have the `pthread_setname_np' function. */
+ #define HAVE_PTHREAD_SETNAME_NP 1


### PR DESCRIPTION
These are the latest tags that correspond to the just-announced Swift 5.1 release. I'm looking into building a Swift 5.1 package also, but I've been using Swift master so far so I'm checking if 5.1 will work, since 5.1 was branched in March and doesn't have some Android patches that were since merged to Swift master. 