### PR TITLE
rlwrap: Disable bracketed paste

### DIFF
--- a/packages/rlwrap/build.sh
+++ b/packages/rlwrap/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Wrapper using readline to enable editing of keyboard inp
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.45.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://fossies.org/linux/privat/rlwrap-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=feb49c4ffa79f78d2439b4ffa933c77eed57eeb614ab84d967b8d692e0f6beb1
 TERMUX_PKG_DEPENDS="ncurses, readline"

--- a/packages/rlwrap/disable-bracketed-paste.patch
+++ b/packages/rlwrap/disable-bracketed-paste.patch
@@ -1,0 +1,13 @@
+https://github.com/termux/termux-packages/issues/12282
+
+--- a/src/readline.c
++++ b/src/readline.c
+@@ -103,7 +103,7 @@
+ 				   in .inputrc */
+ 
+   /* put the next variable binding(s) *after* rl_initialize(), so they cannot be overridden */
+-  /* rl_variable_bind("enable-bracketed-paste","off"); */     /* enable-bracketed-paste changes cursor positioning after printing the prompt ...
++  rl_variable_bind("enable-bracketed-paste","off");     /* enable-bracketed-paste changes cursor positioning after printing the prompt ...
+                                                            ... causing rlwrap to overwrite it after accepting input                        */
+  
+   using_history();


### PR DESCRIPTION
Could cause regressions elsewhere though.

Fixes #12282.