### PR TITLE
htop: add checks if a user is rooted

### DIFF
--- a/packages/htop/build.sh
+++ b/packages/htop/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Interactive process viewer for Linux"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.1.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/htop-dev/htop/archive/${TERMUX_PKG_VERSION}/htop-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=fe9559637c8f21f5fd531a4c072048a404173806acbdad1359c6b82fd87aa001
 # htop checks setlocale() return value for UTF-8 support, so use libandroid-support.

--- a/packages/htop/root-actual-procstat-file.patch
+++ b/packages/htop/root-actual-procstat-file.patch
@@ -1,0 +1,20 @@
+diff -uNr htop-3.1.2/linux/LinuxProcessList.c htop-3.1.2.mod/linux/LinuxProcessList.c
+--- htop-3.1.2/linux/LinuxProcessList.c	2021-11-30 01:03:21.000000000 +0000
++++ htop-3.1.2.mod/linux/LinuxProcessList.c	2022-04-27 07:36:29.194907488 +0000
+@@ -1898,7 +1898,15 @@
+ 
+    LinuxProcessList_updateCPUcount(super);
+ 
+-   FILE* file = fopen(PROCSTATFILE, "r");
++   FILE* file;
++
++   /* Read the actual procstat file only if we're rooted */
++   if (getuid() == 0){
++      file = fopen("/proc/stat", "r");
++   } else {
++      file = fopen(PROCSTATFILE, "r");
++   }
++
+    if (!file)
+       CRT_fatalError("Cannot open " PROCSTATFILE);
+ 


### PR DESCRIPTION
There are some reports on which the user complains about static CPU usage in `htop` even if they're rooted. this PR should read `/proc/stat` inside the `LinuxProcessList.c` and not relying on the `PROCSTATFILE` macro which points to `$PREFIX/var/htop/stat`