### PR TITLE
libmesode: disable auto-update

### DIFF
--- a/packages/libmesode/build.sh
+++ b/packages/libmesode/build.sh
@@ -6,7 +6,6 @@ TERMUX_PKG_REVISION=3
 TERMUX_PKG_MAINTAINER="Oliver Schmidhauser @Neo-Oli"
 TERMUX_PKG_SRCURL=https://github.com/boothj5/libmesode/archive/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=c9dd90648e73d92b90f2b0ae41a75d8f469b116d3e6aa297c14cd57be937d99e
-TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="openssl,libexpat"
 TERMUX_PKG_BREAKS="libmesode-dev"
 TERMUX_PKG_REPLACES="libmesode-dev"


### PR DESCRIPTION
libmesode has been archived by its maintainers. So I think there is no need to auto-update this package.