### PR TITLE
direnv: Fix installation location and update to 2.28.0

### DIFF
--- a/packages/direnv/build.sh
+++ b/packages/direnv/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://github.com/direnv/direnv
 TERMUX_PKG_DESCRIPTION="Environment switcher for shell"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=2.27.0
+TERMUX_PKG_VERSION=2.28.0
 TERMUX_PKG_SRCURL=https://github.com/direnv/direnv/archive/v$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_SHA256=9dc5ce43c63d9d9ff510c6bcd6ae06f3f2f907347e7cbb2bb6513bfb0f151621
+TERMUX_PKG_SHA256=fa539c63034b6161d8238299bb516dcec79e8905cd43ff2b9559ad6bf047cc93
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_make() {
@@ -13,5 +13,5 @@ termux_step_make() {
 }
 
 termux_step_make_install() {
-	make install DESTDIR=$TERMUX_PREFIX
+	make install PREFIX=$TERMUX_PREFIX
 }


### PR DESCRIPTION
direnv has these variable set by default:

PREFIX   = /usr/local
BINDIR   = ${PREFIX}/bin
SHAREDIR = ${PREFIX}/share
MANDIR   = ${SHAREDIR}/man

We are overriding $DESTDIR while leaving $PREFIX unchanged which installs the binary to $DESTDIR/$BINDIR (i.e, $TERMUX_PREFIX/usr/local/bin instead of $TERMUX/bin).

P.S: Assuming we don't want to install direnv in $TERMUX_PREFIX/local/bin (which is what it should be installed to by default , judging from direnv's GNUmakefile) as most termux packages goes to $TERMUX/bin.