### PR TITLE
added conf to dictd client to use dict.org default server

### DIFF
--- a/packages/dictd/build.sh
+++ b/packages/dictd/build.sh
@@ -2,11 +2,12 @@ TERMUX_PKG_HOMEPAGE=https://sourceforge.net/projects/dict/
 TERMUX_PKG_DESCRIPTION="Online dictionary client and server"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=1.13.0
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/project/dict/dictd/dictd-${TERMUX_PKG_VERSION}/dictd-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=eeba51af77e87bb1b166c6bc469aad463632d40fb2bdd65e6675288d8e1a81e4
 TERMUX_PKG_DEPENDS="libmaa, zlib"
+TERMUX_PKG_CONFFILES="etc/dict.conf"
 
 termux_step_post_make_install() {
-	cp $TERMUX_PKG_BUILDER_DIR/dict.conf $TERMUX_PREFIX/etc/dict.conf
+	install -Dm600 $TERMUX_PKG_BUILDER_DIR/dict.conf $TERMUX_PREFIX/etc/dict.conf
 }

--- a/packages/dictd/build.sh
+++ b/packages/dictd/build.sh
@@ -2,6 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://sourceforge.net/projects/dict/
 TERMUX_PKG_DESCRIPTION="Online dictionary client and server"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_VERSION=1.13.0
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/project/dict/dictd/dictd-${TERMUX_PKG_VERSION}/dictd-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=eeba51af77e87bb1b166c6bc469aad463632d40fb2bdd65e6675288d8e1a81e4
 TERMUX_PKG_DEPENDS="libmaa, zlib"
+
+termux_step_post_make_install() {
+	cp $TERMUX_PKG_BUILDER_DIR/dict.conf $TERMUX_PREFIX/etc/dict.conf
+}

--- a/packages/dictd/dict.conf
+++ b/packages/dictd/dict.conf
@@ -1,0 +1,3 @@
+#Default configuration
+server localhost
+server dict.org


### PR DESCRIPTION
Added a basic configuration file for the dict client so that it is usable from install.
Default configuration uses servers on localhost and dict.org.