### PR TITLE
proot: Update package

### DIFF
--- a/packages/proot/build.sh
+++ b/packages/proot/build.sh
@@ -2,11 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://proot-me.github.io/
 TERMUX_PKG_DESCRIPTION="Emulate chroot, bind mount and binfmt_misc for non-root users"
 TERMUX_PKG_LICENSE="GPL-2.0"
 # Just bump commit and version when needed:
-_COMMIT=3ea655b1ae40bfa2ee612d45bf1e7ad97c4559f8
+_COMMIT=38042a5f60b5b6a2db68f18bd8b644748b530c8b
 TERMUX_PKG_VERSION=5.1.107
-TERMUX_PKG_REVISION=22
+TERMUX_PKG_REVISION=23
 TERMUX_PKG_SRCURL=https://github.com/termux/proot/archive/${_COMMIT}.zip
-TERMUX_PKG_SHA256=4b649d88e6953b8f127fa79d078f7a773d84aba97211696d53a7d0cced810151
+TERMUX_PKG_SHA256=28820f7b903f5e7a15012f2c8499ba8e8acbe73afefee69f66854325d552c851
 TERMUX_PKG_DEPENDS="libtalloc"
 
 # Install loader in libexec instead of extracting it every time


### PR DESCRIPTION
* termux/proot#77 - Support running 32-bit guests on AArch64
* termux/proot#75 - Fixed crashes on 32-bit ARM devices with kernels using new syscall order