### PR TITLE
openmpi: Link against libandroid-posix-semaphore

### DIFF
--- a/packages/openmpi/build.sh
+++ b/packages/openmpi/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="Open source Message Passing Interface implementation"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
 TERMUX_PKG_VERSION=4.1.1
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=https://download.open-mpi.org/release/open-mpi/v${TERMUX_PKG_VERSION:0:3}/openmpi-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=d80b9219e80ea1f8bcfe5ad921bd9014285c4948c5965f4156a3831e60776444
-TERMUX_PKG_DEPENDS="libandroid-shmem, libandroid-posix-semaphore"
+TERMUX_PKG_DEPENDS="libandroid-posix-semaphore, libandroid-shmem"
 TERMUX_PKG_BREAKS="openmpi-dev"
 TERMUX_PKG_REPLACES="openmpi-dev"
 TERMUX_PKG_GROUPS="science"
@@ -21,10 +21,7 @@ ac_cv_member_struct_ifreq_ifr_hwaddr=no
 termux_step_pre_configure () {
 	# rindex is an obsolete version of strrchr which is not available in Android:
 	CFLAGS+=" -Drindex=strrchr -Dbcmp=memcmp"
-	# This (--no-as-needed) may not be needed after fix in libandroid-shmem
-	# by commit 92668b208de7802da97221ace1107c4b5ae6cfc4.
-	LDFLAGS="${LDFLAGS/-Wl,--as-needed/}"
-	LDFLAGS+=" -landroid-shmem"
+	LDFLAGS+=" -landroid-posix-semaphore -landroid-shmem"
 	if [ $TERMUX_ARCH == "i686" ]; then
 		# fails with "undefined reference to __atomic..."
 		LDFLAGS+=" -latomic"


### PR DESCRIPTION
and cleanup `build.sh`.