### PR TITLE
Rebuild LLVM

### DIFF
--- a/packages/libllvm/build.sh
+++ b/packages/libllvm/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Modular compiler and toolchain technologies library"
 TERMUX_PKG_LICENSE="NCSA"
 TERMUX_PKG_MAINTAINER="@buttaface"
 TERMUX_PKG_VERSION=13.0.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=326335a830f2e32d06d0a36393b5455d17dc73e0bd1211065227ee014f92cbf8
 TERMUX_PKG_SRCURL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$TERMUX_PKG_VERSION/llvm-project-$TERMUX_PKG_VERSION.src.tar.xz
 TERMUX_PKG_HOSTBUILD=true


### PR DESCRIPTION
Some of packages yells out for missing OpenMP libraries. This is the first attempt to fix it.