### PR TITLE
neovim-nightly: update to 0.8.0-dev-1202-g33dd917d7

### DIFF
--- a/packages/neovim-nightly/build.sh
+++ b/packages/neovim-nightly/build.sh
@@ -5,9 +5,9 @@ TERMUX_PKG_MAINTAINER="Aditya Alok <alok@termux.org>"
 # Upstream now has version number like "0.8.0-dev-698-ga5920e98f", but actually
 # "0.8.0-dev-698-g1ef84547a" < "0.8.0-dev-nightly-10-g1a07044c1", we need to bump
 # the epoch of the package version.
-TERMUX_PKG_VERSION="1:0.8.0-dev-1194-ga80ab395a"
+TERMUX_PKG_VERSION="1:0.8.0-dev-1202-g33dd917d7"
 TERMUX_PKG_SRCURL="https://github.com/neovim/neovim/archive/nightly.tar.gz"
-TERMUX_PKG_SHA256=64c28ddcc6494b6bf3cd835d5a2ac2fe9843dffe8db5d6e993774acaca8f2621
+TERMUX_PKG_SHA256=4e8372ef6260a91dbf29049ec8831dc0d5f76b205ee328f1bf25dc59c37749ed
 TERMUX_PKG_DEPENDS="libiconv, libuv, luv, libmsgpack, libandroid-support, libvterm, libtermkey, libluajit, libunibilium, libtreesitter"
 TERMUX_PKG_HOSTBUILD=true
 

--- a/packages/neovim-nightly/revert-libvterm-0.3.patch
+++ b/packages/neovim-nightly/revert-libvterm-0.3.patch
@@ -1,0 +1,53 @@
+From 440568c208908115a2c64f816b28639b4139c695 Mon Sep 17 00:00:00 2001
+From: Chongyun Lee <45286352+licy183@users.noreply.github.com>
+Date: Fri, 30 Sep 2022 17:11:11 +0800
+Subject: [PATCH] Revert "build(deps): require libvterm version 0.3"
+
+As for now, we maintain two packages `neovim` and `neovim-nightly`.
+The former needs `libvterm-0.1.3` but the latter needs `libvterm-0.3`.
+In commit 6917a2e569e9f7306a9858f1aeeb32dd1c3ece4e, `neovim-nightly`
+dropped the support for `libvterm-0.1.3`, which will break the building.
+
+This reverts commit 6917a2e569e9f7306a9858f1aeeb32dd1c3ece4e.
+---
+ CMakeLists.txt      | 2 +-
+ src/nvim/terminal.c | 4 ++++
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 76526d6cc..034c349c9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -502,7 +502,7 @@ if(FEAT_TUI)
+   include_directories(SYSTEM ${LIBTERMKEY_INCLUDE_DIRS})
+ endif()
+ 
+-find_package(LIBVTERM 0.3 REQUIRED)
++find_package(LIBVTERM 0.1 REQUIRED)
+ include_directories(SYSTEM ${LIBVTERM_INCLUDE_DIRS})
+ 
+ option(CLANG_ASAN_UBSAN "Enable Clang address & undefined behavior sanitizer for nvim binary." OFF)
+diff --git a/src/nvim/terminal.c b/src/nvim/terminal.c
+index c52586fea..8ec51438f 100644
+--- a/src/nvim/terminal.c
++++ b/src/nvim/terminal.c
+@@ -908,6 +908,7 @@ static int term_settermprop(VTermProp prop, VTermValue *val, void *data)
+ 
+   case VTERM_PROP_TITLE: {
+     buf_T *buf = handle_get_buffer(term->buf_handle);
++#if VTERM_VERSION_MAJOR > 0 || (VTERM_VERSION_MAJOR == 0 && VTERM_VERSION_MINOR >= 2)
+     VTermStringFragment frag = val->string;
+ 
+     if (frag.initial && frag.final) {
+@@ -932,6 +933,9 @@ static int term_settermprop(VTermProp prop, VTermValue *val, void *data)
+       xfree(term->title);
+       term->title = NULL;
+     }
++#else
++    buf_set_term_title(buf, val->string, strlen(val->string));
++#endif
+     break;
+   }
+ 
+-- 
+2.37.3


### PR DESCRIPTION
Closes #12214.