### PR TITLE
termux_step_massage: check built libs for undefined symbols

### DIFF
--- a/scripts/build/termux_step_massage.sh
+++ b/scripts/build/termux_step_massage.sh
@@ -79,6 +79,20 @@ termux_step_massage() {
 		termux_error_exit "Package contains hard links: $HARDLINKS"
 	fi
 
+	# Check so that package is not affected by https://github.com/android/ndk/issues/1614
+	SYMBOLS="$(readelf -s $($CC -print-libgcc-file-name) | grep "FUNC    GLOBAL HIDDEN" | awk '{print $8}')"
+	LIBRARIES="$(find lib -name "*.so")"
+	for lib in $LIBRARIES; do
+		for sym in $SYMBOLS; do
+			if ! readelf -h $lib &> /dev/null; then
+				continue
+			fi
+			if readelf -s $lib | egrep 'NOTYPE[[:space:]]+GLOBAL[[:space:]]+DEFAULT[[:space:]]+UND[[:space:]]+'$sym'$' &> /dev/null; then
+				termux_error_exit "$lib contains undefined symbol $sym"
+			fi
+		done
+	done
+
 	if [ "$TERMUX_PACKAGE_FORMAT" = "debian" ]; then
 		termux_create_debian_subpackages
 	elif [ "$TERMUX_PACKAGE_FORMAT" = "pacman" ]; then


### PR DESCRIPTION
Building packages that use libtool for linking libraries has issues
with ndk-r23 (https://github.com/android/ndk/issues/1614).  This check
makes sure that the built libraries do not give an error like

    CANNOT LINK EXECUTABLE "tesseract": cannot locate symbol "__extenddftf2" referenced by "/data/data/com.termux/files/usr/lib/libtesseract.so"...

once used on device.  In https://github.com/android/ndk/issues/1614 it
seemed like arm gave false positives and needed special consideration,
but when I tested it again today the same false positives do not occur
in built libraries, so no "if arm then .." workaround has been added
for now.