### PR TITLE
rclone: update to 1.55.1 (+ tagged release, +noselfupdate)

### DIFF
--- a/packages/rclone/build.sh
+++ b/packages/rclone/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://rclone.org/
 TERMUX_PKG_DESCRIPTION="rsync for cloud storage"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1.55.0
+TERMUX_PKG_VERSION=1.55.1
 TERMUX_PKG_SRCURL=https://github.com/rclone/rclone/releases/download/v${TERMUX_PKG_VERSION}/rclone-v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=75accdaedad3b82edc185dc8824a19a59c30dc6392de7074b6cd98d1dc2c9040
+TERMUX_PKG_SHA256=25da7fc5c9269b3897f27b0d946919df595c6dda1b127085fda0fe32aa59d29d
 
 termux_step_make_install() {
 	cd $TERMUX_PKG_SRCDIR
@@ -15,7 +15,7 @@ termux_step_make_install() {
 	ln -sf "$PWD" .gopath/src/github.com/rclone/rclone
 	export GOPATH="$PWD/.gopath"
 
-	go build -v -o rclone
+	go build -v -ldflags "-X github.com/rclone/rclone/fs.Version=${TERMUX_PKG_VERSION}-termux" -tags noselfupdate -o rclone
 
 	# XXX: Fix read-only files which prevents removal of src dir.
 	chmod u+w -R .


### PR DESCRIPTION
Updates rclone to 1.55.1 with two new build flags:
 1. Disable the inbuilt updater (`tags noselfupdate`)
 2. Set the version to indicate that it is built by termux