### PR TITLE
termux-chroot: specify --kill-on-exit option

### DIFF
--- a/packages/proot/build.sh
+++ b/packages/proot/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Just bump commit and version when needed:
 _COMMIT=8f67d6c7fadb445b7a528020d05e72dba717c5b9
 TERMUX_PKG_VERSION=5.1.107
-TERMUX_PKG_REVISION=39
+TERMUX_PKG_REVISION=40
 TERMUX_PKG_SRCURL=https://github.com/termux/proot/archive/${_COMMIT}.zip
 TERMUX_PKG_SHA256=a5d248d307766bb807a35ee88d90456c0d1e0791cecffe5fb5d40d203be663ac
 TERMUX_PKG_DEPENDS="libtalloc"

--- a/packages/proot/termux-chroot
+++ b/packages/proot/termux-chroot
@@ -20,8 +20,11 @@ do
 done
 shift $(($OPTIND-1))
 
+# Kill processes on exit to avoid hanging on exit
+ARGS="--kill-on-exit"
+
 # For the /system/bin/linker(64) to be found:
-ARGS="-b /system:/system"
+ARGS="$ARGS -b /system:/system"
 
 # On some devices /vendor is required for termux packages to work correctly
 # See https://github.com/termux/proot/issues/2#issuecomment-303995382


### PR DESCRIPTION
I added `--kill-on-exit` option to `termux-chroot` script to terminate all processes on `exit`
this should avoid `exit` hanging when a user ran a daemon inside the `termux-chroot` session