### PR TITLE
Force `-fno-strict-aliasing` for Ruby

### DIFF
--- a/packages/ruby/build.sh
+++ b/packages/ruby/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Dynamic programming language with a focus on simplicity 
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.0.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://cache.ruby-lang.org/pub/ruby/${TERMUX_PKG_VERSION:0:3}/ruby-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=d06bccd382d03724b69f674bc46cd6957ba08ed07522694ce44b9e8ffc9c48e2
 # libbffi is used by the fiddle extension module:

--- a/packages/ruby/build.sh
+++ b/packages/ruby/build.sh
@@ -37,7 +37,7 @@ termux_step_pre_configure() {
 	fi
 
 	# Do not remove: fix for Clang's "overoptimization".
-	CFLAGS=${CFLAGS/-Oz/-O2}
+	CFLAGS+=" -fno-strict-aliasing"
 }
 
 termux_step_make_install() {


### PR DESCRIPTION
Optimization level `-O2` is insufficient for avoiding overoptimization, because it enables `-fstrict-aliasing`.

Upstream: https://bugs.ruby-lang.org/issues/17540