### PR TITLE
python: Disable multiarch

### DIFF
--- a/packages/python/build.sh
+++ b/packages/python/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="PythonPL"
 TERMUX_PKG_MAINTAINER="@termux"
 _MAJOR_VERSION=3.10
 TERMUX_PKG_VERSION=${_MAJOR_VERSION}.7
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.python.org/ftp/python/${TERMUX_PKG_VERSION}/Python-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=6eed8415b7516fb2f260906db5d48dd4c06acc0cb24a7d6cc15296a604dcdc48
 TERMUX_PKG_DEPENDS="gdbm, libandroid-posix-semaphore, libandroid-support, libbz2, libcrypt, libexpat, libffi, liblzma, libsqlite, ncurses, ncurses-ui-libs, openssl, readline, zlib"

--- a/packages/python/configure.patch
+++ b/packages/python/configure.patch
@@ -1,6 +1,15 @@
 diff -u -r ../Python-3.6.1/configure ./configure
 --- ../Python-3.6.1/configure	2017-03-21 07:32:38.000000000 +0100
 +++ ./configure	2017-03-23 23:42:47.210898734 +0100
+@@ -5387,6 +5387,8 @@
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for multiarch" >&5
+ $as_echo_n "checking for multiarch... " >&6; }
+ case $ac_sys_system in #(
++  Linux-android) :
++    MULTIARCH="" ;; #(
+   Darwin*) :
+     MULTIARCH="" ;; #(
+   FreeBSD*) :
 @@ -9295,7 +9295,7 @@
  		 then CCSHARED="-fPIC";
  		 else CCSHARED="+z";


### PR DESCRIPTION
First note that multiarch was actually disabled when built with NDK r23.
I would not expect any catastrophe brought by this change.

When multiarch is enabled, crossenv seems to use wrong `EXT_SUFFIX` when
building some extensions.

Fixes #11870.