### PR TITLE
new package: innoextract

### DIFF
--- a/packages/innoextract/build.sh
+++ b/packages/innoextract/build.sh
@@ -1,0 +1,8 @@
+TERMUX_PKG_HOMEPAGE=https://constexpr.org/innoextract/
+TERMUX_PKG_DESCRIPTION="A tool to unpack installers created by Inno Setup"
+TERMUX_PKG_LICENSE="ZLIB"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=1.9
+TERMUX_PKG_SRCURL=https://constexpr.org/innoextract/files/innoextract-${TERMUX_PKG_VERSION}/innoextract-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=6344a69fc1ed847d4ed3e272e0da5998948c6b828cb7af39c6321aba6cf88126
+TERMUX_PKG_DEPENDS="libc++, boost, liblzma, libiconv"


### PR DESCRIPTION
Useful for extracting Windows GOG Installers that are in `.exe` extension, may aid in porting games in the future

The sad part is the small `innoextract` depends on the huge `boost` library so download size will be big