### PR TITLE
compile ledger with Python support

### DIFF
--- a/packages/ledger/CMakeLists.patch
+++ b/packages/ledger/CMakeLists.patch
@@ -7,7 +7,7 @@ index 30d97cb9..341e782e 100644
      install(
        FILES "${CMAKE_BINARY_DIR}/${_ledger_python_module_name}"
 -      DESTINATION ${Python_SITEARCH})
-+      DESTINATION @TERMUX_PREFIX@/lib/python3/dist-packages/)
++      DESTINATION @TERMUX_PREFIX@/lib/python3.9/site-packages/)
    else()
      message(WARNING "Python_SITEARCH not set. Will not install python module.")
    endif()

--- a/packages/ledger/CMakeLists.patch
+++ b/packages/ledger/CMakeLists.patch
@@ -1,0 +1,13 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 30d97cb9..341e782e 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -335,7 +335,7 @@ if (USE_PYTHON)
+       $<TARGET_FILE:libledger> "${CMAKE_BINARY_DIR}/${_ledger_python_module_name}")
+     install(
+       FILES "${CMAKE_BINARY_DIR}/${_ledger_python_module_name}"
+-      DESTINATION ${Python_SITEARCH})
++      DESTINATION @TERMUX_PREFIX@/lib/python3/dist-packages/)
+   else()
+     message(WARNING "Python_SITEARCH not set. Will not install python module.")
+   endif()

--- a/packages/ledger/build.sh
+++ b/packages/ledger/build.sh
@@ -3,15 +3,16 @@ TERMUX_PKG_DESCRIPTION="Powerful, double-entry accounting system"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.2.1
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=https://github.com/ledger/ledger/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=92bf09bc385b171987f456fe3ee9fa998ed5e40b97b3acdd562b663aa364384a
-TERMUX_PKG_DEPENDS="boost, libc++, libedit, libmpfr, libgmp"
+TERMUX_PKG_DEPENDS="boost, libc++, libedit, libmpfr, libgmp, python"
 TERMUX_PKG_BREAKS="ledger-dev"
 TERMUX_PKG_REPLACES="ledger-dev"
 TERMUX_PKG_BUILD_DEPENDS="utf8cpp"
 # See https://gitlab.kitware.com/cmake/cmake/issues/18865:
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DBoost_NO_BOOST_CMAKE=ON
+-DUSE_PYTHON=ON
 -DUTFCPP_PATH=$TERMUX_PREFIX/include/utf8cpp
 "


### PR DESCRIPTION
This adds a compile-time configuration option to compile ledger with Python 3 support and adds Python to the list of dependencies. Not sure if the dependency should be written as `python` or `python3`. Any corrections welcome. This is related to issue #7006 and #4348. Closes #7006