### PR TITLE
dart: support flutter and enable x86_64

### DIFF
--- a/packages/dart/build.sh
+++ b/packages/dart/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_LICENSE_FILE="sdk/LICENSE"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.15.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
 
@@ -47,19 +48,19 @@ termux_step_make_install() {
 	rm -f ./out/*/args.gn
 
 	if [ $TERMUX_ARCH = "arm" ]; then
-		DART_MAKE_PLATFORM_SDK=true python2 ./tools/build.py --no-goma --mode release --arch=arm --os=android create_sdk
+		DART_MAKE_PLATFORM_SDK=true python2 ./tools/build.py --no-goma --mode release --arch=arm --os=android create_sdk dart2js
 		chmod +x ./out/ReleaseAndroidARM/dart-sdk/bin/*
 		cp -r ./out/ReleaseAndroidARM/dart-sdk ${TERMUX_PREFIX}/lib
 	elif [ $TERMUX_ARCH = "i686" ]; then
-		DART_MAKE_PLATFORM_SDK=true python2 ./tools/build.py --no-goma --mode release --arch=ia32 --os=android create_sdk
+		DART_MAKE_PLATFORM_SDK=true python2 ./tools/build.py --no-goma --mode release --arch=ia32 --os=android create_sdk dart2js
 		chmod +x ./out/ReleaseAndroidIA32/dart-sdk/bin/*
 		cp -r ./out/ReleaseAndroidIA32/dart-sdk ${TERMUX_PREFIX}/lib
 	elif [ $TERMUX_ARCH = "aarch64" ]; then
-		DART_MAKE_PLATFORM_SDK=true python2 ./tools/build.py --no-goma --mode release --arch=arm64c --os=android create_sdk
+		DART_MAKE_PLATFORM_SDK=true python2 ./tools/build.py --no-goma --mode release --arch=arm64c --os=android create_sdk dart2js
 		chmod +x ./out/ReleaseAndroidARM64C/dart-sdk/bin/*
 		cp -r ./out/ReleaseAndroidARM64C/dart-sdk ${TERMUX_PREFIX}/lib
 	elif [ $TERMUX_ARCH = "x86_64" ]; then
-		DART_MAKE_PLATFORM_SDK=true python2 ./tools/build.py --no-goma --mode release --arch=x64c --os=android create_sdk
+		DART_MAKE_PLATFORM_SDK=true python2 ./tools/build.py --no-goma --mode release --arch=x64c --os=android create_sdk dart2js
 		chmod +x ./out/ReleaseAndroidX64C/dart-sdk/bin/*
 		cp -r ./out/ReleaseAndroidX64C/dart-sdk ${TERMUX_PREFIX}/lib
 	else

--- a/packages/dart/build.sh
+++ b/packages/dart/build.sh
@@ -6,7 +6,6 @@ TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.15.1
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
-TERMUX_PKG_BLACKLISTED_ARCHES="x86_64"
 
 # Dart uses tar and gzip to extract downloaded packages.
 # Busybox-based versions of such utilities cause issues so
@@ -56,13 +55,13 @@ termux_step_make_install() {
 		chmod +x ./out/ReleaseAndroidIA32/dart-sdk/bin/*
 		cp -r ./out/ReleaseAndroidIA32/dart-sdk ${TERMUX_PREFIX}/lib
 	elif [ $TERMUX_ARCH = "aarch64" ]; then
-		DART_MAKE_PLATFORM_SDK=true python2 ./tools/build.py --no-goma --mode release --arch=arm64 --os=android create_sdk
-		chmod +x ./out/ReleaseAndroidARM64/dart-sdk/bin/*
-		cp -r ./out/ReleaseAndroidARM64/dart-sdk ${TERMUX_PREFIX}/lib
+		DART_MAKE_PLATFORM_SDK=true python2 ./tools/build.py --no-goma --mode release --arch=arm64c --os=android create_sdk
+		chmod +x ./out/ReleaseAndroidARM64C/dart-sdk/bin/*
+		cp -r ./out/ReleaseAndroidARM64C/dart-sdk ${TERMUX_PREFIX}/lib
 	elif [ $TERMUX_ARCH = "x86_64" ]; then
-		DART_MAKE_PLATFORM_SDK=true python2 ./tools/build.py --no-goma --mode release --arch=x64 --os=android create_sdk
-		chmod +x ./out/ReleaseAndroidX64/dart-sdk/bin/*
-		cp -r ./out/ReleaseAndroidX64/dart-sdk ${TERMUX_PREFIX}/lib
+		DART_MAKE_PLATFORM_SDK=true python2 ./tools/build.py --no-goma --mode release --arch=x64c --os=android create_sdk
+		chmod +x ./out/ReleaseAndroidX64C/dart-sdk/bin/*
+		cp -r ./out/ReleaseAndroidX64C/dart-sdk ${TERMUX_PREFIX}/lib
 	else
 		termux_error_exit "Unsupported arch '$TERMUX_ARCH'"
 	fi

--- a/packages/dart/build.sh
+++ b/packages/dart/build.sh
@@ -48,19 +48,19 @@ termux_step_make_install() {
 	rm -f ./out/*/args.gn
 
 	if [ $TERMUX_ARCH = "arm" ]; then
-		DART_MAKE_PLATFORM_SDK=true python2 ./tools/build.py --no-goma --mode release --arch=arm --os=android create_sdk dart2js
+		python2 ./tools/build.py --no-goma --mode release --arch=arm --os=android create_sdk
 		chmod +x ./out/ReleaseAndroidARM/dart-sdk/bin/*
 		cp -r ./out/ReleaseAndroidARM/dart-sdk ${TERMUX_PREFIX}/lib
 	elif [ $TERMUX_ARCH = "i686" ]; then
-		DART_MAKE_PLATFORM_SDK=true python2 ./tools/build.py --no-goma --mode release --arch=ia32 --os=android create_sdk dart2js
+		python2 ./tools/build.py --no-goma --mode release --arch=ia32 --os=android create_sdk
 		chmod +x ./out/ReleaseAndroidIA32/dart-sdk/bin/*
 		cp -r ./out/ReleaseAndroidIA32/dart-sdk ${TERMUX_PREFIX}/lib
 	elif [ $TERMUX_ARCH = "aarch64" ]; then
-		DART_MAKE_PLATFORM_SDK=true python2 ./tools/build.py --no-goma --mode release --arch=arm64c --os=android create_sdk dart2js
+		python2 ./tools/build.py --no-goma --mode release --arch=arm64c --os=android create_sdk
 		chmod +x ./out/ReleaseAndroidARM64C/dart-sdk/bin/*
 		cp -r ./out/ReleaseAndroidARM64C/dart-sdk ${TERMUX_PREFIX}/lib
 	elif [ $TERMUX_ARCH = "x86_64" ]; then
-		DART_MAKE_PLATFORM_SDK=true python2 ./tools/build.py --no-goma --mode release --arch=x64c --os=android create_sdk dart2js
+		python2 ./tools/build.py --no-goma --mode release --arch=x64c --os=android create_sdk
 		chmod +x ./out/ReleaseAndroidX64C/dart-sdk/bin/*
 		cp -r ./out/ReleaseAndroidX64C/dart-sdk ${TERMUX_PREFIX}/lib
 	else


### PR DESCRIPTION
when flutter app loading libapp.so it will check a feature string 'compressed-pointers', the arch build without  'c', gen_snapshot will output libapp.so include 'no-compressed-pointers' not 'compressed-pointers'.