### PR TITLE
Keep ndk and sdk in versioned folders and use termux_download

### DIFF
--- a/scripts/properties.sh
+++ b/scripts/properties.sh
@@ -11,7 +11,14 @@ TERMUX_NDK_VERSION=$TERMUX_NDK_VERSION_NUM$TERMUX_NDK_REVISION
 # update SHA256 sums in scripts/setup-android-sdk.sh
 # check all packages build and run correctly and bump if needed
 
-export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+if [ -d "/usr/lib/jvm/java-8-openjdk-amd64" ]; then
+	export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+elif [ -d "/usr/lib/jvm/java-8-openjdk" ]; then
+	export JAVA_HOME=/usr/lib/jvm/java-8-openjdk
+else
+	echo "Error: /usr/lib/jvm/java-8-openjdk{,-amd64} not found. Is openjdk 8 installed?"
+	exit 1
+fi
 
 if [ "${TERMUX_PACKAGES_OFFLINE-false}" = "true" ]; then
 	export ANDROID_HOME=${TERMUX_SCRIPTDIR}/build-tools/android-sdk-$TERMUX_SDK_REVISION

--- a/scripts/properties.sh
+++ b/scripts/properties.sh
@@ -1,5 +1,6 @@
 # keep repology-metadata in sync with this
 
+TERMUX_SDK_REVISION=7583922
 TERMUX_ANDROID_BUILD_TOOLS_VERSION=30.0.3
 TERMUX_NDK_VERSION_NUM=23
 TERMUX_NDK_REVISION="b"
@@ -13,11 +14,11 @@ TERMUX_NDK_VERSION=$TERMUX_NDK_VERSION_NUM$TERMUX_NDK_REVISION
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 if [ "${TERMUX_PACKAGES_OFFLINE-false}" = "true" ]; then
-	export ANDROID_HOME=${TERMUX_SCRIPTDIR}/build-tools/android-sdk
-	export NDK=${TERMUX_SCRIPTDIR}/build-tools/android-ndk
+	export ANDROID_HOME=${TERMUX_SCRIPTDIR}/build-tools/android-sdk-$TERMUX_SDK_REVISION
+	export NDK=${TERMUX_SCRIPTDIR}/build-tools/android-ndk-r${TERMUX_NDK_VERSION}
 else
-	: "${ANDROID_HOME:="${HOME}/lib/android-sdk"}"
-	: "${NDK:="${HOME}/lib/android-ndk"}"
+	: "${ANDROID_HOME:="${HOME}/lib/android-sdk-$TERMUX_SDK_REVISION"}"
+	: "${NDK:="${HOME}/lib/android-ndk-r${TERMUX_NDK_VERSION}"}"
 fi
 
 # Termux packages configuration.

--- a/scripts/setup-android-sdk.sh
+++ b/scripts/setup-android-sdk.sh
@@ -8,8 +8,7 @@ set -e -u
 . $(cd "$(dirname "$0")"; pwd)/properties.sh
 . $(cd "$(dirname "$0")"; pwd)/build/termux_download.sh
 
-ANDROID_SDK_REVISION=7583922
-ANDROID_SDK_FILE=commandlinetools-linux-${ANDROID_SDK_REVISION}_latest.zip
+ANDROID_SDK_FILE=commandlinetools-linux-${TERMUX_SDK_REVISION}_latest.zip
 ANDROID_SDK_SHA256=124f2d5115eee365df6cf3228ffbca6fc3911d16f8025bebd5b1c6e2fcfa7faf
 ANDROID_NDK_FILE=android-ndk-r${TERMUX_NDK_VERSION}-linux.zip
 ANDROID_NDK_SHA256=c6e97f9c8cfe5b7be0a9e6c15af8e7a179475b7ded23e2d1c1fa0945d6fb4382
@@ -21,10 +20,10 @@ if [ ! -d $ANDROID_HOME ]; then
 	# https://developer.android.com/studio/index.html#command-tools
 	echo "Downloading android sdk..."
 	termux_download https://dl.google.com/android/repository/${ANDROID_SDK_FILE} \
-		tools-$ANDROID_SDK_REVISION.zip \
+		tools-$TERMUX_SDK_REVISION.zip \
 		$ANDROID_SDK_SHA256
