### PR TITLE
Fixed bug with value backup.

### DIFF
--- a/scripts/build/termux_create_pacman_subpackages.sh
+++ b/scripts/build/termux_create_pacman_subpackages.sh
@@ -99,7 +99,7 @@ termux_create_pacman_subpackages() {
 			fi
 
 			if [ -n "$TERMUX_SUBPKG_CONFFILES" ]; then
-				tr ',' '\n' <<< "$TERMUX_SUBPKG_CONFFILES" | awk '{ printf "backup = ${TERMUX_PREFIX}/%s\n", $1 }'
+				tr ',' '\n' <<< "$TERMUX_SUBPKG_CONFFILES" | awk '{ printf "backup = data/data/com.termux/files/usr/%s\n", $1 }'
 			fi
 		} > .PKGINFO
 

--- a/scripts/build/termux_create_pacman_subpackages.sh
+++ b/scripts/build/termux_create_pacman_subpackages.sh
@@ -99,7 +99,7 @@ termux_create_pacman_subpackages() {
 			fi
 
 			if [ -n "$TERMUX_SUBPKG_CONFFILES" ]; then
-				tr ',' '\n' <<< "$TERMUX_SUBPKG_CONFFILES" | awk '{ printf "backup = data/data/com.termux/files/usr/%s\n", $1 }'
+				tr ',' '\n' <<< "$TERMUX_SUBPKG_CONFFILES" | awk '{ printf "backup = '"${TERMUX_PREFIX:1}"'/%s\n", $1 }'
 			fi
 		} > .PKGINFO
 

--- a/scripts/build/termux_step_create_pacman_package.sh
+++ b/scripts/build/termux_step_create_pacman_package.sh
@@ -93,7 +93,7 @@ termux_step_create_pacman_package() {
 		fi
 
 		if [ -n "$TERMUX_PKG_CONFFILES" ]; then
-			tr ',' '\n' <<< "$TERMUX_PKG_CONFFILES" | awk '{ printf "backup = data/data/com.termux/files/usr/%s\n", $1 }'
+			tr ',' '\n' <<< "$TERMUX_PKG_CONFFILES" | awk '{ printf "backup = '"${TERMUX_PREFIX:1}"'/%s\n", $1 }'
 		fi
 	} > .PKGINFO
 

--- a/scripts/build/termux_step_create_pacman_package.sh
+++ b/scripts/build/termux_step_create_pacman_package.sh
@@ -93,7 +93,7 @@ termux_step_create_pacman_package() {
 		fi
 
 		if [ -n "$TERMUX_PKG_CONFFILES" ]; then
-			tr ',' '\n' <<< "$TERMUX_PKG_CONFFILES" | awk '{ printf "backup = ${TERMUX_PREFIX}/%s\n", $1 }'
+			tr ',' '\n' <<< "$TERMUX_PKG_CONFFILES" | awk '{ printf "backup = data/data/com.termux/files/usr/%s\n", $1 }'
 		fi
 	} > .PKGINFO
 


### PR DESCRIPTION
A bug was noticed because the value in the `backup` was not displayed until the end.  
![Screenshot_20210902-125922_Termux](https://user-images.githubusercontent.com/60917834/131841166-9bf30be5-09df-4263-a3d4-48418130aeec.jpg)
In addition to this, the `TERMUX_PREFIX` value is specified with the rood directory, and in the `backup` you need to rewrite the directory without the root directory.