### PR TITLE
k2pdfopt: Depend on djvulibre and gsl

### DIFF
--- a/packages/k2pdfopt/build.sh
+++ b/packages/k2pdfopt/build.sh
@@ -1,9 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://www.willus.com/k2pdfopt/
 TERMUX_PKG_DESCRIPTION="A tool that optimizes PDF files for viewing on mobile readers"
-TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_LICENSE="AGPL-V3"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.53
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.willus.com/k2pdfopt/src/k2pdfopt_v${TERMUX_PKG_VERSION}_src.zip
 TERMUX_PKG_SHA256=58c1b0647be5237570c110b0bb77eb78fab384282a2648edb59eac673070959b
-TERMUX_PKG_DEPENDS="ghostscript, leptonica, libjasper, libjpeg-turbo, libpng, zlib"
+TERMUX_PKG_DEPENDS="djvulibre, ghostscript, gsl, leptonica, libjasper, libjpeg-turbo, libpng, zlib"
 TERMUX_PKG_BUILD_IN_SRC=true


### PR DESCRIPTION
In accordance with Debian package.

Fixes #11162.