### PR TITLE
Create data.tar.xz's without prefixed ./

### DIFF
--- a/scripts/build/termux_step_create_datatar.sh
+++ b/scripts/build/termux_step_create_datatar.sh
@@ -4,5 +4,5 @@ termux_step_create_datatar() {
 		rm -rf data
 	fi
 
-	tar -cJf "$TERMUX_PKG_PACKAGEDIR/data.tar.xz" -H gnu .
+	tar -cJf "$TERMUX_PKG_PACKAGEDIR/data.tar.xz" -H gnu data
 }

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -79,15 +79,23 @@ termux_step_start_build() {
 				echo "Download of $PKG@$DEP_VERSION from $TERMUX_REPO_URL failed, building instead"
 				TERMUX_BUILD_IGNORE_LOCK=true ./build-package.sh -I "${PKG_DIR}"
 				continue
-			else
-				if [ "$TERMUX_ON_DEVICE_BUILD" = "false" ]; then
-					if [ ! "$TERMUX_QUIET_BUILD" = true ]; then echo "extracting $PKG..."; fi
-					(
-						cd $TERMUX_COMMON_CACHEDIR-$DEP_ARCH
-						ar x ${PKG}_${DEP_VERSION}_${DEP_ARCH}.deb data.tar.xz
-						tar -xf data.tar.xz --no-overwrite-dir -C /
-					)
+			fi
+			if [ "$TERMUX_ON_DEVICE_BUILD" = "false" ]; then
+				if [ ! "$TERMUX_QUIET_BUILD" = true ]; then
+					echo "extracting $PKG..."
 				fi
+				(
+					cd $TERMUX_COMMON_CACHEDIR-$DEP_ARCH
+					ar x ${PKG}_${DEP_VERSION}_${DEP_ARCH}.deb data.tar.xz
+					if tar -tf data.tar.xz|grep "^./$">/dev/null; then
+						# Strip prefixed ./, to avoid possible
+						# permission errors from tar
+						tar -xf data.tar.xz --strip-components=1 \
+							--no-overwrite-dir -C /
+					else
+						tar -xf data.tar.xz --no-overwrite-dir -C /
+					fi
+				)
 			fi
 
 			mkdir -p $TERMUX_BUILT_PACKAGES_DIRECTORY

--- a/scripts/generate-bootstraps.sh
+++ b/scripts/generate-bootstraps.sh
@@ -144,7 +144,7 @@ pull_package() {
 
 			if ! ${BOOTSTRAP_ANDROID10_COMPATIBLE}; then
 				# Register extracted files.
-				tar tf "$data_archive" | sed -e 's@^\./@/@' -e 's@^/$@/.@' > "${BOOTSTRAP_ROOTFS}/${TERMUX_PREFIX}/var/lib/dpkg/info/${package_name}.list"
+				tar tf "$data_archive" | sed -E -e 's@^\./@/@' -e 's@^/$@/.@' -e 's@^([^./])@/\1@' > "${BOOTSTRAP_ROOTFS}/${TERMUX_PREFIX}/var/lib/dpkg/info/${package_name}.list"
 
 				# Generate checksums (md5).
 				tar xf "$data_archive"


### PR DESCRIPTION
All, or at least most, of our debs contain "./" as a folder. This causes problems when extracting on some systems, as ./ then is the system root directory /, and tar cannot change the permissions of this folder.  Trying to build on arch for example gives:
    
    tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted
    tar: Exiting with failure status due to previous errors
    
The issue appeared on arch somewhat recently, maybe with tar 1.33. With this we switch to creating data.tar.xz's with `data/data/com.termux/` instead of `./data/data/com.termux/`
    
Need to test and think about this a bit more to see how many other things this might break (bootstrap and command-not-found generation for example).