### PR TITLE
unbound: remove python dependency and add new package unbound-python for it

### DIFF
--- a/packages/hash-slinger/build.sh
+++ b/packages/hash-slinger/build.sh
@@ -3,9 +3,10 @@ TERMUX_PKG_DESCRIPTION="Various tools to generate special DNS records"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/letoams/hash-slinger/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=2f0de62d561e585747732e44ce9ea5fcef93c75c95d66b684bd13b4e70374df6
-TERMUX_PKG_DEPENDS="ca-certificates, gnupg, openssh, python, swig, unbound"
+TERMUX_PKG_DEPENDS="ca-certificates, gnupg, openssh, python, swig, unbound-python"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_BUILD_IN_SRC=true
 

--- a/packages/unbound-python/build.sh
+++ b/packages/unbound-python/build.sh
@@ -1,14 +1,17 @@
 TERMUX_PKG_HOMEPAGE=https://unbound.net/
-TERMUX_PKG_DESCRIPTION="A validating, recursive, caching DNS resolver"
+TERMUX_PKG_DESCRIPTION="A validating, recursive, caching DNS resolver with python support"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
-# Update unbound-python at the same time as unbound
+# Update unbound at the same time as unbound-python
 TERMUX_PKG_VERSION=1.15.0
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://nlnetlabs.nl/downloads/unbound/unbound-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=a480dc6c8937447b98d161fe911ffc76cfaffa2da18788781314e81339f1126f
-TERMUX_PKG_DEPENDS="libevent, libexpat, libnghttp2, openssl"
+TERMUX_PKG_DEPENDS="libevent, libexpat, libnghttp2, openssl, python"
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_CONFLICTS="unbound"
+TERMUX_PKG_REPLACES="unbound"
+TERMUX_PKG_PROVIDES="unbound"
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 ac_cv_func_chown=no
@@ -22,11 +25,27 @@ ac_cv_func_getpwnam=no
 --with-libexpat=$TERMUX_PREFIX
 --without-libhiredis
 --without-libmnl
+--with-pyunbound
+--with-pythonmodule
 --with-libnghttp2=$TERMUX_PREFIX
 --with-ssl=$TERMUX_PREFIX
 --with-pidfile=$TERMUX_PREFIX/var/run/unbound.pid
 --with-username=
 "
+
+termux_step_pre_configure() {
+	_PYTHON_VERSION=$(. $TERMUX_SCRIPTDIR/packages/python/build.sh; echo $_MAJOR_VERSION)
+	termux_setup_python_crossenv
+	pushd $TERMUX_PYTHON_CROSSENV_SRCDIR
+	_CROSSENV_PREFIX=$TERMUX_PKG_BUILDDIR/python-crossenv-prefix
+	python${_PYTHON_VERSION} -m crossenv \
+		$TERMUX_PREFIX/bin/python${_PYTHON_VERSION} \
+		${_CROSSENV_PREFIX}
+	popd
+	. ${_CROSSENV_PREFIX}/bin/activate
+
+	export PYTHON_SITE_PKG=$TERMUX_PREFIX/lib/python${_PYTHON_VERSION}/site-packages
+}
 
 termux_step_post_massage() {
 	mkdir -p "$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/var/run"

--- a/packages/unbound-python/libunbound-libunbound.c.patch
+++ b/packages/unbound-python/libunbound-libunbound.c.patch
@@ -1,0 +1,20 @@
+--- a/libunbound/libunbound.c
++++ b/libunbound/libunbound.c
+@@ -1095,7 +1095,7 @@
+ 
+ 	if(fname == NULL) {
+ #if !defined(UB_ON_WINDOWS) || !defined(HAVE_WINDOWS_H)
+-		fname = "/etc/resolv.conf";
++		fname = "@TERMUX_PREFIX@/etc/resolv.conf";
+ #else
+ 		FIXED_INFO *info;
+ 		ULONG buflen = sizeof(*info);
+@@ -1204,7 +1204,7 @@
+ 		}
+ 		return UB_READFILE;
+ #else
+-		fname = "/etc/hosts";
++		fname = "@TERMUX_PREFIX@/etc/hosts";
+ #endif /* WIN32 */
+ 	}
+ 	in = fopen(fname, "r");

--- a/packages/unbound-python/smallapp-unbound-host.c.patch
+++ b/packages/unbound-python/smallapp-unbound-host.c.patch
@@ -1,0 +1,20 @@
+--- a/smallapp/unbound-host.c
++++ b/smallapp/unbound-host.c
+@@ -99,7 +99,7 @@
+ 	printf("    -C config		use the specified unbound.conf (none read by default)\n");
+ 	printf("			pass as first argument if you want to override some\n");
+ 	printf("			options with further arguments\n");
+-	printf("    -r			read forwarder information from /etc/resolv.conf\n");
++	printf("    -r			read forwarder information from @TERMUX_PREFIX@/etc/resolv.conf\n");
+ 	printf("      			breaks validation if the forwarder does not do DNSSEC.\n");
+ 	printf("    -v			be more verbose, shows nodata and security.\n");
+ 	printf("    -d			debug, traces the action, -d -d shows more.\n");
+@@ -462,7 +462,7 @@
+ 				debuglevel = 2; /* at least VERB_DETAIL */
+ 			break;
+ 		case 'r':
+-			check_ub_res(ub_ctx_resolvconf(ctx, "/etc/resolv.conf"));
++			check_ub_res(ub_ctx_resolvconf(ctx, "@TERMUX_PREFIX@/etc/resolv.conf"));
+ 			break;
+ 		case 't':
+ 			qtype = optarg;


### PR DESCRIPTION
To keep list of libgnutls's dependencies smaller.

Since unbound-python has `TERMUX_PKG_PROVIDES="unbound"` it is possible to install unbound-python (and remove unbound) and still satisfy the dependency. Dpkg issues a warning though when installing unbound-python instead:

```
dpkg: unbound: dependency problems, but removing anyway as you requested:
 libgnutls depends on unbound.
```

but I think we can live with that.