### PR TITLE
ani-cli dependency bugfix

### DIFF
--- a/packages/ani-cli/build.sh
+++ b/packages/ani-cli/build.sh
@@ -2,10 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://github.com/pystardust/ani-cli
 TERMUX_PKG_DESCRIPTION="A cli to browse and watch anime"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=2.1
+TERMUX_PKG_VERSION=2.2
 TERMUX_PKG_SRCURL=https://github.com/pystardust/ani-cli/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=5e4ba037cd2a74e483cf2d9ddfe69335a81ee4d178270b8c6ee946024026ca00
-TERMUX_PKG_DEPENDS="aria2, curl, git, grep, mpv, openssl, sed, ffmpeg"
+TERMUX_PKG_SHA256=973d335a75bd7f920c244000ad6b057f702fb37752e7bea1b5bcf038785ec925
+TERMUX_PKG_DEPENDS="aria2, curl, grep, mpv, openssl-tool, sed, gawk, ffmpeg"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_BUILD_IN_SRC=true
 


### PR DESCRIPTION
I intentionally separated this into 3 commits:

- throughout the lifetime of this package we never depended on git
- we prefer termux-tools over listing curl, grep, sed individually since we may expand our use of other coreutils. If this conflicts with policy, this can easily be reverted
- At least in my personal testing, ani-cli cannot find openssl if you just install openssl. We interact with the openssl commandline programm, so openssl-tool is required

Draft PR because we'll probably release 2.2 soon

Greetings from upstream