### PR TITLE
fix(vulkan-tools): depend on `vulkan-headers` of excatly same version

### DIFF
--- a/packages/vulkan-tools/build.sh
+++ b/packages/vulkan-tools/build.sh
@@ -2,10 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://github.com/KhronosGroup/Vulkan-Tools
 TERMUX_PKG_DESCRIPTION="Vulkan Tools and Utilities"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
+# This package and vulkan-headers should be updated at same time. Otherwise, they do not compile successfully.
 TERMUX_PKG_VERSION=1.3.211
 TERMUX_PKG_SRCURL=https://github.com/KhronosGroup/Vulkan-Tools/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=57b203eb722d9b43b47450739396d7ac1e7d881df31d39d50da39107f0182c3e
-TERMUX_PKG_BUILD_DEPENDS="vulkan-headers, vulkan-loader-android"
+TERMUX_PKG_BUILD_DEPENDS="vulkan-headers (=${TERMUX_PKG_VERSION}), vulkan-loader-android"
 TERMUX_PKG_DEPENDS="libc++"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DBUILD_CUBE=OFF


### PR DESCRIPTION
This package and vulkan-headers should be updated at same time since it
depends upon vulkan-headers of same version (obviously!).

Failing to comply so, they do not compile successfully.

re #10059

%ci:no-build

Signed-off-by: Aditya Alok <dev.aditya.alok@gmail.com>
