### PR TITLE
Update tmux to 3.1c

### DIFF
--- a/packages/tmux/build.sh
+++ b/packages/tmux/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="Terminal multiplexer"
 TERMUX_PKG_LICENSE="BSD"
 # Link against libandroid-support for wcwidth(), see https://github.com/termux/termux-packages/issues/224
 TERMUX_PKG_DEPENDS="ncurses, libevent, libandroid-support, libandroid-glob"
-TERMUX_PKG_VERSION=3.1b
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION=3.1c
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/tmux/tmux/archive/${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=100d0a11a822927172e8b983b5f9401476bd9f2cfa6758512f762b9ad74f9536
+TERMUX_PKG_SHA256=b9617dd4d1c541ebc21b6b5760d58102fc039a593786aab273b5dd95dd514bea
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-static"
 TERMUX_PKG_BUILD_IN_SRC=true
 

--- a/packages/tmux/build.sh
+++ b/packages/tmux/build.sh
@@ -4,7 +4,6 @@ TERMUX_PKG_LICENSE="BSD"
 # Link against libandroid-support for wcwidth(), see https://github.com/termux/termux-packages/issues/224
 TERMUX_PKG_DEPENDS="ncurses, libevent, libandroid-support, libandroid-glob"
 TERMUX_PKG_VERSION=3.1c
-TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/tmux/tmux/archive/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=b9617dd4d1c541ebc21b6b5760d58102fc039a593786aab273b5dd95dd514bea
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-static"

--- a/packages/tmux/socket-path.patch
+++ b/packages/tmux/socket-path.patch
@@ -1,5 +1,5 @@
-diff -u -r ../tmux-3.1b/tmux.1 ./tmux.1
---- ../tmux-3.1b/tmux.1	2020-05-04 10:06:57.000000000 +0200
+diff -u -r ../tmux-3.1c/tmux.1 ./tmux.1
+--- ../tmux-3.1c/tmux.1	2020-05-04 10:06:57.000000000 +0200
 +++ ./tmux.1	2020-08-06 10:59:21.812427968 +0200
 @@ -90,7 +90,7 @@
  .Em server .
@@ -19,8 +19,8 @@ diff -u -r ../tmux-3.1b/tmux.1 ./tmux.1
  if it is unset.
  The default socket is named
  .Em default .
-diff -u -r ../tmux-3.1b/tmux.c ./tmux.c
---- ../tmux-3.1b/tmux.c	2020-05-04 10:06:57.000000000 +0200
+diff -u -r ../tmux-3.1c/tmux.c ./tmux.c
+--- ../tmux-3.1c/tmux.c	2020-05-04 10:06:57.000000000 +0200
 +++ ./tmux.c	2020-08-06 10:57:51.152231951 +0200
 @@ -121,7 +121,7 @@
  	if ((s = getenv("TMUX_TMPDIR")) != NULL && *s != '\0')


### PR DESCRIPTION
I don't know if I should have touched the patch file (to update the dir name) - it still applies fine anyway.

Upstream: https://github.com/tmux/tmux/releases/tag/3.1c