### PR TITLE
nodejs,nodejs-lts: npm: set `foreground-scripts` to true on postinstall

### DIFF
--- a/packages/emscripten/build.sh
+++ b/packages/emscripten/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Emscripten: An LLVM-to-WebAssembly Compiler"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@truboxl"
 TERMUX_PKG_VERSION=3.0.1
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/emscripten-core/emscripten.git
 TERMUX_PKG_GIT_BRANCH=$TERMUX_PKG_VERSION
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
@@ -235,12 +235,23 @@ termux_step_make_install() {
 }
 
 termux_step_create_debscripts() {
+	# emscripten's package-lock.json is generated with nodejs v12.13.0
+	# which comes with npm v6 which used lockfile version 1
+	# which isn't compatible with lockfile version 2 used in npm v7 and v8
 	cat <<- EOF > postinst
-	#!$TERMUX_PREFIX/bin/sh
+	#!$TERMUX_PREFIX/bin/bash
 	if [ -n "\$(command -v npm)" ]; then
-	echo 'Running "npm ci --no-optional --production" in $TERMUX_PREFIX/opt/emscripten ...'
 	cd "$TERMUX_PREFIX/opt/emscripten"
+	NPM_VERSION=\$(npm --version)
+	NPM_MAJOR_VERSION=\${NPM_VERSION:0:1}
+	if [ 6 = \$NPM_MAJOR_VERSION ]; then
+	echo 'Running "npm ci --no-optional --production" in $TERMUX_PREFIX/opt/emscripten ...'
 	npm ci --no-optional --production
+	else
+	echo 'Running "npm install" in $TERMUX_PREFIX/opt/emscripten ...'
+	rm package-lock.json
+	npm install
+	fi
 	else
 	echo 'Warning: npm is not installed! Emscripten may not work properly without installing node modules!' >&2
 	fi

--- a/packages/emscripten/build.sh
+++ b/packages/emscripten/build.sh
@@ -248,9 +248,9 @@ termux_step_create_debscripts() {
 	echo 'Running "npm ci --no-optional --production" in $TERMUX_PREFIX/opt/emscripten ...'
 	npm ci --no-optional --production
 	else
-	echo 'Running "npm install" in $TERMUX_PREFIX/opt/emscripten ...'
+	echo 'Running "npm install --no-optional --production" in $TERMUX_PREFIX/opt/emscripten ...'
 	rm package-lock.json
-	npm install
+	npm install --no-optional --production
 	fi
 	else
 	echo 'Warning: npm is not installed! Emscripten may not work properly without installing node modules!' >&2

--- a/packages/nodejs-lts/build.sh
+++ b/packages/nodejs-lts/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Open Source, cross-platform JavaScript runtime environme
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Yaksh Bariya <yakshbari4@gmail.com>"
 TERMUX_PKG_VERSION=16.13.1
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=4c23004fd75eaf799ad8e76fe34f53e0327f433d4acbfc883396f72e96cc63ad
 # Note that we do not use a shared libuv to avoid an issue with the Android
@@ -86,4 +86,11 @@ termux_step_configure() {
 		$TERMUX_PKG_SRCDIR/out/tools/v8_gypfiles/bytecode_builtins_list_generator.host.mk \
 		$TERMUX_PKG_SRCDIR/out/tools/v8_gypfiles/v8_libbase.host.mk \
 		$TERMUX_PKG_SRCDIR/out/tools/v8_gypfiles/gen-regexp-special-case.host.mk
+}
+
+termux_step_create_debscripts() {
+	cat <<- EOF > ./postinst
+	#!$TERMUX_PREFIX/bin/sh
+	npm config set foreground-scripts true
+	EOF
 }

--- a/packages/nodejs/build.sh
+++ b/packages/nodejs/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Open Source, cross-platform JavaScript runtime environme
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Yaksh Bariya <yakshbari4@gmail.com>"
 TERMUX_PKG_VERSION=17.3.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=e4e4c4e64854698f2590144a177bcc7e7c0befb52020288fdae5c0da0d015d03
 # Note that we do not use a shared libuv to avoid an issue with the Android
@@ -83,4 +84,11 @@ termux_step_configure() {
 		$TERMUX_PKG_SRCDIR/out/tools/v8_gypfiles/bytecode_builtins_list_generator.host.mk \
 		$TERMUX_PKG_SRCDIR/out/tools/v8_gypfiles/v8_libbase.host.mk \
 		$TERMUX_PKG_SRCDIR/out/tools/v8_gypfiles/gen-regexp-special-case.host.mk
+}
+
+termux_step_create_debscripts() {
+	cat <<- EOF > ./postinst
+	#!$TERMUX_PREFIX/bin/sh
+	npm config set foreground-scripts true
+	EOF
 }


### PR DESCRIPTION
Temporary fix for #3188 and #8387

Closes #3188 
Closes #8387

As noted in https://github.com/npm/statusboard/issues/395#issuecomment-1003256492, this seems to be a problem with how npm handles postinstall, preinstall and other package hooks. Adding `--foreground-scripts` is a temporary hack until itis fixed.

