### PR TITLE
proot: Update package

### DIFF
--- a/packages/proot/build.sh
+++ b/packages/proot/build.sh
@@ -2,11 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://proot-me.github.io/
 TERMUX_PKG_DESCRIPTION="Emulate chroot, bind mount and binfmt_misc for non-root users"
 TERMUX_PKG_LICENSE="GPL-2.0"
 # Just bump commit and version when needed:
-_COMMIT=4f554c854df05e78ed6b4e9bc929276275d66ecc
+_COMMIT=c79069fc787f321623a272b66be2147878d98257
 TERMUX_PKG_VERSION=5.1.107
-TERMUX_PKG_REVISION=29
+TERMUX_PKG_REVISION=30
 TERMUX_PKG_SRCURL=https://github.com/termux/proot/archive/${_COMMIT}.zip
-TERMUX_PKG_SHA256=0eb5c00ff96c77ee17cb9e9902eb8b4e9371131627c4a5ee22d3f9a61f68f3f0
+TERMUX_PKG_SHA256=8645cd0b92b8831d29e629764e981a8b4f96fe23e48662d99179d3652a6023c3
 TERMUX_PKG_DEPENDS="libtalloc"
 
 # Install loader in libexec instead of extracting it every time


### PR DESCRIPTION
* Add statx() syscall support (termux/proot#122 termux/proot-distro#14)
* Add readlinkat(fd, "", ...) support (termux/proot#123)

(I'll merge this soon, just checking if CI still can build proot package as it now requires statx struct in headers)