### PR TITLE
rebuild gotop

### DIFF
--- a/packages/gotop/build.sh
+++ b/packages/gotop/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="A terminal based graphical activity monitor inspired by 
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@medzikuser"
 TERMUX_PKG_VERSION=4.1.2
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/xxxserxxx/gotop/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=81518fecfdab4f4c25a4713e24d9c033ba8311bbd3e2c0435ba76349028356da
 


### PR DESCRIPTION
Due to a [github actions error](https://status.github.com/), the build didn't start. 