### PR TITLE
swift: build the corelibs and package manager

### DIFF
--- a/packages/swift/swift-build-script.patch
+++ b/packages/swift/swift-build-script.patch
@@ -26,6 +26,16 @@ index b1d060328bc..218c9215260 100755
          if args.android_deploy_device_path:
              impl_args += [
                  "--android-deploy-device-path",
+@@ -799,8 +807,7 @@
+                 self._execute_install_action(host_target, product_class)
+ 
+         # Non-build-script-impl products...
+-        # Note: currently only supports building for the host.
+-        for host_target in [self.args.host_target]:
++        for host_target in [tgt.name for tgt in all_hosts if StdlibDeploymentTarget.Android.contains(tgt.name)]:
+             for product_class in product_classes:
+                 if product_class.is_build_script_impl_product():
+                     continue
 diff --git a/swift/utils/build-script-impl b/swift/utils/build-script-impl
 index 7f39ff97459..9e5a646b668 100755
 --- a/swift/utils/build-script-impl
@@ -66,7 +76,32 @@ index 7f39ff97459..9e5a646b668 100755
          fi
      else
          local host_install_destdir="${INSTALL_DESTDIR}"
-@@ -1645,6 +1645,13 @@
+@@ -1422,6 +1426,10 @@ function swift_c_flags() {
+     fi
+ }
+ 
++function android_cross_swift_flags() {
++    echo -n "${TERMUX_SWIFT_FLAGS}"
++}
++
+ function cmake_config_opt() {
+     product=$1
+     if [[ "${CMAKE_GENERATOR}" == "Xcode" ]] ; then
+@@ -1634,6 +1642,13 @@ for host in "${ALL_HOSTS[@]}"; do
+         product_cmake_options=(${!product_cmake_options_name}) # convert to array
+         cmake_options+=("${product_cmake_options[@]}")
+ 
++        function skip_configure_and_build() {
++            dir=$1
++            call mkdir -p "${dir}"
++            call touch "${dir}/CMakeCache.txt" "${dir}/build.ninja"
++            skip_build=true
++        }
++
+         case ${product} in
+             cmark)
+                 cmake_options=(
+@@ -1641,6 +1665,13 @@ for host in "${ALL_HOSTS[@]}"; do
                    -DCMAKE_BUILD_TYPE:STRING="${CMARK_BUILD_TYPE}"
                    "${cmark_cmake_options[@]}"
                  )
@@ -80,18 +115,26 @@ index 7f39ff97459..9e5a646b668 100755
                  skip_build=${SKIP_BUILD_CMARK}
                  build_targets=(all)
                  ;;
-@@ -1665,6 +1669,10 @@ for host in "${ALL_HOSTS[@]}"; do
+@@ -1665,6 +1696,10 @@ for host in "${ALL_HOSTS[@]}"; do
                      fi
                  fi
  
-+                if [[ ("${CROSS_COMPILE_HOSTS}" && "${host}" == "${LOCAL_HOST}") ]] ; then
++                if [[ "${CROSS_COMPILE_HOSTS}" && "${host}" == "${LOCAL_HOST}" ]] ; then
 +                    skip_build=true
 +                fi
 +
                  if [ "${HOST_LIBTOOL}" ] ; then
                      cmake_options=(
                          "${cmake_options[@]}"
-@@ -1768,12 +1777,18 @@ for host in "${ALL_HOSTS[@]}"; do
+@@ -1746,6 +1765,7 @@ for host in "${ALL_HOSTS[@]}"; do
+                         -DCLANG_TABLEGEN=$(build_directory "${LOCAL_HOST}" llvm)/bin/clang-tblgen
+                         -DLLVM_NATIVE_BUILD=$(build_directory "${LOCAL_HOST}" llvm)
+                     )
++                    android_cross_cmake_options cmake_options
+                 fi
+ 
+                 ;;
+@@ -1768,12 +1803,18 @@ for host in "${ALL_HOSTS[@]}"; do
  
              swift)
  
@@ -111,7 +154,7 @@ index 7f39ff97459..9e5a646b668 100755
                          -DSWIFT_ANDROID_${ANDROID_ARCH}_ICU_UC:STRING="${ANDROID_ICU_UC}"
                          -DSWIFT_ANDROID_${ANDROID_ARCH}_ICU_UC_INCLUDE:STRING="${ANDROID_ICU_UC_INCLUDE}"
                          -DSWIFT_ANDROID_${ANDROID_ARCH}_ICU_I18N:STRING="${ANDROID_ICU_I18N}"
