### PR TITLE
enforce gnu format for deb tar archives

### DIFF
--- a/scripts/build/termux_step_create_datatar.sh
+++ b/scripts/build/termux_step_create_datatar.sh
@@ -17,5 +17,5 @@ termux_step_create_datatar() {
 		fi
 	fi
 
-	tar -cJf "$TERMUX_PKG_PACKAGEDIR/data.tar.xz" .
+	tar -cJf "$TERMUX_PKG_PACKAGEDIR/data.tar.xz" -H gnu .
 }

--- a/scripts/build/termux_step_create_debfile.sh
+++ b/scripts/build/termux_step_create_debfile.sh
@@ -35,7 +35,7 @@ termux_step_create_debfile() {
 	termux_step_create_debscripts
 
 	# Create control.tar.gz
-	tar -czf "$TERMUX_PKG_PACKAGEDIR/control.tar.gz" .
+	tar -czf "$TERMUX_PKG_PACKAGEDIR/control.tar.gz" -H gnu .
 
 	test ! -f "$TERMUX_COMMON_CACHEDIR/debian-binary" && echo "2.0" > "$TERMUX_COMMON_CACHEDIR/debian-binary"
 	TERMUX_PKG_DEBFILE=$TERMUX_DEBDIR/${TERMUX_PKG_NAME}${DEBUG}_${TERMUX_PKG_FULLVERSION}_${TERMUX_ARCH}.deb


### PR DESCRIPTION
PAX aka POSIX is not supported in termux deb

Some (as openSUSE) distro tars take already the future default tar format PAX instead of gnu. But termux deb fails to install anything but "gnu" format so far.

Fixes install errors with

 corrupted filesystem tarfile in package archive: unsupported PAX tar header type 'x'