### PR TITLE
termux_step_setup_toolchain: `-fPIC` should be in `CFLAGS`

### DIFF
--- a/scripts/build/termux_step_setup_toolchain.sh
+++ b/scripts/build/termux_step_setup_toolchain.sh
@@ -49,7 +49,7 @@ termux_step_setup_toolchain() {
 		CFLAGS+=" -march=i686 -msse3 -mstackrealign -mfpmath=sse"
 		# i686 seem to explicitly require -fPIC, see
 		# https://github.com/termux/termux-packages/issues/7215#issuecomment-906154438
-		CPPFLAGS+=" -fPIC"
+		CFLAGS+=" -fPIC"
 		export GOARCH=386
 		export GO386=sse2
 	elif [ "$TERMUX_ARCH" = "aarch64" ]; then

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -2,7 +2,7 @@ termux_step_start_build() {
 	TERMUX_STANDALONE_TOOLCHAIN="$TERMUX_COMMON_CACHEDIR/android-r${TERMUX_NDK_VERSION}-api-${TERMUX_PKG_API_LEVEL}"
 	# Bump the below version if a change is made in toolchain setup to ensure
 	# that everyone gets an updated toolchain:
-	TERMUX_STANDALONE_TOOLCHAIN+="-v3"
+	TERMUX_STANDALONE_TOOLCHAIN+="-v4"
 
 	# shellcheck source=/dev/null
 	source "$TERMUX_PKG_BUILDER_SCRIPT"


### PR DESCRIPTION
Fixes #8150.