### PR TITLE
fix(main/emscripten): i686 build

### DIFF
--- a/packages/emscripten/build.sh
+++ b/packages/emscripten/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Emscripten: An LLVM-to-WebAssembly Compiler"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@truboxl"
 TERMUX_PKG_VERSION="3.1.23"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/emscripten-core/emscripten.git
 TERMUX_PKG_GIT_BRANCH=$TERMUX_PKG_VERSION
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
@@ -52,8 +53,8 @@ opt/emscripten/LICENSE
 
 # https://github.com/emscripten-core/emscripten/issues/11362
 # can switch to stable LLVM to save space once above is fixed
-_LLVM_COMMIT=8b587113b746f31b63fd6473083df78cef30a72e
-_LLVM_TGZ_SHA256=15490ea18bd050b35dcbd036b60fae1c5f16a9389f95b1a4faca29d2cbf64d94
+_LLVM_COMMIT=945a1468c922573a07b334a130d05f0ecca40926
+_LLVM_TGZ_SHA256=26d6d4ba7844de81ae600d6f804fb047809079925072a557bc3faf4a5d4b0b48
 
 # https://github.com/emscripten-core/emscripten/issues/12252
 # upstream says better bundle the right binaryen revision for now


### PR DESCRIPTION
Closes #12221

It seems like latest tip of tree has fixed the build issue so use that
Tip of tree is what usually emscripten uses for their emsdk "build from source" releases

The build was first broken in commit llvm/llvm-project@f35230ae0a69bbdd74a4faa3ae0b69a46796dc12
The last known working is commit llvm/llvm-project@46525fee812343b5e603a77893dfe2983768ca56
I have yet to determine which commit fix the build, ideally should use that instead