### PR TITLE
nodejs-lts: update to v16.14.2

### DIFF
--- a/packages/nodejs-lts/avoid-ficlone-ioctl.patch
+++ b/packages/nodejs-lts/avoid-ficlone-ioctl.patch
@@ -1,8 +1,7 @@
-
-diff -uNr ./deps/uv/src/unix/fs.c ./deps/uv/src/unix/fs.c.mod
---- ./deps/uv/src/unix/fs.c	2021-06-03 07:15:30.000000000 +0530
-+++ ./deps/uv/src/unix/fs.c.mod	2021-06-18 20:05:49.675642773 +0530
-@@ -1247,6 +1247,7 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/deps/uv/src/unix/fs.c node-v16.14.2/deps/uv/src/unix/fs.c
+--- node-v16.14.2.orig/deps/uv/src/unix/fs.c	2022-03-18 15:06:20.191091189 +0530
++++ node-v16.14.2/deps/uv/src/unix/fs.c	2022-03-18 15:07:35.021091161 +0530
+@@ -1339,6 +1339,7 @@
  #endif  /* !__linux__ */
    }
  
@@ -10,7 +9,7 @@ diff -uNr ./deps/uv/src/unix/fs.c ./deps/uv/src/unix/fs.c.mod
  #ifdef FICLONE
    if (req->flags & UV_FS_COPYFILE_FICLONE ||
        req->flags & UV_FS_COPYFILE_FICLONE_FORCE) {
-@@ -1267,6 +1268,7 @@
+@@ -1359,6 +1360,7 @@
      goto out;
    }
  #endif

--- a/packages/nodejs-lts/build.sh
+++ b/packages/nodejs-lts/build.sh
@@ -2,10 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://nodejs.org/
 TERMUX_PKG_DESCRIPTION="Open Source, cross-platform JavaScript runtime environment"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Yaksh Bariya <yakshbari4@gmail.com>"
-TERMUX_PKG_VERSION=16.14.0
-TERMUX_PKG_REVISION=4
+TERMUX_PKG_VERSION=16.14.2
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=05eb64193e391fa8a2c159c0f60c171824715165f80c67fcab9dbc944e30c623
+TERMUX_PKG_SHA256=e922e215cc68eb5f94d33e8a0b61e2c863b7731cc8600ab955d3822da90ff8d1
 # Note that we do not use a shared libuv to avoid an issue with the Android
 # linker, which does not use symbols of linked shared libraries when resolving
 # symbols on dlopen(). See https://github.com/termux/termux-packages/issues/462.

--- a/packages/nodejs-lts/deps-uv-src-unix-core.c.patch
+++ b/packages/nodejs-lts/deps-uv-src-unix-core.c.patch
@@ -1,7 +1,7 @@
-diff -uNr ./deps/uv/src/unix/core.c ./deps/uv/src/unix/core.c.mod
---- ./deps/uv/src/unix/core.c	2021-06-03 07:15:30.000000000 +0530
-+++ ./deps/uv/src/unix/core.c.mod	2021-06-18 20:10:13.705642672 +0530
-@@ -1116,7 +1116,7 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/deps/uv/src/unix/core.c node-v16.14.2/deps/uv/src/unix/core.c
+--- node-v16.14.2.orig/deps/uv/src/unix/core.c	2022-03-18 15:06:20.191091189 +0530
++++ node-v16.14.2/deps/uv/src/unix/core.c	2022-03-18 15:07:54.421091153 +0530
+@@ -1125,7 +1125,7 @@
  
    /* No temp environment variables defined */
    #if defined(__ANDROID__)

--- a/packages/nodejs-lts/deps-uv-src-unix-process.c.patch
+++ b/packages/nodejs-lts/deps-uv-src-unix-process.c.patch
@@ -1,6 +1,7 @@
---- ./deps/uv/src/unix/process.c	2021-09-10 22:55:12.000000000 +0530
-+++ ./deps/uv/src/unix/process.c.mod	2021-09-11 10:27:22.239600280 +0530
-@@ -283,23 +283,6 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/deps/uv/src/unix/process.c node-v16.14.2/deps/uv/src/unix/process.c
+--- node-v16.14.2.orig/deps/uv/src/unix/process.c	2022-03-18 15:06:20.201091189 +0530
++++ node-v16.14.2/deps/uv/src/unix/process.c	2022-03-18 15:08:12.121091146 +0530
+@@ -303,23 +303,6 @@
    if (options->cwd != NULL && chdir(options->cwd))
      uv__write_errno(error_fd);
  

