### PR TITLE
new package: sops

### DIFF
--- a/packages/sops/build.sh
+++ b/packages/sops/build.sh
@@ -1,0 +1,20 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/mozilla/sops
+TERMUX_PKG_DESCRIPTION=" Simple and flexible tool for managing secrets"
+TERMUX_PKG_LICENSE="MPL-2.0"
+TERMUX_PKG_MAINTAINER="Philipp Schmitt @pschmitt"
+TERMUX_PKG_VERSION=3.6.1
+TERMUX_PKG_SRCURL="https://github.com/mozilla/sops/archive/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=bb6611eb70580ff74a258aa8b9713fdcb9a28de5a20ee716fe6b516608a60237
+
+termux_step_make_install() {
+	termux_setup_golang
+
+	export GOPATH="${TERMUX_PKG_BUILDDIR}"
+	mkdir -p "${GOPATH}/src/go.mozilla.org"
+	cp -a "${TERMUX_PKG_SRCDIR}" "${GOPATH}/src/go.mozilla.org/sops"
+	cd "${GOPATH}/src/go.mozilla.org/sops" || return 9
+	go get -d -v
+	make install
+
+	install -Dm700 "${GOPATH}/bin/"*/sops "${TERMUX_PREFIX}/bin/sops"
+}

--- a/packages/sops/build.sh
+++ b/packages/sops/build.sh
@@ -1,5 +1,5 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/mozilla/sops
-TERMUX_PKG_DESCRIPTION=" Simple and flexible tool for managing secrets"
+TERMUX_PKG_DESCRIPTION="Simple and flexible tool for managing secrets"
 TERMUX_PKG_LICENSE="MPL-2.0"
 TERMUX_PKG_MAINTAINER="Philipp Schmitt @pschmitt"
 TERMUX_PKG_VERSION=3.6.1


### PR DESCRIPTION
Here's another new package: sops!

Upstream: https://github.com/mozilla/sops

In case you are wondering what the `make install` does: it essentially just execs `go install go.mozilla.org/sops/v3/cmd/sops` ([See Makefile](https://github.com/mozilla/sops/blob/38b25bd449619e1d6da20e637702f7c73203aa44/Makefile#L12-L13))