### PR TITLE
new package: ctypes-sh

### DIFF
--- a/packages/ctypes-sh/001-ctypes-android.patch
+++ b/packages/ctypes-sh/001-ctypes-android.patch
@@ -1,0 +1,54 @@
+diff --git a/src/ctypes.c b/src/ctypes.c
+index 7d976ee..cd6411f 100644
+--- a/src/ctypes.c
++++ b/src/ctypes.c
+@@ -452,7 +452,7 @@ static char *dlcall_usage[] = {
+     "These are specified followed by a ':' then the type.",
+     "",
+     "    $ dlopen libc.so.6",
+-    "    $ dlcall lchown string:/tmp/foo int:$UID int:-1",
++    "    $ dlcall lchown string:@TERMUX_PREFIX@/tmp/foo int:$UID int:-1",
+     "",
+     "Options:",
+     "    -a abi      Use the specified ABI rather than the default.",
+diff --git a/src/struct/dutil.h b/src/struct/dutil.h
+index 0401b3e..c6d35f3 100644
+--- a/src/struct/dutil.h
++++ b/src/struct/dutil.h
+@@ -296,7 +296,7 @@ void *zalloc(const size_t size);
+ Elf_Scn *elf_section_by_name(Elf *elf, GElf_Ehdr *ep,
+ 			     GElf_Shdr *shp, const char *name, size_t *index);
+ 
+-#ifndef SHT_GNU_ATTRIBUTES
++#if !defined(SHT_GNU_ATTRIBUTES) && !defined(__ANDROID__)
+ /* Just a way to check if we're using an old elfutils version */
+ static inline int elf_getshdrstrndx(Elf *elf, size_t *dst)
+ {
+diff --git a/src/struct/struct.c b/src/struct/struct.c
+index dd3687d..70d0a8d 100644
+--- a/src/struct/struct.c
++++ b/src/struct/struct.c
+@@ -21,6 +21,10 @@
+ 
+ #define MAX_ELEMENT_SIZE 128    // Maximum length of array_name[element_name]
+ 
++#ifdef __ANDROID__
++#define strdupa(s) strcpy(alloca(strlen(s) + 1), s)
++#endif
++
+ static int select_union_string(char *unionstr, const char *unionname, char *membername, size_t maxlen);
+ 
+ // This is just to disable ctf support.
+diff --git a/src/unpack.c b/src/unpack.c
+index e50c33b..d9dd611 100644
+--- a/src/unpack.c
++++ b/src/unpack.c
+@@ -22,7 +22,7 @@
+ #include "types.h"
+ #include "shell.h"
+ 
+-#if !defined(__GLIBC__) && !defined(__NEWLIB__)
++#if !defined(__GLIBC__) && !defined(__NEWLIB__) && __ANDROID_API__ < 23
+ static inline void *mempcpy(void *dest, const void *src, size_t n)
+ {
+     memcpy(dest, src, n);

--- a/packages/ctypes-sh/002-array-element-fix-from-pahole.patch
+++ b/packages/ctypes-sh/002-array-element-fix-from-pahole.patch
@@ -1,0 +1,113 @@
+From eb6bd05766f54dc921018de1f93fcfa290e4a19d Mon Sep 17 00:00:00 2001
+From: Yonghong Song <yhs@fb.com>
+Date: Thu, 23 Aug 2018 14:04:13 -0700
+Subject: [PATCH] dwarf_loader: Process DW_AT_count in DW_TAG_subrange_type
+
+For array type, gcc and clang generates dwarf info with different tags.  For
+example, with existing pahole,
+
+  $ cat test.c
+    int a[5][5];
+  $ gcc -c -g test.c
+  $ llvm-dwarfdump test.o
+    ...
+    0x0000001d:   DW_TAG_array_type
+                  DW_AT_type    (0x0000003a "int")
+                  DW_AT_sibling (0x00000033)
+
+    0x00000026:     DW_TAG_subrange_type
+                      DW_AT_type        (0x00000033 "long unsigned int")
+                      DW_AT_upper_bound (0x04)
+
+    0x0000002c:     DW_TAG_subrange_type
+                      DW_AT_type        (0x00000033 "long unsigned int")
+                      DW_AT_upper_bound (0x04)
+  $ pahole -JV test.o
+    [1] ARRAY (anon) type_id=3 index_type_id=3 nr_elems=25
+    [2] INT long unsigned int size=8 bit_offset=0 nr_bits=64 encoding=(none)
+    [3] INT int size=4 bit_offset=0 nr_bits=32 encoding=SIGNED
+  $ clang -c -g test.c
+  $ llvm-dwarfdump test.o
+    ...
+    0x00000033:   DW_TAG_array_type
+                    DW_AT_type  (0x00000045 "int")
+
+    0x00000038:     DW_TAG_subrange_type
+                      DW_AT_type        (0x0000004c "__ARRAY_SIZE_TYPE__")
+                      DW_AT_count       (0x05)
+
+    0x0000003e:     DW_TAG_subrange_type
+                      DW_AT_type        (0x0000004c "__ARRAY_SIZE_TYPE__")
+                      DW_AT_count       (0x05)
+  $ pahole -JV test.o
+    [1] ARRAY (anon) type_id=2 index_type_id=2 nr_elems=0
+    [2] INT int size=4 bit_offset=0 nr_bits=32 encoding=SIGNED
+    [3] INT __ARRAY_SIZE_TYPE__ size=8 bit_offset=0 nr_bits=64 encoding=(none)
+
+Current pahole processed DW_AT_upper_bound under DW_TAG_subrange_type to
+get array range, but it did not process DW_AT_count so during pahole
+dwarf2btf conversion, the flattened array size is 0.
+
+This patch fixed the issue by processing DW_AT_count properly.
+With the change, for clang generated test.o, pahole btf conversion output is:
+  $ pahole -JV test.o
+    [1] ARRAY (anon) type_id=2 index_type_id=2 nr_elems=25
+    [2] INT int size=4 bit_offset=0 nr_bits=32 encoding=SIGNED
+    [3] INT __ARRAY_SIZE_TYPE__ size=8 bit_offset=0 nr_bits=64 encoding=(none)
+
+Committer testing:
+
+Before:
+
+  # pahole -C augmented_enter_connect_args augmented_syscalls.bpf.o
+  struct augmented_enter_connect_args {
+          struct syscall_enter_connect_args args;          /*     0    40 */
+          char                       addr[0];              /*    40     0 */
+
+          /* size: 56, cachelines: 1, members: 2 */
+          /* padding: 16 */
+          /* last cacheline: 56 bytes */
+  };
+  # file augmented_syscalls.bpf.o
+  augmented_syscalls.bpf.o: ELF 64-bit LSB relocatable, *unknown arch 0xf7* version 1 (SYSV), with debug_info, not stripped
+  #
+
+After:
+
+  # pahole -C augmented_enter_connect_args augmented_syscalls.bpf.o
+  struct augmented_enter_connect_args {
+	  struct syscall_enter_connect_args args;          /*     0    40 */
+	  char                       addr[14];             /*    40    14 */
+
+	  /* size: 56, cachelines: 1, members: 2 */
+	  /* padding: 2 */
+	  /* last cacheline: 56 bytes */
+  };
+  #
+
+Signed-off-by: Yonghong Song <yhs@fb.com>
+Tested-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+Cc: Martin KaFai Lau <kafai@fb.com>
+Cc: Okash Khawaja <osk@fb.com>
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ dwarf_loader.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/struct/dwarf_loader.c b/src/struct/dwarf_loader.c
+index 037e005..23dfdfb 100644
+--- a/src/struct/dwarf_loader.c
++++ b/src/struct/dwarf_loader.c
+@@ -933,6 +933,12 @@ static uint64_t attr_upper_bound(Dwarf_Die *die)
+ 		if (dwarf_formudata(&attr, &num) == 0) {
+ 			return (uintmax_t)num + 1;
+ 		}
++	} else if (dwarf_attr(die, DW_AT_count, &attr) != NULL) {
++		Dwarf_Word num;
++
++		if (dwarf_formudata(&attr, &num) == 0) {
++			return (uintmax_t)num;
++		}
+ 	}
+ 
+ 	return 0;

--- a/packages/ctypes-sh/build.sh
+++ b/packages/ctypes-sh/build.sh
@@ -1,0 +1,12 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/taviso/ctypes.sh
+TERMUX_PKG_DESCRIPTION="A foreign function interface for bash"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_VERSION=1.1
+TERMUX_PKG_SRCURL=https://github.com/taviso/ctypes.sh/releases/download/v${TERMUX_PKG_VERSION}/ctypes-sh-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=f7c8276b556101c51838296560d152fdcd96b860254a38d216b92986f31f8297
+TERMUX_PKG_DEPENDS="bash, libffi"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+	autoreconf -vif
+}

--- a/packages/ctypes-sh/compile-obstack-c.patch
+++ b/packages/ctypes-sh/compile-obstack-c.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 8a9b682..303f17f 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -10,7 +10,7 @@ if ENABLE_STRUCTS
+ ctypes_la_LIBADD     += libstruct.la
+ noinst_LTLIBRARIES   += libstruct.la
+ noinst_HEADERS       += struct/dutil.h struct/dwarves.h struct/elf_symtab.h struct/gobuffer.h struct/hash.h struct/list.h struct/rbtree.h struct/strings.h
+-libstruct_la_SOURCES  = struct/dutil.c struct/dwarves.c struct/gobuffer.c struct/struct.c struct/strings.c struct/dwarf_loader.c struct/dwarves_fprintf.c struct/elf_symtab.c struct/rbtree.c
++libstruct_la_SOURCES  = ../lib/obstack.c struct/dutil.c struct/dwarves.c struct/gobuffer.c struct/struct.c struct/strings.c struct/dwarf_loader.c struct/dwarves_fprintf.c struct/elf_symtab.c struct/rbtree.c
+ libstruct_la_CFLAGS   = -std=gnu99 -D_GNU_SOURCE
+ libstruct_la_CPPFLAGS = -I../include -I../lib
+ endif

--- a/packages/ctypes-sh/configure_ac.patch
+++ b/packages/ctypes-sh/configure_ac.patch
@@ -1,0 +1,101 @@
+diff --git a/configure.ac b/configure.ac
+index 67d6bc4..29e0e70 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -36,7 +36,7 @@ AC_CHECK_HEADER_STDBOOL
+ AC_PROG_CC
+ AC_FUNC_ALLOCA
+ 
+-AS_IF([test "x$disable_struct_support" == "xyes"], [
++AS_IF([test "x$disable_struct_support" = "xyes"], [
+     AC_FUNC_OBSTACK
+ ])
+ 
+@@ -65,86 +65,10 @@ AC_CHECK_MEMBER([struct builtin.name],
+ 
+ AM_CONDITIONAL([ENABLE_STRUCTS], [test "x$disable_struct_support" != "xyes"])
+ 
+-# Does enable -f work with a very simple plugin?
+-LDFLAGS="${LDFLAGS} -shared -fPIC"
+-
+-AC_MSG_CHECKING([whether a minimal bash plugin compiles])
+-AC_LINK_IFELSE([AC_LANG_SOURCE([[
+-    #include <stddef.h>
+-    #include <unistd.h>
+-
+-    #include "builtins.h"
+-
+-    int conftest_function(WORD_LIST *list)
+-    {
+-        exit(EXIT_SUCCESS);
+-    }
+-
+-    struct builtin conftest_struct = {
+-        .name       = "conftest",
+-        .function   = conftest_function,
+-        .flags      = BUILTIN_ENABLED,
+-        .long_doc   = NULL,
+-        .short_doc  = NULL,
+-        .handle     = NULL,
+-    };
+-]])], [
+-    AC_MSG_RESULT([yes])
+-    AC_MSG_CHECKING([loading simple plugin])
+-    if bash -c "enable -f ./conftest${ac_exeext} conftest && conftest || exit 1"; then
+-        AC_MSG_RESULT([yes])
+-    else
+-        AC_MSG_RESULT([no])
+-        AC_MSG_FAILURE([bash plugins do not appear to work], 1)
+-    fi
+-], [
+-    AC_MSG_RESULT([no])
+-    AC_MSG_FAILURE([unable to build a test extension], 1)
+-])
+-
+-# If this test fails, the distribution has built bash incorrectly and may need
+-# to append -Wl,-export-dynamic to the linker command line. Without exported
+-# symbols, plugins cannot interact with bash.
+-AC_MSG_CHECKING([whether bash symbols are exported])
+-AC_LINK_IFELSE([AC_LANG_SOURCE([[
+-    #include <stddef.h>
+-    #include <unistd.h>
+-
+-    #include "builtins.h"
+-
+-    int conftest_function(WORD_LIST *list)
+-    {
+-        exit(num_shell_builtins
+-                ? EXIT_SUCCESS
+-                : EXIT_FAILURE);
+-    }
+-
+-    struct builtin conftest_struct = {
+-        .name       = "conftest",
+-        .function   = conftest_function,
+-        .flags      = BUILTIN_ENABLED,
+-        .long_doc   = NULL,
+-        .short_doc  = NULL,
+-        .handle     = NULL,
+-    };
+-]])], [
+-    AC_MSG_RESULT([yes])
+-    AC_MSG_CHECKING([loading plugin with external references])
+-    if bash -c "enable -f ./conftest${ac_exeext} conftest && conftest || exit 1"; then
+-        AC_MSG_RESULT([yes])
+-    else
+-        AC_MSG_RESULT([no])
+-        AC_MSG_FAILURE([report this bug to your distribution; bash may be built incorrectly], 1)
+-    fi
+-], [
+-    AC_MSG_RESULT([no])
+-    AC_MSG_FAILURE([unable to build a test extension], 1)
+-])
+-
+ LDFLAGS="${SAVED_LDFLAGS}"
+ CPPFLAGS="${SAVED_CPPFLAGS}"
+ 
+-AS_IF([test "x$disable_struct_support" == "xyes"], [
++AS_IF([test "x$disable_struct_support" = "xyes"], [
+       AS_BOX([!!! AUTOMATIC STRUCT SUPPORT IS DISABLED DUE TO MISSING DEPENDENCIES !!!], [*])
+       AC_SUBST([struct], [])
+       AC_SUBST([sizeof], [])

--- a/packages/ctypes-sh/fix_callback.patch
+++ b/packages/ctypes-sh/fix_callback.patch
@@ -1,0 +1,13 @@
+diff --git a/src/callback.c b/src/callback.c
+index 1c6afe6..357a4b3 100644
+--- a/src/callback.c
++++ b/src/callback.c
+@@ -82,7 +82,7 @@ static int generate_native_callback(WORD_LIST *list)
+     ffi_type *callbacktype;
+     char **proto;
+     char *resultname = "DLRETVAL";
+-    char opt;
++    int opt;
+     reset_internal_getopt();
+ 
+     while ((opt = internal_getopt(list, "d:n:")) != -1) {


### PR DESCRIPTION
[Homepage](https://github.com/taviso/ctypes.sh)

struct support will work (well, the best it can do in the absence of debug symbols) once/if libdw gets added. In the meantime, it's fine as it is.