### PR TITLE
Rebuild mpd

### DIFF
--- a/packages/mpd/build.sh
+++ b/packages/mpd/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Music player daemon"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.23.5
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/MusicPlayerDaemon/MPD/archive/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=d57aec9100539dc6bdb8b06d40114e44d765481bee6bc900d6403e7b67dc8e92
 TERMUX_PKG_DEPENDS="libc++, libcurl, libexpat, libid3tag, libopus, pulseaudio, libmpdclient, openal-soft, libvorbis, libsqlite, ffmpeg, libmp3lame, libbz2, libogg, libnfs, zlib"


### PR DESCRIPTION
```bash
~ $ mpd
CANNOT LINK EXECUTABLE "mpd": library "libomp.so" not found
```