### PR TITLE
tmux: Fix behavior with non-login shell

### DIFF
--- a/packages/tmux/build.sh
+++ b/packages/tmux/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Link against libandroid-support for wcwidth(), see https://github.com/termux/termux-packages/issues/224
 TERMUX_PKG_DEPENDS="ncurses, libevent, libandroid-support, libandroid-glob"
 TERMUX_PKG_VERSION=3.3
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL="https://github.com/tmux/tmux/archive/${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=967044a34cf69197355f18f2f66e7300b29799576f91fbe04200ab71e5ef6913
 TERMUX_PKG_AUTO_UPDATE=true

--- a/packages/tmux/tmux.h.patch
+++ b/packages/tmux/tmux.h.patch
@@ -1,0 +1,11 @@
+--- a/tmux.h
++++ b/tmux.h
+@@ -74,7 +74,7 @@
+ #define TMUX_CONF "/etc/tmux.conf:~/.tmux.conf"
+ #endif
+ #ifndef TMUX_SOCK
+-#define TMUX_SOCK "$TMUX_TMPDIR:" _PATH_TMP
++#define TMUX_SOCK "$TMUX_TMPDIR:@TERMUX_PREFIX@/var/run"
+ #endif
+ #ifndef TMUX_TERM
+ #define TMUX_TERM "screen"


### PR DESCRIPTION
where f8e73d466068c8eb2b5c4e44a663a5c38374e1cf does not work well.

Fixes #11354.