### PR TITLE
libprotobuf: Bump to 3.21.6

### DIFF
--- a/packages/libprotobuf/build.sh
+++ b/packages/libprotobuf/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://github.com/protocolbuffers/protobuf
 TERMUX_PKG_DESCRIPTION="Protocol buffers C++ library"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=2:3.21.5
+TERMUX_PKG_VERSION=2:3.21.6
 TERMUX_PKG_SRCURL=https://github.com/protocolbuffers/protobuf/archive/v${TERMUX_PKG_VERSION:2}.tar.gz
-TERMUX_PKG_SHA256=d7d204a59fd0d2d2387bd362c2155289d5060f32122c4d1d922041b61191d522
+TERMUX_PKG_SHA256=73c95c7b0c13f597a6a1fec7121b07e90fd12b4ed7ff5a781253b3afe07fc077
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_DEPENDS="libc++, zlib"
 TERMUX_PKG_BREAKS="libprotobuf-dev"
@@ -15,3 +15,15 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DBUILD_SHARED_LIBS=ON
 -DCMAKE_INSTALL_LIBDIR=lib
 "
+
+termux_step_post_get_source() {
+	# Do not forget to bump revision of reverse dependencies and rebuild them
+	# after SOVERSION is changed.
+	local _SOVERSION=32
+
+	local v="$(sed -E -n 's/^\s*SOVERSION\s+([0-9]+)\s*$/\1/p' \
+			cmake/libprotobuf.cmake)"
+	if [ "${_SOVERSION}" != "${v}" ]; then
+		termux_error_exit "Error: SOVERSION guard check failed."
+	fi
+}


### PR DESCRIPTION
Both version 3.21.5 and 3.21.6 have the same `SOVERSION` (`32`) and so revdep-rebuild should not be necessary. ~~I will implement a `SOVERSION` guard in the `build.sh` afterwards so that auto-update can be enabled.~~ Now `SOVERSION` guard is implemented.