### PR TITLE
nodejs: avoid FICLONE ioctl

### DIFF
--- a/packages/nodejs/avoid-ficlone-ioctl.patch
+++ b/packages/nodejs/avoid-ficlone-ioctl.patch
@@ -1,0 +1,20 @@
+diff -uNr node-v13.0.0/deps/uv/src/unix/fs.c node-v13.0.0.mod/deps/uv/src/unix/fs.c
+--- node-v13.0.0/deps/uv/src/unix/fs.c	2019-10-22 17:23:28.000000000 +0300
++++ node-v13.0.0.mod/deps/uv/src/unix/fs.c	2020-01-16 02:27:44.944603915 +0200
+@@ -1048,6 +1048,7 @@
+     goto out;
+   }
+ 
++#ifndef __ANDROID__
+ #ifdef FICLONE
+   if (req->flags & UV_FS_COPYFILE_FICLONE ||
+       req->flags & UV_FS_COPYFILE_FICLONE_FORCE) {
+@@ -1072,7 +1073,7 @@
+     goto out;
+   }
+ #endif
+-
++#endif
+   bytes_to_send = src_statsbuf.st_size;
+   in_offset = 0;
+   while (bytes_to_send != 0) {

--- a/packages/nodejs/build.sh
+++ b/packages/nodejs/build.sh
@@ -2,6 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://nodejs.org/
 TERMUX_PKG_DESCRIPTION="Platform built on Chrome's JavaScript runtime for easily building fast, scalable network applications"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_VERSION=13.0.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=45ff3b40afc3fc93fd62e31c0f5dfa046f307f0b33d0f32e09019f306bc74767
 # Note that we do not use a shared libuv to avoid an issue with the Android


### PR DESCRIPTION
FICLONE ioctl may trigger EACCES when executing copyfile().