### PR TITLE
htop: update to 3.2.0

### DIFF
--- a/packages/htop/build.sh
+++ b/packages/htop/build.sh
@@ -2,10 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://htop.dev/
 TERMUX_PKG_DESCRIPTION="Interactive process viewer for Linux"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=3.1.2
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION=3.2.0
 TERMUX_PKG_SRCURL=https://github.com/htop-dev/htop/archive/${TERMUX_PKG_VERSION}/htop-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=fe9559637c8f21f5fd531a4c072048a404173806acbdad1359c6b82fd87aa001
+TERMUX_PKG_SHA256=1a1dd174cc828521fe5fd0e052cff8c30aa50809cf80d3ce3a481c37d476ac54
 # htop checks setlocale() return value for UTF-8 support, so use libandroid-support.
 TERMUX_PKG_DEPENDS="libandroid-support, ncurses"
 TERMUX_PKG_BREAKS="htop-legacy"


### PR DESCRIPTION
This version introduces new disk IO monitoring tab (requires root or selinux permissive) and keeps this package up-to-date