### PR TITLE
build mu4e with emacs on device via postinst

### DIFF
--- a/packages/mu/build.sh
+++ b/packages/mu/build.sh
@@ -3,7 +3,23 @@ TERMUX_PKG_DESCRIPTION="Maildir indexer/searcher and Emacs client (mu4e)"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.6.9
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/djcb/mu/releases/download/$TERMUX_PKG_VERSION-signed/mu-$TERMUX_PKG_VERSION.tar.xz
 TERMUX_PKG_SHA256=8d99430a4f6942eb3122008bb897c4480cda64b30ff4575c32ded86d7edbaf58
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="glib, libc++, libxapian, libgmime"
+TERMUX_PKG_DEPENDS="emacs, glib, libc++, libxapian, libgmime"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-gtk --disable-webkit"
+
+termux_step_create_debscripts() {
+	cat <<- EOF > ./postinst
+	#!$TERMUX_PREFIX/bin/sh
+	echo "(setq byte-compile-warnings nil)" > $TERMUX_PREFIX/share/emacs/site-lisp/mu4e/nowarnings.el
+	LC_ALL=C $TERMUX_PREFIX/bin/emacs -no-site-file -q -batch -l $TERMUX_PREFIX/share/emacs/site-lisp/mu4e/nowarnings.el -f batch-byte-compile $TERMUX_PREFIX/share/emacs/site-lisp/mu4e/*.el
+	rm -f $TERMUX_PREFIX/share/emacs/site-lisp/mu4e/nowarnings.elc
+	chmod 644 $TERMUX_PREFIX/share/emacs/site-lisp/mu4e/*.elc
+	EOF
+
+	cat <<- EOF > ./prerm
+	rm -f $TERMUX_PREFIX/share/emacs/site-lisp/mu4e/*.elc
+	EOF
+}

--- a/packages/mu/mu4e-dont-bytecompile.patch
+++ b/packages/mu/mu4e-dont-bytecompile.patch
@@ -1,0 +1,44 @@
+@@ from https://sources.debian.org/patches/maildir-utils/1.6.9-1/mu4e-dont-bytecompile/
+---
+ configure.ac     |   18 ++++--------------
+ mu4e/Makefile.am |    2 +-
+ 2 files changed, 5 insertions(+), 15 deletions(-)
+
+--- a/mu4e/Makefile.am
++++ b/mu4e/Makefile.am
+@@ -21,7 +21,7 @@ SUBDIRS=
+ info_TEXINFOS=mu4e.texi
+ mu4e_TEXINFOS=fdl.texi
+ 
+-dist_lisp_LISP=			\
++dist_lisp_DATA=			\
+ 	mu4e-actions.el		\
+ 	mu4e-compose.el		\
+ 	mu4e-context.el		\
+--- a/configure.ac
++++ b/configure.ac
+@@ -85,20 +85,10 @@ AM_COND_IF(HAVE_MAKEINFO,[],[
+   AC_SUBST(MAKEINFO,[true])
+ ])
+ 
+-# we need emacs for byte-compiling mu4e
+-build_mu4e=no
+-AC_ARG_ENABLE([mu4e],
+-   AS_HELP_STRING([--disable-mu4e],[Disable building mu4e]))
+-AS_IF([test "x$enable_mu4e" != "xno"], [
+-  AM_PATH_LISPDIR
+-  AS_IF([test "x$lispdir" != "xno"], [
+-    emacs_version="$($EMACS --version | head -1)"
+-    lispdir="${lispdir}/mu4e/"
+-  ])
+-  AS_CASE([$emacs_version],
+-    [*25.3*],[build_mu4e=yes],
+-    [*26*|*27*|*28*|*29*],[build_mu4e=yes],
+-    [AC_WARN([emacs is too old to build mu4e (need emacs >= 25.3)])])
++build_mu4e=yes
++AM_PATH_LISPDIR
++AS_IF([test "x$lispdir" != "xno"], [
++  lispdir="${lispdir}/mu4e/"
+ ])
+ AM_CONDITIONAL(BUILD_MU4E, test "x$build_mu4e" = "xyes")
+ 


### PR DESCRIPTION
This should fix #6394.

Edit: As discussed below, we no longer need emacs in the docker image, but do the following:

- we let `mu` depend on `emacs`
- include the [mu4e-dont-bytecompile patch](https://sources.debian.org/patches/maildir-utils/1.6.9-1/mu4e-dont-bytecompile/) from Debian to include `.el` files of mu4e but not yet compile them
- use a postinst script to compile the `.el` files to `.elc` on the device at install time.