### PR TITLE
remove openssl dependency

### DIFF
--- a/packages/bitcoin/build.sh
+++ b/packages/bitcoin/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_VERSION=0.19.0.1
 TERMUX_PKG_SRCURL=https://github.com/bitcoin/bitcoin/archive/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=1a72f583f7448b3808d84ed7f8d8eb224f44b51291fee774bb9cecbd4fcbaec7
-TERMUX_PKG_DEPENDS="boost, libevent, libzmq, miniupnpc, openssl"
+TERMUX_PKG_DEPENDS="boost, libevent, libzmq, miniupnpc"
 TERMUX_PKG_CONFFILES="var/service/bitcoind/run var/service/bitcoind/log/run"
 TERMUX_PKG_BUILD_IN_SRC=true
 


### PR DESCRIPTION
openssl hasn't really been used when compiling without GUI for a long time. See https://github.com/bitcoin/bitcoin/issues/16751#issuecomment-537416760