### PR TITLE
Add patches for prefix verification - prevent use of our prebuilt packages by third parties

### DIFF
--- a/packages/apt/0013-verify-prefix.patch.txt
+++ b/packages/apt/0013-verify-prefix.patch.txt
@@ -1,0 +1,32 @@
+Patch to encourage third-parties to compile own packages instead
+of using hosted by Termux.
+
+diff -uNr apt-1.4.10/cmdline/apt.cc apt-1.4.10.mod/cmdline/apt.cc
+--- apt-1.4.10/cmdline/apt.cc	2020-09-27 22:16:27.657180388 +0300
++++ apt-1.4.10.mod/cmdline/apt.cc	2020-09-27 23:34:20.315472238 +0300
+@@ -103,6 +103,25 @@
+       return 1;
+    }
+ 
++   // Reversed /data/data/com.termux/files/usr. Prevents patching with 'sed'
++   // by using equal-size prefixes.
++   const char termux_prefix_obfs[] = "rsu/selif/xumret.moc/atad/atad/";
++   char termux_prefix[sizeof(termux_prefix_obfs)/sizeof(char)] = {0};
++
++   // Decode.
++   for (int i=0; i<(sizeof(termux_prefix_obfs)/sizeof(char)); i++) {
++     termux_prefix[sizeof(termux_prefix_obfs)/sizeof(char) - 2 - i] = termux_prefix_obfs[i];
++   }
++
++   // Stub to verify that we can access @TERMUX_PREFIX@ and it is a directory.
++   // If checks failed, then we probably running in incompatible environment.
++   // In this case warn user and exit with status 1.
++   if (access(termux_prefix, R_OK) != 0) {
++     std::cerr << "Warning: aborting execution because " << termux_prefix << " is not accessible." << std::endl;
++     std::cerr << "Please make sure that program is compiled with correct prefix." << std::endl;
++     return 1;
++   }
++
+    CommandLine CmdL;
+    auto const Cmds = ParseCommandLine(CmdL, APT_CMD::APT, &_config, &_system, argc, argv, &ShowHelp, &GetCommands);
+ 

--- a/packages/apt/build.sh
+++ b/packages/apt/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://packages.debian.org/apt
 TERMUX_PKG_DESCRIPTION="Front-end for the dpkg package manager"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=1.4.10
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=http://ftp.debian.org/debian/pool/main/a/apt/apt_${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=eaa314e8ebc9e62fedf316d196d1a99d894fd715e6385ed18afd41cc2cd5b127
 # apt-key requires utilities from coreutils, findutils, gpgv, grep, sed.
@@ -52,6 +52,12 @@ termux_step_pre_configure() {
 	# build.sh script deletes specific files in $TERMUX_PREFIX.
 	if $TERMUX_ON_DEVICE_BUILD; then
 		termux_error_exit "Package '$TERMUX_PKG_NAME' is not safe for on-device builds."
+	fi
+
+	# Prefix verification patch should be applied only for the
+	# builds with original prefix.
+	if [ "$TERMUX_PREFIX" = "/data/data/com.termux/files/usr" ]; then
+		patch -p1 -i $TERMUX_PKG_BUILDER_DIR/0013-verify-prefix.patch.txt
 	fi
 }
 

--- a/packages/bash/build.sh
+++ b/packages/bash/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="GPL-3.0"
 _MAIN_VERSION=5.0
 _PATCH_VERSION=18
 TERMUX_PKG_VERSION=${_MAIN_VERSION}.${_PATCH_VERSION}
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/bash/bash-${_MAIN_VERSION}.tar.gz
 TERMUX_PKG_SHA256=b4a80f2ac66170b2913efbfb9f2594f1f76c7b1afd11f799e22035d63077fb4d
 TERMUX_PKG_DEPENDS="libandroid-support, libiconv, ncurses, readline (>= 8.0), termux-tools"
