### PR TITLE
termux_step_setup_toolchain.sh: don't add duplicate rpath for on-device builds

### DIFF
--- a/scripts/build/termux_step_setup_toolchain.sh
+++ b/scripts/build/termux_step_setup_toolchain.sh
@@ -24,6 +24,7 @@ termux_step_setup_toolchain() {
 		if [ $TERMUX_ARCH = arm ]; then
 			CCTERMUX_HOST_PLATFORM=armv7a-linux-androideabi$TERMUX_PKG_API_LEVEL
 		fi
+		LDFLAGS+=" -Wl,-rpath=$TERMUX_PREFIX/lib"
 	else
 		export CC_FOR_BUILD=$CC
 		# Some build scripts use environment variable 'PKG_CONFIG', so
@@ -53,7 +54,7 @@ termux_step_setup_toolchain() {
 	fi
 
 	# Android 7 started to support DT_RUNPATH (but not DT_RPATH).
-	LDFLAGS+=" -Wl,-rpath=$TERMUX_PREFIX/lib,--enable-new-dtags"
+	LDFLAGS+=" -Wl,--enable-new-dtags"
 
 	# Avoid linking extra (unneeded) libraries.
 	LDFLAGS+=" -Wl,--as-needed"


### PR DESCRIPTION
Unlike the NDK clang, the on-device clang has already been patched to add an rpath to the Termux-prefixed library path, so only have the build script add the rpath flag for NDK builds.

I noticed binaries built on-device had this path listed twice. I don't think this order change of LDFLAGS matters.