### PR TITLE
build ImageMagick with bzip2

### DIFF
--- a/packages/imagemagick/build.sh
+++ b/packages/imagemagick/build.sh
@@ -13,7 +13,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --without-x
 --without-gvc
 --with-magick-plus-plus=no
---with-bzlib=no
+--with-bzlib=yes
 --with-xml=yes
 --with-rsvg=yes
 --with-lzma


### PR DESCRIPTION
libbz2 is listed as a dependency but it's compiled without it
apparently it's been this way since the 1st ever commit!