### PR TITLE
get_hash_from_file.py: ignore Packages.gz/bz2 in Release file

### DIFF
--- a/scripts/get_hash_from_file.py
+++ b/scripts/get_hash_from_file.py
@@ -2,7 +2,7 @@
 
 import sys
 
-def get_pkg_hash_from_Packages(Packages_file, package, version, hash="SHA256"):
+def get_pkg_hash_from_Packages(Packages_file, package, version, hash_type="SHA256"):
     with open(Packages_file, 'r') as Packages:
         package_list = Packages.read().split('\n\n')
     for pkg in package_list:
@@ -16,19 +16,19 @@ def get_pkg_hash_from_Packages(Packages_file, package, version, hash="SHA256"):
                         # Seems the repo contains the wrong version, or several versions
                         # We can't use this one so continue looking
                         break
-                elif line.startswith(hash):
+                elif line.startswith(hash_type):
                     print(line.split(" ")[1])
                     break
 
-def get_Packages_hash_from_Release(Release_file, arch, component, hash="SHA256"):
+def get_Packages_hash_from_Release(Release_file, arch, component, hash_type="SHA256"):
     string_to_find = component+'/binary-'+arch+'/Packages'
     with open(Release_file, 'r') as Release:
         hash_list = Release.readlines()
     for i in range(len(hash_list)):
-        if hash_list[i].startswith(hash+':'):
+        if hash_list[i].startswith(hash_type+':'):
             break
     for j in range(i, len(hash_list)):
-        if string_to_find in hash_list[j].strip(' '):
+        if string_to_find in hash_list[j].strip(' ') and string_to_find+"." not in hash_list[j].strip(' '):
             hash_entry = list(filter(lambda s: s != '', hash_list[j].strip('').split(' ')))
             if hash_entry[2].startswith(".work_"):
                 continue
@@ -36,7 +36,7 @@ def get_Packages_hash_from_Release(Release_file, arch, component, hash="SHA256")
             break
 
 if __name__ == '__main__':
-    if len(sys.argv) < 2:
+    if len(sys.argv) < 4:
         sys.exit('Too few arguments, I need the path to a Packages file, a package name and a version, or an InRelease file, an architecture and a component name. Exiting')
 
     if sys.argv[1].endswith('Packages'):


### PR DESCRIPTION
Fix `get_Packages_hash_from_Release`.

Currently, it works fine when the line containing `Packages` in the `Release` appears before the line containing `Packages.gz/bz2`, like what the `aptly` does. But if some `Release` files put the line containing `Packages.gz/bz2` before the line containing `Packages`, it will show the checksum of `Packages.gz/bz2` rather than `Packages`.