### PR TITLE
Do not reinstall packages in setup-archlinux.sh

### DIFF
--- a/scripts/setup-archlinux.sh
+++ b/scripts/setup-archlinux.sh
@@ -48,7 +48,7 @@ if [ "$(id -u)" = "0" ]; then
 else
 	SUDO="sudo"
 fi
-$SUDO pacman -Syq --noconfirm $PACKAGES
+$SUDO pacman -Syq --needed --noconfirm $PACKAGES
 
 . $(dirname "$(realpath "$0")")/properties.sh
 $SUDO mkdir -p $TERMUX_PREFIX


### PR DESCRIPTION
I have added the --needed option to pacman to prevent reinstalling packages that are already installed and updated.