### PR TITLE
nodejs-lts: update to 16.13.2

### DIFF
--- a/packages/nodejs-lts/build.sh
+++ b/packages/nodejs-lts/build.sh
@@ -2,10 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://nodejs.org/
 TERMUX_PKG_DESCRIPTION="Open Source, cross-platform JavaScript runtime environment"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Yaksh Bariya <yakshbari4@gmail.com>"
-TERMUX_PKG_VERSION=16.13.1
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION=16.13.2
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=4c23004fd75eaf799ad8e76fe34f53e0327f433d4acbfc883396f72e96cc63ad
+TERMUX_PKG_SHA256=98b1de1ff92a292b93d2b2c93bc2a98656647b3d0c0d5623069f4f8047a8b4a0
 # Note that we do not use a shared libuv to avoid an issue with the Android
 # linker, which does not use symbols of linked shared libraries when resolving
 # symbols on dlopen(). See https://github.com/termux/termux-packages/issues/462.


### PR DESCRIPTION
New version has security fixes. See https://github.com/nodejs/node/releases/tag/v16.13.2
