### PR TITLE
apt: add apt-ftparchive and libapt-pkg subpackages

### DIFF
--- a/packages/apt/0000-cmake-fix.patch
+++ b/packages/apt/0000-cmake-fix.patch
@@ -47,20 +47,6 @@ diff -uNr apt-1.4.9/CMakeLists.txt apt-1.4.9.mod/CMakeLists.txt
  # Set compiler flags
  set(CMAKE_CXX_STANDARD 11)
  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-@@ -69,13 +64,6 @@
- add_optional_compile_options(Wsign-promo)
- add_optional_compile_options(Wundef)
- 
--# apt-ftparchive dependencies
--find_package(BerkeleyDB REQUIRED)
--if (BERKELEY_DB_FOUND)
--  set(HAVE_BDB 1)
--endif()
--
--
- # apt-transport-https dependencies
- find_package(CURL REQUIRED)
- if (CURL_FOUND)
 @@ -89,21 +77,12 @@
  endif()
  

--- a/packages/apt/apt-ftparchive.subpackage.sh
+++ b/packages/apt/apt-ftparchive.subpackage.sh
@@ -1,0 +1,5 @@
+TERMUX_SUBPKG_DESCRIPTION="apt-ftparchive is the command line tool that generates the index files that APT uses to access a distribution source"
+TERMUX_SUBPKG_DEPENDS="libdb"
+TERMUX_SUBPKG_INCLUDE="
+bin/apt-ftparchive
+"

--- a/packages/apt/build.sh
+++ b/packages/apt/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://packages.debian.org/apt
 TERMUX_PKG_DESCRIPTION="Front-end for the dpkg package manager"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=1.4.9
-TERMUX_PKG_REVISION=22
+TERMUX_PKG_REVISION=23
 TERMUX_PKG_SRCURL=http://ftp.debian.org/debian/pool/main/a/apt/apt_${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=d4d65e7c84da86f3e6dcc933bba46a08db429c9d933b667c864f5c0e880bac0d
 # apt-key requires utilities from coreutils, findutils, gpgv, grep, sed.
@@ -27,12 +27,17 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DWITH_DOC=OFF
 "
 
+# ubuntu uses instead $PREFIX/lib instead of $PREFIX/libexec to
+# "Work around bug in GNUInstallDirs" (from apt 1.4.8 CMakeLists.txt).
+# Archlinux uses $PREFIX/libexec though, so let's force libexec->lib to
+# get same build result on ubuntu and archlinux.
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+="-DCMAKE_INSTALL_LIBEXECDIR=lib"
+
 TERMUX_PKG_RM_AFTER_INSTALL="
 bin/apt-cdrom
 bin/apt-extracttemplates
 bin/apt-sortpkgs
 etc/apt/apt.conf.d
-lib/apt/apt-helper
 lib/apt/methods/bzip2
 lib/apt/methods/cdrom
 lib/apt/methods/mirror
@@ -40,7 +45,6 @@ lib/apt/methods/rred
 lib/apt/planners/
 lib/apt/solvers/
 lib/dpkg/
-lib/libapt-inst.so
 "
 
 termux_step_pre_configure() {
@@ -54,7 +58,6 @@ termux_step_pre_configure() {
 termux_step_post_make_install() {
 	printf "# The main termux repository:\ndeb https://termux.org/packages/ stable main\n" > $TERMUX_PREFIX/etc/apt/sources.list
 	cp $TERMUX_PKG_BUILDER_DIR/trusted.gpg $TERMUX_PREFIX/etc/apt/
-	rm $TERMUX_PREFIX/include/apt-pkg -r
 
 	# apt-transport-tor
 	ln -sfr $TERMUX_PREFIX/lib/apt/methods/http $TERMUX_PREFIX/lib/apt/methods/tor

--- a/packages/apt/libapt-pkg.subpackage.sh
+++ b/packages/apt/libapt-pkg.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Header files and libraries for libapt-pkg and libapt-inst"
+TERMUX_SUBPKG_INCLUDE="
+include/apt-pkg
+lib/libapt-pkg.so
+lib/libapt-inst.so
+"


### PR DESCRIPTION
`libapt-pkg` is required for https://github.com/termux/termux-packages/issues/4568