### PR TITLE
ffsend: update to 0.2.62

### DIFF
--- a/packages/ffsend/build.sh
+++ b/packages/ffsend/build.sh
@@ -1,9 +1,8 @@
 TERMUX_PKG_HOMEPAGE=https://gitlab.com/timvisee/ffsend
 TERMUX_PKG_DESCRIPTION="A fully featured Firefox Send client"
 TERMUX_PKG_LICENSE="GPL-3.0"
-TERMUX_PKG_VERSION=0.2.61
+TERMUX_PKG_VERSION=0.2.62
 TERMUX_PKG_SRCURL=https://gitlab.com/timvisee/ffsend/-/archive/v$TERMUX_PKG_VERSION/ffsend-v$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_SHA256=5444bc94c4a1177264f9d82e999b2c1b9cc05a5ee66e17e5c1a6f667fa014865
-TERMUX_PKG_DEPENDS="openssl"
+TERMUX_PKG_SHA256=be8227f7b7ed3f3cc914a8dc24ab0d7cb155dfda65df35be23ac5b1b443a0f72
 TERMUX_PKG_BUILD_IN_SRC=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--no-default-features --features send2,send3,history,archive,qrcode,urlshorten,infer-command"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--no-default-features --features send3,crypto-ring,history,archive,qrcode,urlshorten,infer-command"


### PR DESCRIPTION
The `openssl` dependency is not needed anymore, updated the compiler features as well.