### PR TITLE
ani-cli: update to 3.4

### DIFF
--- a/packages/ani-cli/build.sh
+++ b/packages/ani-cli/build.sh
@@ -2,11 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://github.com/pystardust/ani-cli
 TERMUX_PKG_DESCRIPTION="A cli to browse and watch anime"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=2.2
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION=3.4
 TERMUX_PKG_SRCURL=https://github.com/pystardust/ani-cli/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=973d335a75bd7f920c244000ad6b057f702fb37752e7bea1b5bcf038785ec925
-TERMUX_PKG_DEPENDS="aria2, curl, ffmpeg, gawk, grep, openssl-tool, sed"
+TERMUX_PKG_SHA256=45cfd2e43b8b83ae662fc3c8724b250281aca681828101e3bd5eb287a3794167
+TERMUX_PKG_DEPENDS="axel, curl, ffmpeg, gawk, grep, openssl-tool, sed"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_BUILD_IN_SRC=true
 


### PR DESCRIPTION
Just a basic version bump.
Solves ani-cli's [#893](https://github.com/pystardust/ani-cli/issues/893)

We now use axel as our download accelerator.
Also fzf may become a required dependency in our next point release, but I'll make a seperate PR for that when it happensf