### PR TITLE
Chore(lua-language-server): update to 2.5.6

### DIFF
--- a/packages/lua-language-server/build.sh
+++ b/packages/lua-language-server/build.sh
@@ -57,7 +57,7 @@ termux_step_make_install() {
 		else
 			TMPPATH=\$(mktemp -d "${TERMUX_PREFIX}/tmp/${TERMUX_PKG_NAME}.XXXX")
 
-			exec ${INSTALL_DIR}/bin/Android/${TERMUX_PKG_NAME} \\
+			exec ${INSTALL_DIR}/bin/${TERMUX_PKG_NAME} \\
 				--logpath="\${TMPPATH}/log" \\
 				--metapath="\${TMPPATH}/meta" \\
 				"\${@}"
@@ -67,9 +67,9 @@ termux_step_make_install() {
 
 	chmod 744 "${TERMUX_PREFIX}/bin/${TERMUX_PKG_NAME}"
 
-	install -Dm744 -t "${INSTALL_DIR}"/bin/Android ./bin/Android/"${TERMUX_PKG_NAME}"
+	install -Dm744 -t "${INSTALL_DIR}"/bin ./bin/"${TERMUX_PKG_NAME}"
 	install -Dm644 -t "${INSTALL_DIR}" ./{main,debugger}.lua
-	install -Dm644 -t "${INSTALL_DIR}"/bin/Android ./bin/Android/main.lua
+	install -Dm644 -t "${INSTALL_DIR}"/bin ./bin/main.lua
 
 	cp -r ./script ./meta ./locale "${INSTALL_DIR}"
 }

--- a/packages/lua-language-server/build.sh
+++ b/packages/lua-language-server/build.sh
@@ -2,18 +2,16 @@ TERMUX_PKG_HOMEPAGE="https://github.com/sumneko/lua-language-server"
 TERMUX_PKG_DESCRIPTION="Sumneko Lua Language Server coded in Lua"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="MrAdityaAlok <dev.aditya.alok@gmail.com>"
-TERMUX_PKG_VERSION=2.4.7
-TERMUX_PKG_SRCURL=https://github.com/sumneko/lua-language-server.git
+TERMUX_PKG_VERSION=2.5.6
 TERMUX_PKG_GIT_BRANCH="${TERMUX_PKG_VERSION}"
+TERMUX_PKG_SRCURL="https://github.com/sumneko/lua-language-server.git"
 TERMUX_PKG_BUILD_DEPENDS="libandroid-spawn"
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_BUILD_IN_SRC=true
 
-# no cpu_relax support present for these archs.
-# https://github.com/actboy168/bee.lua/blob/32f65b92739fa236d87fc1b2e7617470d47f0355/bee/thread/spinlock.h#L14
-TERMUX_PKG_BLACKLISTED_ARCHES="arm,i686"
+TERMUX_PKG_BLACKLISTED_ARCHES="i686"
 
-_patch() {
+_patch_on_device() {
 	if [ "${TERMUX_ON_DEVICE_BUILD}" = true ]; then
 		current_dir=$(pwd)
 
@@ -25,7 +23,7 @@ _patch() {
 }
 
 termux_step_host_build() {
-	_patch
+	_patch_on_device
 	termux_setup_ninja
 
 	mkdir 3rd
@@ -56,7 +54,7 @@ termux_step_make_install() {
 		# determine its version, so provide it manually.
 		if [ "\$1" = "--version" ]; then
 			echo "${TERMUX_PKG_NAME}: ${TERMUX_PKG_VERSION}"
-		else 
+		else
 			TMPPATH=\$(mktemp -d "${TERMUX_PREFIX}/tmp/${TERMUX_PKG_NAME}.XXXX")
 
 			exec ${INSTALL_DIR}/bin/Android/${TERMUX_PKG_NAME} \\

--- a/packages/lua-language-server/make.lua.diff
+++ b/packages/lua-language-server/make.lua.diff
@@ -1,46 +1,20 @@
---- lua-language-server/make.lua	2021-10-22 15:07:23.591055667 +0530
-+++ lua-language-server-patch/make.lua	2021-10-27 20:41:28.435106500 +0530
-@@ -2,7 +2,10 @@
- local platform = require 'bee.platform'
- local exe      = platform.OS == 'Windows' and ".exe" or ""
- 
--lm.bindir = "bin/"..platform.OS
-+lm.bindir = "bin/Android"
-+
-+lm.flags = "@FLAGS@"
-+lm.ldflags = "@LDFLAGS@"
+--- b/make.lua	2022-01-08 12:10:22.532679720 +0530
++++ a/make.lua	2022-01-08 12:05:20.922679835 +0530
+@@ -6,6 +6,9 @@
  
  lm.EXE_DIR = ""
- lm:import "3rd/bee.lua/make.lua"
-@@ -42,29 +45,7 @@
-     output = lm.bindir.."/main.lua",
+ 
++lm.flags = "@FLAGS@"
++lm.ldflags = "@LDFLAGS@"
++
+ if platform.OS == 'macOS' then
+     if lm.platform == nil then
+     elseif lm.platform == "darwin-arm64" then
+@@ -132,6 +135,5 @@
  }
  
--lm:build "bee-test" {
--    lm.bindir.."/lua-language-server"..exe, "3rd/bee.lua/test/test.lua",
--    pool = "console",
--    deps = {
--        "lua-language-server",
--        "copy_bootstrap",
--    },
--    windows = {
--        deps = {
--            "copy_vcrt"
--        }
--    }
--}
--
--lm:build 'unit-test' {
--    lm.bindir.."/lua-language-server"..exe, 'test.lua',
--    pool = "console",
--    deps = {
--        "bee-test",
--    }
--}
--
  lm:default {
 -    "bee-test",
 -    "unit-test",
-+    "lua-language-server",
-+    "copy_bootstrap",
++    "all",
  }


### PR DESCRIPTION
- remove arm from TERMUX_PKG_BLACKLISTED_ARCHES

Signed-off-by: Aditya Alok <dev.aditya.alok@gmail.com>

#8491 should be closed. That's a wrong patch.