### PR TITLE
libntl: add libgf2x dep, add tune, fix formatting

### DIFF
--- a/packages/libntl/build.sh
+++ b/packages/libntl/build.sh
@@ -5,30 +5,37 @@ TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_LICENSE_FILE="doc/copying.txt"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="11.5.1"
+TERMUX_PKG_REVISION="1"
 TERMUX_PKG_SRCURL="https://libntl.org/ntl-$TERMUX_PKG_VERSION.tar.gz"
 TERMUX_PKG_SHA256=210d06c31306cbc6eaf6814453c56c776d9d8e8df36d74eb306f6a523d1c6a8a
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_BUILD_DEPENDS="perl"
-TERMUX_PKG_DEPENDS="libgmp"
-# TERMUX_PKG_DEPENDS="gf2x, libgmp"
+TERMUX_PKG_DEPENDS="libgf2x, libgmp"
 
 termux_step_configure() {
-    cd src
-    ./configure \
-        PREFIX=$TERMUX_PREFIX\
-        NATIVE=off \
-        TUNE=generic \
-        NTL_GMP_LIP=on \
-        NTL_GF2X_LIB=off
+	cd src
+
+	case "$TERMUX_ARCH" in
+		x86_64 | i686 )
+			tune="x86";;
+		* )
+			tune="generic";;
+	esac
+
+	./configure \
+		PREFIX=$TERMUX_PREFIX\
+		NATIVE=off \
+		TUNE="$tune" \
+		NTL_GMP_LIP=on \
+		NTL_GF2X_LIB=off
 }
 
 termux_step_make() {
-    cd src
-    make
+	cd src
+	make
 }
 
 termux_step_make_install() {
-    cd src
-    make install
+	cd src
+	make install
 }
-


### PR DESCRIPTION
Adds libgf2x dependency for performance improvement.
Add a rule to tune for x86 archs (x86_64 and i686)
Covert spaces to tabs in `build.sh`