### PR TITLE
librsvg: Link against compiler-rt builtins

### DIFF
--- a/packages/librsvg/build.sh
+++ b/packages/librsvg/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Library to render SVG files using cairo"
 TERMUX_PKG_LICENSE="LGPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.52.1
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=http://ftp.gnome.org/pub/GNOME/sources/librsvg/${TERMUX_PKG_VERSION:0:4}/librsvg-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=949dffcb0414865409e17a6c89ae30bc8bb014a51fba5186f73d1a46c6c5ccde
 TERMUX_PKG_DEPENDS="gdk-pixbuf, libcairo, libcroco, pango, zlib"
@@ -17,7 +17,7 @@ ac_cv_path_GDK_PIXBUF_QUERYLOADERS=$TERMUX_PREFIX/bin/gdk-pixbuf-query-loaders
 termux_step_pre_configure() {
 	termux_setup_rust
 
-	LDFLAGS+=" -fuse-ld=lld"
+	LDFLAGS+=" -fuse-ld=lld $($CC -print-libgcc-file-name)"
 
 	# See https://github.com/GNOME/librsvg/blob/master/COMPILING.md
 	export RUST_TARGET=$CARGO_TARGET_NAME


### PR DESCRIPTION
May fix #8235.