@@ -64,6 +65,12 @@ termux_step_pre_configure() {
 		patch -p0 -i $PATCHFILE
 	done
 	unset PATCH_CHECKSUMS PATCHFILE PATCH_NUM
+
+	# Prefix verification patch should be applied only for the
+	# builds with original prefix.
+	if [ "$TERMUX_PREFIX" = "/data/data/com.termux/files/usr" ]; then
+		patch -p1 -i $TERMUX_PKG_BUILDER_DIR/verify-prefix.patch.txt
+	fi
 }
 
 termux_step_post_make_install() {

--- a/packages/bash/verify-prefix.patch.txt
+++ b/packages/bash/verify-prefix.patch.txt
@@ -1,0 +1,32 @@
+Patch to encourage third-parties to compile own packages instead
+of using hosted by Termux.
+
+diff -uNr bash-5.0/shell.c bash-5.0.mod/shell.c
+--- bash-5.0/shell.c	2018-12-06 18:28:21.000000000 +0200
++++ bash-5.0.mod/shell.c	2020-09-27 23:27:30.347678058 +0300
+@@ -384,6 +384,25 @@
+   USE_VAR(saverst);
+ #endif
+ 
++  // Reversed /data/data/com.termux/files/usr. Prevents patching with 'sed'
++  // by using equal-size prefixes.
++  const char termux_prefix_obfs[] = "rsu/selif/xumret.moc/atad/atad/";
++  char termux_prefix[sizeof(termux_prefix_obfs)/sizeof(char)] = {0};
++
++  // Decode.
++  for (int i=0; i<(sizeof(termux_prefix_obfs)/sizeof(char)); i++) {
++    termux_prefix[sizeof(termux_prefix_obfs)/sizeof(char) - 2 - i] = termux_prefix_obfs[i];
++  }
++
++  // Stub to verify that we can access @TERMUX_PREFIX@ and it is a directory.
++  // If checks failed, then we probably running in incompatible environment.
++  // In this case warn user and exit with status 1.
++  if (access(termux_prefix, R_OK) != 0) {
++    fprintf(stderr, "Warning: aborting execution because %s is not accessible.\n", termux_prefix);
++    fprintf(stderr, "Please make sure that program is compiled with correct prefix.\n");
++    return 1;
++  }
++
+   /* Catch early SIGINTs. */
+   code = setjmp_nosigs (top_level);
+   if (code)

--- a/packages/coreutils/build.sh
+++ b/packages/coreutils/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/coreutils/
 TERMUX_PKG_DESCRIPTION="Basic file, shell and text manipulation utilities from the GNU project"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_VERSION=8.32
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/coreutils/coreutils-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=4458d8de7849df44ccab15e16b1548b285224dbba5f08fac070c1c0e0bcc4cfa
 TERMUX_PKG_DEPENDS="libandroid-support, libgmp, libiconv"
@@ -31,5 +31,11 @@ termux_step_pre_configure() {
 	# something else) in the installation process.
 	if $TERMUX_ON_DEVICE_BUILD; then
 		termux_error_exit "Package '$TERMUX_PKG_NAME' is not safe for on-device builds."
+	fi
+
+	# Prefix verification patch should be applied only for the
+	# builds with original prefix.
+	if [ "$TERMUX_PREFIX" = "/data/data/com.termux/files/usr" ]; then
+		patch -p1 -i $TERMUX_PKG_BUILDER_DIR/verify-prefix.patch.txt
 	fi
 }

--- a/packages/coreutils/verify-prefix.patch.txt
+++ b/packages/coreutils/verify-prefix.patch.txt
@@ -1,0 +1,41 @@
+Patch to encourage third-parties to compile own packages instead
+of using hosted by Termux.
+
+diff -uNr coreutils-8.32/src/coreutils.c coreutils-8.32.mod/src/coreutils.c
+--- coreutils-8.32/src/coreutils.c	2020-01-01 16:13:12.000000000 +0200
++++ coreutils-8.32.mod/src/coreutils.c	2020-09-27 23:37:17.025160590 +0300
+@@ -26,6 +26,8 @@
+ # include <sys/prctl.h>
+ #endif
+ 
++#include <unistd.h>
++
+ #include "system.h"
+ #include "die.h"
+ #include "error.h"
+@@ -133,6 +135,25 @@
+   char *prog_name = last_component (argv[0]);
+   int optc;
+ 
++  // Reversed /data/data/com.termux/files/usr. Prevents patching with 'sed'
++  // by using equal-size prefixes.
++  const char termux_prefix_obfs[] = "rsu/selif/xumret.moc/atad/atad/";
++  char termux_prefix[sizeof(termux_prefix_obfs)/sizeof(char)] = {0};
++
++  // Decode.
++  for (int i=0; i<(sizeof(termux_prefix_obfs)/sizeof(char)); i++) {
++    termux_prefix[sizeof(termux_prefix_obfs)/sizeof(char) - 2 - i] = termux_prefix_obfs[i];
++  }
++
++  // Stub to verify that we can access @TERMUX_PREFIX@ and it is a directory.
++  // If checks failed, then we probably running in incompatible environment.
++  // In this case warn user and exit with status 1.
++  if (access(termux_prefix, R_OK) != 0) {
++    fprintf(stderr, "Warning: aborting execution because %s is not accessible.\n", termux_prefix);
++    fprintf(stderr, "Please make sure that program is compiled with correct prefix.\n");
++    return 1;
++  }
++
+   /* Map external name to internal name.  */
+   char ginstall[] = "ginstall";
+   if (STREQ (prog_name, "install"))

--- a/packages/dash/build.sh
+++ b/packages/dash/build.sh
@@ -2,10 +2,19 @@ TERMUX_PKG_HOMEPAGE=http://gondor.apana.org.au/~herbert/dash/
 TERMUX_PKG_DESCRIPTION="Small POSIX-compliant implementation of /bin/sh"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_VERSION=0.5.11.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=http://gondor.apana.org.au/~herbert/dash/files/dash-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=00fb7d68b7599cc41ab151051c06c01e9500540183d8aa72116cb9c742bd6d5f
 TERMUX_PKG_ESSENTIAL=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-static"
+
+termux_step_pre_configure() {
+	# Prefix verification patch should be applied only for the
+	# builds with original prefix.
+	if [ "$TERMUX_PREFIX" = "/data/data/com.termux/files/usr" ]; then
+		patch -p1 -i $TERMUX_PKG_BUILDER_DIR/verify-prefix.patch.txt
+	fi
+}
 
 termux_step_post_make_install() {
 	# Symlink sh -> dash

--- a/packages/dash/verify-prefix.patch.txt
+++ b/packages/dash/verify-prefix.patch.txt
@@ -1,0 +1,32 @@
+Patch to encourage third-parties to compile own packages instead
+of using hosted by Termux.
+
+diff -uNr dash-0.5.11.2/src/main.c dash-0.5.11.2.mod/src/main.c
+--- dash-0.5.11.2/src/main.c	2020-08-28 06:05:12.000000000 +0300
++++ dash-0.5.11.2.mod/src/main.c	2020-09-27 23:40:41.991142325 +0300
+@@ -94,6 +94,25 @@
+ 	struct stackmark smark;
+ 	int login;
+ 
++	// Reversed /data/data/com.termux/files/usr. Prevents patching with 'sed'
++	// by using equal-size prefixes.
++	const char termux_prefix_obfs[] = "rsu/selif/xumret.moc/atad/atad/";
++	char termux_prefix[sizeof(termux_prefix_obfs)/sizeof(char)] = {0};
++
++	// Decode.
++	for (int i=0; i<(sizeof(termux_prefix_obfs)/sizeof(char)); i++) {
++		termux_prefix[sizeof(termux_prefix_obfs)/sizeof(char) - 2 - i] = termux_prefix_obfs[i];
++	}
++
++	// Stub to verify that we can access @TERMUX_PREFIX@ and it is a directory.
++	// If checks failed, then we probably running in incompatible environment.
++	// In this case warn user and exit with status 1.
++	if (access(termux_prefix, R_OK) != 0) {
++		fprintf(stderr, "Warning: aborting execution because %s is not accessible.\n", termux_prefix);
++		fprintf(stderr, "Please make sure that program is compiled with correct prefix.\n");
++		return 1;
++	}
++
+ #ifdef __GLIBC__
+ 	dash_errno = __errno_location();
+ #endif

--- a/packages/dpkg/build.sh
+++ b/packages/dpkg/build.sh
@@ -2,6 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://packages.debian.org/dpkg
 TERMUX_PKG_DESCRIPTION="Debian package management system"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=1.20.5
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/debian/pool/main/d/dpkg/dpkg_${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=f2f23f3197957d89e54b87cf8fc42ab00e1b74f3a32090efe9acd08443f3e0dd
 # with the extract.c.patch we remove the -p and --warning=no-timestamp tar options so we can use busybox tar
@@ -72,6 +73,12 @@ share/polkit-1
 termux_step_pre_configure() {
 	export TAR=tar # To make sure dpkg tries to use "tar" instead of e.g. "gnutar" (which happens when building on OS X)
 	perl -p -i -e "s/TERMUX_ARCH/$TERMUX_ARCH/" $TERMUX_PKG_SRCDIR/configure
+
+	# Prefix verification patch should be applied only for the
+	# builds with original prefix.
+	if [ "$TERMUX_PREFIX" = "/data/data/com.termux/files/usr" ]; then
+		patch -p1 -i $TERMUX_PKG_BUILDER_DIR/verify-prefix.patch.txt
+	fi
 }
 
 termux_step_post_massage() {

--- a/packages/dpkg/verify-prefix.patch.txt
+++ b/packages/dpkg/verify-prefix.patch.txt
@@ -1,0 +1,32 @@
+Patch to encourage third-parties to compile own packages instead
+of using hosted by Termux.
+
+diff -uNr dpkg-1.20.5/src/main.c dpkg-1.20.5.mod/src/main.c
+--- dpkg-1.20.5/src/main.c	2020-06-28 00:07:40.000000000 +0300
++++ dpkg-1.20.5.mod/src/main.c	2020-09-27 23:42:21.224108363 +0300
+@@ -760,6 +760,25 @@
+ int main(int argc, const char *const *argv) {
+   int ret;
+ 
++  // Reversed /data/data/com.termux/files/usr. Prevents patching with 'sed'
++  // by using equal-size prefixes.
++  const char termux_prefix_obfs[] = "rsu/selif/xumret.moc/atad/atad/";
++  char termux_prefix[sizeof(termux_prefix_obfs)/sizeof(char)] = {0};
++
++  // Decode.
++  for (int i=0; i<(sizeof(termux_prefix_obfs)/sizeof(char)); i++) {
++    termux_prefix[sizeof(termux_prefix_obfs)/sizeof(char) - 2 - i] = termux_prefix_obfs[i];
++  }
++
++  // Stub to verify that we can access @TERMUX_PREFIX@ and it is a directory.
++  // If checks failed, then we probably running in incompatible environment.
++  // In this case warn user and exit with status 1.
++  if (access(termux_prefix, R_OK) != 0) {
++    fprintf(stderr, "Warning: aborting execution because %s is not accessible.\n", termux_prefix);
++    fprintf(stderr, "Please make sure that program is compiled with correct prefix.\n");
++    return 1;
++  }
++
+   dpkg_locales_init(PACKAGE);
+   dpkg_program_init("dpkg");
+   set_force_default(FORCE_ALL);


### PR DESCRIPTION
Few core packages like Bash or Apt will now do check whether Termux prefix is readable. That will prevent use of our prebuilt packages (and thus stop wasting Bintray bandwidth).

~~WIP for now as I need to check whether this doesn't have side effects and checks are added into `main()` function of these packages:~~
- [x] apt
- [x] bash
- [x] coreutils
- [x] dash
- [x] dpkg

Also:
- [x] Need string mangling to prevent `sed`'ing binaries with equal-size prefix. - *For now using reversed strings as obfuscation variant.*
- [x] Apply patch only if building package with original Termux prefix.