### PR TITLE
lychee: Bump to latest version

### DIFF
--- a/packages/lychee/build.sh
+++ b/packages/lychee/build.sh
@@ -3,9 +3,9 @@ TERMUX_PKG_DESCRIPTION="A fast, async, resource-friendly link checker written in
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="LICENSE-MIT, LICENSE-APACHE"
 TERMUX_PKG_MAINTAINER="Yaksh Bariya <yakshbari4@gmail.com>"
-TERMUX_PKG_VERSION=0.7.0
-TERMUX_PKG_SRCURL=https://github.com/lycheeverse/lychee/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=bd0873e088701eecdcf6eeb254eed7a4dbe3dd71728e272505c1b8f92c3eebe9
+TERMUX_PKG_VERSION=0.7.1
+TERMUX_PKG_SRCURL=https://github.com/lycheeverse/lychee/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=f6acf92987aae006273b5fd211cb5c6a2f30036b7fd69ac36ecffb2b28cc3101
 TERMUX_PKG_DEPENDS="openssl"
 TERMUX_PKG_BUILD_IN_SRC=true
 


### PR DESCRIPTION
The source URL changed. So autoupdates broke. This PR bumps lychee to latest version