### PR TITLE
Install external completions for fish in `$PREFIX/share/fish/vendor_competions.d`

### DIFF
--- a/packages/chezmoi/build.sh
+++ b/packages/chezmoi/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Manage your dotfiles across multiple machines"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
 TERMUX_PKG_VERSION=2.9.5
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/twpayne/chezmoi/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=10a27e4569c0cd6951a8509a39443f8a918d22d61db0026b78e88ef83fa43e04
 TERMUX_PKG_AUTO_UPDATE=true
@@ -29,11 +30,11 @@ termux_step_make_install() {
 		$TERMUX_PREFIX/share/zsh/site-functions \
 		$TERMUX_PREFIX/share/doc/chezmoi
 
-	install ${TERMUX_PKG_BUILDDIR}/src/github.com/twpayne/chezmoi/completions/chezmoi-completion.bash \
+	install -Dm600 ${TERMUX_PKG_BUILDDIR}/src/github.com/twpayne/chezmoi/completions/chezmoi-completion.bash \
 		$TERMUX_PREFIX/share/bash-completion/completions/chezmoi
-	install ${TERMUX_PKG_BUILDDIR}/src/github.com/twpayne/chezmoi/completions/chezmoi.fish \
-		$TERMUX_PREFIX/share/fish/completions/chezmoi.fish
-	install ${TERMUX_PKG_BUILDDIR}/src/github.com/twpayne/chezmoi/completions/chezmoi.zsh \
+	install -Dm600 ${TERMUX_PKG_BUILDDIR}/src/github.com/twpayne/chezmoi/completions/chezmoi.fish \
+		$TERMUX_PREFIX/share/fish/vendor_completions.d/chezmoi.fish
+	install -Dm600 ${TERMUX_PKG_BUILDDIR}/src/github.com/twpayne/chezmoi/completions/chezmoi.zsh \
 		$TERMUX_PREFIX/share/zsh/site-functions/_chezmoi
 
 	install ${TERMUX_PKG_BUILDDIR}/src/github.com/twpayne/chezmoi/docs/{FAQ,HOWTO,QUICKSTART,REFERENCE,TEMPLATING}.md \

--- a/packages/exa/build.sh
+++ b/packages/exa/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="A modern replacement for ls"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.10.1
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://github.com/ogham/exa/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=ff0fa0bfc4edef8bdbbb3cabe6fdbd5481a71abbbcc2159f402dea515353ae7c
 TERMUX_PKG_AUTO_UPDATE=true
@@ -28,14 +28,14 @@ termux_step_post_make_install() {
 		install -Dm600 completions/completions.bash \
 			$TERMUX_PREFIX/share/bash-completion/completions/exa
 		install -Dm600 completions/completions.fish \
-			$TERMUX_PREFIX/share/fish/completions/exa.fish
+			$TERMUX_PREFIX/share/fish/vendor_completions.d/exa.fish
 		install -Dm600 completions/completions.zsh \
 			$TERMUX_PREFIX/share/zsh/site-functions/_exa
 	else
 		install -Dm600 completions/bash/exa \
 			$TERMUX_PREFIX/share/bash-completion/completions/exa
 		install -Dm600 completions/fish/exa.fish \
-			$TERMUX_PREFIX/share/fish/completions/exa.fish
+			$TERMUX_PREFIX/share/fish/vendor_completions.d/exa.fish
 		install -Dm600 completions/zsh/_exa \
 			$TERMUX_PREFIX/share/zsh/site-functions/_exa
 	fi

--- a/packages/fish/build.sh
+++ b/packages/fish/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="The user-friendly command line shell"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.3.1
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=https://github.com/fish-shell/fish-shell/releases/download/$TERMUX_PKG_VERSION/fish-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=b5b4ee1a5269762cbbe993a4bd6507e675e4100ce9bbe84214a5eeb2b19fae89
 TERMUX_PKG_AUTO_UPDATE=true
@@ -11,11 +11,6 @@ TERMUX_PKG_AUTO_UPDATE=true
 # man is needed since fish calls apropos during command completion.
 TERMUX_PKG_DEPENDS="libc++, ncurses, libandroid-support, ncurses-utils, man, bc, pcre2, libandroid-spawn"
 TERMUX_PKG_BUILD_IN_SRC=true
-# Prevent clashing of shell completions
-TERMUX_PKG_RM_AFTER_INSTALL="
-share/fish/completions/rg.fish
-share/fish/completions/yadm.fish
-"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DBUILD_DOCS=OFF
 "

--- a/packages/lastpass-cli/build.sh
+++ b/packages/lastpass-cli/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="LastPass command line interface tool"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.3.3
-TERMUX_PKG_REVISION=6
+TERMUX_PKG_REVISION=7
 TERMUX_PKG_SRCURL=https://github.com/lastpass/lastpass-cli/archive/v$TERMUX_PKG_VERSION/lastpass-cli-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=f38e1ee7e06e660433a575a23b061c2f66ec666d746e988716b2c88de59aed73
 TERMUX_PKG_AUTO_UPDATE=true
@@ -17,5 +17,5 @@ termux_step_post_make_install() {
 		"$TERMUX_PREFIX"/share/zsh/site-functions/_lpass
 
 	install -Dm600 "$TERMUX_PKG_SRCDIR"/contrib/completions-lpass.fish \
-		"$TERMUX_PREFIX"/share/fish/completions/lpass.fish
+		"$TERMUX_PREFIX"/share/fish/vendor_completions.d/lpass.fish
 }

--- a/packages/lastpass-cli/process.c.patch
+++ b/packages/lastpass-cli/process.c.patch
@@ -1,0 +1,11 @@
+--- ./process.c.orig	2022-01-26 19:56:31.190775659 +0530
++++ ./process.c	2022-01-26 19:56:57.010775649 +0530
+@@ -75,6 +75,8 @@
+ 		   __attribute__((unused)) int w) {}
+ #endif
+ 
++int ARGC;
++char** ARGV;
+ 
+ #if defined(__linux__) || defined(__CYGWIN__) || (defined(__NetBSD__) && !defined(KERN_PROC_PATHNAME))
+ static int pid_to_cmd(pid_t pid, char *cmd, size_t cmd_size)

--- a/packages/lastpass-cli/process.h.patch
+++ b/packages/lastpass-cli/process.h.patch
@@ -1,0 +1,13 @@
+--- ./process.h.orig	2022-01-26 19:24:35.448787927 +0530
++++ ./process.h	2022-01-26 19:25:06.938787915 +0530
+@@ -4,8 +4,8 @@
+ #include <stdbool.h>
+ #include <sys/types.h>
+ 
+-int ARGC;
+-char **ARGV;
++extern int ARGC;
++extern char **ARGV;
+ 
+ void process_set_name(const char *name);
+ void process_disable_ptrace(void);

--- a/packages/nnn/build.sh
+++ b/packages/nnn/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Free, fast, friendly file browser"
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=4.4
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/jarun/nnn/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=e04a3f0f0c2af1e18cb6f005d18267c7703644274d21bb93f03b30e4fd3d1653
 TERMUX_PKG_AUTO_UPDATE=true
@@ -13,7 +14,7 @@ termux_step_post_make_install() {
 	install -Dm600 misc/auto-completion/bash/nnn-completion.bash \
 		$TERMUX_PREFIX/share/bash-completion/completions/nnn
 	install -Dm600 misc/auto-completion/fish/nnn.fish \
-		$TERMUX_PREFIX/share/fish/completions/nnn.fish
+		$TERMUX_PREFIX/share/fish/vendor_completions.d/nnn.fish
 	install -Dm600 misc/auto-completion/zsh/_nnn \
 		$TERMUX_PREFIX/share/zsh/site-functions/_nnn
 }

--- a/packages/pastel/build.sh
+++ b/packages/pastel/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="LICENSE-MIT, LICENSE-APACHE"
 TERMUX_PKG_MAINTAINER="Yaksh Bariya <yakshbari4@gmail.com>"
 TERMUX_PKG_VERSION=0.8.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/sharkdp/pastel/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=e1afcd8035a4c1da7f6d0fc8d5fc703dee72baa77bd0588a67d3b606e70146cb
 TERMUX_PKG_AUTO_UPDATE=true
@@ -26,5 +27,5 @@ termux_step_make_install() {
 	install -Dm600 $TERMUX_PKG_BUILDDIR/completions/pastel.bash \
 		$TERMUX_PREFIX/share/bash-completion/completions/pastel.bash
 	install -Dm600 $TERMUX_PKG_BUILDDIR/completions/pastel.fish \
-		$TERMUX_PREFIX/share/fish/completions/pastel.fish
+		$TERMUX_PREFIX/share/fish/vendor_completions.d/pastel.fish
 }

--- a/packages/ripgrep/build.sh
+++ b/packages/ripgrep/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Search tool like grep and The Silver Searcher"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=13.0.0
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/BurntSushi/ripgrep/archive/$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=0fb17aaf285b3eee8ddab17b833af1e190d73de317ff9648751ab0660d763ed2
 TERMUX_PKG_AUTO_UPDATE=true
@@ -22,7 +22,7 @@ termux_step_post_make_install() {
 
 	# Install fish completion script:
 	mkdir -p $TERMUX_PREFIX/share/fish/completions/
-	cp $(find . -name rg.fish) $TERMUX_PREFIX/share/fish/completions/
+	cp $(find . -name rg.fish) $TERMUX_PREFIX/share/fish/vendor_completions.d/
 
 	# Install zsh completion script:
 	mkdir -p $TERMUX_PREFIX/share/zsh/site-functions/

--- a/packages/yadm/build.sh
+++ b/packages/yadm/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Yet Another Dotfiles Manager"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.1.0
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/TheLocehiliosan/yadm/archive/$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=9f848c80deed2725c012d058bd60d1ea13539fd6fbacd5245bf97d442cb89263
 TERMUX_PKG_DEPENDS="git"
@@ -22,5 +22,5 @@ termux_step_make_install() {
 	install -Dm600 "$TERMUX_PKG_SRCDIR"/completion/zsh/_yadm \
 		"$TERMUX_PREFIX"/share/zsh/site-functions/_yadm
 	install -Dm600 "$TERMUX_PKG_SRCDIR"/completion/fish/yadm.fish \
-		"$TERMUX_PREFIX"/share/fish/completions/yadm.fish
+		"$TERMUX_PREFIX"/share/fish/vendor_completions.d/yadm.fish
 }


### PR DESCRIPTION
Currently we are installing package specific completions for fisg shell
in `$PREFIX/share/fish/completions` which is incorrect. This also fixes
completions from fish ahell conflicting with other packages'
completions.

TODO:
- [x] Do the same thing in x11-repo
- [x] Do the samw thing in root-repo
(No need. A quick `apt-file search` seems to say that there are no packages in these two repos which are messing this around)
