### PR TITLE
build-bootstraps: bump to 0.2.0

### DIFF
--- a/scripts/build-bootstraps.sh
+++ b/scripts/build-bootstraps.sh
@@ -8,7 +8,7 @@
 #                bootstrap archives to be easily built for (forked) termux
 #                apps without having to publish an apt repo first.
 # Usage:         run "build-bootstrap.sh --help"
-version=0.1.0
+version=0.2.0
 
 set -e
 
@@ -57,7 +57,7 @@ done
 
 # Build deb files for package and its dependencies deb from source for arch
 build_package() {
-	
+
 	local return_value
 
 	local package_arch="$1"

--- a/scripts/build-bootstraps.sh
+++ b/scripts/build-bootstraps.sh
@@ -100,6 +100,7 @@ build_package() {
 # Extract *.deb files to the bootstrap root.
 extract_debs() {
 
+	local package_arch="$1"
 	local current_package_name
 	local data_archive
 	local control_archive
@@ -122,7 +123,14 @@ extract_debs() {
 	for deb in *.deb; do
 
 		current_package_name="$(echo "$deb" | sed -E 's/^([^_]+).*/\1/' )"
+		current_package_arch="$(echo "$deb" | sed -E 's/.*_(.*).deb$/\1/' )"
 		echo "current_package_name: '$current_package_name'"
+		echo "current_package_arch: '$current_package_arch'"
+
+		if [[ "$current_package_arch" != "$package_arch" ]] && [[ "$current_package_arch" != "all" ]]; then
+			echo "[*] Skipping incompatible package '$deb' for target '$package_arch'..."
+			continue
+		fi
 
 		if [[ "$current_package_name" == *"-static" ]]; then
 			echo "[*] Skipping static package '$deb'..."
@@ -479,7 +487,7 @@ main() {
 		done
 
 		# Extract all debs.
-		extract_debs || return $?
+		extract_debs "$package_arch" || return $?
 
 		# Create bootstrap archive.
 		create_bootstrap_archive "$package_arch" || return $?


### PR DESCRIPTION
Supersedes #9382

No longer includes no-Neon build option (will reintroduce later)
Add optional build-extra-first option
Fix building bootstraps by only including packages for that specific arch and "all" variant