### PR TITLE
new package: music-file-organizer

### DIFF
--- a/packages/music-file-organizer/build.sh
+++ b/packages/music-file-organizer/build.sh
@@ -1,0 +1,8 @@
+TERMUX_PKG_HOMEPAGE=https://git.zx2c4.com/music-file-organizer/about/
+TERMUX_PKG_DESCRIPTION="Organizer of audio files into directories based on metadata tags"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_VERSION=1.0.3
+TERMUX_PKG_SRCURL=https://git.zx2c4.com/music-file-organizer/snapshot/music-file-organizer-$TERMUX_PKG_VERSION.tar.xz
+TERMUX_PKG_SHA256=042c33f6db7da8889125359db02054fa1fcbfad339e8841e7e26474bf6aed3ad
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_DEPENDS="libicu, taglib"


### PR DESCRIPTION
Old but incredibly useful program, especially on Android for Linux users pushing MP3s over manually or aggregating from multiple sources, who want some saner on-disk organization.