### PR TITLE
irssi: add support for perl and otr

### DIFF
--- a/packages/irssi/build.sh
+++ b/packages/irssi/build.sh
@@ -4,11 +4,43 @@ TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=1.2.2
 TERMUX_PKG_SRCURL=https://github.com/irssi/irssi/releases/download/$TERMUX_PKG_VERSION/irssi-$TERMUX_PKG_VERSION.tar.xz
 TERMUX_PKG_SHA256=6727060c918568ba2ff4295ad736128dba0b995d7b20491bca11f593bd857578
-TERMUX_PKG_DEPENDS="libiconv, ncurses, openssl, glib, libandroid-glob, utf8proc"
+TERMUX_PKG_DEPENDS="glib, libandroid-glob, libiconv, libotr, ncurses, openssl, perl, utf8proc"
 TERMUX_PKG_BREAKS="irssi-dev"
 TERMUX_PKG_REPLACES="irssi-dev"
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+ac_cv_path_perlpath=$TERMUX_PREFIX/bin/perl
+--enable-true-color
+--with-socks
+--with-otr=static
+--with-perl=static
+"
 
 termux_step_pre_configure() {
+	local perl_version=$(. $TERMUX_SCRIPTDIR/packages/perl/build.sh; echo $TERMUX_PKG_VERSION)
+
+	# Irssi has no support for cross-compiling perl module,
+	# so we add it ourselves.
+	sed -e "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|g" \
+		-e "s|@TERMUX_PERL_VERSION@|$perl_version|g" \
+		-e "s|@TERMUX_PERL_TARGET@|${TERMUX_ARCH}-android|g" \
+		$TERMUX_PKG_BUILDER_DIR/perl_config_support.patch.txt | \
+		patch -p1
+	autoconf
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-perl-lib=$TERMUX_PREFIX/lib/perl5/site_perl/$perl_version/${TERMUX_ARCH}-android"
+
 	LDFLAGS+=" -landroid-glob"
+
+	# Make build log less noisy.
+	CFLAGS+=" -Wno-deprecated-declarations"
+
+	# Make sure that perl stuff is reinstalled.
+	rm -rf $TERMUX_PREFIX/lib/perl5/site_perl/$perl_version/${TERMUX_ARCH}-android/x86_64-linux-gnu-thread-multi
+}
+
+termux_step_post_massage() {
+	local perl_version=$(. $TERMUX_SCRIPTDIR/packages/perl/build.sh; echo $TERMUX_PKG_VERSION)
+	mv $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/lib/perl5/site_perl/$perl_version/${TERMUX_ARCH}-android/x86_64-linux-gnu-thread-multi/* \
+		$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/lib/perl5/site_perl/$perl_version/${TERMUX_ARCH}-android/
+	rm -rf $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/lib/perl5/site_perl/$perl_version/${TERMUX_ARCH}-android/x86_64-linux-gnu-thread-multi
 }

--- a/packages/irssi/perl_config_support.patch.txt
+++ b/packages/irssi/perl_config_support.patch.txt
@@ -1,0 +1,83 @@
+diff -uNr irssi-1.2.2/configure.ac irssi-1.2.2.mod/configure.ac
+--- irssi-1.2.2/configure.ac	2019-08-29 16:48:46.000000000 +0300
++++ irssi-1.2.2.mod/configure.ac	2020-01-03 15:41:11.485918924 +0200
+@@ -119,11 +119,7 @@
+ 	elif test "x$withval" = xvendor; then
+ 		want_perl=yes
+ 		perl_prefix_note=no
+-		if test -z "`$perlpath -v|grep '5\.0'`"; then
+-			PERL_MM_PARAMS="INSTALLDIRS=vendor"
+-		else
+-			PERL_MM_PARAMS="INSTALLDIRS=perl PREFIX=`$perlpath -e 'use Config; print $Config{prefix}'`"
+-		fi
++		PERL_MM_PARAMS="INSTALLDIRS=perl PREFIX=@TERMUX_PREFIX@"
+ 		perl_set_use_lib=no
+ 	else
+ 		want_perl=yes
+@@ -401,24 +397,10 @@
+ if test "$want_perl" != "no"; then
+ 	AC_MSG_CHECKING(for working Perl support)
+ 
+-	if test -z "$perlpath"; then
+-		perl_check_error="perl binary not found"
+-	else
+-		PERL_CFLAGS=`$perlpath -MExtUtils::Embed -e ccopts 2>/dev/null`
+-	fi
++	PERL_CFLAGS="-I@TERMUX_PREFIX@/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64  -I@TERMUX_PREFIX@/lib/perl5/@TERMUX_PERL_VERSION@/@TERMUX_PERL_TARGET@/CORE"
+ 
+-	if test "x$ac_cv_prog_gcc" = "xyes" -a -z "`echo $host_os|grep 'bsd\|linux'`"; then
+-		dnl * several systems have Perl compiled with native compiler
+-		dnl * but irssi is being compiled with GCC. Here we try to
+-		dnl * fix those command line options a bit so GCC won't
+-		dnl * complain about them. Normally there's only few options
+-		dnl * that we want to keep:
+-		dnl * -Ddefine -Uundef -I/path -fopt -mopt -iwithsysroot
+-		PERL_CFLAGS=`echo $PERL_CFLAGS | $perlpath -pe 's/^(.* )?-@<:@^DUIifm@:>@@<:@^ @:>@+/\1/g; s/^(.* )?\+@<:@^ @:>@+/\1/g'`
+-
+-		PERL_EXTRA_OPTS="CCCDLFLAGS=\"-fPIC\""
+-		AC_SUBST(PERL_EXTRA_OPTS)
+-	fi
++	PERL_EXTRA_OPTS="CCCDLFLAGS=\"-fPIC\""
++	AC_SUBST(PERL_EXTRA_OPTS)
+ 
+ 	if test -z "$PERL_CFLAGS"; then
+ 		if test -n "$perl_check_error"; then
+@@ -427,7 +409,7 @@
+ 		AC_MSG_RESULT([not found, building without Perl])
+ 		want_perl=no
+ 	else
+-		PERL_LDFLAGS=`$perlpath -MExtUtils::Embed -e ldopts 2>/dev/null`
++		PERL_LDFLAGS="-Wl,-E -I@TERMUX_PREFIX@/include  -L@TERMUX_PREFIX@/lib/perl5/@TERMUX_PERL_VERSION@/@TERMUX_PERL_TARGET@/CORE -lperl -lm -ldl"
+ 
+ 		dnl * remove all database stuffs
+ 		dnl * nsl is already in ldflags
+@@ -500,13 +482,8 @@
+ 
+ 		# remove any prefix from PERL_MM_OPT
+ 		PERL_MM_OPT=`perl -MText::ParseWords -e 'sub qu{$_=shift;s{^(.*?)=(.*)$}{($a,$b)=($1,$2);$b=~s/"/\\\\"/g;qq{$a="$b"}}ge if /@<:@\s"@:>@/;$_} local $,=" "; print map qu($_), grep !/^(INSTALL_BASE|PREFIX)=/, shellwords(@ARGV)' "$PERL_MM_OPT"`
+-		# figure out the correct @INC path - we'll need to do this
+-		# through MakeMaker since it's difficult to get it right
+-		# otherwise.
+-		$perlpath -MExtUtils::MakeMaker -e 'WriteMakefile(NAME => "test", MAKEFILE => "Makefile.test", FIRST_MAKEFILE => "/dev/null", NO_META => 1, NO_MYMETA => 1);' $PERL_MM_PARAMS >/dev/null
+-		echo 'show-INSTALLDIRS:' >> Makefile.test
+-		echo '	@echo $(INSTALLDIRS)' >> Makefile.test
+-		perl_INSTALLDIRS=`$am_make -s -f Makefile.test show-INSTALLDIRS`
++
++		perl_INSTALLDIRS=site
+ 		if test "x$perl_INSTALLDIRS" = "xsite"; then
+ 			perl_library_dir="site default"
+ 			perl_INSTALL_VAR=INSTALLSITEARCH
+@@ -517,10 +494,9 @@
+ 			perl_library_dir="module default"
+ 			perl_INSTALL_VAR=INSTALLARCHLIB
+ 		fi
+-		echo 'show-ARCHLIB:' >> Makefile.test
+-		echo '	@echo $('"$perl_INSTALL_VAR"')' >> Makefile.test
+-		perl_use_lib=`$am_make -s -f Makefile.test show-ARCHLIB`
+-		rm -f Makefile.test
++
++		perl_use_lib="@TERMUX_PREFIX@/lib/perl5/site_perl/@TERMUX_PERL_VERSION@/@TERMUX_PERL_TARGET@"
++
+ 		if test "x$perl_set_use_lib" = "xyes"; then
+ 			if $perlpath -e 'exit ! grep $_ eq $ARGV@<:@0@:>@, grep /^\//, @INC' "$perl_use_lib"; then
+ 				perl_library_dir="other path in @INC"

--- a/packages/irssi/perlfix.patch
+++ b/packages/irssi/perlfix.patch
@@ -1,0 +1,100 @@
+diff -uNr irssi-1.2.2/src/perl/common/Makefile.PL.in irssi-1.2.2.mod/src/perl/common/Makefile.PL.in
+--- irssi-1.2.2/src/perl/common/Makefile.PL.in	2019-08-29 16:48:46.000000000 +0300
++++ irssi-1.2.2.mod/src/perl/common/Makefile.PL.in	2020-01-03 17:29:11.576800661 +0200
+@@ -1,7 +1,7 @@
+ use ExtUtils::MakeMaker;our $AM_DEFAULT_VERBOSITY='@AM_DEFAULT_VERBOSITY@';require "@top_srcdir@/src/perl/Makefile_silent.pm";
+ 
+ WriteMakefile('NAME' => 'Irssi',
+-              'LIBS' => '',
++              'LIBS' => '-L@TERMUX_PREFIX@/lib -lperl -lglib-2.0',
+ 	      'OBJECT' => '$(O_FILES)',
+               'INC' => '-I../../.. -I@top_srcdir@ -I@top_srcdir@/src -I@top_srcdir@/src/core @GLIB_CFLAGS@',
+ 	      'VERSION_FROM' => '@srcdir@/Irssi.pm');
+diff -uNr irssi-1.2.2/src/perl/irc/Makefile.PL.in irssi-1.2.2.mod/src/perl/irc/Makefile.PL.in
+--- irssi-1.2.2/src/perl/irc/Makefile.PL.in	2019-08-29 16:48:46.000000000 +0300
++++ irssi-1.2.2.mod/src/perl/irc/Makefile.PL.in	2020-01-03 17:29:19.232854109 +0200
+@@ -1,7 +1,7 @@
+ use ExtUtils::MakeMaker;our $AM_DEFAULT_VERBOSITY='@AM_DEFAULT_VERBOSITY@';require "@top_srcdir@/src/perl/Makefile_silent.pm";
+ 
+ WriteMakefile('NAME' => 'Irssi::Irc',
+-              'LIBS' => '',
++              'LIBS' => '-L@TERMUX_PREFIX@/lib -lperl -lglib-2.0',
+ 	      'OBJECT' => '$(O_FILES)',
+               'TYPEMAPS' => ['../common/typemap'],
+               'INC' => '-I../../.. -I@top_srcdir@/src -I@top_srcdir@/src/core -I@top_srcdir@/src/irc/core -I@top_srcdir@/src/irc @GLIB_CFLAGS@',
+diff -uNr irssi-1.2.2/src/perl/Makefile.am irssi-1.2.2.mod/src/perl/Makefile.am
+--- irssi-1.2.2/src/perl/Makefile.am	2019-08-29 16:48:46.000000000 +0300
++++ irssi-1.2.2.mod/src/perl/Makefile.am	2020-01-03 17:00:24.640885164 +0200
+@@ -56,7 +56,7 @@
+ 	$(perl_fe_sources)
+ 
+ perl-signals-list.h: $(top_srcdir)/docs/signals.txt $(srcdir)/get-signals.pl
+-	cat $(top_srcdir)/docs/signals.txt | $(perlpath) $(srcdir)/get-signals.pl > perl-signals-list.h
++	cat $(top_srcdir)/docs/signals.txt | perl $(srcdir)/get-signals.pl > perl-signals-list.h
+ 
+ irssi-core.pl.h: irssi-core.pl
+ 	$(top_srcdir)/utils/file2header.sh $(srcdir)/irssi-core.pl irssi_core_code > irssi-core.pl.h
+@@ -136,10 +136,10 @@
+ 	$(AM_V_GEN)for dir in $(perl_dirs); do \
+ 	  cd $$dir && \
+ 	  if [ ! -f Makefile ]; then \
+-	    $(am_v_pl__show_gen)$(perlpath) Makefile.PL $(PERL_MM_PARAMS) $(am_v_pl__hide_gen); \
++	    $(am_v_pl__show_gen)perl Makefile.PL $(PERL_MM_PARAMS) $(am_v_pl__hide_gen); \
+ 	  fi && \
+-	  ($(MAKE) CC="$(CC)" CCFLAGS="$(PERL_CFLAGS) $(CFLAGS)" $(PERL_EXTRA_OPTS) || \
+-	   $(MAKE) CC="$(CC)" CCFLAGS="$(PERL_CFLAGS) $(CFLAGS)" $(PERL_EXTRA_OPTS)) && \
++	  ($(MAKE) CC="$(CC)" LD="$(CC) -Wl,-rpath=@TERMUX_PREFIX@/lib,--enable-new-dtags" CCFLAGS="$(PERL_CFLAGS) $(CFLAGS)" $(PERL_EXTRA_OPTS) || \
++	   $(MAKE) CC="$(CC)" LD="$(CC) -Wl,-rpath=@TERMUX_PREFIX@/lib,--enable-new-dtags" CCFLAGS="$(PERL_CFLAGS) $(CFLAGS)" $(PERL_EXTRA_OPTS)) && \
+ 	  cd ..; \
+ 	done
+ 
+diff -uNr irssi-1.2.2/src/perl/Makefile.in irssi-1.2.2.mod/src/perl/Makefile.in
+--- irssi-1.2.2/src/perl/Makefile.in	2019-08-29 16:49:03.000000000 +0300
++++ irssi-1.2.2.mod/src/perl/Makefile.in	2020-01-03 17:00:24.641885171 +0200
+@@ -880,7 +880,7 @@
+ perl-signals.lo: perl-signals-list.h
+ 
+ perl-signals-list.h: $(top_srcdir)/docs/signals.txt $(srcdir)/get-signals.pl
+-	cat $(top_srcdir)/docs/signals.txt | $(perlpath) $(srcdir)/get-signals.pl > perl-signals-list.h
++	cat $(top_srcdir)/docs/signals.txt | perl $(srcdir)/get-signals.pl > perl-signals-list.h
+ 
+ irssi-core.pl.h: irssi-core.pl
+ 	$(top_srcdir)/utils/file2header.sh $(srcdir)/irssi-core.pl irssi_core_code > irssi-core.pl.h
+@@ -889,10 +889,10 @@
+ 	$(AM_V_GEN)for dir in $(perl_dirs); do \
+ 	  cd $$dir && \
+ 	  if [ ! -f Makefile ]; then \
+-	    $(am_v_pl__show_gen)$(perlpath) Makefile.PL $(PERL_MM_PARAMS) $(am_v_pl__hide_gen); \
++	    $(am_v_pl__show_gen)perl Makefile.PL $(PERL_MM_PARAMS) $(am_v_pl__hide_gen); \
+ 	  fi && \
+-	  ($(MAKE) CC="$(CC)" CCFLAGS="$(PERL_CFLAGS) $(CFLAGS)" $(PERL_EXTRA_OPTS) || \
+-	   $(MAKE) CC="$(CC)" CCFLAGS="$(PERL_CFLAGS) $(CFLAGS)" $(PERL_EXTRA_OPTS)) && \
++	  ($(MAKE) CC="$(CC)" LD="$(CC) -Wl,-rpath=@TERMUX_PREFIX@/lib,--enable-new-dtags" CCFLAGS="$(PERL_CFLAGS) $(CFLAGS)" $(PERL_EXTRA_OPTS) || \
++	   $(MAKE) CC="$(CC)" LD="$(CC) -Wl,-rpath=@TERMUX_PREFIX@/lib,--enable-new-dtags" CCFLAGS="$(PERL_CFLAGS) $(CFLAGS)" $(PERL_EXTRA_OPTS)) && \
+ 	  cd ..; \
+ 	done
+ 
+diff -uNr irssi-1.2.2/src/perl/textui/Makefile.PL.in irssi-1.2.2.mod/src/perl/textui/Makefile.PL.in
+--- irssi-1.2.2/src/perl/textui/Makefile.PL.in	2019-08-29 16:48:46.000000000 +0300
++++ irssi-1.2.2.mod/src/perl/textui/Makefile.PL.in	2020-01-03 17:29:04.152748835 +0200
+@@ -1,7 +1,7 @@
+ use ExtUtils::MakeMaker;our $AM_DEFAULT_VERBOSITY='@AM_DEFAULT_VERBOSITY@';require "@top_srcdir@/src/perl/Makefile_silent.pm";
+ 
+ WriteMakefile('NAME' => 'Irssi::TextUI',
+-              'LIBS' => '',
++              'LIBS' => '-L@TERMUX_PREFIX@/lib -lperl -lglib-2.0',
+ 	      'OBJECT' => '$(O_FILES)',
+               'TYPEMAPS' => ['../common/typemap', '../ui/typemap'],
+               'INC' => '-I../../.. -I@top_srcdir@/src -I@top_srcdir@/src/core -I@top_srcdir@/src/fe-common/core -I@top_srcdir@/src/fe-text @GLIB_CFLAGS@',
+diff -uNr irssi-1.2.2/src/perl/ui/Makefile.PL.in irssi-1.2.2.mod/src/perl/ui/Makefile.PL.in
+--- irssi-1.2.2/src/perl/ui/Makefile.PL.in	2019-08-29 16:48:46.000000000 +0300
++++ irssi-1.2.2.mod/src/perl/ui/Makefile.PL.in	2020-01-03 17:28:55.488688351 +0200
+@@ -1,7 +1,7 @@
+ use ExtUtils::MakeMaker;our $AM_DEFAULT_VERBOSITY='@AM_DEFAULT_VERBOSITY@';require "@top_srcdir@/src/perl/Makefile_silent.pm";
+ 
+ WriteMakefile('NAME' => 'Irssi::UI',
+-              'LIBS' => '',
++              'LIBS' => '-L@TERMUX_PREFIX@/lib -lperl -lglib-2.0',
+ 	      'OBJECT' => '$(O_FILES)',
+               'TYPEMAPS' => ['../common/typemap'],
+               'INC' => '-I../../.. -I@top_srcdir@/src -I@top_srcdir@/src/core -I@top_srcdir@/src/fe-common/core @GLIB_CFLAGS@',


### PR DESCRIPTION
Enables some more features for Irssi.

Modules are static only (due to https://github.com/android/ndk/issues/201).
***

Related issues:

- https://github.com/termux/termux-packages/issues/4036
- https://github.com/termux/termux-packages/issues/2989