### PR TITLE
apt: use redirectable url for main repository

### DIFF
--- a/packages/apt/build.sh
+++ b/packages/apt/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://packages.debian.org/apt
 TERMUX_PKG_DESCRIPTION="Front-end for the dpkg package manager"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=1.4.9
-TERMUX_PKG_REVISION=16
+TERMUX_PKG_REVISION=17
 TERMUX_PKG_SRCURL=http://ftp.debian.org/debian/pool/main/a/apt/apt_${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=d4d65e7c84da86f3e6dcc933bba46a08db429c9d933b667c864f5c0e880bac0d
 # apt-key requires utilities from coreutils, findutils, gpgv, grep, sed.
@@ -52,7 +52,7 @@ termux_step_pre_configure() {
 }
 
 termux_step_post_make_install() {
-	printf "# The main termux repository:\ndeb https://dl.bintray.com/termux/termux-packages-24 stable main\n" > $TERMUX_PREFIX/etc/apt/sources.list
+	printf "# The main termux repository:\ndeb https://termux.org/packages/ stable main\n" > $TERMUX_PREFIX/etc/apt/sources.list
 	cp $TERMUX_PKG_BUILDER_DIR/trusted.gpg $TERMUX_PREFIX/etc/apt/
 	rm $TERMUX_PREFIX/include/apt-pkg -r
 


### PR DESCRIPTION
Makes possible to redirect traffic to mirror in case if main repository is down (like in https://github.com/termux/termux-packages/issues/4358).

Rule for redirecting `https://termux.org/packages/` is already configured on [CF](https://cloudflare.com).

Will add small overhead due to http redirect:
```
Hyperfine benchmark

No redirect:
Benchmark #1: apt update
  Time (mean ± σ):      4.072 s ±  0.206 s    [User: 1.912 s, System: 1.463 s]
  Range (min … max):    3.725 s …  4.574 s    10 runs

With redirect:
Benchmark #1: apt update
  Time (mean ± σ):      4.494 s ±  0.674 s    [User: 2.075 s, System: 1.455 s]
  Range (min … max):    4.032 s …  5.678 s    10 runs
```