--- a/packages/nodejs-lts/deps-uv-uv.gyp.patch
+++ b/packages/nodejs-lts/deps-uv-uv.gyp.patch
@@ -1,5 +1,6 @@
---- ./deps/uv/uv.gyp	2021-09-12 08:37:13.451586303 +0530
-+++ ./deps/uv/uv.gyp.mod	2021-09-12 08:37:58.344924108 +0530
+diff '--color=auto' -uNr node-v16.14.2.orig/deps/uv/uv.gyp node-v16.14.2/deps/uv/uv.gyp
+--- node-v16.14.2.orig/deps/uv/uv.gyp	2022-03-18 15:06:20.271091189 +0530
++++ node-v16.14.2/deps/uv/uv.gyp	2022-03-18 15:08:18.801091144 +0530
 @@ -40,7 +40,7 @@
      {
        'target_name': 'libuv',
@@ -18,11 +19,11 @@
          'conditions': [
            ['OS == "linux"', {
              'defines': [ '_POSIX_C_SOURCE=200112' ],
-@@ -262,6 +262,7 @@
+@@ -247,6 +247,7 @@
              'src/unix/procfs-exepath.c',
              'src/unix/random-getrandom.c',
              'src/unix/random-sysctl-linux.c',
 +            'src/unix/epoll.c',
            ],
            'link_settings': {
-             'libraries': [ '-ldl' ],
+             'libraries': [ '-ldl', '-lrt' ],

--- a/packages/nodejs-lts/deps-v8-src-flags-flag-definitions.h.patch
+++ b/packages/nodejs-lts/deps-v8-src-flags-flag-definitions.h.patch
@@ -1,6 +1,7 @@
---- ./deps/v8/src/flags/flag-definitions.h	2021-06-03 07:15:31.000000000 +0530
-+++ ./deps/v8/src/flags/flag-definitions.h.mod	2021-06-18 20:24:38.915642342 +0530
-@@ -1842,7 +1842,7 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/deps/v8/src/flags/flag-definitions.h node-v16.14.2/deps/v8/src/flags/flag-definitions.h
+--- node-v16.14.2.orig/deps/v8/src/flags/flag-definitions.h	2022-03-18 15:06:21.241091189 +0530
++++ node-v16.14.2/deps/v8/src/flags/flag-definitions.h	2022-03-18 15:08:21.471091143 +0530
+@@ -1980,7 +1980,7 @@
  #undef DEFINE_PERF_PROF_BOOL
  #undef DEFINE_PERF_PROF_IMPLICATION
  

--- a/packages/nodejs-lts/deps-v8-src-logging-log.cc.patch
+++ b/packages/nodejs-lts/deps-v8-src-logging-log.cc.patch
@@ -1,6 +1,7 @@
---- ./deps/v8/src/logging/log.cc	2021-06-03 07:15:31.000000000 +0530
-+++ ./deps/v8/src/logging/log.cc.mod	2021-06-18 20:27:34.605642275 +0530
-@@ -291,7 +291,7 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/deps/v8/src/logging/log.cc node-v16.14.2/deps/v8/src/logging/log.cc
+--- node-v16.14.2.orig/deps/v8/src/logging/log.cc	2022-03-18 15:06:21.641091189 +0530
++++ node-v16.14.2/deps/v8/src/logging/log.cc	2022-03-18 15:08:24.351091142 +0530
+@@ -308,7 +308,7 @@
    FILE* perf_output_handle_;
  };
  

--- a/packages/nodejs-lts/deps-v8-src-trap-handler-trap-handler.h.patch
+++ b/packages/nodejs-lts/deps-v8-src-trap-handler-trap-handler.h.patch
@@ -1,5 +1,6 @@
---- ./deps/v8/src/trap-handler/trap-handler.h	2021-10-08 19:08:46.000000000 +0530
-+++ ./deps/v8/src/trap-handler/trap-handler.h.mod	2021-10-09 19:43:08.715641214 +0530
+diff '--color=auto' -uNr node-v16.14.2.orig/deps/v8/src/trap-handler/trap-handler.h node-v16.14.2/deps/v8/src/trap-handler/trap-handler.h
+--- node-v16.14.2.orig/deps/v8/src/trap-handler/trap-handler.h	2022-03-18 15:06:22.041091188 +0530
++++ node-v16.14.2/deps/v8/src/trap-handler/trap-handler.h	2022-03-18 15:08:37.101091137 +0530
 @@ -17,22 +17,7 @@
  namespace internal {
  namespace trap_handler {

--- a/packages/nodejs-lts/fix_multiple_definitions.patch
+++ b/packages/nodejs-lts/fix_multiple_definitions.patch
@@ -1,5 +1,6 @@
---- ./deps/uv/src/unix/sysinfo-memory.c	2021-06-03 07:15:30.000000000 +0530
-+++ ./deps/uv/src/unix/sysinfo-memory.c.mod	2021-06-18 20:31:00.255642197 +0530
+diff '--color=auto' -uNr node-v16.14.2.orig/deps/uv/src/unix/sysinfo-memory.c node-v16.14.2/deps/uv/src/unix/sysinfo-memory.c
+--- node-v16.14.2.orig/deps/uv/src/unix/sysinfo-memory.c	2022-03-18 15:06:20.201091189 +0530
++++ node-v16.14.2/deps/uv/src/unix/sysinfo-memory.c	2022-03-18 15:08:41.551091135 +0530
 @@ -25,6 +25,7 @@
  #include <stdint.h>
  #include <sys/sysinfo.h>

--- a/packages/nodejs-lts/lib-child_process.js.patch
+++ b/packages/nodejs-lts/lib-child_process.js.patch
@@ -1,6 +1,7 @@
---- ./lib/child_process.js	2021-06-03 07:15:32.000000000 +0530
-+++ ./lib/child_process.js.mod	2021-06-18 20:32:47.215642156 +0530
-@@ -520,7 +520,7 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/lib/child_process.js node-v16.14.2/lib/child_process.js
+--- node-v16.14.2.orig/lib/child_process.js	2022-03-18 15:06:23.711091188 +0530
++++ node-v16.14.2/lib/child_process.js	2022-03-18 15:08:43.931091134 +0530
+@@ -589,7 +589,7 @@
        if (typeof options.shell === 'string')
          file = options.shell;
        else if (process.platform === 'android')

--- a/packages/nodejs-lts/lib-os.js.patch
+++ b/packages/nodejs-lts/lib-os.js.patch
@@ -1,5 +1,6 @@
---- ./lib/os.js	2021-06-03 07:15:32.000000000 +0530
-+++ ./lib/os.js.mod	2021-06-18 20:34:28.215642118 +0530
+diff '--color=auto' -uNr node-v16.14.2.orig/lib/os.js node-v16.14.2/lib/os.js
+--- node-v16.14.2.orig/lib/os.js	2022-03-18 15:06:23.831091188 +0530
++++ node-v16.14.2/lib/os.js	2022-03-18 15:08:46.251091133 +0530
 @@ -183,7 +183,7 @@
      path = safeGetenv('TMPDIR') ||
             safeGetenv('TMP') ||

--- a/packages/nodejs-lts/node.gyp.patch
+++ b/packages/nodejs-lts/node.gyp.patch
@@ -1,6 +1,7 @@
---- ./node.gyp.orig	2021-09-13 15:57:45.411848965 +0530
-+++ ./node.gyp	2021-09-13 15:58:53.811848939 +0530
-@@ -340,6 +340,7 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/node.gyp node-v16.14.2/node.gyp
+--- node-v16.14.2.orig/node.gyp	2022-03-18 15:06:23.851091188 +0530
++++ node-v16.14.2/node.gyp	2022-03-18 15:08:48.671091132 +0530
+@@ -353,6 +353,7 @@
  
        'include_dirs': [
          'src',
@@ -8,7 +9,7 @@
          '<(SHARED_INTERMEDIATE_DIR)' # for node_natives.h
        ],
        'dependencies': [
-@@ -1061,162 +1062,6 @@
+@@ -1075,162 +1076,6 @@
          }],
        ],
      }, # fuzz_env
@@ -171,7 +172,7 @@
  
      {
        'target_name': 'overlapped-checker',
-@@ -1295,59 +1140,13 @@
+@@ -1309,59 +1154,13 @@
              'Ws2_32.lib',
            ],
          }],

