### PR TITLE
the-powder-toy: do not use elf-cleaner

### DIFF
--- a/x11-packages/the-powder-toy/build.sh
+++ b/x11-packages/the-powder-toy/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="The Powder Toy is a free physics sandbox game"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=95.0
-TERMUX_PKG_REVISION=18
+TERMUX_PKG_REVISION=19
 TERMUX_PKG_SRCURL=https://github.com/ThePowderToy/The-Powder-Toy/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=f60c3dc93e4ceddeda92b768e75a2d218f8df3da4a569b7d7cb57fff5515e15b
 TERMUX_PKG_DEPENDS="fftw, libbz2, libc++, libcurl, liblua52, sdl2, libx11, zlib"
@@ -20,5 +20,4 @@ termux_step_make() {
 termux_step_make_install() {
 	install -Dm755 "${TERMUX_PKG_SRCDIR}/build/powder64-legacy" "${TERMUX_PREFIX}/bin/the-powder-toy"
 	ln -sfr "${TERMUX_PREFIX}/bin/the-powder-toy" "${TERMUX_PREFIX}/bin/powder"
-	${TERMUX_ELF_CLEANER} "${TERMUX_PREFIX}/bin/the-powder-toy"
 }


### PR DESCRIPTION
Elf-cleaning should be done in `termux_step_massage`. Fixes #11779.