### PR TITLE
Added some aspell dictionaries

### DIFF
--- a/packages/aspell-de/build.sh
+++ b/packages/aspell-de/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="German dictionary for GNU Aspell"
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="Copyright"
 TERMUX_PKG_VERSION=20161207-7-0
-TERMUX_PKG_PLATFORM_INDEPENDENT=yes
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_SRCURL=ftp://ftp.gnu.org/gnu/aspell/dict/de/aspell6-de-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=c2125d1fafb1d4effbe6c88d4e9127db59da9ed92639c7cbaeae1b7337655571
-TERMUX_PKG_BUILD_IN_SRC=yes
+TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_configure () {
     # aspell configure doesn't play nicely with cross-compile but it's so trivial

--- a/packages/aspell-de/build.sh
+++ b/packages/aspell-de/build.sh
@@ -6,7 +6,6 @@ TERMUX_PKG_VERSION=20161207-7-0
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_SRCURL=ftp://ftp.gnu.org/gnu/aspell/dict/de/aspell6-de-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=c2125d1fafb1d4effbe6c88d4e9127db59da9ed92639c7cbaeae1b7337655571
-TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_configure () {
     # aspell configure doesn't play nicely with cross-compile but it's so trivial

--- a/packages/aspell-de/build.sh
+++ b/packages/aspell-de/build.sh
@@ -1,0 +1,23 @@
+TERMUX_PKG_HOMEPAGE=http://aspell.net
+TERMUX_PKG_DESCRIPTION="German dictionary for GNU Aspell"
+TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_LICENSE_FILE="Copyright"
+TERMUX_PKG_VERSION=20161207-7-0
+TERMUX_PKG_PLATFORM_INDEPENDENT=yes
+TERMUX_PKG_SRCURL=ftp://ftp.gnu.org/gnu/aspell/dict/de/aspell6-de-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_SHA256=c2125d1fafb1d4effbe6c88d4e9127db59da9ed92639c7cbaeae1b7337655571
+TERMUX_PKG_BUILD_IN_SRC=yes
+
+termux_step_configure () {
+    # aspell configure doesn't play nicely with cross-compile but it's so trivial
+    # we can easily replace it.
+    cat > $TERMUX_PKG_SRCDIR/Makefile <<EOF
+ASPELL = `which aspell`
+ASPELL_FLAGS = 
+PREZIP = `which prezip`
+DESTDIR =
+dictdir = $TERMUX_PREFIX/lib/aspell-0.60
+datadir = $TERMUX_PREFIX/lib/aspell-0.60
+EOF
+    cat $TERMUX_PKG_SRCDIR/Makefile.pre >> $TERMUX_PKG_SRCDIR/Makefile
+}

--- a/packages/aspell-en/build.sh
+++ b/packages/aspell-en/build.sh
@@ -1,0 +1,23 @@
+TERMUX_PKG_HOMEPAGE=http://aspell.net
+TERMUX_PKG_DESCRIPTION="English dictionary for GNU Aspell"
+TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_LICENSE_FILE="Copyright"
+TERMUX_PKG_VERSION=2019.10.06-0
+TERMUX_PKG_PLATFORM_INDEPENDENT=yes
+TERMUX_PKG_SRCURL=ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_SHA256=24334b4daac6890a679084f4089e1ce7edbe33c442ace776fa693d8e334f51fd
+TERMUX_PKG_BUILD_IN_SRC=yes
+
+termux_step_configure () {
+    # aspell configure doesn't play nicely with cross-compile but it's so trivial
+    # we can easily replace it.
+    cat > $TERMUX_PKG_SRCDIR/Makefile <<EOF
+ASPELL = `which aspell`
+ASPELL_FLAGS = 
+PREZIP = `which prezip`
+DESTDIR =
+dictdir = $TERMUX_PREFIX/lib/aspell-0.60
+datadir = $TERMUX_PREFIX/lib/aspell-0.60
+EOF
+    cat $TERMUX_PKG_SRCDIR/Makefile.pre >> $TERMUX_PKG_SRCDIR/Makefile
+}

--- a/packages/aspell-en/build.sh
+++ b/packages/aspell-en/build.sh
@@ -6,7 +6,6 @@ TERMUX_PKG_VERSION=2019.10.06-0
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_SRCURL=ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=24334b4daac6890a679084f4089e1ce7edbe33c442ace776fa693d8e334f51fd
-TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_configure () {
     # aspell configure doesn't play nicely with cross-compile but it's so trivial

--- a/packages/aspell-en/build.sh
+++ b/packages/aspell-en/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="English dictionary for GNU Aspell"
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="Copyright"
 TERMUX_PKG_VERSION=2019.10.06-0
-TERMUX_PKG_PLATFORM_INDEPENDENT=yes
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_SRCURL=ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=24334b4daac6890a679084f4089e1ce7edbe33c442ace776fa693d8e334f51fd
-TERMUX_PKG_BUILD_IN_SRC=yes
+TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_configure () {
     # aspell configure doesn't play nicely with cross-compile but it's so trivial

--- a/packages/aspell-es/build.sh
+++ b/packages/aspell-es/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="Spanish dictionary for GNU Aspell"
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="Copyright"
 TERMUX_PKG_VERSION=1.11-2
-TERMUX_PKG_PLATFORM_INDEPENDENT=yes
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_SRCURL=ftp://ftp.gnu.org/gnu/aspell/dict/es/aspell6-es-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=ad367fa1e7069c72eb7ae37e4d39c30a44d32a6aa73cedccbd0d06a69018afcc
-TERMUX_PKG_BUILD_IN_SRC=yes
+TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_configure () {
     # aspell configure doesn't play nicely with cross-compile but it's so trivial

--- a/packages/aspell-es/build.sh
+++ b/packages/aspell-es/build.sh
@@ -1,0 +1,23 @@
+TERMUX_PKG_HOMEPAGE=http://aspell.net
+TERMUX_PKG_DESCRIPTION="Spanish dictionary for GNU Aspell"
+TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_LICENSE_FILE="Copyright"
+TERMUX_PKG_VERSION=1.11-2
+TERMUX_PKG_PLATFORM_INDEPENDENT=yes
+TERMUX_PKG_SRCURL=ftp://ftp.gnu.org/gnu/aspell/dict/es/aspell6-es-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_SHA256=ad367fa1e7069c72eb7ae37e4d39c30a44d32a6aa73cedccbd0d06a69018afcc
+TERMUX_PKG_BUILD_IN_SRC=yes
+
+termux_step_configure () {
+    # aspell configure doesn't play nicely with cross-compile but it's so trivial
+    # we can easily replace it.
+    cat > $TERMUX_PKG_SRCDIR/Makefile <<EOF
+ASPELL = `which aspell`
+ASPELL_FLAGS = 
+PREZIP = `which prezip`
+DESTDIR =
+dictdir = $TERMUX_PREFIX/lib/aspell-0.60
+datadir = $TERMUX_PREFIX/lib/aspell-0.60
+EOF
+    cat $TERMUX_PKG_SRCDIR/Makefile.pre >> $TERMUX_PKG_SRCDIR/Makefile
+}

--- a/packages/aspell-es/build.sh
+++ b/packages/aspell-es/build.sh
@@ -6,7 +6,6 @@ TERMUX_PKG_VERSION=1.11-2
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_SRCURL=ftp://ftp.gnu.org/gnu/aspell/dict/es/aspell6-es-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=ad367fa1e7069c72eb7ae37e4d39c30a44d32a6aa73cedccbd0d06a69018afcc
-TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_configure () {
     # aspell configure doesn't play nicely with cross-compile but it's so trivial

--- a/packages/aspell-fr/build.sh
+++ b/packages/aspell-fr/build.sh
@@ -1,0 +1,23 @@
+TERMUX_PKG_HOMEPAGE=http://aspell.net
+TERMUX_PKG_DESCRIPTION="French dictionary for GNU Aspell"
+TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_LICENSE_FILE="Copyright"
+TERMUX_PKG_VERSION=0.50-3
+TERMUX_PKG_PLATFORM_INDEPENDENT=yes
+TERMUX_PKG_SRCURL=ftp://ftp.gnu.org/gnu/aspell/dict/fr/aspell-fr-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_SHA256=f9421047519d2af9a7a466e4336f6e6ea55206b356cd33c8bd18cb626bf2ce91
+TERMUX_PKG_BUILD_IN_SRC=yes
+
+termux_step_configure () {
+    # aspell configure doesn't play nicely with cross-compile but it's so trivial
+    # we can easily replace it.
+    cat > $TERMUX_PKG_SRCDIR/Makefile <<EOF
+ASPELL = `which aspell`
+ASPELL_FLAGS = 
+PREZIP = `which prezip`
+DESTDIR =
+dictdir = $TERMUX_PREFIX/lib/aspell-0.60
+datadir = $TERMUX_PREFIX/lib/aspell-0.60
+EOF
+    cat $TERMUX_PKG_SRCDIR/Makefile.pre >> $TERMUX_PKG_SRCDIR/Makefile
+}

--- a/packages/aspell-fr/build.sh
+++ b/packages/aspell-fr/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="French dictionary for GNU Aspell"
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="Copyright"
 TERMUX_PKG_VERSION=0.50-3
-TERMUX_PKG_PLATFORM_INDEPENDENT=yes
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_SRCURL=ftp://ftp.gnu.org/gnu/aspell/dict/fr/aspell-fr-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=f9421047519d2af9a7a466e4336f6e6ea55206b356cd33c8bd18cb626bf2ce91
-TERMUX_PKG_BUILD_IN_SRC=yes
+TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_configure () {
     # aspell configure doesn't play nicely with cross-compile but it's so trivial

--- a/packages/aspell-fr/build.sh
+++ b/packages/aspell-fr/build.sh
@@ -6,7 +6,6 @@ TERMUX_PKG_VERSION=0.50-3
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_SRCURL=ftp://ftp.gnu.org/gnu/aspell/dict/fr/aspell-fr-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=f9421047519d2af9a7a466e4336f6e6ea55206b356cd33c8bd18cb626bf2ce91
-TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_configure () {
     # aspell configure doesn't play nicely with cross-compile but it's so trivial


### PR DESCRIPTION
Added aspell dictionaries for English, French, German and Spanish.
Build script is fairly easy to adapt for other languages.
Dictionaries are under a custom license, so licence file is specified in build.
Build script is modelled off pull #1216.