### PR TITLE
Update php-redis to 5.3.4

### DIFF
--- a/packages/php-redis/build.sh
+++ b/packages/php-redis/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://github.com/phpredis/phpredis
 TERMUX_PKG_DESCRIPTION="PHP extension for interfacing with Redis"
 TERMUX_PKG_LICENSE="PHP-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=5.3.1
+TERMUX_PKG_VERSION=5.3.4
 TERMUX_PKG_SRCURL=https://github.com/phpredis/phpredis/archive/${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=930dc88ef126509b8991c52757fdc68908c753b476ad6f25dae0ce6925870f14
+TERMUX_PKG_SHA256=c0df53dc4e8cd2921503fefa224cfd51de7f74561324a6d3c66f30d4016178b3
 TERMUX_PKG_DEPENDS=php
 
 termux_step_pre_configure() {

--- a/packages/php-redis/build.sh
+++ b/packages/php-redis/build.sh
@@ -6,6 +6,11 @@ TERMUX_PKG_VERSION=5.3.4
 TERMUX_PKG_SRCURL=https://github.com/phpredis/phpredis/archive/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=c0df53dc4e8cd2921503fefa224cfd51de7f74561324a6d3c66f30d4016178b3
 TERMUX_PKG_DEPENDS=php
+# php is (currently) blacklisted for x86_64. Need to blacklist
+# php-redis as well for the same arch for
+#   ./build-package.sh -a all -i php-redis
+# to succeed
+TERMUX_PKG_BLACKLISTED_ARCHES="x86_64"
 
 termux_step_pre_configure() {
 	$TERMUX_PREFIX/bin/phpize


### PR DESCRIPTION
It would also need to be rebuilt anyway as it is currently broken. This
fixes that too

```
NOTICE: PHP message: PHP Warning:  PHP Startup: Unable to load dynamic library 'redis.so' (tried: /data/data/com.termux/files/usr/lib/php/redis.so (dlopen failed: cannot locate symbol &quot;_call_user_function_ex&quot; referenced by
&quot;/data/data/com.termux/files/usr/lib/php/redis.so&quot;...), /data/data/com.termux/files/usr/lib/php/redis.so.so (dlopen failed: library &quot;/data/data/com.termux/files/usr/lib/php/redis.so.so&quot; not found)) in Unknown on
line 0
```