### PR TITLE
Change gitea version info to official versioning

### DIFF
--- a/packages/gitea/build.sh
+++ b/packages/gitea/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Git with a cup of tea, painless self-hosted git service"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Leonid Pliushch <leonid.pliushch@gmail.com>"
 TERMUX_PKG_VERSION=1.12.4
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/go-gitea/gitea/archive/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=526843f3f8e5c6ab6d7d4edf75f15492a163eed929450ae5de8bfb90d60b2147
 TERMUX_PKG_DEPENDS="dash, git"

--- a/packages/gitea/build.sh
+++ b/packages/gitea/build.sh
@@ -20,7 +20,7 @@ termux_step_make() {
 	LDFLAGS+=" -X code.gitea.io/gitea/modules/setting.CustomConf=$TERMUX_PREFIX/etc/gitea/app.ini"
 	LDFLAGS+=" -X code.gitea.io/gitea/modules/setting.AppWorkPath=$TERMUX_PREFIX/var/lib/gitea"
 	LDFLAGS+=" -X code.gitea.io/gitea/modules/setting.CustomPath=$TERMUX_PREFIX/var/lib/gitea"
-	TAGS="bindata sqlite" make all
+	GITEA_VERSION=v"$TERMUX_PKG_VERSION" TAGS="bindata sqlite" make all
 }
 
 termux_step_make_install() {


### PR DESCRIPTION
Change the output of `gitea --version` to official, currntly the command outputs the termux-packages commit hash as version (I think) so it is not compatible with `gitnex`. This change makes it compatible with gitnex.