### PR TITLE
apktool: Always assume custom `aapt`

### DIFF
--- a/packages/apktool/AndrolibResources.java.patch
+++ b/packages/apktool/AndrolibResources.java.patch
@@ -1,0 +1,11 @@
+--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
++++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
+@@ -611,7 +611,7 @@
+             throws AndrolibException {
+ 
+         String aaptPath = apkOptions.aaptPath;
+-        boolean customAapt = !aaptPath.isEmpty();
++        boolean customAapt = true;
+         List<String> cmd = new ArrayList<>();
+ 
+         try {

--- a/packages/apktool/build.sh
+++ b/packages/apktool/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A tool for reverse engineering 3rd party, closed, binary
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.6.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/iBotPeaches/Apktool/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=74739cdb1434ca35ec34e51ca7272ad3f378ae3ed0a2d5805d9a2fab5016037f
 # aapt2 is not available (yet)

--- a/packages/apktool/build.sh
+++ b/packages/apktool/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.6.0
 TERMUX_PKG_SRCURL=https://github.com/iBotPeaches/Apktool/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=74739cdb1434ca35ec34e51ca7272ad3f378ae3ed0a2d5805d9a2fab5016037f
+# aapt2 is not available (yet)
 TERMUX_PKG_DEPENDS="aapt, openjdk-17"
 TERMUX_PKG_BUILD_IN_SRC=true
 

--- a/packages/apktool/build.sh
+++ b/packages/apktool/build.sh
@@ -17,6 +17,7 @@ termux_step_pre_configure() {
 		$CC $CFLAGS $CPPFLAGS aapt-wrapper/${exe_name}-wrapper.c \
 			-o ${exe_path} $LDFLAGS
 		$STRIP --strip-unneeded ${exe_path}
+		$TERMUX_ELF_CLEANER ${exe_path}
 		cp -a ${exe_path} ${exe_path}_64
 	done
 }


### PR DESCRIPTION
that does not have `--forced-package-id` option.

Fixes #8295.