### PR TITLE
picolisp: Move sysdefs file.

### DIFF
--- a/packages/picolisp/build.sh
+++ b/packages/picolisp/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=21.12
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=http://archive.ubuntu.com/ubuntu/pool/universe/p/picolisp/picolisp_$TERMUX_PKG_VERSION.orig.tar.gz
 TERMUX_PKG_SHA256=a06838236b7f5b52c5d587d32d31627f73cdb9775cc02a80f2cdaedd12888c7d
 TERMUX_PKG_DEPENDS="libcrypt, libffi, openssl, readline"
@@ -68,11 +68,11 @@ termux_step_make_install() {
 termux_step_create_debscripts() {
 	cat <<- EOF > ./postinst
 	#!$TERMUX_PREFIX/bin/sh
-	$TERMUX_PREFIX/lib/picolisp/sysdefs-gen > $TERMUX_PREFIX/lib/picolisp/sysdefs
+	$TERMUX_PREFIX/lib/picolisp/sysdefs-gen > $TERMUX_PREFIX/lib/picolisp/lib/sysdefs
 	EOF
 
 	cat <<- EOF > ./prerm
 	#!$TERMUX_PREFIX/bin/sh
-	rm -f $TERMUX_PREFIX/lib/picolisp/sysdefs
+	rm -f $TERMUX_PREFIX/lib/picolisp/lib/sysdefs
 	EOF
 }


### PR DESCRIPTION
Tried to run `pil`, got the following error message:
```
(ins)~ $ pil
[/data/data/com.termux/files/usr/lib/picolisp/lib/net.l:3] !? (in (or "Alt" "@lib/sysdefs") (if (from (pack "^J[" "Sym" "]^J")) (while (and (skip) (<> "[" @)) (def (read) (read))) (quit "No sysdefs" "Sym")))
"@lib/sysdefs" -- Open error: No such file or directory
```

Ran `strace` on `pil`, saw that It look for `sysdefs` in `/data/data/com.termux/files/usr/lib/picolisp/lib/sysdefs` and not in `/data/data/com.termux/files/usr/lib/picolisp/sysdefs`

```
(ins)~ $ cat trace | rg sysdefs
openat(AT_FDCWD, "/data/data/com.termux/files/usr/lib/picolisp/lib/sysdefs", O_RDONLY) = -1 ENOENT (No such file or directory)
write(2, "\"@lib/sysdefs\" -- Open error: No"..., 56) = 56
```

Moved `sysdefs` into `/data/data/com.termux/files/usr/lib/picolisp/lib/sysdefs` and the error was gone.

Ran `grep` on `$PREFIX/lib/piclisp` and on binaries in `$PREFIX/bin` (`pil` and `picolisp`) and couldn't find any references besides `lib.l`