### PR TITLE
Add package for Dungeon Crawl Stone Soup

### DIFF
--- a/packages/crawl/Makefile.patch
+++ b/packages/crawl/Makefile.patch
@@ -1,0 +1,54 @@
+--- a/crawl-ref/source/Makefile
++++ b/crawl-ref/source/Makefile
+@@ -165,8 +165,8 @@ endif
+ #
+ AR = ar
+ RANLIB = ranlib
+-CC = $(GCC)
+-CXX = $(GXX)
++CC := $(CC)
++CXX := $(CXX)
+ RM = rm -f
+ COPY = cp
+ COPY_R = cp -r
+@@ -474,10 +474,10 @@ ifdef MACOSX_MIN_VERSION
+ 	CFLAGS_ARCH += -mmacosx-version-min=$(MACOSX_MIN_VERSION)
+ 	CFLAGS_DEPCC_ARCH += -mmacosx-version-min=$(MACOSX_MIN_VERSION)
+ endif
+-CC = $(GCC) $(CFLAGS_ARCH)
+-CXX = $(GXX) $(CFLAGS_ARCH) -stdlib=libc++
+-DEPCC = $(GCC) $(or $(CFLAGS_DEPCC_ARCH),$(CFLAGS_ARCH))
+-DEPCXX = $(GXX) $(or $(CFLAGS_DEPCC_ARCH),$(CFLAGS_ARCH)) -stdlib=libc++
++CC := $(CC) $(CFLAGS_ARCH)
++CXX := $(CXX) $(CFLAGS_ARCH) -stdlib=libc++
++DEPCC := $(CC) $(or $(CFLAGS_DEPCC_ARCH),$(CFLAGS_ARCH))
++DEPCXX := $(CXX) $(or $(CFLAGS_DEPCC_ARCH),$(CFLAGS_ARCH)) -stdlib=libc++
+
+ ifdef USE_ICC
+ CC += -gcc-name=gcc-$(GCC_VER) -gxx-name=g++-$(GCC_VER)
+@@ -532,12 +532,10 @@ endif
+ else
+
+ # Cross-compiling is a weird case.
+-GCC := $(CROSSHOST)-gcc
+-GXX := $(CROSSHOST)-g++
+-AR := $(CROSSHOST)-ar
+-RANLIB := $(CROSSHOST)-ranlib
+-STRIP := $(CROSSHOST)-strip
+-WINDRES := $(CROSSHOST)-windres
++AR := llvm-ar
++RANLIB := llvm-ranlib
++STRIP := llvm-strip
++WINDRES := llvm-windres
+
+ endif
+
+@@ -1039,5 +1037,5 @@ else
+   NCURSESLIB = ncursesw
+ endif
+
+-NC_LIBS := -L$(NC_PREFIX)/lib -l$(NCURSESLIB)
++NC_LIBS := -L@TERMUX_PREFIX@/lib -lncurses
+ NC_CFLAGS := -isystem $(NC_PREFIX)/include/$(NCURSESLIB)
+
+ ifndef NO_PKGCONFIG

--- a/packages/crawl/build.sh
+++ b/packages/crawl/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE=https://crawl.develz.org/
+TERMUX_PKG_DESCRIPTION="Roguelike adventure through dungeons filled with dangerous monsters"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_SRCURL=https://github.com/crawl/crawl.git
+TERMUX_PKG_VERSION=0.29-a0
+TERMUX_PKG_GIT_BRANCH=0.29-a0
+TERMUX_PKG_DEPENDS="ncurses, zlib"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+    export CROSSHOST="$TERMUX_HOST_PLATFORM"
+    export TERMUX_PKG_BUILDDIR="$TERMUX_PKG_SRCDIR/crawl-ref/source"
+
+    export INCLUDES_L="-I$TERMUX_PREFIX/include"
+    export LIBS="-llog -Wl,--rpath=$TERMUX_PREFIX/lib"
+}
+
+termux_step_post_configure() {
+    sed -i 's,#ifdef __ANDROID__,#ifdef __NO_THANKS__,g' "$TERMUX_PKG_BUILDDIR/syscalls.cc"
+}


### PR DESCRIPTION
Ages ago I made [this pull](https://github.com/termux/game-packages/pull/60) in the games repo, but after noticing some architecture-dependent build weirdness, I figured it shouldn't be merged until I figured that out.....then I kinda fell off the planet.

But I tried again recently, and managed to figure out how to get this to build on all architectures!

There was some Makefile weirdness, and I had to rpath the libraries so cross compiling wouldn't cause the linker to not know where to find its shared libraries, but we now have a working version of DCSS that can finally be added to the repos~ \^\^