### PR TITLE
mediainfo: update from 20.03 to 20.08

### DIFF
--- a/packages/libmediainfo/build.sh
+++ b/packages/libmediainfo/build.sh
@@ -2,10 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://mediaarea.net/en/MediaInfo
 TERMUX_PKG_DESCRIPTION="Library for reading information from media files"
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_LICENSE_FILE="../../../LICENSE"
-TERMUX_PKG_VERSION=20.03
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION=20.08
 TERMUX_PKG_SRCURL=https://mediaarea.net/download/source/libmediainfo/${TERMUX_PKG_VERSION}/libmediainfo_${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=90ea6395a5b5b6a138c2f85e9afe9723cb97bca6f9137529a0a2052acf2fe0d7
+TERMUX_PKG_SHA256=700365b85259b86dcf0278568c6a7f998e6caa9ff88504dda4a8f8b4b45bbd2b
 TERMUX_PKG_DEPENDS="libcurl, libzen, zlib"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-shared --enable-static --with-libcurl"
 

--- a/packages/mediainfo/build.sh
+++ b/packages/mediainfo/build.sh
@@ -2,12 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://mediaarea.net/en/MediaInfo
 TERMUX_PKG_DESCRIPTION="Command-line utility for reading information from media files"
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_LICENSE_FILE="../../../LICENSE"
-TERMUX_PKG_VERSION=20.03
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION=20.08
 TERMUX_PKG_SRCURL=https://mediaarea.net/download/source/mediainfo/${TERMUX_PKG_VERSION}/mediainfo_${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=55bea28ce0d39c88677c58e3a002bbb95e206749be1d3d0c9134514b4c27acdc
+TERMUX_PKG_SHA256=cf7dcd874a6d7f7208f01fc73f02652d4aab213b236e41cdcf2c69d9823a45a7
 TERMUX_PKG_DEPENDS="libmediainfo"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-dll"
 
 termux_step_pre_configure() {
 	TERMUX_PKG_SRCDIR="${TERMUX_PKG_SRCDIR}/Project/GNU/CLI"


### PR DESCRIPTION
Updated the packages mediainfo and libmediainfo from version 20.03 to 20.08

Also removed the extra configure arg "--with-dll" in mediainfo to switch from dynamic loading to dynamic linking to libmediainfo.