### PR TITLE
new package: mold

### DIFF
--- a/packages/mold/build.sh
+++ b/packages/mold/build.sh
@@ -1,0 +1,43 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/rui314/mold
+TERMUX_PKG_DESCRIPTION="mold: A Modern Linker"
+TERMUX_PKG_LICENSE="AGPL-V3"
+TERMUX_PKG_MAINTAINER="@termux"
+_COMMIT=ce744aeca423954c9152a6c1c2185f149bf50ad8
+TERMUX_PKG_VERSION=1.0.3.20220212
+TERMUX_PKG_SRCURL=https://github.com/rui314/mold.git
+TERMUX_PKG_GIT_BRANCH=main
+TERMUX_PKG_DEPENDS="libc++, openssl, zlib, libandroid-spawn"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_post_get_source() {
+	git fetch --unshallow
+	git reset --hard ${_COMMIT}
+}
+
+termux_step_pre_configure() {
+	# onetbb use cmake
+	termux_setup_cmake
+}
+
+termux_step_make() {
+	# Have to override Makefile variables here
+	# else need to patch Makefile
+	# When building mold-wrapper.so cant find
+	# spawn.h from libandroid-spawn for some reason
+	# Manually link just in case to avoid runtime surprises
+	make -j ${TERMUX_MAKE_PROCESSES} \
+		PREFIX="${TERMUX_PREFIX}" \
+		CFLAGS="${CFLAGS} -I${TERMUX_PREFIX}/include" \
+		CXXFLAGS="${CXXFLAGS}" \
+		STRIP="${STRIP}" \
+		MOLD_WRAPPER_LDFLAGS=" -ldl -landroid-spawn"
+}
+
+termux_step_make_install() {
+	make -j 1 install \
+		PREFIX="${TERMUX_PREFIX}" \
+		CFLAGS="${CFLAGS} -I${TERMUX_PREFIX}/include" \
+		CXXFLAGS="${CXXFLAGS}" \
+		STRIP="${STRIP}" \
+		MOLD_WRAPPER_LDFLAGS=" -ldl -landroid-spawn"
+}


### PR DESCRIPTION
TLDR mold is likely to be faster than lld at linking phase. Downside seems to be producing a bit larger binary (and missing LTO support, etc) at the moment. Currently use the latest main branch to allow working with clang. Note that I have no idea whether it works on ARM or not since others reported to upstream its not building for Linux ARM.

Fun fact: mold and lld are created by the same person.

Example of usage:
```
~/bin $ cat hello.c
#include <stdio.h>

int main(void) {
        puts("Hello world!");
        return 0;
}
~/bin $ time cc hello.c -o hello-lld

real    0m0.445s
user    0m0.164s
sys     0m0.280s
~/bin $ time cc hello.c -o hello-mold -fuse-ld=mold

real    0m0.420s
user    0m0.136s
sys     0m0.208s
~/bin $ readelf -p .comment hello-lld

String dump of section '.comment':
  [     0]  Android (7714059, based on r416183c1) clang version 12.0.8 (https://android.googlesource.com/toolchain/llvm-project c935d99d7cf2016289302412d708641d52d2f7ee)
  [    9e]  Linker: LLD 13.0.0
  [    b1]  clang version 13.0.0
~/bin $ readelf -p .comment hello-mold

String dump of section '.comment':
  [     0]  Android (7714059, based on r416183c1) clang version 12.0.8 (https://android.googlesource.com/toolchain/llvm-project c935d99d7cf2016289302412d708641d52d2f7ee)
  [    9e]  clang version 13.0.0
  [    b3]  mold 1.0.3 (07a480c43c990a280eea8aa71bad1e82663e0715; compatible with GNU ld)

~/bin $ du hello-lld hello-mold
12      hello-lld
40      hello-mold
~/bin $ strip hello-lld hello-mold
~/bin $ du hello-lld hello-mold
12      hello-lld
20      hello-mold
```