### PR TITLE
ghc-libs: Enable `network` support in `libiserv`

### DIFF
--- a/packages/ghc-libs/libiserv-enable-network.patch
+++ b/packages/ghc-libs/libiserv-enable-network.patch
@@ -1,0 +1,21 @@
+--- ghc-9.2.5.orig/ghc.mk	2022-11-07 01:10:29.000000000 +0530
++++ ghc-9.2.5/ghc.mk	2023-02-22 10:09:29.618460290 +0530
+@@ -485,6 +485,7 @@
+ PACKAGES_STAGE1 += exceptions
+ PACKAGES_STAGE1 += haskeline
+ PACKAGES_STAGE1 += ghci
++PACKAGES_STAGE1 += network
+ PACKAGES_STAGE1 += libiserv
+ 
+ # See Note [No stage2 packages when CrossCompiling or Stage1Only].
+
+--- ghc-9.2.5.orig/packages	2022-11-07 01:10:29.000000000 +0530
++++ ghc-9.2.5/packages	2023-02-22 03:00:20.038470113 +0530
+@@ -53,6 +53,7 @@
+ libraries/haskeline          -           -                               https://github.com/judah/haskeline.git
+ libraries/hpc                -           -                               -
+ libraries/libiserv           -           -                               -
++libraries/network            -           -                               -
+ libraries/mtl                -           -                               https://github.com/haskell/mtl.git
+ libraries/parsec             -           -                               https://github.com/haskell/parsec.git
+ libraries/pretty             -           -                               https://github.com/haskell/pretty.git


### PR DESCRIPTION
It will be used to build `iserv-proxy` which will be used to cross compile template-haskell.

For reference see: https://medium.com/@zw3rk/cross-compiling-template-haskell-7e38c00c2914

