### PR TITLE
libandroid-posix-semaphore: fix deadlock and add parameter check

### DIFF
--- a/packages/libandroid-posix-semaphore/build.sh
+++ b/packages/libandroid-posix-semaphore/build.sh
@@ -3,13 +3,12 @@ TERMUX_PKG_DESCRIPTION="Shared library for the posix semaphore system function"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.1
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_make() {
-	$CC $CFLAGS $CPPFLAGS -DPREFIX="\"$TERMUX_PREFIX\"" \
-		-c $TERMUX_PKG_BUILDER_DIR/semaphore.c
+	$CC $CFLAGS $CPPFLAGS -c $TERMUX_PKG_BUILDER_DIR/semaphore.c
 	$CC $LDFLAGS -shared semaphore.o -o libandroid-posix-semaphore.so
 	$AR rcu libandroid-posix-semaphore.a semaphore.o
 	cp -f $TERMUX_PKG_BUILDER_DIR/LICENSE $TERMUX_PKG_SRCDIR/


### PR DESCRIPTION
(1) Replace defined macro `PREFIX` with `_PATH_TMP` in `<paths.h>`, as `libandroid-shmem` does.
(2) Initialize the static variable `pthread_mutex_t lock` with `PTHREAD_MUTEX_INITIALIZER`.
(3) Fix a possible deadlock when the number of semaphores reaches `SEM_NSEMS_MAX`.
(4) Add parameter check. Now running `__import__("ctypes").CDLL("libandroid-posix-semaphore.so").sem_close(0)` will not cause a segmentation fault and will return `-1`.