### PR TITLE
Full version of apksigner from Android SDK

### DIFF
--- a/packages/apksigner/Asn1BerParser.java.patch
+++ b/packages/apksigner/Asn1BerParser.java.patch
@@ -1,0 +1,30 @@
+--- ../platform-tools-29.0.2/src/main/java/com/android/apksig/internal/asn1/Asn1BerParser.java	2020-07-16 21:18:25.186996621 +0800
++++ ../com/android/apksig/internal/asn1/Asn1BerParser.java	2020-07-16 21:17:19.166996646 +0800
+@@ -26,6 +26,7 @@
+ import java.lang.reflect.Field;
+ import java.lang.reflect.Modifier;
+ import java.math.BigInteger;
++import java.math.BigDecimal;
+ import java.nio.ByteBuffer;
+ import java.util.ArrayList;
+ import java.util.Collections;
+@@ -506,7 +507,8 @@
+     }
+ 
+     private static int integerToInt(ByteBuffer encoded) throws Asn1DecodingException {
+-        BigInteger value = integerToBigInteger(encoded);
++        BigInteger prevalue = integerToBigInteger(encoded);
++        BigDecimal value = new BigDecimal(prevalue);
+         try {
+             return value.intValueExact();
+         } catch (ArithmeticException e) {
+@@ -516,7 +518,8 @@
+     }
+ 
+     private static long integerToLong(ByteBuffer encoded) throws Asn1DecodingException {
+-        BigInteger value = integerToBigInteger(encoded);
++        BigInteger prevalue = integerToBigInteger(encoded);
++        BigDecimal value = new BigDecimal(prevalue);
+         try {
+             return value.longValueExact();
+         } catch (ArithmeticException e) {

--- a/packages/apksigner/build.sh
+++ b/packages/apksigner/build.sh
@@ -1,31 +1,35 @@
-TERMUX_PKG_HOMEPAGE=https://github.com/fornwall/apksigner
+TERMUX_PKG_HOMEPAGE=https://developer.android.com/studio/command-line/apksigner
 TERMUX_PKG_DESCRIPTION="APK signing tool"
 TERMUX_PKG_LICENSE="Apache-2.0"
-TERMUX_PKG_VERSION=0.7
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://github.com/fornwall/apksigner/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=340560c4f75af3501f037452bcf184fa48fd18bc877a4cce9a51a3fa047b4b38
+TERMUX_PKG_VERSION=${TERMUX_ANDROID_BUILD_TOOLS_VERSION}
+TERMUX_PKG_SKIP_SRC_EXTRACT=true
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 
+termux_step_pre_configure() {
+	# Requires Android SDK, not available on device
+	if $TERMUX_ON_DEVICE_BUILD; then
+		termux_error_exit "Package '$TERMUX_PKG_NAME' is not safe for on-device builds."
+	fi
+}
+
 termux_step_make() {
-	mkdir -p $TERMUX_PREFIX/share/{dex,man/man1}
+	mkdir -p $TERMUX_PREFIX/share/dex
+	SOURCEFILE=$ANDROID_HOME/build-tools/${TERMUX_PKG_VERSION}/lib/apksigner.jar
 
-	cp apksigner.1 $TERMUX_PREFIX/share/man/man1/
-
-	GRADLE_OPTS=" -Dorg.gradle.daemon=false" ./gradlew
 	$TERMUX_D8 \
 		--classpath $ANDROID_HOME/platforms/android-$TERMUX_PKG_API_LEVEL/android.jar \
 		--release \
 		--min-api $TERMUX_PKG_API_LEVEL \
 		--output $TERMUX_PKG_TMPDIR \
-		./build/libs/src-all.jar
+		$SOURCEFILE
 
 	cd $TERMUX_PKG_TMPDIR
-	jar cf apksigner.jar classes.dex
+	unzip $SOURCEFILE */*.txt
+	jar cf apksigner.jar classes.dex com/
 	mv apksigner.jar $TERMUX_PREFIX/share/dex/apksigner.jar
 
 	echo '#!/bin/sh' > $TERMUX_PREFIX/bin/apksigner
-	echo "dalvikvm -cp $TERMUX_PREFIX/share/dex/apksigner.jar net.fornwall.apksigner.Main \$@" >> $TERMUX_PREFIX/bin/apksigner
+	echo "dalvikvm -cp $TERMUX_PREFIX/share/dex/apksigner.jar com.android.apksigner.ApkSignerTool \$@" >> $TERMUX_PREFIX/bin/apksigner
 	chmod +x $TERMUX_PREFIX/bin/apksigner
 }

--- a/packages/apksigner/build.sh
+++ b/packages/apksigner/build.sh
@@ -29,7 +29,7 @@ termux_step_make() {
 
 	cd "$TERMUX_PKG_SRCDIR"
 	javac -cp "$SOURCEFILE" com/android/apksig/internal/asn1/Asn1BerParser.java
-	jar -uf "$SOURCEFILE" com/android/apksig/internal/asn1/Asn1BerParser.class
+	jar uf "$SOURCEFILE" com/android/apksig/internal/asn1/Asn1BerParser.class
 
 	$TERMUX_D8 \
 		--classpath $ANDROID_HOME/platforms/android-$TERMUX_PKG_API_LEVEL/android.jar \

--- a/packages/apksigner/build.sh
+++ b/packages/apksigner/build.sh
@@ -29,7 +29,7 @@ termux_step_make() {
 
 	cd "$TERMUX_PKG_SRCDIR"
 	javac -cp "$SOURCEFILE" com/android/apksig/internal/asn1/Asn1BerParser.java
-	jar uf "$SOURCEFILE" com/android/apksig/internal/asn1/Asn1BerParser.class
+	zip -u "$SOURCEFILE" com/android/apksig/internal/asn1/Asn1BerParser.class
 
 	$TERMUX_D8 \
 		--classpath $ANDROID_HOME/platforms/android-$TERMUX_PKG_API_LEVEL/android.jar \

--- a/packages/apksigner/build.sh
+++ b/packages/apksigner/build.sh
@@ -9,7 +9,7 @@ termux_step_extract_package() {
 	mkdir -p "$TERMUX_PKG_SRCDIR" && cd "$TERMUX_PKG_SRCDIR"
 	mkdir -p com/android/apksig/internal/asn1
 	termux_download \
-		"https://android.googlesource.com/platform/tools/apksig/+/refs/tags/platform-tools-29.0.2/src/main/java/com/android/apksig/internal/asn1/Asn1BerParser.java?format=TEXT" \
+		"https://android.googlesource.com/platform/tools/apksig/+/refs/tags/platform-tools-$TERMUX_PKG_VERSION/src/main/java/com/android/apksig/internal/asn1/Asn1BerParser.java?format=TEXT" \
 		com/android/apksig/internal/asn1/Asn1BerParser_b64.java \
 		f0506dedb7291dce1066b7aec3fc42c70b1862b39d9cdb176ba75d24b870765e
 	base64 -d com/android/apksig/internal/asn1/Asn1BerParser_b64.java > com/android/apksig/internal/asn1/Asn1BerParser.java


### PR DESCRIPTION
The current version of `apksigner` by fornwall only supports signing but not verifying `apk`.
On the other hand, this new version extracted directly from `build-tools` of Android SDK contains all the functions of the original `apksigner`. Therefore, it seems to be a much better alternative.