### PR TITLE
rip: fix `/tmp` directory path

### DIFF
--- a/packages/rip/build.sh
+++ b/packages/rip/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A command-line deletion tool focused on safety, ergonomi
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.13.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/nivekuil/rip.git
 TERMUX_PKG_GIT_BRANCH="${TERMUX_PKG_VERSION}"
 TERMUX_PKG_BUILD_IN_SRC=true

--- a/packages/rip/src-main.rs.patch
+++ b/packages/rip/src-main.rs.patch
@@ -1,0 +1,11 @@
+--- ./src/main.rs.bak	2022-02-18 01:48:31.328900348 +0530
++++ ./src/main.rs	2022-02-18 01:49:09.720900351 +0530
+@@ -20,7 +20,7 @@
+ 
+ include!("util.rs");
+ 
+-const GRAVEYARD: &'static str = "/tmp/graveyard";
++const GRAVEYARD: &'static str = "@TERMUX_PREFIX@/tmp/graveyard";
+ const RECORD: &'static str = ".record";
+ const LINES_TO_INSPECT: usize = 6;
+ const FILES_TO_INSPECT: usize = 6;


### PR DESCRIPTION
Fixes the following error when running `rip something`:
```error: Failed to bury file
caused by: Failed to move /data/data/com.termux/files/home/something to /tmp/graveyard-u0_a427/data/data/com.termux/files/home/something
caused by: No such file or directory (os error 2)
```

Signed-off-by: PeroSar <perosar1111@gmail.com>