### PR TITLE
New packages: mediainfo, libmediainfo, libzen

### DIFF
--- a/packages/libmediainfo/01_remove_libpthread.patch
+++ b/packages/libmediainfo/01_remove_libpthread.patch
@@ -1,0 +1,11 @@
+--- old/Project/GNU/Library/libmediainfo.pc.in	2019-09-10 21:27:35.000000000 +0200
++++ Project/GNU/Library/libmediainfo.pc.in	2019-12-05 13:05:47.469137700 +0100
+@@ -3,7 +3,7 @@
+ libdir=@libdir@
+ includedir=@includedir@
+ Unicode=@MediaInfoLib_Unicode@
+-Libs_Static=${libdir}/lib@MediaInfoLib_LibName@.a ${libdir}/libzen.a -lpthread -lz@Curl_Lib@
++Libs_Static=${libdir}/lib@MediaInfoLib_LibName@.a ${libdir}/libzen.a -lz@Curl_Lib@
+ la_name=lib@MediaInfoLib_LibName@.la
+ 
+ Name: libmediainfo

--- a/packages/libmediainfo/build.sh
+++ b/packages/libmediainfo/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE=https://mediaarea.net/en/MediaInfo
+TERMUX_PKG_DESCRIPTION="Library for reading information from media files"
+TERMUX_PKG_LICENSE="BSD 2-Clause"
+TERMUX_PKG_VERSION=19.09
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=https://mediaarea.net/download/source/libmediainfo/${TERMUX_PKG_VERSION}/libmediainfo_${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=602131fc1730154ca083c8bec6fe42aa2f1f43b36dbaedf26917e27dd8a38e73
+TERMUX_PKG_DEPENDS="libcurl, libzen, zlib"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-shared --enable-static --with-libcurl"
+
+termux_step_pre_configure() {
+  TERMUX_PKG_SRCDIR="${TERMUX_PKG_SRCDIR}/Project/GNU/Library"
+  TERMUX_PKG_BUILDDIR="${TERMUX_PKG_SRCDIR}"
+  cd "${TERMUX_PKG_SRCDIR}" || return
+  ./autogen.sh
+}
+
+termux_step_post_make_install() {
+  ln -sf "${TERMUX_PREFIX}/lib/libmediainfo.so" "${TERMUX_PREFIX}/lib/libmediainfo.so.0"
+  ln -sf "${TERMUX_PREFIX}/lib/libmediainfo.so" "${TERMUX_PREFIX}/lib/libmediainfo.so.0.0"
+}

--- a/packages/libzen/01_remove_libpthread.patch
+++ b/packages/libzen/01_remove_libpthread.patch
@@ -1,0 +1,41 @@
+diff -r -u old/Project/GNU/Library/configure.ac Project/GNU/Library/configure.ac
+--- old/Project/GNU/Library/configure.ac	2017-11-02 13:44:15.000000000 +0100
++++ Project/GNU/Library/configure.ac	2019-12-05 13:03:44.363859500 +0100
+@@ -124,10 +124,10 @@
+ dnl Common
+ dnl
+ if test "$enable_shared" = "yes"; then
+-    ZenLib_LIBS="-L$(pwd)/.libs -lzen -lpthread -lstdc++ $ZenLib_LIBS"
++    ZenLib_LIBS="-L$(pwd)/.libs -lzen -lstdc++ $ZenLib_LIBS"
+ fi
+ if test "$enable_static" = "yes"; then
+-    ZenLib_LIBS_Static="$(pwd)/.libs/libzen.a -lpthread -lstdc++ $ZenLib_LIBS_Static"
++    ZenLib_LIBS_Static="$(pwd)/.libs/libzen.a -lstdc++ $ZenLib_LIBS_Static"
+ fi
+ 
+ dnl #########################################################################
+@@ -232,7 +232,7 @@
+ dnl -------------------------------------------------------------------------
+ dnl External libs
+ dnl
+-LDFLAGS="$LDFLAGS -lpthread -lstdc++"
++LDFLAGS="$LDFLAGS -lstdc++"
+ 
+ dnl #########################################################################
+ dnl ### Output
+diff -r -u old/Project/GNU/Library/libzen.pc.in Project/GNU/Library/libzen.pc.in
+--- old/Project/GNU/Library/libzen.pc.in	2017-11-02 13:44:14.000000000 +0100
++++ Project/GNU/Library/libzen.pc.in	2019-12-05 13:03:44.363859500 +0100
+@@ -4,10 +4,10 @@
+ includedir=@includedir@
+ Unicode=@ZenLib_Unicode@
+ WstringMissing=@ZenLib_wstring_missing@
+-Libs_Static=@libdir@/libzen.a -lpthread
++Libs_Static=@libdir@/libzen.a
+ 
+ Name: libzen
+ Version: @PACKAGE_VERSION@
+ Description: ZenLib
+-Libs: -L${libdir} -lzen -lpthread -lstdc++
++Libs: -L${libdir} -lzen -lstdc++
+ Cflags: -I${includedir} @ZenLib_CXXFLAGS@

