### PR TITLE
rust: update to 1.49.0

### DIFF
--- a/packages/rust/build.sh
+++ b/packages/rust/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.rust-lang.org/
 TERMUX_PKG_DESCRIPTION="Systems programming language focused on safety, speed and concurrency"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Kevin Cotugno @kcotugno"
-TERMUX_PKG_VERSION=1.48.0
+TERMUX_PKG_VERSION=1.49.0
 TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/rustc-$TERMUX_PKG_VERSION-src.tar.xz
-TERMUX_PKG_SHA256=ff0a242392a1865d7b2d08eb5ca6c1b3fd0820741d4c13a51a4b2d5d2bb53908
+TERMUX_PKG_SHA256=ebe910edc824a0a037a10be443446a0511923ba8342fa3c331ec8a22481d5d15
 TERMUX_PKG_DEPENDS="libc++, clang, openssl, lld, zlib, libllvm"
 
 termux_step_configure() {
@@ -18,7 +18,7 @@ termux_step_configure() {
 	# like 30 to 40 + minutes ... so lets get it right
 
 	# upstream only tests build ver one version behind $TERMUX_PKG_VERSION
-	local BOOTSTRAP_VERSION=1.47.0
+	local BOOTSTRAP_VERSION=1.48.0
 	rustup install $BOOTSTRAP_VERSION
 	rustup default $BOOTSTRAP_VERSION-x86_64-unknown-linux-gnu
 	export PATH=$HOME/.rustup/toolchains/$BOOTSTRAP_VERSION-x86_64-unknown-linux-gnu/bin:$PATH


### PR DESCRIPTION
I was not sure if just bumping the version number is enough, turns out [it builds successfully](https://github.com/kidonng/termux-packages/runs/1654945511).