### PR TITLE
Add termux_step_install_service_scripts and TERMUX_PKG_SERVICE_SCRIPT

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -159,6 +159,10 @@ termux_step_post_make_install() {
 	return
 }
 
+# Add service scripts from array TERMUX_PKG_SERVICE_SCRIPT, if it is set
+# shellcheck source=scripts/build/termux_step_install_service_scripts.sh
+source "$TERMUX_SCRIPTDIR/scripts/build/termux_step_install_service_scripts.sh"
+
 # Link/copy the LICENSE for the package to $TERMUX_PREFIX/share/$TERMUX_PKG_NAME/
 # shellcheck source=scripts/build/termux_step_install_license.sh
 source "$TERMUX_SCRIPTDIR/scripts/build/termux_step_install_license.sh"
@@ -322,6 +326,7 @@ while (($# > 0)); do
 		termux_step_make_install
 		cd "$TERMUX_PKG_BUILDDIR"
 		termux_step_post_make_install
+                termux_step_install_service_scripts
 		termux_step_install_license
 		cd "$TERMUX_PKG_MASSAGEDIR"
 		termux_step_extract_into_massagedir

--- a/packages/busybox/build.sh
+++ b/packages/busybox/build.sh
@@ -77,7 +77,7 @@ termux_step_post_make_install() {
 	cd $TERMUX_PREFIX/var/service
 	mkdir -p ftpd/log telnetd/log
 	echo "#!$TERMUX_PREFIX/bin/sh" > ftpd/run
-	echo 'exec busybox tcpsvd -vE 0.0.0.0 8021 ftpd /data/data/com.termux/files/home' >> ftpd/run
+	echo 'exec busybox tcpsvd -vE 0.0.0.0 8021 ftpd $HOME' >> ftpd/run
 	echo "#!$TERMUX_PREFIX/bin/sh" > telnetd/run
 	echo 'exec busybox telnetd -F' >> telnetd/run
 	chmod +x */run

--- a/packages/busybox/build.sh
+++ b/packages/busybox/build.sh
@@ -8,10 +8,11 @@ TERMUX_PKG_SHA256=d0f940a72f648943c1f2211e0e3117387c31d765137d92bd8284a3fb9752a9
 TERMUX_PKG_BUILD_IN_SRC=true
 # We replace env in the old coreutils package:
 TERMUX_PKG_CONFLICTS="coreutils (<< 8.25-4)"
-TERMUX_PKG_CONFFILES="
-var/service/telnetd/run var/service/telnetd/log/run
-var/service/ftpd/run var/service/ftpd/log/run
-var/service/crond/run var/service/crond/log/run"
+TERMUX_PKG_SERVICE_SCRIPT=(
+	"telnetd" 'exec busybox telnetd -F'
+	"ftpd" 'exec busybox tcpsvd -vE 0.0.0.0 8021 ftpd $HOME'
+	"crond" 'exec buxybox crond -f -d 0 2>&1'
+)
 
 termux_step_pre_configure() {
 	# Certain packages are not safe to build on device because their
@@ -74,20 +75,4 @@ termux_step_post_make_install() {
 	local _CRONTABS=$TERMUX_PREFIX/var/spool/cron/crontabs
 	mkdir -p $_CRONTABS
 	echo "Used by the busybox crontab and crond tools" > $_CRONTABS/README.termux
-
-	# Setup some services
-	mkdir -p $TERMUX_PREFIX/var/service
-	cd $TERMUX_PREFIX/var/service
-	mkdir -p ftpd/log telnetd/log crond/log
-	echo "#!$TERMUX_PREFIX/bin/sh" > ftpd/run
-	echo 'exec busybox tcpsvd -vE 0.0.0.0 8021 ftpd $HOME' >> ftpd/run
-	echo "#!$TERMUX_PREFIX/bin/sh" > telnetd/run
-	echo 'exec busybox telnetd -F' >> telnetd/run
-	echo "#!$TERMUX_PREFIX/bin/sh" > crond/run
-	echo 'exec crond -f -d 0 2>&1' >> crond/run
-	chmod +x */run
-	touch telnetd/down ftpd/down crond/down
-	ln -sf $TERMUX_PREFIX/share/termux-services/svlogger telnetd/log/run
-	ln -sf $TERMUX_PREFIX/share/termux-services/svlogger ftpd/log/run
-	ln -sf $TERMUX_PREFIX/share/termux-services/svlogger crond/log/run
 }

--- a/packages/busybox/build.sh
+++ b/packages/busybox/build.sh
@@ -2,13 +2,16 @@ TERMUX_PKG_HOMEPAGE=https://busybox.net/
 TERMUX_PKG_DESCRIPTION="Tiny versions of many common UNIX utilities into a single small executable"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=1.31.1
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://busybox.net/downloads/busybox-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=d0f940a72f648943c1f2211e0e3117387c31d765137d92bd8284a3fb9752a998
 TERMUX_PKG_BUILD_IN_SRC=true
 # We replace env in the old coreutils package:
 TERMUX_PKG_CONFLICTS="coreutils (<< 8.25-4)"
-TERMUX_PKG_CONFFILES="var/service/telnetd/run var/service/telnetd/log/run var/service/ftpd/run var/service/ftpd/log/run"
+TERMUX_PKG_CONFFILES="
+var/service/telnetd/run var/service/telnetd/log/run
+var/service/ftpd/run var/service/ftpd/log/run
+var/service/crond/run var/service/crond/log/run"
 
 termux_step_pre_configure() {
 	# Certain packages are not safe to build on device because their
@@ -75,14 +78,16 @@ termux_step_post_make_install() {
 	# Setup some services
 	mkdir -p $TERMUX_PREFIX/var/service
 	cd $TERMUX_PREFIX/var/service
-	mkdir -p ftpd/log telnetd/log
+	mkdir -p ftpd/log telnetd/log crond/log
 	echo "#!$TERMUX_PREFIX/bin/sh" > ftpd/run
 	echo 'exec busybox tcpsvd -vE 0.0.0.0 8021 ftpd $HOME' >> ftpd/run
 	echo "#!$TERMUX_PREFIX/bin/sh" > telnetd/run
 	echo 'exec busybox telnetd -F' >> telnetd/run
+	echo "#!$TERMUX_PREFIX/bin/sh" > crond/run
+	echo 'exec crond -f -d 0 2>&1' >> crond/run
 	chmod +x */run
-	touch telnetd/down ftpd/down
-	ln -sf $PREFIX/share/termux-services/svlogger telnetd/log/run
-	ln -sf $PREFIX/share/termux-services/svlogger ftpd/log/run
+	touch telnetd/down ftpd/down crond/down
+	ln -sf $TERMUX_PREFIX/share/termux-services/svlogger telnetd/log/run
+	ln -sf $TERMUX_PREFIX/share/termux-services/svlogger ftpd/log/run
+	ln -sf $TERMUX_PREFIX/share/termux-services/svlogger crond/log/run
 }
-

--- a/packages/emacs/build.sh
+++ b/packages/emacs/build.sh
@@ -8,7 +8,7 @@ TERMUX_PKG_SHA256=4d90e6751ad8967822c6e092db07466b9d383ef1653feb2f95c93e7de66d34
 TERMUX_PKG_DEPENDS="ncurses, gnutls, libxml2"
 TERMUX_PKG_BREAKS="emacs-dev"
 TERMUX_PKG_REPLACES="emacs-dev"
-TERMUX_PKG_CONFFILES="var/service/emacsd/run var/service/emacsd/log/run"
+TERMUX_PKG_SERVICE_SCRIPT=("emacsd" 'exec emacs --fg-daemon 2>&1')
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-autodepend
 --with-gif=no
@@ -84,17 +84,6 @@ termux_step_post_configure() {
 
 termux_step_post_make_install() {
 	cp $TERMUX_PKG_BUILDER_DIR/site-init.el $TERMUX_PREFIX/share/emacs/${TERMUX_PKG_VERSION}/lisp/emacs-lisp/
-
-	# Setup emacs --daemon service script
-	mkdir -p $TERMUX_PREFIX/var/service
-	cd $TERMUX_PREFIX/var/service
-	mkdir -p emacsd/log
-	echo "#!$TERMUX_PREFIX/bin/sh" > emacsd/run
-	echo 'exec emacs --fg-daemon 2>&1' >> emacsd/run
-	chmod +x emacsd/run
-	touch emacsd/down
-
-	ln -sf $TERMUX_PREFIX/share/termux-services/svlogger emacsd/log/run
 }
 
 termux_step_create_debscripts() {

--- a/packages/mpd/build.sh
+++ b/packages/mpd/build.sh
@@ -17,7 +17,8 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dpcre=disabled
 -Dsndio=disabled
 "
-TERMUX_PKG_CONFFILES="etc/mpd.conf var/service/mpd/run var/service/mpd/log/run"
+TERMUX_PKG_CONFFILES="etc/mpd.conf"
+TERMUX_PKG_SERVICE_SCRIPT=("mpd" 'if [ -f "$HOME/.mpd/mpd.conf" ]; then CONFIG="$HOME/.mpd/mpd.conf"; else CONFIG="$PREFIX/etc/mpd.conf"; fi\nexec mpd --stdout --no-daemon $CONFIG 2>&1')
 
 termux_step_pre_configure() {
 	# Certain packages are not safe to build on device because their
@@ -33,17 +34,6 @@ termux_step_pre_configure() {
 
 termux_step_post_make_install() {
 	install -Dm600 $TERMUX_PKG_SRCDIR/doc/mpdconf.example $TERMUX_PREFIX/etc/mpd.conf
-
-	# Setup mpd service script
-	mkdir -p $TERMUX_PREFIX/var/service
-	cd $TERMUX_PREFIX/var/service
-	mkdir -p mpd/log
-	echo "#!$TERMUX_PREFIX/bin/sh" > mpd/run
-	echo 'if [ -f "$HOME/.mpd/mpd.conf" ]; then CONFIG="$HOME/.mpd/mpd.conf"; else CONFIG="$PREFIX/etc/mpd.conf"; fi' >> mpd/run
-	echo 'exec mpd --stdout --no-daemon $CONFIG 2>&1' >> mpd/run
-	chmod +x mpd/run
-	touch mpd/down
-	ln -sf $PREFIX/share/termux-services/svlogger mpd/log/run
 }
 
 termux_step_create_debscripts() {

--- a/packages/openssh/build.sh
+++ b/packages/openssh/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://www.openssh.com/
 TERMUX_PKG_DESCRIPTION="Secure shell for logging into a remote machine"
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_VERSION=8.1p1
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=https://fastly.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=02f5dbef3835d0753556f973cd57b4c19b6b1f6cd24c03445e23ac77ca1b93ff
 TERMUX_PKG_DEPENDS="libandroid-support, ldns, openssl, libedit, termux-auth, krb5, zlib"
@@ -41,7 +41,8 @@ ac_cv_func_bzero=yes
 "
 TERMUX_PKG_MAKE_INSTALL_TARGET="install-nokeys"
 TERMUX_PKG_RM_AFTER_INSTALL="bin/slogin share/man/man1/slogin.1"
-TERMUX_PKG_CONFFILES="etc/ssh/ssh_config etc/ssh/sshd_config var/service/sshd/run var/service/sshd/log/run"
+TERMUX_PKG_CONFFILES="etc/ssh/ssh_config etc/ssh/sshd_config"
+TERMUX_PKG_SERVICE_SCRIPT=("sshd" 'exec sshd -D -e 2>&1')
 
 termux_step_pre_configure() {
 	# Certain packages are not safe to build on device because their
@@ -83,16 +84,6 @@ termux_step_post_make_install() {
 
 	mkdir -p $TERMUX_PREFIX/etc/ssh/
 	cp $TERMUX_PKG_SRCDIR/moduli $TERMUX_PREFIX/etc/ssh/moduli
-
-	# Setup sshd services
-	mkdir -p $TERMUX_PREFIX/var/service
-	cd $TERMUX_PREFIX/var/service
-	mkdir -p sshd/log
-	echo '#!/bin/sh' > sshd/run
-	echo 'exec sshd -D -e 2>&1' >> sshd/run
-	chmod +x sshd/run
-	touch sshd/down
-	ln -sf $TERMUX_PREFIX/share/termux-services/svlogger sshd/log/run
 }
 
 termux_step_post_massage() {

--- a/packages/tor/build.sh
+++ b/packages/tor/build.sh
@@ -7,19 +7,10 @@ TERMUX_PKG_SRCURL=https://www.torproject.org/dist/tor-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=4d5975862e7808faebe9960def6235669fafeeac844cb76965501fa7af79d8c2
 TERMUX_PKG_DEPENDS="libevent, openssl, liblzma, zlib"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-zstd --disable-unittests"
-TERMUX_PKG_CONFFILES="etc/tor/torrc var/service/tor/run var/service/tor/log/run"
+TERMUX_PKG_CONFFILES="etc/tor/torrc"
+TERMUX_PKG_SERVICE_SCRIPT=("tor" 'exec tor 2>&1')
 
 termux_step_post_make_install() {
 	# use default config
 	mv "$TERMUX_PREFIX/etc/tor/torrc.sample" "$TERMUX_PREFIX/etc/tor/torrc"
-
-	# Setup tor service script
-	mkdir -p $TERMUX_PREFIX/var/service
-	cd $TERMUX_PREFIX/var/service
-	mkdir -p tor/log
-	echo "#!$TERMUX_PREFIX/bin/sh" > tor/run
-	echo 'exec tor 2>&1' >> tor/run
-	chmod +x tor/run
-	touch tor/down
-	ln -sf $PREFIX/share/termux-services/svlogger tor/log/run
 }

--- a/packages/transmission/build.sh
+++ b/packages/transmission/build.sh
@@ -7,7 +7,12 @@ TERMUX_PKG_SRCURL=https://github.com/transmission/transmission/archive/${TERMUX_
 TERMUX_PKG_SHA256=440c2fd0f89b1ab59d8a4b79ecd7bffd61bc000e36fb5b6c8e88142a4fadbb1f
 TERMUX_PKG_DEPENDS="libcurl, libevent, miniupnpc, openssl"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-gtk --enable-lightweight --cache-file=termux_configure.cache"
-TERMUX_PKG_CONFFILES="var/service/transmission/run var/service/transmission/log/run"
+# transmission already puts timestamps in the info printed to stdout so no need for svlogd -tt,
+# therefore we override the transmission/log run script
+TERMUX_PKG_SERVICE_SCRIPT=(
+	"transmission" 'mkdir -p ~/torrent/torrent-files\nmkdir -p ~/torrent/download\nexec transmission-daemon -f -c ~/torrent/torrent-files -w ~/torrent/download 2>&1'
+	"transmission/log" 'mkdir -p "$LOGDIR/sv/transmission"\nexec svlogd "$LOGDIR/sv/transmission"'
+)
 
 termux_step_pre_configure() {
 	./autogen.sh
@@ -15,26 +20,4 @@ termux_step_pre_configure() {
 	echo "ac_cv_func_getmntent=no" >> termux_configure.cache
 	echo "ac_cv_search_getmntent=false" >> termux_configure.cache
 	chmod a-w termux_configure.cache
-}
-
-termux_step_post_make_install() {
-	# Setup transmission service script
-	mkdir -p $TERMUX_PREFIX/var/service
-	cd $TERMUX_PREFIX/var/service
-	mkdir -p transmission/log
-	echo "#!$TERMUX_PREFIX/bin/sh" > transmission/run
-	echo 'mkdir -p ~/torrent/torrent-files' >> transmission/run
-	echo 'mkdir -p ~/torrent/download' >> transmission/run
-	echo 'exec transmission-daemon \' >> transmission/run
-	echo '    -f \' >> transmission/run
-	echo '    -c ~/torrent/torrent-files \' >> transmission/run
-	echo '    -w ~/torrent/download \' >> transmission/run
-	echo '    2>&1' >> transmission/run
-	chmod +x transmission/run
-	touch transmission/down
-
-	echo "#!$TERMUX_PREFIX/bin/sh" > transmission/log/run
-	echo 'mkdir -p "$LOGDIR/sv/transmission"' >> transmission/log/run
-	echo 'exec svlogd "$LOGDIR/sv/transmission"' >> transmission/log/run
-	chmod +x transmission/log/run
 }

--- a/scripts/build/termux_step_install_service_scripts.sh
+++ b/scripts/build/termux_step_install_service_scripts.sh
@@ -1,0 +1,26 @@
+termux_step_install_service_scripts() {
+	array_length=${#TERMUX_PKG_SERVICE_SCRIPT[@]}
+	if [ $array_length -eq 0 ]; then return; fi
+
+	# TERMUX_PKG_SERVICE_SCRIPT should have the structure =("daemon name" 'script to execute')
+	if [ $(( $array_length & 1 )) -eq 1 ]; then
+		termux_error_exit "TERMUX_PKG_SERVICE_SCRIPT has to be an array of even length"
+	fi
+
+	mkdir -p $TERMUX_PREFIX/var/service
+	cd $TERMUX_PREFIX/var/service
+	for ((i=0; i<${array_length}; i+=2)); do
+		mkdir -p ${TERMUX_PKG_SERVICE_SCRIPT[$i]}/log
+		echo "#!$TERMUX_PREFIX/bin/sh" > ${TERMUX_PKG_SERVICE_SCRIPT[$i]}/run
+		echo -e ${TERMUX_PKG_SERVICE_SCRIPT[$((i + 1))]} >> ${TERMUX_PKG_SERVICE_SCRIPT[$i]}/run
+
+		TERMUX_PKG_CONFFILES+="
+		var/service/${TERMUX_PKG_SERVICE_SCRIPT[$i]}/run
+		var/service/${TERMUX_PKG_SERVICE_SCRIPT[$i]}/log/run
+		"
+
+		chmod +x ${TERMUX_PKG_SERVICE_SCRIPT[$i]}/run
+		touch ${TERMUX_PKG_SERVICE_SCRIPT[$i]}/down
+		ln -sf $TERMUX_PREFIX/share/termux-services/svlogger ${TERMUX_PKG_SERVICE_SCRIPT[$i]}/log/run
+	done
+}

--- a/scripts/build/termux_step_setup_variables.sh
+++ b/scripts/build/termux_step_setup_variables.sh
@@ -125,6 +125,7 @@ termux_step_setup_variables() {
 	TERMUX_PKG_SUGGESTS=""
 	TERMUX_PKG_REPLACES=""
 	TERMUX_PKG_PROVIDES="" #https://www.debian.org/doc/debian-policy/#virtual-packages-provides
+        TERMUX_PKG_SERVICE_SCRIPT=() # Fill with entries like: ("daemon name" 'script to execute'). Script is echoed with -e so can contain \n for multiple lines
 	TERMUX_PKG_CONFFILES=""
 	# Set if a host build should be done in TERMUX_PKG_HOSTBUILD_DIR:
 	TERMUX_PKG_HOSTBUILD=false

--- a/scripts/lint-packages.sh
+++ b/scripts/lint-packages.sh
@@ -378,6 +378,17 @@ lint_package() {
 			unset file_path_ok
 		fi
 
+		if [ -n "$TERMUX_PKG_SERVICE_SCRIPT" ]; then
+			echo -n "TERMUX_PKG_SERVICE_SCRIPT: "
+			array_length=${#TERMUX_PKG_SERVICE_SCRIPT[@]}
+			if [ $(( $array_length & 1 )) -eq 1 ]; then
+				echo "INVALID (TERMUX_PKG_SERVICE_SCRIPT has to be an array of even length)"
+				pkg_lint_error=true
+			else
+				echo "PASS"
+			fi
+		fi
+
 		if $pkg_lint_error; then
 			exit 1
 		else


### PR DESCRIPTION
Makes it easier to add termux-services script. 

termux_step_install_service_scripts is run after
termux_step_post_make_install and loops over the new array
TERMUX_PKG_SERVICE_SCRIPT to add service scripts for termux-services.

The service scripts are usually only a one-liner so we might just as
well define it in a variable like TERMUX_PKG_SERVICE_SCRIPT.

TERMUX_PKG_SERVICE_SCRIPT should be an array on the format
("daemon-name" 'script to execute' "another daemon" 'multi\n line\n script'),
i.e. it should be of even length with name + script where the script
part preferably is within single quotes (to avoid accidental expansion
of for example $HOME).