### PR TITLE
stylua: enable lua52 & luau support

### DIFF
--- a/packages/stylua/build.sh
+++ b/packages/stylua/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="An opinionated Lua code formatter"
 TERMUX_PKG_LICENSE="MPL-2.0"
 TERMUX_PKG_MAINTAINER="@shadmansaleh"
 TERMUX_PKG_VERSION=0.12.4
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/JohnnyMorganz/StyLua/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=ce6b4a6767b17f8d609e8c9d666c5f6f5c2863edd0638e70392bfe55f99b4fd0
 TERMUX_PKG_AUTO_UPDATE=true
@@ -10,7 +11,8 @@ TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_make() {
 	termux_setup_rust
-	cargo build --jobs $TERMUX_MAKE_PROCESSES --target $CARGO_TARGET_NAME --release
+	cargo build --jobs $TERMUX_MAKE_PROCESSES --target $CARGO_TARGET_NAME --release --all-features
+
 }
 
 termux_step_make_install() {


### PR DESCRIPTION
Enabling lua5.2 and lua [feature flags](https://github.com/JohnnyMorganz/StyLua#from-cratesio) in stylua

Without lua52 feature enabled stylua fails to parse lua 5.2 specific syntaxes . Also stylua releases are built with `--all-features`   https://github.com/JohnnyMorganz/StyLua/blob/49436232d9b3450ef818a0f434413dd7eba6e6d4/.github/workflows/release.yml#L54