### PR TITLE
libass: Disable nasm

### DIFF
--- a/packages/libass/build.sh
+++ b/packages/libass/build.sh
@@ -3,9 +3,12 @@ TERMUX_PKG_DESCRIPTION="A portable library for SSA/ASS subtitles rendering"
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.15.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/libass/libass/releases/download/$TERMUX_PKG_VERSION/libass-$TERMUX_PKG_VERSION.tar.xz
 TERMUX_PKG_SHA256=1be2df9c4485a57d78bb18c0a8ed157bc87a5a8dd48c661961c625cb112832fd
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="fontconfig, fribidi, glib, harfbuzz"
 TERMUX_PKG_BREAKS="libass-dev"
 TERMUX_PKG_REPLACES="libass-dev"
+# Avoid text relocations.
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_prog_nasm_check=no"


### PR DESCRIPTION
To avoid text relocations.

Fixes #7648.