### PR TITLE
build gnutls with p11-kit

### DIFF
--- a/packages/libgnutls/build.sh
+++ b/packages/libgnutls/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="Secure communications library implementing the SSL, TLS 
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.6.16
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://www.gnupg.org/ftp/gcrypt/gnutls/v${TERMUX_PKG_VERSION:0:3}/gnutls-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=1b79b381ac283d8b054368b335c408fedcb9b7144e0c07f531e3537d4328f3b3
-TERMUX_PKG_DEPENDS="libgmp, libnettle, ca-certificates, libidn2, libunistring, unbound"
+TERMUX_PKG_DEPENDS="libgmp, libnettle, ca-certificates, libidn2, libunistring, unbound, p11-kit"
 TERMUX_PKG_BREAKS="libgnutls-dev"
 TERMUX_PKG_REPLACES="libgnutls-dev"
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -20,7 +20,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --with-unbound-root-key-file=$TERMUX_PREFIX/etc/unbound/root.key
 --with-included-libtasn1
 --enable-local-libopts
---without-p11-kit
 --disable-guile
 --disable-doc
 "


### PR DESCRIPTION
When i was building `glib-networking` then i got undefined reference errors like `undefined reference to gnutls_pkcs11_init` and we have **p11-kit** already so..