### PR TITLE
Really fix nodejs log

### DIFF
--- a/packages/nodejs/build.sh
+++ b/packages/nodejs/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_MAINTAINER="Yaksh Bariya <yakshbari4@gmail.com>"
 # Note: package build may fail on Github Actions CI due to out-of-memory
 # condition. It should be built locally instead.
 TERMUX_PKG_VERSION=16.9.1
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=97f50ec53c050e7ac97bdbe5586aaca380dd23064064c85a1f2017a35244131c
 # Note that we do not use a shared libuv to avoid an issue with the Android

--- a/packages/nodejs/src-debug_utils.cc.patch
+++ b/packages/nodejs/src-debug_utils.cc.patch
@@ -1,0 +1,11 @@
+--- ./src/debug_utils.cc	2021-09-10 22:55:14.000000000 +0530
++++ ./src/debug_utils.cc.mod	2021-09-15 13:24:35.606133999 +0530
+@@ -500,7 +500,7 @@
+ 
+   WriteConsoleW(handle, wbuf.data(), n, nullptr, nullptr);
+   return;
+-#elif defined(__ANDROID__)
++#elif defined(__ANDROID__) && !defined(__TERMUX__)
+   if (file == stderr) {
+     __android_log_print(ANDROID_LOG_ERROR, "nodejs", "%s", str.data());
+     return;


### PR DESCRIPTION
I reached home and tried the deb, but it still logged to Android logcat. This patch stolen from nodejs-lts should really really fix it.

Sorry for the inconvenience caused 😔

PS, don't merge this until, I check if it's really fixed