### PR TITLE
libarrow-cpp: Include libarrow-python as a subpackage

### DIFF
--- a/packages/libarrow-cpp/build.sh
+++ b/packages/libarrow-cpp/build.sh
@@ -2,15 +2,48 @@ TERMUX_PKG_HOMEPAGE=https://github.com/apache/arrow
 TERMUX_PKG_DESCRIPTION="C++ libraries for Apache Arrow"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=7.0.0
-TERMUX_PKG_SRCURL=https://github.com/apache/arrow/archive/refs/tags/apache-arrow-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=57e13c62f27b710e1de54fd30faed612aefa22aa41fa2c0c3bacd204dd18a8f3
-TERMUX_PKG_DEPENDS="libc++"
+TERMUX_PKG_VERSION=(7.0.0)
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION+=(1.22.3) # NumPy version
+TERMUX_PKG_SRCURL=(https://github.com/apache/arrow/archive/refs/tags/apache-arrow-${TERMUX_PKG_VERSION}.tar.gz
+                   https://github.com/numpy/numpy/archive/refs/tags/v${TERMUX_PKG_VERSION[1]}.tar.gz)
+TERMUX_PKG_SHA256=(57e13c62f27b710e1de54fd30faed612aefa22aa41fa2c0c3bacd204dd18a8f3
+                   c8f3ec591e3f17b939220f2b9eabb4c5e2db330f8af62c0a3aeee8a4d1a6c0db)
+TERMUX_PKG_DEPENDS="libc++, libre2, utf8proc"
+TERMUX_PKG_BUILD_DEPENDS="rapidjson"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DARROW_BUILD_STATIC=OFF
 -DARROW_JEMALLOC=OFF
+-DARROW_PYTHON=ON
 "
 
+termux_step_post_get_source() {
+	mv numpy-${TERMUX_PKG_VERSION[1]} numpy
+}
+
 termux_step_pre_configure() {
+	_PYTHON_VERSION=$(. $TERMUX_SCRIPTDIR/packages/python/build.sh; echo $_MAJOR_VERSION)
+	termux_setup_python_crossenv
+	pushd $TERMUX_PYTHON_CROSSENV_SRCDIR
+	_CROSSENV_PREFIX=$TERMUX_PKG_BUILDDIR/python-crossenv-prefix
+	python${_PYTHON_VERSION} -m crossenv \
+		$TERMUX_PREFIX/bin/python${_PYTHON_VERSION} \
+		${_CROSSENV_PREFIX}
+	popd
+	. ${_CROSSENV_PREFIX}/bin/activate
+	LDFLAGS+=" -lpython${_PYTHON_VERSION}"
+	export NPY_DISABLE_SVML=1
+	pushd $TERMUX_PKG_SRCDIR/numpy
+	pip install .
+	popd
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+="
+		-DPYTHON_EXECUTABLE=python
+		-DPYTHON_INCLUDE_DIRS=$TERMUX_PREFIX/include/python${_PYTHON_VERSION}
+		-DPYTHON_LIBRARIES=$TERMUX_PREFIX/lib/libpython${_PYTHON_VERSION}.so
+		-DPYTHON_OTHER_LIBS=
+		-DNUMPY_INCLUDE_DIRS=${_CROSSENV_PREFIX}/cross/lib/python${_PYTHON_VERSION}/site-packages/numpy/core/include
+		"
+
 	TERMUX_PKG_SRCDIR+="/cpp"
 
 	_NEED_DUMMY_LIBRT_A=

--- a/packages/libarrow-cpp/cpp-cmake_modules-FindPython3Alt.cmake.patch
+++ b/packages/libarrow-cpp/cpp-cmake_modules-FindPython3Alt.cmake.patch
@@ -1,0 +1,18 @@
+--- a/cpp/cmake_modules/FindPython3Alt.cmake
++++ b/cpp/cmake_modules/FindPython3Alt.cmake
+@@ -23,6 +23,7 @@
+ # - PYTHON_OTHER_LIBS
+ # - NUMPY_INCLUDE_DIRS
+ 
++if(FALSE)
+ # Need CMake 3.15 or later for Python3_FIND_STRATEGY
+ if(${CMAKE_VERSION} VERSION_LESS "3.15.0")
+   # Use deprecated Python- and NumPy-finding code
+@@ -69,6 +70,7 @@
+ set(PYTHON_OTHER_LIBS)
+ 
+ get_target_property(NUMPY_INCLUDE_DIRS Python3::NumPy INTERFACE_INCLUDE_DIRECTORIES)
++endif(FALSE)
+ 
+ # CMake's python3_add_library() doesn't apply the required extension suffix,
+ # detect it ourselves.

--- a/packages/libarrow-cpp/libarrow-python.subpackage.sh
+++ b/packages/libarrow-cpp/libarrow-python.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_INCLUDE="
+lib/libarrow_python*
+lib/cmake/arrow/*ArrowPython*.cmake
+lib/pkgconfig/arrow-python.pc
+include/arrow/python
+"
+TERMUX_SUBPKG_DESCRIPTION="Arrow CPython extensions"
+TERMUX_SUBPKG_DEPENDS="python"


### PR DESCRIPTION
Closes #10326.