### PR TITLE
aapt, aidl: depend on googletest package

### DIFF
--- a/packages/aapt/aidl.subpackage.sh
+++ b/packages/aapt/aidl.subpackage.sh
@@ -1,3 +1,3 @@
 TERMUX_SUBPKG_INCLUDE="bin/aidl"
 TERMUX_SUBPKG_DESCRIPTION="Android Interface Definition Language (AIDL)"
-TERMUX_SUBPKG_DEPENDS="libgtest"
+TERMUX_SUBPKG_DEPENDS="googletest"

--- a/packages/aapt/build.sh
+++ b/packages/aapt/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _TAG_VERSION=12.0.0
 _TAG_REVISION=27
 TERMUX_PKG_VERSION=${_TAG_VERSION}.${_TAG_REVISION}
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=(https://android.googlesource.com/platform/frameworks/base
                    https://android.googlesource.com/platform/system/core
                    https://android.googlesource.com/platform/system/libbase
@@ -25,7 +26,7 @@ TERMUX_PKG_SHA256=(SKIP_CHECKSUM
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_DEPENDS="libc++, libexpat, libpng, libzopfli, zlib"
-TERMUX_PKG_BUILD_DEPENDS="fmt, libgtest"
+TERMUX_PKG_BUILD_DEPENDS="fmt, googletest"
 TERMUX_PKG_HOSTBUILD=true
 
 termux_step_post_get_source() {

--- a/packages/libgtest/build.sh
+++ b/packages/libgtest/build.sh
@@ -1,9 +1,0 @@
-TERMUX_PKG_HOMEPAGE=https://google.github.io/googletest/
-TERMUX_PKG_DESCRIPTION="Google Testing and Mocking Framework"
-TERMUX_PKG_LICENSE="BSD 3-Clause"
-TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1.11.0
-TERMUX_PKG_SRCURL=https://github.com/google/googletest/archive/refs/tags/release-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5
-TERMUX_PKG_DEPENDS="libc++"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DBUILD_SHARED_LIBS=ON"


### PR DESCRIPTION
Fixes #8961 

`libgtest` and `googletest` are exactly the same package. and we can only have one, resulting a conflict error in dpkg