### PR TITLE
ctypes-sh: enable struct support

### DIFF
--- a/packages/ctypes-sh/build.sh
+++ b/packages/ctypes-sh/build.sh
@@ -2,9 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://github.com/taviso/ctypes.sh
 TERMUX_PKG_DESCRIPTION="A foreign function interface for bash"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_VERSION=1.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/taviso/ctypes.sh/releases/download/v${TERMUX_PKG_VERSION}/ctypes-sh-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=f7c8276b556101c51838296560d152fdcd96b860254a38d216b92986f31f8297
-TERMUX_PKG_DEPENDS="bash, libffi"
+TERMUX_PKG_DEPENDS="bash, libelf, libdw, libffi, zlib"
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_pre_configure() {


### PR DESCRIPTION
Thanks for merging my other PRs, xeffyr. And thanks to buttaface for putting libblocksruntime into its own package.

Sorry if this causes any inconvenience, but this is a small bump to ctypes-sh to enable struct support now that libdw is present.  