### PR TITLE
build-package: add option to continue builds

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -276,7 +276,7 @@ _show_usage() {
 	exit 1
 }
 
-while getopts :a:hdDfiIqso: option; do
+while getopts :a:hdDfiIqso:c option; do
 	case "$option" in
 		a)
 			if [ "$TERMUX_ON_DEVICE_BUILD" = "true" ]; then
@@ -300,6 +300,7 @@ while getopts :a:hdDfiIqso: option; do
 		q) export TERMUX_QUIET_BUILD=true;;
 		s) export TERMUX_SKIP_DEPCHECK=true;;
 		o) TERMUX_DEBDIR=$(realpath -m "$OPTARG");;
+		c) TERMUX_CONTINUE_BUILD="true";;
 		?) termux_error_exit "./build-package.sh: illegal option -$OPTARG";;
 	esac
 done
@@ -373,22 +374,38 @@ while (($# > 0)); do
 		termux_step_setup_variables
 		termux_step_handle_buildarch
 		termux_step_start_build
-		termux_step_get_dependencies
+		if [ "$TERMUX_CONTINUE_BUILD" == "false" ]; then
+			termux_step_get_dependencies
+		fi
+
 		termux_step_create_timestamp_file
-		cd "$TERMUX_PKG_CACHEDIR"
-		termux_step_get_source
-		cd "$TERMUX_PKG_SRCDIR"
-		termux_step_post_get_source
-		termux_step_handle_hostbuild
+
+		if [ "$TERMUX_CONTINUE_BUILD" == "false" ]; then
+			cd "$TERMUX_PKG_CACHEDIR"
+			termux_step_get_source
+			cd "$TERMUX_PKG_SRCDIR"
+			termux_step_post_get_source
+			termux_step_handle_hostbuild
+		fi
+
 		termux_step_setup_toolchain
-		termux_step_patch_package
-		termux_step_replace_guess_scripts
-		cd "$TERMUX_PKG_SRCDIR"
-		termux_step_pre_configure
+
+		if [ "$TERMUX_CONTINUE_BUILD" == "false" ]; then
+			termux_step_patch_package
+			termux_step_replace_guess_scripts
+			cd "$TERMUX_PKG_SRCDIR"
+			termux_step_pre_configure
+		fi
+
+		# Even on continued build we might need to setup paths
+		# to tools so need to run part of configure step
 		cd "$TERMUX_PKG_BUILDDIR"
 		termux_step_configure
-		cd "$TERMUX_PKG_BUILDDIR"
-		termux_step_post_configure
+
+		if [ "$TERMUX_CONTINUE_BUILD" == "false" ]; then
+			cd "$TERMUX_PKG_BUILDDIR"
+			termux_step_post_configure
+		fi
 		cd "$TERMUX_PKG_BUILDDIR"
 		termux_step_make
 		cd "$TERMUX_PKG_BUILDDIR"

--- a/build-package.sh
+++ b/build-package.sh
@@ -103,6 +103,10 @@ source "$TERMUX_SCRIPTDIR/scripts/build/termux_get_repo_files.sh"
 # shellcheck source=scripts/build/termux_step_get_dependencies.sh
 source "$TERMUX_SCRIPTDIR/scripts/build/termux_step_get_dependencies.sh"
 
+# Remove old src and build folders and create new ones
+# shellcheck source=scripts/build/termux_step_setup_build_folders.sh
+source "$TERMUX_SCRIPTDIR/scripts/build/termux_step_setup_build_folders.sh"
+
 # Source the package build script and start building. Not to be overridden by packages.
 # shellcheck source=scripts/build/termux_step_start_build.sh
 source "$TERMUX_SCRIPTDIR/scripts/build/termux_step_start_build.sh"
@@ -373,7 +377,13 @@ while (($# > 0)); do
 
 		termux_step_setup_variables
 		termux_step_handle_buildarch
+
+		if [ "$TERMUX_CONTINUE_BUILD" == "false" ]; then
+			termux_step_setup_build_folders
+		fi
+
 		termux_step_start_build
+
 		if [ "$TERMUX_CONTINUE_BUILD" == "false" ]; then
 			termux_step_get_dependencies
 		fi

--- a/packages/libllvm/build.sh
+++ b/packages/libllvm/build.sh
@@ -64,11 +64,9 @@ termux_step_host_build() {
 }
 
 termux_step_pre_configure() {
-	if [ "$TERMUX_PKG_QUICK_REBUILD" = "false" ]; then
-		mkdir openmp/runtime/src/android
-		cp $TERMUX_PKG_BUILDER_DIR/nl_types.h openmp/runtime/src/android
-		cp $TERMUX_PKG_BUILDER_DIR/nltypes_stubs.cpp openmp/runtime/src/android
-	fi
+	mkdir openmp/runtime/src/android
+	cp $TERMUX_PKG_BUILDER_DIR/nl_types.h openmp/runtime/src/android
+	cp $TERMUX_PKG_BUILDER_DIR/nltypes_stubs.cpp openmp/runtime/src/android
 
 	# Add unknown vendor, otherwise it screws with the default LLVM triple
 	# detection.

--- a/packages/swift/build.sh
+++ b/packages/swift/build.sh
@@ -24,61 +24,60 @@ SWIFT_BINDIR="$TERMUX_PKG_HOSTBUILD_DIR/$SWIFT_BIN/usr/bin"
 fi
 
 termux_step_post_get_source() {
-	if [ "$TERMUX_PKG_QUICK_REBUILD" = "false" ]; then
-		# The Swift build-script requires a particular organization of source
-		# directories, which the following sets up.
-		mkdir .temp
-		mv [a-zA-Z]* .temp/
-		mv .temp swift
+	# The Swift build-script requires a particular organization of source
+	# directories, which the following sets up.
+	mkdir .temp
+	mv [a-zA-Z]* .temp/
+	mv .temp swift
 
-		declare -A library_checksums
-		library_checksums[swift-cmark]=d1c2d9728667a563e9420c608ef4fcde749a86e38ee373e8b109bce5eb94510d
-		library_checksums[llvm-project]=50401b5b696292ccf6dc11f59f34f8958fdc0097c7d4db9cd862a4622ee1676a
-		library_checksums[swift-corelibs-libdispatch]=84602423596712a1fd0d866d640af0c2de56c52ea03c95864af900a55945ef37
-		library_checksums[swift-corelibs-foundation]=38e15b60188a4240fe71b9ca6e9409d423d342896102ac957db42d7fa8b4ad23
-		library_checksums[swift-corelibs-xctest]=5e0bede769b0869e65d2626a3bfdab09faf99dfe48366a37e5c72dc3b7dc9287
-		library_checksums[swift-llbuild]=d5562e63fd68f6fcd64c60820a1be0142592a2742c71c1c6fe673f34854ac599
-		library_checksums[swift-argument-parser]=6743338612be50a5a32127df0a3dd1c34e695f5071b1213f128e6e2b27c4364a
-		library_checksums[Yams]=8bbb28ef994f60afe54668093d652e4d40831c79885fa92b1c2cd0e17e26735a
-		library_checksums[swift-driver]=9907e6d41236cf543a43a89b5ff67b6cb12474692f96069908d4b6f92b617518
-		library_checksums[swift-tools-support-core]=a4bc991cf601fe0f45edc7d0a6248f1a19def4d149b3e86b37361f34b0ecbd2c
-		library_checksums[swift-package-manager]=3648d7cbf74a2ad69b444d78b53e278541b1bd0e4e54fb1b8bc9002596bbaf4b
+	declare -A library_checksums
+	library_checksums[swift-cmark]=d1c2d9728667a563e9420c608ef4fcde749a86e38ee373e8b109bce5eb94510d
+	library_checksums[llvm-project]=50401b5b696292ccf6dc11f59f34f8958fdc0097c7d4db9cd862a4622ee1676a
+	library_checksums[swift-corelibs-libdispatch]=84602423596712a1fd0d866d640af0c2de56c52ea03c95864af900a55945ef37
+	library_checksums[swift-corelibs-foundation]=38e15b60188a4240fe71b9ca6e9409d423d342896102ac957db42d7fa8b4ad23
+	library_checksums[swift-corelibs-xctest]=5e0bede769b0869e65d2626a3bfdab09faf99dfe48366a37e5c72dc3b7dc9287
+	library_checksums[swift-llbuild]=d5562e63fd68f6fcd64c60820a1be0142592a2742c71c1c6fe673f34854ac599
+	library_checksums[swift-argument-parser]=6743338612be50a5a32127df0a3dd1c34e695f5071b1213f128e6e2b27c4364a
+	library_checksums[Yams]=8bbb28ef994f60afe54668093d652e4d40831c79885fa92b1c2cd0e17e26735a
+	library_checksums[swift-driver]=9907e6d41236cf543a43a89b5ff67b6cb12474692f96069908d4b6f92b617518
+	library_checksums[swift-tools-support-core]=a4bc991cf601fe0f45edc7d0a6248f1a19def4d149b3e86b37361f34b0ecbd2c
+	library_checksums[swift-package-manager]=3648d7cbf74a2ad69b444d78b53e278541b1bd0e4e54fb1b8bc9002596bbaf4b
 
-		for library in "${!library_checksums[@]}"; do \
-			if [ "$library" = "swift-argument-parser" ]; then
-				GH_ORG="apple"
-				SRC_VERSION="0.4.1"
-				TAR_NAME=$SRC_VERSION
-			elif [ "$library" = "Yams" ]; then
-				GH_ORG="jpsim"
-				SRC_VERSION="4.0.2"
-				TAR_NAME=$SRC_VERSION
-			else
-				GH_ORG="apple"
-				SRC_VERSION=$SWIFT_RELEASE
-				TAR_NAME=swift-$TERMUX_PKG_VERSION-$SWIFT_RELEASE
-			fi
-
-			termux_download \
-				https://github.com/$GH_ORG/$library/archive/$TAR_NAME.tar.gz \
-				$TERMUX_PKG_CACHEDIR/$library-$SRC_VERSION.tar.gz \
-				${library_checksums[$library]}
-			tar xf $TERMUX_PKG_CACHEDIR/$library-$SRC_VERSION.tar.gz
-			mv $library-$TAR_NAME $library
-		done
-
-		mv swift-cmark cmark
-		mv swift-llbuild llbuild
-		mv Yams yams
-		mv swift-package-manager swiftpm
-
-		if [ "$TERMUX_ON_DEVICE_BUILD" = "false" ]; then
-			termux_download \
-				https://swift.org/builds/swift-$TERMUX_PKG_VERSION-release/ubuntu2004/swift-$TERMUX_PKG_VERSION-$SWIFT_RELEASE/$SWIFT_BIN.tar.gz \
-				$TERMUX_PKG_CACHEDIR/$SWIFT_BIN.tar.gz \
-				86b849d9f6ba2eda4e12ea5eafaa0748bffcd6272466b514c2b0fd4a829c63a4
+	for library in "${!library_checksums[@]}"; do \
+		if [ "$library" = "swift-argument-parser" ]; then
+			GH_ORG="apple"
+			SRC_VERSION="0.4.1"
+			TAR_NAME=$SRC_VERSION
+		elif [ "$library" = "Yams" ]; then
+			GH_ORG="jpsim"
+			SRC_VERSION="4.0.2"
+			TAR_NAME=$SRC_VERSION
+		else
+			GH_ORG="apple"
+			SRC_VERSION=$SWIFT_RELEASE
+			TAR_NAME=swift-$TERMUX_PKG_VERSION-$SWIFT_RELEASE
 		fi
+
+		termux_download \
+			https://github.com/$GH_ORG/$library/archive/$TAR_NAME.tar.gz \
+			$TERMUX_PKG_CACHEDIR/$library-$SRC_VERSION.tar.gz \
+			${library_checksums[$library]}
+		tar xf $TERMUX_PKG_CACHEDIR/$library-$SRC_VERSION.tar.gz
+		mv $library-$TAR_NAME $library
+	done
+
+	mv swift-cmark cmark
+	mv swift-llbuild llbuild
+	mv Yams yams
+	mv swift-package-manager swiftpm
+
+	if [ "$TERMUX_ON_DEVICE_BUILD" = "false" ]; then
+		termux_download \
+			https://swift.org/builds/swift-$TERMUX_PKG_VERSION-release/ubuntu2004/swift-$TERMUX_PKG_VERSION-$SWIFT_RELEASE/$SWIFT_BIN.tar.gz \
+			$TERMUX_PKG_CACHEDIR/$SWIFT_BIN.tar.gz \
+			86b849d9f6ba2eda4e12ea5eafaa0748bffcd6272466b514c2b0fd4a829c63a4
 	fi
+
 	# The Swift compiler searches for the clang headers so symlink against them.
 	export TERMUX_CLANG_VERSION=$(grep ^TERMUX_PKG_VERSION= $TERMUX_PKG_BUILDER_DIR/../libllvm/build.sh | cut -f2 -d=)
 }
@@ -103,28 +102,26 @@ termux_step_host_build() {
 termux_step_pre_configure() {
 	export SWIFT_ARCH=$TERMUX_ARCH
 	test $SWIFT_ARCH == 'arm' && SWIFT_ARCH='armv7'
-	if [ "$TERMUX_PKG_QUICK_REBUILD" = "false" ]; then
-		cd llbuild
-		# A single patch needed from the existing llbuild package
-		patch -p1 < $TERMUX_PKG_BUILDER_DIR/../llbuild/lib-llvm-Support-CmakeLists.txt.patch
+	cd llbuild
+	# A single patch needed from the existing llbuild package
+	patch -p1 < $TERMUX_PKG_BUILDER_DIR/../llbuild/lib-llvm-Support-CmakeLists.txt.patch
 
-		cd ../llvm-project
-		patch -p1 < $TERMUX_PKG_BUILDER_DIR/../libllvm/clang-lib-Driver-ToolChain.cpp.patch
-		patch -p1 < $TERMUX_PKG_BUILDER_DIR/../libllvm/clang-lib-Driver-ToolChains-Linux.cpp.patch
-		cd ..
+	cd ../llvm-project
+	patch -p1 < $TERMUX_PKG_BUILDER_DIR/../libllvm/clang-lib-Driver-ToolChain.cpp.patch
+	patch -p1 < $TERMUX_PKG_BUILDER_DIR/../libllvm/clang-lib-Driver-ToolChains-Linux.cpp.patch
+	cd ..
 
-		sed "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" \
-		$TERMUX_PKG_BUILDER_DIR/swiftpm-Utilities-bootstrap | \
-		sed "s%\@TERMUX_PKG_BUILDDIR\@%${TERMUX_PKG_BUILDDIR}%g" | patch -p1
+	sed "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" \
+	$TERMUX_PKG_BUILDER_DIR/swiftpm-Utilities-bootstrap | \
+	sed "s%\@TERMUX_PKG_BUILDDIR\@%${TERMUX_PKG_BUILDDIR}%g" | patch -p1
 
-		if [ "$TERMUX_ON_DEVICE_BUILD" = "false" ]; then
-			sed "s%\@TERMUX_STANDALONE_TOOLCHAIN\@%${TERMUX_STANDALONE_TOOLCHAIN}%g" \
-			$TERMUX_PKG_BUILDER_DIR/swiftpm-android-flags.json | \
-			sed "s%\@CCTERMUX_HOST_PLATFORM\@%${CCTERMUX_HOST_PLATFORM}%g" | \
-			sed "s%\@TERMUX_HOST_PLATFORM\@%${TERMUX_HOST_PLATFORM}%g" | \
-			sed "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" | \
-			sed "s%\@SWIFT_ARCH\@%${SWIFT_ARCH}%g" > $TERMUX_PKG_BUILDDIR/swiftpm-android-flags.json
-		fi
+	if [ "$TERMUX_ON_DEVICE_BUILD" = "false" ]; then
+		sed "s%\@TERMUX_STANDALONE_TOOLCHAIN\@%${TERMUX_STANDALONE_TOOLCHAIN}%g" \
+		$TERMUX_PKG_BUILDER_DIR/swiftpm-android-flags.json | \
+		sed "s%\@CCTERMUX_HOST_PLATFORM\@%${CCTERMUX_HOST_PLATFORM}%g" | \
+		sed "s%\@TERMUX_HOST_PLATFORM\@%${TERMUX_HOST_PLATFORM}%g" | \
+		sed "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" | \
+		sed "s%\@SWIFT_ARCH\@%${SWIFT_ARCH}%g" > $TERMUX_PKG_BUILDDIR/swiftpm-android-flags.json
 	fi
 }
 

--- a/packages/swift/build.sh
+++ b/packages/swift/build.sh
@@ -12,6 +12,12 @@ TERMUX_PKG_DEPENDS="binutils-gold, clang, libc++, ndk-sysroot, libandroid-glob, 
 TERMUX_PKG_BUILD_DEPENDS="cmake, ninja, perl, pkg-config, rsync"
 TERMUX_PKG_BLACKLISTED_ARCHES="i686"
 TERMUX_PKG_NO_STATICSPLIT=true
+# Build of swift uses cmake, but the standard
+# termux_step_configure_cmake function is not used. Instead we set
+# TERMUX_PKG_FORCE_CMAKE to make the build system aware that cmake is
+# needed.
+TERMUX_PKG_FORCE_CMAKE=true
+TERMUX_CMAKE_BUILD=Ninja
 
 SWIFT_COMPONENTS="autolink-driver;compiler;clang-resource-dir-symlink;swift-remote-mirror;parser-lib;license;sourcekit-inproc;stdlib;sdk-overlay"
 SWIFT_TOOLCHAIN_FLAGS="-R --no-assertions --llvm-targets-to-build='X86;ARM;AArch64' -j $TERMUX_MAKE_PROCESSES"

--- a/scripts/build/configure/termux_step_configure.sh
+++ b/scripts/build/configure/termux_step_configure.sh
@@ -2,10 +2,23 @@ termux_step_configure() {
 	[ "$TERMUX_PKG_METAPACKAGE" = "true" ] && return
 
 	if [ "$TERMUX_PKG_FORCE_CMAKE" = "false" ] && [ -f "$TERMUX_PKG_SRCDIR/configure" ]; then
+		if [ "$TERMUX_CONTINUE_BUILD" == "true" ]; then
+			return;
+		fi
 		termux_step_configure_autotools
-	elif [ -f "$TERMUX_PKG_SRCDIR/CMakeLists.txt" ]; then
+	elif [ "$TERMUX_PKG_FORCE_CMAKE" = "true" ] || [ -f "$TERMUX_PKG_SRCDIR/CMakeLists.txt" ]; then
+		if [ "$TERMUX_CONTINUE_BUILD" == "true" ]; then
+			termux_setup_cmake
+			if [ "$TERMUX_CMAKE_BUILD" = Ninja ]; then
+				termux_setup_ninja
+			fi
+			return;
+		fi
 		termux_step_configure_cmake
 	elif [ -f "$TERMUX_PKG_SRCDIR/meson.build" ]; then
+		if [ "$TERMUX_CONTINUE_BUILD" == "true" ]; then
+			return;
+		fi
 		termux_step_configure_meson
 	fi
 }

--- a/scripts/build/configure/termux_step_configure.sh
+++ b/scripts/build/configure/termux_step_configure.sh
@@ -7,14 +7,19 @@ termux_step_configure() {
 		fi
 		termux_step_configure_autotools
 	elif [ "$TERMUX_PKG_FORCE_CMAKE" = "true" ] || [ -f "$TERMUX_PKG_SRCDIR/CMakeLists.txt" ]; then
-		if [ "$TERMUX_CONTINUE_BUILD" == "true" ]; then
-			termux_setup_cmake
-			if [ "$TERMUX_CMAKE_BUILD" = Ninja ]; then
-				termux_setup_ninja
-			fi
-			return;
+		termux_setup_cmake
+		if [ "$TERMUX_CMAKE_BUILD" = Ninja ]; then
+			termux_setup_ninja
 		fi
-		termux_step_configure_cmake
+
+		# Some packages, for example swift, uses cmake
+		# internally, but cannot be configured with our
+		# termux_step_configure_cmake function (CMakeLists.txt
+		# is not in src dir)
+		if [ -f "$TERMUX_PKG_SRCDIR/CMakeLists.txt" ] && \
+			[ "$TERMUX_CONTINUE_BUILD" == "false" ]; then
+			termux_step_configure_cmake
+		fi
 	elif [ -f "$TERMUX_PKG_SRCDIR/meson.build" ]; then
 		if [ "$TERMUX_CONTINUE_BUILD" == "true" ]; then
 			return;

--- a/scripts/build/configure/termux_step_configure_cmake.sh
+++ b/scripts/build/configure/termux_step_configure_cmake.sh
@@ -14,6 +14,9 @@ termux_step_configure_cmake() {
 		MAKE_PROGRAM_PATH=$(command -v make)
 	fi
 
+	if [ "$TERMUX_CONTINUE_BUILD" == "true" ]; then
+		return
+	fi
 	local CMAKE_ADDITIONAL_ARGS=()
 	if [ "$TERMUX_ON_DEVICE_BUILD" = "false" ]; then
 		CXXFLAGS+=" --target=$CCTERMUX_HOST_PLATFORM"

--- a/scripts/build/configure/termux_step_configure_cmake.sh
+++ b/scripts/build/configure/termux_step_configure_cmake.sh
@@ -1,22 +1,14 @@
 termux_step_configure_cmake() {
-	termux_setup_cmake
-
-	local BUILD_TYPE=Release
-	[ "$TERMUX_DEBUG_BUILD" = "true" ] && BUILD_TYPE=Debug
-
-	local CMAKE_PROC=$TERMUX_ARCH
-	test $CMAKE_PROC == "arm" && CMAKE_PROC='armv7-a'
-	local MAKE_PROGRAM_PATH
 	if [ "$TERMUX_CMAKE_BUILD" = Ninja ]; then
-		termux_setup_ninja
 		MAKE_PROGRAM_PATH=$(command -v ninja)
 	else
 		MAKE_PROGRAM_PATH=$(command -v make)
 	fi
+	BUILD_TYPE=Release
+	test "$TERMUX_DEBUG_BUILD" == "true" && BUILD_TYPE=Debug
+	CMAKE_PROC=$TERMUX_ARCH
+	test $CMAKE_PROC == "arm" && CMAKE_PROC='armv7-a'
 
-	if [ "$TERMUX_CONTINUE_BUILD" == "true" ]; then
-		return
-	fi
 	local CMAKE_ADDITIONAL_ARGS=()
 	if [ "$TERMUX_ON_DEVICE_BUILD" = "false" ]; then
 		CXXFLAGS+=" --target=$CCTERMUX_HOST_PLATFORM"

--- a/scripts/build/termux_step_handle_hostbuild.sh
+++ b/scripts/build/termux_step_handle_hostbuild.sh
@@ -3,19 +3,15 @@ termux_step_handle_hostbuild() {
 	[ "$TERMUX_PKG_HOSTBUILD" = "false" ] && return
 
 	cd "$TERMUX_PKG_SRCDIR"
-	if [ "$TERMUX_PKG_QUICK_REBUILD" = "false" ]; then
-		for patch in $TERMUX_PKG_BUILDER_DIR/*.patch.beforehostbuild; do
-			echo "Applying patch: $(basename $patch)"
-			test -f "$patch" && sed "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" "$patch" | patch --silent -p1
-		done
-	fi
+	for patch in $TERMUX_PKG_BUILDER_DIR/*.patch.beforehostbuild; do
+		echo "Applying patch: $(basename $patch)"
+		test -f "$patch" && sed "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" "$patch" | patch --silent -p1
+	done
 
 	local TERMUX_HOSTBUILD_MARKER="$TERMUX_PKG_HOSTBUILD_DIR/TERMUX_BUILT_FOR_$TERMUX_PKG_VERSION"
 	if [ ! -f "$TERMUX_HOSTBUILD_MARKER" ]; then
-		if [ "$TERMUX_PKG_QUICK_REBUILD" = "false" ]; then
-			rm -Rf "$TERMUX_PKG_HOSTBUILD_DIR"
-			mkdir -p "$TERMUX_PKG_HOSTBUILD_DIR"
-		fi
+		rm -Rf "$TERMUX_PKG_HOSTBUILD_DIR"
+		mkdir -p "$TERMUX_PKG_HOSTBUILD_DIR"
 		cd "$TERMUX_PKG_HOSTBUILD_DIR"
 		termux_step_host_build
 		touch "$TERMUX_HOSTBUILD_MARKER"

--- a/scripts/build/termux_step_handle_hostbuild.sh
+++ b/scripts/build/termux_step_handle_hostbuild.sh
@@ -8,7 +8,6 @@ termux_step_handle_hostbuild() {
 		test -f "$patch" && sed "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" "$patch" | patch --silent -p1
 	done
 
-	local TERMUX_HOSTBUILD_MARKER="$TERMUX_PKG_HOSTBUILD_DIR/TERMUX_BUILT_FOR_$TERMUX_PKG_VERSION"
 	if [ ! -f "$TERMUX_HOSTBUILD_MARKER" ]; then
 		rm -Rf "$TERMUX_PKG_HOSTBUILD_DIR"
 		mkdir -p "$TERMUX_PKG_HOSTBUILD_DIR"

--- a/scripts/build/termux_step_patch_package.sh
+++ b/scripts/build/termux_step_patch_package.sh
@@ -6,19 +6,17 @@ termux_step_patch_package() {
 	if [ "$TERMUX_DEBUG_BUILD" = "true" ]; then
 		DEBUG_PATCHES=$(find $TERMUX_PKG_BUILDER_DIR -mindepth 1 -maxdepth 1 -name \*.patch.debug)
 	fi
-	if [ "$TERMUX_PKG_QUICK_REBUILD" = "false" ]; then
-		# Suffix patch with ".patch32" or ".patch64" to only apply for these bitnesses:
-		shopt -s nullglob
-		for patch in $TERMUX_PKG_BUILDER_DIR/*.patch{$TERMUX_ARCH_BITS,} $DEBUG_PATCHES; do
-			echo "Applying patch: $(basename $patch)"
-			test -f "$patch" && sed \
-				-e "s%\@TERMUX_APP_PACKAGE\@%${TERMUX_APP_PACKAGE}%g" \
-				-e "s%\@TERMUX_BASE_DIR\@%${TERMUX_BASE_DIR}%g" \
-				-e "s%\@TERMUX_CACHE_DIR\@%${TERMUX_CACHE_DIR}%g" \
-				-e "s%\@TERMUX_HOME\@%${TERMUX_ANDROID_HOME}%g" \
-				-e "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" \
-				"$patch" | patch --silent -p1
-		done
-		shopt -u nullglob
-	fi
+	# Suffix patch with ".patch32" or ".patch64" to only apply for these bitnesses:
+	shopt -s nullglob
+	for patch in $TERMUX_PKG_BUILDER_DIR/*.patch{$TERMUX_ARCH_BITS,} $DEBUG_PATCHES; do
+		echo "Applying patch: $(basename $patch)"
+		test -f "$patch" && sed \
+			-e "s%\@TERMUX_APP_PACKAGE\@%${TERMUX_APP_PACKAGE}%g" \
+			-e "s%\@TERMUX_BASE_DIR\@%${TERMUX_BASE_DIR}%g" \
+			-e "s%\@TERMUX_CACHE_DIR\@%${TERMUX_CACHE_DIR}%g" \
+			-e "s%\@TERMUX_HOME\@%${TERMUX_ANDROID_HOME}%g" \
+			-e "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" \
+			"$patch" | patch --silent -p1
+	done
+	shopt -u nullglob
 }

--- a/scripts/build/termux_step_setup_build_folders.sh
+++ b/scripts/build/termux_step_setup_build_folders.sh
@@ -1,0 +1,25 @@
+termux_step_setup_build_folders() {
+	# Following directories may contain files with read-only permissions which
+	# makes them undeletable. We need to fix that.
+	[ -d "$TERMUX_PKG_BUILDDIR" ] && chmod +w -R "$TERMUX_PKG_BUILDDIR"
+	[ -d "$TERMUX_PKG_SRCDIR" ] && chmod +w -R "$TERMUX_PKG_SRCDIR"
+
+	# Cleanup old build state:
+	rm -Rf "$TERMUX_PKG_BUILDDIR" \
+		"$TERMUX_PKG_SRCDIR"
+
+	# Cleanup old packaging state:
+	rm -Rf "$TERMUX_PKG_PACKAGEDIR" \
+		"$TERMUX_PKG_TMPDIR" \
+		"$TERMUX_PKG_MASSAGEDIR"
+
+	# Ensure folders present (but not $TERMUX_PKG_SRCDIR, it will be created in build)
+	mkdir -p "$TERMUX_COMMON_CACHEDIR" \
+		 "$TERMUX_DEBDIR" \
+		 "$TERMUX_PKG_BUILDDIR" \
+		 "$TERMUX_PKG_PACKAGEDIR" \
+		 "$TERMUX_PKG_TMPDIR" \
+		 "$TERMUX_PKG_CACHEDIR" \
+		 "$TERMUX_PKG_MASSAGEDIR" \
+		 $TERMUX_PREFIX/{bin,etc,lib,libexec,share,share/LICENSES,tmp,include}
+}

--- a/scripts/build/termux_step_setup_variables.sh
+++ b/scripts/build/termux_step_setup_variables.sh
@@ -8,6 +8,7 @@ termux_step_setup_variables() {
 	: "${TERMUX_NO_CLEAN:="false"}"
 	: "${TERMUX_PACKAGES_DIRECTORIES:="packages"}"
 	: "${TERMUX_PKG_API_LEVEL:="24"}"
+	: "${TERMUX_CONTINUE_BUILD:="false"}"
 	: "${TERMUX_QUIET_BUILD:="false"}"
 	: "${TERMUX_SKIP_DEPCHECK:="false"}"
 	: "${TERMUX_TOPDIR:="$HOME/.termux-build"}"
@@ -122,7 +123,6 @@ termux_step_setup_variables() {
 	TERMUX_PKG_PLATFORM_INDEPENDENT=false
 	TERMUX_PKG_PRE_DEPENDS=""
 	TERMUX_PKG_PROVIDES="" #https://www.debian.org/doc/debian-policy/#virtual-packages-provides
-	TERMUX_PKG_QUICK_REBUILD=false # set this temporarily when iterating on a large package and you don't want the source and build directories wiped every time you make a mistake
 	TERMUX_PKG_RECOMMENDS="" # https://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps
 	TERMUX_PKG_REPLACES=""
 	TERMUX_PKG_REVISION="0" # http://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -6,6 +6,8 @@ termux_step_start_build() {
 
 	# shellcheck source=/dev/null
 	source "$TERMUX_PKG_BUILDER_SCRIPT"
+	# Path to hostbuild marker, for use if package has hostbuild step
+	TERMUX_HOSTBUILD_MARKER="$TERMUX_PKG_HOSTBUILD_DIR/TERMUX_BUILT_FOR_$TERMUX_PKG_VERSION"
 
 	if [ "$TERMUX_PKG_METAPACKAGE" = "true" ]; then
 		# Metapackage has no sources and therefore platform-independent.
@@ -59,6 +61,11 @@ termux_step_start_build() {
 	fi
 
 	if [ "$TERMUX_CONTINUE_BUILD" == "true" ]; then
+		# If the package has a hostbuild step, verify that it has been built
+		if [ "$TERMUX_PKG_HOSTBUILD" == "true" ] && [ ! -f "$TERMUX_HOSTBUILD_MARKER" ]; then
+			termux_error_exit "Cannot continue this build, hostbuilt tools are missing"
+		fi
+
 		# Do not remove source dir on continued builds, the
 		# rest in this function can be skipped in this case
 		return

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -92,29 +92,6 @@ termux_step_start_build() {
 			-e "s|@TERMUX_ARCH@|$TERMUX_ARCH|g" > $TERMUX_PREFIX/bin/llvm-config
 		chmod 755 $TERMUX_PREFIX/bin/llvm-config
 	fi
-	# Following directories may contain files with read-only permissions which
-	# makes them undeletable. We need to fix that.
-	[ -d "$TERMUX_PKG_BUILDDIR" ] && chmod +w -R "$TERMUX_PKG_BUILDDIR"
-	[ -d "$TERMUX_PKG_SRCDIR" ] && chmod +w -R "$TERMUX_PKG_SRCDIR"
-
-	# Cleanup old build state:
-	rm -Rf "$TERMUX_PKG_BUILDDIR" \
-		"$TERMUX_PKG_SRCDIR"
-
-	# Cleanup old packaging state:
-	rm -Rf "$TERMUX_PKG_PACKAGEDIR" \
-		"$TERMUX_PKG_TMPDIR" \
-		"$TERMUX_PKG_MASSAGEDIR"
-
-	# Ensure folders present (but not $TERMUX_PKG_SRCDIR, it will be created in build)
-	mkdir -p "$TERMUX_COMMON_CACHEDIR" \
-		 "$TERMUX_DEBDIR" \
-		 "$TERMUX_PKG_BUILDDIR" \
-		 "$TERMUX_PKG_PACKAGEDIR" \
-		 "$TERMUX_PKG_TMPDIR" \
-		 "$TERMUX_PKG_CACHEDIR" \
-		 "$TERMUX_PKG_MASSAGEDIR" \
-		 $TERMUX_PREFIX/{bin,etc,lib,libexec,share,share/LICENSES,tmp,include}
 
 	# Make $TERMUX_PREFIX/bin/sh executable on the builder, so that build
 	# scripts can assume that it works on both builder and host later on:

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -66,8 +66,8 @@ termux_step_start_build() {
 			termux_error_exit "Cannot continue this build, hostbuilt tools are missing"
 		fi
 
-		# Do not remove source dir on continued builds, the
-		# rest in this function can be skipped in this case
+		# The rest in this function can be skipped when doing
+		# a continued build
 		return
 	fi
 


### PR DESCRIPTION
Replaces the `TERMUX_PKG_QUICK_REBUILD` flag that we currently have. Instead of setting that temporarily we can now run `./build-package.sh -c <package>`, and it skips source extraction and configure and starts directly from `termux_step_make`.

Works well with libllvm, but need to be tested with rust and swift and other large packages.