--- a/packages/libzen/02_add_libandroid_glob.patch
+++ b/packages/libzen/02_add_libandroid_glob.patch
@@ -1,0 +1,41 @@
+diff -r -u old/Project/GNU/Library/configure.ac Project/GNU/Library/configure.ac
+--- old/Project/GNU/Library/configure.ac	2019-12-09 18:08:43.564751200 +0100
++++ Project/GNU/Library/configure.ac	2019-12-09 18:10:34.999619900 +0100
+@@ -124,10 +124,10 @@
+ dnl Common
+ dnl
+ if test "$enable_shared" = "yes"; then
+-    ZenLib_LIBS="-L$(pwd)/.libs -lzen -lstdc++ $ZenLib_LIBS"
++    ZenLib_LIBS="-L$(pwd)/.libs -lzen -lstdc++ -landroid-glob $ZenLib_LIBS"
+ fi
+ if test "$enable_static" = "yes"; then
+-    ZenLib_LIBS_Static="$(pwd)/.libs/libzen.a -lstdc++ $ZenLib_LIBS_Static"
++    ZenLib_LIBS_Static="$(pwd)/.libs/libzen.a -lstdc++ -landroid-glob $ZenLib_LIBS_Static"
+ fi
+ 
+ dnl #########################################################################
+@@ -232,7 +232,7 @@
+ dnl -------------------------------------------------------------------------
+ dnl External libs
+ dnl
+-LDFLAGS="$LDFLAGS -lstdc++"
++LDFLAGS="$LDFLAGS -lstdc++ -landroid-glob"
+ 
+ dnl #########################################################################
+ dnl ### Output
+diff -r -u old/Project/GNU/Library/libzen.pc.in Project/GNU/Library/libzen.pc.in
+--- old/Project/GNU/Library/libzen.pc.in	2019-12-09 18:08:43.564751200 +0100
++++ Project/GNU/Library/libzen.pc.in	2019-12-09 18:10:52.801637000 +0100
+@@ -4,10 +4,10 @@
+ includedir=@includedir@
+ Unicode=@ZenLib_Unicode@
+ WstringMissing=@ZenLib_wstring_missing@
+-Libs_Static=@libdir@/libzen.a
++Libs_Static=@libdir@/libzen.a -landroid-glob
+ 
+ Name: libzen
+ Version: @PACKAGE_VERSION@
+ Description: ZenLib
+-Libs: -L${libdir} -lzen -lstdc++
++Libs: -L${libdir} -lzen -lstdc++ -landroid-glob
+ Cflags: -I${includedir} @ZenLib_CXXFLAGS@

--- a/packages/libzen/build.sh
+++ b/packages/libzen/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE=https://mediaarea.net/en/MediaInfo
+TERMUX_PKG_DESCRIPTION="ZenLib C++ utility library"
+TERMUX_PKG_LICENSE="ZLIB"
+TERMUX_PKG_VERSION=0.4.37
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=https://mediaarea.net/download/source/libzen/${TERMUX_PKG_VERSION}/libzen_${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=8c4323bd3f1a286a565b634cb00c9877922296679f49ac55b05f7c6e56d77c43
+TERMUX_PKG_DEPENDS=libandroid-glob
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-shared --enable-static"
+
+termux_step_pre_configure() {
+  TERMUX_PKG_SRCDIR="${TERMUX_PKG_SRCDIR}/Project/GNU/Library"
+  TERMUX_PKG_BUILDDIR="${TERMUX_PKG_SRCDIR}"
+  cd "${TERMUX_PKG_SRCDIR}" || return
+  ./autogen.sh
+}
+
+termux_step_post_make_install() {
+  ln -sf "${TERMUX_PREFIX}/lib/libzen.so" "${TERMUX_PREFIX}/lib/libzen.so.${TERMUX_PKG_VERSION:0:1}"
+  ln -sf "${TERMUX_PREFIX}/lib/libzen.so" "${TERMUX_PREFIX}/lib/libzen.so.${TERMUX_PKG_VERSION}"
+}

--- a/packages/mediainfo/build.sh
+++ b/packages/mediainfo/build.sh
@@ -1,0 +1,16 @@
+TERMUX_PKG_HOMEPAGE=https://mediaarea.net/en/MediaInfo
+TERMUX_PKG_DESCRIPTION="Command-line utility for reading information from media files"
+TERMUX_PKG_LICENSE="BSD 2-Clause"
+TERMUX_PKG_VERSION=19.09
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=https://mediaarea.net/download/source/mediainfo/${TERMUX_PKG_VERSION}/mediainfo_${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=1db9a8d9416e0d276a209eee784d9865b8b4c71a26873c6b72badacc2a4ee670
+TERMUX_PKG_DEPENDS=libmediainfo
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-dll"
+
+termux_step_pre_configure() {
+  TERMUX_PKG_SRCDIR="${TERMUX_PKG_SRCDIR}/Project/GNU/CLI"
+  TERMUX_PKG_BUILDDIR="${TERMUX_PKG_SRCDIR}"
+  cd "${TERMUX_PKG_SRCDIR}" || return
+  ./autogen.sh
+}


### PR DESCRIPTION
MediaInfo is a convenient unified display of the most relevant technical and tag data for video and audio files.

https://mediaarea.net/en/MediaInfo

These build scripts are the product of trial and error. There may be a more elegant way to implement them. The challenge here is that the build files are in a subfolder (Project/GNU/Library or Project/GNU/CLI) and have relative references to the parent directories, so the build process must take place in the Project/GNU/Library directory.

Setting only TERMUX_PKG_SRCDIR to $TERMUX_PKG_SRCDIR/Project/GNU/Library and using TERMUX_PKG_BUILD_IN_SRC=true does not work because then TERMUX_PKG_BUILDDIR still points to $TERMUX_PKG_SRCDIR instead of $TERMUX_PKG_SRCDIR/Project/GNU/Library.

Versioned libraries are linked after install because other software expects them (e.g. [pymediainfo](https://github.com/sbraz/pymediainfo/blob/master/pymediainfo/__init__.py) looks for libmediainfo.so.0) and because the DEB packages provided in the official MediaInfo page have them too.