-@@ -1973,7 +1997,11 @@ for host in "${ALL_HOSTS[@]}"; do
+@@ -1973,7 +2014,11 @@ for host in "${ALL_HOSTS[@]}"; do
                      )
                  fi
  
@@ -123,7 +166,7 @@ index 7f39ff97459..9e5a646b668 100755
                  if [[ $(true_false "${build_perf_testsuite_this_time}") == "TRUE" ]]; then
                      native_swift_tools_path="$(build_directory_bin ${LOCAL_HOST} swift)"
                      cmake_options=(
-@@ -1984,6 +1999,9 @@ for host in "${ALL_HOSTS[@]}"; do
+@@ -1984,6 +2029,9 @@ for host in "${ALL_HOSTS[@]}"; do
                                     "${SWIFT_BENCHMARK_TARGETS[@]}")
                  fi
                  skip_build=${SKIP_BUILD_SWIFT}
@@ -133,7 +176,146 @@ index 7f39ff97459..9e5a646b668 100755
                  ;;
              lldb)
                  if [ ! -d "${LLDB_SOURCE_DIR}" ]; then
-@@ -2446,6 +2456,8 @@ for host in "${ALL_HOSTS[@]}"; do
+@@ -2101,7 +2149,6 @@ for host in "${ALL_HOSTS[@]}"; do
+ 
+                     -DCMAKE_BUILD_TYPE:STRING="${LLBUILD_BUILD_TYPE}"
+                     -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
+-                    -DCMAKE_Swift_COMPILER:PATH="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
+ 
+                     -DLLBUILD_ENABLE_ASSERTIONS:BOOL=$(true_false "${LLBUILD_ENABLE_ASSERTIONS}")
+                     -DLLBUILD_SUPPORT_BINDINGS:=Swift
+@@ -2130,6 +2177,23 @@ for host in "${ALL_HOSTS[@]}"; do
+                         -DSQLite3_LIBRARY:PATH="/usr/lib/libsqlite3.dylib"
+                     )
+                 fi
++
++                if [[ $(is_cross_tools_host ${host}) ]] ; then
++                    cmake_options+=(
++                        -DCMAKE_Swift_COMPILER:PATH="${HOST_SWIFTC}"
++                        -DCMAKE_Swift_FLAGS="$(android_cross_swift_flags)"
++                    )
++                    android_cross_cmake_options cmake_options
++                    build_targets=(llbuildSwift)
++                else
++                    cmake_options+=(
++                        -DCMAKE_Swift_COMPILER:PATH="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
++                    )
++                fi
++
++                if [[ "${CROSS_COMPILE_HOSTS}" && "${host}" == "${LOCAL_HOST}" ]] ; then
++                    skip_configure_and_build ${build_dir}
++                fi
+                 ;;
+             xctest)
+                 SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
+@@ -2175,9 +2235,6 @@ for host in "${ALL_HOSTS[@]}"; do
+                   cmake_options=(
+                     ${cmake_options[@]}
+                     -DCMAKE_BUILD_TYPE:STRING="${XCTEST_BUILD_TYPE}"
+-                    -DCMAKE_C_COMPILER:PATH="${LLVM_BIN}/clang"
+-                    -DCMAKE_CXX_COMPILER:PATH="${LLVM_BIN}/clang++"
+-                    -DCMAKE_Swift_COMPILER:PATH="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
+                     -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
+                     -DCMAKE_INSTALL_LIBDIR:PATH="lib"
+ 
+@@ -2193,6 +2250,24 @@ for host in "${ALL_HOSTS[@]}"; do
+ 
+                     -DENABLE_TESTING=YES
+                   )
++
++                  if [[ $(is_cross_tools_host ${host}) ]] ; then
++                    cmake_options+=(
++                      -DCMAKE_Swift_COMPILER:PATH="${HOST_SWIFTC}"
++                      -DCMAKE_Swift_FLAGS="$(android_cross_swift_flags)"
++                    )
++                    android_cross_cmake_options cmake_options
++                  else
++                    cmake_options+=(
++                      -DCMAKE_C_COMPILER:PATH="${LLVM_BIN}/clang"
++                      -DCMAKE_CXX_COMPILER:PATH="${LLVM_BIN}/clang++"
++                      -DCMAKE_Swift_COMPILER:PATH="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
++                    )
++                  fi
++
++                  if [[ "${CROSS_COMPILE_HOSTS}" && "${host}" == "${LOCAL_HOST}" ]] ; then
++                    skip_configure_and_build ${build_dir}
++                  fi
+                 ;;
+                 esac
+ 
+@@ -2257,10 +2328,7 @@ for host in "${ALL_HOSTS[@]}"; do
+                 cmake_options=(
+                   ${cmake_options[@]}
+                   -DCMAKE_BUILD_TYPE:STRING=${FOUNDATION_BUILD_TYPE}
+-                  -DCMAKE_C_COMPILER:PATH=${LLVM_BIN}/clang
+-                  -DCMAKE_CXX_COMPILER:PATH=${LLVM_BIN}/clang++
+                   -DCMAKE_SWIFT_COMPILER:PATH=${SWIFTC_BIN}
+-                  -DCMAKE_Swift_COMPILER:PATH=${SWIFTC_BIN}
+                   -DCMAKE_INSTALL_PREFIX:PATH=$(get_host_install_prefix ${host})
+ 
+                   ${LIBICU_BUILD_ARGS[@]}
+@@ -2273,6 +2341,23 @@ for host in "${ALL_HOSTS[@]}"; do
+                   -DBUILD_SHARED_LIBS=$([[ ${product} == foundation_static ]] && echo "NO" || echo "YES")
+                 )
+ 
++                if [[ $(is_cross_tools_host ${host}) ]] ; then
++                  cmake_options+=(
++                    -DCMAKE_Swift_COMPILER:PATH="${HOST_SWIFTC}"
++                    -DCMAKE_Swift_FLAGS="$(android_cross_swift_flags)"
++                  )
++                  android_cross_cmake_options cmake_options
++                else
++                  cmake_options+=(
++                    -DCMAKE_C_COMPILER:PATH=${LLVM_BIN}/clang
++                    -DCMAKE_CXX_COMPILER:PATH=${LLVM_BIN}/clang++
++                    -DCMAKE_Swift_COMPILER:PATH=${SWIFTC_BIN}
++                  )
++                fi
++
++                if [[ "${CROSS_COMPILE_HOSTS}" && "${host}" == "${LOCAL_HOST}" ]] ; then
++                  skip_configure_and_build ${build_dir}
++                fi
+                 ;;
+             libdispatch|libdispatch_static)
+                 LIBDISPATCH_BUILD_DIR=$(build_directory ${host} ${product})
+@@ -2297,10 +2378,7 @@ for host in "${ALL_HOSTS[@]}"; do
+                     -DENABLE_SWIFT=YES
+                     ${cmake_options[@]}
+                     -DCMAKE_BUILD_TYPE:STRING="${LIBDISPATCH_BUILD_TYPE}"
+-                    -DCMAKE_C_COMPILER:PATH="${LLVM_BIN}/clang"
+-                    -DCMAKE_CXX_COMPILER:PATH="${LLVM_BIN}/clang++"
+                     -DCMAKE_SWIFT_COMPILER:PATH="${SWIFTC_BIN}"
+-                    -DCMAKE_Swift_COMPILER:PATH="${SWIFTC_BIN}"
+                     -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
+                     -DCMAKE_INSTALL_LIBDIR:PATH="lib"
+ 
+@@ -2309,6 +2387,25 @@ for host in "${ALL_HOSTS[@]}"; do
+                     -DENABLE_TESTING=YES
+                     -DBUILD_SHARED_LIBS=$([[ ${product} == libdispatch_static ]] && echo "NO" || echo "YES")
+                   )
++
++                  if [[ $(is_cross_tools_host ${host}) ]] ; then
++                    cmake_options+=(
++                      -DCMAKE_Swift_COMPILER:PATH="${HOST_SWIFTC}"
++                      -DCMAKE_Swift_FLAGS="$(android_cross_swift_flags)"
++                    )
++                    android_cross_cmake_options cmake_options
++                    build_targets=(swiftDispatch)
++                  else
++                    cmake_options+=(
++                      -DCMAKE_C_COMPILER:PATH="${LLVM_BIN}/clang"
++                      -DCMAKE_CXX_COMPILER:PATH="${LLVM_BIN}/clang++"
++                      -DCMAKE_Swift_COMPILER:PATH="${SWIFTC_BIN}"
++                    )
++                  fi
++
++                  if [[ "${CROSS_COMPILE_HOSTS}" && "${host}" == "${LOCAL_HOST}" ]] ; then
++                    skip_configure_and_build ${build_dir}
++                  fi
+                 ;;
+                 esac
+ 
+@@ -2446,6 +2539,8 @@ for host in "${ALL_HOSTS[@]}"; do
                HOST_CXX_HEADERS_DIR="$HOST_CXX_DIR/../../usr/include/c++"
              elif [[ "$(uname -s)" == "Haiku" ]] ; then
                HOST_CXX_HEADERS_DIR="/boot/system/develop/headers/c++"
