### PR TITLE
lua-language-server: Depends on `libandroid-spawn`

### DIFF
--- a/packages/lua-language-server/build.sh
+++ b/packages/lua-language-server/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="Sumneko Lua Language Server coded in Lua"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="MrAdityaAlok <dev.aditya.alok@gmail.com>"
 TERMUX_PKG_VERSION=2.6.0
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_GIT_BRANCH="${TERMUX_PKG_VERSION}"
 TERMUX_PKG_SRCURL="https://github.com/sumneko/lua-language-server.git"
-TERMUX_PKG_BUILD_DEPENDS="libandroid-spawn"
+TERMUX_PKG_DEPENDS="libandroid-spawn"
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_BUILD_IN_SRC=true
 


### PR DESCRIPTION
* CANNOT LINK EXECUTABLE "/data/data/com.termux/files/usr/lib/lua-language-server/bin/lua-language-server": library "libandroid-spawn.so" not found: needed by main executable