### PR TITLE
fzf: Add zsh completions and fish keybindings

### DIFF
--- a/packages/fzf/build.sh
+++ b/packages/fzf/build.sh
@@ -45,10 +45,6 @@ termux_step_make_install() {
 	mkdir -p $TERMUX_PREFIX/share/man/man1/
 	cp $TERMUX_PKG_SRCDIR/man/man1/fzf.1 $TERMUX_PREFIX/share/man/man1/
 
-	# Install fish script:
-	mkdir -p $TERMUX_PREFIX/share/fish/vendor_functions.d
-	cp $TERMUX_PKG_SRCDIR/shell/key-bindings.fish "$TERMUX_PREFIX"/share/fish/vendor_functions.d/fzf_key_bindings.fish
-
 	# Install the rest of the shell scripts:
 	mkdir -p $TERMUX_PREFIX/share/fzf
 	cp $TERMUX_PKG_SRCDIR/shell/* $TERMUX_PREFIX/share/fzf/
@@ -58,6 +54,10 @@ termux_step_make_install() {
 	ln -sfr $TERMUX_PREFIX/share/fzf/completion.bash $TERMUX_PREFIX/share/bash-completion/completions/fzf
 	mkdir -p $TERMUX_PREFIX/share/zsh/site-functions
 	ln -sfr $TERMUX_PREFIX/share/fzf/completion.zsh $TERMUX_PREFIX/share/zsh/site-functions/_fzf
+	
+	# Fish keybindings.
+	mkdir -p $TERMUX_PREFIX/share/fish/vendor_functions.d
+	ln -sfr $TERMUX_PREFIX/share/fzf/key-bindings.fish $TERMUX_PREFIX/share/fish/vendor_functions.d/fzf_key_bindings.fish
 
 	# Install the nvim plugin:
 	mkdir -p $TERMUX_PREFIX/share/nvim/runtime/plugin

--- a/packages/fzf/build.sh
+++ b/packages/fzf/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Command-line fuzzy finder"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.27.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/junegunn/fzf/archive/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=7798a9e22fc363801131456dc21026ccb0f037aed026d17df60b1178b3f24111
 
@@ -47,6 +48,15 @@ termux_step_make_install() {
 	# Install bash completion script:
 	mkdir -p $TERMUX_PREFIX/share/bash-completion/completions/
 	cp $TERMUX_PKG_SRCDIR/shell/completion.bash $TERMUX_PREFIX/share/bash-completion/completions/fzf
+
+	# Install zsh script:
+	mkdir -p $TERMUX_PREFIX/share/zsh/site-functions
+	cp $TERMUX_PKG_SRCDIR/shell/completion.zsh "$TERMUX_PREFIX"/share/zsh/site-functions/_fzf
+
+	# Install fish script:
+	mkdir -p $TERMUX_PREFIX/share/fish/vendor_functions.d
+	cp $TERMUX_PKG_SRCDIR/shell/key-bindings.fish "$TERMUX_PREFIX"/share/fish/vendor_functions.d/fzf_key_bindings.fish
+
 
 	# Install the rest of the shell scripts:
 	mkdir -p $TERMUX_PREFIX/share/fzf

--- a/packages/fzf/build.sh
+++ b/packages/fzf/build.sh
@@ -45,22 +45,19 @@ termux_step_make_install() {
 	mkdir -p $TERMUX_PREFIX/share/man/man1/
 	cp $TERMUX_PKG_SRCDIR/man/man1/fzf.1 $TERMUX_PREFIX/share/man/man1/
 
-	# Install bash completion script:
-	mkdir -p $TERMUX_PREFIX/share/bash-completion/completions/
-	cp $TERMUX_PKG_SRCDIR/shell/completion.bash $TERMUX_PREFIX/share/bash-completion/completions/fzf
-
-	# Install zsh script:
-	mkdir -p $TERMUX_PREFIX/share/zsh/site-functions
-	cp $TERMUX_PKG_SRCDIR/shell/completion.zsh "$TERMUX_PREFIX"/share/zsh/site-functions/_fzf
-
 	# Install fish script:
 	mkdir -p $TERMUX_PREFIX/share/fish/vendor_functions.d
 	cp $TERMUX_PKG_SRCDIR/shell/key-bindings.fish "$TERMUX_PREFIX"/share/fish/vendor_functions.d/fzf_key_bindings.fish
 
-
 	# Install the rest of the shell scripts:
 	mkdir -p $TERMUX_PREFIX/share/fzf
 	cp $TERMUX_PKG_SRCDIR/shell/* $TERMUX_PREFIX/share/fzf/
+	
+	# Symlink shell completions.
+	mkdir -p $TERMUX_PREFIX/share/bash-completion/completions/
+	ln -sfr $TERMUX_PREFIX/share/fzf/completion.bash $TERMUX_PREFIX/share/bash-completion/completions/fzf
+	mkdir -p $TERMUX_PREFIX/share/zsh/site-functions
+	ln -sfr $TERMUX_PREFIX/share/fzf/completion.zsh $TERMUX_PREFIX/share/zsh/site-functions/_fzf
 
 	# Install the nvim plugin:
 	mkdir -p $TERMUX_PREFIX/share/nvim/runtime/plugin


### PR DESCRIPTION
These two were missing from the build script.
Still missing: key-bindings.bash and key-bindings.zsh which I guess should be sourced in their respective .rcs.

Previous discussion: 
 @xeffyr xeffyr 28 minutes ago Member
Shell completion files are already copied into prefix. Why not to just symlink (ln -sfr src dest) them?

@pvonmoradi pvonmoradi 22 minutes ago Author Contributor

I tried to replicated aur script:
https://github.com/archlinux/svntogit-community/blob/packages/fzf/trunk/PKGBUILD
