### PR TITLE
upgpkg(main/dialog): to 1.3-20220526

### DIFF
--- a/packages/dialog/build.sh
+++ b/packages/dialog/build.sh
@@ -3,9 +3,9 @@ TERMUX_PKG_DESCRIPTION="Application used in shell scripts which displays text us
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_DEPENDS="libandroid-support, ncurses"
-TERMUX_PKG_VERSION="1.3-20220117"
+TERMUX_PKG_VERSION="1.3-20220526"
 TERMUX_PKG_SRCURL=https://fossies.org/linux/misc/dialog-${TERMUX_PKG_VERSION}.tgz
-TERMUX_PKG_SHA256=754cb6bf7dc6a9ac5c1f80c13caa4d976e30a5a6e8b46f17b3bb9b080c31041f
+TERMUX_PKG_SHA256=858c9a625b20fde19fb7b19949ee9e9efcade23c56d917b1adb30e98ff6d6b33
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-ncursesw --enable-widec --with-pkg-config"
 
 termux_step_pre_configure() {


### PR DESCRIPTION
The old link now returns error 410
```sh
termux - building dialog for arch arm...
Downloading https://fossies.org/linux/misc/dialog-1.3-20220117.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0  2158    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
curl: (22) The requested URL returned error: 410
Failed to download https://fossies.org/linux/misc/dialog-1.3-20220117.tgz
Failed to build package 'bash' for arch 'arm'
[*] Building 'bash' exited with exit code 1
```