### PR TITLE
github actions: append commit hash to artifacts archive name

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -93,7 +93,7 @@ jobs:
         test -f ./deleted_packages.txt && mv ./deleted_packages.txt ./debs/
         # Files containing certain symbols (e.g. ":") will cause failure in actions/upload-artifact.
         # Archiving *.deb files in a tarball to avoid issues with uploading.
-        tar cf artifacts/debs-${{ matrix.target_arch }}.tar debs
+        tar cf artifacts/debs-${{ matrix.target_arch }}-${{ github.sha }}.tar debs
     - name: Checksums for built *.deb files
       run: |
         find debs -type f -name "*.deb" -exec sha256sum "{}" \; | sort -k2
@@ -121,7 +121,7 @@ jobs:
         BINTRAY_GPG_SUBJECT: termux
         BINTRAY_GPG_PASSPHRASE: ${{ secrets.BINTRAY_GPG_PASSWORD }}
       run: |
-        for i in debs-*.tar; do
+        for i in debs-*-${{ github.sha }}.tar; do
           tar xf $i
         done
         # Purging debfiles of removed packages.
@@ -149,8 +149,8 @@ jobs:
         # Zip the deb archives to only do one transfer to the repo.
         # This makes it easier to parse it, we can run one update job
         # instead of one for each arch on the server.
-        archive="termux-packages-$(tr -dc A-Za-z0-9 </dev/urandom | head -c 6).zip"
-        zip $archive debs-aarch64.tar debs-arm.tar debs-i686.tar debs-x86_64.tar
+        archive="termux-packages-${{ github.sha }}.zip"
+        zip $archive debs-*-${{ github.sha }}.tar
         sftp -P ${{ secrets.PORT }} ${{ secrets.USER }}@grimler.se <<EOF
           put $archive /debs/
         EOF


### PR DESCRIPTION
@Grimler91 I'm changing the name of `debs` tarball so it will also have a commit hash in name for tracking the corresponding commits. Making a PR so you can review your setup on grimler.se whether these changes are applicable.