### PR TITLE
Updates ngspice 35 to 37

### DIFF
--- a/packages/ngspice/build.sh
+++ b/packages/ngspice/build.sh
@@ -3,8 +3,16 @@ TERMUX_PKG_DESCRIPTION="A mixed-level/mixed-signal circuit simulator"
 TERMUX_PKG_LICENSE="BSD 3-Clause, LGPL-2.1"
 TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=35
+TERMUX_PKG_VERSION=37
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/ngspice/ngspice-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=c1b7f5c276db579acb3f0a7afb64afdeb4362289a6cab502d4ca302d6e5279ec
-TERMUX_PKG_DEPENDS="libc++"
+TERMUX_PKG_SHA256=9beea6741a36a36a70f3152a36c82b728ee124c59a495312796376b30c8becbe
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--build=x86_64-linux-gnu
+--host=$TERMUX_HOST_PLATFORM
+--enable-xspice
+--enable-cider
+--with-readline=yes
+--enable-openmp
+"
+TERMUX_PKG_DEPENDS="libc++, readline, fftw"
 TERMUX_PKG_GROUPS="science"

--- a/packages/ngspice/src-frontend-com_shell.c.patch
+++ b/packages/ngspice/src-frontend-com_shell.c.patch
@@ -1,5 +1,5 @@
---- a/src/frontend/com_shell.c
-+++ b/src/frontend/com_shell.c
+--- ngspice-37/src/frontend/com_shell.c	2022-05-17 18:00:52.000000000 +0800
++++ ngspice-37.mod/src/frontend/com_shell.c	2022-06-16 22:56:25.591998228 +0800
 @@ -14,7 +14,7 @@
  #ifdef _WIN32
  #define SHELL "cmd /k"
@@ -9,3 +9,12 @@
  #endif
  
  /* Fork a shell. */
