### PR TITLE
jftui: add package

### DIFF
--- a/packages/jftui/build.sh
+++ b/packages/jftui/build.sh
@@ -15,7 +15,7 @@ termux_step_pre_configure() {
 }
 
 termux_step_make() {
-    make CFLAGS="$CPPFLAGS" LFLAGS="$LDFLAGS"
+	make CFLAGS="$CPPFLAGS" LFLAGS="$LDFLAGS"
 }
 
 termux_step_make_install() {

--- a/packages/jftui/build.sh
+++ b/packages/jftui/build.sh
@@ -3,7 +3,6 @@ TERMUX_PKG_DESCRIPTION="jftui is a minimalistic, lightweight C99 command line cl
 TERMUX_PKG_LICENSE="Unlicense"
 TERMUX_PKG_MAINTAINER="Maxr1998 <max.rumpf1998@gmail.com>"
 TERMUX_PKG_VERSION=0.3.0
-TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/Aanok/jftui/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=336cc17a67bb91ee0b1ca0a5a3d2e415054806cb80f9b1c9b382eb4fdcde3bb5
 TERMUX_PKG_DEPENDS="libcurl, yajl, mpv"

--- a/packages/jftui/build.sh
+++ b/packages/jftui/build.sh
@@ -11,10 +11,11 @@ TERMUX_PKG_BUILD_IN_SRC=true
 termux_step_pre_configure() {
 	sed -i 's| -march=native||' Makefile
 	sed -i 's|^CFLAGS=|override CFLAGS+=|' Makefile
+	sed -i 's|^LFLAGS=|override LFLAGS+=|' Makefile
 }
 
 termux_step_make() {
-    make CFLAGS="-I${TERMUX_PREFIX}/include"
+    make CFLAGS="$CPPFLAGS" LFLAGS="$LDFLAGS"
 }
 
 termux_step_make_install() {

--- a/packages/jftui/build.sh
+++ b/packages/jftui/build.sh
@@ -1,0 +1,23 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/Aanok/jftui
+TERMUX_PKG_DESCRIPTION="jftui is a minimalistic, lightweight C99 command line client for the open source Jellyfin media server."
+TERMUX_PKG_LICENSE="Unlicense"
+TERMUX_PKG_MAINTAINER="Maxr1998 <max.rumpf1998@gmail.com>"
+TERMUX_PKG_VERSION=0.3.0
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=https://github.com/Aanok/jftui/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=336cc17a67bb91ee0b1ca0a5a3d2e415054806cb80f9b1c9b382eb4fdcde3bb5
+TERMUX_PKG_DEPENDS="libcurl, yajl, mpv"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+	sed -i 's| -march=native||' Makefile
+	sed -i 's|^CFLAGS=|override CFLAGS+=|' Makefile
+}
+
+termux_step_make() {
+    make CFLAGS="-I${TERMUX_PREFIX}/include"
+}
+
+termux_step_make_install() {
+	install -Dm700 $TERMUX_PKG_SRCDIR/build/jftui "$TERMUX_PREFIX/bin/jftui"
+}

--- a/packages/mpv/build.sh
+++ b/packages/mpv/build.sh
@@ -22,6 +22,7 @@ termux_step_make_install() {
 		--disable-jpeg \
 		--disable-lcms2 \
 		--enable-libarchive \
+		--enable-libmpv-shared \
 		--disable-libass \
 		--enable-lua \
 		--enable-pulse \

--- a/packages/mpv/build.sh
+++ b/packages/mpv/build.sh
@@ -2,6 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://mpv.io/
 TERMUX_PKG_DESCRIPTION="Command-line media player"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_VERSION=0.32.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/mpv-player/mpv/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=9163f64832226d22e24bbc4874ebd6ac02372cd717bef15c28a0aa858c5fe592
 TERMUX_PKG_DEPENDS="ffmpeg, libandroid-glob, libandroid-support, libarchive, libcaca, libiconv, liblua52, pulseaudio, openal-soft, zlib"


### PR DESCRIPTION
This PR adds buildscripts for [jftui](https://github.com/Aanok/jftui), and configures mpv to also build the shared library. Unfortunately, there are still some build issues: running it after installation results in `CANNOT LINK EXECUTABLE "jftui": library "libyajl.so" not found` (also applies to all other dependencies).

Interestingly, when running it with `env LD_PRELOAD="$PREFIX/lib/libyajl.so $PREFIX/lib/libmpv.so $PREFIX/lib/libcurl.so" jftui`, it works fine, so there seems to be some linker issue in my buildscript. However, I couldn't figure out what to change yet, so I'm hoping anyone seeing this has some ideas.