### PR TITLE
libblocksruntime: split off sub-package

### DIFF
--- a/packages/libdispatch/build.sh
+++ b/packages/libdispatch/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="The libdispatch project, for concurrency on multicore ha
 TERMUX_PKG_LICENSE="Apache-2.0"
 _VERSION=5.2
 TERMUX_PKG_VERSION=1:${_VERSION}
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/apple/swift-corelibs-libdispatch/archive/swift-${_VERSION}-RELEASE.tar.gz
 TERMUX_PKG_SHA256=11797a43c509a603434c64c1041f208f0f25c3233d6c6493d53704e682634edb
 TERMUX_PKG_DEPENDS="libc++, libblocksruntime"

--- a/packages/libdispatch/build.sh
+++ b/packages/libdispatch/build.sh
@@ -5,4 +5,4 @@ _VERSION=5.2
 TERMUX_PKG_VERSION=1:${_VERSION}
 TERMUX_PKG_SRCURL=https://github.com/apple/swift-corelibs-libdispatch/archive/swift-${_VERSION}-RELEASE.tar.gz
 TERMUX_PKG_SHA256=11797a43c509a603434c64c1041f208f0f25c3233d6c6493d53704e682634edb
-TERMUX_PKG_DEPENDS="libc++"
+TERMUX_PKG_DEPENDS="libc++, libblocksruntime"

--- a/packages/libdispatch/libblocksruntime.subpackage.sh
+++ b/packages/libdispatch/libblocksruntime.subpackage.sh
@@ -1,0 +1,2 @@
+TERMUX_SUBPKG_INCLUDE="include/Block.h lib/libBlocksRuntime.so"
+TERMUX_SUBPKG_DESCRIPTION="LLVM Blocks runtime library"


### PR DESCRIPTION
Splitting it off as suggested in #5409 and needed by #5411.