### PR TITLE
ffmpeg: Backport patch for VP9 DTS correction

### DIFF
--- a/packages/ffmpeg/build.sh
+++ b/packages/ffmpeg/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # NOTE: mpv has to be rebuilt and version bumped after updating ffmpeg.
 TERMUX_PKG_VERSION=5.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.ffmpeg.org/releases/ffmpeg-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=51e919f7d205062c0fd4fae6243a84850391115104ccf1efc451733bc0ac7298
 TERMUX_PKG_DEPENDS="libaom, libass, libbz2, libdav1d, libiconv, librav1e, libsoxr, libx264, libx265, xvidcore, libvorbis, libmp3lame, libopus, libvpx, libgnutls, libandroid-glob, freetype, zlib, liblzma, libvidstab, libwebp, libxml2"

--- a/packages/ffmpeg/ffmpeg-5.0-vp9-dts-correction.patch
+++ b/packages/ffmpeg/ffmpeg-5.0-vp9-dts-correction.patch
@@ -1,0 +1,36 @@
+From 68595b46cb374658432fff998e82e5ff434557ac Mon Sep 17 00:00:00 2001
+From: Danny Wu <admin@glados.cc>
+Date: Wed, 12 May 2021 08:51:13 -0400
+Subject: [PATCH] fftools/ffmpeg: Restore DTS correction for VP9 copies
+
+Fixes ticket 9086.
+
+Since early 2021, some of YouTube's VP9 encodes have non-monotonous DTS.
+This makes ffmpeg fatally fail when trying to copy or encode the V9 video.
+
+ffmpeg already includes functionality to correct this, however it was
+disabled without explanation for VP9 stream copies in
+2e6636aa87303d37b112e79f093ca39500f92364
+
+This patch restores the DTS correction logic, and allows ffmpeg to correctly
+encode (invalid) videos produced by youtube.com. I have verified that frames
+are NOT being cut (so it does not re-introduce 4313).
+
+Reviwed-by: Ronald S. Bultje <rsbultje@gmail.com>
+Signed-off-by: James Almer <jamrial@gmail.com>
+---
+ fftools/ffmpeg.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/fftools/ffmpeg.c b/fftools/ffmpeg.c
+index d909fa58a7ff..7beea119333f 100644
+--- a/fftools/ffmpeg.c
++++ b/fftools/ffmpeg.c
+@@ -812,7 +812,6 @@ static void write_packet(OutputFile *of, AVPacket *pkt, OutputStream *ost, int u
+         }
+         if ((st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO || st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO || st->codecpar->codec_type == AVMEDIA_TYPE_SUBTITLE) &&
+             pkt->dts != AV_NOPTS_VALUE &&
+-            !(st->codecpar->codec_id == AV_CODEC_ID_VP9 && ost->stream_copy) &&
+             ost->last_mux_dts != AV_NOPTS_VALUE) {
+             int64_t max = ost->last_mux_dts + !(s->oformat->flags & AVFMT_TS_NONSTRICT);
+             if (pkt->dts < max) {


### PR DESCRIPTION
from https://github.com/FFmpeg/FFmpeg/commit/68595b46cb374658432fff998e82e5ff434557ac.

Closes #9115.