### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/bootstrap_archives.yml
+++ b/.github/workflows/bootstrap_archives.yml
@@ -5,12 +5,16 @@ on:
     - cron: "0 0 * * 0"
   workflow_dispatch:
 
+permissions: {} # none
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:
   build:
+    permissions:
+      contents: read # actions/upload-artifact doesn't need contents: write
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -30,6 +34,8 @@ jobs:
           name: bootstrap-archives-${{ github.sha }}
           path: "*.zip"
   publish:
+    permissions:
+      contents: write # for git push
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/package_updates.yml
+++ b/.github/workflows/package_updates.yml
@@ -9,9 +9,14 @@ on:
         description: "A space-seperated list of packages to update. Defaults to all packages"
         default: "@all"
         required: false
+        
+permissions: {} # none
 
 jobs:
   update-packages:
+    permissions:
+      issues: write
+      contents: write
     if: github.repository == 'termux/termux-packages'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -18,9 +18,13 @@ on:
       packages:
         description: "A space-separated names of packages selected for rebuilding"
         required: true
+        
+permissions: {} # none
 
 jobs:
   build:
+    permissions:
+      contents: read # actions/upload-artifact doesn't need contents: write
     runs-on: ubuntu-latest
     env:
       ANDROID_HOME: "/opt/termux/android-sdk"
@@ -223,6 +227,8 @@ jobs:
         path: ./artifacts
 
   upload:
+    permissions:
+      contents: read
     if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.