### PR TITLE
nginx: Migrate to using PCRE2

### DIFF
--- a/packages/nginx/build.sh
+++ b/packages/nginx/build.sh
@@ -3,9 +3,10 @@ TERMUX_PKG_DESCRIPTION="Lightweight HTTP server"
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.23.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=http://nginx.org/download/nginx-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=5eee1bd1c23e3b9477a45532f1f36ae6178b43d571a9607e6953cef26d5df1e2
-TERMUX_PKG_DEPENDS="libandroid-glob, libcrypt, pcre, openssl, zlib"
+TERMUX_PKG_DEPENDS="libandroid-glob, libcrypt, pcre2, openssl, zlib"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_SERVICE_SCRIPT=("nginx" "mkdir -p $TERMUX_ANDROID_HOME/.nginx\nif [ -f \"$TERMUX_ANDROID_HOME/.nginx/nginx.conf\" ]; then CONFIG=\"$TERMUX_ANDROID_HOME/.nginx/nginx.conf\"; else CONFIG=\"$TERMUX_PREFIX/etc/nginx/nginx.conf\"; fi\nexec nginx -p ~/.nginx -g \"daemon off;\" -c \$CONFIG 2>&1")
 TERMUX_PKG_CONFFILES="
@@ -45,8 +46,6 @@ termux_step_configure() {
 		--with-cpp=$CPP \
 		--with-cc-opt="$CPPFLAGS $CFLAGS" \
 		--with-ld-opt="$LDFLAGS" \
-		--with-pcre \
-		--with-pcre-jit \
 		--with-threads \
 		--sbin-path="$TERMUX_PREFIX/bin/nginx" \
 		--conf-path="$TERMUX_PREFIX/etc/nginx/nginx.conf" \


### PR DESCRIPTION
PCRE (8.x) is now EOL. Packages are recommended to migrate to PCRE2 (10.x) as far as possible.