--- a/packages/nodejs-lts/src-debug_utils.cc.patch
+++ b/packages/nodejs-lts/src-debug_utils.cc.patch
@@ -1,5 +1,6 @@
---- ./src/debug_utils.cc	2021-09-10 22:55:14.000000000 +0530
-+++ ./src/debug_utils.cc.mod	2021-09-15 13:24:35.606133999 +0530
+diff '--color=auto' -uNr node-v16.14.2.orig/src/debug_utils.cc node-v16.14.2/src/debug_utils.cc
+--- node-v16.14.2.orig/src/debug_utils.cc	2022-03-18 15:06:23.901091188 +0530
++++ node-v16.14.2/src/debug_utils.cc	2022-03-18 15:08:50.991091132 +0530
 @@ -500,7 +500,7 @@
  
    WriteConsoleW(handle, wbuf.data(), n, nullptr, nullptr);

--- a/packages/nodejs-lts/src-node_internals.h.patch
+++ b/packages/nodejs-lts/src-node_internals.h.patch
@@ -1,11 +1,12 @@
---- ./src/node_internals.h	2021-06-03 07:15:32.000000000 +0530
-+++ ./src/node_internals.h.mod	2021-06-18 20:49:41.375641769 +0530
-@@ -286,7 +286,7 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/src/node_internals.h node-v16.14.2/src/node_internals.h
+--- node-v16.14.2.orig/src/node_internals.h	2022-03-18 15:06:23.951091188 +0530
++++ node-v16.14.2/src/node_internals.h	2022-03-18 15:08:53.321091131 +0530
+@@ -281,7 +281,7 @@
  
  // Functions defined in node.cc that are exposed via the bootstrapper object
  
 -#if defined(__POSIX__) && !defined(__ANDROID__) && !defined(__CloudABI__)
 +#if defined(__POSIX__) && !defined(__CloudABI__)
  #define NODE_IMPLEMENTS_POSIX_CREDENTIALS 1
