### PR TITLE
golang: Fix hardcoded `/etc/resolv.conf` and friends

### DIFF
--- a/packages/golang/build.sh
+++ b/packages/golang/build.sh
@@ -5,10 +5,15 @@ TERMUX_PKG_MAINTAINER="@termux"
 _MAJOR_VERSION=1.18
 # Use the ~ deb versioning construct in the future:
 TERMUX_PKG_VERSION=3:${_MAJOR_VERSION}
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://storage.googleapis.com/golang/go${_MAJOR_VERSION}.src.tar.gz
 TERMUX_PKG_SHA256=38f423db4cc834883f2b52344282fa7a39fbb93650dc62a11fdf0be6409bdad6
 TERMUX_PKG_DEPENDS="clang"
 TERMUX_PKG_NO_STATICSPLIT=true
+
+termux_step_post_get_source() {
+	. $TERMUX_PKG_BUILDER_DIR/fix-hardcoded-etc-resolv-conf.sh
+}
 
 termux_step_make_install() {
 	termux_setup_golang

--- a/packages/golang/fix-hardcoded-etc-resolv-conf.diff
+++ b/packages/golang/fix-hardcoded-etc-resolv-conf.diff
@@ -1,0 +1,93 @@
+--- a/src/net/conf.go
++++ b/src/net/conf.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
++//go:build aix || darwin || dragonfly || freebsd || (linux && !android) || netbsd || openbsd || solaris
+ 
+ package net
+ 
+--- a/src/net/conf_android.go
++++ b/src/net/conf_android.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
++//go:build android
+ 
+ package net
+ 
+@@ -95,10 +95,10 @@
+ 	}
+ 
+ 	if runtime.GOOS != "openbsd" {
+-		confVal.nss = parseNSSConfFile("/etc/nsswitch.conf")
++		confVal.nss = parseNSSConfFile("@TERMUX_PREFIX@/etc/nsswitch.conf")
+ 	}
+ 
+-	confVal.resolv = dnsReadConfig("/etc/resolv.conf")
++	confVal.resolv = dnsReadConfig("@TERMUX_PREFIX@/etc/resolv.conf")
+ 	if confVal.resolv.err != nil && !os.IsNotExist(confVal.resolv.err) &&
+ 		!os.IsPermission(confVal.resolv.err) {
+ 		// If we can't read the resolv.conf file, assume it
+@@ -108,7 +108,7 @@
+ 		confVal.forceCgoLookupHost = true
+ 	}
+ 
+-	if _, err := os.Stat("/etc/mdns.allow"); err == nil {
++	if _, err := os.Stat("@TERMUX_PREFIX@/etc/mdns.allow"); err == nil {
+ 		confVal.hasMDNSAllow = true
+ 	}
+ }
+--- a/src/net/dnsclient_unix.go
++++ b/src/net/dnsclient_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
++//go:build aix || darwin || dragonfly || freebsd || (linux && !android) || netbsd || openbsd || solaris
+ 
+ // DNS client: see RFC 1035.
+ // Has to be linked into package net for Dial.
+--- a/src/net/dnsclient_android.go
++++ b/src/net/dnsclient_android.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
++//go:build android
+ 
+ // DNS client: see RFC 1035.
+ // Has to be linked into package net for Dial.
+@@ -338,7 +338,7 @@
+ 	// resolv.conf twice the first time.
+ 	conf.dnsConfig = systemConf().resolv
+ 	if conf.dnsConfig == nil {
+-		conf.dnsConfig = dnsReadConfig("/etc/resolv.conf")
++		conf.dnsConfig = dnsReadConfig("@TERMUX_PREFIX@/etc/resolv.conf")
+ 	}
+ 	conf.lastChecked = time.Now()
+ 
+@@ -401,7 +401,7 @@
+ 		// For consistency with libc resolvers, report no such host.
+ 		return dnsmessage.Parser{}, "", &DNSError{Err: errNoSuchHost.Error(), Name: name, IsNotFound: true}
+ 	}
+-	resolvConf.tryUpdate("/etc/resolv.conf")
++	resolvConf.tryUpdate("@TERMUX_PREFIX@/etc/resolv.conf")
+ 	resolvConf.mu.RLock()
+ 	conf := resolvConf.dnsConfig
+ 	resolvConf.mu.RUnlock()
+@@ -578,7 +578,7 @@
+ 		// See comment in func lookup above about use of errNoSuchHost.
+ 		return nil, dnsmessage.Name{}, &DNSError{Err: errNoSuchHost.Error(), Name: name, IsNotFound: true}
+ 	}
+-	resolvConf.tryUpdate("/etc/resolv.conf")
++	resolvConf.tryUpdate("@TERMUX_PREFIX@/etc/resolv.conf")
+ 	resolvConf.mu.RLock()
+ 	conf := resolvConf.dnsConfig
+ 	resolvConf.mu.RUnlock()

--- a/packages/golang/fix-hardcoded-etc-resolv-conf.sh
+++ b/packages/golang/fix-hardcoded-etc-resolv-conf.sh
@@ -1,0 +1,12 @@
+for f in src/net/conf_android.go src/net/dnsclient_android.go; do
+	if [ -e "${f}" ]; then
+		termux_error_exit "Error: file ${f} already exists."
+	fi
+done
+
+cp -T src/net/conf.go src/net/conf_android.go
+cp -T src/net/dnsclient_unix.go src/net/dnsclient_android.go
+
+sed -e "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|" \
+	${TERMUX_SCRIPTDIR}/packages/golang/fix-hardcoded-etc-resolv-conf.diff \
+	| patch --silent -p1

--- a/scripts/build/setup/termux_setup_golang.sh
+++ b/scripts/build/setup/termux_setup_golang.sh
@@ -23,9 +23,11 @@ termux_setup_golang() {
 			e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f
 
 		( cd "$TERMUX_COMMON_CACHEDIR"; tar xf "$TERMUX_BUILDGO_TAR"; mv go "$TERMUX_BUILDGO_FOLDER"; rm "$TERMUX_BUILDGO_TAR" )
+
+		( cd "$TERMUX_BUILDGO_FOLDER"; . ${TERMUX_SCRIPTDIR}/packages/golang/fix-hardcoded-etc-resolv-conf.sh )
 	else
 		if [[ "$TERMUX_MAIN_PACKAGE_FORMAT" = "debian" && "$(dpkg-query -W -f '${db:Status-Status}\n' golang 2>/dev/null)" != "installed" ]] ||
-                   [[ "$TERMUX_MAIN_PACKAGE_FORMAT" = "pacman" && ! "$(pacman -Q golang 2>/dev/null)" ]]; then
+		   [[ "$TERMUX_MAIN_PACKAGE_FORMAT" = "pacman" && ! "$(pacman -Q golang 2>/dev/null)" ]]; then
 			echo "Package 'golang' is not installed."
 			echo "You can install it with"
 			echo


### PR DESCRIPTION
referred to by comments in #9680 and #9683.