### PR TITLE
chore(CONTRIBUTING.md): Remove unnecessary message for update and downgrade

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -351,17 +351,17 @@ Any line in the commit **should not exceed 80 characters**. In case it does, con
 Examples of good commit messages:
 
 1. ```
-   upgpkg(main/nodejs): upgrade to v18.2.0
+   upgpkg(main/nodejs): v18.2.0
    ```
 
 2. ```
-   dwnpkg(main/htop): downgrade to v2.2.0
+   dwnpkg(main/htop): v2.2.0
 
    v3.x needs access to /proc/stat which is now restricted by Android
    ```
 
 3. ```
-   enhance,upgpkg(main/nodejs): update to v18.2.0 and use shared libuv
+   enhance,upgpkg(main/nodejs): v18.2.0 and use shared libuv
 
    # Describe the technical reasons of how using shared libuv is beneficial
    ```

--- a/scripts/bin/update-checksum
+++ b/scripts/bin/update-checksum
@@ -93,13 +93,13 @@ for package in "${@}"; do
 			git --no-pager diff --patch "${buildsh_path}"
 			echo "--------------------"
 			echo
-			echo "upgpkg(${repo}/${package}): update to $(. "${buildsh_path}"; echo "${TERMUX_PKG_VERSION}" | cut -d: -f2-)"
+			echo "upgpkg(${repo}/${package}): $(. "${buildsh_path}"; echo "${TERMUX_PKG_VERSION}" | cut -d: -f2-)"
 			echo
 			read -re -p "Do you want to commit changes ? (y/n) " CHOICE
 			echo
 			if [[ ${CHOICE} =~ (Y|y) ]]; then
 				git add "${buildsh_path}"
-				git commit -m "upgpkg(${repo}/${package}): update to $(. "${buildsh_path}"; echo "${TERMUX_PKG_VERSION}" | cut -d: -f2-)"
+				git commit -m "upgpkg(${repo}/${package}): $(. "${buildsh_path}"; echo "${TERMUX_PKG_VERSION}" | cut -d: -f2-)"
 			else
 				echo "Not committing to Git!"
 			fi

--- a/scripts/updates/utils/termux_pkg_upgrade_version.sh
+++ b/scripts/updates/utils/termux_pkg_upgrade_version.sh
@@ -70,7 +70,7 @@ termux_pkg_upgrade_version() {
 				echo "INFO: Committing package."
 				stderr="$(
 					git add "${TERMUX_PKG_BUILDER_DIR}" 2>&1 >/dev/null
-					git commit -m "upgpkg(${repo}/${TERMUX_PKG_NAME}): update to ${LATEST_VERSION}" \
+					git commit -m "upgpkg(${repo}/${TERMUX_PKG_NAME}): ${LATEST_VERSION}" \
 						-m "This commit has been automatically submitted by Github Actions." 2>&1 >/dev/null
 				)" || {
 					termux_error_exit <<-EndOfError


### PR DESCRIPTION
Earlier convention:
  upgpkg(<repo>/<package>): update to <ver>
Newer convention:
  upgpkg(<repo>/<package>): <ver>
Similarly same for dwnpkg.

Thanks to @truboxl for the suggestion
