### PR TITLE
croc: update to 9.1.0

### DIFF
--- a/packages/croc/build.sh
+++ b/packages/croc/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://github.com/schollz/croc
 TERMUX_PKG_DESCRIPTION="Easily and securely send things from one computer to another."
 TERMUX_PKG_LICENSE=MIT
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=8.6.7
+TERMUX_PKG_VERSION=9.1.0
 TERMUX_PKG_SRCURL=https://github.com/schollz/croc/releases/download/v${TERMUX_PKG_VERSION}/croc_${TERMUX_PKG_VERSION}_src.tar.gz
-TERMUX_PKG_SHA256=9be0a9e11160d3b3293cefa14fa2b99283c4d0dcb753dbc31502c28f10ca6b82
+TERMUX_PKG_SHA256=575069fc1c966518e66fafae50415811133398179182310ee710708e36a08d89
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_make() {


### PR DESCRIPTION
Croc 8.x no longer works out of the box as there was a vulnerability in the public relay, so an upgrade to the latest version is required to get things back up and running

Edit: issue comment explaining the situation https://github.com/schollz/croc/issues/371#issuecomment-822721592