### PR TITLE
links: add brotli as runtime dependency

### DIFF
--- a/packages/links/build.sh
+++ b/packages/links/build.sh
@@ -2,10 +2,10 @@ TERMUX_PKG_HOMEPAGE=http://links.twibright.com
 TERMUX_PKG_DESCRIPTION="Links is a text and graphics mode WWW browser"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=2.21
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=http://links.twibright.com/download/links-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=f0e1fd131b5e9ff943bcc667e0aa6331048749ad4b921b6fadd14e919d9f79ac
-TERMUX_PKG_DEPENDS="libbz2, libevent, liblzma, libpng, librsvg, libtiff, libx11, openssl, zlib, zstd"
+TERMUX_PKG_DEPENDS="brotli, libbz2, libevent, liblzma, libpng, librsvg, libtiff, libx11, openssl, zlib, zstd"
 TERMUX_PKG_BUILD_DEPENDS="libxt"
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="


### PR DESCRIPTION
Brotli is widely used compression for http web servers (RFC7932).
Debian has already enabled brotli decompression for links package, so
brotli decompression has been sufficiently tried and tested.

With this addition, links will add br as Accept-Encoding so that web
servers can serve brotli compressed contents for this text-mode web
browser.