### PR TITLE
moreutils: exclude parallel(1) manpage

### DIFF
--- a/packages/moreutils/build.sh
+++ b/packages/moreutils/build.sh
@@ -11,4 +11,5 @@ TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_RM_AFTER_INSTALL="
 bin/chronic
 share/man/man1/chronic.1
+share/man/man1/parallel.1
 "


### PR DESCRIPTION
parallel isn't built so why include its manpage?