### PR TITLE
libtool: don't create libtool-static

### DIFF
--- a/packages/libtool/build.sh
+++ b/packages/libtool/build.sh
@@ -2,12 +2,13 @@ TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/libtool/
 TERMUX_PKG_DESCRIPTION="Generic library support script hiding the complexity of using shared libraries behind a consistent, portable interface"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=2.4.6
-TERMUX_PKG_REVISION=7
+TERMUX_PKG_REVISION=8
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/libtool/libtool-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3
-TERMUX_PKG_DEPENDS="bash,grep,sed,libltdl"
-TERMUX_PKG_CONFLICTS="libtool-dev"
-TERMUX_PKG_REPLACES="libtool-dev"
+TERMUX_PKG_DEPENDS="bash, grep, sed, libltdl"
+TERMUX_PKG_CONFLICTS="libtool-dev, libtool-static"
+TERMUX_PKG_REPLACES="libtool-dev, libtool-static"
+TERMUX_PKG_NO_STATICSPLIT=true
 
 termux_step_post_make_install() {
 	perl -p -i -e "s|\"/bin/|\"$TERMUX_PREFIX/bin/|" $TERMUX_PREFIX/bin/{libtool,libtoolize}


### PR DESCRIPTION
libltdl.la is needed by the accompanying ltdl.m4 script:
https://git.savannah.gnu.org/cgit/libtool.git/tree/m4/ltdl.m4?h=v2.4.6#n285
so it does not really make sense to split the package.