### PR TITLE
apkeep: update to v0.12.1

### DIFF
--- a/packages/apkeep/build.sh
+++ b/packages/apkeep/build.sh
@@ -2,15 +2,15 @@ TERMUX_PKG_HOMEPAGE=https://github.com/EFForg/apkeep
 TERMUX_PKG_DESCRIPTION="A command-line tool for downloading APK files from various sources"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=0.12.0
+TERMUX_PKG_VERSION=0.12.1
 TERMUX_PKG_SRCURL=https://github.com/EFForg/apkeep/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=a1ab0121e53cc63cad042c378ea3c28779fd201287917186b429aec69522f224
-TERMUX_PKG_DEPENDS="openssl"
+TERMUX_PKG_SHA256=366d65464c5cfb9a27114dcb91e7bae2d91ced09bd8412eb5e608a1e14e8f2ba
+TERMUX_PKG_DEPENDS="openssl-1.1"
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_pre_configure() {
-	export OPENSSL_INCLUDE_DIR=$TERMUX_PREFIX/include/openssl
-	export OPENSSL_LIB_DIR=$TERMUX_PREFIX/lib
+	export OPENSSL_INCLUDE_DIR=$TERMUX_PREFIX/include/openssl-1.1/openssl
+	export OPENSSL_LIB_DIR=$TERMUX_PREFIX/lib/openssl-1.1
 }
 
 termux_step_make() {


### PR DESCRIPTION
Also fixes dependency to ensure `openssl-1.1` is used