### PR TITLE
proot: Update package

### DIFF
--- a/packages/proot/build.sh
+++ b/packages/proot/build.sh
@@ -2,11 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://proot-me.github.io/
 TERMUX_PKG_DESCRIPTION="Emulate chroot, bind mount and binfmt_misc for non-root users"
 TERMUX_PKG_LICENSE="GPL-2.0"
 # Just bump commit and version when needed:
-_COMMIT=38042a5f60b5b6a2db68f18bd8b644748b530c8b
+_COMMIT=1f4ec1c9d3fcc5d44c2a252eda6d09b0c24928cd
 TERMUX_PKG_VERSION=5.1.107
-TERMUX_PKG_REVISION=24
+TERMUX_PKG_REVISION=25
 TERMUX_PKG_SRCURL=https://github.com/termux/proot/archive/${_COMMIT}.zip
-TERMUX_PKG_SHA256=28820f7b903f5e7a15012f2c8499ba8e8acbe73afefee69f66854325d552c851
+TERMUX_PKG_SHA256=1119f1d27ca7a655eb627ad227fbd9c7a0343ea988dad3ed620fd6cd98723c20
 TERMUX_PKG_DEPENDS="libtalloc"
 
 # Install loader in libexec instead of extracting it every time


### PR DESCRIPTION
* Report /dev/shm as tmpfs (termux/proot#79)
* Avoid accessing nonexistent files on buggy f2fs file system (termux/proot#87)
* Change TCSAFLUSH flag to TCSANOW (termux/proot#88)