### PR TITLE
cava: Fix hardcoded paths in LDFLAGS

### DIFF
--- a/packages/cava/Makefile.am.patch
+++ b/packages/cava/Makefile.am.patch
@@ -2,7 +2,12 @@ diff --git a/Makefile.am b/Makefile.am
 index 8419207..1bd48e4 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -15,12 +15,11 @@ cava_LDFLAGS = -L/usr/local/lib -Wl,-rpath /usr/local/lib
+@@ -11,16 +11,15 @@
+ bin_PROGRAMS = cava
+ cava_SOURCES = cava.c config.c input/common.c input/fifo.c input/shmem.c \
+                output/terminal_noncurses.c output/raw.c
+-cava_LDFLAGS = -L/usr/local/lib -Wl,-rpath /usr/local/lib
++cava_LDFLAGS = 
  cava_CPPFLAGS = -DPACKAGE=\"$(PACKAGE)\" -DVERSION=\"$(VERSION)\" \
             -D_POSIX_SOURCE -D _POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE_EXTENDED \
  	   -DFONTDIR=\"@FONT_DIR@\"

--- a/packages/cava/build.sh
+++ b/packages/cava/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Console-based Audio Visualizer. Works with MPD and Pulse
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Oliver Schmidhauser @Neo-Oli"
 TERMUX_PKG_VERSION=0.7.4
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/karlstav/cava/archive/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=fefd3cc04d41b03ca416630cafadbfda6c75e2ca0869da1f03963dcb13e1ecb7
 TERMUX_PKG_AUTO_UPDATE=true


### PR DESCRIPTION
This is not relevant to #7377, maybe.