### PR TITLE
enhance(scripts): use GitHub package registry for Docker image

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -16,6 +16,9 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
     - name: Clone repository
       uses: actions/checkout@v3
@@ -23,13 +26,22 @@ jobs:
       run: |
         cd ./scripts
         docker build --tag termux/package-builder:latest .
+        docker tag termux/package-builder:latest ghcr.io/termux/package-builder:latest
+    - name: Login to GHCR
+      if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'termux/termux-packages'
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Login to Docker Hub
       if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'termux/termux-packages'
       uses: docker/login-action@v1
       with:
         username: grimler
         password: ${{ secrets.DOCKER_TOKEN }}
-    - name: Push to Docker Hub
+    - name: Push
       if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'termux/termux-packages'
       run: |
+        docker push ghcr.io/termux/package-builder:latest
         docker push termux/package-builder:latest

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -22,6 +22,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     env:
       ANDROID_HOME: "/opt/termux/android-sdk"
       NDK: "/opt/termux/android-ndk"
@@ -34,6 +37,12 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 1000
+    - name: Login to GHCR
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Gather build summary
       run: |
         if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
@@ -74,7 +83,7 @@ jobs:
           if grep -qP '^scripts/(Dockerfile|setup-android-sdk\.sh|setup-ubuntu\.sh)$' <<< "$CHANGED_FILES"; then
             echo "Detected changes for environment setup scripts. Building custom Docker image now."
             cd ./scripts
-            docker build -t termux/package-builder:latest .
+            docker build -t ghcr.io/termux/package-builder:latest .
             cd ..
           fi
 

--- a/scripts/run-docker.ps1
+++ b/scripts/run-docker.ps1
@@ -4,7 +4,7 @@
 #
 # .\scripts\run-docker.ps1 ./build-package.sh -a arm libandroid-support
 
-Set-Variable -Name IMAGE_NAME -Value "termux/package-builder"
+Set-Variable -Name IMAGE_NAME -Value "ghcr.io/termux/package-builder"
 Set-Variable -Name CONTAINER_NAME -Value "termux-package-builder"
 
 Write-Output "Running container ${CONTAINER_NAME} from image ${IMAGE_NAME}..."

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -21,7 +21,7 @@ else
 	VOLUME=$REPOROOT:$CONTAINER_HOME_DIR/termux-packages
 fi
 
-: ${TERMUX_BUILDER_IMAGE_NAME:=termux/package-builder}
+: ${TERMUX_BUILDER_IMAGE_NAME:=ghcr.io/termux/package-builder}
 : ${CONTAINER_NAME:=termux-package-builder}
 
 USER=builder

--- a/scripts/update-docker.ps1
+++ b/scripts/update-docker.ps1
@@ -5,7 +5,7 @@
 # .\scripts\update-docker.ps1
 
 Set-Variable -Name CONTAINER -Value "termux-package-builder"
-Set-Variable -Name IMAGE -Value "termux/package-builder"
+Set-Variable -Name IMAGE -Value "ghcr.io/termux/package-builder"
 
 docker pull $IMAGE
 

--- a/scripts/update-docker.sh
+++ b/scripts/update-docker.sh
@@ -2,7 +2,7 @@
 set -e -u
 
 CONTAINER=termux-package-builder
-IMAGE=termux/package-builder
+IMAGE=ghcr.io/termux/package-builder
 
 docker pull $IMAGE
 


### PR DESCRIPTION
ghcr.io should provide better download speed under GitHub Actions than Docker Hub. After these changes, GitHub Docker registry will be a primary distribution source of our package builder image and Docker Hub will be a mirror.