### PR TITLE
fix(main/angle-grinder): arm build

### DIFF
--- a/packages/angle-grinder/build.sh
+++ b/packages/angle-grinder/build.sh
@@ -7,3 +7,14 @@ TERMUX_PKG_SRCURL="https://github.com/rcoh/angle-grinder/archive/v$TERMUX_PKG_VE
 TERMUX_PKG_SHA256=7a282d9eff88bb2e224b02d80b887de92286e451abf8a193248d30136d08f4e0
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+	# ```
+	# ld: error: undefined symbol: __emutls_get_address
+	# ```
+	# It isn't able to find/link with `libgcc` during arm build.
+
+	if [[ "${TERMUX_ARCH}" == "arm" ]]; then
+		RUSTFLAGS+=" -C link-arg=$($CC -print-libgcc-file-name)"
+	fi
+}


### PR DESCRIPTION
* It was unable to find/link with `libgcc`.
* This must be due to shift of Android from `libgcc` to clang's
  `libclang_rt.builtins` in ndk-r23.

Closes #10957
