### PR TITLE
TERMUX_PKG_QUICK_REBUILD: disable reapplying the host build patches too

### DIFF
--- a/scripts/build/termux_step_handle_hostbuild.sh
+++ b/scripts/build/termux_step_handle_hostbuild.sh
@@ -3,9 +3,11 @@ termux_step_handle_hostbuild() {
 	[ "$TERMUX_PKG_HOSTBUILD" = "false" ] && return
 
 	cd "$TERMUX_PKG_SRCDIR"
-	for patch in $TERMUX_PKG_BUILDER_DIR/*.patch.beforehostbuild; do
-		test -f "$patch" && sed "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" "$patch" | patch --silent -p1
-	done
+	if [ "$TERMUX_PKG_QUICK_REBUILD" = "false" ]; then
+		for patch in $TERMUX_PKG_BUILDER_DIR/*.patch.beforehostbuild; do
+			test -f "$patch" && sed "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" "$patch" | patch --silent -p1
+		done
+	fi
 
 	local TERMUX_HOSTBUILD_MARKER="$TERMUX_PKG_HOSTBUILD_DIR/TERMUX_BUILT_FOR_$TERMUX_PKG_VERSION"
 	if [ ! -f "$TERMUX_HOSTBUILD_MARKER" ]; then

--- a/scripts/build/termux_step_patch_package.sh
+++ b/scripts/build/termux_step_patch_package.sh
@@ -6,7 +6,7 @@ termux_step_patch_package() {
 	if [ "$TERMUX_DEBUG" = "true" ]; then
 		DEBUG_PATCHES=$(find $TERMUX_PKG_BUILDER_DIR -mindepth 1 -maxdepth 1 -name \*.patch.debug)
 	fi
-	if [ "$TERMUX_PKG_QUICK_REBUILD" != "true" ]; then
+	if [ "$TERMUX_PKG_QUICK_REBUILD" = "false" ]; then
 		# Suffix patch with ".patch32" or ".patch64" to only apply for these bitnesses:
 		shopt -s nullglob
 		for patch in $TERMUX_PKG_BUILDER_DIR/*.patch{$TERMUX_ARCH_BITS,} $DEBUG_PATCHES; do

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -128,7 +128,7 @@ termux_step_start_build() {
                         -e "s|@TERMUX_ARCH@|$TERMUX_ARCH|g" > $TERMUX_PREFIX/bin/llvm-config
                         chmod 755 $TERMUX_PREFIX/bin/llvm-config
 	fi
-	if [ "$TERMUX_PKG_QUICK_REBUILD" != "true" ]; then
+	if [ "$TERMUX_PKG_QUICK_REBUILD" = "false" ]; then
 		# Following directories may contain files with read-only permissions which
 		# makes them undeletable. We need to fix that.
 		[ -d "$TERMUX_PKG_BUILDDIR" ] && chmod +w -R "$TERMUX_PKG_BUILDDIR"


### PR DESCRIPTION
Just realized I missed this in #4911 after trying to use this flag with a host build package.