### PR TITLE
enhance(run-docker.sh): add support for Fedora

### DIFF
--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -12,6 +12,15 @@ else
 	SEC_OPT=" --security-opt seccomp=$REPOROOT/scripts/profile.json"
 fi
 
+# Required for Linux with SELinux and btrfs to avoid permission issues, eg: Fedora
+# To reset, use "restorecon -Fr ."
+# To check, use "ls -Z ."
+if [ -n "$(command -v getenforce)" ] && [ "$(getenforce)" = Enforcing ]; then
+	VOLUME=$REPOROOT:$CONTAINER_HOME_DIR/termux-packages:z
+else
+	VOLUME=$REPOROOT:$CONTAINER_HOME_DIR/termux-packages
+fi
+
 : ${TERMUX_BUILDER_IMAGE_NAME:=termux/package-builder}
 : ${CONTAINER_NAME:=termux-package-builder}
 
@@ -37,7 +46,7 @@ $SUDO docker start $CONTAINER_NAME >/dev/null 2>&1 || {
 	$SUDO docker run \
 		--detach \
 		--name $CONTAINER_NAME \
-		--volume $REPOROOT:$CONTAINER_HOME_DIR/termux-packages \
+		--volume $VOLUME \
 		$SEC_OPT \
 		--tty \
 		$TERMUX_BUILDER_IMAGE_NAME


### PR DESCRIPTION
Mainly to fix issues like this:
```sh
[jylo@t430-2022-04-10 Projects]$ cd termux-packages/
[jylo@t430-2022-04-10 termux-packages]$ ./scripts/run-docker.sh 
Running container 'termux-package-builder' from image 'termux/package-builder'...
Creating new container...
18e47a1c3cf39a3237fd43506beb7dfb62dd01febeddf5ee7f4265abd2b1bc3a
builder@18e47a1c3cf3:~/termux-packages$ ls
ls: cannot open directory '.': Permission denied
builder@18e47a1c3cf3:~/termux-packages$ pwd
/home/builder/termux-packages
```
Should only affect newly created containers moving forward...