### PR TITLE
upgpkg(main/nodejs-lts): v16.18.0

### DIFF
--- a/packages/nodejs-lts/build.sh
+++ b/packages/nodejs-lts/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://nodejs.org/
 TERMUX_PKG_DESCRIPTION="Open Source, cross-platform JavaScript runtime environment"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Yaksh Bariya <yakshbari4@gmail.com>"
-TERMUX_PKG_VERSION=16.17.1
+TERMUX_PKG_VERSION=16.18.0
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=6721feb4152d56d2c6b358ce397abd5a7f1daf09ee2e25c5021b9b4d3f86a330
+TERMUX_PKG_SHA256=fcfe6ad2340f229061d3e81a94df167fe3f77e01712dedc0144a0e7d58e2c69b
 # Note that we do not use a shared libuv to avoid an issue with the Android
 # linker, which does not use symbols of linked shared libraries when resolving
 # symbols on dlopen(). See https://github.com/termux/termux-packages/issues/462.

--- a/packages/nodejs-lts/configure.py.patch
+++ b/packages/nodejs-lts/configure.py.patch
@@ -1,0 +1,13 @@
+--- ./configure.py.orig	2022-10-20 13:35:36.500629016 +0530
++++ ./configure.py	2022-10-20 13:35:54.980629009 +0530
+@@ -1241,10 +1241,6 @@
+ 
+   o['variables']['want_separate_host_toolset'] = int(cross_compiling)
+ 
+-  # Enable branch protection for arm64
+-  if target_arch == 'arm64':
+-    o['cflags']+=['-msign-return-address=all']
+-
+   if options.node_snapshot_main is not None:
+     if options.shared:
+       # This should be possible to fix, but we will need to refactor the

--- a/packages/nodejs-lts/node.gyp.patch
+++ b/packages/nodejs-lts/node.gyp.patch
@@ -1,7 +1,6 @@
-diff '--color=auto' -uNr node-v16.14.2.orig/node.gyp node-v16.14.2/node.gyp
---- node-v16.14.2.orig/node.gyp	2022-03-18 15:06:23.851091188 +0530
-+++ node-v16.14.2/node.gyp	2022-03-18 15:08:48.671091132 +0530
-@@ -353,6 +353,7 @@
+--- ./node.gyp.orig	2022-10-12 17:19:36.000000000 +0530
++++ ./node.gyp	2022-10-20 06:36:48.853792369 +0530
+@@ -402,6 +402,7 @@
  
        'include_dirs': [
          'src',
@@ -9,7 +8,7 @@ diff '--color=auto' -uNr node-v16.14.2.orig/node.gyp node-v16.14.2/node.gyp
          '<(SHARED_INTERMEDIATE_DIR)' # for node_natives.h
        ],
        'dependencies': [
-@@ -1075,162 +1076,6 @@
+@@ -1126,165 +1127,6 @@
          }],
        ],
      }, # fuzz_env
@@ -19,6 +18,7 @@ diff '--color=auto' -uNr node-v16.14.2.orig/node.gyp node-v16.14.2/node.gyp
 -
 -      'dependencies': [
 -        '<(node_lib_target_name)',
+-        'deps/base64/base64.gyp:base64',
 -        'deps/googletest/googletest.gyp:gtest',
 -        'deps/googletest/googletest.gyp:gtest_main',
 -        'deps/histogram/histogram.gyp:histogram',
@@ -63,6 +63,7 @@ diff '--color=auto' -uNr node-v16.14.2.orig/node.gyp node-v16.14.2/node.gyp
 -        'test/cctest/test_node_api.cc',
 -        'test/cctest/test_per_process.cc',
 -        'test/cctest/test_platform.cc',
+-        'test/cctest/test_report.cc',
 -        'test/cctest/test_json_utils.cc',
 -        'test/cctest/test_sockaddr.cc',
 -        'test/cctest/test_traced_value.cc',
@@ -76,6 +77,7 @@ diff '--color=auto' -uNr node-v16.14.2.orig/node.gyp node-v16.14.2/node.gyp
 -            'HAVE_OPENSSL=1',
 -          ],
 -          'sources': [
+-            'test/cctest/test_crypto_clienthello.cc',
 -            'test/cctest/test_node_crypto.cc',
 -          ]
 -        }],
@@ -172,7 +174,7 @@ diff '--color=auto' -uNr node-v16.14.2.orig/node.gyp node-v16.14.2/node.gyp
  
      {
        'target_name': 'overlapped-checker',
-@@ -1309,59 +1154,13 @@
+@@ -1363,59 +1205,13 @@
              'Ws2_32.lib',
            ],
          }],

--- a/scripts/build/setup/termux_setup_nodejs.sh
+++ b/scripts/build/setup/termux_setup_nodejs.sh
@@ -1,6 +1,6 @@
 termux_setup_nodejs() {
 	# Use LTS version for now
-	local NODEJS_VERSION=16.17.1
+	local NODEJS_VERSION=16.18.0
 	local NODEJS_FOLDER
 
 	if [ "${TERMUX_PACKAGES_OFFLINE-false}" = "true" ]; then
@@ -15,7 +15,7 @@ termux_setup_nodejs() {
 			local NODEJS_TAR_FILE=$TERMUX_PKG_TMPDIR/nodejs-$NODEJS_VERSION.tar.xz
 			termux_download https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-linux-x64.tar.xz \
 				"$NODEJS_TAR_FILE" \
-				06ba2eb34aa385967f5f58c87a44753f83212f6cccea892b33f80a2e7fda8384
+				a50dd97f8deb363c61d7026e5f0abc0f140916d7fcabcc549e9444c1f5c97f03
 			tar -xf "$NODEJS_TAR_FILE" -C "$NODEJS_FOLDER" --strip-components=1
 		fi
 		export PATH=$NODEJS_FOLDER/bin:$PATH


### PR DESCRIPTION
Let's get the LTS first, then will update nodejs to latest v18 too. Wont be updating it to v19 atleast till v18 is declared as LTS, then nodejs-lts will have v18 and nodejs will have v19
