### PR TITLE
libjxl: Fix build

### DIFF
--- a/packages/libjxl/a2x-is-shell-script.patch
+++ b/packages/libjxl/a2x-is-shell-script.patch
@@ -1,0 +1,13 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -355,8 +355,8 @@ if (ASCIIDOC_PY_FOUND)
+     # does not recognize it.
+     add_custom_command(
+       OUTPUT "${PAGE}.1"
+-      COMMAND "${ASCIIDOC_PY}"
+-      ARGS "${ASCIIDOC}"
++      COMMAND "${ASCIIDOC}"
++      ARGS
+         --format manpage --destination-dir="${CMAKE_CURRENT_BINARY_DIR}"
+         "${CMAKE_CURRENT_SOURCE_DIR}/doc/man/${PAGE}.txt"
+       MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/doc/man/${PAGE}.txt")


### PR DESCRIPTION
on environment where `a2x` is a shell script.

Closes #11595.