### PR TITLE
bat: remove unnecessary LIBGIT2_SYS_USE_PKG_CONFIG

### DIFF
--- a/packages/bat/build.sh
+++ b/packages/bat/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A cat(1) clone with wings"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.17.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/sharkdp/bat/archive/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=16d39414e8a3b80d890cfdbca6c0e6ff280058397f4a3066c37e0998985d87c4
 # bat calls less with '--RAW-CONTROL-CHARS' which busybox less does not support:
@@ -14,7 +15,6 @@ termux_step_pre_configure() {
 	# See https://github.com/nagisa/rust_libloading/issues/54
 	export CC_x86_64_unknown_linux_gnu=gcc
 	export CFLAGS_x86_64_unknown_linux_gnu=""
-	export LIBGIT2_SYS_USE_PKG_CONFIG=1 
 }
 
 termux_step_post_make_install() {


### PR DESCRIPTION
Reference: https://github.com/rust-lang/git2-rs/issues/180#issuecomment-678740147

[The build runs successfully](https://github.com/kidonng/termux-packages/actions/runs/467770672).