### PR TITLE
gdb: Explicitly link against compiler-rt builtins

### DIFF
--- a/packages/gdb/build.sh
+++ b/packages/gdb/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="The standard GNU Debugger that runs on many Unix-like sy
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=10.1
-TERMUX_PKG_REVISION=5
+TERMUX_PKG_REVISION=6
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/gdb/gdb-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=f82f1eceeec14a3afa2de8d9b0d3c91d5a3820e23e0a01bbb70ef9f0276b62c0
 TERMUX_PKG_DEPENDS="libc++, liblzma, libexpat, readline, ncurses, libmpfr, python, zlib"
@@ -31,4 +31,6 @@ termux_step_pre_configure() {
 	export gl_cv_func_strerror_0_works=yes
 	export gl_cv_func_working_strerror=yes
 	export gl_cv_func_getcwd_path_max=yes
+
+	LDFLAGS+=" $($CC -print-libgcc-file-name)"
 }


### PR DESCRIPTION
Fixes #8167.