### PR TITLE
binutils: Remove `ldd` command

### DIFF
--- a/packages/binutils/build.sh
+++ b/packages/binutils/build.sh
@@ -3,9 +3,11 @@ TERMUX_PKG_DESCRIPTION="Collection of binary tools, the main ones being ld, the 
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.39
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/binutils/binutils-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=645c25f563b8adc0a81dbd6a41cffbf4d37083a382e02d5d3df4f65c09516d00
 TERMUX_PKG_DEPENDS="binutils-libs (>= ${TERMUX_PKG_VERSION}), libc++, zlib"
+TERMUX_PKG_SUGGESTS="ldd"
 TERMUX_PKG_BREAKS="binutils-dev"
 TERMUX_PKG_REPLACES="binutils-dev"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
@@ -35,7 +37,6 @@ termux_step_pre_configure() {
 }
 
 termux_step_post_make_install() {
-	cp $TERMUX_PKG_BUILDER_DIR/ldd $TERMUX_PREFIX/bin/ldd
 	cd $TERMUX_PREFIX/bin
 	# Setup symlinks as these are used when building, so used by
 	# system setup in e.g. python, perl and libtool:

--- a/packages/binutils/ldd
+++ b/packages/binutils/ldd
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-case $# in
-	0) echo 'usage: ldd FILE...';;
-	1) objdump -p -- "$@" | grep NEEDED | cut -d' ' -f18;;
-	*) objdump -p -- "$@" | grep 'NEEDED\|file format' | cut -d' ' -f1,18
-esac

--- a/packages/ldd/build.sh
+++ b/packages/ldd/build.sh
@@ -3,9 +3,10 @@ TERMUX_PKG_DESCRIPTION="Fake ldd command"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
-TERMUX_PKG_DEPENDS="bash, binutils-is-llvm"
-TERMUX_PKG_CONFLICTS="binutils"
+TERMUX_PKG_DEPENDS="bash, binutils-is-llvm | binutils"
+TERMUX_PKG_CONFLICTS="binutils (<< 2.39-1)"
 
 termux_step_make_install() {
 	local ldd="$TERMUX_PREFIX/bin/ldd"


### PR DESCRIPTION
now that we have a separate package that provides one.

See https://github.com/termux/termux-packages/pull/12426#issuecomment-1283145628.