### PR TITLE
nodejs: Bump to 17.2.0

### DIFF
--- a/packages/nodejs/build.sh
+++ b/packages/nodejs/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://nodejs.org/
 TERMUX_PKG_DESCRIPTION="Open Source, cross-platform JavaScript runtime environment"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Yaksh Bariya <yakshbari4@gmail.com>"
-TERMUX_PKG_VERSION=17.1.0
+TERMUX_PKG_VERSION=17.2.0
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=6b803f37eb92b009f9162a489d647611aa95393e488fff0fc4fd8efd2effcac7
+TERMUX_PKG_SHA256=2b47cc7b5ec189d7b637454732f36f8d3c2c0ef81bec3c278b566f67159e659a
 # Note that we do not use a shared libuv to avoid an issue with the Android
 # linker, which does not use symbols of linked shared libraries when resolving
 # symbols on dlopen(). See https://github.com/termux/termux-packages/issues/462.
@@ -51,7 +51,6 @@ termux_step_configure() {
 		DEST_CPU="arm"
 	elif [ $TERMUX_ARCH = "i686" ]; then
 		DEST_CPU="ia32"
-		LDFLAGS+=" -u __atomic_fetch_add_8 -u __atomic_load_8 -u __atomic_compare_exchange_8 -latomic"
 	elif [ $TERMUX_ARCH = "aarch64" ]; then
 		DEST_CPU="arm64"
 	elif [ $TERMUX_ARCH = "x86_64" ]; then

--- a/packages/nodejs/deps-v8-src-trap-handler-trap-handler.h.patch
+++ b/packages/nodejs/deps-v8-src-trap-handler-trap-handler.h.patch
@@ -1,6 +1,6 @@
---- ./deps/v8/src/trap-handler/trap-handler.h	2021-10-08 19:08:46.000000000 +0530
-+++ ./deps/v8/src/trap-handler/trap-handler.h.mod	2021-10-09 19:43:08.715641214 +0530
-@@ -17,22 +17,7 @@
+--- ./deps/v8/src/trap-handler/trap-handler.h	2021-11-30 19:26:35.000000000 +0530
++++ ./deps/v8/src/trap-handler/trap-handler.h.mod	2021-12-01 19:12:48.402386879 +0530
+@@ -17,23 +17,7 @@
  namespace internal {
  namespace trap_handler {
  
@@ -12,8 +12,9 @@
 -// Arm64 (non-simulator) on Mac.
 -#elif V8_TARGET_ARCH_ARM64 && V8_HOST_ARCH_ARM64 && V8_OS_MACOSX
 -#define V8_TRAP_HANDLER_SUPPORTED true
--// Arm64 simulator on x64 on Linux or Mac.
--#elif V8_TARGET_ARCH_ARM64 && V8_HOST_ARCH_X64 && (V8_OS_LINUX || V8_OS_MACOSX)
+-// Arm64 simulator on x64 on Linux, Mac, or Windows.
+-#elif V8_TARGET_ARCH_ARM64 && V8_HOST_ARCH_X64 && \
+-    (V8_OS_LINUX || V8_OS_MACOSX)
 -#define V8_TRAP_HANDLER_VIA_SIMULATOR
 -#define V8_TRAP_HANDLER_SUPPORTED true
 -// Everything else is unsupported.


### PR DESCRIPTION
Additional changes made:
~~- The patch `deps-v8-src-trap-handler-trap-handler.h.patch` should no longer be needed needed. This should also have been fixed https://github.com/nodejs/node/issues/36287. If this PR succeeds to build, I will report that this has been fixed by https://github.com/nodejs/node/commit/e3f89881183c70c02797ba096c50765b5bdc2433#diff-f350b1b5e53caf9ecde4240ba8f544b3be4f278e4f8efa86b54c30ea625b8b1d~~ Mistaken
- The libatomic hack has been removed since https://github.com/termux/termux-packages/issues/3092 has been reported to have been fixed with newer NDK
