### PR TITLE
mpd: add pulseaudio output to the default config

### DIFF
--- a/packages/mpd/build.sh
+++ b/packages/mpd/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Music player daemon"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.23.12"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/MusicPlayerDaemon/MPD/archive/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=592192b75d33e125eacef43824901cab98a621f5f7f655da66d3072955508c69
 TERMUX_PKG_DEPENDS="dbus, ffmpeg, game-music-emu, libao, libbz2, libc++, libcurl, libexpat, libflac, libicu, libid3tag, libmad, libmp3lame, libmpdclient, libnfs, libogg, libopus, libsndfile, libsoxr, libsqlite, libvorbis, openal-soft, pulseaudio, zlib"

--- a/packages/mpd/doc-mpdconf.example.patch
+++ b/packages/mpd/doc-mpdconf.example.patch
@@ -1,5 +1,5 @@
---- a/doc/mpdconf.example	2022-03-14 17:55:47.000000000 +0000
-+++ b/doc/mpdconf.example	2022-04-19 04:52:49.436770322 +0000
+--- a/doc/mpdconf.example
++++ b/doc/mpdconf.example
 @@ -10,14 +10,14 @@
  # be disabled and audio files will only be accepted over ipc socket (using
  # file:// protocol) or streaming files over an accepted protocol.
@@ -135,6 +135,21 @@
  ##	quality		"5.0"			# do not define if bitrate is defined
  #	bitrate		"128"			# do not define if quality is defined
  #	format		"44100:16:1"
+@@ -285,6 +267,14 @@
+ #	max_clients	"0"			# optional 0=no limit
+ #}
+ #
++# An example of a pulseaudio output
++#
++audio_output {
++	type		"pulse"
++	name		"PulseAudio Output"
++	enabled		"no"
++}
++#
+ # An example of a pulseaudio output (streaming to a remote pulseaudio server)
+ #
+ #audio_output {
 @@ -295,55 +277,31 @@
  ##	media_role	"media_role"		#optional
  #}


### PR DESCRIPTION
Since mpd depends on pulseaudio, add the possibility to use pulseaudio
output. Disabled by default.