### PR TITLE
build-package: use xz compression for control archives (again)

### DIFF
--- a/scripts/build/termux_create_subpackages.sh
+++ b/scripts/build/termux_create_subpackages.sh
@@ -87,15 +87,15 @@ termux_create_subpackages() {
 		# Allow packages to create arbitrary control files.
 		termux_step_create_subpkg_debscripts
 
-		# Create control.tar.gz
-		tar -czf "$SUB_PKG_PACKAGE_DIR/control.tar.gz" -H gnu .
+		# Create control.tar.xz
+		tar -cJf "$SUB_PKG_PACKAGE_DIR/control.tar.xz" -H gnu .
 
 		# Create the actual .deb file:
 		TERMUX_SUBPKG_DEBFILE=$TERMUX_DEBDIR/${SUB_PKG_NAME}${DEBUG}_${TERMUX_PKG_FULLVERSION}_${SUB_PKG_ARCH}.deb
 		test ! -f "$TERMUX_COMMON_CACHEDIR/debian-binary" && echo "2.0" > "$TERMUX_COMMON_CACHEDIR/debian-binary"
 		ar cr "$TERMUX_SUBPKG_DEBFILE" \
 				   "$TERMUX_COMMON_CACHEDIR/debian-binary" \
-				   "$SUB_PKG_PACKAGE_DIR/control.tar.gz" \
+				   "$SUB_PKG_PACKAGE_DIR/control.tar.xz" \
 				   "$SUB_PKG_PACKAGE_DIR/data.tar.xz"
 
 		# Go back to main package:

--- a/scripts/build/termux_step_create_debfile.sh
+++ b/scripts/build/termux_step_create_debfile.sh
@@ -34,14 +34,14 @@ termux_step_create_debfile() {
 	cd DEBIAN
 	termux_step_create_debscripts
 
-	# Create control.tar.gz
-	tar -czf "$TERMUX_PKG_PACKAGEDIR/control.tar.gz" -H gnu .
+	# Create control.tar.xz
+	tar -cJf "$TERMUX_PKG_PACKAGEDIR/control.tar.xz" -H gnu .
 
 	test ! -f "$TERMUX_COMMON_CACHEDIR/debian-binary" && echo "2.0" > "$TERMUX_COMMON_CACHEDIR/debian-binary"
 	TERMUX_PKG_DEBFILE=$TERMUX_DEBDIR/${TERMUX_PKG_NAME}${DEBUG}_${TERMUX_PKG_FULLVERSION}_${TERMUX_ARCH}.deb
 	# Create the actual .deb file:
 	ar cr "$TERMUX_PKG_DEBFILE" \
 	       "$TERMUX_COMMON_CACHEDIR/debian-binary" \
-	       "$TERMUX_PKG_PACKAGEDIR/control.tar.gz" \
+	       "$TERMUX_PKG_PACKAGEDIR/control.tar.xz" \
 	       "$TERMUX_PKG_PACKAGEDIR/data.tar.xz"
 }


### PR DESCRIPTION
All packages that have conffiles, and a gz compressed control.tar.gz, currently fails to install on arm if the deb is built locally or downloaded and then installed with `apt install ./foo_1.0_arm.deb`. The error looks like:

    $ apt install ./tmp/foo.deb
    Reading package lists... Error!
    E: Tar checksum failed, archive corrupted
    E: Could not read meta data from /data/data/com.termux/files/home/tmp/foo.deb
    E: The package lists or status file could not be parsed or opened.

If the package does not have conffiles, or if xz compression is used, everything works. Let's change back to xz compression for all new and updated packages for now to workaround this issue.

Even if `apt install ./foo.deb` fails the deb can still be installed with `dpkg -i ./foo.deb` (seems dpkg does not do the same  checksum check?).