### PR TITLE
new package: python-cryptography

### DIFF
--- a/packages/python-cryptography/build.sh
+++ b/packages/python-cryptography/build.sh
@@ -1,0 +1,56 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/pyca/cryptography
+TERMUX_PKG_DESCRIPTION="Provides cryptographic recipes and primitives to Python developers"
+# Licenses: Apache-2.0, BSD 3-Clause, PSFL
+TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_LICENSE_FILE="LICENSE, LICENSE.APACHE, LICENSE.BSD, LICENSE.PSF"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=38.0.1
+TERMUX_PKG_SRCURL=https://github.com/pyca/cryptography/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=4d2e2b3192cd3767bdb68c22dd40c07a1deb209a05daee21df74fbf2df8bfbed
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="openssl, python"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+_PYTHON_VERSION=$(. $TERMUX_SCRIPTDIR/packages/python/build.sh; echo $_MAJOR_VERSION)
+
+TERMUX_PKG_RM_AFTER_INSTALL="
+lib/python${_PYTHON_VERSION}/site-packages/__pycache__
+lib/python${_PYTHON_VERSION}/site-packages/easy-install.pth
+lib/python${_PYTHON_VERSION}/site-packages/site.py
+"
+
+termux_step_post_get_source() {
+	echo "Applying openssl-libs.diff"
+	sed "s%@PYTHON_VERSION@%$_PYTHON_VERSION%g" \
+		$TERMUX_PKG_BUILDER_DIR/openssl-libs.diff | patch --silent -p1
+}
+
+termux_step_pre_configure() {
+	termux_setup_rust
+
+	termux_setup_python_crossenv
+	pushd $TERMUX_PYTHON_CROSSENV_SRCDIR
+	_CROSSENV_PREFIX=$TERMUX_PKG_BUILDDIR/python-crossenv-prefix
+	python${_PYTHON_VERSION} -m crossenv \
+		$TERMUX_PREFIX/bin/python${_PYTHON_VERSION} \
+		${_CROSSENV_PREFIX}
+	popd
+	. ${_CROSSENV_PREFIX}/bin/activate
+
+	build-pip install cffi setuptools-rust
+}
+
+termux_step_make_install() {
+	export CARGO_BUILD_TARGET=${CARGO_TARGET_NAME}
+	export PYO3_CROSS_LIB_DIR=$TERMUX_PREFIX/lib
+	export PYTHONPATH=$TERMUX_PREFIX/lib/python${_PYTHON_VERSION}/site-packages
+	pip install --no-deps . --prefix $TERMUX_PREFIX
+}
+
+termux_step_create_debscripts() {
+	cat <<- EOF > ./postinst
+	#!$TERMUX_PREFIX/bin/sh
+	echo "Installing dependencies through pip..."
+	pip3 install --no-binary cffi 'cffi>=1.12'
+	EOF
+}

--- a/packages/python-cryptography/openssl-libs.diff
+++ b/packages/python-cryptography/openssl-libs.diff
@@ -1,0 +1,11 @@
+--- a/src/_cffi_src/build_openssl.py
++++ b/src/_cffi_src/build_openssl.py
+@@ -38,7 +38,7 @@ def _get_openssl_libraries(platform):
+         if sys.platform == "zos":
+             return ["ssl", "crypto"]
+         else:
+-            return ["ssl", "crypto", "pthread"]
++            return ["ssl", "crypto", "python@PYTHON_VERSION@"]
+ 
+ 
+ def _extra_compile_args(platform):


### PR DESCRIPTION
As of now, installing `cryptography` through `pip` does not work without non-trivial workaround (#12083).