### PR TITLE
Compiler improvement - adding TERMUX_PKG_FORMAT_IGNORE value

### DIFF
--- a/scripts/build/termux_step_setup_variables.sh
+++ b/scripts/build/termux_step_setup_variables.sh
@@ -133,6 +133,7 @@ termux_step_setup_variables() {
 	TERMUX_PKG_SERVICE_SCRIPT=() # Fill with entries like: ("daemon name" 'script to execute'). Script is echoed with -e so can contain \n for multiple lines
 	TERMUX_PKG_GROUPS="" # https://wiki.archlinux.org/title/Pacman#Installing_package_groups
 	TERMUX_PKG_NO_SHEBANG_FIX=false # if true, skip fixing shebang accordingly to TERMUX_PREFIX
+	TERMUX_PKG_FORMAT_IGNORE=""
 
 	unset CFLAGS CPPFLAGS LDFLAGS CXXFLAGS
 }

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -9,6 +9,10 @@ termux_step_start_build() {
 	# Path to hostbuild marker, for use if package has hostbuild step
 	TERMUX_HOSTBUILD_MARKER="$TERMUX_PKG_HOSTBUILD_DIR/TERMUX_BUILT_FOR_$TERMUX_PKG_VERSION"
 
+	if [[ "$TERMUX_SKIP_DEPCHECK" = "false" && "$TERMUX_PKG_FORMAT_IGNORE" = "$TERMUX_PACKAGE_FORMAT" ]]; then
+		termux_error_exit "Cannot continue, this package is set to ignore ${TERMUX_PKG_FORMAT_IGNORE} format"
+	fi
+
 	if [ "$TERMUX_PKG_METAPACKAGE" = "true" ]; then
 		# Metapackage has no sources and therefore platform-independent.
 		TERMUX_PKG_SKIP_SRC_EXTRACT=true

--- a/scripts/lint-packages.sh
+++ b/scripts/lint-packages.sh
@@ -399,6 +399,19 @@ lint_package() {
 			fi
 		fi
 
+		if [ -n "$TERMUX_PKG_FORMAT_IGNORE" ]; then
+			echo -n "TERMUX_PKG_FORMAT_IGNORE: "
+			case $TERMUX_PKG_FORMAT_IGNORE in
+				"debian"|"pacman")
+					echo "PASS"
+					;;
+				*)
+					echo "INVALID (TERMUX_PKG_FORMAT_IGNORE can only be debian or pacman)"
+					pkg_lint_error=true
+					;;
+			esac
+		fi
+
 		if $pkg_lint_error; then
 			exit 1
 		else


### PR DESCRIPTION
Thanks to this value, you can ignore (stop) compilation of a package for a certain format.  This is necessary so that there are no non-working packages in the hosting.  For example, the x11-repp package will not work for pacman.