### PR TITLE
Vagrantfile: update to Ubuntu 22.04 jammy

### DIFF
--- a/scripts/Vagrantfile
+++ b/scripts/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
 
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "ubuntu/jammy64"
 
   # use vagrant-disksize plugin to resize partition - https://github.com/sprotheroe/vagrant-disksize
   config.disksize.size = '50GB'


### PR DESCRIPTION
This PR updates the vagrant box to `ubuntu/jammy64` which corresponds to Ubuntu 22.04.

The motivation for the update is because I was unable to prepare an environment for building with the existing `Vagrantfile`.

I think this was because the `setup-ubuntu.sh` script doesn't complete successfully.

The error output was:
```
   default: Reading state information...
    default: E: Unable to locate package python3.10-venv
    default: E: Couldn't find any package by glob 'python3.10-venv'
    default: E: Couldn't find any package by regex 'python3.10-venv'
    default: E: Unable to locate package openjdk-18-jdk
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

Using the `ubuntu/jammy64` box yielded a successful setup.
