### PR TITLE
upgpkg(tinyproxy): update to 1.11.1

### DIFF
--- a/packages/tinyproxy/build.sh
+++ b/packages/tinyproxy/build.sh
@@ -2,18 +2,17 @@ TERMUX_PKG_HOMEPAGE=https://tinyproxy.github.io/
 TERMUX_PKG_DESCRIPTION="Light-weight HTTP proxy daemon for POSIX operating systems"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1.11.0
+TERMUX_PKG_VERSION=1.11.1
 TERMUX_PKG_SRCURL=https://github.com/tinyproxy/tinyproxy/releases/download/${TERMUX_PKG_VERSION}/tinyproxy-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=c1ec81cfc4c551d2c24e0227a5aeeaad8723bd9a39b61cd729e516b82eaa3f32
+TERMUX_PKG_SHA256=d66388448215d0aeb90d0afdd58ed00386fb81abc23ebac9d80e194fceb40f7c
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-regexcheck"
 
-termux_step_post_massage() {
-	mkdir -p $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/var/log/$TERMUX_PKG_NAME
-	mkdir -p $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/var/run/$TERMUX_PKG_NAME
-	find $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/var -exec chmod -f u+w,g-rwx,o-rwx \{\} \;
-}
-
 termux_step_pre_configure() {
 	CPPFLAGS+=" -DLINE_MAX=_POSIX2_LINE_MAX"
+}
+
+termux_step_post_massage() {
+	mkdir -p "${TERMUX_PKG_MASSAGEDIR}/${TERMUX_PREFIX}/var/log/${TERMUX_PKG_NAME}"
+	mkdir -p "${TERMUX_PKG_MASSAGEDIR}/${TERMUX_PREFIX}/var/run/${TERMUX_PKG_NAME}"
 }

--- a/packages/tinyproxy/pthread_flag.patch
+++ b/packages/tinyproxy/pthread_flag.patch
@@ -1,11 +1,10 @@
---- a/src/Makefile.in	2021-04-16 12:31:11.000000000 +0000
-+++ b/src/Makefile.in	2021-06-25 04:30:56.242203644 +0000
-@@ -58,7 +58,7 @@
+--- ./src/Makefile.in	2022-05-28 17:46:47.805190949 +0000
++++ ./src/Makefile.in	2022-05-28 17:47:03.734181908 +0000
+@@ -349,7 +349,7 @@
  	transparent-proxy.c transparent-proxy.h
 
  tinyproxy_DEPENDENCIES = @ADDITIONAL_OBJECTS@
 -tinyproxy_LDADD = @ADDITIONAL_OBJECTS@ -lpthread
 +tinyproxy_LDADD = @ADDITIONAL_OBJECTS@
- EXTRA_DIST = conf-tokens.gperf
+ EXTRA_DIST = conf-tokens.gperf conf-tokens-gperf.inc
  all: all-am
- 


### PR DESCRIPTION
- updated srm-m.patch and renamed to pthread_flag.patch
- removed adding permissions to files since there is no meaning of 'other'
  and 'group' users in Termux.

Closes #10832
