### PR TITLE
starship: upgrade to 0.20.2

### DIFF
--- a/packages/starship/build.sh
+++ b/packages/starship/build.sh
@@ -1,9 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://starship.rs
 TERMUX_PKG_DESCRIPTION="A minimal, blazing fast, and extremely customizable prompt for any shell"
 TERMUX_PKG_LICENSE="ISC"
-TERMUX_PKG_VERSION=0.18.0
+TERMUX_PKG_VERSION=0.20.2
 TERMUX_PKG_SRCURL=https://github.com/starship/starship/archive/v$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_SHA256=6792e7359577eca6f858559ebbee80dee4ccb97039973f8ba6f14a05c6e38c13
+TERMUX_PKG_SHA256=7d69b44db4f8fb31f92c0f9766598496156c8ede8f44ee0681436129aefdfc3c
 TERMUX_PKG_DEPENDS="openssl, zlib"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--no-default-features"


### PR DESCRIPTION
Neither 0.18.0 or 0.20.2 is possible to build at the moment, it fails when trying to compile `libgit2-sys v0.9.1`

Edit: nevermind, I guess I haven't cleaned my build environment