### PR TITLE
tergent: fix compilation errors for 32bit arches

### DIFF
--- a/packages/tergent/0002-Go-through-c_ulong-u64-u32-usage-to-allow-compilatio.patch
+++ b/packages/tergent/0002-Go-through-c_ulong-u64-u32-usage-to-allow-compilatio.patch
@@ -1,0 +1,442 @@
+From a6d5c72f34079c8bc94a932f8f0e52eaba12de53 Mon Sep 17 00:00:00 2001
+From: Henrik Grimler <henrik@grimler.se>
+Date: Mon, 12 Jul 2021 14:17:54 +0200
+Subject: [PATCH 1/3] Go through c_ulong/u64/u32 usage to allow compilation on
+ 32bit
+
+Previously compilation on arm and i686 failed, due to unsigned long
+being 4 bytes there but 8 bytes on aarch64 and x86_64.  This changes
+so that c_ulong is used in more places, or so that the variables are
+converted into the type they need to be.
+---
+ src/lib.rs                             | 18 +++++++++---------
+ src/pkcs11/attribute_type.rs           |  4 ++--
+ src/pkcs11/certificate_category.rs     |  4 ++--
+ src/pkcs11/certificate_type.rs         |  4 ++--
+ src/pkcs11/hardware_feature_type.rs    |  4 ++--
+ src/pkcs11/key_derivation_function.rs  |  4 ++--
+ src/pkcs11/key_type.rs                 |  4 ++--
+ src/pkcs11/mask_generation_function.rs |  4 ++--
+ src/pkcs11/mechanism_type.rs           |  4 ++--
+ src/pkcs11/mod.rs                      |  3 ++-
+ src/pkcs11/notification.rs             |  4 ++--
+ src/pkcs11/object_class.rs             |  4 ++--
+ src/pkcs11/otp.rs                      |  8 ++++----
+ src/pkcs11/pseudo_random_function.rs   |  4 ++--
+ src/pkcs11/return_value.rs             |  4 ++--
+ src/pkcs11/security_domain.rs          |  4 ++--
+ src/pkcs11/session_state.rs            |  4 ++--
+ src/pkcs11/user_type.rs                |  4 ++--
+ 18 files changed, 45 insertions(+), 44 deletions(-)
+
+diff --git a/src/lib.rs b/src/lib.rs
+index bf8ace5..9676a13 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -96,7 +96,7 @@ pub extern "C" fn C_GetTokenInfo(slot_id: c_ulong, info: *mut TokenInfo) -> c_ul
+             return ReturnValue::GeneralError.try_into().unwrap();
+         }
+     };
+-    let unavailable_information = UNAVAILABLE_INFORMATION as u64;
++    let unavailable_information = UNAVAILABLE_INFORMATION as c_ulong;
+ 
+     let mut token_info = unsafe { &mut *info };
+     copy_padded(&mut token_info.label, "tergent");
+@@ -193,7 +193,7 @@ pub extern "C" fn C_OpenSession(
+     }
+     match state::new() {
+         Some(index) => {
+-            unsafe { *session = index }
++            unsafe { *session = index as c_ulong}
+             ReturnValue::Ok
+         }
+         None => ReturnValue::GeneralError,
+@@ -205,7 +205,7 @@ pub extern "C" fn C_OpenSession(
+ #[no_mangle]
+ pub extern "C" fn C_CloseSession(session: c_ulong) -> c_ulong {
+     // Free up the state associated with the given session.
+-    match state::remove(session) {
++    match state::remove(session.into()) {
+         Some(_) => ReturnValue::Ok,
+         None => ReturnValue::SessionHandleInvalid,
+     }
+@@ -301,7 +301,7 @@ pub extern "C" fn C_GetAttributeValue(
+     count: c_ulong,
+ ) -> c_ulong {
+     // Main function that is used to query the details of a key.
+-    let state = state::get(session);
++    let state = state::get(session.into());
+     let state = match state {
+         Some(state) => state,
+         None => {
+@@ -434,7 +434,7 @@ pub extern "C" fn C_FindObjectsInit(
+         match AttributeType::try_from(template.type_) {
+             Ok(AttributeType::Class) => {
+                 // We only support searching for public/private keys for now.
+-                let value = template.value as *mut u64;
++                let value = template.value as *mut c_ulong;
+                 let class = unsafe { *value };
+                 if let Ok(ObjectClass::PublicKey) | Ok(ObjectClass::PrivateKey) = class.try_into() {
+                     find_keys = true;
+@@ -460,7 +460,7 @@ pub extern "C" fn C_FindObjectsInit(
+             }
+         }
+     }
+-    let state = state::get(session);
++    let state = state::get(session.into());
+     let state = match state {
+         Some(state) => state,
+         None => {
+@@ -484,7 +484,7 @@ pub extern "C" fn C_FindObjects(
+     let object_count = unsafe { &mut *object_count };
+     *object_count = 0;
+ 
+-    let state = state::get(session);
++    let state = state::get(session.into());
+     let state = match state {
+         Some(state) => state,
+         None => {
+@@ -640,7 +640,7 @@ pub extern "C" fn C_DigestFinal(
+ #[no_mangle]
+ pub extern "C" fn C_SignInit(session: c_ulong, mechanism: *mut Mechanism, key: c_ulong) -> c_ulong {
+     // Initialize a sign operation.
+-    let state = state::get(session);
++    let state = state::get(session.into());
+     let state = match state {
+         Some(state) => state,
+         None => {
+@@ -694,7 +694,7 @@ pub extern "C" fn C_Sign(
+     let signature_out = {
+         let data = unsafe { slice::from_raw_parts_mut(data, data_len.try_into().unwrap()) };
+ 
+-        let state = state::get(session);
++        let state = state::get(session.into());
+         let state = match state {
+             Some(state) => state,
+             None => {
+diff --git a/src/pkcs11/attribute_type.rs b/src/pkcs11/attribute_type.rs
+index 52fc0ea..995cbc0 100644
+--- a/src/pkcs11/attribute_type.rs
++++ b/src/pkcs11/attribute_type.rs
+@@ -117,11 +117,11 @@ pub enum AttributeType {
+ impl TryFrom<c_ulong> for AttributeType {
+     type Error = ();
+     fn try_from(value: c_ulong) -> Result<Self, Self::Error> {
+-        AttributeType::from_u64(value).ok_or(())
++        AttributeType::from_u64(value.into()).ok_or(())
+     }
+ }
+ 
+-impl TryFrom<AttributeType> for c_ulong {
++impl TryFrom<AttributeType> for u64 {
+     type Error = ();
+     fn try_from(value: AttributeType) -> Result<Self, Self::Error> {
+         AttributeType::to_u64(&value).ok_or(())
+diff --git a/src/pkcs11/certificate_category.rs b/src/pkcs11/certificate_category.rs
+index 88f2d3a..8eee34d 100644
+--- a/src/pkcs11/certificate_category.rs
++++ b/src/pkcs11/certificate_category.rs
+@@ -15,11 +15,11 @@ pub enum CertificateCategory {
+ impl TryFrom<c_ulong> for CertificateCategory {
+     type Error = ();
+     fn try_from(value: c_ulong) -> Result<Self, Self::Error> {
+-        CertificateCategory::from_u64(value).ok_or(())
++        CertificateCategory::from_u64(value.into()).ok_or(())
+     }
+ }
+ 
+-impl TryFrom<CertificateCategory> for c_ulong {
++impl TryFrom<CertificateCategory> for u64 {
+     type Error = ();
+     fn try_from(value: CertificateCategory) -> Result<Self, Self::Error> {
+         CertificateCategory::to_u64(&value).ok_or(())
+diff --git a/src/pkcs11/certificate_type.rs b/src/pkcs11/certificate_type.rs
+index 1045e7b..bc5bd13 100644
+--- a/src/pkcs11/certificate_type.rs
++++ b/src/pkcs11/certificate_type.rs
+@@ -15,11 +15,11 @@ pub enum CertificateType {
+ impl TryFrom<c_ulong> for CertificateType {
+     type Error = ();
+     fn try_from(value: c_ulong) -> Result<Self, Self::Error> {
+-        CertificateType::from_u64(value).ok_or(())
++        CertificateType::from_u64(value.into()).ok_or(())
+     }
+ }
+ 
+-impl TryFrom<CertificateType> for c_ulong {
++impl TryFrom<CertificateType> for u64 {
+     type Error = ();
+     fn try_from(value: CertificateType) -> Result<Self, Self::Error> {
+         CertificateType::to_u64(&value).ok_or(())
+diff --git a/src/pkcs11/hardware_feature_type.rs b/src/pkcs11/hardware_feature_type.rs
+index 413ca35..af4d4cd 100644
+--- a/src/pkcs11/hardware_feature_type.rs
++++ b/src/pkcs11/hardware_feature_type.rs
+@@ -15,11 +15,11 @@ pub enum HardwareFeatureType {
+ impl TryFrom<c_ulong> for HardwareFeatureType {
+     type Error = ();
+     fn try_from(value: c_ulong) -> Result<Self, Self::Error> {
+-        HardwareFeatureType::from_u64(value).ok_or(())
++        HardwareFeatureType::from_u64(value.into()).ok_or(())
+     }
+ }
+ 
+-impl TryFrom<HardwareFeatureType> for c_ulong {
++impl TryFrom<HardwareFeatureType> for u64 {
+     type Error = ();
+     fn try_from(value: HardwareFeatureType) -> Result<Self, Self::Error> {
+         HardwareFeatureType::to_u64(&value).ok_or(())
+diff --git a/src/pkcs11/key_derivation_function.rs b/src/pkcs11/key_derivation_function.rs
+index 6da1cd3..d9e8969 100644
+--- a/src/pkcs11/key_derivation_function.rs
++++ b/src/pkcs11/key_derivation_function.rs
+@@ -20,11 +20,11 @@ pub enum KeyDerivationFunction {
+ impl TryFrom<c_ulong> for KeyDerivationFunction {
+     type Error = ();
+     fn try_from(value: c_ulong) -> Result<Self, Self::Error> {
+-        KeyDerivationFunction::from_u64(value).ok_or(())
++        KeyDerivationFunction::from_u64(value.into()).ok_or(())
+     }
+ }
+ 
+-impl TryFrom<KeyDerivationFunction> for c_ulong {
++impl TryFrom<KeyDerivationFunction> for u64 {
+     type Error = ();
+     fn try_from(value: KeyDerivationFunction) -> Result<Self, Self::Error> {
+         KeyDerivationFunction::to_u64(&value).ok_or(())
+diff --git a/src/pkcs11/key_type.rs b/src/pkcs11/key_type.rs
+index 6f4ffb3..2be7134 100644
+--- a/src/pkcs11/key_type.rs
++++ b/src/pkcs11/key_type.rs
+@@ -53,11 +53,11 @@ pub enum KeyType {
+ impl TryFrom<c_ulong> for KeyType {
+     type Error = ();
+     fn try_from(value: c_ulong) -> Result<Self, Self::Error> {
+-        KeyType::from_u64(value).ok_or(())
++        KeyType::from_u64(value.into()).ok_or(())
+     }
+ }
+ 
+-impl TryFrom<KeyType> for c_ulong {
++impl TryFrom<KeyType> for u64 {
+     type Error = ();
+     fn try_from(value: KeyType) -> Result<Self, Self::Error> {
+         KeyType::to_u64(&value).ok_or(())
+diff --git a/src/pkcs11/mask_generation_function.rs b/src/pkcs11/mask_generation_function.rs
+index 679e44f..833bd94 100644
+--- a/src/pkcs11/mask_generation_function.rs
++++ b/src/pkcs11/mask_generation_function.rs
+@@ -16,11 +16,11 @@ pub enum MaskGenerationFunction {
+ impl TryFrom<c_ulong> for MaskGenerationFunction {
+     type Error = ();
+     fn try_from(value: c_ulong) -> Result<Self, Self::Error> {
+-        MaskGenerationFunction::from_u64(value).ok_or(())
++        MaskGenerationFunction::from_u64(value.into()).ok_or(())
+     }
+ }
+ 
+-impl TryFrom<MaskGenerationFunction> for c_ulong {
++impl TryFrom<MaskGenerationFunction> for u64 {
+     type Error = ();
+     fn try_from(value: MaskGenerationFunction) -> Result<Self, Self::Error> {
+         MaskGenerationFunction::to_u64(&value).ok_or(())
+diff --git a/src/pkcs11/mechanism_type.rs b/src/pkcs11/mechanism_type.rs
+index 7bdfe40..ec1148a 100644
+--- a/src/pkcs11/mechanism_type.rs
++++ b/src/pkcs11/mechanism_type.rs
+@@ -335,11 +335,11 @@ pub enum MechanismType {
+ impl TryFrom<c_ulong> for MechanismType {
+     type Error = ();
+     fn try_from(value: c_ulong) -> Result<Self, Self::Error> {
+-        MechanismType::from_u64(value).ok_or(())
++        MechanismType::from_u64(value.into()).ok_or(())
+     }
+ }
+ 
+-impl TryFrom<MechanismType> for c_ulong {
++impl TryFrom<MechanismType> for u64 {
+     type Error = ();
+     fn try_from(value: MechanismType) -> Result<Self, Self::Error> {
+         MechanismType::to_u64(&value).ok_or(())
+diff --git a/src/pkcs11/mod.rs b/src/pkcs11/mod.rs
+index 55295ea..38f2b24 100644
+--- a/src/pkcs11/mod.rs
++++ b/src/pkcs11/mod.rs
+@@ -4,6 +4,7 @@
+ 
+ use std::convert::TryInto;
+ use std::slice;
++use std::os::raw::c_ulong;
+ 
+ pub const CRYPTOKI_VERSION_MAJOR: u32 = 2;
+ pub const CRYPTOKI_VERSION_MINOR: u32 = 40;
+@@ -59,7 +60,7 @@ impl Attribute {
+     /// As attribute does not own the value field (instead it contains a pointer)
+     /// any safety considerations regarding pointers apply.
+     pub fn set_value(&mut self, value: &[u8]) -> Option<()> {
+-        let len: u64 = value.len().try_into().ok()?;
++        let len: c_ulong = value.len().try_into().ok()?;
+         if self.value.is_null() {
+             self.value_len = len;
+             return Some(());
+diff --git a/src/pkcs11/notification.rs b/src/pkcs11/notification.rs
+index ac9c5f2..47d3433 100644
+--- a/src/pkcs11/notification.rs
++++ b/src/pkcs11/notification.rs
+@@ -13,11 +13,11 @@ pub enum Notification {
+ impl TryFrom<c_ulong> for Notification {
+     type Error = ();
+     fn try_from(value: c_ulong) -> Result<Self, Self::Error> {
+-        Notification::from_u64(value).ok_or(())
++        Notification::from_u64(value.into()).ok_or(())
+     }
+ }
+ 
+-impl TryFrom<Notification> for c_ulong {
++impl TryFrom<Notification> for u64 {
+     type Error = ();
+     fn try_from(value: Notification) -> Result<Self, Self::Error> {
+         Notification::to_u64(&value).ok_or(())
+diff --git a/src/pkcs11/object_class.rs b/src/pkcs11/object_class.rs
+index cf88ba0..92a45f3 100644
+--- a/src/pkcs11/object_class.rs
++++ b/src/pkcs11/object_class.rs
+@@ -21,11 +21,11 @@ pub enum ObjectClass {
+ impl TryFrom<c_ulong> for ObjectClass {
+     type Error = ();
+     fn try_from(value: c_ulong) -> Result<Self, Self::Error> {
+-        ObjectClass::from_u64(value).ok_or(())
++        ObjectClass::from_u64(value.into()).ok_or(())
+     }
+ }
+ 
+-impl TryFrom<ObjectClass> for c_ulong {
++impl TryFrom<ObjectClass> for u64 {
+     type Error = ();
+     fn try_from(value: ObjectClass) -> Result<Self, Self::Error> {
+         ObjectClass::to_u64(&value).ok_or(())
+diff --git a/src/pkcs11/otp.rs b/src/pkcs11/otp.rs
+index 2717fbe..f87c1d6 100644
+--- a/src/pkcs11/otp.rs
++++ b/src/pkcs11/otp.rs
+@@ -31,11 +31,11 @@ pub enum Param {
+ impl TryFrom<c_ulong> for Format {
+     type Error = ();
+     fn try_from(value: c_ulong) -> Result<Self, Self::Error> {
+-        Format::from_u64(value).ok_or(())
++        Format::from_u64(value.into()).ok_or(())
+     }
+ }
+ 
+-impl TryFrom<Format> for c_ulong {
++impl TryFrom<Format> for u64 {
+     type Error = ();
+     fn try_from(value: Format) -> Result<Self, Self::Error> {
+         Format::to_u64(&value).ok_or(())
+@@ -45,11 +45,11 @@ impl TryFrom<Format> for c_ulong {
+ impl TryFrom<c_ulong> for Param {
+     type Error = ();
+     fn try_from(value: c_ulong) -> Result<Self, Self::Error> {
+-        Param::from_u64(value).ok_or(())
++        Param::from_u64(value.into()).ok_or(())
+     }
+ }
+ 
+-impl TryFrom<Param> for c_ulong {
++impl TryFrom<Param> for u64 {
+     type Error = ();
+     fn try_from(value: Param) -> Result<Self, Self::Error> {
+         Param::to_u64(&value).ok_or(())
+diff --git a/src/pkcs11/pseudo_random_function.rs b/src/pkcs11/pseudo_random_function.rs
+index 94361a6..1398812 100644
+--- a/src/pkcs11/pseudo_random_function.rs
++++ b/src/pkcs11/pseudo_random_function.rs
+@@ -19,11 +19,11 @@ pub enum PseudoRandomFunction {
+ impl TryFrom<c_ulong> for PseudoRandomFunction {
+     type Error = ();
+     fn try_from(value: c_ulong) -> Result<Self, Self::Error> {
+-        PseudoRandomFunction::from_u64(value).ok_or(())
++        PseudoRandomFunction::from_u64(value.into()).ok_or(())
+     }
+ }
+ 
+-impl TryFrom<PseudoRandomFunction> for c_ulong {
++impl TryFrom<PseudoRandomFunction> for u64 {
+     type Error = ();
+     fn try_from(value: PseudoRandomFunction) -> Result<Self, Self::Error> {
+         PseudoRandomFunction::to_u64(&value).ok_or(())
+diff --git a/src/pkcs11/return_value.rs b/src/pkcs11/return_value.rs
+index 56601d7..51a54b2 100644
+--- a/src/pkcs11/return_value.rs
++++ b/src/pkcs11/return_value.rs
+@@ -106,11 +106,11 @@ pub enum ReturnValue {
+ impl TryFrom<c_ulong> for ReturnValue {
+     type Error = ();
+     fn try_from(value: c_ulong) -> Result<Self, Self::Error> {
+-        ReturnValue::from_u64(value).ok_or(())
++        ReturnValue::from_u64(value.into()).ok_or(())
+     }
+ }
+ 
+-impl TryFrom<ReturnValue> for c_ulong {
++impl TryFrom<ReturnValue> for u64 {
+     type Error = ();
+     fn try_from(value: ReturnValue) -> Result<Self, Self::Error> {
+         ReturnValue::to_u64(&value).ok_or(())
+diff --git a/src/pkcs11/security_domain.rs b/src/pkcs11/security_domain.rs
+index e315933..c12fe92 100644
+--- a/src/pkcs11/security_domain.rs
++++ b/src/pkcs11/security_domain.rs
+@@ -15,11 +15,11 @@ pub enum SecurityDomain {
+ impl TryFrom<c_ulong> for SecurityDomain {
+     type Error = ();
+     fn try_from(value: c_ulong) -> Result<Self, Self::Error> {
+-        SecurityDomain::from_u64(value).ok_or(())
++        SecurityDomain::from_u64(value.into()).ok_or(())
+     }
+ }
+ 
+-impl TryFrom<SecurityDomain> for c_ulong {
++impl TryFrom<SecurityDomain> for u64 {
+     type Error = ();
+     fn try_from(value: SecurityDomain) -> Result<Self, Self::Error> {
+         SecurityDomain::to_u64(&value).ok_or(())
+diff --git a/src/pkcs11/session_state.rs b/src/pkcs11/session_state.rs
+index 319e553..08be89d 100644
+--- a/src/pkcs11/session_state.rs
++++ b/src/pkcs11/session_state.rs
+@@ -16,11 +16,11 @@ pub enum SessionState {
+ impl TryFrom<c_ulong> for SessionState {
+     type Error = ();
+     fn try_from(value: c_ulong) -> Result<Self, Self::Error> {
+-        SessionState::from_u64(value).ok_or(())
++        SessionState::from_u64(value.into()).ok_or(())
+     }
+ }
+ 
+-impl TryFrom<SessionState> for c_ulong {
++impl TryFrom<SessionState> for u64 {
+     type Error = ();
+     fn try_from(value: SessionState) -> Result<Self, Self::Error> {
+         SessionState::to_u64(&value).ok_or(())
+diff --git a/src/pkcs11/user_type.rs b/src/pkcs11/user_type.rs
+index f40dc3a..d971119 100644
+--- a/src/pkcs11/user_type.rs
++++ b/src/pkcs11/user_type.rs
+@@ -14,11 +14,11 @@ pub enum UserType {
+ impl TryFrom<c_ulong> for UserType {
+     type Error = ();
+     fn try_from(value: c_ulong) -> Result<Self, Self::Error> {
+-        UserType::from_u64(value).ok_or(())
++        UserType::from_u64(value.into()).ok_or(())
+     }
+ }
+ 
+-impl TryFrom<UserType> for c_ulong {
++impl TryFrom<UserType> for u64 {
+     type Error = ();
+     fn try_from(value: UserType) -> Result<Self, Self::Error> {
+         UserType::to_u64(&value).ok_or(())
+-- 
+2.32.0
+

--- a/packages/tergent/0003-Add-return-value-variant-for-u32.patch
+++ b/packages/tergent/0003-Add-return-value-variant-for-u32.patch
@@ -1,0 +1,31 @@
+From 3bb95e41eace910553b847bdac5d824c17a47bc5 Mon Sep 17 00:00:00 2001
+From: Henrik Grimler <henrik@grimler.se>
+Date: Mon, 12 Jul 2021 14:22:21 +0200
+Subject: [PATCH 2/3] Add return value variant for u32
+
+Needed when c_ulong might be u32.
+---
+ src/pkcs11/return_value.rs | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/pkcs11/return_value.rs b/src/pkcs11/return_value.rs
+index 51a54b2..74d3918 100644
+--- a/src/pkcs11/return_value.rs
++++ b/src/pkcs11/return_value.rs
+@@ -110,6 +110,13 @@ impl TryFrom<c_ulong> for ReturnValue {
+     }
+ }
+ 
++impl TryFrom<ReturnValue> for u32 {
++    type Error = ();
++    fn try_from(value: ReturnValue) -> Result<Self, Self::Error> {
++        ReturnValue::to_u32(&value).ok_or(())
++    }
++}
++
+ impl TryFrom<ReturnValue> for u64 {
+     type Error = ();
+     fn try_from(value: ReturnValue) -> Result<Self, Self::Error> {
+-- 
+2.32.0
+

--- a/packages/tergent/0004-pkcs11-add-repr-u64-to-enums-with-VendorDefined-0x80.patch
+++ b/packages/tergent/0004-pkcs11-add-repr-u64-to-enums-with-VendorDefined-0x80.patch
@@ -1,0 +1,111 @@
+From 5e95e37d284eeeb67ccb484de26a3f72bfc920c5 Mon Sep 17 00:00:00 2001
+From: Henrik Grimler <henrik@grimler.se>
+Date: Mon, 12 Jul 2021 14:24:37 +0200
+Subject: [PATCH 3/3] pkcs11: add repr(u64) to enums with VendorDefined =
+ 0x80000000
+
+Otherwise we get an overflow:
+
+impl TryFrom<ReturnValue> for u32 {
+    type Error = ();
+    fn try_from(value: ReturnValue) -> Result<Self, Self::Error> {
+        ReturnValue::to_u32(&value).ok_or(())
+    }
+}
+---
+ src/pkcs11/attribute_type.rs        | 1 +
+ src/pkcs11/certificate_type.rs      | 1 +
+ src/pkcs11/hardware_feature_type.rs | 1 +
+ src/pkcs11/key_type.rs              | 1 +
+ src/pkcs11/mechanism_type.rs        | 1 +
+ src/pkcs11/object_class.rs          | 1 +
+ src/pkcs11/return_value.rs          | 1 +
+ 7 files changed, 7 insertions(+)
+
+diff --git a/src/pkcs11/attribute_type.rs b/src/pkcs11/attribute_type.rs
+index 995cbc0..fdc418c 100644
+--- a/src/pkcs11/attribute_type.rs
++++ b/src/pkcs11/attribute_type.rs
+@@ -4,6 +4,7 @@ use std::os::raw::c_ulong;
+ use num_derive::{FromPrimitive, ToPrimitive};
+ use num_traits::{FromPrimitive, ToPrimitive};
+ 
++#[repr(u64)]
+ #[derive(Debug, FromPrimitive, ToPrimitive)]
+ pub enum AttributeType {
+     Class = 0x0000,
+diff --git a/src/pkcs11/certificate_type.rs b/src/pkcs11/certificate_type.rs
+index bc5bd13..82e2e07 100644
+--- a/src/pkcs11/certificate_type.rs
++++ b/src/pkcs11/certificate_type.rs
+@@ -4,6 +4,7 @@ use std::os::raw::c_ulong;
+ use num_derive::{FromPrimitive, ToPrimitive};
+ use num_traits::{FromPrimitive, ToPrimitive};
+ 
++#[repr(u64)]
+ #[derive(Debug, FromPrimitive, ToPrimitive)]
+ pub enum CertificateType {
+     X509 = 0,
+diff --git a/src/pkcs11/hardware_feature_type.rs b/src/pkcs11/hardware_feature_type.rs
+index af4d4cd..05835cb 100644
+--- a/src/pkcs11/hardware_feature_type.rs
++++ b/src/pkcs11/hardware_feature_type.rs
+@@ -4,6 +4,7 @@ use std::os::raw::c_ulong;
+ use num_derive::{FromPrimitive, ToPrimitive};
+ use num_traits::{FromPrimitive, ToPrimitive};
+ 
++#[repr(u64)]
+ #[derive(Debug, FromPrimitive, ToPrimitive)]
+ pub enum HardwareFeatureType {
+     MonotonicCounter = 0x01,
+diff --git a/src/pkcs11/key_type.rs b/src/pkcs11/key_type.rs
+index 2be7134..06c8292 100644
+--- a/src/pkcs11/key_type.rs
++++ b/src/pkcs11/key_type.rs
+@@ -4,6 +4,7 @@ use std::os::raw::c_ulong;
+ use num_derive::{FromPrimitive, ToPrimitive};
+ use num_traits::{FromPrimitive, ToPrimitive};
+ 
++#[repr(u64)]
+ #[derive(Debug, FromPrimitive, ToPrimitive)]
+ pub enum KeyType {
+     Rsa = 0x0000,
+diff --git a/src/pkcs11/mechanism_type.rs b/src/pkcs11/mechanism_type.rs
+index ec1148a..ec9068b 100644
+--- a/src/pkcs11/mechanism_type.rs
++++ b/src/pkcs11/mechanism_type.rs
+@@ -4,6 +4,7 @@ use std::os::raw::c_ulong;
+ use num_derive::{FromPrimitive, ToPrimitive};
+ use num_traits::{FromPrimitive, ToPrimitive};
+ 
++#[repr(u64)]
+ #[derive(Debug, FromPrimitive, ToPrimitive)]
+ pub enum MechanismType {
+     RsaPkcsKeyPairGen = 0x0000,
+diff --git a/src/pkcs11/object_class.rs b/src/pkcs11/object_class.rs
+index 92a45f3..addfd7c 100644
+--- a/src/pkcs11/object_class.rs
++++ b/src/pkcs11/object_class.rs
+@@ -4,6 +4,7 @@ use std::os::raw::c_ulong;
+ use num_derive::{FromPrimitive, ToPrimitive};
+ use num_traits::{FromPrimitive, ToPrimitive};
+ 
++#[repr(u64)]
+ #[derive(Debug, FromPrimitive, ToPrimitive)]
+ pub enum ObjectClass {
+     Data = 0,
+diff --git a/src/pkcs11/return_value.rs b/src/pkcs11/return_value.rs
+index 74d3918..2d06d05 100644
+--- a/src/pkcs11/return_value.rs
++++ b/src/pkcs11/return_value.rs
+@@ -4,6 +4,7 @@ use std::os::raw::c_ulong;
+ use num_derive::{FromPrimitive, ToPrimitive};
+ use num_traits::{FromPrimitive, ToPrimitive};
+ 
++#[repr(u64)]
+ #[derive(Debug, FromPrimitive, ToPrimitive)]
+ pub enum ReturnValue {
+     Ok = 0x0000,
+-- 
+2.32.0
+

--- a/packages/tergent/build.sh
+++ b/packages/tergent/build.sh
@@ -3,12 +3,11 @@ TERMUX_PKG_DESCRIPTION="A cryptoki/PKCS#11 library for Termux that uses Android 
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.0.0
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=https://github.com/aeolwyr/tergent/archive/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=0b59cf0ced3f693fb19396a986326963f3763e6bf65d3e56af0a03d206d69428
 TERMUX_PKG_DEPENDS="termux-api"
 TERMUX_PKG_BUILD_IN_SRC=true
-TERMUX_PKG_BLACKLISTED_ARCHES="arm, i686"
 
 termux_step_pre_configure() {
 	termux_setup_rust

--- a/packages/tergent/build.sh
+++ b/packages/tergent/build.sh
@@ -10,10 +10,27 @@ TERMUX_PKG_DEPENDS="termux-api"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_BLACKLISTED_ARCHES="arm, i686"
 
-termux_step_make_install() {
+termux_step_pre_configure() {
 	termux_setup_rust
-	cargo build --jobs $TERMUX_MAKE_PROCESSES --target $CARGO_TARGET_NAME --release
-	install -Dm600 -t $TERMUX_PREFIX/lib target/${CARGO_TARGET_NAME}/release/libtergent.so
+}
+
+termux_step_make() {
+	local BUILD_FLAG=""
+	if [ "$TERMUX_DEBUG" == "false" ]; then
+		BUILD_FLAG="--release"
+	fi
+	cargo build --jobs $TERMUX_MAKE_PROCESSES --target $CARGO_TARGET_NAME $BUILD_FLAG
+}
+
+termux_step_make_install() {
+	if [ "$TERMUX_DEBUG" == "true" ]; then
+		local BUILD_TYPE="debug"
+	else
+		local BUILD_TYPE="release"
+	fi
+
+	install -Dm600 -t $TERMUX_PREFIX/lib \
+		target/${CARGO_TARGET_NAME}/${BUILD_TYPE}/libtergent.so
 }
 
 termux_step_create_debscripts() {


### PR DESCRIPTION
With this tergent compiles for all arches. 

With a debug build everything works, but unfortunately with a release build ssh crashes with a "Bus error" on arm.
On aarch64 everything still seem to work both for debug and release builds.

A gdb backtrace shows that the issue is somewhere in the [GetAttributeValue function](https://github.com/aeolwyr/tergent/blob/d4b25663d773572c0052071f54f9577741672238/src/lib.rs#L297):

```
~ $ gdb --args ssh <some-host>
GNU gdb (GDB) 10.1
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "arm-linux-androideabi".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ssh...
(gdb) handle SIGILL nostop
Signal        Stop	Print	Pass to program	Description
SIGILL        No	Yes	Yes		Illegal instruction
(gdb) r
Starting program: /data/data/com.termux/files/usr/bin/ssh <some-host>

Program received signal SIGILL, Illegal instruction.
[Detaching after fork from child process 12971]

Program received signal SIGBUS, Bus error.
0xb5c15bba in C_GetAttributeValue () from /data/data/com.termux/files/usr/lib/libtergent.so
(gdb) bt
#0  0xb5c15bba in C_GetAttributeValue () from /data/data/com.termux/files/usr/lib/libtergent.so
#1  0x7f59f09e in pkcs11_check_obj_bool_attrib (k11=0xb6503cb0, obj=0, type=514, val=0xbeffe5f8) at /home/builder/.termux-build/openssh/src/ssh-pkcs11.c:334
#2  0x7f59edac in pkcs11_get_key (k11=0xb6503cb0, mech_type=1) at /home/builder/.termux-build/openssh/src/ssh-pkcs11.c:407
#3  0x7f59ebaa in pkcs11_rsa_private_encrypt (flen=83, from=0xb6300240 "0Q0\r\006\t`\206H\001e\003\004\002\003\005", to=0xb6202f80 "ssh-ed25519-cert-v01@openssh.com", rsa=0xb63009b0, padding=1)
    at /home/builder/.termux-build/openssh/src/ssh-pkcs11.c:437
#4  0xb6b31808 in RSA_sign () from /data/data/com.termux/files/usr/lib/libcrypto.so.1.1
#5  0x7f59a634 in ssh_rsa_sign (key=0xb63012e0, sigp=0xb6300240, lenp=0xbeffe838, data=0xb5cc0cd0 "", datalen=635, alg_ident=0xb6504190 "rsa-sha2-512") at /home/builder/.termux-build/openssh/src/ssh-rsa.c:206
#6  0x7f57d2ae in sshkey_sign (key=0xb63012e0, sigp=0xbeffe83c, lenp=0xbeffe838, data=0xb5cc0cd0 "", datalen=635, alg=0xb6504190 "rsa-sha2-512", sk_provider=0x0, sk_pin=0x0, compat=67108864)
    at /home/builder/.termux-build/openssh/src/sshkey.c:2757
#7  0x7f5728b8 in identity_sign (id=0xb6540970, sigp=0xbeffe83c, lenp=0xbeffe838, data=0xb5cc0cd0 "", datalen=635, compat=67108864, alg=0xb6504190 "rsa-sha2-512") at /home/builder/.termux-build/openssh/src/sshconnect2.c:1271
#8  0x7f572008 in sign_and_send_pubkey (ssh=<optimized out>, id=0xb6540970) at /home/builder/.termux-build/openssh/src/sshconnect2.c:1426
#9  0x7f572632 in input_userauth_pk_ok (type=<optimized out>, seq=<optimized out>, ssh=0xb6101bd0) at /home/builder/.termux-build/openssh/src/sshconnect2.c:749
#10 0x7f594dd0 in ssh_dispatch_run (ssh=0xb6101bd0, mode=0, done=0xbeffe934) at /home/builder/.termux-build/openssh/src/dispatch.c:113
#11 0x7f594e2e in ssh_dispatch_run_fatal (ssh=0xb6101bd0, mode=0, done=0x202) at /home/builder/.termux-build/openssh/src/dispatch.c:133
#12 0x7f56ff40 in ssh_userauth2 (ssh=0xb6101bd0, local_user=<optimized out>, server_user=0xb6503910 "grimler", host=0xb65039b0 "1.2.3.4", sensitive=0x7f5e7750 <sensitive_data>)
    at /home/builder/.termux-build/openssh/src/sshconnect2.c:484
#13 0x7f56de26 in ssh_login (ssh=0xb6101bd0, sensitive=0x7f5e7750 <sensitive_data>, orighost=<optimized out>, hostaddr=0x7f5e76c8 <hostaddr>, port=8022, pw=0xb65407f0, timeout_ms=-1000, cinfo=0xb6380710)
    at /home/builder/.termux-build/openssh/src/sshconnect.c:1573
#14 0x7f55e38a in main (ac=<optimized out>, av=0x7f5e5cb8 <options>) at /home/builder/.termux-build/openssh/src/ssh.c:1658
```
 
 Opening this as a draft for now in case anyone wants to try it out and help iron out the last issue.