### PR TITLE
termux_step_start_build: define TERMUX_STANDALONE_TOOLCHAIN before sourcing build script

### DIFF
--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -1,4 +1,9 @@
 termux_step_start_build() {
+	TERMUX_STANDALONE_TOOLCHAIN="$TERMUX_COMMON_CACHEDIR/android-r${TERMUX_NDK_VERSION}-api-${TERMUX_PKG_API_LEVEL}"
+	# Bump the below version if a change is made in toolchain setup to ensure
+	# that everyone gets an updated toolchain:
+	TERMUX_STANDALONE_TOOLCHAIN+="-v3"
+
 	# shellcheck source=/dev/null
 	source "$TERMUX_PKG_BUILDER_SCRIPT"
 
@@ -7,11 +12,6 @@ termux_step_start_build() {
 		TERMUX_PKG_SKIP_SRC_EXTRACT=true
 		TERMUX_PKG_PLATFORM_INDEPENDENT=true
 	fi
-
-	TERMUX_STANDALONE_TOOLCHAIN="$TERMUX_COMMON_CACHEDIR/android-r${TERMUX_NDK_VERSION}-api-${TERMUX_PKG_API_LEVEL}"
-	# Bump the below version if a change is made in toolchain setup to ensure
-	# that everyone gets an updated toolchain:
-	TERMUX_STANDALONE_TOOLCHAIN+="-v3"
 
 	if [ -n "${TERMUX_PKG_BLACKLISTED_ARCHES:=""}" ] && [ "$TERMUX_PKG_BLACKLISTED_ARCHES" != "${TERMUX_PKG_BLACKLISTED_ARCHES/$TERMUX_ARCH/}" ]; then
 		echo "Skipping building $TERMUX_PKG_NAME for arch $TERMUX_ARCH"


### PR DESCRIPTION
This is useful so the host build can use the standalone toolchain if wanted. I'm currently working on a package that builds a couple needed bits for the host and cross-compiles some code for Android, using its builtin NDK support that doesn't need all the cross-compilation flags that these scripts initialize later on in `termux_step_setup_toolchain()`.

However, the `TERMUX_STANDALONE_TOOLCHAIN` variable wasn't defined before the package build script was sourced, so I move it up in this pull.

Now, there's always a chance that the standalone toolchain won't be setup before the host build for my package, so it might make sense to move that also before the host build, but it shouldn't be a problem most of the time. If you want me to move the standalone toolchain setup also before the host build to account for that possibility, ie by splitting that portion alone off from `termux_step_setup_toolchain()` and leaving the cross-compilation flag initialization there,  just let me know and I can make that change too.