### PR TITLE
new package: aamath

### DIFF
--- a/packages/aamath/build.sh
+++ b/packages/aamath/build.sh
@@ -1,0 +1,17 @@
+TERMUX_PKG_HOMEPAGE="https://github.com/gchudnov/aamath"
+TERMUX_PKG_DESCRIPTION="Renders mathematical expressions as ASCII art"
+TERMUX_PKG_GROUPS="science"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.3"
+TERMUX_PKG_SRCURL="https://github.com/gchudnov/aamath/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=b1354c0ad6ad9f0b2a941833fbbce142f3c5b0170f7f551ed5630193d5e15d8a
+TERMUX_PKG_DEPENDS="readline"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_EXTRA_MAKE_ARGS="DESTDIR=$TERMUX_PREFIX/bin VERBOSE=1"
+
+termux_step_post_make_install() {
+	install -Dm600 -t $TERMUX_PREFIX/share/man/man1 \
+		$TERMUX_PKG_SRCDIR/aamath.1
+}


### PR DESCRIPTION
Adds [aamath](https://github.com/gchudnov/aamath/).

`aamath` has a dependency on `readline` but adding `TERMUX_PKG_DEPENDS="readline"` to build script produces errors.

Even the `readline` package itself can't be built independently `$ ./scripts/run-docker.sh ./build-package.sh -f readline` : 
[log.txt](https://github.com/termux/termux-packages/files/9213176/log.txt)
```
configure: WARNING: If you wanted to set the --build type, don't use --host.
    If a cross compiler is detected then cross compile mode will be used.
configure: WARNING: cross compiling: assume setvbuf params not reversed
1788 entries written to /data/data/com.termux/files/usr/share/terminfo
"/home/builder/.termux-build/ncurses/src/kitty-0.25.0/terminfo/kitty.terminfo", line 1, col 22, terminal 'xterm-kitty': older tic versions may treat the description field as an alias
ERROR: No files in package. Maybe you need to run autoreconf -fi before configuring.
```