### PR TITLE
rgbds: update rgbds version from 0.4.1 to 0.4.2

### DIFF
--- a/packages/rgbds/build.sh
+++ b/packages/rgbds/build.sh
@@ -1,7 +1,7 @@
-TERMUX_PKG_HOMEPAGE=https://rednex.github.io/rgbds/
-TERMUX_PKG_DESCRIPTION="Rednex Game Boy Development System"
+TERMUX_PKG_HOMEPAGE=https://rgbds.gbdev.io
+TERMUX_PKG_DESCRIPTION="Rednex Game Boy Development System - An assembly toolchain for the Nintendo Game Boy & Game Boy Color"
 TERMUX_PKG_LICENSE="MIT"
-TERMUX_PKG_VERSION=0.4.1
-TERMUX_PKG_SRCURL=https://github.com/rednex/rgbds/releases/download/v${TERMUX_PKG_VERSION}/rgbds-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=e4253de7f1fdf1cd202276b07150010e182490052c6da6ae6ddac5685b9fec45
-TERMUX_PKG_DEPENDS="libpng, zlib"
+TERMUX_PKG_VERSION=0.4.2
+TERMUX_PKG_SRCURL=https://github.com/gbdev/rgbds/releases/download/v${TERMUX_PKG_VERSION}/rgbds-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=2579cbd6cc47bc944038d17ec3af640e2782c67fdffe7093e6083430543c9780
+TERMUX_PKG_DEPENDS="libpng, pkg-config, bison"

--- a/packages/rgbds/build.sh
+++ b/packages/rgbds/build.sh
@@ -3,5 +3,5 @@ TERMUX_PKG_DESCRIPTION="Rednex Game Boy Development System - An assembly toolcha
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_VERSION=0.4.2
 TERMUX_PKG_SRCURL=https://github.com/gbdev/rgbds/releases/download/v${TERMUX_PKG_VERSION}/rgbds-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=2579cbd6cc47bc944038d17ec3af640e2782c67fdffe7093e6083430543c9780
+TERMUX_PKG_SHA256=0bac46f0d3cfabf8683c62145b9f01a607c703295ef2978a3e548f106f50fac1
 TERMUX_PKG_DEPENDS="libpng, pkg-config, bison"

--- a/packages/rgbds/build.sh
+++ b/packages/rgbds/build.sh
@@ -4,4 +4,4 @@ TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_VERSION=0.4.2
 TERMUX_PKG_SRCURL=https://github.com/gbdev/rgbds/releases/download/v${TERMUX_PKG_VERSION}/rgbds-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=0bac46f0d3cfabf8683c62145b9f01a607c703295ef2978a3e548f106f50fac1
-TERMUX_PKG_DEPENDS="libpng, pkg-config, bison"
+TERMUX_PKG_DEPENDS="libpng"


### PR DESCRIPTION
Since rgbds is currently outdated and many repos which require it are updating to the latest version... have an update's pull request from a representative of the GBZ80 Assembly Termux community.