### PR TITLE
mlocate: Add message for absence of `mlocate.db`

### DIFF
--- a/packages/mlocate/build.sh
+++ b/packages/mlocate/build.sh
@@ -7,7 +7,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 # like in '*.deb'.
 TERMUX_PKG_DEPENDS="libandroid-support"
 TERMUX_PKG_VERSION=0.26
-TERMUX_PKG_REVISION=4
+TERMUX_PKG_REVISION=5
 TERMUX_PKG_SRCURL=https://releases.pagure.org/mlocate/mlocate-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=3063df79fe198fb9618e180c54baf3105b33d88fe602ff2d8570aaf944f1263e
 
@@ -18,6 +18,9 @@ termux_step_pre_configure() {
 termux_step_create_debscripts() {
 	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
 	echo "mkdir -p $TERMUX_PREFIX/var/mlocate/" >> postinst
+	echo "if [ ! -e $TERMUX_PREFIX/var/mlocate/mlocate.db ]; then" >> postinst
+	echo "  echo Remember to run \\\`updatedb\\'." >> postinst
+	echo "fi" >> postinst
 	echo "exit 0" >> postinst
 	chmod 0755 postinst
 }

--- a/packages/mlocate/src-locate.c.patch
+++ b/packages/mlocate/src-locate.c.patch
@@ -4,18 +4,6 @@ with Android 7.0.
 diff -u -r ../mlocate-0.26/src/locate.c ./src/locate.c
 --- ../mlocate-0.26/src/locate.c	2012-09-22 03:48:54.000000000 +0200
 +++ ./src/locate.c	2017-09-22 20:57:44.062275402 +0200
-@@ -973,7 +973,10 @@
-       if (stat (entry, &st) != 0)
- 	{
- 	  if (conf_quiet == false)
--	    error (0, errno, _("can not stat () `%s'"), entry);
-+	    {
-+	      error (0, errno, _("can not stat () `%s'"), entry);
-+	      fprintf (stderr, "HINT: you may need to run `updatedb'\n");
-+	    }
- 	  goto err;
- 	}
-       if (!db_is_privileged (&st))
 @@ -1026,11 +1027,6 @@
    uc_obstack_mark = obstack_alloc (&uc_obstack, 0);
    obstack_init (&check_stack_obstack);

--- a/packages/mlocate/src-locate.c.patch
+++ b/packages/mlocate/src-locate.c.patch
@@ -4,6 +4,18 @@ with Android 7.0.
 diff -u -r ../mlocate-0.26/src/locate.c ./src/locate.c
 --- ../mlocate-0.26/src/locate.c	2012-09-22 03:48:54.000000000 +0200
 +++ ./src/locate.c	2017-09-22 20:57:44.062275402 +0200
+@@ -973,7 +973,10 @@
+       if (stat (entry, &st) != 0)
+ 	{
+ 	  if (conf_quiet == false)
+-	    error (0, errno, _("can not stat () `%s'"), entry);
++	    {
++	      error (0, errno, _("can not stat () `%s'"), entry);
++	      fprintf (stderr, "HINT: you may need to run `updatedb'\n");
++	    }
+ 	  goto err;
+ 	}
+       if (!db_is_privileged (&st))
 @@ -1026,11 +1027,6 @@
    uc_obstack_mark = obstack_alloc (&uc_obstack, 0);
    obstack_init (&check_stack_obstack);


### PR DESCRIPTION
Closes #8115.