### PR TITLE
termux_step_massage: Avoid using `CC`

### DIFF
--- a/scripts/build/termux_step_massage.sh
+++ b/scripts/build/termux_step_massage.sh
@@ -80,7 +80,7 @@ termux_step_massage() {
 	fi
 
 	# Check so that package is not affected by https://github.com/android/ndk/issues/1614
-	SYMBOLS="$(readelf -s $($CC -print-libgcc-file-name) | grep "FUNC    GLOBAL HIDDEN" | awk '{print $8}')"
+	SYMBOLS="$(readelf -s $($TERMUX_HOST_PLATFORM-clang -print-libgcc-file-name) | grep "FUNC    GLOBAL HIDDEN" | awk '{print $8}')"
 	LIBRARIES=""
 	if [ -d "lib" ]; then
 		LIBRARIES="$(find lib -name "*.so")"


### PR DESCRIPTION
which may be unset.