### PR TITLE
Fix bug with db

### DIFF
--- a/scripts/build/termux_create_pacman_subpackages.sh
+++ b/scripts/build/termux_create_pacman_subpackages.sh
@@ -66,6 +66,8 @@ termux_create_pacman_subpackages() {
 			TERMUX_SUBPKG_DEPENDS+=", $TERMUX_PKG_DEPENDS"
 		fi
 
+		local TERMUX_PKG_VERSION=$(echo $TERMUX_PKG_VERSION | sed "s|-|.|")
+
 		# Package metadata.
 		{
 			echo "pkgname = $SUB_PKG_NAME"

--- a/scripts/build/termux_step_create_pacman_package.sh
+++ b/scripts/build/termux_step_create_pacman_package.sh
@@ -37,6 +37,8 @@ termux_step_create_pacman_package() {
 
 	local PACMAN_FILE=$TERMUX_OUTPUT_DIR/${TERMUX_PKG_NAME}${DEBUG}-${TERMUX_PKG_FULLVERSION}-${TERMUX_ARCH}.pkg.tar.${PKG_FORMAT}
 
+	local TERMUX_PKG_VERSION=$(echo $TERMUX_PKG_VERSION | sed "s|-|.|")
+
 	local BUILD_DATE
 	BUILD_DATE=$(date +%s)
 

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -23,6 +23,9 @@ termux_step_start_build() {
 	TERMUX_PKG_FULLVERSION=$TERMUX_PKG_VERSION
 	if [ "$TERMUX_PKG_REVISION" != "0" ] || [ "$TERMUX_PKG_FULLVERSION" != "${TERMUX_PKG_FULLVERSION/-/}" ]; then
 		# "0" is the default revision, so only include it if the upstream versions contains "-" itself
+		if [ "$TERMUX_PACKAGE_FORMAT" = "pacman" ]; then
+			TERMUX_PKG_FULLVERSION=$(echo $TERMUX_PKG_FULLVERSION | sed 's|-|.|')
+		fi
 		TERMUX_PKG_FULLVERSION+="-$TERMUX_PKG_REVISION"
 	fi
 

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -23,9 +23,6 @@ termux_step_start_build() {
 	TERMUX_PKG_FULLVERSION=$TERMUX_PKG_VERSION
 	if [ "$TERMUX_PKG_REVISION" != "0" ] || [ "$TERMUX_PKG_FULLVERSION" != "${TERMUX_PKG_FULLVERSION/-/}" ]; then
 		# "0" is the default revision, so only include it if the upstream versions contains "-" itself
-		if [ "$TERMUX_PACKAGE_FORMAT" = "pacman" ]; then
-			TERMUX_PKG_FULLVERSION=$(echo $TERMUX_PKG_FULLVERSION | sed 's|-|.|')
-		fi
 		TERMUX_PKG_FULLVERSION+="-$TERMUX_PKG_REVISION"
 	fi
 


### PR DESCRIPTION
The compiler adds an extra "-" separator.  Because of this, an error occurs from the database from the service.  
![Screenshot_20210913-134114_Termux](https://user-images.githubusercontent.com/60917834/133152639-88a530bb-73cd-4647-b9ce-885585400ca6.jpg)  

Can experiment and add a function that will add the `epoch` value, but this is quite risky.  
https://wiki.archlinux.org/title/PKGBUILD#epoch
