### PR TITLE
samba: remove tdb related utilities

### DIFF
--- a/packages/samba/build.sh
+++ b/packages/samba/build.sh
@@ -6,7 +6,7 @@ TERMUX_PKG_VERSION=4.14.13
 TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://download.samba.org/pub/samba/samba-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=e1df792818a17d8d21faf33580d32939214694c92b84fb499464210d86a7ff75
-TERMUX_PKG_DEPENDS="libbsd, libcap, libcrypt, libgnutls, libiconv, libicu, libpopt, libtalloc, libtirpc, ncurses, openssl, readline, zlib"
+TERMUX_PKG_DEPENDS="libbsd, libcap, libcrypt, libgnutls, libiconv, libicu, libpopt, libtalloc, libtirpc, ncurses, openssl, readline, tdb-tools, zlib"
 TERMUX_PKG_BUILD_DEPENDS="e2fsprogs"
 TERMUX_PKG_BUILD_IN_SRC=true
 

--- a/packages/samba/build.sh
+++ b/packages/samba/build.sh
@@ -3,12 +3,24 @@ TERMUX_PKG_DESCRIPTION="SMB/CIFS fileserver"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=4.14.13
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://download.samba.org/pub/samba/samba-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=e1df792818a17d8d21faf33580d32939214694c92b84fb499464210d86a7ff75
 TERMUX_PKG_DEPENDS="libbsd, libcap, libcrypt, libgnutls, libiconv, libicu, libpopt, libtalloc, libtirpc, ncurses, openssl, readline, zlib"
 TERMUX_PKG_BUILD_DEPENDS="e2fsprogs"
 TERMUX_PKG_BUILD_IN_SRC=true
+
+# These files are already present in the package tdb-tools
+TERMUX_PKG_RM_AFTER_INSTALL="
+bin/tdbbackup
+bin/tdbdump
+bin/tdbrestore
+bin/tdbtool
+share/man/man8/tdbbackup.8.gz
+share/man/man8/tdbdump.8.gz
+share/man/man8/tdbrestore.8.gz
+share/man/man8/tdbtool.8.gz
+"
 
 termux_step_configure() {
 	:


### PR DESCRIPTION
Causes conflicts upon installation. showing these two outputs that `samba` has its own tdb tools while the standalone version also has it. separating them maybe a good idea

tdb-tools:
```console
~ $ apt-file list tdb-tools
tdb-tools: /data/data/com.termux/files/usr/bin/tdbbackup
tdb-tools: /data/data/com.termux/files/usr/bin/tdbdump
tdb-tools: /data/data/com.termux/files/usr/bin/tdbrestore
tdb-tools: /data/data/com.termux/files/usr/bin/tdbtool
tdb-tools: /data/data/com.termux/files/usr/share/man/man8/tdbbackup.8.gz
tdb-tools: /data/data/com.termux/files/usr/share/man/man8/tdbdump.8.gz
tdb-tools: /data/data/com.termux/files/usr/share/man/man8/tdbrestore.8.gz
tdb-tools: /data/data/com.termux/files/usr/share/man/man8/tdbtool.8.gz
```

samba:
```console
~ $ apt-file list samba | grep 'tdbbackup\|tdbdump\|tdbrestore\|tdbtool'
samba: /data/data/com.termux/files/usr/bin/tdbbackup
samba: /data/data/com.termux/files/usr/bin/tdbdump
samba: /data/data/com.termux/files/usr/bin/tdbrestore
samba: /data/data/com.termux/files/usr/bin/tdbtool
samba: /data/data/com.termux/files/usr/share/man/man8/tdbbackup.8.gz
samba: /data/data/com.termux/files/usr/share/man/man8/tdbdump.8.gz
samba: /data/data/com.termux/files/usr/share/man/man8/tdbrestore.8.gz
samba: /data/data/com.termux/files/usr/share/man/man8/tdbtool.8.gz
```