### PR TITLE
termux-tools: use --no-install-recommends in pkg

### DIFF
--- a/packages/termux-tools/pkg
+++ b/packages/termux-tools/pkg
@@ -130,7 +130,7 @@ case "$CMD" in
 	add|i*)
 		select_mirror
 		update_apt_cache
-		apt install "$@"
+		apt install --no-install-recommends "$@"
 		;;
 	autoc*) apt autoclean;;
 	cl*) apt clean;;


### PR DESCRIPTION
Termux are usually (if not always) used on devices with relatively limited storage, so we probably want to avoid pulling too much by default. (Not to mention that we have repo traffic issue, and the new default behaviour almost makes the recommend field pointless.)