### PR TITLE
build-package.sh: verify release files with gpg when doing autobuilds

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -271,10 +271,22 @@ unset -f _show_usage
 if [ "$TERMUX_INSTALL_DEPS" = "true" ]; then
 	# Setup PGP keys for verifying integrity of dependencies.
 	# Keys are obtained from our keyring package.
-	gpg --import "$TERMUX_SCRIPTDIR/packages/termux-keyring/fornwall.gpg"
-	gpg --import "$TERMUX_SCRIPTDIR/packages/termux-keyring/grimler.gpg"
-	gpg --import "$TERMUX_SCRIPTDIR/packages/termux-keyring/termux-autobuilds.gpg"
-	gpg --import "$TERMUX_SCRIPTDIR/packages/termux-keyring/xeffyr.gpg"
+	gpg --list-keys 2218893D3F679BEFC421FD976700B77E6D8D0AE7 > /dev/null 2>&1 || {
+		gpg --import "$TERMUX_SCRIPTDIR/packages/termux-keyring/fornwall.gpg"
+		gpg --command-file <(echo -e "trust\n5\ny")  --edit-key 2218893D3F679BEFC421FD976700B77E6D8D0AE7
+	}
+	gpg --list-keys B63168609E8839CA9150CE2DD9EFD56891B2BB50 > /dev/null 2>&1 || {
+		gpg --import "$TERMUX_SCRIPTDIR/packages/termux-keyring/grimler.gpg"
+		gpg --command-file <(echo -e "trust\n5\ny")  --edit-key B63168609E8839CA9150CE2DD9EFD56891B2BB50
+	}
+	gpg --list-keys CC72CF8BA7DBFA0182877D045A897D96E57CF20C > /dev/null 2>&1 || {
+		gpg --import "$TERMUX_SCRIPTDIR/packages/termux-keyring/termux-autobuilds.gpg"
+		gpg --command-file <(echo -e "trust\n5\ny")  --edit-key CC72CF8BA7DBFA0182877D045A897D96E57CF20C
+	}
+	gpg --list-keys 3B6B548ADE5EA3BDD33CEEF045F2964132545795 > /dev/null 2>&1 || {
+		gpg --import "$TERMUX_SCRIPTDIR/packages/termux-keyring/xeffyr.gpg"
+		gpg --command-file <(echo -e "trust\n5\ny")  --edit-key 3B6B548ADE5EA3BDD33CEEF045F2964132545795
+	}
 fi
 
 while (($# > 0)); do

--- a/build-package.sh
+++ b/build-package.sh
@@ -268,6 +268,15 @@ shift $((OPTIND-1))
 if [ "$#" -lt 1 ]; then _show_usage; fi
 unset -f _show_usage
 
+if [ "$TERMUX_INSTALL_DEPS" = "true" ]; then
+	# Setup PGP keys for verifying integrity of dependencies.
+	# Keys are obtained from our keyring package.
+	gpg --import "$TERMUX_SCRIPTDIR/packages/termux-keyring/fornwall.gpg"
+	gpg --import "$TERMUX_SCRIPTDIR/packages/termux-keyring/grimler.gpg"
+	gpg --import "$TERMUX_SCRIPTDIR/packages/termux-keyring/termux-autobuilds.gpg"
+	gpg --import "$TERMUX_SCRIPTDIR/packages/termux-keyring/xeffyr.gpg"
+fi
+
 while (($# > 0)); do
 	# Following commands must be executed under lock to prevent running
 	# multiple instances of "./build-package.sh".

--- a/scripts/build/termux_get_repo_files.sh
+++ b/scripts/build/termux_get_repo_files.sh
@@ -28,6 +28,11 @@ termux_get_repo_files() {
 			termux_download "${TERMUX_REPO_URL[$idx-1]}/dists/${TERMUX_REPO_DISTRIBUTION[$idx-1]}/Release" \
 				"$RELEASE_FILE" SKIP_CHECKSUM
 
+			termux_download "${TERMUX_REPO_URL[$idx-1]}/dists/${TERMUX_REPO_DISTRIBUTION[$idx-1]}/Release.gpg" \
+				"${RELEASE_FILE}.gpg" SKIP_CHECKSUM
+
+			gpg --verify "${RELEASE_FILE}.gpg" "$RELEASE_FILE"
+
 			for arch in all $TERMUX_ARCH; do
 				local PACKAGES_HASH=$(./scripts/get_hash_from_file.py ${RELEASE_FILE} $arch ${TERMUX_REPO_COMPONENT[$idx-1]})
 				# If packages_hash = "" then the repo probably doesn't contain debs for $arch

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -7,7 +7,8 @@ PACKAGES=""
 PACKAGES+=" locales"
 
 # Used by build-package.sh and CI/CD scripts.
-PACKAGES+=" curl" # Used for fetching sources.
+PACKAGES+=" curl"
+PACKAGES+=" gnupg"
 PACKAGES+=" jq"
 
 # Used for fetching package sources from Git repositories.


### PR DESCRIPTION
When using mirrors, it is necessary to verify downloaded stuff with our PGP keys.