### PR TITLE
sqlcipher: update to 4.5.0

### DIFF
--- a/packages/sqlcipher/build.sh
+++ b/packages/sqlcipher/build.sh
@@ -2,10 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://github.com/sqlcipher/sqlcipher
 TERMUX_PKG_DESCRIPTION="SQLCipher is an SQLite extension that provides 256 bit AES encryption of database files"
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=4.4.3
+TERMUX_PKG_VERSION=4.5.0
 TERMUX_PKG_SRCURL=https://github.com/sqlcipher/sqlcipher/archive/v$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_SHA256=b8df69b998c042ce7f8a99f07cf11f45dfebe51110ef92de95f1728358853133
-TERMUX_PKG_DEPENDS="libsqlite, openssl"
+TERMUX_PKG_SHA256=20c46a855c47d5a0a159fdcaa8491ec7bdbaa706a734ee52bc76188b929afb14
+TERMUX_PKG_DEPENDS="openssl"
 TERMUX_PKG_BUILD_DEPENDS="tcl"
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="


### PR DESCRIPTION
Also, sqlcipher does not depend on sqlite (unless there's something Termux-specific I'm not aware of), so this commit removes that dependency as well.