### PR TITLE
Adding TERMUX_PKG_GROUPS value for pacman packages.

### DIFF
--- a/scripts/build/termux_create_pacman_subpackages.sh
+++ b/scripts/build/termux_create_pacman_subpackages.sh
@@ -107,6 +107,10 @@ termux_create_pacman_subpackages() {
 			if [ -n "$TERMUX_SUBPKG_CONFFILES" ]; then
 				tr ',' '\n' <<< "$TERMUX_SUBPKG_CONFFILES" | awk '{ printf "backup = '"${TERMUX_PREFIX:1}"'/%s\n", $1 }'
 			fi
+
+			if [ -n "$TERMUX_PKG_GROUPS" ]; then
+				tr ',' '\n' <<< "${TERMUX_PKG_GROUPS/#, /}" | awk '{ printf "group = %s\n", $1 }'
+			fi
 		} > .PKGINFO
 
 		# Build metadata.

--- a/scripts/build/termux_step_create_pacman_package.sh
+++ b/scripts/build/termux_step_create_pacman_package.sh
@@ -101,6 +101,10 @@ termux_step_create_pacman_package() {
 		if [ -n "$TERMUX_PKG_CONFFILES" ]; then
 			tr ',' '\n' <<< "$TERMUX_PKG_CONFFILES" | awk '{ printf "backup = '"${TERMUX_PREFIX:1}"'/%s\n", $1 }'
 		fi
+
+		if [ -n "$TERMUX_PKG_GROUPS" ]; then
+			tr ',' '\n' <<< "${TERMUX_PKG_GROUPS/#, /}" | awk '{ printf "group = %s\n", $1 }'
+		fi
 	} > .PKGINFO
 
 	# Build metadata.

--- a/scripts/build/termux_step_setup_variables.sh
+++ b/scripts/build/termux_step_setup_variables.sh
@@ -134,6 +134,7 @@ termux_step_setup_variables() {
 	TERMUX_PKG_SUGGESTS=""
 	TERMUX_PKG_TMPDIR=$TERMUX_TOPDIR/$TERMUX_PKG_NAME/tmp
 	TERMUX_PKG_SERVICE_SCRIPT=() # Fill with entries like: ("daemon name" 'script to execute'). Script is echoed with -e so can contain \n for multiple lines
+	TERMUX_PKG_GROUPS="" # https://wiki.archlinux.org/title/Pacman#Installing_package_groups
 
 	unset CFLAGS CPPFLAGS LDFLAGS CXXFLAGS
 }


### PR DESCRIPTION
Thanks to this value, can set the group that the package will belong to.  
#### Example:
```
TERMUX_PKG_GROUPS="base-devel"
```
or
```
TERMUX_PKG_GROUPS="base-devel, base"
```
If anything is there in more detail: https://wiki.archlinux.org/title/Pacman#Installing_package_groups