### PR TITLE
termux_step_setup_toolchain: skip running termux-elf-cleaner

### DIFF
--- a/scripts/build/termux_step_setup_toolchain.sh
+++ b/scripts/build/termux_step_setup_toolchain.sh
@@ -158,8 +158,6 @@ termux_step_setup_toolchain() {
 		sed -i "s/define __ANDROID_API__ __ANDROID_API_FUTURE__/define __ANDROID_API__ $TERMUX_PKG_API_LEVEL/" \
 			usr/include/android/api-level.h
 
-		$TERMUX_ELF_CLEANER usr/lib/*/*/*.so usr/lib/*/*.so
-
 		grep -lrw $_TERMUX_TOOLCHAIN_TMPDIR/sysroot/usr/include/c++/v1 -e '<version>'   | xargs -n 1 sed -i 's/<version>/\"version\"/g'
 		mv $_TERMUX_TOOLCHAIN_TMPDIR $TERMUX_STANDALONE_TOOLCHAIN
 	fi


### PR DESCRIPTION
https://github.com/termux/termux-packages/issues/4287 can be fixed by reverting https://github.com/termux/termux-elf-cleaner/commit/334efd1923c563e19d00e655dfbfb2f9f7031bb1 (I confirmed it), but that breaks libc++_shared as reported in https://github.com/termux/termux-packages/issues/3990. [@xeffyr looked into it and found](https://github.com/termux/termux-packages/issues/3990#issuecomment-507618608) that libc++_shared only breaks if termux-elf-cleaner is run before the binaries are stripped. 

So, do we need to strip the ndk libraries in termux_step_setup_toolchain? I don't get any problems for libandroid-support or libc++ during build or when linking against them on device.
Do we suspect that other packages will behave differently when building with un-cleaned android-ndk?