### PR TITLE
unar, uwsgi: Fix bug in `sys_time.c`

### DIFF
--- a/packages/unar/build.sh
+++ b/packages/unar/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Command line tools for archive and file unarchiving and 
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=()
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_VERSION+=(1.10.7)
 TERMUX_PKG_VERSION+=(1.1)
 TERMUX_PKG_SRCURL=(https://github.com/MacPaw/XADMaster/archive/v${TERMUX_PKG_VERSION}/XADMaster-${TERMUX_PKG_VERSION}.tar.gz

--- a/packages/unar/sys_time.c
+++ b/packages/unar/sys_time.c
@@ -34,21 +34,21 @@
 
 #pragma GCC visibility push(hidden)
 
-int timespec_from_timeval(struct timespec ts, const struct timeval tv) {
+int timespec_from_timeval(struct timespec* ts, const struct timeval tv) {
   // Whole seconds can just be copied.
-  ts.tv_sec = tv.tv_sec;
+  ts->tv_sec = tv.tv_sec;
 
   // But we might overflow when converting microseconds to nanoseconds.
   if (tv.tv_usec >= 1000000 || tv.tv_usec < 0) {
     return 0;
   }
-  ts.tv_nsec = tv.tv_usec * 1000;
+  ts->tv_nsec = tv.tv_usec * 1000;
   return 1;
 }
 
 static int futimesat(int fd, const char* path, const struct timeval tv[2], int flags) {
   struct timespec ts[2];
-  if (tv && (!timespec_from_timeval(ts[0], tv[0]) || !timespec_from_timeval(ts[1], tv[1]))) {
+  if (tv && (!timespec_from_timeval(&ts[0], tv[0]) || !timespec_from_timeval(&ts[1], tv[1]))) {
     errno = EINVAL;
     return -1;
   }

--- a/packages/uwsgi/build.sh
+++ b/packages/uwsgi/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="uWSGI application server container"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.0.19.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/unbit/uwsgi/archive/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=bf17cdbb9bd8bcb7c1633e34d9d7308cb4cc19eb0ff2d61057f840c1ba1fc41b
 TERMUX_PKG_DEPENDS="libandroid-glob, libcap, libcrypt, libjansson, libuuid, libxml2, openssl, pcre, python"

--- a/packages/uwsgi/sys_time.c
+++ b/packages/uwsgi/sys_time.c
@@ -34,21 +34,21 @@
 
 #pragma GCC visibility push(hidden)
 
-int timespec_from_timeval(struct timespec ts, const struct timeval tv) {
+int timespec_from_timeval(struct timespec* ts, const struct timeval tv) {
   // Whole seconds can just be copied.
-  ts.tv_sec = tv.tv_sec;
+  ts->tv_sec = tv.tv_sec;
 
   // But we might overflow when converting microseconds to nanoseconds.
   if (tv.tv_usec >= 1000000 || tv.tv_usec < 0) {
     return 0;
   }
-  ts.tv_nsec = tv.tv_usec * 1000;
+  ts->tv_nsec = tv.tv_usec * 1000;
   return 1;
 }
 
 int futimes(int fd, const struct timeval tv[2]) {
   struct timespec ts[2];
-  if (tv && (!timespec_from_timeval(ts[0], tv[0]) || !timespec_from_timeval(ts[1], tv[1]))) {
+  if (tv && (!timespec_from_timeval(&ts[0], tv[0]) || !timespec_from_timeval(&ts[1], tv[1]))) {
     errno = EINVAL;
     return -1;
   }


### PR DESCRIPTION
The first argument of `timespec_from_timeval()` must be a pointer.

Fixes #8647.