### PR TITLE
ncurses: Use alternative source url

### DIFF
--- a/packages/ncurses/build.sh
+++ b/packages/ncurses/build.sh
@@ -7,7 +7,7 @@ TERMUX_PKG_VERSION=(6.3
 		    15
 		    0.20.3
 		    0.9.0)
-TERMUX_PKG_SRCURL=(https://invisible-mirror.net/archives/ncurses/ncurses-${TERMUX_PKG_VERSION[0]}.tar.gz
+TERMUX_PKG_SRCURL=(https://ftp.gnu.org/gnu/ncurses/ncurses-${TERMUX_PKG_VERSION[0]}.tar.gz
 		   https://fossies.org/linux/misc/rxvt-unicode-${TERMUX_PKG_VERSION[1]}.tar.bz2
 		   https://github.com/thestinger/termite/archive/v${TERMUX_PKG_VERSION[2]}.tar.gz
 		   https://github.com/kovidgoyal/kitty/archive/v${TERMUX_PKG_VERSION[3]}.tar.gz


### PR DESCRIPTION
due to timeout issue for invisible-mirror.net.