### PR TITLE
Add ToME 2

### DIFF
--- a/packages/tome2/LICENSE
+++ b/packages/tome2/LICENSE
@@ -1,0 +1,3 @@
+Copyright (c) 1997 Ben Harrison, James E. Wilson, Robert A. Koeneke
+
+This software may be copied and distributed for educational, research, and not for profit purposes provided that this copyright and statement are included in all such copies. Other copyrights may also apply.

--- a/packages/tome2/build.sh
+++ b/packages/tome2/build.sh
@@ -1,0 +1,28 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/tome2/tome2
+TERMUX_PKG_DESCRIPTION="An open world roguelike adventure set in middle earth"
+TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_SRCURL=https://github.com/tome2/tome2.git
+TERMUX_PKG_VERSION=2022.02.24
+TERMUX_PKG_GIT_BRANCH=master
+_COMMIT=d25bdae09bffea46ac54e51b99b2c166d9be7db8
+TERMUX_PKG_DEPENDS="ncurses, boost"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DSYSTEM_INSTALL=YES"
+
+termux_step_post_get_source() {
+	git fetch --unshallow || true
+	git checkout $_COMMIT
+
+	local version="$(git rev-parse HEAD)"
+	if [ "$version" != "$_COMMIT" ]; then
+		echo -n "ERROR: Failed to check out the specified version; \"$_COMMIT\""
+		echo " differs from the current HEAD: \"$version\""
+		return 1
+	fi
+}
+
+termux_step_install_license() {
+	install -Dm600 $TERMUX_PKG_BUILDER_DIR/LICENSE \
+		$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/LICENSE
+}


### PR DESCRIPTION
This PR adds the roguelike ToME 2, an open world band roguelike~

![The player character standing in the middle of a town called Bree](https://user-images.githubusercontent.com/1385527/172516507-8763ce83-d7d5-4be8-84a9-a676e02c5074.png)

This also the game that [this issue](https://github.com/termux/termux-packages/issues/10904) was requesting, so this solves that too~