### PR TITLE
golang: Update to 1.18

### DIFF
--- a/packages/golang/build.sh
+++ b/packages/golang/build.sh
@@ -2,11 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://golang.org/
 TERMUX_PKG_DESCRIPTION="Go programming language compiler"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
-_MAJOR_VERSION=1.17.8
+_MAJOR_VERSION=1.18
 # Use the ~ deb versioning construct in the future:
 TERMUX_PKG_VERSION=3:${_MAJOR_VERSION}
 TERMUX_PKG_SRCURL=https://storage.googleapis.com/golang/go${_MAJOR_VERSION}.src.tar.gz
-TERMUX_PKG_SHA256=2effcd898140da79a061f3784ca4f8d8b13d811fb2abe9dad2404442dabbdf7a
+TERMUX_PKG_SHA256=38f423db4cc834883f2b52344282fa7a39fbb93650dc62a11fdf0be6409bdad6
 TERMUX_PKG_DEPENDS="clang"
 TERMUX_PKG_NO_STATICSPLIT=true
 

--- a/scripts/build/setup/termux_setup_golang.sh
+++ b/scripts/build/setup/termux_setup_golang.sh
@@ -1,7 +1,7 @@
 # Utility function for golang-using packages to setup a go toolchain.
 termux_setup_golang() {
 	if [ "$TERMUX_ON_DEVICE_BUILD" = "false" ]; then
-		local TERMUX_GO_VERSION=go1.17.8
+		local TERMUX_GO_VERSION=go1.18
 		local TERMUX_GO_PLATFORM=linux-amd64
 
 		local TERMUX_BUILDGO_FOLDER
@@ -20,7 +20,7 @@ termux_setup_golang() {
 		rm -Rf "$TERMUX_COMMON_CACHEDIR/go" "$TERMUX_BUILDGO_FOLDER"
 		termux_download https://golang.org/dl/${TERMUX_GO_VERSION}.${TERMUX_GO_PLATFORM}.tar.gz \
 			"$TERMUX_BUILDGO_TAR" \
-			980e65a863377e69fd9b67df9d8395fd8e93858e7a24c9f55803421e453f4f99
+			e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f
 
 		( cd "$TERMUX_COMMON_CACHEDIR"; tar xf "$TERMUX_BUILDGO_TAR"; mv go "$TERMUX_BUILDGO_FOLDER"; rm "$TERMUX_BUILDGO_TAR" )
 	else


### PR DESCRIPTION
We should take a bit extra care when merging this because it is known to break build of some packages: https://bugs.gentoo.org/835378.

It is true that `golang` is at most only a build dependency for every other package and therefore is not going to break existing binary packages. But I just want to avoid extra work to adapt other packages to Go 1.18 on my own. As Go 1.17.x is still being supported, I insist we wait at least one ~~month~~ week before merging Go 1.18.