### PR TITLE
python: Add binutils to `TERMUX_PKG_RECOMMENDS`

### DIFF
--- a/packages/python/build.sh
+++ b/packages/python/build.sh
@@ -4,10 +4,11 @@ TERMUX_PKG_LICENSE="PythonPL"
 TERMUX_PKG_MAINTAINER="@termux"
 _MAJOR_VERSION=3.10
 TERMUX_PKG_VERSION=${_MAJOR_VERSION}.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.python.org/ftp/python/${TERMUX_PKG_VERSION}/Python-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=17de3ac7da9f2519aa9d64378c603a73a0e9ad58dffa8812e45160c086de64c7
 TERMUX_PKG_DEPENDS="gdbm, libandroid-support, libbz2, libcrypt, libexpat, libffi, liblzma, libsqlite, ncurses, ncurses-ui-libs, openssl, readline, zlib"
-TERMUX_PKG_RECOMMENDS="clang, make, pkg-config"
+TERMUX_PKG_RECOMMENDS="binutils, clang, make, pkg-config"
 TERMUX_PKG_SUGGESTS="python-tkinter"
 TERMUX_PKG_BREAKS="python2 (<= 2.7.15), python-dev"
 TERMUX_PKG_REPLACES="python-dev"


### PR DESCRIPTION
The script `$PREFIX/lib/python3.10/ctypes/util.py` hardcodes command
names from binutils such as `ld` and `objdump`. Ideally we could use
alternative commands coming from Clang/LLVM toolchain.

Closes #8478.