### PR TITLE
libllvm: check usr/include instead of usr/local/include for headers

### DIFF
--- a/packages/libllvm/tools-clang-lib-Driver-ToolChains-Linux.cpp.patch
+++ b/packages/libllvm/tools-clang-lib-Driver-ToolChains-Linux.cpp.patch
@@ -46,6 +46,8 @@
      return;
  
    if (!DriverArgs.hasArg(options::OPT_nostdlibinc))
+-    addSystemInclude(DriverArgs, CC1Args, SysRoot + "/usr/local/include");
+-
 +	if  (getTriple().isAndroid()) {
 +	  switch (getTriple().getArch()) {
 +        case llvm::Triple::x86_64:
@@ -64,19 +66,9 @@
 +	default:
 +	break;
 +	}
-+	                                                                                                       
-     addSystemInclude(DriverArgs, CC1Args, SysRoot + "/usr/local/include");
--
++
++    addSystemInclude(DriverArgs, CC1Args, SysRoot + "/usr/include");
 +  }
    SmallString<128> ResourceDirInclude(D.ResourceDir);
    llvm::sys::path::append(ResourceDirInclude, "include");
    if (!DriverArgs.hasArg(options::OPT_nobuiltininc) &&
-@@ -975,7 +1029,7 @@
- }
- 
- bool Linux::isPIEDefault() const {
--  return (getTriple().isAndroid() && !getTriple().isAndroidVersionLT(16)) ||
-+  return getTriple().isAndroid()  ||
-           getTriple().isMusl() || getSanitizerArgs().requiresPIE();
- }
- 


### PR DESCRIPTION
I recently found [this change to be useful when building the Swift package](https://github.com/buttaface/termux-packages/commit/a02f6856d2f37f91438f2acef69a92aeb22dea00#diff-f1dd144618494a04e2f3015e3a53fbaaL68), makes sense to use it here too. I also removed the last change for Android older than API 16, as nobody is likely dealing with that anymore.

Also, has anybody tried setting the `SysRoot` variable here to `@TERMUX_PREFIX@` by default, rather than appending to the current default value of `/`? I ask because sometimes Swift will pass a different sysroot to clang, and then all the prior appended paths don't work at all.