### PR TITLE
recompile ttyd for libwebsockets 4.2.0

### DIFF
--- a/packages/ttyd/build.sh
+++ b/packages/ttyd/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Command-line tool for sharing terminal over the web"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.6.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/tsl0922/ttyd/archive/$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=1116419527edfe73717b71407fb6e06f46098fc8a8e6b0bb778c4c75dc9f64b9
 TERMUX_PKG_DEPENDS="json-c, libuv, libwebsockets, zlib"


### PR DESCRIPTION
bump TERMUX_PKG_REVISION for ttyd 1.6.3 to 1
fix for #6845 

tested - works ok

```
~ $ ttyd -p 8080 bash
[2021/05/21 12:19:04:2233] N: ttyd 1.6.3 (libwebsockets 4.2.0-no_hash)
[2021/05/21 12:19:04:2244] N: tty configuration:
[2021/05/21 12:19:04:2245] N:   start command: bash
[2021/05/21 12:19:04:2245] N:   close signal: SIGHUP (1)
[2021/05/21 12:19:04:2246] N:   terminal type: xterm-256color
[2021/05/21 12:19:04:2246] N: LWS: 4.2.0-no_hash, loglevel 7
[2021/05/21 12:19:04:2246] N: NET CLI SRV H1 H2 WS ConMon IPv6-absent
[2021/05/21 12:19:04:2284] N:    /data/data/pl.sviete.dom/files/usr/lib/libwebsockets-evlib_uv.so
[2021/05/21 12:19:04:2330] N:  Using foreign event loop...
[2021/05/21 12:19:04:2332] N:  ++ [wsi|0|pipe] (1)
[2021/05/21 12:19:04:2333] N:  ++ [vh|0|default||8080] (1)
[2021/05/21 12:19:04:2337] N: lws_socket_bind: nowsi: source ads 0.0.0.0
[2021/05/21 12:19:04:2338] N:  ++ [wsi|1|listen|default||8080] (2)
[2021/05/21 12:19:04:2339] N:  Listening on port: 8080
```