### PR TITLE
Revert "ghc-libs: depend on libandroid-posix-semaphore"

### DIFF
--- a/packages/ghc-libs/build.sh
+++ b/packages/ghc-libs/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="The Glasgow Haskell Compiler - Dynamic Libraries"
 TERMUX_PKG_LICENSE="BSD 2-Clause, BSD 3-Clause, LGPL-2.1"
 TERMUX_PKG_MAINTAINER="Aditya Alok <dev.aditya.alok@gmail.com>"
 TERMUX_PKG_VERSION=8.10.7
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL="https://downloads.haskell.org/~ghc/${TERMUX_PKG_VERSION}/ghc-${TERMUX_PKG_VERSION}-src.tar.xz"
 TERMUX_PKG_SHA256=e3eef6229ce9908dfe1ea41436befb0455fefb1932559e860ad4c606b0d03c9d
-TERMUX_PKG_DEPENDS="iconv, libffi, ncurses, libgmp, libandroid-posix-semaphore"
+TERMUX_PKG_DEPENDS="iconv, libffi, ncurses, libgmp"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-ld-override


### PR DESCRIPTION
This reverts commit 3f8aeb2fb27ea6593dd22576d4d0c4e769a11c59.

`lib/ghc-8.10.7/unix-2.7.2.2/libHSunix-2.7.2.2-ghc8.10.7.so` continues
referencing libc symbols, i.e. `sem_{open,close,unlink}`, regardless of
declarations in `<semaphore.h>`.

%ci:no-build