### PR TITLE
mediainfo: libandroid-support must be `DT_NEEDED` by main executable

### DIFF
--- a/packages/mediainfo/build.sh
+++ b/packages/mediainfo/build.sh
@@ -4,13 +4,16 @@ TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_LICENSE_FILE="../../../LICENSE"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=21.09
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mediaarea.net/download/source/mediainfo/${TERMUX_PKG_VERSION}/mediainfo_${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=7b8fd9a502ec64afe1315072881b6385ba57ca69f2f82c625b1672e151c50c57
-TERMUX_PKG_DEPENDS="libmediainfo"
+TERMUX_PKG_DEPENDS="libandroid-support, libmediainfo"
 
 termux_step_pre_configure() {
 	TERMUX_PKG_SRCDIR="${TERMUX_PKG_SRCDIR}/Project/GNU/CLI"
 	TERMUX_PKG_BUILDDIR="${TERMUX_PKG_SRCDIR}"
 	cd "${TERMUX_PKG_SRCDIR}"
 	./autogen.sh
+
+	LDFLAGS+=" -Wl,--no-as-needed,-landroid-support,--as-needed"
 }


### PR DESCRIPTION
Fixes #5124.