### PR TITLE
Switch to nightly channel

### DIFF
--- a/packages/rust/config.toml
+++ b/packages/rust/config.toml
@@ -25,7 +25,7 @@ optimize = true
 debug = false
 codegen-units = 0
 jemalloc = false
-channel = "stable"
+channel = "nightly"
 rpath = false
 
 [target.x86_64-unknown-linux-gnu]


### PR DESCRIPTION
Please, compile nightly channel for arm, it's more useful then stable. I can't use many rust features now.