### PR TITLE
proot: Update to fix brk() before execve()

### DIFF
--- a/packages/proot/build.sh
+++ b/packages/proot/build.sh
@@ -2,11 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://proot-me.github.io/
 TERMUX_PKG_DESCRIPTION="Emulate chroot, bind mount and binfmt_misc for non-root users"
 TERMUX_PKG_LICENSE="GPL-2.0"
 # Just bump commit and version when needed:
-_COMMIT=0782d176818ed9865a2148605561eae6e1be9352
+_COMMIT=b9588b1edff5069118c50f2f9b19397fce39f5c7
 TERMUX_PKG_VERSION=5.1.107
-TERMUX_PKG_REVISION=27
+TERMUX_PKG_REVISION=28
 TERMUX_PKG_SRCURL=https://github.com/termux/proot/archive/${_COMMIT}.zip
-TERMUX_PKG_SHA256=40a23592fb108401286a0a53e2df27433546b42c0d28438db7d7c7ce22b3f0a7
+TERMUX_PKG_SHA256=0e7d806d689b8943496ab18388e0cf141fdf2b66fbda3f5c9dc69cfab5ddeec9
 TERMUX_PKG_DEPENDS="libtalloc"
 
 # Install loader in libexec instead of extracting it every time


### PR DESCRIPTION
Fixes termux/proot#102