### PR TITLE
New package: croc

### DIFF
--- a/packages/croc/build.sh
+++ b/packages/croc/build.sh
@@ -1,0 +1,19 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/schollz/croc
+TERMUX_PKG_DESCRIPTION="Easily and securely send things from one computer to another."
+TERMUX_PKG_LICENSE=MIT
+TERMUX_PKG_VERSION=8.3.1
+TERMUX_PKG_SRCURL=https://github.com/schollz/croc/releases/download/v${TERMUX_PKG_VERSION}/croc_${TERMUX_PKG_VERSION}_src.tar.gz
+TERMUX_PKG_SHA256=58dbe55cdbd0c8255c40ac5045676b7e8a0af8e21732f80502efc8cd27330d87
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make() {
+	cd $TERMUX_PKG_SRCDIR
+
+	termux_setup_golang
+
+	go build -o croc -trimpath
+}
+
+termux_step_make_install() {
+	install -m755 croc $TERMUX_PREFIX/bin/croc
+}


### PR DESCRIPTION
This PR adds package for [croc](https://github.com/schollz/croc), a tool that allows any two computers to simply and securely transfer files and folders, similar to [magic-wormhole](https://github.com/warner/magic-wormhole).