### PR TITLE
add(main): new package lowdown

### DIFF
--- a/packages/lowdown/build.sh
+++ b/packages/lowdown/build.sh
@@ -1,0 +1,25 @@
+TERMUX_PKG_HOMEPAGE="https://kristaps.bsd.lv/lowdown"
+TERMUX_PKG_DESCRIPTION="Markdown utilities and library (fork of hoedown -> sundown -> libsoldout)"
+TERMUX_PKG_LICENSE="ISC"
+TERMUX_PKG_LICENSE_FILE="LICENSE.md"
+TERMUX_PKG_MAINTAINER="@flosnvjx"
+TERMUX_PKG_VERSION="1.0.0"
+TERMUX_PKG_SRCURL="https://kristaps.bsd.lv/lowdown/snapshots/lowdown-${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=a7c9dbbd40e3e9d9296ff6ef6ac54fec83b1abe54db7b6113cd9c0f692a20c13
+#TERMUX_PKG_BUILD_DEPENDS="libseccomp" ## it is merely a checkdepends for now and we dont run check during build
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_MAKE_INSTALL_TARGET="install install_libs" ## add "regress" target if one wanna run check
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_METHOD=repology
+
+termux_step_configure() {
+	## avoid hard-linking during make
+	sed -Ee 's%^([\t ]*ln) -f (lowdown lowdown-diff)$%\1 -srf \2%' -i Makefile
+
+	## not an autoconf script
+	./configure \
+		LDFLAGS="$LDFLAGS" \
+		CPPFLAGS="$CPPFLAGS" \
+		PREFIX="$TERMUX_PREFIX" \
+		MANDIR="$TERMUX_PREFIX/share/man"
+}


### PR DESCRIPTION
what: fork of hoedown from bsd.lv, has different underlying implementation, plus man(7)/latex output that hoedown does not have

regress check run w/o error in local build