@@ -142,20 +324,21 @@ index 7f39ff97459..9e5a646b668 100755
              else # Linux
                HOST_CXX_HEADERS_DIR="/usr/include/c++"
              fi
-@@ -2934,8 +2941,12 @@
+@@ -2903,9 +2998,13 @@ for host in "${ALL_HOSTS[@]}"; do
+                 fi
                  if [[ "${LLVM_INSTALL_COMPONENTS}" == "all" ]]; then
                      INSTALL_TARGETS=install
-                 else
++                else
 +                if [[ ("${CROSS_COMPILE_HOSTS}" && "${host}" == "${LOCAL_HOST}") ]] ; then
 +                    continue
-+                else
+                 else
                      INSTALL_TARGETS=install-$(echo ${LLVM_INSTALL_COMPONENTS} | sed -E 's/;/ install-/g')
                  fi
 +                fi
                  ;;
              libcxx)
                  if [[ -z "${INSTALL_LIBCXX}" ]] ; then
-@@ -2941,7 +2954,11 @@ for host in "${ALL_HOSTS[@]}"; do
+@@ -2917,13 +3052,24 @@ for host in "${ALL_HOSTS[@]}"; do
                  if [[ -z "${INSTALL_SWIFT}" ]] ; then
                      continue
                  fi
