### PR TITLE
New package: fselect

### DIFF
--- a/packages/fselect/build.sh
+++ b/packages/fselect/build.sh
@@ -1,0 +1,13 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/jhspetersson/fselect
+TERMUX_PKG_DESCRIPTION="Find files with SQL-like queries"
+TERMUX_PKG_LICENSE="Apache-2.0, MIT"
+TERMUX_PKG_VERSION=0.6.9
+TERMUX_PKG_SRCURL=https://github.com/jhspetersson/fselect/archive/$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=8a280ccd96c9aa0b638065eb4d17e9e75a185a89afb56d0bae522645bd8b3c66
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_post_make_install() {
+	install -Dm700 \
+		"$TERMUX_PKG_SRCDIR/target/$CARGO_TARGET_NAME"/release/fselect \
+		"$TERMUX_PREFIX"/bin/fselect
+}


### PR DESCRIPTION
[https://github.com/jhspetersson/fselect](https://github.com/jhspetersson/fselect)

Find files with SQL-like queries

### Why use fselect?

While it doesn't tend to fully replace traditional `find` and `ls`, **fselect** has these nice features:

* SQL-like (not real SQL, but highly relaxed!) grammar easily understandable by humans
* complex queries
* aggregate, date, and other functions
* search within archives
* `.gitignore` and `.hgignore` support (experimental)
* search by width and height of images, EXIF metadata
* search by MP3 info
* search by extended file attributes
* search by file hashes
* search by MIME type
* shortcuts to common file types
* various output formatting (CSV, JSON, and others)
