### PR TITLE
ca-certificates: make it possible to have custom CA certificates in bundle

### DIFF
--- a/packages/ca-certificates/build.sh
+++ b/packages/ca-certificates/build.sh
@@ -2,6 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://curl.haxx.se/docs/caextract.html
 TERMUX_PKG_DESCRIPTION="Common CA certificates"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=20190828
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://curl.haxx.se/ca/cacert.pem
 # If the checksum has changed, it may be time to update the package version:
 TERMUX_PKG_SHA256=38b6230aa4bee062cd34ee0ff6da173250899642b1937fc130896290b6bd91e3
@@ -10,7 +11,7 @@ TERMUX_PKG_PLATFORM_INDEPENDENT=true
 
 termux_step_make_install() {
 	local CERTDIR=$TERMUX_PREFIX/etc/tls
-	local CERTFILE=$CERTDIR/cert.pem
+	local CERTFILE=$CERTDIR/cert.orig.pem
 
 	mkdir -p $CERTDIR
 
@@ -35,4 +36,17 @@ termux_step_make_install() {
 		--password changeit \
 		--force-new-overwrite \
 		--import-pem-file $CERTFILE
+
+	mkdir -p $CERTDIR/user-certs.d
+	echo "Place your PEM certificates here and then execute command 'update-ca-certificates'." > $CERTDIR/user-certs.d/README.txt
+
+	sed "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|g" \
+		$TERMUX_PKG_BUILDER_DIR/update-ca-certificates.sh \
+		> $TERMUX_PREFIX/bin/update-ca-certificates
+	chmod 700 $TERMUX_PREFIX/bin/update-ca-certificates
+}
+
+termux_step_create_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" > ./postinst
+	echo "exec $TERMUX_PREFIX/bin/update-ca-certificates" >> ./postinst
 }

--- a/packages/ca-certificates/update-ca-certificates.sh
+++ b/packages/ca-certificates/update-ca-certificates.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+shopt -s nullglob
+
+CA_CERT_BUNDLE=@TERMUX_PREFIX@/etc/tls/cert.pem
+ORIG_CA_CERT_BUNDLE=@TERMUX_PREFIX@/etc/tls/cert.orig.pem
+USER_CA_CERT_DIR=@TERMUX_PREFIX@/etc/tls/user-certs.d
+
+echo "Generating CA certificate bundle..."
+
+cat "$ORIG_CA_CERT_BUNDLE" > "$CA_CERT_BUNDLE"
+mkdir -p "$USER_CA_CERT_DIR"
+for user_cert in "$USER_CA_CERT_DIR"/*.pem; do
+	echo "Adding $user_cert to CA bundle..."
+
+	# Certificate name.
+	echo >> "$CA_CERT_BUNDLE"
+	echo "$(basename "$user_cert")" >> "$CA_CERT_BUNDLE"
+	for _ in $(seq 1 $(echo -n "$(basename "$user_cert")" | wc -c)); do
+		echo -n "="
+	done >> "$CA_CERT_BUNDLE"
+	echo >> "$CA_CERT_BUNDLE"
+
+	# Certificate data.
+	cat "$user_cert" >> "$CA_CERT_BUNDLE"
+done


### PR DESCRIPTION
Original certificates will be located in `$PREFIX/etc/tls/certs.orig.pem`. User can place own certificates (**PEM format only**) to `$PREFIX/etc/tls/user-certs.d` and then regenerate working CA bundle with script `update-ca-certificates`. Same script will be executed each time automatically on package update.

Solves https://github.com/termux/termux-packages/issues/1546.

***

Will require hook for bootstrap generating scripts to ensure that `$PREFIX/etc/tls/cert.pem` is present.