### PR TITLE
webkit2gtk: Disable OpenGL

### DIFF
--- a/x11-packages/webkit2gtk/build.sh
+++ b/x11-packages/webkit2gtk/build.sh
@@ -3,11 +3,12 @@ TERMUX_PKG_DESCRIPTION="A full-featured port of the WebKit rendering engine"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.32.4
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://webkitgtk.org/releases/webkitgtk-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=00ce2d3f798d7bc5e9039d9059f0c3c974d51de38c8b716f00e94452a177d3fd
 TERMUX_PKG_DEPENDS="atk, enchant, fontconfig, freetype, glib, gst-plugins-base, gstreamer, gtk3, harfbuzz, harfbuzz-icu, libc++, libcairo, libgcrypt, libhyphen, libicu, libjpeg-turbo, libnotify, libpng, libsoup, libtasn1, libwebp, libxml2, libx11, libxcomposite, libxdamage, libxslt, libxt, openjpeg, pango, woff2"
 TERMUX_PKG_BUILD_DEPENDS="xorgproto"
+TERMUX_PKG_RECOMMENDS="glib-networking"
 TERMUX_PKG_BREAKS="webkit, webkitgtk"
 TERMUX_PKG_REPLACES="webkit, webkitgtk"
 
@@ -20,4 +21,5 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DUSE_WPE_RENDERER=OFF
 -DENABLE_BUBBLEWRAP_SANDBOX=OFF
 -DUSE_LD_GOLD=OFF
+-DUSE_OPENGL_OR_ES=OFF
 "


### PR DESCRIPTION
that seems to cause crashes.

Fixes #10080.