### PR TITLE
Update Node.js LTS

### DIFF
--- a/packages/nodejs-lts/build.sh
+++ b/packages/nodejs-lts/build.sh
@@ -1,10 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://nodejs.org/
 TERMUX_PKG_DESCRIPTION="Platform built on Chrome's JavaScript runtime for easily building fast, scalable network applications"
 TERMUX_PKG_LICENSE="MIT"
-TERMUX_PKG_VERSION=12.14.1
+TERMUX_PKG_VERSION=12.16.1
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=877b4b842318b0e09bc754faf7343f2f097f0fc4f88ab9ae57cf9944e88e7adb
+TERMUX_PKG_SHA256=0a95845ba02c46102b5671d0c5732460073f2d397488337e18d1fc30146d412d
 # Note that we do not use a shared libuv to avoid an issue with the Android
 # linker, which does not use symbols of linked shared libraries when resolving
 # symbols on dlopen(). See https://github.com/termux/termux-packages/issues/462.


### PR DESCRIPTION
Problem: The previous Node.js version was outdated.

Solution: Change the version string and update the SHA256 sum.

This is completely 100% untested but my hope is that the tests will pass and it might resolve https://github.com/nodejs/node-gyp/issues/2051?