### PR TITLE
Decrease build times: simplify loop that checks for undefined symbols in massage step 

### DIFF
--- a/scripts/build/termux_error_exit.sh
+++ b/scripts/build/termux_error_exit.sh
@@ -1,4 +1,4 @@
 termux_error_exit() {
-	echo "ERROR: $*" 1>&2
+	echo -e "ERROR: $*" 1>&2
 	exit 1
 }


### PR DESCRIPTION
By stripping, fixing shebangs and checking for undefined syms in parallel we can speed up build time by around 15 - 45 %, at least in my tests done when building on device.

For a package with many files like boost build time went from 89 minutes to 74 minutes, and for smaller library packages like libandroid-support and libcap build time went from around 1min40s to 1min0s