### PR TITLE
libxfixes: Create `lib/libXfixes.so.3` symlink

### DIFF
--- a/packages/libxfixes/build.sh
+++ b/packages/libxfixes/build.sh
@@ -4,7 +4,16 @@ TERMUX_PKG_DESCRIPTION="X11 miscellaneous 'fixes' extension library"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=6.0.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://xorg.freedesktop.org/releases/individual/lib/libXfixes-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=a7c1a24da53e0b46cac5aea79094b4b2257321c621b258729bc3139149245b4c
 TERMUX_PKG_DEPENDS="libx11"
 TERMUX_PKG_BUILD_DEPENDS="xorgproto, xorg-util-macros"
+
+termux_step_post_massage() {
+	cd ${TERMUX_PKG_MASSAGEDIR}/${TERMUX_PREFIX}/lib || exit 1
+	if [ ! -e "./libXfixes.so.3" ]; then
+		ln -sf libXfixes.so libXfixes.so.3
+	fi
+}
+


### PR DESCRIPTION
for backward compatibility.

Partially fixes #12139.