### PR TITLE
build-package: add new function termux_step_create_subpkg_debscripts

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -171,6 +171,11 @@ source "$TERMUX_SCRIPTDIR/scripts/build/termux_step_install_license.sh"
 # shellcheck source=scripts/build/termux_step_extract_into_massagedir.sh
 source "$TERMUX_SCRIPTDIR/scripts/build/termux_step_extract_into_massagedir.sh"
 
+# Hook function to create {pre,post}install, {pre,post}rm-scripts for subpkgs
+termux_step_create_subpkg_debscripts() {
+	return
+}
+
 # Create all subpackages. Run from termux_step_massage
 # shellcheck source=scripts/build/termux_create_subpackages.sh
 source "$TERMUX_SCRIPTDIR/scripts/build/termux_create_subpackages.sh"

--- a/scripts/build/termux_create_subpackages.sh
+++ b/scripts/build/termux_create_subpackages.sh
@@ -84,7 +84,11 @@ termux_create_subpackages() {
 
 		for f in $TERMUX_SUBPKG_CONFFILES; do echo "$TERMUX_PREFIX/$f" >> conffiles; done
 
-		tar -czf "$SUB_PKG_PACKAGE_DIR/control.tar.gz" .
+		# Allow packages to create arbitrary control files.
+		termux_step_create_subpkg_debscripts
+
+		# Create control.tar.gz
+		tar -czf "$SUB_PKG_PACKAGE_DIR/control.tar.gz" -H gnu .
 
 		# Create the actual .deb file:
 		TERMUX_SUBPKG_DEBFILE=$TERMUX_DEBDIR/${SUB_PKG_NAME}${DEBUG}_${TERMUX_PKG_FULLVERSION}_${SUB_PKG_ARCH}.deb


### PR DESCRIPTION
Makes it possible to create postinst scripts and similar or subpackages as well