### PR TITLE
Log applied patches during build

### DIFF
--- a/scripts/build/termux_step_patch_package.sh
+++ b/scripts/build/termux_step_patch_package.sh
@@ -10,6 +10,7 @@ termux_step_patch_package() {
 		# Suffix patch with ".patch32" or ".patch64" to only apply for these bitnesses:
 		shopt -s nullglob
 		for patch in $TERMUX_PKG_BUILDER_DIR/*.patch{$TERMUX_ARCH_BITS,} $DEBUG_PATCHES; do
+			echo "Applying patch: $(basename $patch)"
 			test -f "$patch" && sed "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" "$patch" | \
 				sed "s%\@TERMUX_HOME\@%${TERMUX_ANDROID_HOME}%g" | \
 				patch --silent -p1


### PR DESCRIPTION
Resolves #5326 

Logs patches that are applied during build.

**Current behaviour:**

```
$ ./scripts/run-docker.sh ./build-package.sh bitcoin
Running container 'termux-package-builder' from image 'termux/package-builder'...
termux - building bitcoin for arch aarch64...
Downloading https://github.com/bitcoin/bitcoin/archive/v0.19.1.tar.gz
Fetching boost_1_70_0.tar.bz2 from https://dl.bintray.com/boostorg/release/1.70.0/source/
```

**New behaviour:**

```
$ ./scripts/run-docker.sh ./build-package.sh bitcoin
Running container 'termux-package-builder' from image 'termux/package-builder'...
termux - building bitcoin for arch aarch64...
Downloading https://github.com/bitcoin/bitcoin/archive/v0.19.1.tar.gz
Applying patch: 0001-android-patches.patch
Applying patch: build-aux-m4-ax_boost_thread.m4.patch
Applying patch: libevent-version.patch
Fetching boost_1_70_0.tar.bz2 from https://dl.bintray.com/boostorg/release/1.70.0/source/
```