### PR TITLE
ncurses: Do not rely on `nl_langinfo(CODESET)`

### DIFF
--- a/packages/ncurses/build.sh
+++ b/packages/ncurses/build.sh
@@ -7,6 +7,7 @@ TERMUX_PKG_VERSION=(6.3
 		    15
 		    0.20.3
 		    0.9.0)
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=(https://ftp.gnu.org/gnu/ncurses/ncurses-${TERMUX_PKG_VERSION[0]}.tar.gz
 		   https://fossies.org/linux/misc/rxvt-unicode-${TERMUX_PKG_VERSION[1]}.tar.bz2
 		   https://github.com/thestinger/termite/archive/v${TERMUX_PKG_VERSION[2]}.tar.gz
@@ -24,6 +25,7 @@ TERMUX_PKG_REPLACES="ncurses-dev, ncurses-utils (<< 6.1.20190511-4)"
 # --disable-stripping to disable -s argument to install which does not work when cross compiling:
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 ac_cv_header_locale_h=no
+am_cv_langinfo_codeset=no
 --disable-stripping
 --enable-const
 --enable-ext-colors


### PR DESCRIPTION
when determining the current locale.

Fixes #10676.