-	rm -Rf android-sdk
-	unzip -q tools-$ANDROID_SDK_REVISION.zip -d android-sdk
+	rm -Rf android-sdk-$TERMUX_SDK_REVISION
+	unzip -q tools-$TERMUX_SDK_REVISION.zip -d android-sdk-$TERMUX_SDK_REVISION
 fi
 
 if [ ! -d $NDK ]; then
@@ -37,7 +36,6 @@ if [ ! -d $NDK ]; then
 		$ANDROID_NDK_SHA256
 	rm -Rf android-ndk-r$TERMUX_NDK_VERSION
 	unzip -q ndk-r${TERMUX_NDK_VERSION}.zip
-	mv android-ndk-r$TERMUX_NDK_VERSION $(basename $NDK)
 fi
 
 yes | $ANDROID_HOME/cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME --licenses

--- a/scripts/setup-android-sdk.sh
+++ b/scripts/setup-android-sdk.sh
@@ -1,10 +1,15 @@
-#!/bin/sh
+#!/bin/bash
+
 set -e -u
+
+: "${TERMUX_PKG_TMPDIR:="/tmp"}"
 
 # Install desired parts of the Android SDK:
 . $(cd "$(dirname "$0")"; pwd)/properties.sh
+. $(cd "$(dirname "$0")"; pwd)/build/termux_download.sh
 
-ANDROID_SDK_FILE=commandlinetools-linux-7583922_latest.zip
+ANDROID_SDK_REVISION=7583922
+ANDROID_SDK_FILE=commandlinetools-linux-${ANDROID_SDK_REVISION}_latest.zip
 ANDROID_SDK_SHA256=124f2d5115eee365df6cf3228ffbca6fc3911d16f8025bebd5b1c6e2fcfa7faf
 ANDROID_NDK_FILE=android-ndk-r${TERMUX_NDK_VERSION}-linux.zip
 ANDROID_NDK_SHA256=c6e97f9c8cfe5b7be0a9e6c15af8e7a179475b7ded23e2d1c1fa0945d6fb4382
@@ -14,15 +19,12 @@ if [ ! -d $ANDROID_HOME ]; then
 	rm -Rf $(basename $ANDROID_HOME)
 
 	# https://developer.android.com/studio/index.html#command-tools
-	# The downloaded version below is 26.1.1.:
 	echo "Downloading android sdk..."
-	curl --fail --retry 3 \
-		-o tools.zip \
-		https://dl.google.com/android/repository/${ANDROID_SDK_FILE}
-	echo "${ANDROID_SDK_SHA256} tools.zip" | sha256sum -c -
+	termux_download https://dl.google.com/android/repository/${ANDROID_SDK_FILE} \
+		tools-$ANDROID_SDK_REVISION.zip \
+		$ANDROID_SDK_SHA256
 	rm -Rf android-sdk
-	unzip -q tools.zip -d android-sdk
-	rm tools.zip
+	unzip -q tools-$ANDROID_SDK_REVISION.zip -d android-sdk
 fi
 
 if [ ! -d $NDK ]; then
@@ -30,13 +32,12 @@ if [ ! -d $NDK ]; then
 	cd $NDK/..
 	rm -Rf $(basename $NDK)
 	echo "Downloading android ndk..."
-	curl --fail --retry 3 -o ndk.zip \
-		https://dl.google.com/android/repository/${ANDROID_NDK_FILE}
-	echo "${ANDROID_NDK_SHA256} ndk.zip" | sha256sum -c -
+	termux_download https://dl.google.com/android/repository/${ANDROID_NDK_FILE} \
+		ndk-r${TERMUX_NDK_VERSION}.zip \
+		$ANDROID_NDK_SHA256
 	rm -Rf android-ndk-r$TERMUX_NDK_VERSION
-	unzip -q ndk.zip
+	unzip -q ndk-r${TERMUX_NDK_VERSION}.zip
 	mv android-ndk-r$TERMUX_NDK_VERSION $(basename $NDK)
-	rm ndk.zip
 fi
 
 yes | $ANDROID_HOME/cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME --licenses


### PR DESCRIPTION
To make it a bit easier to try out different ndk versions.

setup-android-sdk and building packages seem to work, but need to think about if there are other scripts that have to be changed.