### PR TITLE
nodejs: prevent calling setgroups(), setuid(), setgid()

### DIFF
--- a/packages/nodejs-lts/build.sh
+++ b/packages/nodejs-lts/build.sh
@@ -2,6 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://nodejs.org/
 TERMUX_PKG_DESCRIPTION="Platform built on Chrome's JavaScript runtime for easily building fast, scalable network applications"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_VERSION=10.16.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=7bf1123d7415964775b8f81fe6ec6dd5c3c08abb42bb71dfe4409dbeeba26bbd
 # Note that we do not use a shared libuv to avoid an issue with the Android

--- a/packages/nodejs-lts/deps-uv-src-unix-process.c.patch
+++ b/packages/nodejs-lts/deps-uv-src-unix-process.c.patch
@@ -1,0 +1,31 @@
+diff -uNr node-v12.10.0/deps/uv/src/unix/process.c node-v12.10.0.mod/deps/uv/src/unix/process.c
+--- node-v12.10.0/deps/uv/src/unix/process.c	2019-09-04 18:36:23.000000000 +0300
++++ node-v12.10.0.mod/deps/uv/src/unix/process.c	2019-09-23 01:39:39.069030779 +0300
+@@ -351,27 +351,6 @@
+     _exit(127);
+   }
+ 
+-  if (options->flags & (UV_PROCESS_SETUID | UV_PROCESS_SETGID)) {
+-    /* When dropping privileges from root, the `setgroups` call will
+-     * remove any extraneous groups. If we don't call this, then
+-     * even though our uid has dropped, we may still have groups
+-     * that enable us to do super-user things. This will fail if we
+-     * aren't root, so don't bother checking the return value, this
+-     * is just done as an optimistic privilege dropping function.
+-     */
+-    SAVE_ERRNO(setgroups(0, NULL));
+-  }
+-
+-  if ((options->flags & UV_PROCESS_SETGID) && setgid(options->gid)) {
+-    uv__write_int(error_fd, UV__ERR(errno));
+-    _exit(127);
+-  }
+-
+-  if ((options->flags & UV_PROCESS_SETUID) && setuid(options->uid)) {
+-    uv__write_int(error_fd, UV__ERR(errno));
+-    _exit(127);
+-  }
+-
+   if (options->env != NULL) {
+     environ = options->env;
+   }

--- a/packages/nodejs/build.sh
+++ b/packages/nodejs/build.sh
@@ -2,6 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://nodejs.org/
 TERMUX_PKG_DESCRIPTION="Platform built on Chrome's JavaScript runtime for easily building fast, scalable network applications"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_VERSION=12.10.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=2515b87c60921f22514a58830e86e54831daa2453d0e82f2ed7ab02134ee30cd
 # Note that we do not use a shared libuv to avoid an issue with the Android

--- a/packages/nodejs/deps-uv-src-unix-process.c.patch
+++ b/packages/nodejs/deps-uv-src-unix-process.c.patch
@@ -1,0 +1,31 @@
+diff -uNr node-v12.10.0/deps/uv/src/unix/process.c node-v12.10.0.mod/deps/uv/src/unix/process.c
+--- node-v12.10.0/deps/uv/src/unix/process.c	2019-09-04 18:36:23.000000000 +0300
++++ node-v12.10.0.mod/deps/uv/src/unix/process.c	2019-09-23 01:39:39.069030779 +0300
+@@ -351,27 +351,6 @@
+     _exit(127);
+   }
+ 
+-  if (options->flags & (UV_PROCESS_SETUID | UV_PROCESS_SETGID)) {
+-    /* When dropping privileges from root, the `setgroups` call will
+-     * remove any extraneous groups. If we don't call this, then
+-     * even though our uid has dropped, we may still have groups
+-     * that enable us to do super-user things. This will fail if we
+-     * aren't root, so don't bother checking the return value, this
+-     * is just done as an optimistic privilege dropping function.
+-     */
+-    SAVE_ERRNO(setgroups(0, NULL));
+-  }
+-
+-  if ((options->flags & UV_PROCESS_SETGID) && setgid(options->gid)) {
+-    uv__write_int(error_fd, UV__ERR(errno));
+-    _exit(127);
+-  }
+-
+-  if ((options->flags & UV_PROCESS_SETUID) && setuid(options->uid)) {
+-    uv__write_int(error_fd, UV__ERR(errno));
+-    _exit(127);
+-  }
+-
+   if (options->env != NULL) {
+     environ = options->env;
+   }


### PR DESCRIPTION
Should fix https://github.com/termux/termux-packages/issues/4065.
```
17829 close(22)                         = 0
17829 close(24)                         = 0
17829 close(26)                         = 0
17829 chdir("/data/data/com.termux/files/home/.npm/_cacache/tmp/git-clone-12251ed6") = 0
17829 setgroups(0, NULL)                = -1 EPERM (Operation not permitted)
17829 setgid(10088)                     = 0
17829 setuid(10088)                     = 0
17829 rt_sigaction(SIGHUP, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=SA_RESTART}, {sa_handler=0x7b5cb3c744, sa_mask=~[KILL STOP RTMIN RT_1 RT_2 RT_3], sa_flags=SA_RESTART}, 8) = 0
```