### PR TITLE
[Merge order 046] Update package pdf2svg

### DIFF
--- a/packages/pdf2svg/build.sh
+++ b/packages/pdf2svg/build.sh
@@ -7,3 +7,7 @@ TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://github.com/db9052/pdf2svg/archive/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=4fb186070b3e7d33a51821e3307dce57300a062570d028feccd4e628d50dea8a
 TERMUX_PKG_DEPENDS="glib, libcairo, poppler"
+
+termux_step_pre_configure() {
+	autoreconf -fi
+}


### PR DESCRIPTION
Update to make pdf2svg buildable again.