### PR TITLE
openssl: Also install manpages

### DIFF
--- a/packages/openssl/build.sh
+++ b/packages/openssl/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Library implementing the SSL and TLS protocols as well a
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.1.1m
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.openssl.org/source/openssl-${TERMUX_PKG_VERSION/\~/-}.tar.gz
 TERMUX_PKG_SHA256=f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96
 TERMUX_PKG_DEPENDS="ca-certificates, zlib"
@@ -48,8 +49,7 @@ termux_step_make() {
 }
 
 termux_step_make_install() {
-	# "install_sw" instead of "install" to not install man pages:
-	make -j 1 install_sw MANDIR=$TERMUX_PREFIX/share/man MANSUFFIX=.ssl
+	make -j 1 install MANDIR=$TERMUX_PREFIX/share/man MANSUFFIX=.ssl
 
 	mkdir -p $TERMUX_PREFIX/etc/tls/
 


### PR DESCRIPTION
Might be helpful for anyone working with openssl

If the manpages increase the package size by a huge amount, I'll split the manpages into openssl-manpages subpackage
