### PR TITLE
rclone: update to 1.52.0

### DIFF
--- a/packages/rclone/build.sh
+++ b/packages/rclone/build.sh
@@ -1,9 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://rclone.org/
 TERMUX_PKG_DESCRIPTION="rsync for cloud storage"
 TERMUX_PKG_LICENSE="MIT"
-TERMUX_PKG_VERSION=1.51.0
+TERMUX_PKG_VERSION=1.52.0
 TERMUX_PKG_SRCURL=https://github.com/rclone/rclone/releases/download/v${TERMUX_PKG_VERSION}/rclone-v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=3eb5b7ffce17e56fadb29bf854666723a14c93fedc02046c7f34c792dbd227ee
+TERMUX_PKG_SHA256=b8cd06f62fa1623aa77e8a8f60f4a30c02c84c97488ded159968bf07beedf31b
 
 termux_step_make_install() {
 	cd $TERMUX_PKG_SRCDIR


### PR DESCRIPTION
Note: [1.52.1 might drop soon](https://github.com/rclone/rclone/pull/4287#issuecomment-636928176), if you want to hold of until then.