### PR TITLE
fix pkg-config issues

### DIFF
--- a/packages/libflac/build.sh
+++ b/packages/libflac/build.sh
@@ -7,3 +7,7 @@ TERMUX_PKG_SHA256=668cdeab898a7dd43cf84739f7e1f3ed6b35ece2ef9968a5c7079fe9adfe16
 TERMUX_PKG_DEPENDS="libc++, libogg"
 TERMUX_PKG_BREAKS="libflac-dev"
 TERMUX_PKG_REPLACES="libflac-dev"
+TERMUX_PKG_REVISION=1
+termux_step_pre_configure() {
+	./autogen.sh
+}


### PR DESCRIPTION
using cmake makes broken and misplaced pkg-config files flac.pc and flac++.pc so using autogen.sh instead. 