- #endif  // __POSIX__ && !defined(__ANDROID__) && !defined(__CloudABI__)
+ #endif  // defined(__POSIX__) && !defined(__ANDROID__) && !defined(__CloudABI__)
  

--- a/packages/nodejs-lts/src-node_main.cc.patch
+++ b/packages/nodejs-lts/src-node_main.cc.patch
@@ -1,5 +1,6 @@
---- ./src/node_main.cc	2021-06-03 07:15:32.000000000 +0530
-+++ ./src/node_main.cc.mod	2021-06-18 21:13:57.512327727 +0530
+diff '--color=auto' -uNr node-v16.14.2.orig/src/node_main.cc node-v16.14.2/src/node_main.cc
+--- node-v16.14.2.orig/src/node_main.cc	2022-03-18 15:06:23.951091188 +0530
++++ node-v16.14.2/src/node_main.cc	2022-03-18 15:08:55.611091130 +0530
 @@ -124,6 +124,10 @@
    // calls elsewhere in the program (e.g., any logging from V8.)
    setvbuf(stdout, nullptr, _IONBF, 0);

--- a/packages/nodejs-lts/tools-v8_gypfiles-toolchain.gypi.patch
+++ b/packages/nodejs-lts/tools-v8_gypfiles-toolchain.gypi.patch
@@ -1,5 +1,6 @@
---- ./tools/v8_gypfiles/toolchain.gypi	2021-09-15 07:18:39.300327067 +0530
-+++ ./tools/v8_gypfiles/toolchain.gypi.mod	2021-09-15 07:18:22.990327073 +0530
+diff '--color=auto' -uNr node-v16.14.2.orig/tools/v8_gypfiles/toolchain.gypi node-v16.14.2/tools/v8_gypfiles/toolchain.gypi
+--- node-v16.14.2.orig/tools/v8_gypfiles/toolchain.gypi	2022-03-18 15:06:28.221091186 +0530
++++ node-v16.14.2/tools/v8_gypfiles/toolchain.gypi	2022-03-18 15:08:57.961091129 +0530
 @@ -62,7 +62,7 @@
      'mips_use_msa%': 0,
  

--- a/packages/nodejs-lts/tools-v8_gypfiles-v8.gyp.patch
+++ b/packages/nodejs-lts/tools-v8_gypfiles-v8.gyp.patch
@@ -1,5 +1,6 @@
---- ./tools/v8_gypfiles/v8.gyp.orig	2021-10-28 12:42:10.582850598 +0530
-+++ ./tools/v8_gypfiles/v8.gyp	2021-10-28 12:42:16.502850595 +0530
+diff '--color=auto' -uNr node-v16.14.2.orig/tools/v8_gypfiles/v8.gyp node-v16.14.2/tools/v8_gypfiles/v8.gyp
+--- node-v16.14.2.orig/tools/v8_gypfiles/v8.gyp	2022-03-18 15:06:28.221091186 +0530
++++ node-v16.14.2/tools/v8_gypfiles/v8.gyp	2022-03-18 15:09:00.361091128 +0530
 @@ -1121,6 +1121,7 @@
              '<(V8_ROOT)/src/base/platform/platform-posix.h',
              '<(V8_ROOT)/src/base/platform/platform-posix-time.cc',


### PR DESCRIPTION
We missed v16.14.1, which seems to have some small changes, but since this is an LTS version, I'll make sure that this doesn't break anything by running the test suite as usual. Or else it could have been updated as is as done with nodejs. For context see d5704f5d531debeecf71345aef33be62d6495b42
