### PR TITLE
boinc: bump revision and small patch to build

### DIFF
--- a/packages/boinc/_autosetup.patch
+++ b/packages/boinc/_autosetup.patch
@@ -1,0 +1,12 @@
+diff -uNr boinc-client_release-7.16-7.16.16/_autosetup boinc-client_release-7.16-7.16.16.mod/_autosetup
+--- boinc-client_release-7.16-7.16.16/_autosetup	2021-02-01 07:38:58.000000000 +0800
++++ boinc-client_release-7.16-7.16.16.mod/_autosetup	2021-10-23 10:32:01.471359652 +0800
+@@ -19,7 +19,7 @@
+ check_version()
+ {
+     dir=`pwd`
+-    cd /tmp
++    cd "${TMPDIR:-/tmp}"
+     foundit=
+     ## get current version of $1
+     desired=`echo $2 | awk -F. '{print $1*100+$2}'`

--- a/packages/boinc/build.sh
+++ b/packages/boinc/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Open-source software for volunteer computing"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=7.16.16
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/BOINC/boinc/archive/client_release/${TERMUX_PKG_VERSION:0:4}/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=0d5656a9f8ed1048936a5764270848b892d63f27bdb863d0ace447f1eaae6002
 TERMUX_PKG_DEPENDS="libandroid-shmem, libc++, libcurl, openssl, zlib"
@@ -18,8 +18,9 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 TERMUX_PKG_CONFFILES="etc/boinc-client.conf"
 
 termux_step_pre_configure() {
-	CFLAGS="${CFLAGS/-Oz/-O2}"
-	CXXFLAGS="${CXXFLAGS/-Oz/-O2}"
+	# for benchmark purposes
+	CFLAGS="${CFLAGS/-Oz/-Os}"
+	CXXFLAGS="${CXXFLAGS/-Oz/-Os}"
 	LDFLAGS+=" -landroid-shmem"
 	./_autosetup
 }


### PR DESCRIPTION
Ugh... Looks like the ageing build system for boinc is starting to show its age. It pulls in X11 when it shouldn't. Not sure which package in https://github.com/termux/termux-packages/commit/a2187e62dfd67f91099f069fbdcb95144cbb8595 pulls in X11 that polluted the build. I don't think there's any option to disable this in the build system. I may or may not work to switch to CMake since upstream is relentless doing so. For now, let's isolate this to another build and bump revision to fix the issue.

Also added minor patch and adjustment to build.sh
```
~ $ ldd `which boinc`
libandroid-shmem.so
libcurl.so
libcrypto.so.1.1
libdl.so
libz.so.1
libX11.so
libXss.so
libm.so
libc++_shared.so
libc.so
~ $ ldd `which boinc`
libandroid-shmem.so
libcurl.so
libcrypto.so.1.1
libdl.so
libz.so.1
libm.so
libc++_shared.so
libc.so
```