### PR TITLE
 CI: fix occasional dependency upload issue

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -134,16 +134,26 @@ jobs:
 
         if [ -f ./built_packages.txt ]; then
           ./scripts/lint-packages.sh $(cat ./built_packages.txt | awk '{print "packages/"$1"/build.sh"}')
-          ./scripts/run-docker.sh ./build-package.sh -o ./debs -I -a ${{ matrix.target_arch }} $(cat ./built_packages.txt)
+          ./scripts/run-docker.sh ./build-package.sh -I -a ${{ matrix.target_arch }} $(cat ./built_packages.txt)
         fi
 
-        test -d ./termux-packages/debs && mv ./termux-packages/debs/* ./debs/
+        mkdir -p debs
+        test -d termux-packages/output && mv termux-packages/output/* ./output/
+
         # Put package lists into directory with *.deb files so they will be transferred to
         # upload job.
         test -f ./built_packages.txt && mv ./built_packages.txt ./debs/
         test -f ./built_subpackages.txt && cat ./built_subpackages.txt >> ./debs/built_packages.txt \
           && rm ./built_subpackages.txt
         test -f ./deleted_packages.txt && mv ./deleted_packages.txt ./debs/
+
+        # Move only debs from built_packages into debs/ folder before
+        # creating an archive.
+        while read -r pkg; do
+          # Match both $pkg.deb and $pkg-static.deb.
+          find output \( -name "$pkg_*.deb" -o -name "$pkg-static_*.deb" \) -type f -print0 | xargs -0r mv -t debs/
+        done < <(cat ./debs/built_packages.txt)
+
         # Files containing certain symbols (e.g. ":") will cause failure in actions/upload-artifact.
         # Archiving *.deb files in a tarball to avoid issues with uploading.
         tar cf artifacts/debs-${{ matrix.target_arch }}-${{ github.sha }}.tar debs


### PR DESCRIPTION
Previously we were outputting built debs into ./debs instead of standard folder ./output.  We were also sorting built_packages.txt so that $(cat ./built_packages.txt) returned an alphabetically sorted list.

This caused issues for pushes that updated both a package and one or more of its dependencies, if the dependencies start with a letter that is later in the alphabet.

Latest example was libforestdb and libsnappy.  Libforestdb depends on libsnappy, but the buildorder as given to build-package.sh was "libforestdb libsnappy".  During the libforestdb build libsnappy was built first, but the deb put into the standard ./output folder (that's how our build system currently handles built dependency debs).  When build-package.sh then later tries building libsnappy it skips it since it has already been built.  We then end up with only libforestdb in the ./debs folder.

Fix this issue by putting all debs in ./output/, and then moving the once mentioned in built_packages.txt to ./debs/.

Fixes #8773.

(try it out on CI before merging)