### PR TITLE
github actions: print subpackages to built_packages.txt as well

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -68,28 +68,62 @@ jobs:
           docker build -t termux/package-builder:latest .
           cd ..
         fi
-        # Remove duplicates and deleted packages from $PACKAGE_NAMES.
-        # Write names of deleted packages to a list that will be passed to upload job for
+        # Parse changed files and identify new packages and deleted packages.
+        # Create lists of those packages that will be passed to upload job for
         # further processing.
-        PACKAGE_NAMES=$(sed -nE 's@^packages/([^/]*)/([^/]*)(/.*)?$@\1@p' <<< "$CHANGED_FILES" | sort | uniq)
-        for pkg in $PACKAGE_NAMES; do
-          if [ ! -d "./packages/${pkg}" ]; then
-            PACKAGE_NAMES=$(sed -E "s/(^|\s\s*)${pkg}(\$|\s\s*)/ /g" <<< "$PACKAGE_NAMES")
-            echo "$pkg" >> ./deleted_packages.txt
+        while read -r file; do
+          if ! [[ $file == packages/* ]]; then
+            # This file does not belong to a package, so ignore it
+            continue
           fi
-        done
-        # Remove trailing spaces.
-        PACKAGE_NAMES=$(sed 's/[[:blank:]]*$//' <<< "$PACKAGE_NAMES")
-        # Process added or updated packages. Create a list of packages for further processing
-        # in upload job.
-        if [ -n "$PACKAGE_NAMES" ]; then
-          ./scripts/lint-packages.sh $(echo "$PACKAGE_NAMES" | grep -P '^[a-zA-Z0-9]' | awk '{ print "./packages/"$0"/build.sh" }')
-          ./scripts/run-docker.sh env TERMUX_TOPDIR=/home/builder/termux-packages/.termux-builder ./build-package.sh -a ${{ matrix.target_arch }} -I ${PACKAGE_NAMES}
-          echo "${PACKAGE_NAMES}" > ./built_packages.txt
+          if [[ $file =~ ^packages/([a-z0-9-]*)/([a-z0-9-]*).subpackage.sh$ ]]; then
+            # A subpackage was modified, check if it was deleted or just updated
+            pkg=${BASH_REMATCH[1]}
+            subpkg=${BASH_REMATCH[2]}
+            if [ ! -f "packages/${pkg}/${subpkg}.subpackage.sh" ]; then
+              echo "$subpkg" >> ./deleted_packages.txt
+            fi
+          elif [[ $file =~ ^packages/([a-z0-9-]*)/.*$ ]]; then
+            # package, check if it was deleted or updated
+            pkg=${BASH_REMATCH[1]}
+            if [ ! -d "packages/${pkg}" ]; then
+              echo "$pkg" >> ./deleted_packages.txt
+            else
+              echo "$pkg" >> ./built_packages.txt
+              # If there are subpackages we want to create a list of those
+              # as well
+              for file in $(find "packages/${pkg}/" -maxdepth 1 -type f -name \*.subpackage.sh | sort); do
+                echo "$(basename "${file%%.subpackage.sh}")" >> ./built_subpackages.txt
+              done
+            fi
+          fi
+        done<<<${CHANGED_FILES}
+
+        # Fix so that lists do not contain duplicates
+        if [ -f ./built_packages.txt ]; then
+          uniq ./built_packages.txt > ./built_packages.txt.tmp
+          mv ./built_packages.txt.tmp ./built_packages.txt
         fi
+        if [ -f ./built_subpackages.txt ]; then
+          uniq ./built_subpackages.txt > ./built_subpackages.txt.tmp
+          mv ./built_subpackages.txt.tmp ./built_subpackages.txt
+        fi
+        if [ -f ./deleted_packages.txt ]; then
+          uniq ./deleted_packages.txt > ./deleted_packages.txt.tmp
+          mv ./deleted_packages.txt.tmp ./deleted_packages.txt
+        fi
+
+        if [ -f ./built_packages.txt ]; then
+          ./scripts/lint-packages.sh $(cat ./built_packages.txt | awk '{print "packages/"$1"/build.sh"}')
+          ./start-builder.sh ./build-package.sh -a ${{ matrix.target_arch }} -I $(cat ./built_packages.txt)
+        fi
+
+        test -d ./termux-packages/debs && mv ./termux-packages/debs/* ./debs/
         # Put package lists into directory with *.deb files so they will be transferred to
         # upload job.
         test -f ./built_packages.txt && mv ./built_packages.txt ./debs/
+        test -f ./built_subpackages.txt && cat ./built_subpackages.txt >> ./debs/built_packages.txt \
+          && rm ./built_subpackages.txt
         test -f ./deleted_packages.txt && mv ./deleted_packages.txt ./debs/
         # Files containing certain symbols (e.g. ":") will cause failure in actions/upload-artifact.
         # Archiving *.deb files in a tarball to avoid issues with uploading.


### PR DESCRIPTION
But only (try to) build the main packages. For each modified package we check if there are subpackages and in that case save them in built_packages.txt as well, so that the repository server does not have to parse the git repo to find out if there are subpackages.

@xeffyr is this fine to merge or do you need to do modifications on your box?