### PR TITLE
Enable PulseAudio's GLIB component and put it in subpackages

### DIFF
--- a/packages/pulseaudio/build.sh
+++ b/packages/pulseaudio/build.sh
@@ -4,18 +4,19 @@ TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_SRCURL=https://github.com/pulseaudio/pulseaudio.git
 TERMUX_PKG_VERSION=14.2
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_DEPENDS="libltdl, libsndfile, libandroid-glob, libsoxr, speexdsp, libwebrtc-audio-processing"
 TERMUX_PKG_BREAKS="libpulseaudio-dev, libpulseaudio"
 TERMUX_PKG_REPLACES="libpulseaudio-dev, libpulseaudio"
-TERMUX_PKG_BUILD_DEPENDS="libtool"
+# glib is only a runtime dependency of pulseaudio-glib subpackage
+TERMUX_PKG_BUILD_DEPENDS="libtool, glib"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-neon-opt
 --disable-alsa
 --disable-esound
---disable-glib2
 --disable-x11
 --disable-gtk3
 --disable-openssl
+--enable-glib2
 --without-caps
 --with-database=simple
 --disable-memfd

--- a/packages/pulseaudio/pulseaudio-glib-static.subpackage.sh
+++ b/packages/pulseaudio/pulseaudio-glib-static.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_DESCRIPTION="Static library for PulseAudio GLIB mainloop component"
+TERMUX_SUBPKG_DEPENDS="pulseaudio-static, pulseaudio-glib"
+TERMUX_SUBPKG_INCLUDE="
+lib/libpulse-mainloop-glib.a
+lib/libpulse-mainloop-glib.la
+"

--- a/packages/pulseaudio/pulseaudio-glib.subpackage.sh
+++ b/packages/pulseaudio/pulseaudio-glib.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_DESCRIPTION="PulseAudio GLIB mainloop component"
+TERMUX_SUBPKG_DEPENDS="glib"
+TERMUX_SUBPKG_INCLUDE="
+share/vala/vapi/libpulse-mainloop-glib.*
+include/pulse/glib-mainloop.h
+lib/libpulse-mainloop-glib.so
+lib/pkgconfig/libpulse-mainloop-glib.pc
+"


### PR DESCRIPTION
The GLIB mainloop component is widely used (e.g. `pavucontrol-qt`)

To avoid introducing extra runtime dependencies for most current users, they're packaged as subpackages if for some reason `glib` is not wanted