### PR TITLE
Update clash to 1.5.0

### DIFF
--- a/packages/clash/build.sh
+++ b/packages/clash/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://github.com/Dreamacro/clash
 TERMUX_PKG_DESCRIPTION="A rule-based tunnel in Go."
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="Philipp Schmitt <philipp@schmitt.co>"
-TERMUX_PKG_VERSION=1.3.5
+TERMUX_PKG_VERSION=1.5.0
 TERMUX_PKG_SRCURL="https://github.com/Dreamacro/clash/archive/v${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256=89f39540a698fab82728c80e903d7750894789621595ca11a4777afdfc3e265d
+TERMUX_PKG_SHA256=766fa180c0d95cdbaaf0383c0f1f5b9129643a30166155cdab30922ebfbbee7d
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_make() {


### PR DESCRIPTION
Upstream release:

https://github.com/Dreamacro/clash/releases/tag/v1.5.0