### PR TITLE
new package: mosh-git

### DIFF
--- a/packages/mosh-git/build.sh
+++ b/packages/mosh-git/build.sh
@@ -1,0 +1,31 @@
+TERMUX_PKG_HOMEPAGE=https://mosh.org
+TERMUX_PKG_DESCRIPTION="Mobile shell that supports roaming and intelligent local echo. Bleeding edge git version."
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=2022.02.04
+TERMUX_PKG_GIT_BRANCH=master
+TERMUX_PKG_SRCURL=https://github.com/mobile-shell/mosh.git
+TERMUX_PKG_DEPENDS="libandroid-support, libc++, libprotobuf, ncurses, openssl, openssh, perl"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_CONFLICTS="mosh, mosh-perl"
+TERMUX_PKG_REPLACES="mosh, mosh-perl"
+TERMUX_PKG_PROVIDES="mosh, mosh-perl"
+_COMMIT=dbe419d0e069df3fedc212d456449f64d0280c76
+
+termux_step_pre_configure() {
+	termux_setup_protobuf
+	./autogen.sh
+}
+
+termux_step_post_get_source() {
+	git fetch --unshallow
+	git checkout "$_COMMIT"
+
+	local version
+	version="$(git log -1 --format=%cs | sed 's/-/./g')"
+	if [ "$version" != "$TERMUX_PKG_VERSION" ]; then
+		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
+		echo " is different from what is expected to be: \"$version\""
+		return 1
+	fi
+}

--- a/packages/mosh-git/mosh-server.cc.patch
+++ b/packages/mosh-git/mosh-server.cc.patch
@@ -1,0 +1,14 @@
+diff -uNr mosh-1.3.2/src/frontend/mosh-server.cc mosh-1.3.2.mod/src/frontend/mosh-server.cc
+--- mosh-1.3.2/src/frontend/mosh-server.cc	2017-07-23 00:14:53.000000000 +0300
++++ mosh-1.3.2.mod/src/frontend/mosh-server.cc	2019-03-01 22:37:18.009498882 +0200
+@@ -562,8 +562,8 @@
+       // this always happens.
+       // XXX Hackish knowledge of Ubuntu PAM configuration.
+       // But this seems less awful than build-time detection with autoconf.
+-      if (!print_motd("/run/motd.dynamic")) {
+-	print_motd("/var/run/motd.dynamic");
++      if (!print_motd("@TERMUX_PREFIX@/run/motd.dynamic")) {
++	print_motd("@TERMUX_PREFIX@/var/run/motd.dynamic");
+       }
+       // Always print traditional /etc/motd.
+       print_motd("/etc/motd");


### PR DESCRIPTION
It's been 5 years since the Mosh team have officially made a new
release. Meanwhile the master branch has seen many updates. Most notably
for me, 24 bit true colour.

There's been quite some discussion about cutting a new release. But see
here to start: https://github.com/mobile-shell/mosh/issues/1115