### PR TITLE
rsync: configure.ac patch for IPv6 support

### DIFF
--- a/packages/rsync/build.sh
+++ b/packages/rsync/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Utility that provides fast incremental file transfer"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.2.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://rsync.samba.org/ftp/rsync/src/rsync-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=becc3c504ceea499f4167a260040ccf4d9f2ef9499ad5683c179a697146ce50e
 TERMUX_PKG_DEPENDS="libiconv, liblz4, libpopt, openssh | dropbear, openssl-tool, zlib, zstd"

--- a/packages/rsync/configure.ac.patch
+++ b/packages/rsync/configure.ac.patch
@@ -1,0 +1,12 @@
+diff -uNr rsync-3.1.3/configure.ac rsync-3.1.3.mod/configure.ac
+--- rsync-3.1.3/configure.ac	2020-07-31 01:33:58.000000000 +0000
++++ rsync-3.1.3.mod/configure.ac	2021-04-11 01:45:27.000000000 +0000
+@@ -380,7 +380,7 @@
+ 			# http://www.v6.linux.or.jp/
+ 			AC_EGREP_CPP(yes, [
+ #include <features.h>
+-#if defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 1
++#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 1) || defined(__ANDROID__)
+ yes
+ #endif],
+ 				[ipv6type=$i;

--- a/packages/rsync/configure.sh.patch
+++ b/packages/rsync/configure.sh.patch
@@ -1,0 +1,12 @@
+diff -uNr rsync-3.1.3/configure.sh rsync-3.1.3.mod/configure.sh
+--- rsync-3.1.3/configure.sh	2020-08-07 03:48:27.000000000 +0000
++++ rsync-3.1.3.mod/configure.sh	2021-04-11 01:45:27.000000000 +0000
+@@ -5420,7 +5420,7 @@
+ /* end confdefs.h.  */
+ 
+ #include <features.h>
+-#if defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 1
++#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 1) || defined(__ANDROID__)
+ yes
+ #endif
+ _ACEOF


### PR DESCRIPTION
Should work, but if anyone could test if it compiles with termux tooling, cheers. It compiled on my side but it was with the hack @alexzhang describes, this way its nicer.

Basically GLIBC is not defined when using the aarm64 compiler because it uses clang (part of issue #5826), we can check if we're compiling for android and enable IPv6 support that way.
If anyone has a better fix feel free to submit that, but this should be a working solution. (Tested on actual phone, and rsync has IPv6 support this way)