@@ -166,17 +349,64 @@ index 7f39ff97459..9e5a646b668 100755
 +                fi
                  ;;
              llbuild)
-                 if [[ -z "${INSTALL_LLBUILD}" ]] ; then
+-                if [[ -z "${INSTALL_LLBUILD}" ]] ; then
++                if [[ -z "${INSTALL_LLBUILD}" || ("${CROSS_COMPILE_HOSTS}" && "${host}" == "${LOCAL_HOST}") ]] ; then
+                     continue
+                 fi
+-                INSTALL_TARGETS="install-swift-build-tool install-libllbuildSwift"
++                INSTALL_TARGETS="install-libllbuildSwift"
++                rm @TERMUX_PREFIX@/lib/swift/android/lib{dispatch,BlocksRuntime}.so
++                rm -rf @TERMUX_PREFIX@/lib/swift{,_static}/{Block,os}
++                rm  @TERMUX_PREFIX@/lib/swift{,_static}/dispatch/*.h
++                sed -i -e "s%dispatch\.h%@TERMUX_PREFIX@/include/dispatch/dispatch.h%" \
++                -e "s%introspection\.h%@TERMUX_PREFIX@/include/dispatch/introspection.h%" \
++                @TERMUX_PREFIX@/lib/swift/dispatch/module.modulemap
++                cp @TERMUX_PREFIX@/lib/swift/dispatch/module.modulemap @TERMUX_PREFIX@/lib/swift_static/dispatch/module.modulemap
+                 ;;
+             # Products from this here install themselves; they don't fall-through.
+             lldb)
+@@ -2937,7 +3040,7 @@ for host in "${ALL_HOSTS[@]}"; do
+                 INSTALL_TARGETS="install-distribution"
+                 ;;
+             xctest)
+-                if [[ -z "${INSTALL_XCTEST}" ]] ; then
++                if [[ -z "${INSTALL_XCTEST}" || ("${CROSS_COMPILE_HOSTS}" && "${host}" == "${LOCAL_HOST}") ]] ; then
+                     continue
+                 fi
+                 if [[ -z "${INSTALL_DESTDIR}" ]] ; then
+@@ -2961,7 +3064,7 @@ for host in "${ALL_HOSTS[@]}"; do
+                     continue
+                 fi
+ 
+-                if [[ -z "${INSTALL_FOUNDATION}" ]] ; then
++                if [[ -z "${INSTALL_FOUNDATION}" || ("${CROSS_COMPILE_HOSTS}" && "${host}" == "${LOCAL_HOST}") ]] ; then
+                     continue
+                 fi
+ 
+@@ -2972,7 +3075,7 @@ for host in "${ALL_HOSTS[@]}"; do
+ 
+                 ;;
+             libdispatch|libdispatch_static)
+-                if [[ -z "${INSTALL_LIBDISPATCH}" ]] ; then
++                if [[ -z "${INSTALL_LIBDISPATCH}" || ("${CROSS_COMPILE_HOSTS}" && "${host}" == "${LOCAL_HOST}") ]] ; then
+                     continue
+                 fi
+ 
 diff --git a/swift/utils/swift_build_support/swift_build_support/products/swiftpm.py b/swift/utils/swift_build_support/swift_build_support/products/swiftpm.py
 index 475483618f1..2bea230012b 100644
 --- a/swift/utils/swift_build_support/swift_build_support/products/swiftpm.py
 +++ b/swift/utils/swift_build_support/swift_build_support/products/swiftpm.py
-@@ -32,7 +32,7 @@ class SwiftPM(product.Product):
+@@ -31,8 +31,11 @@ class SwiftPM(product.Product):
+     def run_bootstrap_script(self, action, host_target, additional_params=[]):
          script_path = os.path.join(
              self.source_dir, 'Utilities', 'new-bootstrap')
-         toolchain_path = self.install_toolchain_path()
+-        toolchain_path = self.install_toolchain_path()
 -        swiftc = os.path.join(toolchain_path, "usr", "bin", "swiftc")
-+        swiftc = os.path.join(toolchain_path, "bin", "swiftc")
++        if os.getenv("HOST_SWIFTC"):
++            swiftc = os.getenv("HOST_SWIFTC")
++        else:
++            toolchain_path = self.install_toolchain_path()
++            swiftc = os.path.join(toolchain_path, "bin", "swiftc")
  
          # FIXME: We require llbuild build directory in order to build. Is
          # there a better way to get this?

--- a/packages/swift/swift-utils-build-script-impl
+++ b/packages/swift/swift-utils-build-script-impl
@@ -2,26 +2,30 @@ diff --git a/swift/utils/build-script-impl b/swift/utils/build-script-impl
 index b1d060328bc..218c9215260 100755
 --- a/swift/utils/build-script-impl
 +++ b/swift/utils/build-script-impl
-@@ -1745,6 +1753,13 @@ for host in "${ALL_HOSTS[@]}"; do
-                         -DLLVM_TABLEGEN=$(build_directory "${LOCAL_HOST}" llvm)/bin/llvm-tblgen
-                         -DCLANG_TABLEGEN=$(build_directory "${LOCAL_HOST}" llvm)/bin/clang-tblgen
-                         -DLLVM_NATIVE_BUILD=$(build_directory "${LOCAL_HOST}" llvm)
-+                        -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS --target=$CCTERMUX_HOST_PLATFORM"
-+                        -DCMAKE_MODULE_LINKER_FLAGS="$LDFLAGS --target=$CCTERMUX_HOST_PLATFORM"
-+                        -DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS --target=$CCTERMUX_HOST_PLATFORM"
-+                        -DCMAKE_SYSTEM_NAME=Android
-+                        -DCMAKE_SYSTEM_VERSION=@TERMUX_PKG_API_LEVEL@
-+                        -DCMAKE_SYSTEM_PROCESSOR=@TERMUX_ARCH@
-+                        -DCMAKE_ANDROID_STANDALONE_TOOLCHAIN="@TERMUX_STANDALONE_TOOLCHAIN@"
-                     )
-                 fi
+@@ -1430,6 +1430,26 @@ function android_cross_swift_flags() {
+     echo -n "${TERMUX_SWIFT_FLAGS}"
+ }
  
-@@ -2471,7 +2480,7 @@ for host in "${ALL_HOSTS[@]}"; do
-             elif [[ "${ANDROID_DATA}" ]] ; then
-               HOST_CXX_HEADERS_DIR="$PREFIX/include/c++"
-             else # Linux
--              HOST_CXX_HEADERS_DIR="/usr/include/c++"
-+              HOST_CXX_HEADERS_DIR="@TERMUX_STANDALONE_TOOLCHAIN@/sysroot/usr/include/c++"
-             fi
- 
-             # Find the path in which the local clang build is expecting to find
++function android_cross_cmake_options() {
++    local -n options=$1
++    options+=(
++        -DCMAKE_SYSTEM_NAME=Android
++        -DCMAKE_SYSTEM_VERSION=@TERMUX_PKG_API_LEVEL@
++        -DCMAKE_SYSTEM_PROCESSOR=@TERMUX_ARCH@
++        -DCMAKE_ANDROID_STANDALONE_TOOLCHAIN="@TERMUX_STANDALONE_TOOLCHAIN@"
++        -DCMAKE_C_FLAGS="$CFLAGS --target=$CCTERMUX_HOST_PLATFORM $CPPFLAGS"
++        -DCMAKE_CXX_FLAGS="$CXXFLAGS --target=$CCTERMUX_HOST_PLATFORM $CPPFLAGS"
++        -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS --target=$CCTERMUX_HOST_PLATFORM"
++        -DCMAKE_MODULE_LINKER_FLAGS="$LDFLAGS --target=$CCTERMUX_HOST_PLATFORM"
++        -DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS --target=$CCTERMUX_HOST_PLATFORM"
++        -DCMAKE_FIND_ROOT_PATH=@TERMUX_PREFIX@
++        -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER
++        -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY
++        -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY
++        -DCMAKE_HAVE_LIBC_PTHREAD=True
++    )
++}
++
+ function cmake_config_opt() {
+     product=$1
+     if [[ "${CMAKE_GENERATOR}" == "Xcode" ]] ; then

--- a/packages/swift/swiftpm-Utilities-bootstrap
+++ b/packages/swift/swiftpm-Utilities-bootstrap
@@ -1,0 +1,92 @@
+diff --git a/swiftpm/Utilities/bootstrap b/swiftpm/Utilities/bootstrap
+index f7439427..56166b7a 100755
+--- a/swiftpm/Utilities/bootstrap
++++ b/swiftpm/Utilities/bootstrap
+@@ -164,7 +164,10 @@ def parse_build_args(args):
+     args.target_dir = os.path.join(args.build_dir, get_build_target(args))
+     args.bootstrap_dir = os.path.join(args.target_dir, "bootstrap")
+     args.conf = 'release' if args.release else 'debug'
+-    args.bin_dir = os.path.join(args.target_dir, args.conf)
++    if args.cross_compiling:
++        args.bin_dir = os.path.join(args.target_dir, 'bootstrap', 'bin')
++    else:
++        args.bin_dir = os.path.join(args.target_dir, args.conf)
+ 
+ def parse_test_args(args):
+     """Parses and cleans arguments necessary for the test action."""
+@@ -232,6 +235,8 @@ def get_ninja_path(args):
+ def get_build_target(args):
+     """Returns the target-triple of the current machine."""
+     try:
++        if args.cross_compiling:
++            return 'linux-android'
+         target_info_json = subprocess.check_output([args.swiftc_path, '-print-target-info'], stderr=subprocess.PIPE, universal_newlines=True).strip()
+         args.target_info = json.loads(target_info_json)
+         return args.target_info["target"]["unversionedTriple"]
+@@ -255,6 +260,7 @@ def clean(args):
+ 
+ def build(args):
+     """Builds SwiftPM using a two-step process: first using CMake, then with itself."""
++    args.cross_compiling = 'ANDROID_DATA' not in os.environ
+     parse_build_args(args)
+ 
+     # Build llbuild if its build path is not passed in.
+@@ -263,7 +269,8 @@ def build(args):
+ 
+     build_tsc(args)
+     build_swiftpm_with_cmake(args)
+-    build_swiftpm_with_swiftpm(args)
++    if not args.cross_compiling:
++        build_swiftpm_with_swiftpm(args)
+ 
+ def test(args):
+     """Builds SwiftPM, then tests itself."""
+@@ -366,14 +373,24 @@ def build_with_cmake(args, cmake_args, source_path, build_dir):
+     """Runs CMake if needed, then builds with Ninja."""
+     cache_path = os.path.join(build_dir, "CMakeCache.txt")
+     if not os.path.isfile(cache_path) or args.reconfigure:
+-        swift_flags = ""
++        if args.cross_compiling:
++            # The two termux prefix flags are needed because the Swift flags pass the
++            # standalone toolchain as the sdk, or sysroot.
++            swift_flags = os.getenv("TERMUX_SWIFT_FLAGS") + \
++            " -L @TERMUX_PREFIX@/lib -Xcc -I@TERMUX_PREFIX@/include \
++            -Xlinker -rpath -Xlinker '$$ORIGIN/../android'"
++            build_type = 'Release'
++        else:
++            swift_flags = ""
++            build_type = 'Debug'
++
+         if args.sysroot:
+             swift_flags = "-sdk %s" % args.sysroot
+ 
+         cmd = [
+             args.cmake_path, "-G", "Ninja",
+             "-DCMAKE_MAKE_PROGRAM=%s" % args.ninja_path,
+-            "-DCMAKE_BUILD_TYPE:=Debug",
++            "-DCMAKE_BUILD_TYPE:=%s" % build_type,
+             "-DCMAKE_Swift_FLAGS=" + swift_flags,
+             "-DCMAKE_Swift_COMPILER:=%s" % (args.swiftc_path),
+         ] + cmake_args + [source_path]
+@@ -424,6 +441,13 @@ def build_tsc(args):
+         cmake_flags.append("-DCMAKE_C_FLAGS=-target x86_64-apple-macosx10.10")
+         cmake_flags.append("-DCMAKE_OSX_DEPLOYMENT_TARGET=10.10")
+ 
++    if args.cross_compiling:
++        cmake_flags.append("-DCMAKE_SYSTEM_NAME=Android")
++        cmake_flags.append("-DCMAKE_SYSTEM_VERSION=@TERMUX_PKG_API_LEVEL@")
++        cmake_flags.append("-DCMAKE_SYSTEM_PROCESSOR=@TERMUX_ARCH@")
++        cmake_flags.append("-DCMAKE_ANDROID_STANDALONE_TOOLCHAIN=@TERMUX_STANDALONE_TOOLCHAIN@")
++        cmake_flags.append("-DCMAKE_EXE_LINKER_FLAGS=--target={}".format(os.getenv("CCTERMUX_HOST_PLATFORM")))
++
+     build_with_cmake(args, cmake_flags, args.tsc_source_dir, args.tsc_build_dir)
+ 
+ def build_swiftpm_with_cmake(args):
+@@ -574,6 +598,7 @@ def get_swiftpm_flags(args):
+     if 'ANDROID_DATA' in os.environ:
+         build_flags.extend(["-Xswiftc", "-Xcc", "-Xswiftc", "-U_GNU_SOURCE"])
+ 
++    build_flags.extend(["-Xswiftc", "-no-toolchain-stdlib-rpath", "-Xlinker", "-landroid-spawn"])
+     return build_flags
+ 
+ # -----------------------------------------------------------

--- a/packages/swift/swiftpm-rpath.patch
+++ b/packages/swift/swiftpm-rpath.patch
@@ -13,7 +13,7 @@ index b6d925e1..3e546554 100644
          Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}
 +        BUILD_WITH_INSTALL_RPATH TRUE
          INSTALL_NAME_DIR \\@rpath
-+        INSTALL_RPATH "$ORIGIN/../../$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>"
++        INSTALL_RPATH "$ORIGIN/../../android"
          OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}
          OUTPUT_NAME PackageDescription
          ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}
@@ -30,15 +30,67 @@ index 50e1ba60..e47b87e7 100644
  endif()
  # NOTE(compnerd) workaround for CMake not setting up include flags yet
  set_target_properties(TSCBasic PROPERTIES
-diff --git a/swiftpm/Utilities/bootstrap b/swiftpm/Utilities/bootstrap
-index f7439427..b3edbbea 100755
---- a/swiftpm/Utilities/bootstrap
-+++ b/swiftpm/Utilities/bootstrap
-@@ -574,6 +574,7 @@ def get_swiftpm_flags(args):
-     if 'ANDROID_DATA' in os.environ:
-         build_flags.extend(["-Xswiftc", "-Xcc", "-Xswiftc", "-U_GNU_SOURCE"])
+diff --git a/swiftpm/Sources/swift-build/CMakeLists.txt b/swiftpm/Sources/swift-build/CMakeLists.txt
+index 6f8a8747..b52c1295 100644
+--- a/swiftpm/Sources/swift-build/CMakeLists.txt
++++ b/swiftpm/Sources/swift-build/CMakeLists.txt
+@@ -10,6 +10,11 @@ add_executable(swift-build
+     main.swift)
+ target_link_libraries(swift-build PRIVATE
+     Commands)
++if(CMAKE_HOST_SYSTEM_NAME STREQUAL Linux)
++set_target_properties(swift-build PROPERTIES
++    INSTALL_RPATH "$ORIGIN/../lib/swift/android:$ORIGIN/../lib/swift/pm:$ORIGIN/../lib/swift/pm/llbuild"
++    BUILD_WITH_INSTALL_RPATH TRUE)
++endif()
  
-+    build_flags.extend(["-Xswiftc", "-no-toolchain-stdlib-rpath", "-Xlinker", "-landroid-spawn"])
-     return build_flags
+ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+     install(TARGETS swift-build
+diff --git a/swiftpm/Sources/swift-package/CMakeLists.txt b/swiftpm/Sources/swift-package/CMakeLists.txt
+index 1ebf9a3a..700594dd 100644
+--- a/swiftpm/Sources/swift-package/CMakeLists.txt
++++ b/swiftpm/Sources/swift-package/CMakeLists.txt
+@@ -10,6 +10,11 @@ add_executable(swift-package
+   main.swift)
+ target_link_libraries(swift-package PRIVATE
+   Commands)
++if(CMAKE_HOST_SYSTEM_NAME STREQUAL Linux)
++set_target_properties(swift-package PROPERTIES
++    INSTALL_RPATH "$ORIGIN/../lib/swift/android:$ORIGIN/../lib/swift/pm:$ORIGIN/../lib/swift/pm/llbuild"
++    BUILD_WITH_INSTALL_RPATH TRUE)
++endif()
  
- # -----------------------------------------------------------
+ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+ install(TARGETS swift-package
+diff --git a/swiftpm/Sources/swift-run/CMakeLists.txt b/swiftpm/Sources/swift-run/CMakeLists.txt
+index d879e3c9..307edb47 100644
+--- a/swiftpm/Sources/swift-run/CMakeLists.txt
++++ b/swiftpm/Sources/swift-run/CMakeLists.txt
+@@ -10,6 +10,11 @@ add_executable(swift-run
+   main.swift)
+ target_link_libraries(swift-run PRIVATE
+   Commands)
++if(CMAKE_HOST_SYSTEM_NAME STREQUAL Linux)
++set_target_properties(swift-run PROPERTIES
++    INSTALL_RPATH "$ORIGIN/../lib/swift/android:$ORIGIN/../lib/swift/pm:$ORIGIN/../lib/swift/pm/llbuild"
++    BUILD_WITH_INSTALL_RPATH TRUE)
++endif()
+ 
+ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+ install(TARGETS swift-run
+diff --git a/swiftpm/Sources/swift-test/CMakeLists.txt b/swiftpm/Sources/swift-test/CMakeLists.txt
+index fc4912ef..04a585da 100644
+--- a/swiftpm/Sources/swift-test/CMakeLists.txt
++++ b/swiftpm/Sources/swift-test/CMakeLists.txt
+@@ -10,6 +10,11 @@ add_executable(swift-test
+   main.swift)
+ target_link_libraries(swift-test PRIVATE
+   Commands)
++if(CMAKE_HOST_SYSTEM_NAME STREQUAL Linux)
++set_target_properties(swift-test PROPERTIES
++    INSTALL_RPATH "$ORIGIN/../lib/swift/android:$ORIGIN/../lib/swift/pm:$ORIGIN/../lib/swift/pm/llbuild"
++    BUILD_WITH_INSTALL_RPATH TRUE)
++endif()
+ 
+ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+ install(TARGETS swift-test


### PR DESCRIPTION
~Testing this WIP pull out by disabling the compiler build in the second commit for now, and only building the core libraries like Foundation and XCTest on Ubuntu to make sure they work.~

~I'm going to try cross-compiling the Swift package manager locally next, and once that's done, I'll remove the second commit and~ built the full Swift toolchain on the CI, ready to merge.