### PR TITLE
packages: Fix hardcoded package name

### DIFF
--- a/packages/asciidoctor/build.sh
+++ b/packages/asciidoctor/build.sh
@@ -30,7 +30,7 @@ termux_step_make_install() {
 
 termux_step_install_license() {
 	local gemdir="$TERMUX_PREFIX/lib/ruby/gems/${ruby_version:0:3}.0"
-	mkdir -p $TERMUX_PREFIX/share/doc/asciidoctor
+	mkdir -p $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME
 	cp $gemdir/gems/asciidoctor-${TERMUX_PKG_VERSION}/LICENSE \
-		$TERMUX_PREFIX/share/doc/asciidoctor/
+		$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/
 }

--- a/packages/frogcomposband/build.sh
+++ b/packages/frogcomposband/build.sh
@@ -20,5 +20,5 @@ termux_step_post_make_install () {
 
 termux_step_install_license() {
 	install -Dm600 $TERMUX_PKG_BUILDER_DIR/LICENSE \
-		$TERMUX_PREFIX/share/doc/frogcomposband/LICENSE
+		$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/LICENSE
 }

--- a/packages/ghc-libs/build.sh
+++ b/packages/ghc-libs/build.sh
@@ -129,5 +129,6 @@ termux_step_post_make_install() {
 }
 
 termux_step_install_license() {
-	install -Dm600 -t "${TERMUX_PREFIX}/share/doc/ghc" "${TERMUX_PKG_SRCDIR}/LICENSE"
+	install -Dm600 -t "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}" \
+		"${TERMUX_PKG_SRCDIR}/LICENSE"
 }

--- a/packages/lsof/build.sh
+++ b/packages/lsof/build.sh
@@ -20,5 +20,6 @@ termux_step_make_install() {
 }
 
 termux_step_install_license() {
-	install -Dm600 -t $TERMUX_PREFIX/share/doc/lsof $TERMUX_PKG_BUILDER_DIR/license.txt
+	install -Dm600 -t $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME \
+		$TERMUX_PKG_BUILDER_DIR/license.txt
 }

--- a/packages/netcat-openbsd/build.sh
+++ b/packages/netcat-openbsd/build.sh
@@ -35,6 +35,6 @@ termux_step_make_install() {
 }
 
 termux_step_install_license() {
-	mkdir -p $TERMUX_PREFIX/share/doc/netcat-openbsd
-	head -n28 netcat.c | tail -n+2 > $TERMUX_PREFIX/share/doc/netcat-openbsd/LICENSE
+	mkdir -p $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME
+	head -n28 netcat.c | tail -n+2 > $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/LICENSE
 }

--- a/packages/ovmf/build.sh
+++ b/packages/ovmf/build.sh
@@ -44,5 +44,5 @@ termux_step_make_install() {
 
 termux_step_install_license() {
 	install -Dm600 $TERMUX_PKG_BUILDER_DIR/License.txt \
-		$TERMUX_PREFIX/share/doc/ovmf/LICENSE.txt
+		$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/LICENSE.txt
 }

--- a/packages/snake/build.sh
+++ b/packages/snake/build.sh
@@ -14,6 +14,6 @@ termux_step_make_install() {
 }
 
 termux_step_install_license() {
-	install -Dm644 -t $TERMUX_PREFIX/share/doc/snake/ \
+	install -Dm644 -t $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/ \
 		$TERMUX_PKG_BUILDER_DIR/LICENSE
 }

--- a/packages/srelay/build.sh
+++ b/packages/srelay/build.sh
@@ -26,6 +26,6 @@ termux_step_make_install() {
 }
 
 termux_step_install_license() {
-	install -Dm600 -t "$TERMUX_PREFIX/share/doc/srelay" \
+	install -Dm600 -t "$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME" \
 		"$TERMUX_PKG_BUILDER_DIR"/LICENSE.txt
 }

--- a/x11-packages/libdrm/build.sh
+++ b/x11-packages/libdrm/build.sh
@@ -19,5 +19,6 @@ termux_step_pre_configure() {
 }
 
 termux_step_install_license() {
-	install -Dm600 -t $TERMUX_PREFIX/share/doc/libdrm $TERMUX_PKG_BUILDER_DIR/LICENSE
+	install -Dm600 -t $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME \
+		$TERMUX_PKG_BUILDER_DIR/LICENSE
 }

--- a/x11-packages/xcb-util-keysyms/build.sh
+++ b/x11-packages/xcb-util-keysyms/build.sh
@@ -10,5 +10,6 @@ TERMUX_PKG_DEPENDS="libxcb"
 TERMUX_PKG_BUILD_DEPENDS="xorg-util-macros"
 
 termux_step_install_license() {
-	install -Dm600 -t $TERMUX_PREFIX/share/doc/xcb-util-keysyms $TERMUX_PKG_BUILDER_DIR/LICENSE
+	install -Dm600 -t $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME \
+		$TERMUX_PKG_BUILDER_DIR/LICENSE
 }

--- a/x11-packages/xorg-fonts-100dpi/build.sh
+++ b/x11-packages/xorg-fonts-100dpi/build.sh
@@ -50,5 +50,6 @@ termux_step_post_make_install() {
 }
 
 termux_step_install_license() {
-    install -Dm600 -t $TERMUX_PREFIX/share/doc/xorg-fonts-100dpi $TERMUX_PKG_BUILDER_DIR/COPYING 
+	install -Dm600 -t $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME \
+		$TERMUX_PKG_BUILDER_DIR/COPYING
 }

--- a/x11-packages/xorg-fonts-75dpi/build.sh
+++ b/x11-packages/xorg-fonts-75dpi/build.sh
@@ -50,5 +50,6 @@ termux_step_post_make_install() {
 }
 
 termux_step_install_license() {
-	install -Dm600 -t $TERMUX_PREFIX/share/doc/xorg-fonts-75dpi $TERMUX_PKG_BUILDER_DIR/COPYING
+	install -Dm600 -t $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME \
+		$TERMUX_PKG_BUILDER_DIR/COPYING
 }


### PR DESCRIPTION
in `termux_step_install_license()`.