### PR TITLE
libandroid-spawn: use CXX so it links c++ lib

### DIFF
--- a/packages/libandroid-spawn/build.sh
+++ b/packages/libandroid-spawn/build.sh
@@ -4,10 +4,11 @@ TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_VERSION=0.2
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_REVISION=1
 
 termux_step_make() {
-	$CC $CFLAGS $CPPFLAGS -I$TERMUX_PKG_BUILDER_DIR -c $TERMUX_PKG_BUILDER_DIR/posix_spawn.cpp
-	$CC $LDFLAGS -shared posix_spawn.o -o libandroid-spawn.so
+	$CXX $CFLAGS $CPPFLAGS -I$TERMUX_PKG_BUILDER_DIR -c $TERMUX_PKG_BUILDER_DIR/posix_spawn.cpp
+	$CXX $LDFLAGS -shared posix_spawn.o -o libandroid-spawn.so
 	$AR rcu libandroid-spawn.a posix_spawn.o
 }
 


### PR DESCRIPTION
fixes linking with c since it won't find cpp symbols