### PR TITLE
add(main): stdoutisatty

### DIFF
--- a/packages/stdoutisatty/build.sh
+++ b/packages/stdoutisatty/build.sh
@@ -1,0 +1,14 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/lilydjwg/stdoutisatty
+TERMUX_PKG_DESCRIPTION="Patch the isatty() calls for colored output in pipeline"
+TERMUX_PKG_LICENSE="BSD 2-Clause"
+TERMUX_PKG_MAINTAINER="@flosnvjx"
+TERMUX_PKG_VERSION=1.0
+TERMUX_PKG_SRCURL=https://github.com/lilydjwg/stdoutisatty/archive/refs/tags/"$TERMUX_PKG_VERSION".tar.gz
+TERMUX_PKG_SHA256=fadc12401cd89e718d7b0127b882cf47335f436ffcc7b83a9fbf557befe5beb2
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
+
+termux_step_post_make_install() {
+	cd "$TERMUX_PKG_SRCDIR"
+	install -Dm600 -t $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME README.*
+}

--- a/packages/stdoutisatty/soname.patch
+++ b/packages/stdoutisatty/soname.patch
@@ -1,0 +1,13 @@
+diff --git a/libstdoutisatty.c b/libstdoutisatty.c
+index 0516cdd..a5f4762 100644
+--- a/libstdoutisatty.c
++++ b/libstdoutisatty.c
+@@ -43,7 +43,7 @@ __attribute__ ((constructor)) static void setup(void) {
+   void *libhdl;
+   char *dlerr;
+ 
+-  if (!(libhdl=dlopen("libc.so.6", RTLD_LAZY)))
++  if (!(libhdl=dlopen("libc.so", RTLD_LAZY)))
+     die("Failed to patch library calls: %s", dlerror());
+ 
+   orig_isatty = dlsym(libhdl, "isatty");


### PR DESCRIPTION
what: [ArchWiki entry](https://wiki.archlinux.org/title/Color_output_in_console#Reading_from_stdin)

why: unlike unbuffer, this only does not employ pty pair reduced resource usage a little.

It also supports `ld_preload` usage, avoiding extra `execve()`.