### PR TITLE
chore: Move REPO-related variables to properties.sh

### DIFF
--- a/scripts/build/termux_step_setup_variables.sh
+++ b/scripts/build/termux_step_setup_variables.sh
@@ -44,24 +44,6 @@ termux_step_setup_variables() {
 	# TERMUX_PKG_MAINTAINER should be explicitly set in build.sh of the package.
 	: "${TERMUX_PKG_MAINTAINER:="default"}"
 
-	TERMUX_REPO_URL=(
-		https://packages-cf.termux.dev/apt/termux-main
-		https://packages-cf.termux.dev/apt/termux-root
-		https://packages-cf.termux.dev/apt/termux-x11
-	)
-
-	TERMUX_REPO_DISTRIBUTION=(
-		stable
-		root
-		x11
-	)
-
-	TERMUX_REPO_COMPONENT=(
-		main
-		stable
-		main
-	)
-
 	if [ "x86_64" = "$TERMUX_ARCH" ] || [ "aarch64" = "$TERMUX_ARCH" ]; then
 		TERMUX_ARCH_BITS=64
 	else

--- a/scripts/properties.sh
+++ b/scripts/properties.sh
@@ -32,6 +32,25 @@ TERMUX_ANDROID_HOME="${TERMUX_BASE_DIR}/home"
 TERMUX_APPS_DIR="${TERMUX_BASE_DIR}/apps"
 TERMUX_PREFIX="${TERMUX_BASE_DIR}/usr"
 
+# Termux repo urls.
+TERMUX_REPO_URL=(
+	https://packages-cf.termux.dev/apt/termux-main
+	https://packages-cf.termux.dev/apt/termux-root
+	https://packages-cf.termux.dev/apt/termux-x11
+)
+
+TERMUX_REPO_DISTRIBUTION=(
+	stable
+	root
+	x11
+)
+
+TERMUX_REPO_COMPONENT=(
+	main
+	stable
+	main
+)
+
 # Allow to override setup.
 if [ -f "$HOME/.termuxrc" ]; then
 	. "$HOME/.termuxrc"


### PR DESCRIPTION
Currently, we have `TERMUX_REPO_URL`, `TERMUX_REPO_DISTRIBUTION` and `TERMUX_REPO_COMPONENT` in `termux_step_setup_variables` to make the building system download pre-built debs from APT Repo.

This commit will move these variables to `properties.sh`, which will make it possible for us to override them in `.termuxrc`, and will make it easier to switch to other mirrors of main repo (`packages(-cf).termux.dev` is slow in some countries and regions, e.g. China) and will make it possible to add community repos to download pre-built debs.
