### PR TITLE
add protobuf-compiler

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -149,6 +149,7 @@ PACKAGES+=" xfonts-utils"
 # Needed by packages in science repository
 PACKAGES+=" sqlite3"
 PACKAGES+=" protobuf-c-compiler"
+PACKAGES+=" protobuf-compiler"
 
 # Needed by packages in game repository
 PACKAGES+=" python3-yaml"


### PR DESCRIPTION
I am building some packages ( on the basis of package requests ) but some packages needs `protoc` ( which is in package protobuf-compiler ) and this is not big package ( **installed size is only 100kb** ) so it would be great to include it.
For example https://github.com/termux/termux-root-packages/issues/185  needs it.