### PR TITLE
nsis: Create symlink to `makensis` from `bin/`

### DIFF
--- a/packages/nsis/build.sh
+++ b/packages/nsis/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.08
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://prdownloads.sourceforge.net/nsis/nsis-${TERMUX_PKG_VERSION}-src.tar.bz2
 TERMUX_PKG_SHA256=a85270ad5386182abecb2470e3d7e9bec9fe4efd95210b13551cb386830d1e87
 TERMUX_PKG_DEPENDS="libandroid-support, libc++, libiconv, zlib"
@@ -23,4 +24,8 @@ termux_step_make_install() {
 		NSIS_CONFIG_CONST_DATA_PATH=no \
 		PREFIX="$TERMUX_PREFIX/opt/nsis" \
 		install-compiler
+}
+
+termux_step_post_make_install() {
+	ln -sf $TERMUX_PREFIX/opt/nsis/makensis $TERMUX_PREFIX/bin/
 }


### PR DESCRIPTION
so that `command-not-found` can find it.

Closes https://github.com/termux/command-not-found/issues/10.