### PR TITLE
Bug fix (with depends value).

### DIFF
--- a/scripts/build/termux_create_pacman_subpackages.sh
+++ b/scripts/build/termux_create_pacman_subpackages.sh
@@ -58,8 +58,8 @@ termux_create_pacman_subpackages() {
 		local PKG_DEPS_SPC=" ${TERMUX_PKG_DEPENDS//,/} "
 		if [ -z "$TERMUX_SUBPKG_DEPEND_ON_PARENT" ] && [ "${PKG_DEPS_SPC/ $SUB_PKG_NAME /}" = "$PKG_DEPS_SPC" ]; then
 			# Does pacman supports versioned dependencies?
-			#TERMUX_SUBPKG_DEPENDS+=", $TERMUX_PKG_NAME (= $TERMUX_PKG_FULLVERSION)"
-			TERMUX_SUBPKG_DEPENDS+=", $TERMUX_PKG_NAME"
+			#TERMUX_SUBPKG_DEPENDS+="$TERMUX_PKG_NAME (= $TERMUX_PKG_FULLVERSION)"
+			TERMUX_SUBPKG_DEPENDS+="$TERMUX_PKG_NAME"
 		elif [ "$TERMUX_SUBPKG_DEPEND_ON_PARENT" = unversioned ]; then
 			TERMUX_SUBPKG_DEPENDS+=", $TERMUX_PKG_NAME"
 		elif [ "$TERMUX_SUBPKG_DEPEND_ON_PARENT" = deps ]; then
@@ -95,7 +95,7 @@ termux_create_pacman_subpackages() {
 			fi
 
 			if [ -n "$TERMUX_SUBPKG_DEPENDS" ]; then
-				tr ',' '\n' <<< "$TERMUX_SUBPKG_BREAKS" | awk '{ printf "depend = %s\n", $1 }'
+				tr ',' '\n' <<< "$TERMUX_SUBPKG_DEPENDS" | awk '{ printf "depend = %s\n", $1 }'
 			fi
 
 			if [ -n "$TERMUX_SUBPKG_CONFFILES" ]; then

--- a/scripts/build/termux_create_pacman_subpackages.sh
+++ b/scripts/build/termux_create_pacman_subpackages.sh
@@ -122,7 +122,9 @@ termux_create_pacman_subpackages() {
 		#termux_step_create_subpkg_debscripts
 
 		# Configuring the selection of a copress for a batch.
-		case $PKG_COMPRESS in
+		local COMPRESS
+		local PKG_FORMAT
+		case $TERMUX_PACMAN_PACKAGE_COMPRESSION in
 			"gzip")
 				COMPRESS=(gzip -c -f -n)
 				PKG_FORMAT="gz";;

--- a/scripts/build/termux_step_create_pacman_package.sh
+++ b/scripts/build/termux_step_create_pacman_package.sh
@@ -5,7 +5,37 @@ termux_step_create_pacman_package() {
 	# From here on TERMUX_ARCH is set to "all" if TERMUX_PKG_PLATFORM_INDEPENDENT is set by the package
 	[ "$TERMUX_PKG_PLATFORM_INDEPENDENT" = "true" ] && TERMUX_ARCH=any
 
-	local PACMAN_FILE=$TERMUX_OUTPUT_DIR/${TERMUX_PKG_NAME}${DEBUG}-${TERMUX_PKG_FULLVERSION}-${TERMUX_ARCH}.pkg.tar.xz
+	# Configuring the selection of a copress for a batch.
+	local COMPRESS
+	local PKG_FORMAT
+	case $TERMUX_PACMAN_PACKAGE_COMPRESSION in
+		"gzip")
+			COMPRESS=(gzip -c -f -n)
+			PKG_FORMAT="gz";;
+		"bzip2")
+			COMPRESS=(bzip2 -c -f)
+			PKG_FORMAT="bz2";;
+		"zstd")
+			COMPRESS=(zstd -c -z -q -)
+			PKG_FORMAT="zst";;
+		"lrzip")
+			COMPRESS=(lrzip -q)
+			PKG_FORMAT="lrz";;
+		"lzop")
+			COMPRESS=(lzop -q)
+			PKG_FORMAT="lzop";;
+		"lz4")
+			COMPRESS=(lz4 -q)
+			PKG_FORMAT="lz4";;
+		"lzip")
+			COMPRESS=(lzip -c -f)
+			PKG_FORMAT="lz";;
+		"xz" | *)
+			COMPRESS=(xz -c -z -)
+			PKG_FORMAT="xz";;
+	esac
+
+	local PACMAN_FILE=$TERMUX_OUTPUT_DIR/${TERMUX_PKG_NAME}${DEBUG}-${TERMUX_PKG_FULLVERSION}-${TERMUX_ARCH}.pkg.tar.${PKG_FORMAT}
 
 	local BUILD_DATE
 	BUILD_DATE=$(date +%s)
@@ -89,6 +119,6 @@ termux_step_create_pacman_package() {
 			--null --files-from - --exclude .MTREE | \
 			gzip -c -f -n > .MTREE
 		printf '%s\0' **/* | bsdtar --no-fflags -cnf - --null --files-from - | \
-			xz -9 > "$PACMAN_FILE"
+			$COMPRESS > "$PACMAN_FILE"
 	)
 }

--- a/scripts/build/termux_step_create_pacman_package.sh
+++ b/scripts/build/termux_step_create_pacman_package.sh
@@ -77,7 +77,7 @@ termux_step_create_pacman_package() {
 		fi
 
 		if [ -n "$TERMUX_PKG_DEPENDS" ]; then
-			tr ',' '\n' <<< "$TERMUX_PKG_BREAKS" | awk '{ printf "depend = %s\n", $1 }'
+			tr ',' '\n' <<< "$TERMUX_PKG_DEPENDS" | awk '{ printf "depend = %s\n", $1 }'
 		fi
 
 		if [ -n "$TERMUX_PKG_RECOMMENDS" ]; then

--- a/scripts/build/termux_step_setup_variables.sh
+++ b/scripts/build/termux_step_setup_variables.sh
@@ -133,6 +133,7 @@ termux_step_setup_variables() {
 	TERMUX_PKG_SUGGESTS=""
 	TERMUX_PKG_TMPDIR=$TERMUX_TOPDIR/$TERMUX_PKG_NAME/tmp
 	TERMUX_PKG_SERVICE_SCRIPT=() # Fill with entries like: ("daemon name" 'script to execute'). Script is echoed with -e so can contain \n for multiple lines
+	TERMUX_PACMAN_PACKAGE_COMPRESSION="" # Compressor for pacman formats
 
 	unset CFLAGS CPPFLAGS LDFLAGS CXXFLAGS
 }


### PR DESCRIPTION
I noticed a bug due to which `depends` incorrectly specified in the `.PKGINFO` file.  

Also one more question: why create two packages but with different depends values?  A package named static is set to the value of a regular package.  
#### Example
```
file-5.40-aarch64.pkg.tar.xz
-> depends=zlib

file-static-5.40-aarch64.pkg.tar.xz
-> depends=file
```