### PR TITLE
strace: update to 5.16 + enable mpers for aarch64

### DIFF
--- a/packages/strace/build.sh
+++ b/packages/strace/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://strace.io/
 TERMUX_PKG_DESCRIPTION="Debugging utility to monitor system calls and signals received"
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=5.14
+TERMUX_PKG_VERSION=5.16
 TERMUX_PKG_SRCURL=https://github.com/strace/strace/releases/download/v$TERMUX_PKG_VERSION/strace-$TERMUX_PKG_VERSION.tar.xz
-TERMUX_PKG_SHA256=901bee6db5e17debad4530dd9ffb4dc9a96c4a656edbe1c3141b7cb307b11e73
+TERMUX_PKG_SHA256=dc7db230ff3e57c249830ba94acab2b862da1fcaac55417e9b85041a833ca285
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libdw"
 
@@ -20,6 +20,5 @@ TERMUX_PKG_RM_AFTER_INSTALL="bin/strace-graph"
 
 termux_step_pre_configure() {
 	autoreconf # for configure.ac in 5.11fix.patch
-	CPPFLAGS+=" -Dfputs_unlocked=fputs -DPR_SET_VMA=0x53564d41"
-	# remove the -DPR_SET_VMA for >5.13
+	CPPFLAGS+=" -Dfputs_unlocked=fputs"
 }

--- a/packages/strace/build.sh
+++ b/packages/strace/build.sh
@@ -8,10 +8,7 @@ TERMUX_PKG_SHA256=dc7db230ff3e57c249830ba94acab2b862da1fcaac55417e9b85041a833ca2
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libdw"
 
-# Without st_cv_m32_mpers=no the build fails if gawk is installed.
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
-st_cv_m32_mpers=no
---enable-mpers=no
 --with-libdw
 "
 
@@ -19,6 +16,11 @@ st_cv_m32_mpers=no
 TERMUX_PKG_RM_AFTER_INSTALL="bin/strace-graph"
 
 termux_step_pre_configure() {
-	autoreconf # for configure.ac in 5.11fix.patch
+	if [ "$TERMUX_ARCH" = "arm" ] || [ "$TERMUX_ARCH" = "i686" ] || [ "$TERMUX_ARCH" = "x86_64" ]; then
+		# Without st_cv_m32_mpers=no the build fails if gawk is installed.
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" st_cv_m32_mpers=no"
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --enable-mpers=no"
+	fi
+	autoreconf # for configure.ac in configure-find-armv7-cc.patch
 	CPPFLAGS+=" -Dfputs_unlocked=fputs"
 }

--- a/packages/strace/configure-find-armv7-cc.patch
+++ b/packages/strace/configure-find-armv7-cc.patch
@@ -1,0 +1,18 @@
+diff --git a/configure.ac b/configure.ac
+index d17ba04a7..9b677a77f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -753,10 +753,10 @@ AS_IF([test x$arch = xaarch64],
+        #   Red Hat: arm-redhat-linux-gnu-gcc
+        #   Fedora:  arm-linux-gnu-gcc
+        #   ALT:     armh-alt-linux-gnueabi-gcc
+-       m4_foreach([triplet1], [arm, arm7, arm7hl, armh], dnl
++       m4_foreach([triplet1], [arm, arm7, armv7a, arm7hl, armh], dnl
+ 		  [m4_foreach([triplet2], [, $host_vendor-], dnl
+-			      [m4_foreach([triplet3], [gnu, gnueabi, gnueabihf], dnl
+-					  [m4_foreach([triplet_cc], [gcc, cc], dnl
++			      [m4_foreach([triplet3], [gnu, gnueabi, gnueabihf, androideabi], dnl
++					  [m4_foreach([triplet_cc], [gcc, cc, clang], dnl
+ 						      [m4_append([arm_compat_compilers], dnl
+ 								 triplet1[-]triplet2[linux-]triplet3[-]triplet_cc)])])])])
+        AC_CHECK_PROGS(CC_FOR_M32, arm_compat_compilers)

--- a/packages/strace/mpers-use-host-readelf-for-debug-dump.patch
+++ b/packages/strace/mpers-use-host-readelf-for-debug-dump.patch
@@ -1,0 +1,13 @@
+diff --git a/src/mpers.sh b/src/mpers.sh
+index bb5685465..ae309caed 100755
+--- a/src/mpers.sh
++++ b/src/mpers.sh
+@@ -15,7 +15,7 @@ ARCH_FLAG=$1
+ CC_ARCH_FLAG=$2
+ PARSER_FILE=$3
+ 
+-READELF="${READELF:-readelf}"
++READELF="readelf"
+ CC="${CC-gcc}"
+ CFLAGS="$CFLAGS -gdwarf-2 -c"
+ CPP="${CPP-$CC -E}"

--- a/packages/strace/sigreturn.c.patch
+++ b/packages/strace/sigreturn.c.patch
@@ -1,10 +1,11 @@
 --- strace-5.11/src/sigreturn.c     2021-02-16 08:00:00.000000000 +0000
 +++ strace-5.11.mod/src/sigreturn.c 2021-02-24 13:57:17.100000000 +0000
-@@ -14,14 +14,16 @@
+@@ -14,15 +14,17 @@
  # include <asm/sigcontext.h>
  #endif
  
 +#if !(defined(__ANDROID__) && (defined(__arm__) || defined(__aarch64__)))
+ /* The following function might be unused, hence the inline qualifier.  */
  static inline void
  print_sigmask_addr_size(const void *const addr, const unsigned int size)
  {


### PR DESCRIPTION
The mpers support doesn't appear to break anything: I was able to `strace` an obfuscated 32-bit ARM binary on my 64-bit ARM phone without problems. There's no point in enabling it for `arm` and `i686`. Sadly, `x86_64` builds fail with mpers support enabled, so it's excluded from build there. The Ubuntu host's `readelf` binary is used, because it's the only one with support for the `--debug-dump` argument.