### PR TITLE
hub: attempt to fix build error

### DIFF
--- a/packages/hub/build.sh
+++ b/packages/hub/build.sh
@@ -17,6 +17,11 @@ termux_step_host_build() {
 	cp -a "${TERMUX_PKG_SRCDIR}" "${GOPATH}/src/github.com/github/hub"
 
 	cd "${GOPATH}/src/github.com/github/hub"
+
+	sudo apt update
+	sudo apt install -yq locales
+	sudo locale-gen --purge en_US.UTF-8
+	export LANG=en_US.UTF-8
 	make man-pages
 }
 


### PR DESCRIPTION
Attempt to fix
```
groff -Wall -mtty-char -mandoc -Tutf8 -rLL=87n share/man/man1/hub.1 | col -b >share/man/man1/hub.1.txt
col: Invalid or incomplete multibyte or wide character
make: *** [Makefile:77: share/man/man1/hub.1.txt] Error 1
```
which is unreproducible locally.