### PR TITLE
new package: fclones

### DIFF
--- a/packages/fclones/build.sh
+++ b/packages/fclones/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE="https://github.com/pkolaczk/fclones"
+TERMUX_PKG_DESCRIPTION="Efficient Duplicate File Finder"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.27.0"
+TERMUX_PKG_SRCURL="https://github.com/pkolaczk/fclones/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=ed135983bccac8f7568d51cde7752a25f46f7ba191dee7b74600ffba8f43039e
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_BUILD_IN_SRC=true


### PR DESCRIPTION
Adds [fclones](https://github.com/pkolaczk/fclones), an efficient duplicate file finder.
For this functionality, fdupes is already present in Termux repos but fclones is [faster](https://github.com/pkolaczk/fclones#benchmarks) than fdupes and [jdupes](https://github.com/termux/termux-packages/pull/10915) (@Efreak).