### PR TITLE
apksigner: fix word splitting in script

### DIFF
--- a/packages/apksigner/build.sh
+++ b/packages/apksigner/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="APK signing tool"
 TERMUX_PKG_LICENSE="Apache-2.0, GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=${TERMUX_ANDROID_BUILD_TOOLS_VERSION}
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
@@ -66,7 +66,7 @@ termux_step_make_install() {
 	mv apksigner.jar $TERMUX_PREFIX/share/dex/apksigner.jar
 
 	echo '#!/bin/sh' > $TERMUX_PREFIX/bin/apksigner
-	echo "dalvikvm -Xcompiler-option --compiler-filter=speed -cp $TERMUX_PREFIX/share/dex/apksigner.jar com.android.apksigner.ApkSignerTool \$@" >> $TERMUX_PREFIX/bin/apksigner
+	echo "dalvikvm -Xcompiler-option --compiler-filter=speed -cp $TERMUX_PREFIX/share/dex/apksigner.jar com.android.apksigner.ApkSignerTool \"\$@\"" >> $TERMUX_PREFIX/bin/apksigner
 	chmod +x $TERMUX_PREFIX/bin/apksigner
 }
 


### PR DESCRIPTION
Any argument with an IFS char in it used to get resplit when passed to apksigner.
Adding quotes around `$@` preserves the intended arguments.

@Grimler91 apologies for the duplicate request, github doesn't seem to allow pushing to a pull request linked to a dead branch. Made the changes and closed the older PR.