### PR TITLE
rust: Bump to 1.56.0

### DIFF
--- a/packages/rust/build.sh
+++ b/packages/rust/build.sh
@@ -2,10 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.rust-lang.org/
 TERMUX_PKG_DESCRIPTION="Systems programming language focused on safety, speed and concurrency"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1.55.0
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION=1.56.0
 TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/rustc-$TERMUX_PKG_VERSION-src.tar.xz
-TERMUX_PKG_SHA256=aec85a7c1f40b7a40818a58ae13632f8a12cfaa4d3e2a10957d0e9d16dfdd556
+TERMUX_PKG_SHA256=f13468889833c88e744ad579c5d8fbb7ecb53216159b54481a90e5dcdaa9e320
 TERMUX_PKG_DEPENDS="libc++, clang, openssl, lld, zlib, libllvm"
 TERMUX_PKG_RM_AFTER_INSTALL="bin/llvm-dwp"
 
@@ -20,7 +19,7 @@ termux_step_configure() {
 	# like 30 to 40 + minutes ... so lets get it right
 
 	# upstream only tests build ver one version behind $TERMUX_PKG_VERSION
-	local BOOTSTRAP_VERSION=1.54.0
+	local BOOTSTRAP_VERSION=1.55.0
 	rustup install $BOOTSTRAP_VERSION
 	rustup default $BOOTSTRAP_VERSION-x86_64-unknown-linux-gnu
 	export PATH=$HOME/.rustup/toolchains/$BOOTSTRAP_VERSION-x86_64-unknown-linux-gnu/bin:$PATH

--- a/packages/rust/compiler-rustc_driver-src-lib.rs.patch
+++ b/packages/rust/compiler-rustc_driver-src-lib.rs.patch
@@ -1,0 +1,20 @@
+--- ./compiler/rustc_driver/src/lib.rs	2021-10-24 13:20:05.833987999 +0530
++++ ./compiler/rustc_driver/src/lib.rs.mod	2021-10-24 13:21:43.523987961 +0530
+@@ -1296,7 +1296,7 @@
+     tracing::subscriber::set_global_default(subscriber).unwrap();
+ }
+ 
+-#[cfg(all(unix, any(target_env = "gnu", target_os = "macos")))]
++#[cfg(all(unix, any(target_env = "gnu", target_os = "macos"), not(target_os = "android")))]
+ mod signal_handler {
+     extern "C" {
+         fn backtrace_symbols_fd(
+@@ -1340,7 +1340,7 @@
+     }
+ }
+ 
+-#[cfg(not(all(unix, any(target_env = "gnu", target_os = "macos"))))]
++#[cfg(not(all(unix, any(target_env = "gnu", target_os = "macos"), not(target_os = "android"))))]
+ mod signal_handler {
+     pub(super) fn install() {}
+ }


### PR DESCRIPTION
Rust has some build errors as in https://github.com/termux/termux-packages/pull/7339#issuecomment-946920752

Lets fix this
