### PR TITLE
New package: n-t-roff-sc, a maintained fork of sc 7.16

### DIFF
--- a/packages/n-t-roff-sc/Makefile.patch
+++ b/packages/n-t-roff-sc/Makefile.patch
@@ -1,0 +1,35 @@
+diff -uNr sc/configure sc.mod/configure
+--- sc/configure	2022-04-12 17:42:09.891984764 -0700
++++ sc.mod/configure	2022-04-12 21:21:41.160050820 -0700
+@@ -30,9 +30,7 @@
+ while [ $# -gt 0 ]; do
+ 	case $1 in
+ 	-s) SFLAG=1;;
+-	*)
+-		echo "$0: $1: Unknown option" >&2
+-		usage 1;;
++	*) ;;
+ 	esac
+ 	shift
+ done
+diff -uNr sc/Makefile.in sc.mod/Makefile.in
+--- sc/Makefile.in	2022-04-12 17:45:34.738634444 -0700
++++ sc.mod/Makefile.in	2022-04-12 18:04:04.218706481 -0700
+@@ -20,7 +20,7 @@
+ # packaging this with an O/S, for example, you'll probably want to change
+ # this to /usr.  Otherwise, /usr/local is probably more appropriate, unless
+ # you're replacing the vendor-supplied version.
+-prefix=/usr/local
++prefix=@TERMUX_PREFIX@
+ 
+ # This is where the install step puts it.
+ EXDIR=${prefix}/bin
+@@ -169,7 +169,7 @@
+ # Command to use to make temporary copies of some source files.
+ #LN=ln -s
+ #LN=cp
+-LN=ln
++LN=ln -s
+ 
+ #### SYSTEM DEFINES ####
+ 

--- a/packages/n-t-roff-sc/build.sh
+++ b/packages/n-t-roff-sc/build.sh
@@ -1,14 +1,15 @@
-_VERSION=7.16_1.1.2
-
 TERMUX_PKG_HOMEPAGE="https://github.com/n-t-roff/sc"
 TERMUX_PKG_DESCRIPTION="A vi-like spreadsheet calculator"
 TERMUX_PKG_LICENSE="Public Domain"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=${_VERSION//_/-}
-TERMUX_PKG_SRCURL=https://github.com/n-t-roff/sc/archive/refs/tags/$_VERSION.tar.gz
+# TERMUX_PKG_VERSION does not support underscores
+_REAL_VERSION=7.16_1.1.2
+TERMUX_PKG_VERSION=${_REAL_VERSION//_/-}
+TERMUX_PKG_SRCURL=https://github.com/n-t-roff/sc/archive/refs/tags/$_REAL_VERSION.tar.gz
 TERMUX_PKG_SHA256=1802c9d3d60dac85feb783adf967bc0d2fd7e5f592d9d1df15e4e87d83efcf14
 TERMUX_PKG_DEPENDS="ncurses"
 TERMUX_PKG_BUILD_IN_SRC=true
+# n-t-roff-sc is a maintained fork of sc and thus replaces the original
 TERMUX_PKG_CONFLICTS="sc"
 TERMUX_PKG_REPLACES="sc"
 TERMUX_PKG_PROVIDES="sc"

--- a/packages/n-t-roff-sc/build.sh
+++ b/packages/n-t-roff-sc/build.sh
@@ -1,0 +1,18 @@
+_VERSION=7.16_1.1.2
+
+TERMUX_PKG_HOMEPAGE="https://github.com/n-t-roff/sc"
+TERMUX_PKG_DESCRIPTION="A vi-like spreadsheet calculator"
+TERMUX_PKG_LICENSE="Public Domain"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=${_VERSION//_/-}
+TERMUX_PKG_SRCURL=https://github.com/n-t-roff/sc/archive/refs/tags/$_VERSION.tar.gz
+TERMUX_PKG_SHA256=1802c9d3d60dac85feb783adf967bc0d2fd7e5f592d9d1df15e4e87d83efcf14
+TERMUX_PKG_DEPENDS="ncurses"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_CONFLICTS="sc"
+TERMUX_PKG_REPLACES="sc"
+TERMUX_PKG_PROVIDES="sc"
+
+termux_step_post_configure () {
+	CFLAGS+=" -I$TERMUX_PREFIX/include"
+}


### PR DESCRIPTION
I'm proposing ~~switching sc's upstream~~ from the original 20 year old 7.16 source code on ibiblio.org to a maintained fork [n-t-roff/sc](https://github.com/n-t-roff/sc) on github.

I changed my proposal to adding this maintained fork as a separate package `n-t-roff-sc` alongside `sc`

## Why?
~~This commit~~ bumps version number to 7.16_1.1.2 from n-t-roff's fork of sc that fixes sc compile-time errors ~~that were previously being patched by this repo~~ and has none of the run-time issues I've been experiencing with the currently packaged sc 7.16 that make it unusable for me, specifically:
* When opening sc, it hangs and does not redraw the TUI unless I resize the Termux window by changing device orientation or opening and closing the on screen keyboard.
* sc does not allow me to populate any cells without giving a syntax error as described by issue #5889
* When opening *.sc files, every single line within the .sc file throws a syntax error and no .sc files can be read.

This maintained fork fixes all these issues for me, it compiles and works perfectly for me under `arm` Termux 0.118.0 with the following changes in the included patch.
* `Makefile.in` uses hard links during the build process, causing the build to fail under Termux, changing these for symlinks lets the build finish successfully.