### PR TITLE
apt: update from 1.4.9 to 1.4.10, use Termux cache directory, and keep downloaded packages by default

### DIFF
--- a/packages/apt/0012-keep-downloaded-packages.patch
+++ b/packages/apt/0012-keep-downloaded-packages.patch
@@ -1,0 +1,13 @@
+diff --git a/apt-private/private-cmndline.cc b/apt-private/private-cmndline.cc
+index de3992a00..96b2c1251 100644
+--- a/apt-private/private-cmndline.cc
++++ b/apt-private/private-cmndline.cc
+@@ -461,7 +461,7 @@ static void BinarySpecificConfiguration(char const * const Binary)	/*{{{*/
+       _config->CndSet("Binary::apt::APT::Get::Upgrade-Allow-New", true);
+       _config->CndSet("Binary::apt::APT::Cmd::Show-Update-Stats", true);
+       _config->CndSet("Binary::apt::DPkg::Progress-Fancy", true);
+-      _config->CndSet("Binary::apt::APT::Keep-Downloaded-Packages", false);
++      _config->CndSet("Binary::apt::APT::Keep-Downloaded-Packages", true);
+    }
+    if (binary == "apt-config")
+       _config->CndSet("Binary::apt-get::Acquire::AllowInsecureRepositories", true);

--- a/packages/apt/build.sh
+++ b/packages/apt/build.sh
@@ -1,10 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://packages.debian.org/apt
 TERMUX_PKG_DESCRIPTION="Front-end for the dpkg package manager"
 TERMUX_PKG_LICENSE="GPL-2.0"
-TERMUX_PKG_VERSION=1.4.9
-TERMUX_PKG_REVISION=29
+TERMUX_PKG_VERSION=1.4.10
 TERMUX_PKG_SRCURL=http://ftp.debian.org/debian/pool/main/a/apt/apt_${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=d4d65e7c84da86f3e6dcc933bba46a08db429c9d933b667c864f5c0e880bac0d
+TERMUX_PKG_SHA256=eaa314e8ebc9e62fedf316d196d1a99d894fd715e6385ed18afd41cc2cd5b127
 # apt-key requires utilities from coreutils, findutils, gpgv, grep, sed.
 TERMUX_PKG_DEPENDS="coreutils, dpkg, findutils, gpgv, grep, libc++, libcurl, liblzma, sed, termux-licenses, zlib"
 TERMUX_PKG_CONFLICTS="apt-transport-https, libapt-pkg"
@@ -19,8 +18,9 @@ etc/apt/trusted.gpg
 "
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--DPERL_EXECUTABLE=$(which perl)
+-DPERL_EXECUTABLE=$(command -v perl)
 -DCMAKE_INSTALL_FULL_LOCALSTATEDIR=$TERMUX_PREFIX
+-DCACHE_DIR=/data/data/com.termux/cache/apt
 -DCOMMON_ARCH=$TERMUX_ARCH
 -DDPKG_DATADIR=$TERMUX_PREFIX/share/dpkg
 -DUSE_NLS=OFF


### PR DESCRIPTION
Tested this out locally and it works fine. I wanted something like this, as I uninstall the official Swift package all the time when I build locally updated or patched versions, and when I'd go back to installing the official package, it would need to download that 50 MB file again each time. It got to the point where I keep that package stored locally and reinstall it with `dpkg`, rather than have `apt` download it each time. With this change, `apt` will do this for me, for any packages that I uninstall, until `apt clean` is run. This new default can always be overriden on the commandline or [by adding a config file](https://salsa.debian.org/apt-team/apt/-/blob/1.4.y/debian/NEWS#L39).

I'll make some changes to add `clean` commands to the `pkg` install script and surface some cache info to the user and this should be ready to go. I won't commit until another maintainer approves, as this is a core package.