### PR TITLE
findutils: use fflush wrapper

### DIFF
--- a/packages/findutils/build.sh
+++ b/packages/findutils/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Utilities to find files meeting specified criteria and p
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=4.9.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/findutils/findutils-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=a2bfb8c09d436770edc59f50fa483e785b161a3b7b9d547573cb08065fd462fe
 TERMUX_PKG_DEPENDS="libandroid-support"
@@ -10,7 +11,7 @@ TERMUX_PKG_ESSENTIAL=true
 TERMUX_PKG_GROUPS="base-devel"
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
-gl_cv_func_fflush_stdin=yes
+gl_cv_func_fflush_stdin=no
 SORT_SUPPORTS_Z=yes
 SORT=$TERMUX_PREFIX/bin/sort
 "


### PR DESCRIPTION
Since `findutils-4.9.0`, it starts to use a wrapper of `fclose` (`rpl_close`), which will `fflush` before closing it. But `fflush` from Bionic Libc doen't support flushing on an input stream. Set `gl_cv_func_fflush_stdin=no` to let it use a wrapper of `fflush` (`rpl_fflush`) which support these operations.
Closes #9506.
Tested on `Bluestacks` (x86_64).