### PR TITLE
Add setpriv

### DIFF
--- a/packages/libcap-ng/build.sh
+++ b/packages/libcap-ng/build.sh
@@ -2,10 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://people.redhat.com/sgrubb/libcap-ng/
 TERMUX_PKG_DESCRIPTION="Library making programming with POSIX capabilities easier than traditional libcap"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=0.8.2
-TERMUX_PKG_REVISION=4
-TERMUX_PKG_SRCURL=https://github.com/stevegrubb/libcap-ng/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=65b86885b8d873e55c05bd49427fd370d559b26f0c2089ac9194828e6a2fe233
+TERMUX_PKG_VERSION=0.8.3~pre1
+TERMUX_PKG_SRCURL="https://github.com/stevegrubb/libcap-ng/archive/187ed5355ce23333331187312c54d38390f3d6b6.tar.gz"
+#TERMUX_PKG_SRCURL=https://github.com/stevegrubb/libcap-ng/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=108e6be17b4c9b8c6249e5f12041fce4078de91515a00e93af400bfb40cfd538
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --without-python

--- a/packages/util-linux/build.sh
+++ b/packages/util-linux/build.sh
@@ -5,13 +5,14 @@ TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.37.2
 TERMUX_PKG_SRCURL=https://www.kernel.org/pub/linux/utils/util-linux/v${TERMUX_PKG_VERSION:0:4}/util-linux-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=6a0764c1aae7fb607ef8a6dd2c0f6c47d5e5fd27aa08820abaad9ec14e28e9d9
-TERMUX_PKG_DEPENDS="ncurses, libcrypt, zlib"
+TERMUX_PKG_DEPENDS="ncurses, libcap-ng, libcrypt, zlib"
 TERMUX_PKG_ESSENTIAL=true
 TERMUX_PKG_BREAKS="util-linux-dev"
 TERMUX_PKG_REPLACES="util-linux-dev"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 ac_cv_func_setns=yes
 ac_cv_func_unshare=yes
+--enable-setpriv
 --disable-agetty
 --disable-ctrlaltdel
 --disable-eject

--- a/packages/util-linux/build.sh
+++ b/packages/util-linux/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Miscellaneous system utilities"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.37.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.kernel.org/pub/linux/utils/util-linux/v${TERMUX_PKG_VERSION:0:4}/util-linux-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=6a0764c1aae7fb607ef8a6dd2c0f6c47d5e5fd27aa08820abaad9ec14e28e9d9
 TERMUX_PKG_DEPENDS="ncurses, libcap-ng, libcrypt, zlib"


### PR DESCRIPTION
Added `setpriv` in `util-linux`.

Android `7` and some Android devices `8` do not support ambient capabilities and will return `activate capabilities: Invalid argument` when running `setpriv`.

strace shows `"prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET, CAP_CHOWN, 0, 0) = -1 EINVAL (Invalid argument)"`

This was an issue with `libcap-ng` where support for `PR_CAP_AMBIENT` was checked at compile time, so `setpriv` only worked on Android > `7`/`8` when `capng_apply()` was called.

`4.3    kernel   PR_CAP_AMBIENT`

https://github.com/util-linux/util-linux/blob/v2.37.1/sys-utils/setpriv.c#L1010
https://github.com/stevegrubb/libcap-ng/blob/v0.8.2/src/cap-ng.c#L59
https://github.com/stevegrubb/libcap-ng/blob/v0.8.2/src/cap-ng.c#L716
https://source.android.com/devices/architecture/kernel/android-common

This has been fixed in `libcap-ng` by checking `PR_CAP_AMBIENT` at runtime with `187ed535`. `libcap-ng` `0.8.3` has not been released yet and so we use a pre release version `0.8.3~pre1`.

https://github.com/stevegrubb/libcap-ng/issues/28
https://github.com/stevegrubb/libcap-ng/commit/187ed535

Let me know if someone is willing to test it out. I have confirmed its working on android `7`, did some basic run test on android `10` avd as well and it ran fine, but since patching selinux policy isn't working on it, so can't fully test dropping to app context currently. The `setrpriv` binary should help people who want to run commands in termux or other app contexts from scripts running as `root`. `nsenter` is already provided by `util-linux`. I'll release a script soon for it as well. Check https://android.stackexchange.com/questions/217016/how-to-run-a-program-in-an-app-context-with-magisk for details.