### PR TITLE
modification of pulseaudio's module-opensles-source to allow headset in

### DIFF
--- a/packages/pulseaudio/module-sles-source.c
+++ b/packages/pulseaudio/module-sles-source.c
@@ -215,7 +215,7 @@ static int pa_init_sles_record(struct userdata *u, pa_sample_spec *ss) {
     CHK((*u->EngineItf)->CreateAudioRecorder(u->EngineItf, &u->RecorderObject, &recSource, &recDest,
 		    2, iidArray, required));
     CHK((*u->engineObject)->GetInterface(u->RecorderObject, SL_IID_ANDROIDCONFIGURATION, (void*)&configItf));
-    SLuint32 presetValue = SL_ANDROID_RECORDING_PRESET_CAMCORDER;
+    SLuint32 presetValue = SL_ANDROID_RECORDING_PRESET_VOICE_RECOGNITION;
     CHK((*configItf)->SetConfiguration(configItf, SL_ANDROID_KEY_RECORDING_PRESET,
 		    &presetValue, sizeof(SLuint32)));
 
@@ -223,7 +223,7 @@ static int pa_init_sles_record(struct userdata *u, pa_sample_spec *ss) {
     SLuint32 presetSize = 2*sizeof(SLuint32); // intentionally too big       
     CHK((*configItf)->GetConfiguration(configItf, SL_ANDROID_KEY_RECORDING_PRESET,
 		    &presetSize, (void*)&presetValue)); 
-if (presetValue != SL_ANDROID_RECORDING_PRESET_CAMCORDER) {
+if (presetValue != SL_ANDROID_RECORDING_PRESET_VOICE_RECOGNITION) {
 	fprintf(stderr, "Error retrieved recording preset\n");
 }
 


### PR DESCRIPTION
The current SL_ANDROID_RECORDING_PRESET_CAMCORDER value forced to use the internal mic.
By using SL_ANDROID_RECORDING_PRESET_VOICE_RECOGNITION, instead, the pulseaudio module will follow the general behavior of the operating system ( if external headset is plugged in, audio source will be the headset, otherwise it will be the internal mic. ) 
(The value names are not really indicative, this behavior has been found out by trial  and error following OpenSLES_AndroidConfiguration.h)