### PR TITLE
libdav1d: enable asm unless i686

### DIFF
--- a/packages/libdav1d/build.sh
+++ b/packages/libdav1d/build.sh
@@ -3,10 +3,18 @@ TERMUX_PKG_DESCRIPTION="AV1 cross-platform decoder focused on speed and correctn
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.9.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://downloads.videolan.org/pub/videolan/dav1d/${TERMUX_PKG_VERSION}/dav1d-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=e3235ab6c43c0135b0db1d131e1923fad4c84db9d85683e30b91b33a52d61c71
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--Denable_asm=false
+-Dwindres=$TERMUX_HOST_PLATFORM$TERMUX_PKG_API_LEVEL-windres
 -Denable_tools=false
 -Denable_tests=false
 "
+
+termux_step_pre_configure() {
+        if [ $TERMUX_ARCH = "i686" ]; then
+                # Avoid text relocations.
+                TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -Denable_asm=false"
+        fi
+}


### PR DESCRIPTION
I reckon, disabling `asm` is a bad idea, specially for mobile devices.