### PR TITLE
apt, python-apt: update and fix

### DIFF
--- a/packages/apt/9999-pkgTagSection-Key-visiable.patch
+++ b/packages/apt/9999-pkgTagSection-Key-visiable.patch
@@ -1,0 +1,15 @@
+This is a temp fix for termux/termux-packages#11120.
+diff -uNr a/apt-pkg/tagfile.h b/apt-pkg/tagfile.h
+--- a/apt-pkg/tagfile.h 2022-07-02 19:02:18.806569800 +0800
++++ b/apt-pkg/tagfile.h 2022-07-02 19:03:23.976744900 +0800
+@@ -70,9 +70,9 @@
+    std::string FindS(APT::StringView sv) const { return Find(sv).to_string(); }
+    std::string FindRawS(APT::StringView sv) const { return FindRaw(sv).to_string(); };
+ 
+-#ifdef APT_COMPILING_APT
+    // Functions for lookup with a perfect hash function
+    enum class Key;
++#ifdef APT_COMPILING_APT
+    bool Find(Key key,const char *&Start, const char *&End) const;
+    bool Find(Key key,unsigned int &Pos) const;
+    signed int FindI(Key key,signed long Default = 0) const;

--- a/packages/apt/build.sh
+++ b/packages/apt/build.sh
@@ -2,10 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://packages.debian.org/apt
 TERMUX_PKG_DESCRIPTION="Front-end for the dpkg package manager"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=2.5.0
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION=2.5.1
 TERMUX_PKG_SRCURL=https://deb.debian.org/debian/pool/main/a/apt/apt_${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=61cd84d04e2a7858f70dca21160977479c74150853cdeef7c843d59e72488c1f
+TERMUX_PKG_SHA256=dafeab05f985a4851daa6baf4e3358c6585a161a1d6c6867db1a538a6a71fbb1
 # apt-key requires utilities from coreutils, findutils, gpgv, grep, sed.
 TERMUX_PKG_DEPENDS="coreutils, dpkg, findutils, gpgv, grep, libandroid-glob, libbz2, libc++, libcurl, libgnutls, liblz4, liblzma, sed, termux-keyring, termux-licenses, xxhash, zlib"
 TERMUX_PKG_BUILD_DEPENDS="docbook-xsl"

--- a/packages/python-apt/build.sh
+++ b/packages/python-apt/build.sh
@@ -3,9 +3,10 @@ TERMUX_PKG_DESCRIPTION="Python bindings for APT"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.3.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://ftp.debian.org/debian/pool/main/p/python-apt/python-apt_${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=de4a284bc7a738793615631d451524f42404034f4d787953b7621b25bc29e474
-TERMUX_PKG_DEPENDS="apt, libc++, python"
+TERMUX_PKG_DEPENDS="apt, build-essential, libc++, python, texinfo"
 TERMUX_PKG_BUILD_IN_SRC=true
 
 _PYTHON_VERSION=$(. $TERMUX_SCRIPTDIR/packages/python/build.sh; echo $_MAJOR_VERSION)


### PR DESCRIPTION
* python-apt: dependency issues in #10960.
* apt: update to 2.5.1

Continuation of https://github.com/termux/termux-packages/pull/10960.
Temporary fix for #11120.