### PR TITLE
enhance(main/termux-tools): new motd design

### DIFF
--- a/packages/termux-tools/build.sh
+++ b/packages/termux-tools/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://termux.dev/
 TERMUX_PKG_DESCRIPTION="Basic system tools for Termux"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1.20
+TERMUX_PKG_VERSION=1.21
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_ESSENTIAL=true
@@ -10,7 +10,7 @@ TERMUX_PKG_BREAKS="termux-keyring (<< 1.9)"
 TERMUX_PKG_CONFLICTS="procps (<< 3.3.15-2)"
 TERMUX_PKG_SUGGESTS="termux-api"
 TERMUX_PKG_CONFFILES="
-etc/motd
+etc/motd.sh
 etc/motd-playstore
 etc/termux-login.sh
 "
@@ -54,30 +54,33 @@ termux_step_make_install() {
 	done
 
 	{
-		echo ""
-		echo "Welcome to Termux!"
-		echo ""
-		echo "Communities: https://termux.dev/community"
-		echo "Gitter chat: https://gitter.im/termux/termux"
-		echo "IRC channel: #termux on libera.chat"
-		echo ""
-		echo "Working with packages:"
-		echo ""
-		echo " * Search packages:   pkg search <query>"
-		echo " * Install a package: pkg install <package>"
-		echo " * Upgrade packages:  pkg upgrade"
-		echo ""
+		echo 'echo ""'
+		echo 'echo -e " \033[47m                \033[0m  \e[1mWelcome to Termux!\e[0m"'
+		echo 'echo -e " \033[47m  \033[0m            \033[47m  \033[0m"'
+		echo 'echo -e " \033[47m  \033[0m  \033[47m  \033[0m        \033[47m  \033[0m  \e[1mDocs:\e[0m   \e[4mtermux.dev/docs\e[0m"'
+		echo 'echo -e " \033[47m  \033[0m  \033[47m  \033[0m        \033[47m  \033[0m  \e[1mGitter:\e[0m \e[4mgitter.im/termux/termux\e[0m"'
+		echo 'echo -e " \033[47m  \033[0m            \033[47m  \033[0m  \e[1mCommunity:\e[0m \e[4mtermux.dev/community\e[0m"'
+		echo 'echo -e " \033[47m  \033[0m            \033[47m  \033[0m"'
+		echo 'echo -e " \033[47m                \033[0m  \e[1mTermux version:\e[0m ${TERMUX_VERSION-Unknown}"'
+		echo 'echo ""'
+		echo 'echo -e "                   \e[1mWorking with packages:\e[0m"'
+		echo 'echo -e "                       \e[1mSearch:\e[0m  pkg search <query>"'
+		echo 'echo -e "                       \e[1mInstall:\e[0m pkg install <package>"'
+		echo 'echo -e "                       \e[1mUpdate:\e[0m  pkg update"'
+		echo 'echo ""'
 		if [ "$TERMUX_PACKAGE_FORMAT" = "debian" ]; then
-			echo "Subscribing to additional repositories:"
-			echo ""
-			echo " * Root:     pkg install root-repo"
-			echo " * X11:      pkg install x11-repo"
-			echo ""
+			echo 'echo -e "                   \e[1mSubscribing to additional repos:\e[0m"'
+			echo 'echo -e "                       \e[1mRoot:\e[0m pkg install root-repo"'
+			echo 'echo -e "                       \e[1mX11: \e[0m pkg install x11-repo"'
+			echo 'echo ""'
+			echo 'echo "                   For fixing any repository issues,"'
+			echo "echo \"                   try 'termux-change-repo' command.\""
+			echo 'echo ""'
 		fi
-		echo "Report issues at https://termux.dev/issues"
-		echo ""
-	} > $TERMUX_PKG_BUILDER_DIR/motd
-	install -Dm600 $TERMUX_PKG_BUILDER_DIR/motd $TERMUX_PREFIX/etc/motd
+		echo 'echo -e "                   Report issues at \e[4mtermux.dev/issues\e[0m"'
+		echo 'echo ""'
+	} > $TERMUX_PKG_BUILDER_DIR/motd.sh
+	install -Dm600 $TERMUX_PKG_BUILDER_DIR/motd.sh $TERMUX_PREFIX/etc/motd.sh
 	install -Dm600 $TERMUX_PKG_BUILDER_DIR/motd-playstore $TERMUX_PREFIX/etc/motd-playstore
 	ln -sfr $TERMUX_PREFIX/bin/termux-open $TERMUX_PREFIX/bin/xdg-open
 

--- a/packages/termux-tools/login
+++ b/packages/termux-tools/login
@@ -1,11 +1,18 @@
 #!/bin/sh
 
-if [ $# = 0 ] && [ -f @TERMUX_PREFIX@/etc/motd ] && [ ! -f ~/.hushlogin ] && [ -z "$TERMUX_HUSHLOGIN" ]; then
-	cat @TERMUX_PREFIX@/etc/motd
+if [ $# = 0 ] && [ -f @TERMUX_PREFIX@/etc/motd ] || [ -f @TERMUX_PREFIX@/etc/motd.sh ] && [ ! -f ~/.hushlogin ] && [ -z "$TERMUX_HUSHLOGIN" ]; then
+    # Dynamic motd check
+    if [ -e @TERMUX_PREFIX@/etc/motd.sh ]; then
+	    bash @TERMUX_PREFIX@/etc/motd.sh
+    else
+        cat @TERMUX_PREFIX@/etc/motd
+    fi
 else
 	# This variable shouldn't be kept set.
 	unset TERMUX_HUSHLOGIN
 fi
+
+
 
 # TERMUX_VERSION env variable has been exported since v0.107 and PATH was being set to following value in <0.104. Last playstore version was v0.101.
 if [ $# = 0 ] && [ -f @TERMUX_PREFIX@/etc/motd-playstore ] && [ -z "$TERMUX_VERSION" ] && [ "$PATH" = "@TERMUX_PREFIX@/bin:@TERMUX_PREFIX@/bin/applets" ]; then


### PR DESCRIPTION
For aesthetic pruposes, changed the motd by adding a small termux icon, termux version display and a hint to fix repo issues related to termux-change repo. 
And also, now login executes a dynamic motd.sh, which can expand environment variables and display text formatting.
Common motd support wasn't removed, since now the login just distinguishes between dynamic and common motd (prioritising the dynamic motd)

Preview: 
![Screenshot_20220710-214038_Termux~01](https://user-images.githubusercontent.com/103902727/178170466-460ed8df-4969-4b50-a588-49501f9402f2.png)

(Duplicate of #11222. Previous commit got broken)

Co-authored-by: [TomJo2000](https://github.com/TomJo2000/)