### PR TITLE
new package: magic-wormhole-rs

### DIFF
--- a/packages/magic-wormhole-rs/build.sh
+++ b/packages/magic-wormhole-rs/build.sh
@@ -1,0 +1,20 @@
+TERMUX_PKG_HOMEPAGE="https://github.com/magic-wormhole/magic-wormhole.rs"
+TERMUX_PKG_DESCRIPTION=" Rust implementation of Magic Wormhole, with new features and enhancements"
+TERMUX_PKG_LICENSE="EUPL-1.2"
+TERMUX_PKG_LICENSE_FILE="LICENSE"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.5.0"
+TERMUX_PKG_SRCURL="https://github.com/magic-wormhole/magic-wormhole.rs/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=fdd1d0bd00948f9bdce28b7d21e84bebd25d08502efe30408ded91a150afa5ce
+TERMUX_PKG_BUILD_IN_SRC=true
+# disable auto-update since 'remove-clipboard' patch was maually crafted for v0.5.0
+TERMUX_PKG_AUTO_UPDATE=false
+
+termux_step_make() {
+	termux_setup_rust
+	cargo build --jobs "$TERMUX_MAKE_PROCESSES" --target "$CARGO_TARGET_NAME" --release
+}
+
+termux_step_make_install() {
+	install -Dm700 -t "$TERMUX_PREFIX/bin" "target/${CARGO_TARGET_NAME}/release/wormhole-rs"
+}

--- a/packages/magic-wormhole-rs/remove-clipboard.patch
+++ b/packages/magic-wormhole-rs/remove-clipboard.patch
@@ -1,0 +1,99 @@
+diff --git a/cli/Cargo.toml b/cli/Cargo.toml
+index a613541..d1b903f 100644
+--- a/cli/Cargo.toml
++++ b/cli/Cargo.toml
+@@ -22,4 +22,3 @@ dialoguer = "0.10.0"
+ color-eyre = "0.6.0"
+ number_prefix = "0.4.0"
+ ctrlc = "3.2.1"
+-cli-clipboard = { git = "https://github.com/ActuallyAllie/cli-clipboard" }
+diff --git a/cli/src/main.rs b/cli/src/main.rs
+index 86d3150..9cb822e 100644
+--- a/cli/src/main.rs
++++ b/cli/src/main.rs
+@@ -8,7 +8,6 @@ use std::{
+ 
+ use async_std::{fs::OpenOptions, sync::Arc};
+ use clap::{crate_description, crate_name, crate_version, Arg, Args, Command, Parser, Subcommand};
+-use cli_clipboard::{ClipboardContext, ClipboardProvider};
+ use color_eyre::{eyre, eyre::Context};
+ use console::{style, Term};
+ use futures::{future::Either, Future, FutureExt};
+@@ -276,12 +275,6 @@ async fn main() -> eyre::Result<()> {
+             .try_init()?;
+     }
+ 
+-    let mut clipboard = ClipboardContext::new()
+-        .map_err(|err| {
+-            log::warn!("Failed to initialize clipboard support: {}", err);
+-        })
+-        .ok();
+-
+     let concat_file_name = |file_path: &Path, file_name: Option<_>| {
+         // TODO this has gotten out of hand (it ugly)
+         // The correct solution would be to make `file_name` an Option everywhere and
+@@ -330,7 +323,6 @@ async fn main() -> eyre::Result<()> {
+                     true,
+                     transfer::APP_CONFIG,
+                     Some(&sender_print_code),
+-                    clipboard.as_mut(),
+                 ),
+                 ctrl_c(),
+             )
+@@ -368,7 +360,6 @@ async fn main() -> eyre::Result<()> {
+                     true,
+                     transfer::APP_CONFIG,
+                     Some(&sender_print_code),
+-                    clipboard.as_mut(),
+                 );
+                 futures::pin_mut!(connect_fut);
+                 match futures::future::select(connect_fut, ctrl_c()).await {
+@@ -415,7 +406,6 @@ async fn main() -> eyre::Result<()> {
+                     false,
+                     transfer::APP_CONFIG,
+                     None,
+-                    clipboard.as_mut(),
+                 );
+                 futures::pin_mut!(connect_fut);
+                 match futures::future::select(connect_fut, ctrl_c()).await {
+@@ -491,7 +481,6 @@ async fn main() -> eyre::Result<()> {
+                     true,
+                     app_config,
+                     Some(&server_print_code),
+-                    clipboard.as_mut(),
+                 );
+                 futures::pin_mut!(connect_fut);
+                 let (wormhole, _code, relay_server) =
+@@ -529,7 +518,6 @@ async fn main() -> eyre::Result<()> {
+                 false,
+                 app_config,
+                 None,
+-                clipboard.as_mut(),
+             )
+             .await?;
+             let relay_server = vec![transit::RelayHint::from_urls(None, [relay_server])];
+@@ -587,7 +575,6 @@ async fn parse_and_connect(
+     is_send: bool,
+     mut app_config: magic_wormhole::AppConfig<impl serde::Serialize + Send + Sync + 'static>,
+     print_code: Option<&dyn Fn(&mut Term, &magic_wormhole::Code) -> eyre::Result<()>>,
+-    clipboard: Option<&mut ClipboardContext>,
+ ) -> eyre::Result<(Wormhole, magic_wormhole::Code, url::Url)> {
+     // TODO handle multiple relay servers correctly
+     let relay_server: url::Url = common_args
+@@ -626,15 +613,8 @@ async fn parse_and_connect(
+             let (server_welcome, connector) =
+                 magic_wormhole::Wormhole::connect_without_code(app_config, numwords).await?;
+             print_welcome(term, &server_welcome)?;
+-            /* Print code and also copy it to clipboard */
++            /* Print code */
+             if is_send {
+-                if let Some(clipboard) = clipboard {
+-                    match clipboard.set_contents(server_welcome.code.to_string()) {
+-                        Ok(()) => log::info!("Code copied to clipboard"),
+-                        Err(err) => log::warn!("Failed to copy code to clipboard: {}", err),
+-                    }
+-                }
+-
+                 print_code.expect("`print_code` must be `Some` when `is_send` is `true`")(
+                     term,
+                     &server_welcome.code,


### PR DESCRIPTION
Adds a Rust client for [magic-wormhole](https://github.com/magic-wormhole).
The reference impl. is in Python. Installing a python tool requires python and pip. This single static binary client is better suited for those who don't want to install python dependencies.
Note that `wormhole-rs` still is not in feature-parity with Python's magic-wormhole, but it offers some [improvements](https://github.com/magic-wormhole/magic-wormhole.rs#comparison-with-the-python-implementation). Also it is a project from the same GitHub organization.
The dependency on `libxcb` is for handling clipboard in a graphical environment. It works in headless setups so this is not a X11 package.
Regarding the naming of the package: https://repology.org/project/magic-wormhole-rs/versions