### PR TITLE
New Package: gogs v0.12.3

### DIFF
--- a/packages/gogs/app.ini
+++ b/packages/gogs/app.ini
@@ -1,0 +1,22 @@
+; Either "dev", "prod" or "test", default is "dev"
+APP_NAME = Termux Gogs
+RUN_MODE = prod
+
+[repository]
+ROOT = @TERMUX_PREFIX@/var/lib/gogs/git-data
+
+[lfs]
+STORAGE = local
+OBJECTS_PATH = @TERMUX_PREFIX@/var/lib/gogs/lfs-data
+
+[database]
+DB_TYPE = sqlite3
+PATH = @TERMUX_PREFIX@/var/lib/gogs/gogs.db
+
+[log]
+ROOT_PATH = @TERMUX_PREFIX@/var/log/gogs
+MODE = file
+LEVEL = Info
+
+[cron.update_mirrors]
+SCHEDULE = @every 120m

--- a/packages/gogs/build.sh
+++ b/packages/gogs/build.sh
@@ -1,0 +1,39 @@
+TERMUX_PKG_HOMEPAGE=https://gogs.io
+TERMUX_PKG_DESCRIPTION="A painless self-hosted Git service."
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="Injamul Mohammad Mollah <mrinjamul@gmail.com>"
+TERMUX_PKG_VERSION=0.12.3
+TERMUX_PKG_SRCURL=https://github.com/gogs/gogs/archive/v$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=6a0e1e369d2e097a73fe99fb78046db0b022ce0c229d3977068e7b21e2e364c8
+TERMUX_PKG_DEPENDS="dash, git"
+TERMUX_PKG_CONFFILES="etc/gogs/app.ini"
+
+termux_step_make() {
+	termux_setup_golang
+	export GOPATH=$TERMUX_PKG_BUILDDIR
+
+	mkdir -p "$GOPATH"/src/gogs.io
+	cp -a "$TERMUX_PKG_SRCDIR" "$GOPATH"/src/gogs.io/gogs
+	cd "$GOPATH"/src/gogs.io/gogs
+
+	LDFLAGS=""
+	LDFLAGS+=" -X gogs.io/gogs/internal/conf.CustomConf=$TERMUX_PREFIX/etc/gogs/app.ini"
+	LDFLAGS+=" -X gogs.io/gogs/internal/conf.AppWorkPath=$TERMUX_PREFIX/var/lib/gogs"
+	LDFLAGS+=" -X gogs.io/gogs/internal/conf.CustomPath=$TERMUX_PREFIX/var/lib/gogs"
+	GOGS_VERSION=v"$TERMUX_PKG_VERSION" TAGS="bindata sqlite" make all
+}
+
+termux_step_make_install() {
+	install -Dm700 \
+		"$GOPATH"/src/gogs.io/gogs/gogs \
+		"$TERMUX_PREFIX"/bin/gogs
+
+	mkdir -p "$TERMUX_PREFIX"/etc/gogs
+	sed "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" \
+		"$TERMUX_PKG_BUILDER_DIR"/app.ini > "$TERMUX_PREFIX"/etc/gogs/app.ini
+}
+
+termux_step_post_massage() {
+	mkdir -p "$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX"/var/lib/gogs
+	mkdir -p "$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX"/var/log/gogs
+}


### PR DESCRIPTION
A lightweight self-hosted Git service

- It uses very low memory, memory usage around 30MB.
- Its performance is great in low-end mobile devices.
- It's available in most Linux distros.
- Licensed under MIT
- [Gogs](https://gogs.io/)