### PR TITLE
new package: sfeed -- a scriptable feed aggregator

### DIFF
--- a/packages/sfeed/Makefile.patch
+++ b/packages/sfeed/Makefile.patch
@@ -1,0 +1,24 @@
+diff --git sfeed-1.6.old/Makefile sfeed-1.6/Makefile
+index 9958954..3112e11 100644
+--- sfeed-1.6.old/Makefile
++++ sfeed-1.6/Makefile
+@@ -7,8 +7,8 @@ VERSION = 1.6
+ SFEED_THEME = mono
+ 
+ # paths
+-PREFIX = /usr/local
+-MANPREFIX = ${PREFIX}/man
++PREFIX ?= /usr/local
++MANPREFIX ?= ${PREFIX}/share/man
+ DOCPREFIX = ${PREFIX}/share/doc/${NAME}
+ 
+ RANLIB = ranlib
+@@ -16,7 +16,7 @@ RANLIB = ranlib
+ # use system flags.
+ SFEED_CFLAGS = ${CFLAGS}
+ SFEED_LDFLAGS = ${LDFLAGS}
+-SFEED_CPPFLAGS = -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=700 -D_BSD_SOURCE
++SFEED_CPPFLAGS = -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=700 -D_BSD_SOURCE ${CPPFLAGS}
+ 
+ # uncomment for conservative locked I/O.
+ #SFEED_CPPFLAGS = -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=700 -D_BSD_SOURCE \

--- a/packages/sfeed/build.sh
+++ b/packages/sfeed/build.sh
@@ -1,0 +1,11 @@
+TERMUX_PKG_HOMEPAGE="https://codemadness.org/sfeed-simple-feed-parser.html"
+TERMUX_PKG_DESCRIPTION="Shell-script/crontab oriented feed aggregator and parser utility (curses-based reader included)"
+TERMUX_PKG_LICENSE="ISC"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="1.6"
+TERMUX_PKG_SRCURL="https://codemadness.org/releases/sfeed/sfeed-$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=bfd6d24ce98619726aa411a7a0d969806ad08a73c9adc3a8d04508e00eea6aea
+TERMUX_PKG_DEPENDS="ncurses"
+TERMUX_PKG_RECOMMENDS="curl"
+TERMUX_PKG_SUGGESTS="lynx, termux-tools"
+TERMUX_PKG_BUILD_IN_SRC=true


### PR DESCRIPTION
*tldr*: this package consists of a shell scriptable feed aggregator, a RSS/Atom-to-TSV parser, and a curses-based feed entires reader.

Project is actively maintained and written in portable C and POSIX shell, listed on [suckless.org recommends](http://suckless.org/rocks).

------

`sfeed(1)` is a RSS/Atom feed parsing utility written in C that aimed to be used in a scriptable feed aggregating pipeline (or newsreading workflow, for a more generally speaking) on UNIX.

`sfeed_update(1)` is the POSIX shell script aimed to be placed in crontab for periodical updating of feeds, as the "aggregator".

**NOTE:** Crontab entries is not defined in `build.sh`.  On Termux things in crontab usually read/write to `$PREFIX/var`,
I'd leave this simple task to users for more flexibility (i.e. I may want to write to homedir or even adaptive storage instead, with different params.)

(See [README](https://codemadness.org/git/sfeed/file/README.html#l176), [manpages](https://man.voidlinux.org/sfeed.1) and `sfeed_update(1)` source code to get a feel of overall workflow.)

Once the feeds are updated, it will be totally up to user that how the entires should be handled, for examples:

 - send/sync feed entries to a mailbox using `sendmail(1)`/`isync(1)`, then read entries in Gmail App.
 - read gathered feed entries via TUI using `sfeed_curses(1)`
 - `sfeed_html(1)`, then using something like miniserve to read entries in Web browser.