### PR TITLE
node v16.10

### DIFF
--- a/packages/nodejs/build.sh
+++ b/packages/nodejs/build.sh
@@ -2,12 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://nodejs.org/
 TERMUX_PKG_DESCRIPTION="Open Source, cross-platform JavaScript runtime environment"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Yaksh Bariya <yakshbari4@gmail.com>"
-# Note: package build may fail on Github Actions CI due to out-of-memory
-# condition. It should be built locally instead.
-TERMUX_PKG_VERSION=16.9.1
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION=16.10.0
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=97f50ec53c050e7ac97bdbe5586aaca380dd23064064c85a1f2017a35244131c
+TERMUX_PKG_SHA256=97dc1aca232b4911e0b9e5a23a03200ab8ef05157e03c732315b579481bf7912
 # Note that we do not use a shared libuv to avoid an issue with the Android
 # linker, which does not use symbols of linked shared libraries when resolving
 # symbols on dlopen(). See https://github.com/termux/termux-packages/issues/462.


### PR DESCRIPTION
Bump nodejs to 16.10.0

Additional changes made:-
- Removed comment about out of memory while building on CI, since it is not reproducible since a while now
