### PR TITLE
emacs: configure with --with-modules and --without-selinux

### DIFF
--- a/packages/emacs/build.sh
+++ b/packages/emacs/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/emacs/
 TERMUX_PKG_DESCRIPTION="Extensible, customizable text editor-and more"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_VERSION=26.3
-TERMUX_PKG_REVISION=6
+TERMUX_PKG_REVISION=7
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/emacs/emacs-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=4d90e6751ad8967822c6e092db07466b9d383ef1653feb2f95c93e7de66d3485
 TERMUX_PKG_DEPENDS="ncurses, gnutls, libxml2"
@@ -23,6 +23,8 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --with-xml2
 --with-xpm=no
 --without-dbus
+--without-selinux
+--with-modules
 "
 # Ensure use of system malloc:
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" emacs_cv_sanitize_address=yes"


### PR DESCRIPTION
--with-modules solves https://github.com/termux/termux-packages/issues/5011,
--without-selinux is needed for on device builds.