### PR TITLE
fix(main/boinc): add fallback android version to 7.0

### DIFF
--- a/packages/boinc/build.sh
+++ b/packages/boinc/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Open-source software for volunteer computing"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=7.18.1
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=https://github.com/BOINC/boinc/archive/client_release/${TERMUX_PKG_VERSION:0:4}/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=274388d9c49e488b6c8502ffc6eb605d5ceae391fb0c2fc56dbb0254d0ceb27e
 TERMUX_PKG_DEPENDS="libandroid-shmem, libc++, libcurl, openssl, zlib"
@@ -21,11 +21,12 @@ termux_step_pre_configure() {
 	# for benchmark purposes
 	CFLAGS="${CFLAGS/-Oz/-Os}"
 	CXXFLAGS="${CXXFLAGS/-Oz/-Os}"
+	CFLAGS+=" -fPIC -DTERMUX_PKG_ANDROID_VERSION=\\\"7.0\\\""
+	CXXFLAGS+=" -fPIC -DTERMUX_PKG_ANDROID_VERSION=\\\"7.0\\\""
 	LDFLAGS+=" -landroid-shmem $($CC -print-libgcc-file-name)"
 	./_autosetup
 }
 
 termux_step_post_make_install() {
-	mkdir -p "$TERMUX_PREFIX/share/bash-completion/completions"
-	install -m 644 "$TERMUX_PKG_SRCDIR/client/scripts/boinc.bash" "$TERMUX_PREFIX/share/bash-completion/completions/boinc"
+	install -Dm644 "$TERMUX_PKG_SRCDIR/client/scripts/boinc.bash" "$TERMUX_PREFIX/share/bash-completion/completions/boinc"
 }

--- a/packages/boinc/client-hostinfo_unix.cpp.patch
+++ b/packages/boinc/client-hostinfo_unix.cpp.patch
@@ -1,6 +1,6 @@
 diff -uNr boinc/client/hostinfo_unix.cpp boinc.mod/client/hostinfo_unix.cpp
 --- boinc/client/hostinfo_unix.cpp	2021-08-03 23:52:19.000000000 +0800
-+++ boinc.mod/client/hostinfo_unix.cpp	2022-06-09 00:02:01.071996878 +0800
++++ boinc.mod/client/hostinfo_unix.cpp	2022-07-30 19:04:03.029152379 +0800
 @@ -169,6 +169,10 @@
  #include <OS.h>
  #endif
@@ -12,7 +12,7 @@ diff -uNr boinc/client/hostinfo_unix.cpp boinc.mod/client/hostinfo_unix.cpp
  // Some OS define _SC_PAGE_SIZE instead of _SC_PAGESIZE
  #if defined(_SC_PAGE_SIZE) && !defined(_SC_PAGESIZE)
  #define _SC_PAGESIZE _SC_PAGE_SIZE
-@@ -1536,12 +1540,19 @@
+@@ -1536,12 +1540,21 @@
  #if HAVE_SYS_UTSNAME_H
      struct utsname u;
      uname(&u);
@@ -26,16 +26,18 @@ diff -uNr boinc/client/hostinfo_unix.cpp boinc.mod/client/hostinfo_unix.cpp
 +#endif
 +#ifdef __ANDROID__
 +    // remove the need of query Android version through Java API
-+    // which then process in client/gui_rpc_server_ops.cpp,
-+    // handle_set_host_info()
++    // which then process in client/gui_rpc_server_ops.cpp, handle_set_host_info()
 +    char android_version[PROP_VALUE_MAX];
 +    __system_property_get("ro.build.version.release", android_version);
++#ifdef __TERMUX__
++    if (strlen(android_version) == 0) { safe_strcpy(android_version, TERMUX_PKG_ANDROID_VERSION); }
++#endif
 +    snprintf(os_version, sizeof(os_version), "%s (Android %s)", u.release, android_version);
 +#elif defined(__EMX__) // OS2: version is in u.version
      safe_strcpy(os_version, u.version);
  #elif defined(__HAIKU__)
      snprintf(os_version, sizeof(os_version), "%s, %s", u.release, u.version);
-@@ -1698,7 +1709,7 @@
+@@ -1698,7 +1711,7 @@
          return false;
      }
  } tty_patterns[] = {


### PR DESCRIPTION
Needed for special case like `termux-docker`