### PR TITLE
fix fdupes

### DIFF
--- a/packages/fdupes/build.sh
+++ b/packages/fdupes/build.sh
@@ -2,6 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://github.com/adrianlopezroche/fdupes
 TERMUX_PKG_DESCRIPTION="Duplicates file detector"
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_VERSION=2.1.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/adrianlopezroche/fdupes/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=37b1a499f6eb8b625b45641a2600be69ef591cd1e737e75afd50aa72ac215ea4
 TERMUX_PKG_DEPENDS="ncurses, pcre2"
+
+termux_step_pre_configure() {
+	autoreconf --install
+}


### PR DESCRIPTION
fixes #5575
turns out it was just because 287d37c53e874744ac10e7491ccc677158a677b0 changed it from the release tarball in to the development one without reconfiguring