### PR TITLE
libllvm: use armv7a-linux-androideabi as default target triple

### DIFF
--- a/packages/libllvm/build.sh
+++ b/packages/libllvm/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://clang.llvm.org/
 TERMUX_PKG_DESCRIPTION="Modular compiler and toolchain technologies library"
 TERMUX_PKG_LICENSE="NCSA"
 TERMUX_PKG_VERSION=8.0.1
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SHA256=(44787a6d02f7140f145e2250d56c9f849334e11f9ae379827510ed72f12b75e7
                    70effd69f7a8ab249f66b0a68aba8b08af52aa2ab710dfb8a0fba102685b1646
                    9fba1e94249bd7913e8a6c3aadcb308b76c8c3d83c5ce36c99c3f34d73873d88
@@ -79,8 +79,10 @@ termux_step_pre_configure() {
 	cd $TERMUX_PKG_BUILDDIR
 	export LLVM_DEFAULT_TARGET_TRIPLE=$TERMUX_HOST_PLATFORM
 	export LLVM_TARGET_ARCH
+
 	if [ $TERMUX_ARCH = "arm" ]; then
 		LLVM_TARGET_ARCH=ARM
+		LLVM_DEFAULT_TARGET_TRIPLE="armv7a-linux-androideabi"
 	elif [ $TERMUX_ARCH = "aarch64" ]; then
 		LLVM_TARGET_ARCH=AArch64
 	elif [ $TERMUX_ARCH = "i686" ]; then


### PR DESCRIPTION
Fixes https://github.com/termux/termux-packages/issues/3686.