### PR TITLE
speechd: Backport patch to fix uninitialized variables

### DIFF
--- a/packages/speechd/build.sh
+++ b/packages/speechd/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Common interface to speech synthesis"
 TERMUX_PKG_LICENSE="LGPL-2.1, GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.11.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=6dd8566188f70b1e971fe18f78960e30cb7daee88f147e5235b5cdfaf6184bb8
 TERMUX_PKG_SRCURL=https://github.com/brailcom/speechd/archive/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_DEPENDS="dotconf, espeak, glib, libiconv, pulseaudio, python"

--- a/packages/speechd/speechd-0.11.1-fix-uninitialized-variables.patch
+++ b/packages/speechd/speechd-0.11.1-fix-uninitialized-variables.patch
@@ -1,0 +1,31 @@
+From 3071e7d8553b245b4adc15edd44c5c309b881846 Mon Sep 17 00:00:00 2001
+From: Samuel Thibault <samuel.thibault@ens-lyon.org>
+Date: Sat, 12 Mar 2022 09:19:34 +0100
+Subject: [PATCH] Fix uninitialized variables
+
+---
+ src/server/output.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/server/output.c b/src/server/output.c
+index f30d4303..b634ec4c 100644
+--- a/src/server/output.c
++++ b/src/server/output.c
+@@ -287,7 +287,7 @@ static int output_reading_message;
+ 
+ GString *output_read_reply(OutputModule * output)
+ {
+-	GString *message;
++	GString *message = NULL;
+ 	pthread_mutex_lock(&output_read_mutex);
+ 	while (!message) {
+ 		while (output_reading_message && !output_reply)
+@@ -325,7 +325,7 @@ GString *output_read_reply(OutputModule * output)
+ 
+ GString *output_read_event(OutputModule * output)
+ {
+-	GString *message;
++	GString *message = NULL;
+ 	pthread_mutex_lock(&output_read_mutex);
+ 	while (!message) {
+ 		while (output_reading_message && !output_event)


### PR DESCRIPTION
Fixes #10380.