### PR TITLE
Introduce TERMUX_PKG_QUICK_REBUILD

### DIFF
--- a/packages/libllvm/build.sh
+++ b/packages/libllvm/build.sh
@@ -58,9 +58,11 @@ TERMUX_PKG_HAS_DEBUG=false
 # common.min.50.ompt.optional should be common.deb.50.ompt.optional when doing debug build
 
 termux_step_post_extract_package() {
-	mv clang-${TERMUX_PKG_VERSION}.src tools/clang
-	mv lld-${TERMUX_PKG_VERSION}.src tools/lld
-	mv openmp-${TERMUX_PKG_VERSION}.src projects/openmp
+	if [ "$TERMUX_PKG_QUICK_REBUILD" != "true" ]; then
+		mv clang-${TERMUX_PKG_VERSION}.src tools/clang
+		mv lld-${TERMUX_PKG_VERSION}.src tools/lld
+		mv openmp-${TERMUX_PKG_VERSION}.src projects/openmp
+	fi
 }
 
 termux_step_host_build() {
@@ -72,9 +74,11 @@ termux_step_host_build() {
 }
 
 termux_step_pre_configure() {
-	mkdir projects/openmp/runtime/src/android
-	cp $TERMUX_PKG_BUILDER_DIR/nl_types.h projects/openmp/runtime/src/android
-	cp $TERMUX_PKG_BUILDER_DIR/nltypes_stubs.cpp projects/openmp/runtime/src/android
+	if [ "$TERMUX_PKG_QUICK_REBUILD" != "true" ]; then
+		mkdir projects/openmp/runtime/src/android
+		cp $TERMUX_PKG_BUILDER_DIR/nl_types.h projects/openmp/runtime/src/android
+		cp $TERMUX_PKG_BUILDER_DIR/nltypes_stubs.cpp projects/openmp/runtime/src/android
+	fi
 
 	cd $TERMUX_PKG_BUILDDIR
 	export LLVM_DEFAULT_TARGET_TRIPLE=$TERMUX_HOST_PLATFORM

--- a/scripts/build/termux_step_patch_package.sh
+++ b/scripts/build/termux_step_patch_package.sh
@@ -6,12 +6,14 @@ termux_step_patch_package() {
 	if [ "$TERMUX_DEBUG" = "true" ]; then
 		DEBUG_PATCHES=$(find $TERMUX_PKG_BUILDER_DIR -mindepth 1 -maxdepth 1 -name \*.patch.debug)
 	fi
-	# Suffix patch with ".patch32" or ".patch64" to only apply for these bitnesses:
-	shopt -s nullglob
-	for patch in $TERMUX_PKG_BUILDER_DIR/*.patch{$TERMUX_ARCH_BITS,} $DEBUG_PATCHES; do
-		test -f "$patch" && sed "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" "$patch" | \
-			sed "s%\@TERMUX_HOME\@%${TERMUX_ANDROID_HOME}%g" | \
-			patch --silent -p1
-	done
-	shopt -u nullglob
+	if [ "$TERMUX_PKG_QUICK_REBUILD" != "true" ]; then
+		# Suffix patch with ".patch32" or ".patch64" to only apply for these bitnesses:
+		shopt -s nullglob
+		for patch in $TERMUX_PKG_BUILDER_DIR/*.patch{$TERMUX_ARCH_BITS,} $DEBUG_PATCHES; do
+			test -f "$patch" && sed "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" "$patch" | \
+				sed "s%\@TERMUX_HOME\@%${TERMUX_ANDROID_HOME}%g" | \
+				patch --silent -p1
+		done
+		shopt -u nullglob
+	fi
 }

--- a/scripts/build/termux_step_setup_variables.sh
+++ b/scripts/build/termux_step_setup_variables.sh
@@ -133,6 +133,7 @@ termux_step_setup_variables() {
 	TERMUX_CMAKE_BUILD=Ninja # Which cmake generator to use
 	TERMUX_PKG_HAS_DEBUG=true # set to false if debug build doesn't exist or doesn't work, for example for python based packages
 	TERMUX_PKG_METAPACKAGE=false
+	TERMUX_PKG_QUICK_REBUILD=false # set this temporarily when iterating on a large package and you don't want the source and build directories wiped every time you make a mistake
 
 	unset CFLAGS CPPFLAGS LDFLAGS CXXFLAGS
 }

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -128,15 +128,21 @@ termux_step_start_build() {
                         -e "s|@TERMUX_ARCH@|$TERMUX_ARCH|g" > $TERMUX_PREFIX/bin/llvm-config
                         chmod 755 $TERMUX_PREFIX/bin/llvm-config
 	fi
-	# Following directories may contain files with read-only permissions which
-	# makes them undeletable. We need to fix that.
-	[ -d "$TERMUX_PKG_BUILDDIR" ] && chmod +w -R "$TERMUX_PKG_BUILDDIR"
-	[ -d "$TERMUX_PKG_SRCDIR" ] && chmod +w -R "$TERMUX_PKG_SRCDIR"
+	if [ "$TERMUX_PKG_QUICK_REBUILD" != "true" ]; then
+		# Following directories may contain files with read-only permissions which
+		# makes them undeletable. We need to fix that.
+		[ -d "$TERMUX_PKG_BUILDDIR" ] && chmod +w -R "$TERMUX_PKG_BUILDDIR"
+		[ -d "$TERMUX_PKG_SRCDIR" ] && chmod +w -R "$TERMUX_PKG_SRCDIR"
 
-	# Cleanup old state:
-	rm -Rf "$TERMUX_PKG_BUILDDIR" \
-		"$TERMUX_PKG_PACKAGEDIR" \
-		"$TERMUX_PKG_SRCDIR" \
+		# Cleanup old build state:
+		rm -Rf "$TERMUX_PKG_BUILDDIR" \
+			"$TERMUX_PKG_SRCDIR"
+	else
+		TERMUX_PKG_SKIP_SRC_EXTRACT=true
+	fi
+
+	# Cleanup old packaging state:
+	rm -Rf "$TERMUX_PKG_PACKAGEDIR" \
 		"$TERMUX_PKG_TMPDIR" \
 		"$TERMUX_PKG_MASSAGEDIR"
 


### PR DESCRIPTION
This new variable is extremely useful when iterating on creating a large package, as otherwise you have to wipe the source and rebuild each time you make a mistake with the patches or build.sh script.

Simply set TERMUX_PKG_QUICK_REBUILD=true in build.sh if a build fails and then the TERMUX_PKG_SRCDIR and TERMUX_PKG_BUILDDIR will not be touched when you rebuild, including that the patches will not be applied again. When you're done iterating, diff for any new patches, save them, and remove this variable before rebuilding from scratch, hopefully for the last time. ;)

An example is shown for the giant libllvm package, where other modifications are also excluded if this variable is set.

This pull was tested by building some of the long-running libllvm package, stopping it after a while, setting this variable and starting again, and the build successfully picked up where it left off.