### PR TITLE
aspell: Configure with `--enable-32-bit-hash-fun`

### DIFF
--- a/packages/aspell/build.sh
+++ b/packages/aspell/build.sh
@@ -3,5 +3,8 @@ TERMUX_PKG_DESCRIPTION="A free and open source spell checker designed to replace
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.60.8
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://ftp.gnu.org/gnu/aspell/aspell-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=f9b77e515334a751b2e60daab5db23499e26c9209f5e7b7443b05235ad0226f2
+# To use the same compiled dictionaries on every platform:
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --enable-32-bit-hash-fun"


### PR DESCRIPTION
This is needed because the dictionary packages (e.g. aspell-en) are annotated as `TERMUX_PKG_PLATFORM_INDEPENDENT=true`.

See also http://aspell.net/0.61/man-html/Using-32_002dBit-Dictionaries-on-a-64_002dBit-System.html

Fixes #6500.