### PR TITLE
unbound: Build without `pythonmodule`

### DIFF
--- a/packages/hash-slinger/build.sh
+++ b/packages/hash-slinger/build.sh
@@ -3,9 +3,10 @@ TERMUX_PKG_DESCRIPTION="Various tools to generate special DNS records"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/letoams/hash-slinger/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=2f0de62d561e585747732e44ce9ea5fcef93c75c95d66b684bd13b4e70374df6
-TERMUX_PKG_DEPENDS="ca-certificates, gnupg, openssh, python, swig, unbound"
+TERMUX_PKG_DEPENDS="ca-certificates, gnupg, openssh, python, pyunbound, swig"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_BUILD_IN_SRC=true
 

--- a/packages/unbound/build.sh
+++ b/packages/unbound/build.sh
@@ -3,11 +3,13 @@ TERMUX_PKG_DESCRIPTION="A validating, recursive, caching DNS resolver"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.15.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://nlnetlabs.nl/downloads/unbound/unbound-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=a480dc6c8937447b98d161fe911ffc76cfaffa2da18788781314e81339f1126f
-TERMUX_PKG_DEPENDS="libevent, libexpat, libnghttp2, openssl, python"
+TERMUX_PKG_DEPENDS="libevent, libexpat, libnghttp2, openssl"
 TERMUX_PKG_BUILD_IN_SRC=true
 
+# `pythonmodule` makes core lib/libunbound.so depend on python. Do not enable it.
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 ac_cv_func_chown=no
 ac_cv_func_chroot=no
@@ -21,7 +23,7 @@ ac_cv_func_getpwnam=no
 --without-libhiredis
 --without-libmnl
 --with-pyunbound
---with-pythonmodule
+--without-pythonmodule
 --with-libnghttp2=$TERMUX_PREFIX
 --with-ssl=$TERMUX_PREFIX
 --with-pidfile=$TERMUX_PREFIX/var/run/unbound.pid

--- a/packages/unbound/pyunbound.subpackage.sh
+++ b/packages/unbound/pyunbound.subpackage.sh
@@ -1,0 +1,4 @@
+TERMUX_SUBPKG_INCLUDE="lib/python*"
+TERMUX_SUBPKG_DESCRIPTION="Python bindings for Unbound"
+TERMUX_SUBPKG_DEPENDS="python"
+TERMUX_SUBPKG_CONFLICTS="unbound (<< 1.15.0-1)"


### PR DESCRIPTION
and separate `pyunbound` as a subpackage.

Alternative to #9973.