### PR TITLE
swift: tweaks to get on-device build working again

### DIFF
--- a/packages/swift/build.sh
+++ b/packages/swift/build.sh
@@ -76,7 +76,7 @@ termux_step_post_extract_package() {
 			patch -p1
 
 		# The Swift build scripts still depend on Python 2, so make sure it's used.
-		ln -s $(which python2) $TERMUX_PKG_BUILDDIR/python
+		ln -s $(command -v python2) $TERMUX_PKG_BUILDDIR/python
 	fi
 	export PATH=$TERMUX_PKG_BUILDDIR:$PATH
 }
@@ -133,9 +133,9 @@ termux_step_pre_configure() {
 		patch -p2 < $TERMUX_PKG_BUILDER_DIR/../libllvm/tools-clang-lib-Driver-ToolChain.cpp.patch
 		cd llvm
 		patch -p1 < $TERMUX_PKG_BUILDER_DIR/../libllvm/include-llvm-ADT-Triple.h.patch
+		cd ../..
 
 		if [ "$TERMUX_ON_DEVICE_BUILD" = "false" ]; then
-			cd ../..
 			# Build patch needed only when cross-compiling the compiler.
 			sed "s%\@TERMUX_STANDALONE_TOOLCHAIN\@%${TERMUX_STANDALONE_TOOLCHAIN}%g" \
 			$TERMUX_PKG_BUILDER_DIR/swift-utils-build-script-impl | \
@@ -158,7 +158,7 @@ termux_step_make() {
 		-resource-dir $TERMUX_PREFIX/lib/swift -sdk $TERMUX_STANDALONE_TOOLCHAIN/sysroot \
 		-L$TERMUX_STANDALONE_TOOLCHAIN/lib/gcc/$TERMUX_HOST_PLATFORM/4.9.x \
 		-tools-directory $TERMUX_STANDALONE_TOOLCHAIN/$TERMUX_HOST_PLATFORM/bin \
-		-Xclang-linker -nostdlib++ -Xlinker -rpath -Xlinker $TERMUX_PREFIX/lib"
+		-Xlinker -rpath -Xlinker $TERMUX_PREFIX/lib"
 		export HOST_SWIFTC="$TERMUX_PKG_HOSTBUILD_DIR/swift-$TERMUX_PKG_VERSION-$SWIFT_RELEASE-ubuntu20.04/usr/bin/swiftc"
 
 		# Use the modulemap that points to the sysroot headers in the standalone NDK

--- a/packages/swift/swift-build-script.patch
+++ b/packages/swift/swift-build-script.patch
@@ -421,3 +421,26 @@ index 5e4f30ef194..16ef23f40da 100644
 +    else:
 +        built_toolchain_path += install_prefix
      return built_toolchain_path
+diff --git a/swift/utils/swift_build_support/swift_build_support/which.py b/swift/utils/swift_build_support/swift_build_support/which.py
+index 8b329cc95cc..14df9d0aff0 100644
+--- a/swift/utils/swift_build_support/swift_build_support/which.py
++++ b/swift/utils/swift_build_support/swift_build_support/which.py
+@@ -17,6 +17,7 @@
+ # ----------------------------------------------------------------------------
+ 
+ from __future__ import absolute_import
++import os
+ 
+ from . import cache_util
+ from . import shell
+@@ -34,7 +35,9 @@ def which(cmd):
+     We provide our own implementation because shutil.which() has not
+     been backported to Python 2.7, which we support.
+     """
+-    out = shell.capture(['which', cmd],
++
++    which = 'which' if 'ANDROID_DATA' not in os.environ else '/system/bin/which'
++    out = shell.capture([which, cmd],
+                         dry_run=False, echo=False,
+                         optional=True, stderr=shell.DEVNULL)
+     if out is None:


### PR DESCRIPTION
`which` is no longer there by default. No need for a revision bump since this doesn't affect the official package built in the CI.