### PR TITLE
valgrind: Fix build for aarch64

### DIFF
--- a/packages/valgrind/aarch64_have_lse_atomics.patch
+++ b/packages/valgrind/aarch64_have_lse_atomics.patch
@@ -1,0 +1,17 @@
+In compiler-rt, `__aarch64_have_lse_atomics` is initialized by
+`init_have_lse_atomics()` which calls `getauxval()` defined in libc.
+Let's always assume that the system does not have LSE atomics.
+
+--- a/coregrind/m_scheduler/ticket-lock-linux.c
++++ b/coregrind/m_scheduler/ticket-lock-linux.c
+@@ -66,6 +66,10 @@
+ static Bool s_debug = True;
+ #endif
+ 
++#if defined __ANDROID__ && defined __aarch64__
++Bool __aarch64_have_lse_atomics = False;
++#endif
++
+ static const HChar *get_sched_lock_name(void)
+ {
+    return "ticket lock";


### PR DESCRIPTION
In compiler-rt, `__aarch64_have_lse_atomics` is initialized by `init_have_lse_atomics()` which calls `getauxval()` defined in libc. Let's always assume that the system does not have LSE atomics.

Closes #12224.