### PR TITLE
debianutils: update to 5.7

### DIFF
--- a/packages/debianutils/build.sh
+++ b/packages/debianutils/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://packages.debian.org/debianutils
 TERMUX_PKG_DESCRIPTION="Small utilities which are used primarily by the installation scripts of Debian packages"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=5.5
-TERMUX_PKG_SRCURL=http://ftp.debian.org/debian/pool/main/d/debianutils/debianutils_${TERMUX_PKG_VERSION}.orig.tar.xz
-TERMUX_PKG_SHA256=2b0fad5c00eb2b8461523b2950e6f06e6ddbb0ac3384c5a3377867d51098d102
+TERMUX_PKG_VERSION=5.7
+TERMUX_PKG_SRCURL=https://ftp.debian.org/debian/pool/main/d/debianutils/debianutils_${TERMUX_PKG_VERSION}.orig.tar.gz
+TERMUX_PKG_SHA256=27ec9e0e7e44dc8ab611aa576330471bacb07e4491ffecf0d3aa6909c92f9022
 
 TERMUX_PKG_RM_AFTER_INSTALL="
 bin/add-shell


### PR DESCRIPTION
debianutils 5.5 now returns 404
Also seems like debianutils 5.7 only available in tar.gz
Also switch the source URL to https