### PR TITLE
termux_step_extract_into_massagedir.sh: don't add tmp/ files to packages, particularly on-device

### DIFF
--- a/scripts/build/termux_step_extract_into_massagedir.sh
+++ b/scripts/build/termux_step_extract_into_massagedir.sh
@@ -4,7 +4,7 @@ termux_step_extract_into_massagedir() {
 	# Build diff tar with what has changed during the build:
 	cd $TERMUX_PREFIX
 	tar -N "$TERMUX_BUILD_TS_FILE" \
-		--exclude='lib/libutil.so' \
+		--exclude='lib/libutil.so' --exclude='tmp' \
 		-czf "$TARBALL_ORIG" .
 
 	# Extract tar in order to massage it


### PR DESCRIPTION
I've been running into problems with this for on-device builds from the beginning, where it will try to stick files from `$PREFIX/tmp` into packages and fail for various reasons. Finally looked into how new packages are generated, this seems to fix it.