### PR TITLE
Add sbindir flag to configure script

### DIFF
--- a/scripts/build/configure/termux_step_configure_autotools.sh
+++ b/scripts/build/configure/termux_step_configure_autotools.sh
@@ -102,6 +102,7 @@ termux_step_configure_autotools() {
 		--disable-dependency-tracking \
 		--prefix=$TERMUX_PREFIX \
 		--libdir=$TERMUX_PREFIX/lib \
+		--sbindir=$TERMUX_PREFIX/bin \
 		--disable-rpath --disable-rpath-hack \
 		$HOST_FLAG \
 		$TERMUX_PKG_EXTRA_CONFIGURE_ARGS \


### PR DESCRIPTION
Some packages install binaries to sbin folder. Since termux doesn't use sbin, just map it to bin folder. This eliminates the need of using this flag with TERMUX_PKG_EXTRA_CONFIGURE_ARGS in the build.sh script.

Also, libdir already maps to `prefix/lib` by default, so the `--libdir=$TERMUX_PREFIX/lib` flag is not necessary.