### PR TITLE
(maint) update build-all.sh

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -9,7 +9,7 @@ if [ "$(uname -o)" = "Android" ] || [ -e "/system/bin/app_process" ]; then
 fi
 
 # Read settings from .termuxrc if existing
-test -f $HOME/.termuxrc && . $HOME/.termuxrc
+test -f "$HOME"/.termuxrc && . "$HOME"/.termuxrc
 : ${TERMUX_TOPDIR:="$HOME/.termux-build"}
 : ${TERMUX_ARCH:="aarch64"}
 : ${TERMUX_DEBUG:=""}
@@ -31,8 +31,9 @@ case "$option" in
 	a) TERMUX_ARCH="$OPTARG";;
 	d) TERMUX_DEBUG='-d';;
 	i) TERMUX_INSTALL_DEPS='-i';;
-	o) TERMUX_DEBDIR="$(realpath -m $OPTARG)";;
+	o) TERMUX_DEBDIR="$(realpath -m "$OPTARG")";;
 	h) _show_usage;;
+	*) _show_usage >&2 ;;
 esac
 done
 shift $((OPTIND-1))
@@ -43,45 +44,45 @@ if [[ ! "$TERMUX_ARCH" =~ ^(all|aarch64|arm|i686|x86_64)$ ]]; then
 	exit 1
 fi
 
-BUILDSCRIPT=$(dirname $0)/build-package.sh
+BUILDSCRIPT=$(dirname "$0")/build-package.sh
 BUILDALL_DIR=$TERMUX_TOPDIR/_buildall-$TERMUX_ARCH
 BUILDORDER_FILE=$BUILDALL_DIR/buildorder.txt
 BUILDSTATUS_FILE=$BUILDALL_DIR/buildstatus.txt
 
-if [ -e $BUILDORDER_FILE ]; then
+if [ -e "$BUILDORDER_FILE" ]; then
 	echo "Using existing buildorder file: $BUILDORDER_FILE"
 else
-	mkdir -p $BUILDALL_DIR
-	./scripts/buildorder.py > $BUILDORDER_FILE
+	mkdir -p "$BUILDALL_DIR"
+	./scripts/buildorder.py > "$BUILDORDER_FILE"
 fi
-if [ -e $BUILDSTATUS_FILE ]; then
+if [ -e "$BUILDSTATUS_FILE" ]; then
 	echo "Continuing build-all from: $BUILDSTATUS_FILE"
 fi
 
-exec >	>(tee -a $BUILDALL_DIR/ALL.out)
-exec 2> >(tee -a $BUILDALL_DIR/ALL.err >&2)
-trap "echo ERROR: See $BUILDALL_DIR/\${PKG}.err" ERR
+exec >	>(tee -a "$BUILDALL_DIR"/ALL.out)
+exec 2> >(tee -a "$BUILDALL_DIR"/ALL.err >&2)
+trap 'echo ERROR: See $BUILDALL_DIR/\${PKG}.err' ERR
 
-while read PKG PKG_DIR; do
+while read -r PKG PKG_DIR; do
 	# Check build status (grepping is a bit crude, but it works)
-	if [ -e $BUILDSTATUS_FILE ] && grep "^$PKG\$" $BUILDSTATUS_FILE >/dev/null; then
+	if [ -e "$BUILDSTATUS_FILE" ] && grep "^$PKG\$" "$BUILDSTATUS_FILE" >/dev/null; then
 		echo "Skipping $PKG"
 		continue
 	fi
 
 	echo -n "Building $PKG... "
 	BUILD_START=$(date "+%s")
-	bash -x $BUILDSCRIPT -a $TERMUX_ARCH $TERMUX_DEBUG \
-		${TERMUX_DEBDIR+-o $TERMUX_DEBDIR} $TERMUX_INSTALL_DEPS $PKG_DIR \
-		> $BUILDALL_DIR/${PKG}.out 2> $BUILDALL_DIR/${PKG}.err
+	bash -x "$BUILDSCRIPT" -a "$TERMUX_ARCH" $TERMUX_DEBUG \
+		${TERMUX_DEBDIR+-o $TERMUX_DEBDIR} $TERMUX_INSTALL_DEPS "$PKG_DIR" \
+		> "$BUILDALL_DIR"/"${PKG}".out 2> "$BUILDALL_DIR"/"${PKG}".err
 	BUILD_END=$(date "+%s")
-	BUILD_SECONDS=$(( $BUILD_END - $BUILD_START ))
+	BUILD_SECONDS=$(( BUILD_END - BUILD_START ))
 	echo "done in $BUILD_SECONDS"
 
 	# Update build status
-	echo "$PKG" >> $BUILDSTATUS_FILE
-done<${BUILDORDER_FILE}
+	echo "$PKG" >> "$BUILDSTATUS_FILE"
+done<"${BUILDORDER_FILE}"
 
 # Update build status
-rm -f $BUILDSTATUS_FILE
+rm -f "$BUILDSTATUS_FILE"
 echo "Finished"


### PR DESCRIPTION
- quote bash vars
- handle unknown flags in `getopts`
- add `-r` flag in `read` to avoid mangling `\`
- remove `$` in arithmetic which gives it PEMDAS characteristic
- single quote trap to expand when signaled vs. when defined