### PR TITLE
libllvm: update from 14.0.0 to 14.0.1

### DIFF
--- a/packages/libllvm/build.sh
+++ b/packages/libllvm/build.sh
@@ -2,8 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://clang.llvm.org/
 TERMUX_PKG_DESCRIPTION="Modular compiler and toolchain technologies library"
 TERMUX_PKG_LICENSE="NCSA"
 TERMUX_PKG_MAINTAINER="@buttaface"
-TERMUX_PKG_VERSION=14.0.0
-TERMUX_PKG_SHA256=35ce9edbc8f774fe07c8f4acdf89ec8ac695c8016c165dd86b8d10e7cba07e23
+LLVM_MAJOR_VERSION=14
+TERMUX_PKG_VERSION=${LLVM_MAJOR_VERSION}.0.1
+TERMUX_PKG_SHA256=1a3c2e57916c5a70153aaf0a0e6f1230d6368b9e0f4d04dcb9e039a31b1cd4e6
 TERMUX_PKG_SRCURL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$TERMUX_PKG_VERSION/llvm-project-$TERMUX_PKG_VERSION.src.tar.xz
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_RM_AFTER_INSTALL="
@@ -109,10 +110,11 @@ termux_step_post_make_install() {
 
 	cp docs/man/* $TERMUX_PREFIX/share/man/man1
 	cp tools/clang/docs/man/{clang,diagtool}.1 $TERMUX_PREFIX/share/man/man1
+	ln -s $TERMUX_PKG_VERSION $TERMUX_PREFIX/lib/clang/$LLVM_MAJOR_VERSION
 	cd $TERMUX_PREFIX/bin
 
 	for tool in clang clang++ cc c++ cpp gcc g++ ${TERMUX_HOST_PLATFORM}-{clang,clang++,gcc,g++,cpp}; do
-		ln -f -s clang-${TERMUX_PKG_VERSION:0:2} $tool
+		ln -f -s clang-${LLVM_MAJOR_VERSION} $tool
 	done
 
 	if [ $TERMUX_ARCH == "arm" ]; then

--- a/packages/libllvm/clang.subpackage.sh
+++ b/packages/libllvm/clang.subpackage.sh
@@ -16,6 +16,7 @@ bin/pp-trace
 bin/scan-*
 include/clang*
 include/omp*.h
+lib/clang/${LLVM_MAJOR_VERSION}
 lib/clang/*/include/*.h
 lib/clang/*/include/*.modulemap
 lib/clang/*/include/cuda_wrappers/

--- a/packages/ndk-multilib/build.sh
+++ b/packages/ndk-multilib/build.sh
@@ -3,7 +3,8 @@ TERMUX_PKG_DESCRIPTION="Multilib binaries for cross-compilation"
 TERMUX_PKG_LICENSE="NCSA"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=$TERMUX_NDK_VERSION
-TERMUX_PKG_REVISION=3
+# Bump the revision on any libllvm major version update
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_NO_STATICSPLIT=true
@@ -44,7 +45,7 @@ prepare_libs() {
 add_cross_compiler_rt() {
 	RT_PREFIX=$NDK/toolchains/llvm/prebuilt/linux-x86_64/lib64/clang/*/lib/linux
 	RT_OPT_DIR=$TERMUX_PREFIX/opt/ndk-multilib/cross-compiler-rt
-	LIBLLVM_VERSION=$(. $TERMUX_SCRIPTDIR/packages/libllvm/build.sh; echo $TERMUX_PKG_VERSION)
+	LIBLLVM_VERSION=$(. $TERMUX_SCRIPTDIR/packages/libllvm/build.sh; echo $LLVM_MAJOR_VERSION)
 	RT_PATH=$TERMUX_PREFIX/lib/clang/$LIBLLVM_VERSION/lib/linux
 	mkdir -p $TERMUX_PKG_MASSAGEDIR/$RT_OPT_DIR
 	cp $RT_PREFIX/* $TERMUX_PKG_MASSAGEDIR/$RT_OPT_DIR || true


### PR DESCRIPTION
Looks like [a lot more patch releases of LLVM incoming](https://discourse.llvm.org/t/llvm-14-0-1-release/61700), we may need to change how we handle it.