### PR TITLE
[ca-certificates] Update to new uptream cacert.pem

### DIFF
--- a/packages/ca-certificates/build.sh
+++ b/packages/ca-certificates/build.sh
@@ -1,10 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://curl.haxx.se/docs/caextract.html
 TERMUX_PKG_DESCRIPTION="Common CA certificates"
 TERMUX_PKG_LICENSE="GPL-2.0"
-TERMUX_PKG_VERSION=20201027
+TERMUX_PKG_VERSION=20201208
 TERMUX_PKG_SRCURL=https://curl.haxx.se/ca/cacert.pem
 # If the checksum has changed, it may be time to update the package version:
-TERMUX_PKG_SHA256=bb28d145ed1a4ee67253d8ddb11268069c9dafe3db25a9eee654974c4e43eee5
+TERMUX_PKG_SHA256=313d562594ebd07846ad6b840dd18993f22e0f8b3f275d9aacfae118f4f00fb7
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 


### PR DESCRIPTION
  - Update pakage version to cacert.pem of 20201208.
  - It prevented other packages from being upgraded.