### PR TITLE
kibi: add package

### DIFF
--- a/packages/kibi/build.sh
+++ b/packages/kibi/build.sh
@@ -1,0 +1,12 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/ilai-deutel/kibi
+TERMUX_PKG_DESCRIPTION="A tiny terminal text editor, written in Rust"
+TERMUX_PKG_LICENSE="Apache-2.0, MIT"
+TERMUX_PKG_VERSION=0.2.0
+TERMUX_PKG_SRCURL=https://github.com/ilai-deutel/kibi/archive/v$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=7af69657ce50816e45e9111138cf9e050f74289bba3ceaa2a52e4715951c8885
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_post_make_install() {
+    install -Dm644 "config_example.ini" "$TERMUX_PREFIX/etc/kibi/config.ini"
+    install -Dm644 syntax.d/* -t "$TERMUX_PREFIX/share/kibi/syntax.d"
+}

--- a/packages/kibi/fsh-path-replacement.patch
+++ b/packages/kibi/fsh-path-replacement.patch
@@ -1,0 +1,25 @@
+--- a/src/unix.rs
++++ b/src/unix.rs
+@@ -28,7 +28,7 @@
+     // If environment variable `home_key` (e.g. `$XDG_CONFIG_HOME`) is set, add its value to `dirs`.
+     // Otherwise, if environment variable `$HOME` is set, add `$HOME{def_home_suffix}`
+     // (e.g. `$HOME/.config`) to `dirs`.
+-    dirs.extend(var(home_key).or_else(|_| var("HOME").map(|d| d + def_home_suffix)).into_iter());
++    dirs.push(var(home_key).unwrap_or(format!("@TERMUX_HOME@{}", def_home_suffix)));
+ 
+     // If environment variable `dirs_key` (e.g. `XDG_CONFIG_DIRS`) is set, split by `:` and add the
+     // parts to `dirs`.
+@@ -39,11 +39,11 @@
+ }
+ 
+ /// Return configuration directories for UNIX systems
+-pub fn conf_dirs() -> Vec<String> { xdg_dirs("CONFIG", "/.config", "/etc/xdg:/etc") }
++pub fn conf_dirs() -> Vec<String> { xdg_dirs("CONFIG", "/.config", "@TERMUX_PREFIX@/etc") }
+ 
+ /// Return syntax directories for UNIX systems
+ pub fn data_dirs() -> Vec<String> {
+-    xdg_dirs("DATA", "/.local/share", "/usr/local/share/:/usr/share/")
++    xdg_dirs("DATA", "/.local/share", "@TERMUX_PREFIX@/share/")
+ }
+ 
+ /// Return the current window size as (rows, columns).


### PR DESCRIPTION
Add [`kibi`](https://github.com/ilai-deutel/kibi), a text editor written in Rust.

I had to patch [`src/unix.rs`](https://github.com/ilai-deutel/kibi/blob/0.2.0/src/unix.rs) to replace FSH paths.