### PR TITLE
tmux: fix socket path in manual page

### DIFF
--- a/packages/tmux/build.sh
+++ b/packages/tmux/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="BSD"
 # Link against libandroid-support for wcwidth(), see https://github.com/termux/termux-packages/issues/224
 TERMUX_PKG_DEPENDS="ncurses, libevent, libandroid-support, libandroid-glob"
 TERMUX_PKG_VERSION=3.1b
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/tmux/tmux/archive/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=100d0a11a822927172e8b983b5f9401476bd9f2cfa6758512f762b9ad74f9536
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-static"

--- a/packages/tmux/socket-path.patch
+++ b/packages/tmux/socket-path.patch
@@ -1,5 +1,27 @@
---- ../tmux.c.orig	2019-08-24 20:23:15.576000965 +0200
-+++ ./tmux.c	2019-08-24 22:11:56.316981911 +0200
+diff -u -r ../tmux-3.1b/tmux.1 ./tmux.1
+--- ../tmux-3.1b/tmux.1	2020-05-04 10:06:57.000000000 +0200
++++ ./tmux.1	2020-08-06 10:59:21.812427968 +0200
+@@ -90,7 +90,7 @@
+ .Em server .
+ The server and each client are separate processes which communicate through a
+ socket in
+-.Pa /tmp .
++.Pa @TERMUX_PREFIX@/var/run .
+ .Pp
+ The options are as follows:
+ .Bl -tag -width "XXXXXXXXXXXX"
+@@ -145,7 +145,7 @@
+ stores the server socket in a directory under
+ .Ev TMUX_TMPDIR
+ or
+-.Pa /tmp
++.Pa @TERMUX_PREFIX@/var/run
+ if it is unset.
+ The default socket is named
+ .Em default .
+diff -u -r ../tmux-3.1b/tmux.c ./tmux.c
+--- ../tmux-3.1b/tmux.c	2020-05-04 10:06:57.000000000 +0200
++++ ./tmux.c	2020-08-06 10:57:51.152231951 +0200
 @@ -121,7 +121,7 @@
  	if ((s = getenv("TMUX_TMPDIR")) != NULL && *s != '\0')
  		xasprintf(&base, "%s/tmux-%ld", s, (long)uid);


### PR DESCRIPTION
The socket path was changed from /tmp to @TERMUX_PREFIX@/var/run. Update the manual accordingly.