### PR TITLE
libseccomp: add to main repo

### DIFF
--- a/packages/libseccomp/build.sh
+++ b/packages/libseccomp/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/seccomp/libseccomp
+TERMUX_PKG_DESCRIPTION="Enhanced seccomp library"
+TERMUX_PKG_LICENSE="LGPL-2.1"
+TERMUX_PKG_MAINTAINER="Leonid Pliushch <leonid.pliushch@gmail.com>"
+TERMUX_PKG_VERSION=2.5.1
+TERMUX_PKG_SRCURL=https://github.com/seccomp/libseccomp/releases/download/v${TERMUX_PKG_VERSION}/libseccomp-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=ee307e383c77aa7995abc5ada544d51c9723ae399768a97667d4cdb3c3a30d55
+TERMUX_PKG_BREAKS="libseccomp-dev"
+TERMUX_PKG_REPLACES="libseccomp-dev"

--- a/packages/libseccomp/build.sh
+++ b/packages/libseccomp/build.sh
@@ -2,6 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://github.com/seccomp/libseccomp
 TERMUX_PKG_DESCRIPTION="Enhanced seccomp library"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="Leonid Pliushch <leonid.pliushch@gmail.com>"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_VERSION=2.5.1
 TERMUX_PKG_SRCURL=https://github.com/seccomp/libseccomp/releases/download/v${TERMUX_PKG_VERSION}/libseccomp-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=ee307e383c77aa7995abc5ada544d51c9723ae399768a97667d4cdb3c3a30d55


### PR DESCRIPTION
This exists in the root repo, but packages from main repo may require it also.