+@@ -41,7 +41,7 @@
+             _exit(99);
+         } else {
+             char * const com = wl_flatten(wl);
+-            execl("/bin/sh", "sh", "-c", com, 0);
++            execl("@TERMUX_PREFIX@/bin/sh", "sh", "-c", com, 0);
+             txfree(com);
+         }
+     } else {

--- a/packages/ngspice/src-frontend-inp.c.patch
+++ b/packages/ngspice/src-frontend-inp.c.patch
@@ -1,6 +1,6 @@
---- a/src/frontend/inp.c
-+++ b/src/frontend/inp.c
-@@ -1653,7 +1653,7 @@
+--- ngspice-37/src/frontend/inp.c	2022-05-17 18:00:52.000000000 +0800
++++ ngspice-37.mod/src/frontend/inp.c	2022-06-16 20:41:04.550164798 +0800
+@@ -1697,7 +1697,7 @@
              if (Def_Editor && *Def_Editor)
                  editor = Def_Editor;
              else

--- a/packages/ngspice/src-frontend-parser-complete.c.patch
+++ b/packages/ngspice/src-frontend-parser-complete.c.patch
@@ -1,5 +1,5 @@
---- a/src/frontend/parser/complete.c
-+++ b/src/frontend/parser/complete.c
+--- ngspice-37/src/frontend/parser/complete.c	2022-05-17 18:00:52.000000000 +0800
++++ ngspice-37.mod/src/frontend/parser/complete.c	2022-06-16 22:58:12.747998151 +0800
 @@ -213,10 +213,12 @@
          lcomp = buf;
          if (*buf == cp_til) {   /* User name completion... */

--- a/packages/ngspice/src-frontend-plotting-gnuplot.c.patch
+++ b/packages/ngspice/src-frontend-plotting-gnuplot.c.patch
@@ -1,0 +1,11 @@
+diff -uNr ngspice-37/src/frontend/plotting/gnuplot.c ngspice-37.mod/src/frontend/plotting/gnuplot.c
+--- ngspice-37/src/frontend/plotting/gnuplot.c  2022-05-17 18:00:52.000000000 +0800
++++ ngspice-37.mod/src/frontend/plotting/gnuplot.c      2022-06-16 21:26:14.926999780 +0800
+@@ -388,6 +388,7 @@
+ #ifndef EXT_ASC
+     fprintf(file, "set encoding utf8\n");
+ #endif
++    fprintf(file, "set term dumb\n");
+     fprintf(file, "set termoption noenhanced\n");
+
+     if (contours) {

--- a/packages/ngspice/src-include-ngspice-defines.h.patch
+++ b/packages/ngspice/src-include-ngspice-defines.h.patch
@@ -1,9 +1,10 @@
---- a/src/include/ngspice/defines.h
-+++ b/src/include/ngspice/defines.h
+diff -uNr ngspice-37/src/include/ngspice/defines.h ngspice-37.mod/src/include/ngspice/defines.h
+--- ngspice-37/src/include/ngspice/defines.h    2022-05-17 18:00:52.000000000 +0800
++++ ngspice-37.mod/src/include/ngspice/defines.h        2022-06-16 20:46:02.258164585 +0800
 @@ -82,8 +82,8 @@
  #define DIR_TERM            '/'
  #define DIR_CWD             "."
- 
+
 -#define TEMPFORMAT          "/tmp/%s%d"
 -#define TEMPFORMAT2         "/tmp/%s%d_%d"
 +#define TEMPFORMAT          "@TERMUX_PREFIX@/tmp/%s%d"

--- a/packages/ngspice/src-include-ngspice-ipctiein.h.patch
+++ b/packages/ngspice/src-include-ngspice-ipctiein.h.patch
@@ -1,0 +1,13 @@
+diff -uNr ngspice-37/src/include/ngspice/ipctiein.h ngspice-37.mod/src/include/ngspice/ipctiein.h
+--- ngspice-37/src/include/ngspice/ipctiein.h   2022-05-17 18:00:52.000000000 +0800
++++ ngspice-37.mod/src/include/ngspice/ipctiein.h       2022-06-16 20:38:56.018164890 +0800
+@@ -45,8 +45,8 @@
+ #include "ngspice/ipcproto.h"
+
+
+-#define  IPC_STDOUT_FILE_NAME  "/usr/tmp/atesse_xspice.out"
+-#define  IPC_STDERR_FILE_NAME  "/usr/tmp/atesse_xspice.err"
++#define  IPC_STDOUT_FILE_NAME  "@TERMUX_PREFIX@/tmp/atesse_xspice.out"
++#define  IPC_STDERR_FILE_NAME  "@TERMUX_PREFIX@/tmp/atesse_xspice.err"
+
+ /*

--- a/packages/ngspice/src-tclspice.c.patch
+++ b/packages/ngspice/src-tclspice.c.patch
@@ -1,0 +1,39 @@
+--- ngspice-37/src/tclspice.c	2022-05-17 18:00:52.000000000 +0800
++++ ngspice-37.mod/src/tclspice.c	2022-06-16 20:43:28.390164695 +0800
+@@ -1252,14 +1252,14 @@
+         return TCL_ERROR;
+     }
+     tmp_1 = dup(1);
+-    outfd = open("/tmp/tclspice.tmp_out", O_WRONLY|O_CREAT|O_TRUNC, S_IRWXU);
++    outfd = open("@TERMUX_PREFIX@/tmp/tclspice.tmp_out", O_WRONLY|O_CREAT|O_TRUNC, S_IRWXU);
+     if (argc == 3) {
+         tmp_2 = dup(2);
+-        outfd2 = open("/tmp/tclspice.tmp_err", O_WRONLY|O_CREAT|O_TRUNC, S_IRWXU);
++        outfd2 = open("@TERMUX_PREFIX@/tmp/tclspice.tmp_err", O_WRONLY|O_CREAT|O_TRUNC, S_IRWXU);
+     }
+-    freopen("/tmp/tclspice.tmp_out", "w", stdout);
++    freopen("@TERMUX_PREFIX@/tmp/tclspice.tmp_out", "w", stdout);
+     if (argc == 3)
+-        freopen("/tmp/tclspice.tmp_err", "w", stderr);
++        freopen("@TERMUX_PREFIX@/tmp/tclspice.tmp_err", "w", stderr);
+     dup2(outfd, 1);
+     if (argc == 3)
+         dup2(outfd2, 2);
+@@ -1281,7 +1281,7 @@
+     freopen("/dev/fd/1", "w", stdout);
+     if (argc == 3)
+         freopen("/dev/fd/2", "w", stderr);
+-    pipein = fopen("/tmp/tclspice.tmp_out", "r");
++    pipein = fopen("@TERMUX_PREFIX@/tmp/tclspice.tmp_out", "r");
+     if (pipein == NULL)
+         fprintf(stderr, "pipein==NULL\n");
+ 
+@@ -1291,7 +1291,7 @@
+ 
+     fclose(pipein);
+     if (argc == 3) {
+-        pipein = fopen("/tmp/tclspice.tmp_err", "r");
++        pipein = fopen("@TERMUX_PREFIX@/tmp/tclspice.tmp_err", "r");
+         Tcl_SetVar(interp, argv[2], "", 0);
+         while (fgets(buf, 1024, pipein) != NULL)
+             Tcl_SetVar(interp, argv[2], buf, TCL_APPEND_VALUE);


### PR DESCRIPTION
By default, when called by ngspice, gnuplot uses an unknown terminal type. This has been solved in this patch by setting the term type to "dumb" which prints an ASCII of the plot.

For some reason, when ngspice is installed with the deb generated from actions with `dpkg -i` and then ran with `ngspice`, ngspice reports:

```
.../lib/ngspice $ ngspice
Error opening code model "/data/data/com.termux/files/usr/lib/ngspice/spice2poly.cm": dlopen failed: cannot locate symbol "spice2poly_info" referenced by "/data/data/com.termux/files/usr/lib/ngspice/spice2poly.cm"...
Error: Library /data/data/com.termux/files/usr/lib/ngspice/spice2poly.cm couldn't be loaded!
Error opening code model "/data/data/com.termux/files/usr/lib/ngspice/analog.cm": dlopen failed: cannot locate symbol "cm_climit_info" referenced by "/data/data/com.termux/files/usr/lib/ngspice/analog.cm"...
Error: Library /data/data/com.termux/files/usr/lib/ngspice/analog.cm couldn't be loaded!
Error opening code model "/data/data/com.termux/files/usr/lib/ngspice/digital.cm": dlopen failed: cannot locate symbol "cm_adc_bridge_info" referenced by "/data/data/com.termux/files/usr/lib/ngspice/digital.cm"...
Error: Library /data/data/com.termux/files/usr/lib/ngspice/digital.cm couldn't be loaded!
Error opening code model "/data/data/com.termux/files/usr/lib/ngspice/xtradev.cm": dlopen failed: cannot locate symbol "cm_aswitch_info" referenced by "/data/data/com.termux/files/usr/lib/ngspice/xtradev.cm"...
Error: Library /data/data/com.termux/files/usr/lib/ngspice/xtradev.cm couldn't be loaded!
Error opening code model "/data/data/com.termux/files/usr/lib/ngspice/xtraevt.cm": dlopen failed: cannot locate symbol "ucm_d_to_real_info" referenced by "/data/data/com.termux/files/usr/lib/ngspice/xtraevt.cm"...
Error: Library /data/data/com.termux/files/usr/lib/ngspice/xtraevt.cm couldn't be loaded!
Error opening code model "/data/data/com.termux/files/usr/lib/ngspice/table.cm": dlopen failed: cannot locate symbol "cm_table2D_info" referenced by "/data/data/com.termux/files/usr/lib/ngspice/table.cm"...
Error: Library /data/data/com.termux/files/usr/lib/ngspice/table.cm couldn't be loaded!
******
** ngspice-37 : Circuit level simulation program
** The U. C. Berkeley CAD Group
** Copyright 1985-1994, Regents of the University of California.
** Copyright 2001-2022, The ngspice team.
** Please get your ngspice manual from http://ngspice.sourceforge.net/docs.html
** Please file your bug-reports at http://ngspice.sourceforge.net/bugrep.html
** Creation Date: Thu Jun 16 15:52:08 UTC 2022
******
```

even though this files *.cm exists in this directories. I suspect something went wrong with the compilation of the *.cm.

I have manage to build it on my Android phone and this error did not appear. 