### PR TITLE
rw: add package 'rw', a Rust analogue of sponge(1)

### DIFF
--- a/packages/rw/build.sh
+++ b/packages/rw/build.sh
@@ -1,0 +1,17 @@
+TERMUX_PKG_HOMEPAGE="https://github.com/jridgewell/rw"
+TERMUX_PKG_DESCRIPTION="A Rust implementation of sponge(1) that never write to TMPDIR"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=1.0.1
+TERMUX_PKG_SRCURL=("https://github.com/jridgewell/rw/archive/c13c24e011ef5a79ea60bc51bb0d3fa930326146.tar.gz")
+TERMUX_PKG_SHA256=(699c32045c713bcfc8e7b89d5bd24d89d1cbb887ba8570b857391f98b64e6a9a)
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make() {
+	termux_setup_rust
+	cargo build --jobs $TERMUX_MAKE_PROCESSES --target $CARGO_TARGET_NAME --release
+}
+
+termux_step_make_install() {
+	install -Dm700 -t $TERMUX_PREFIX/bin target/${CARGO_TARGET_NAME}/release/rw
+}


### PR DESCRIPTION
The current version of `sponge(1)` from moreutils always write to `TMPDIR` for atomic write, even if we point it to stdout.

This will double the wearout of flash storage if target is stdout, e.g:

```sh
$ curl .... | sponge | sort | rev > filename.txt
```

the data will got written to flash storage in twice:
`$TMPDIR/spongeXXXX` and then sort/rev'd `filename.txt`.

Since on unrooted device `TMPDIR` is usually not a tmpfs, using sponge in similar cases will result in unnecessary wearout of flash storage when:

 - invoke sponge w/o params, or target is stdout
 - end of pipeline point to a file in a filesystem different than TMPDIR resides

In case of the length of input data is prior known or splited to a size smaller than available memory, we can use `rw` instead.