### PR TITLE
apt: use redirectable (termux.org) url for main repository

### DIFF
--- a/packages/apt/build.sh
+++ b/packages/apt/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://packages.debian.org/apt
 TERMUX_PKG_DESCRIPTION="Front-end for the dpkg package manager"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=1.4.9
-TERMUX_PKG_REVISION=18
+TERMUX_PKG_REVISION=19
 TERMUX_PKG_SRCURL=http://ftp.debian.org/debian/pool/main/a/apt/apt_${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=d4d65e7c84da86f3e6dcc933bba46a08db429c9d933b667c864f5c0e880bac0d
 # apt-key requires utilities from coreutils, findutils, gpgv, grep, sed.
@@ -52,7 +52,7 @@ termux_step_pre_configure() {
 }
 
 termux_step_post_make_install() {
-	printf "# The main termux repository:\ndeb https://dl.bintray.com/termux/termux-packages-24 stable main\n" > $TERMUX_PREFIX/etc/apt/sources.list
+	printf "# The main termux repository:\ndeb https://termux.org/packages/ stable main\n" > $TERMUX_PREFIX/etc/apt/sources.list
 	cp $TERMUX_PKG_BUILDER_DIR/trusted.gpg $TERMUX_PREFIX/etc/apt/
 	rm $TERMUX_PREFIX/include/apt-pkg -r
 


### PR DESCRIPTION
~~*Reworked variant of https://github.com/termux/termux-packages/pull/4426.*~~

* Makes possible to redirect traffic to mirror in case if main repository is down (like in https://github.com/termux/termux-packages/issues/4358).