### PR TITLE
rsync: Bump revision to rebuild

### DIFF
--- a/packages/rsync/build.sh
+++ b/packages/rsync/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="Utility that provides fast incremental file transfer"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.2.3
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://rsync.samba.org/ftp/rsync/src/rsync-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=becc3c504ceea499f4167a260040ccf4d9f2ef9499ad5683c179a697146ce50e
-TERMUX_PKG_DEPENDS="libiconv, liblz4, libpopt, openssh | dropbear, openssl-tool, zlib, zstd"
+TERMUX_PKG_DEPENDS="libiconv, liblz4, libpopt, openssh | dropbear, openssl, openssl-tool, zlib, zstd"
 TERMUX_PKG_BUILD_IN_SRC=true
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="


### PR DESCRIPTION
and add `openssl` to `TERMUX_PKG_DEPENDS`.

Closes #9167.