### PR TITLE
new package: n2n

### DIFF
--- a/packages/n2n/Makefile.in.patch
+++ b/packages/n2n/Makefile.in.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -69,7 +69,7 @@
+ ifeq ($(CONFIG_TARGET),darwin)
+ SBINDIR=$(PREFIX)/local/sbin
+ else
+-SBINDIR=$(PREFIX)/sbin
++SBINDIR=$(PREFIX)/bin
+ endif
+ 
+ MANDIR?=$(PREFIX)/share/man

--- a/packages/n2n/build.sh
+++ b/packages/n2n/build.sh
@@ -1,0 +1,24 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/ntop/n2n
+TERMUX_PKG_DESCRIPTION="A light VPN software"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=3.1.1
+TERMUX_PKG_SRCURL=https://github.com/ntop/n2n/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=311f89d147558ae4dfb0d8f8698f5429c05a3e19a9d25cb8c85bd73d02aff834
+TERMUX_PKG_DEPENDS="libcap, libpcap, openssl, zstd"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_FORCE_CMAKE=false
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--disable-miniupnp
+--disable-natpmp
+--enable-pcap
+--enable-cap
+--disable-pthread
+--with-zstd
+--with-openssl
+"
+TERMUX_PKG_EXTRA_MAKE_ARGS="PREFIX=$TERMUX_PREFIX"
+
+termux_step_pre_configure() {
+	autoreconf -fi
+}


### PR DESCRIPTION
In this package some commands (e.g. `edge`) are only usable with root privilege but others (e.g. `supernode`) are not. So I believe this should go to main repo rather than root repo, just like `softether-vpn` package.

Closes #10661.