### PR TITLE
fix(yara): depend on `libandroid-posix-semaphore`, update to 4.2.1

### DIFF
--- a/packages/yara/build.sh
+++ b/packages/yara/build.sh
@@ -2,15 +2,16 @@ TERMUX_PKG_HOMEPAGE=https://github.com/VirusTotal/yara
 TERMUX_PKG_DESCRIPTION="Tool aimed at helping malware researchers to identify and classify malware samples"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=4.2.0
+TERMUX_PKG_VERSION=4.2.1
 TERMUX_PKG_SRCURL=https://github.com/VirusTotal/yara/archive/v$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_SHA256=6f567d4e4b79a210cd57a820f59f19ee69b024188ef4645b1fc11488a4660951
+TERMUX_PKG_SHA256=f26d9c481e6789181431ac410665f6ba25d551c2948995f84c9e17df7a93731a
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+\.\d+"
-TERMUX_PKG_DEPENDS="file, openssl"
+TERMUX_PKG_DEPENDS="file, openssl, libandroid-posix-semaphore"
 TERMUX_PKG_BREAKS="yara-dev"
 TERMUX_PKG_REPLACES="yara-dev"
 
 termux_step_pre_configure() {
+	LDFLAGS+=" -landroid-posix-semaphore"
 	./bootstrap.sh
 }


### PR DESCRIPTION
fix #10343

Signed-off-by: Aditya Alok <dev.aditya.alok@gmail.com>
