### PR TITLE
ci: switch to 22.04

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     permissions:
       contents: read # actions/upload-artifact doesn't need contents: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       ANDROID_HOME: "/opt/termux/android-sdk"
       NDK: "/opt/termux/android-ndk"


### PR DESCRIPTION
A lot of packages cannot be built since we switch our docker image to ubuntu-22.04, such as #11357, #11578 and #11518. Until now, `seccomp`'s version in `ubuntu-latest (ubuntu-20.04)`  is `2.5.1-1ubuntu1~20.04.2` and doesn't have `close_range` syscall. Until we drop the usage of docker image, we could use ubuntu-22.04 as ci's base system to avoid the errors related to `close_range` syscall.