### PR TITLE
add(main): pipebuffer

### DIFF
--- a/packages/pipebuffer/build.sh
+++ b/packages/pipebuffer/build.sh
@@ -1,0 +1,19 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/tfenne/pipebuffer
+TERMUX_PKG_DESCRIPTION="Arbitrary-sized in-memory buffer between pipelined programs (non-blocking mbuffer analogue for pipeline)"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.0.git20211120"
+TERMUX_PKG_SRCURL=https://github.com/tfenne/pipebuffer/archive/9af1e18b38b9a62b054047e4131d4077cce101ae.tar.gz
+TERMUX_PKG_SHA256=cc73135fa4f3bec90ab762271122dd7671bfc9f664a9c4bda9734b661372ac6d
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make() {
+	termux_setup_rust
+	cargo build --jobs $TERMUX_MAKE_PROCESSES --target $CARGO_TARGET_NAME --release
+}
+
+termux_step_make_install() {
+	install -vDm700 -t $TERMUX_PREFIX/bin target/${CARGO_TARGET_NAME}/release/pipebuffer
+	mkdir -vp $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME
+	install -vpm600 -t $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME README.*
+}


### PR DESCRIPTION
a stdio-only, non-blocking `mbuffer(1)` (`-m`) analogue, that buffering stdin in given size then flush to stdout

(or like memory-only `sponge(1)` but flush to output on buffer exceeding)

NOTE: Some other implementation that provide similar functionality (afaict) does exist but is either unmaintained, require #8871, or use Perl/Python.