### PR TITLE
Correction of the version view in the file name (add pkgrel)

### DIFF
--- a/scripts/build/termux_create_pacman_subpackages.sh
+++ b/scripts/build/termux_create_pacman_subpackages.sh
@@ -69,16 +69,18 @@ termux_create_pacman_subpackages() {
 		# Version view revisions.
 		local TERMUX_PKG_VERSION=$(echo $TERMUX_PKG_VERSION | sed "s|-|.|")
 		local TERMUX_PKG_VERSION=${TERMUX_PKG_VERSION/[a-z]/.${TERMUX_PKG_VERSION//[0-9.]/}}
+		local TERMUX_PKG_FULLVERSION="${TERMUX_PKG_VERSION}"
+		if [ -n "$TERMUX_PKG_REVISION" ]; then
+			TERMUX_PKG_FULLVERSION+="-${TERMUX_PKG_REVISION}"
+		else
+			TERMUX_PKG_FULLVERSION+="-0"
+		fi
 
 		# Package metadata.
 		{
 			echo "pkgname = $SUB_PKG_NAME"
 			echo "pkgbase = $TERMUX_PKG_NAME"
-			if [ -n "$TERMUX_PKG_REVISION" ]; then
-				echo "pkgver = $TERMUX_PKG_VERSION-${TERMUX_PKG_REVISION}"
-			else
-				echo "pkgver = $TERMUX_PKG_VERSION-0"
-			fi
+			echo "pkgver = $TERMUX_PKG_FULLVERSION"
 			echo "pkgdesc = $(echo "$TERMUX_SUBPKG_DESCRIPTION" | tr '\n' ' ')"
 			echo "url = $TERMUX_PKG_HOMEPAGE"
 			echo "builddate = $BUILD_DATE"
@@ -112,11 +114,7 @@ termux_create_pacman_subpackages() {
 			echo "format = 2"
 			echo "pkgname = $SUB_PKG_NAME"
 			echo "pkgbase = $TERMUX_PKG_NAME"
-			if [ -n "$TERMUX_PKG_REVISION" ]; then
-				echo "pkgver = $TERMUX_PKG_VERSION-${TERMUX_PKG_REVISION}"
-			else
-				echo "pkgver = $TERMUX_PKG_VERSION-0"
-			fi
+			echo "pkgver = $TERMUX_PKG_FULLVERSION"
 			echo "pkgarch = $SUB_PKG_ARCH"
 			echo "packager = $TERMUX_PKG_MAINTAINER"
 			echo "builddate = $BUILD_DATE"

--- a/scripts/build/termux_step_create_pacman_package.sh
+++ b/scripts/build/termux_step_create_pacman_package.sh
@@ -35,11 +35,17 @@ termux_step_create_pacman_package() {
 			PKG_FORMAT="xz";;
 	esac
 
-	local PACMAN_FILE=$TERMUX_OUTPUT_DIR/${TERMUX_PKG_NAME}${DEBUG}-${TERMUX_PKG_FULLVERSION}-${TERMUX_ARCH}.pkg.tar.${PKG_FORMAT}
-
 	# Version view revisions.
 	local TERMUX_PKG_VERSION=$(echo $TERMUX_PKG_VERSION | sed "s|-|.|")
 	local TERMUX_PKG_VERSION=${TERMUX_PKG_VERSION/[a-z]/.${TERMUX_PKG_VERSION//[0-9.]/}}
+	local TERMUX_PKG_FULLVERSION="${TERMUX_PKG_VERSION}"
+	if [ -n "$TERMUX_PKG_REVISION" ]; then
+		TERMUX_PKG_FULLVERSION+="-${TERMUX_PKG_REVISION}"
+	else
+		TERMUX_PKG_FULLVERSION+="-0"
+	fi
+
+	local PACMAN_FILE=$TERMUX_OUTPUT_DIR/${TERMUX_PKG_NAME}${DEBUG}-${TERMUX_PKG_FULLVERSION}-${TERMUX_ARCH}.pkg.tar.${PKG_FORMAT}
 
 	local BUILD_DATE
 	BUILD_DATE=$(date +%s)
@@ -48,11 +54,7 @@ termux_step_create_pacman_package() {
 	{
 		echo "pkgname = $TERMUX_PKG_NAME"
 		echo "pkgbase = $TERMUX_PKG_NAME"
-		if [ -n "$TERMUX_PKG_REVISION" ]; then
-			echo "pkgver = $TERMUX_PKG_VERSION-${TERMUX_PKG_REVISION}"
-		else
-			echo "pkgver = $TERMUX_PKG_VERSION-0"
-		fi
+		echo "pkgver = $TERMUX_PKG_FULLVERSION"
 		echo "pkgdesc = $(echo "$TERMUX_PKG_DESCRIPTION" | tr '\n' ' ')"
 		echo "url = $TERMUX_PKG_HOMEPAGE"
 		echo "builddate = $BUILD_DATE"
@@ -106,11 +108,7 @@ termux_step_create_pacman_package() {
 		echo "format = 2"
 		echo "pkgname = $TERMUX_PKG_NAME"
 		echo "pkgbase = $TERMUX_PKG_NAME"
-		if [ -n "$TERMUX_PKG_REVISION" ]; then
-			echo "pkgver = $TERMUX_PKG_VERSION-${TERMUX_PKG_REVISION}"
-		else
-			echo "pkgver = $TERMUX_PKG_VERSION-0"
-		fi
+		echo "pkgver = $TERMUX_PKG_FULLVERSION"
 		echo "pkgarch = $TERMUX_ARCH"
 		echo "packager = $TERMUX_PKG_MAINTAINER"
 		echo "builddate = $BUILD_DATE"


### PR DESCRIPTION
This is necessary for the service to work stably.  The service has a bot that updates the db.  One of the required values ​​is the filename, but there is a problem.  If you take the name from the file name, then the file name is not stable for this.  And if with PKGINFO, it will not work with remote packages.