### PR TITLE
improve(termux_step_create_pacman_install_hook.sh): adding preupg and postupg function

### DIFF
--- a/scripts/build/termux_step_create_pacman_install_hook.sh
+++ b/scripts/build/termux_step_create_pacman_install_hook.sh
@@ -13,6 +13,18 @@ termux_step_create_pacman_install_hook() {
 		echo "}" >> .INSTALL
 		rm -f postinst
 	fi
+	if [ -f "./preupg" ]; then
+		echo "pre_upgrade() {" >> .INSTALL
+		cat preupg | grep -v '^#' >> .INSTALL
+		echo "}" >> .INSTALL
+		rm -f preupg
+	fi
+	if [ -f "./postupg" ]; then
+		echo "post_upgrade() {" >> .INSTALL
+		cat postupg | grep -v '^#' >> .INSTALL
+		echo "}" >> .INSTALL
+		rm -f postupg
+	fi
 	if [ -f "./prerm" ]; then
 		echo "pre_remove() {" >> .INSTALL
 		cat prerm | grep -v '^#' >> .INSTALL


### PR DESCRIPTION
`postupg` - script that will run after the package is updated (`post_upgrade()` is responsible for this function in pacman).
`preupg` - script to be run before updating packages (`pre_upgrade()` is responsible for this function in pacman).

I don't know if there are similar functions in `apt`, but they will definitely be useful for `pacman`.