### PR TITLE
zpaq: new package

### DIFF
--- a/packages/zpaq/Makefile.patch
+++ b/packages/zpaq/Makefile.patch
@@ -1,0 +1,15 @@
+diff --color -uNr zpaq-7.15/Makefile zpaq-7.15.mod/Makefile
+--- zpaq-7.15/Makefile	2016-08-17 18:49:18.000000000 -0300
++++ zpaq-7.15.mod/Makefile	2022-06-07 18:22:22.816761025 -0300
+@@ -1,8 +1,6 @@
+-CXX=g++
+-CPPFLAGS+=-Dunix
+-# CPPFLAGS+=NOJIT
+-CXXFLAGS=-O3 -march=native
+-PREFIX=/usr/local
++# CPPFLAGS+=-Dunix
++# CPPFLAGS+=-DNOJIT
++PREFIX=@TERMUX_PREFIX@
+ BINDIR=$(PREFIX)/bin
+ MANDIR=$(PREFIX)/share/man
+ 

--- a/packages/zpaq/build.sh
+++ b/packages/zpaq/build.sh
@@ -1,0 +1,22 @@
+TERMUX_PKG_HOMEPAGE=http://mattmahoney.net/dc/zpaq.html
+TERMUX_PKG_DESCRIPTION="Programmable file compressor, library and utilities. Based on the PAQ compression algorithm"
+TERMUX_PKG_LICENSE="MIT, Unlicense"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=7.15
+TERMUX_PKG_SRCURL=https://github.com/zpaq/zpaq/archive/refs/tags/${TERMUX_PKG_VERSION}.zip
+TERMUX_PKG_SHA256=2d13de90fdd89a8e9eeda4afbf76610d3ace4aa675795b7c3a9f13b21fbdbe3e
+TERMUX_PKG_BUILD_DEPENDS="perl"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+	CXXFLAGS+=" -O3"
+	if [ $TERMUX_ARCH = "aarch64" ]; then
+		CPPFLAGS+=" -DNOJIT"
+	elif [ $TERMUX_ARCH = "arm" ]; then
+		CPPFLAGS+=" -DNOJIT"
+	elif [ $TERMUX_ARCH = "i686" ]; then
+		CPPFLAGS+=" -Dunix"
+	elif [ $TERMUX_ARCH = "x86_64" ]; then
+		CPPFLAGS+=" -Dunix"
+	fi
+}


### PR DESCRIPTION

Greetings, i need some advice here. The Makefile passes the LDFLAGS to g++ when compiling, however, it also passes the -static-openmp flag that is in the LDFLAGS, which g++ just, doesn't know what do with and fails the build. 

How can i specifically remove only that argument from the LDFLAGS instead of setting the whole thing manually like i ended up doing? Which just seems wrong