### PR TITLE
Add rq

### DIFF
--- a/packages/rq/build.sh
+++ b/packages/rq/build.sh
@@ -1,0 +1,8 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/dflemstr/rq
+TERMUX_PKG_DESCRIPTION="A tool for doing record analysis and transformation"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=1.0.2
+TERMUX_PKG_SRCURL=https://github.com/dflemstr/rq/archive/v$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=c9caaaa236b121ffff53877a8c72643f44bfcb3bfb1a7ede4fd64495103ba600
+TERMUX_PKG_BUILD_IN_SRC=true

--- a/packages/rq/lib.rs.patch
+++ b/packages/rq/lib.rs.patch
@@ -1,0 +1,10 @@
+--- rq-1.0.2/src/lib.rs	2019-11-21 01:04:26.000000000 +0330
++++ rq-1.0.2.mod/src/lib.rs	2021-08-07 17:46:03.808318020 +0430
+@@ -3,7 +3,6 @@
+ 
+ // For pest parser generation
+ #![recursion_limit = "1024"]
+-#![deny(warnings)]
+ #![deny(clippy::all)]
+ #![deny(
+     missing_debug_implementations,


### PR DESCRIPTION
This tool is used to convert between [different structured data formats](https://github.com/dflemstr/rq#format-support-status).  
The patch removes 'treating-warning-as-error' attribute which is applied similar to https://github.com/NixOS/nixpkgs/blob/e60eb84b7cb68ed6e2fd4f7524fa61ce721566f1/pkgs/development/tools/rq/default.nix#L19 .