### PR TITLE
Add muchsync build definition

### DIFF
--- a/packages/muchsync/build.sh
+++ b/packages/muchsync/build.sh
@@ -1,23 +1,7 @@
 TERMUX_PKG_HOMEPAGE=http://www.muchsync.org/
-TERMUX_PKG_DESCRIPTION="synchronize notmuch mail across machines"
-TERMUX_PKG_LICENSE="GPL2"
+TERMUX_PKG_DESCRIPTION="Synchronize notmuch mail across machines"
+TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=5
-TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=www.muchsync.org/src/muchsync-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=8b0afc2ce2dca636ae318659452902e26ac804d1b8b1982e74dbc4222f2155cc
-TERMUX_PKG_DEPENDS="libc++, notmuch, libxapian, libsqlite, openssl"
-
-termux_step_configure() {
-        # Use python3 so that the python3-sphinx package is
-        # found for man page generation.
-        export PYTHON=python3
-
-        cd $TERMUX_PKG_SRCDIR
-        XAPIAN_CONFIG=$TERMUX_PREFIX/bin/xapian-config ./configure \
-                --prefix=$TERMUX_PREFIX \
-                --without-api-docs \
-                --without-desktop \
-                --without-emacs \
-                --without-ruby
-}
-
+TERMUX_PKG_DEPENDS="libc++, libsqlite, libxapian, notmuch, openssl"

--- a/packages/muchsync/build.sh
+++ b/packages/muchsync/build.sh
@@ -1,0 +1,23 @@
+TERMUX_PKG_HOMEPAGE=http://www.muchsync.org/
+TERMUX_PKG_DESCRIPTION="synchronize notmuch mail across machines"
+TERMUX_PKG_LICENSE="GPL2"
+TERMUX_PKG_VERSION=5
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=www.muchsync.org/src/muchsync-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=8b0afc2ce2dca636ae318659452902e26ac804d1b8b1982e74dbc4222f2155cc
+TERMUX_PKG_DEPENDS="libc++, notmuch, libxapian, libsqlite, openssl"
+
+termux_step_configure() {
+        # Use python3 so that the python3-sphinx package is
+        # found for man page generation.
+        export PYTHON=python3
+
+        cd $TERMUX_PKG_SRCDIR
+        XAPIAN_CONFIG=$TERMUX_PREFIX/bin/xapian-config ./configure \
+                --prefix=$TERMUX_PREFIX \
+                --without-api-docs \
+                --without-desktop \
+                --without-emacs \
+                --without-ruby
+}
+

--- a/packages/muchsync/build.sh
+++ b/packages/muchsync/build.sh
@@ -2,6 +2,6 @@ TERMUX_PKG_HOMEPAGE=http://www.muchsync.org/
 TERMUX_PKG_DESCRIPTION="Synchronize notmuch mail across machines"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=5
-TERMUX_PKG_SRCURL=www.muchsync.org/src/muchsync-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SRCURL=http://www.muchsync.org/src/muchsync-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=8b0afc2ce2dca636ae318659452902e26ac804d1b8b1982e74dbc4222f2155cc
 TERMUX_PKG_DEPENDS="libc++, libsqlite, libxapian, notmuch, openssl"


### PR DESCRIPTION
Hi,

I'm trying to solve #5020 myself, but I'm getting

```
Downloading www.muchsync.org/src/muchsync-5.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current 
                                 Dload  Upload   Total   Spent    Left  Speed
100  130k  100  130k    0     0   118k      0  0:00:01  0:00:01 --:--:--  118k                      
configure: WARNING: unrecognized options: --without-api-docs, --without-desktop, --without-emacs, --witho
ut-ruby                                             
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes          
checking whether make supports nested variables... yes
checking whether the C++ compiler works... yes    
checking for C++ compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... configure: error: in `/home/builder/.termux-build/muchsync/src
':
configure: error: cannot run C++ compiled programs.
If you meant to cross compile, use `--host'.                                                             
See `config.log' for more details 
```

When compiling the sources. Can someone help me how to debug/fix this? I'm using the docker-based build infrastructure, if that matters.

---

FWIW I largely copied the `build.sh` script of notmuch itself.