### PR TITLE
Fix missing library for ttyd: libcap

### DIFF
--- a/packages/ttyd/build.sh
+++ b/packages/ttyd/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="Command-line tool for sharing terminal over the web"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.6.3
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/tsl0922/ttyd/archive/$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=1116419527edfe73717b71407fb6e06f46098fc8a8e6b0bb778c4c75dc9f64b9
-TERMUX_PKG_DEPENDS="json-c, libuv, libwebsockets, zlib"
+TERMUX_PKG_DEPENDS="json-c, libuv, libwebsockets, zlib, libcap"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DCMAKE_XXD=$TERMUX_PKG_TMPDIR/xxd"
 
 termux_step_pre_configure() {


### PR DESCRIPTION
Fix a missing library for ttyd. Adding libcap as dependencies would fix the issue (tested)