### PR TITLE
gst-plugins-base: Remove `include/KHR` after install

### DIFF
--- a/packages/gst-plugins-base/build.sh
+++ b/packages/gst-plugins-base/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="GStreamer base plug-ins"
 TERMUX_PKG_LICENSE="LGPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.20.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=4cb66fccf730b1037e6533862c2128990912a6db4e5bbd14e0ef914450eb4c7c
 TERMUX_PKG_DEPENDS="gstreamer, libandroid-shmem, libjpeg-turbo, libopus, libpng, libvorbis, zlib"
@@ -15,7 +16,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 "
 
 # Conflicts with Mesa.
-TERMUX_PKG_RM_AFTER_INSTALL="include/GL"
+TERMUX_PKG_RM_AFTER_INSTALL="include/GL include/KHR"
 
 termux_step_pre_configure() {
 	LDFLAGS+=" -landroid-shmem"


### PR DESCRIPTION
Fixes #9407.