### PR TITLE
new package: libatomic-ops

### DIFF
--- a/packages/libatomic-ops/build.sh
+++ b/packages/libatomic-ops/build.sh
@@ -1,0 +1,8 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/ivmai/libatomic_ops
+TERMUX_PKG_DESCRIPTION="Provides semi-portable access to hardware-provided atomic memory update operations"
+TERMUX_PKG_LICENSE="GPL-2.0, MIT"
+TERMUX_PKG_LICENSE_FILE="README.md, doc/LICENSING.txt"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=7.6.12
+TERMUX_PKG_SRCURL=https://github.com/ivmai/libatomic_ops/releases/download/v${TERMUX_PKG_VERSION}/libatomic_ops-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=f0ab566e25fce08b560e1feab6a3db01db4a38e5bc687804334ef3920c549f3e


### PR DESCRIPTION
Intended to be used for the `gauche` package but it turns out to be unnecessary.