### PR TITLE
termux-tools: Add the first Russian mirror

### DIFF
--- a/root-packages/aircrack-ng/build.sh
+++ b/root-packages/aircrack-ng/build.sh
@@ -2,16 +2,15 @@ TERMUX_PKG_HOMEPAGE="https://www.aircrack-ng.org/"
 TERMUX_PKG_DESCRIPTION="WiFi security auditing tools suite"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="Marlin Sööse <marlin.soose@laro.se>"
-_COMMIT=f94a3fe3f1c74938169317a6395b7f72452499c4
-TERMUX_PKG_VERSION="2:2021.12.19-${_COMMIT:0:8}"
-TERMUX_PKG_REVISION=2
-TERMUX_PKG_SRCURL="https://github.com/aircrack-ng/aircrack-ng/archive/$_COMMIT.tar.gz"
-TERMUX_PKG_SHA256="d79c02351fe389c41e6c29ef4381109f78ae5f3ba552f776ee08b6a3cbd3aa13"
+TERMUX_PKG_VERSION="1.7"
+TERMUX_PKG_SRCURL="https://github.com/aircrack-ng/aircrack-ng/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256="05a704e3c8f7792a17315080a21214a4448fd2452c1b0dd5226a3a55f90b58c3"
 TERMUX_PKG_DEPENDS="libc++, libnl, openssl, libpcap"
 # static build gives errors:
 #   error: undefined reference to 'ac_crypto_engine_init'
 #   error: cannot find the library 'libaircrack-ce-wpa.la' or unhandled argument 'libaircrack-ce-wpa.la'
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-static"
+TERMUX_PKG_AUTO_UPDATE=true
 
 termux_step_pre_configure() {
         NOCONFIGURE=1 ./autogen.sh


### PR DESCRIPTION
Resolved: #7941, #9549

|  Repository   | sources.list entry  |
|  ----  | ----  |
| [Main](https://github.com/termux/termux-packages)  | `deb http://mirror.mephi.ru/termux/termux-main stable main` |
| [Root](https://github.com/termux/termux-root-packages)  | `deb http://mirror.mephi.ru/termux/termux-root root stable` |
| [X11](https://github.com/termux/x11-packages)  |`deb http://mirror.mephi.ru/termux/termux-x11 x11 main` |

The mirror from National Research Nuclear University - Moscow Engineering Physics Institute ,Supports IPV4 and http only.