### PR TITLE
Indirect explicit_bzero through memset pointer.

### DIFF
--- a/packages/openssh/openbsd-compat-explicit_bzero.c.patch
+++ b/packages/openssh/openbsd-compat-explicit_bzero.c.patch
@@ -3,7 +3,7 @@ On Android bzero() is a macro.
 diff -u -r ../openssh-7.4p1/openbsd-compat/explicit_bzero.c ./openbsd-compat/explicit_bzero.c
 --- ../openssh-7.4p1/openbsd-compat/explicit_bzero.c	2016-12-18 23:59:41.000000000 -0500
 +++ ./openbsd-compat/explicit_bzero.c	2016-12-20 19:57:24.595833810 -0500
-@@ -25,12 +25,6 @@
+@@ -25,12 +25,12 @@
  
  #else /* HAVE_MEMSET_S */
  
@@ -13,15 +13,21 @@ diff -u -r ../openssh-7.4p1/openbsd-compat/explicit_bzero.c ./openbsd-compat/exp
 - */
 -static void (* volatile ssh_bzero)(void *, size_t) = bzero;
 -
++/*
++ * Indirect memset through a volatile pointer to hopefully avoid
++ * dead-store optimisation eliminating the call.
++ */
++static void* (* volatile ssh_memset)(void *, int, size_t) = memset;
++
  void
  explicit_bzero(void *p, size_t n)
  {
-@@ -45,7 +39,7 @@
+@@ -45,7 +45,7 @@
  # endif
  #endif
  
 -	ssh_bzero(p, n);
-+	bzero(p, n);
++	ssh_memset(p, 0, n);
  }
  
  #endif /* HAVE_MEMSET_S */


### PR DESCRIPTION
The original comment indicates that using `bzero()` directly may result in dead store elimination, so they explicitly avoided calling `bzero()` as you do now. `explicit_bzero` is used in cryptographic software to clear keys from process memory after use, even if that memory is not read any more afterwards.

Maybe it would be safer like this? (I copied the approach from https://android.googlesource.com/platform/external/openssh/+/refs/tags/android-6.0.1_r70/openbsd-compat/explicit_bzero.c, so that should work on Android.)

Caveat, I was hand-editing the diff and did not find time to set up the toolchain to build this; but the general approach should work?