### PR TITLE
new package: libandroid-sysv-semaphore

### DIFF
--- a/packages/libandroid-sysv-semaphore/LICENSE
+++ b/packages/libandroid-sysv-semaphore/LICENSE
@@ -1,0 +1,25 @@
+Copyright (C) 2016 The Android Open Source Project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/packages/libandroid-sysv-semaphore/build.sh
+++ b/packages/libandroid-sysv-semaphore/build.sh
@@ -1,0 +1,30 @@
+TERMUX_PKG_HOMEPAGE=https://android.googlesource.com/platform/bionic/+/refs/heads/master/libc/bionic/sys_sem.cpp
+TERMUX_PKG_DESCRIPTION="A shared library providing System V semaphores"
+TERMUX_PKG_LICENSE="BSD 2-Clause"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=0.1
+TERMUX_PKG_SKIP_SRC_EXTRACT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_post_get_source() {
+	local f
+	for f in LICENSE sys_sem.{c,h}; do
+		cp $TERMUX_PKG_BUILDER_DIR/${f} ./
+	done
+}
+
+termux_step_pre_configure() {
+	CPPFLAGS+=" -D__USE_GNU"
+	CFLAGS+=" -fPIC"
+}
+
+termux_step_make() {
+	$CC $CFLAGS $CPPFLAGS sys_sem.c -c
+	$CC $CFLAGS sys_sem.o -shared $LDFLAGS -o libandroid-sysv-semaphore.so
+	$AR cru libandroid-sysv-semaphore.a sys_sem.o
+}
+
+termux_step_make_install() {
+	install -Dm600 -t $TERMUX_PREFIX/lib libandroid-sysv-semaphore.{a,so}
+	install -Dm600 -T sys_sem.h $TERMUX_PREFIX/include/sys/sem.h
+}

--- a/packages/libandroid-sysv-semaphore/sys_sem.c
+++ b/packages/libandroid-sysv-semaphore/sys_sem.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "sys_sem.h"
+
+#include <stdarg.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+int semctl(int id, int num, int cmd, ...) {
+#if !defined(__LP64__)
+  // Annoyingly, the kernel requires this for 32-bit but rejects it for 64-bit.
+  cmd |= IPC_64;
+#endif
+  va_list ap;
+  va_start(ap, cmd);
+  union semun arg = va_arg(ap, union semun);
+  va_end(ap);
+#if defined(SYS_semctl)
+  return syscall(SYS_semctl, id, num, cmd, arg);
+#else
+  return syscall(SYS_ipc, SEMCTL, id, num, cmd, &arg, 0);
+#endif
+}
+
+int semget(key_t key, int n, int flags) {
+#if defined(SYS_semget)
+  return syscall(SYS_semget, key, n, flags);
+#else
+  return syscall(SYS_ipc, SEMGET, key, n, flags, 0, 0);
+#endif
+}
+
+int semop(int id, struct sembuf* ops, size_t op_count) {
+  return semtimedop(id, ops, op_count, NULL);
+}
+
+int semtimedop(int id, struct sembuf* ops, size_t op_count, const struct timespec* ts) {
+#if defined(SYS_semtimedop)
+  return syscall(SYS_semtimedop, id, ops, op_count, ts);
+#else
+  return syscall(SYS_ipc, SEMTIMEDOP, id, op_count, 0, ops, ts);
+#endif
+}
+
+/* Make alias for use with e.g. dlopen() */
+#undef semctl
+int semctl(int id, int num, int cmd, ...) __attribute__((alias("libandroid_semctl")));
+#undef semget
+int semget(key_t key, int n, int flags) __attribute__((alias("libandroid_semget")));
+#undef semop
+int semop(int id, struct sembuf* ops, size_t op_count) __attribute__((alias("libandroid_semop")));
+#undef semtimedop
+int semtimedop(int id, struct sembuf* ops, size_t op_count, const struct timespec* ts) __attribute__((alias("libandroid_semtimedop")));

--- a/packages/libandroid-sysv-semaphore/sys_sem.h
+++ b/packages/libandroid-sysv-semaphore/sys_sem.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _SYS_SEM_H_
+#define _SYS_SEM_H_
+
+#include <sys/cdefs.h>
+#include <sys/ipc.h>
+#include <sys/types.h>
+
+#if defined(__USE_GNU)
+#include <bits/timespec.h>
+#endif
+
+#include <linux/sem.h>
+
+__BEGIN_DECLS
+
+#define semid_ds semid64_ds
+
+union semun {
+  int val;
+  struct semid_ds* buf;
+  unsigned short* array;
+  struct seminfo* __buf;
+  void* __pad;
+};
+
+
+#undef semctl
+#define semctl libandroid_semctl
+int semctl(int __sem_id, int __sem_num, int __cmd, ...);
+#undef semget
+#define semget libandroid_semget
+int semget(key_t __key, int __sem_count, int __flags);
+#undef semop
+#define semop libandroid_semop
+int semop(int __sem_id, struct sembuf* __ops, size_t __op_count);
+
+
+#if defined(__USE_GNU)
+
+#undef semtimedop
+#define semtimedop libandroid_semtimedop
+int semtimedop(int __sem_id, struct sembuf* __ops, size_t __op_count, const struct timespec* __timeout);
+
+#endif
+
+__END_DECLS
+
+#endif


### PR DESCRIPTION
Used by `mercury`, `monetdb`, `uwsgi` and `qt5-qtbase`.