### PR TITLE
avahi: Enable use of D-Bus / Enable libdns_sd compat

### DIFF
--- a/packages/avahi/build.sh
+++ b/packages/avahi/build.sh
@@ -3,16 +3,19 @@ TERMUX_PKG_DESCRIPTION="A system for service discovery on a local network via mD
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.8
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://github.com/lathiat/avahi/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=c15e750ef7c6df595fb5f2ce10cac0fee2353649600e6919ad08ae8871e4945f
-TERMUX_PKG_DEPENDS="glib, libandroid-glob, libcap, libdaemon, libevent, libexpat"
+TERMUX_PKG_DEPENDS="dbus, glib, libandroid-glob, libcap, libdaemon, libevent, libexpat"
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
---disable-dbus
+--enable-dbus
 --disable-gdbm
 --disable-gtk3
+--disable-mono
 --disable-pygobject
+--disable-python
+--disable-python-dbus
 --disable-qt5
 --with-distro=none
 ac_cv_func_chroot=no

--- a/packages/avahi/build.sh
+++ b/packages/avahi/build.sh
@@ -9,6 +9,7 @@ TERMUX_PKG_SHA256=c15e750ef7c6df595fb5f2ce10cac0fee2353649600e6919ad08ae8871e494
 TERMUX_PKG_DEPENDS="dbus, glib, libandroid-glob, libcap, libdaemon, libevent, libexpat"
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--enable-compat-libdns_sd
 --enable-dbus
 --disable-gdbm
 --disable-gtk3
@@ -23,4 +24,8 @@ ac_cv_func_chroot=no
 termux_step_pre_configure() {
 	autoreconf -fi
 	LDFLAGS+=" -landroid-glob"
+}
+
+termux_step_post_make_install() {
+	ln -sf avahi-compat-libdns_sd/dns_sd.h $TERMUX_PREFIX/include/dns_sd.h
 }

--- a/packages/avahi/libdns-sd-static.subpackage.sh
+++ b/packages/avahi/libdns-sd-static.subpackage.sh
@@ -1,0 +1,3 @@
+TERMUX_SUBPKG_INCLUDE="lib/libdns_sd.a lib/libdns_sd.la"
+TERMUX_SUBPKG_DESCRIPTION="Compatibility layer for libdns_sd (static library)"
+TERMUX_SUBPKG_DEPENDS="libdns-sd"

--- a/packages/avahi/libdns-sd.subpackage.sh
+++ b/packages/avahi/libdns-sd.subpackage.sh
@@ -1,0 +1,7 @@
+TERMUX_SUBPKG_INCLUDE="
+include/avahi-compat-libdns_sd/
+include/dns_sd.h
+lib/libdns_sd.so
+lib/pkgconfig/avahi-compat-libdns_sd.pc
+"
+TERMUX_SUBPKG_DESCRIPTION="Compatibility layer for libdns_sd"


### PR DESCRIPTION
Closes #8687.

Also enables compatibility layer for libdns_sd, closes #182.