### PR TITLE
Remove manual pages from ant

### DIFF
--- a/packages/ant/build.sh
+++ b/packages/ant/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=http://ant.apache.org/
 TERMUX_PKG_DESCRIPTION="Java based build tool like make"
 TERMUX_PKG_VERSION=1.10.11
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=http://apache.mirrors.spacedump.net//ant/binaries/apache-ant-${TERMUX_PKG_VERSION}-bin.tar.bz2
 TERMUX_PKG_SHA256=ffc6c9eb2d153db76e18df70fa145744ddd0d754339df5a797a47603cfeaa8a6
 TERMUX_PKG_LICENSE="Apache-2.0"
@@ -14,6 +14,7 @@ termux_step_make_install() {
 	mv ./bin/ant .
 	rm -f ./bin/*
 	mv ./ant ./bin/
+	rm -rf manual
 	rm -rf $TERMUX_PREFIX/opt/ant
 	mkdir -p $TERMUX_PREFIX/opt/ant
 	cp -r ./* $TERMUX_PREFIX/opt/ant


### PR DESCRIPTION
I forgot to do this earlier but I believe we should remove the manual folder. They are HTML files and is also available online. Main issue being storage as that manual folder alone is taking 40 MB.