### PR TITLE
toolchain: add -fPIC to CPPFLAGS for i686

### DIFF
--- a/packages/libandroid-spawn/build.sh
+++ b/packages/libandroid-spawn/build.sh
@@ -8,7 +8,7 @@ TERMUX_PKG_SKIP_SRC_EXTRACT=true
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_make() {
-	$CXX $CFLAGS $CPPFLAGS -fPIC -I$TERMUX_PKG_BUILDER_DIR -c $TERMUX_PKG_BUILDER_DIR/posix_spawn.cpp
+	$CXX $CFLAGS $CPPFLAGS -I$TERMUX_PKG_BUILDER_DIR -c $TERMUX_PKG_BUILDER_DIR/posix_spawn.cpp
 	$CXX $LDFLAGS -shared posix_spawn.o -o libandroid-spawn.so
 	$AR rcu libandroid-spawn.a posix_spawn.o
 	cp -f $TERMUX_PKG_BUILDER_DIR/LICENSE $TERMUX_PKG_SRCDIR/

--- a/scripts/build/termux_step_setup_toolchain.sh
+++ b/scripts/build/termux_step_setup_toolchain.sh
@@ -44,6 +44,9 @@ termux_step_setup_toolchain() {
 	elif [ "$TERMUX_ARCH" = "i686" ]; then
 		# From $NDK/docs/CPU-ARCH-ABIS.html:
 		CFLAGS+=" -march=i686 -msse3 -mstackrealign -mfpmath=sse"
+		# i686 seem to explicitly require -fPIC, see
+		# https://github.com/termux/termux-packages/issues/7215#issuecomment-906154438
+		CPPFLAGS+=" -fPIC"
 		export GOARCH=386
 		export GO386=sse2
 	elif [ "$TERMUX_ARCH" = "aarch64" ]; then

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -2,7 +2,7 @@ termux_step_start_build() {
 	TERMUX_STANDALONE_TOOLCHAIN="$TERMUX_COMMON_CACHEDIR/android-r${TERMUX_NDK_VERSION}-api-${TERMUX_PKG_API_LEVEL}"
 	# Bump the below version if a change is made in toolchain setup to ensure
 	# that everyone gets an updated toolchain:
-	TERMUX_STANDALONE_TOOLCHAIN+="-v4"
+	TERMUX_STANDALONE_TOOLCHAIN+="-v5"
 
 	# shellcheck source=/dev/null
 	source "$TERMUX_PKG_BUILDER_SCRIPT"


### PR DESCRIPTION
When adding this, we go from compiling with
```
/home/builder/.termux-build/_cache/android-r21d-api-24-v4/bin/clang++ [...] -mrelocation-model pic -pic-level 2 -pic-is-pie [...]
```
to
```
/home/builder/.termux-build/_cache/android-r21d-api-24-v5/bin/clang++ [...] -mrelocation-model pic -pic-level 2 [...]
```
on i686. These flags can be seen when adding -v flag to CFLAGS, so that clang is more verbose.

Before, we got a warning when compiling libandroid-spawn:
```
/home/builder/.termux-build/_cache/android-r21d-api-24-v4/bin/../lib/gcc/i686-linux-android/4.9.x/../../../../i686-linux-android/bin/ld: warning: shared library text segment is not shareable
```
and trying to use a program linked against libandroid-spawn gave an error, see https://github.com/termux/termux-packages/issues/7215#issuecomment-906154438. For some reason it does not seem to be an issue on the other arches.

Is there a good way to check for libraries with text relocations? I guess we might have a bunch of packages on i686 that needs to be rebuilt after this change.