### PR TITLE
emacs: potential fix for segfaults on arm

### DIFF
--- a/packages/emacs/build.sh
+++ b/packages/emacs/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/emacs/
 TERMUX_PKG_DESCRIPTION="Extensible, customizable text editor-and more"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_VERSION=26.3
-TERMUX_PKG_REVISION=4
+TERMUX_PKG_REVISION=5
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/emacs/emacs-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=4d90e6751ad8967822c6e092db07466b9d383ef1653feb2f95c93e7de66d3485
 TERMUX_PKG_DEPENDS="ncurses, gnutls, libxml2"
@@ -34,6 +34,12 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_lib_elf_elf_begin=no"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" gl_cv_func_dup2_works=no"
 # disable setrlimit function to make termux-am work from within emacs
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_func_setrlimit=no"
+if [ "$TERMUX_ARCH" == "arm" ]; then
+	# setjmp does not work properly on arm:
+	# https://github.com/termux/termux-packages/issues/2599
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" emacs_cv_func__setjmp=no"
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" emacs_cv_func_sigsetjmp=no"
+fi
 TERMUX_PKG_HOSTBUILD=true
 
 # Remove some irrelevant files:


### PR DESCRIPTION
I have not been able to crash emacs all day so this might fix #2599. Ready to be tested by more people. Just having 
`TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" emacs_cv_func_sigsetjmp=no` 
does not work, but I have not tested only 
~~`TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" emacs_cv_func__setjmp=no"`, I should probably test that before merging~~, only having `emacs_cv_func__setjmp=no`, or only `emacs_cv_func_sigsetjmp=no` still segfaults