### PR TITLE
cmus: Update to 2.9.0

### DIFF
--- a/packages/cmus/build.sh
+++ b/packages/cmus/build.sh
@@ -2,11 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://cmus.github.io/
 TERMUX_PKG_DESCRIPTION="Small, fast and powerful console music player"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=2.8.0
-TERMUX_PKG_REVISION=6
+TERMUX_PKG_VERSION=2.9.0
 TERMUX_PKG_DEPENDS="libandroid-support, libiconv, ncurses, pulseaudio, ffmpeg, libmad, opusfile, libflac, libvorbis"
-TERMUX_PKG_SRCURL=https://github.com/cmus/cmus/archive/2748d40bb670558b523d5b47b4af442e82c7ffd2.tar.gz
-TERMUX_PKG_SHA256=37b5a1889a97cdfd319880bc5925c179119330163315dc3f408145c66d352f6b
+TERMUX_PKG_SRCURL=https://github.com/cmus/cmus/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=e7ea7f5ec52b991cf378a9caf19e479be16a165a5b26adca058de711e72ad2a0
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_pre_configure() {


### PR DESCRIPTION
Also use `v${TERMUX_PKG_VERSION}` instead of commit bash for `TERMUX_PKG_SRCURL`.