### PR TITLE
Pass: termux-clipboard-set even if DISPLAY is set

### DIFF
--- a/packages/pass/build.sh
+++ b/packages/pass/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Lightweight directory-based password manager"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.7.4
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://git.zx2c4.com/password-store/snapshot/password-store-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=cfa9faf659f2ed6b38e7a7c3fb43e177d00edbacc6265e6e32215ff40e3793c0
 TERMUX_PKG_DEPENDS="bash, coreutils, gnupg (>= 2.2.9-1), tree"

--- a/packages/pass/src-password-store.sh.patch
+++ b/packages/pass/src-password-store.sh.patch
@@ -1,7 +1,21 @@
-diff -uNr password-store-1.7.4/src/password-store.sh password-store-1.7.4.mod/src/password-store.sh
---- password-store-1.7.4/src/password-store.sh	2021-06-11 19:49:06.000000000 +0300
-+++ password-store-1.7.4.mod/src/password-store.sh	2021-07-17 22:45:01.663534629 +0300
-@@ -168,7 +168,9 @@
+--- password-store-1.7.4/src/password-store.sh	2021-06-11 18:49:06.000000000 +0200
++++ password-store-1.7.4.mod/src/password-store.sh	2021-07-26 10:10:09.076790995 +0200
+@@ -155,7 +155,7 @@
+ #
+ 
+ clip() {
+-	if [[ -n $WAYLAND_DISPLAY ]]; then
++	if [[ -n $WAYLAND_DISPLAY ]] && hash wl-copy 2>/dev/null && hash wl-paste 2>/dev/null; then
+ 		local copy_cmd=( wl-copy )
+ 		local paste_cmd=( wl-paste -n )
+ 		if [[ $X_SELECTION == primary ]]; then
+@@ -163,12 +163,14 @@
+ 			paste_cmd+=( --primary )
+ 		fi
+ 		local display_name="$WAYLAND_DISPLAY"
+-	elif [[ -n $DISPLAY ]]; then
++	elif [[ -n $DISPLAY ]] && hash xclip 2>/dev/null; then
+ 		local copy_cmd=( xclip -selection "$X_SELECTION" )
  		local paste_cmd=( xclip -o -selection "$X_SELECTION" )
  		local display_name="$DISPLAY"
  	else


### PR DESCRIPTION
With the current patch, pass will try to use `xclip` when `$DISPLAY` is
set. Termux (most of the time) doesn't have `xclip` even if `$DISPLAY`
is set, so this change will check for `xclip` specifically (and
`wl-copy`/`wl-paste` in case of `$WAYLAND_DISPLAY`).

So, if a user has `xclip` and `$DISPLAY` set, it will still use `xclip`,
otherwise it will use `termux-clipboard-set`.

```
~ $ echo $DISPLAY
localhost:10.0
~ $ pass -c Steam
/data/data/com.termux/files/usr/bin/pass: line 182: xclip: command not found
Error: Could not copy data to the clipboard
~ 1 $ dpkg -i pass_1.7.4-1_all.deb
(Reading database ... 145411 files and directories currently installed.)
Preparing to unpack pass_1.7.4-1_all.deb ...
Unpacking pass (1.7.4-1) over (1.7.4) ...
Setting up pass (1.7.4-1) ...
Processing triggers for man (1.14.5-2) ...
~ $ pass -c Steam
Copied Steam to clipboard. Will clear in 45 seconds.
~ $ echo "echo foobar" > ~/bin/xclip; chmod +x ~/bin/xclip
~ $ pass -c Steam
foobar
Copied Steam to clipboard. Will clear in 45 seconds.

```

