### PR TITLE
libx265: Update from 3.3 to 3.5

### DIFF
--- a/packages/libx265/build.sh
+++ b/packages/libx265/build.sh
@@ -2,17 +2,35 @@ TERMUX_PKG_HOMEPAGE=http://x265.org/
 TERMUX_PKG_DESCRIPTION="H.265/HEVC video stream encoder library"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=3.3
+TERMUX_PKG_VERSION=3.5
 TERMUX_PKG_SRCURL=https://bitbucket.org/multicoreware/x265_git/downloads/x265_$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_SHA256=c6d744a87eda55560da715f56f878640554ddc06e2d0fcbd822fa330affc22cc
+TERMUX_PKG_SHA256=e70a3335cacacbba0b3a20ec6fecd6783932288ebc8163ad74bcc9606477cae8
 TERMUX_PKG_DEPENDS="libc++"
 TERMUX_PKG_BREAKS="libx265-dev"
 TERMUX_PKG_REPLACES="libx265-dev"
 
 termux_step_pre_configure() {
-	if [ $TERMUX_ARCH = "i686" ]; then
+	local ARM_ARGS
+
+	# Not sure if this is necessary for on-device build
+	ARM_ARGS="-fno-integrated-as"
+
+	# Not sure if this is necessary for on-device build
+	# Follow termux_step_configure_cmake.sh for now
+	if [ "$TERMUX_ON_DEVICE_BUILD" = false ]; then
+		ARM_ARGS+=" --target=${CCTERMUX_HOST_PLATFORM}"
+	fi
+
+	if [ "$TERMUX_ARCH" = i686 ]; then
 		# Avoid text relocations.
 		TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DENABLE_ASSEMBLY=OFF"
+	elif [ "$TERMUX_ARCH" = arm ]; then
+		# Follow termux_step_setup_toolchain.sh
+		ARM_ARGS+=" -march=armv7-a -mfpu=neon -mfloat-abi=softfp -mthumb"
 	fi
+
 	TERMUX_PKG_SRCDIR="$TERMUX_PKG_SRCDIR/source"
+
+	sed -i "s/@ARM_ARGS@/${ARM_ARGS}/" \
+		${TERMUX_PKG_SRCDIR}/CMakeLists.txt
 }

--- a/packages/libx265/source-CMakeLists.txt.patch
+++ b/packages/libx265/source-CMakeLists.txt.patch
@@ -1,18 +1,46 @@
-Submitted upstream at:
-https://bitbucket.org/multicoreware/x265/pull-requests/31
-
-diff -u -r ../x265_2.2/source/CMakeLists.txt ./source/CMakeLists.txt
---- ../x265_2.2/source/CMakeLists.txt	2016-12-23 00:57:39.000000000 -0500
-+++ ./source/CMakeLists.txt	2017-01-03 18:42:19.823674722 -0500
-@@ -80,7 +80,10 @@
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index a407271b4..6ecfda3ee 100755
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -40,7 +40,7 @@ SET(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" "${CMAKE_MODULE_PATH}")
+ # System architecture detection
+ string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" SYSPROC)
+ set(X86_ALIASES x86 i386 i686 x86_64 amd64)
+-set(ARM_ALIASES armv6l armv7l aarch64)
++set(ARM_ALIASES armv6l armv7l armv7-a aarch64)
+ list(FIND X86_ALIASES "${SYSPROC}" X86MATCH)
+ list(FIND ARM_ALIASES "${SYSPROC}" ARMMATCH)
+ set(POWER_ALIASES ppc64 ppc64le)
+@@ -85,7 +85,10 @@ else()
  endif()
  
  if(UNIX)
 -    list(APPEND PLATFORM_LIBS pthread)
 +    find_library(LIBPTHREAD pthread)
 +    if(LIBPTHREAD)
-+         list(APPEND PLATFORM_LIBS pthread)
++        list(APPEND PLATFORM_LIBS pthread)
 +    endif()
      find_library(LIBRT rt)
      if(LIBRT)
          list(APPEND PLATFORM_LIBS rt)
+@@ -246,18 +249,8 @@ if(GCC)
+         endif()
+         message(STATUS "cross compile arm")
+     elseif(ARM)
+-        if(ARM64)
+-            set(ARM_ARGS -fPIC)
+-            add_definitions(-DHAVE_NEON)
+-        else()
+-            find_package(Neon)
+-            if(CPU_HAS_NEON)
+-                set(ARM_ARGS -mcpu=native -mfloat-abi=hard -mfpu=neon -marm -fPIC)
+-                add_definitions(-DHAVE_NEON)
+-            else()
+-                set(ARM_ARGS -mcpu=native -mfloat-abi=hard -mfpu=vfp -marm)
+-            endif()
+-        endif()
++        set(ARM_ARGS @ARM_ARGS@ -fPIC)
++        add_definitions(-DHAVE_NEON)
+     endif()
+     add_definitions(${ARM_ARGS})
+     if(FPROFILE_GENERATE)


### PR DESCRIPTION
Build hacks necessary for aarch64 (`-fno-integrated-as` + ` --target=${CCTERMUX_HOST_PLATFORM}`) credit goes to @jeevatattva (#7548).

EDIT: Turns out the reason that `CROSS_COMPILE_ARM` is problematic for arm is that `ARM_ALIASES` has `armv7l` instead of `armv7-a` (and it appears that `armv7l` is not accepted by cmake as the value for `CMAKE_SYSTEM_PROCESSOR`). While `CROSS_COMPILE_ARM` is not necessary / does not seem to cause any actual effect, I included the fix in the patch so that `CROSS_COMPILE_ARM` won't cause any problem. (Though the fix seems to have made `-fno-integrated-as` necessary for arm additionally.)