### PR TITLE
libllvm: fix Android versioning regression that broke setting PIE on ARM

### DIFF
--- a/packages/libllvm/build.sh
+++ b/packages/libllvm/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://clang.llvm.org/
 TERMUX_PKG_DESCRIPTION="Modular compiler and toolchain technologies library"
 TERMUX_PKG_LICENSE="NCSA"
 TERMUX_PKG_VERSION=9.0.1
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SHA256=(00a1ee1f389f81e9979f3a640a01c431b3021de0d42278f6508391a2f0b81c9a
 		   5778512b2e065c204010f88777d44b95250671103e434f9dc7363ab2e3804253		   
 		   86262bad3e2fd784ba8c5e2158d7aa36f12b85f2515e95bc81d65d75bb9b0c82
@@ -59,7 +59,7 @@ TERMUX_PKG_HAS_DEBUG=false
 # common.min.50.ompt.optional should be common.deb.50.ompt.optional when doing debug build
 
 termux_step_post_extract_package() {
-	if [ "$TERMUX_PKG_QUICK_REBUILD" != "true" ]; then
+	if [ "$TERMUX_PKG_QUICK_REBUILD" = "false" ]; then
 		mv clang-${TERMUX_PKG_VERSION}.src tools/clang
 		mv lld-${TERMUX_PKG_VERSION}.src tools/lld
 		mv openmp-${TERMUX_PKG_VERSION}.src projects/openmp
@@ -75,7 +75,7 @@ termux_step_host_build() {
 }
 
 termux_step_pre_configure() {
-	if [ "$TERMUX_PKG_QUICK_REBUILD" != "true" ]; then
+	if [ "$TERMUX_PKG_QUICK_REBUILD" = "false" ]; then
 		mkdir projects/openmp/runtime/src/android
 		cp $TERMUX_PKG_BUILDER_DIR/nl_types.h projects/openmp/runtime/src/android
 		cp $TERMUX_PKG_BUILDER_DIR/nltypes_stubs.cpp projects/openmp/runtime/src/android

--- a/packages/libllvm/include-llvm-ADT-Triple.h.patch
+++ b/packages/libllvm/include-llvm-ADT-Triple.h.patch
@@ -1,0 +1,15 @@
+diff --git a/include/llvm/ADT/Triple.h b/include/llvm/ADT/Triple.h
+index 926039ca5982..0e4b55733f5e 100644
+--- a/include/llvm/ADT/Triple.h
++++ b/include/llvm/ADT/Triple.h
+@@ -666,6 +666,10 @@ public:
+     unsigned Env[3];
+     getEnvironmentVersion(Env[0], Env[1], Env[2]);
+ 
++    // If not specified, set a default Android API.
++    if (Env[0] == 0)
++      Env[0] = __ANDROID_API__;
++
+     // 64-bit targets did not exist before API level 21 (Lollipop).
+     if (isArch64Bit() && Env[0] < 21)
+       Env[0] = 21;


### PR DESCRIPTION
I think this should fix #5076 and allow [other places where this `isAndroidVersionLT()` function is called](https://github.com/llvm/llvm-project/blob/7802be4a3d86743242273593d43a78df84ece8c1/llvm/lib/CodeGen/TargetLoweringBase.cpp#L202) to work properly.

The problem was that if an Android version isn't specified in the triple, it sets it to 0. That required the previous hack to ignore the version when figuring out whether to build PIE or not, but this is a better way to do it, ie set a default API level of `__ANDROID_API__` (24) if none is given in the triple.