### PR TITLE
CI: Do not stop all tests on failure of one

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -19,6 +19,7 @@ jobs:
     strategy:
       matrix:
         target_arch: [aarch64, arm, i686, x86_64]
+      fail-fast: false
     steps:
     - name: Clone repository
       uses: actions/checkout@v2


### PR DESCRIPTION
This can be helpful while building large packages which often fail to
compile on some archs but compile well on other
