### PR TITLE
Add clash tunnel manager

### DIFF
--- a/packages/clash/build.sh
+++ b/packages/clash/build.sh
@@ -1,0 +1,28 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/Dreamacro/clash
+TERMUX_PKG_DESCRIPTION="A rule-based tunnel in Go."
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="Philipp Schmitt <philipp@schmitt.co>"
+TERMUX_PKG_VERSION=1.2.0
+TERMUX_PKG_SRCURL="https://github.com/Dreamacro/clash/archive/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=7278c8e28641c452c275bb5e1f1216b35e0b5d4a85374fa01d21d8defa282452
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make() {
+	termux_setup_golang
+
+	mkdir ./gopath
+	export GOPATH="$PWD/gopath"
+
+	GOBUILD=CGO_ENABLED=0 \
+		go build \
+			-trimpath \
+			-ldflags "-X 'github.com/Dreamacro/clash/constant.Version=${TERMUX_PKG_VERSION}'
+								-X 'github.com/Dreamacro/clash/constant.BuildTime=$(date -u)'
+								-w -s -buildid='" \
+			-o "clash.bin" \
+			main.go
+}
+
+termux_step_make_install() {
+	mv ./clash.bin "${TERMUX_PREFIX}/bin/clash"
+}


### PR DESCRIPTION
This adds a package for clash, GPL-3 licensed tunnel manager.
Upstream project: https://github.com/Dreamacro/clash

They do provide arm/aarch64 packages, but these obviously don't work on Termux.