### PR TITLE
docker image: install heimdal-multidev and comerr-dev

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -126,7 +126,10 @@ PACKAGES+=" python-yaml"
 # Java.
 PACKAGES+=" openjdk-8-jdk"
 
+# Samba (in unstable repository)
 PACKAGE+=" libparse-yapp-perl"
+PACKAGE+=" heimdal-multidev"
+PACKAGE+=" comerr-dev"
 
 # Needed by packages in unstable repository.
 PACKAGES+=" docbook-to-man"


### PR DESCRIPTION
I'm ready to submit samba to unstable-packages, but more packages need to be installed on the host. 

heimdal-multidev provides asn1_compile;  comerr-dev provides compile_et

If these aren't present, they get built during the build process by Samba, but with the cross-compiler... However, these programs need to run on the host at build time.