### PR TITLE
libmicrohttpd: Rebuild with NDK r23b

### DIFF
--- a/packages/gnunet/build.sh
+++ b/packages/gnunet/build.sh
@@ -1,10 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://gnunet.org
 TERMUX_PKG_DESCRIPTION="A framework for secure peer-to-peer networking"
-TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_LICENSE="AGPL-V3"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_SRCURL=https://git.gnunet.org/git/gnunet.git
 TERMUX_PKG_VERSION=0.16.1
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_DEPENDS="gnurl, libgcrypt, libgmp, libidn, libjansson, libltdl, libmicrohttpd, libsqlite, libunistring, libsodium"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="ac_cv_have_decl_struct_in6_ifreq=yes"

--- a/packages/libmicrohttpd/build.sh
+++ b/packages/libmicrohttpd/build.sh
@@ -1,8 +1,9 @@
 TERMUX_PKG_HOMEPAGE=http://www.gnu.org/software/libmicrohttpd/
 TERMUX_PKG_DESCRIPTION="A small C library that is supposed to make it easy to run an HTTP server as part of another application"
-TERMUX_PKG_LICENSE="LGPL-2.0"
+TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.9.73
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=a37b2f1b88fd1bfe74109586be463a434d34e773530fc2a74364cfcf734c032e
 TERMUX_PKG_DEPENDS="libgnutls"


### PR DESCRIPTION
* gnunet: Get rid of references to leaked builtins