### PR TITLE
ndk-sysroot: bump version after ndk-patches is modified

### DIFF
--- a/packages/ndk-sysroot/build.sh
+++ b/packages/ndk-sysroot/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="System header and library files from the Android NDK nee
 TERMUX_PKG_LICENSE="NCSA"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=$TERMUX_NDK_VERSION
-TERMUX_PKG_REVISION=4
+TERMUX_PKG_REVISION=5
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
 # This package has taken over <pty.h> from the previous libutil-dev
 # and iconv.h from libandroid-support-dev:


### PR DESCRIPTION
The patch of function `wait3` has been removed from the standalone toolchain, a new version of `ndk-sysroot` should be bumped.