### PR TITLE
termux-tools: add script for resetting Termux installation

### DIFF
--- a/packages/termux-tools/build.sh
+++ b/packages/termux-tools/build.sh
@@ -1,8 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://termux.com/
 TERMUX_PKG_DESCRIPTION="Basic system tools for Termux"
 TERMUX_PKG_LICENSE="GPL-3.0"
-TERMUX_PKG_VERSION=0.80
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION=0.81
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_ESSENTIAL=true
@@ -34,8 +33,8 @@ termux_step_make_install() {
 	done
 
 	for script in chsh dalvikvm login pkg su termux-fix-shebang termux-info \
-		termux-open termux-open-url termux-reload-settings termux-setup-storage \
-		termux-wake-lock termux-wake-unlock termux-change-repo; do
+		termux-open termux-open-url termux-reload-settings termux-reset \
+		termux-setup-storage termux-wake-lock termux-wake-unlock termux-change-repo; do
 			install -Dm700 $TERMUX_PKG_BUILDER_DIR/$script $TERMUX_PREFIX/bin/$script
 			perl -p -i -e "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" $TERMUX_PREFIX/bin/$script
 			perl -p -i -e "s%\@TERMUX_HOME\@%${TERMUX_ANDROID_HOME}%g" $TERMUX_PREFIX/bin/$script

--- a/packages/termux-tools/build.sh
+++ b/packages/termux-tools/build.sh
@@ -36,8 +36,10 @@ termux_step_make_install() {
 		termux-open termux-open-url termux-reload-settings termux-reset \
 		termux-setup-storage termux-wake-lock termux-wake-unlock termux-change-repo; do
 			install -Dm700 $TERMUX_PKG_BUILDER_DIR/$script $TERMUX_PREFIX/bin/$script
-			perl -p -i -e "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" $TERMUX_PREFIX/bin/$script
-			perl -p -i -e "s%\@TERMUX_HOME\@%${TERMUX_ANDROID_HOME}%g" $TERMUX_PREFIX/bin/$script
+			sed -i -e "s|@TERMUX_PREFIX@|${TERMUX_PREFIX}|g" \
+				-e "s|@TERMUX_HOME@|${TERMUX_ANDROID_HOME}|g" \
+				-e "s|@TERMUX_CACHE_DIR@|$(realpath ${TERMUX_PREFIX}/../../cache)|g" \
+				$TERMUX_PREFIX/bin/$script
 	done
 
 	install -Dm600 $TERMUX_PKG_BUILDER_DIR/motd $TERMUX_PREFIX/etc/motd

--- a/packages/termux-tools/termux-reset
+++ b/packages/termux-tools/termux-reset
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+unset LD_PRELOAD LD_LIBRARY_PATH
+
 echo
 echo "You are going to reset your Termux installation."
 echo
@@ -14,14 +16,34 @@ if ! [[ $CHOICE =~ (Y|y) ]]; then
 	echo "Leaving intact the contents of \$PREFIX"
 	exit 1
 else
+	HAS_TERMUX_AM=false
+
+	if [ -f "@TERMUX_PREFIX@/libexec/termux-am/am.apk" ]; then
+		HAS_TERMUX_AM=true
+
+		echo "Preserving package 'termux-am' for later use..."
+
+		if [ -d "@TERMUX_CACHE_DIR@" ]; then
+			/system/bin/rm -rf "@TERMUX_CACHE_DIR@/termux-am"
+			/system/bin/mkdir -p "@TERMUX_CACHE_DIR@/termux-am"
+			/system/bin/cp "@TERMUX_PREFIX@/libexec/termux-am/am.apk" "@TERMUX_CACHE_DIR@/termux-am/am.apk"
+
+			# In case if copying am.apk failed.
+			if [ ! -e "@TERMUX_CACHE_DIR@/termux-am/am.apk" ]; then
+				HAS_TERMUX_AM=false
+			fi
+		fi
+	fi
+
 	echo "Erasing '@TERMUX_PREFIX@'..."
-	rm -rf "@TERMUX_PREFIX@"
+	/system/bin/rm -rf "@TERMUX_PREFIX@"
 	echo "Done. You need to close Termux application now."
 
-	# Prefix is now gone.
-	unset LD_PRELOAD LD_LIBRARY_PATH
-	if [ -x "/system/bin/killall" ]; then
+	if ! $HAS_TERMUX_AM && [ -x "/system/bin/killall" ]; then
 		echo "Terminating all sessions..."
 		/system/bin/killall -9 "$SHELL"
+	else
+		export CLASSPATH="@TERMUX_CACHE_DIR@/termux-am/am.apk"
+		/system/bin/app_process / com.example.termuxam.Am stopservice com.termux/.app.TermuxService
 	fi
 fi

--- a/packages/termux-tools/termux-reset
+++ b/packages/termux-tools/termux-reset
@@ -13,7 +13,7 @@ echo
 read -re -p "Do you want to continue ? (y/n) " CHOICE
 
 if ! [[ $CHOICE =~ (Y|y) ]]; then
-	echo "Leaving intact the contents of \$PREFIX"
+	echo "Leaving intact the contents of \$PREFIX."
 	exit 1
 else
 	HAS_TERMUX_AM=false

--- a/packages/termux-tools/termux-reset
+++ b/packages/termux-tools/termux-reset
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+echo
+echo "You are going to reset your Termux installation."
+echo
+echo "This script will erase everything under \$PREFIX. All files under that directory will be lost, that includes packages, configuration files, databases, etc."
+echo
+echo "Termux home directory as well as data on your shared or external storage will not be removed and leaved as-is."
+echo
+
+read -re -p "Do you want to continue ? (y/n) " CHOICE
+
+if ! [[ $CHOICE =~ (Y|y) ]]; then
+	echo "Leaving intact the contents of \$PREFIX"
+	exit 1
+else
+	echo "Erasing '@TERMUX_PREFIX@'..."
+	rm -rf "@TERMUX_PREFIX@"
+	echo "Done. You need to close Termux application now."
+
+	# Prefix is now gone.
+	unset LD_PRELOAD LD_LIBRARY_PATH
+	if [ -x "/system/bin/killall" ]; then
+		echo "Terminating all sessions..."
+		/system/bin/killall -9 "$SHELL"
+	fi
+fi


### PR DESCRIPTION
Provides a script which will:
* Tell user about things which will happen when $PREFIX will be erased.
* Prompt user for confirmation.
* Terminate all sessions after finish.

instead of simple `rm -rf $PREFIX` which is suggested on Wiki currently.
