### PR TITLE
m4: Mitigate temp file issue on 32-bit archs

### DIFF
--- a/packages/m4/build.sh
+++ b/packages/m4/build.sh
@@ -3,14 +3,16 @@ TERMUX_PKG_DESCRIPTION="Traditional Unix macro processor"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.4.19
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/m4/m4-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=63aede5c6d33b6d9b13511cd0be2cac046f2e70fd0a07aa9573a04a82783af96
-TERMUX_PKG_DEPENDS="libandroid-spawn"
+TERMUX_PKG_BUILD_DEPENDS="libandroid-spawn"
 TERMUX_PKG_GROUPS="base-devel"
 TERMUX_PKG_EXTRA_MAKE_ARGS="
 HELP2MAN=:
 "
+# Avoid automagic dependency on libiconv
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" am_cv_func_iconv=no"
 
 termux_step_pre_configure() {
 	CPPFLAGS+=" -D__USE_FORTIFY_LEVEL=0"

--- a/packages/m4/src-output.c.patch
+++ b/packages/m4/src-output.c.patch
@@ -1,0 +1,15 @@
+--- a/src/output.c
++++ b/src/output.c
+@@ -423,8 +423,12 @@
+ 
+   /* Check if we are exceeding the maximum amount of buffer memory.  */
+ 
++#if defined __ANDROID__ && !defined __LP64__
++  if (0)
++#else
+   if (total_buffer_size - output_diversion->size + wanted_size
+       > MAXIMUM_TOTAL_SIZE)
++#endif
+     {
+       int selected_used;
+       char *selected_buffer;


### PR DESCRIPTION
Allocates *indefinite* amount of in-memory buffer.

Mitigates #9056.