### PR TITLE
tuxpaint: Make `trans` directory in advance

### DIFF
--- a/x11-packages/tuxpaint/build.sh
+++ b/x11-packages/tuxpaint/build.sh
@@ -36,3 +36,8 @@ termux_step_pre_configure() {
 
 	LDFLAGS+=" -landroid-wordexp"
 }
+
+termux_step_post_configure() {
+	# https://github.com/termux/termux-packages/issues/12458
+	mkdir -p trans
+}


### PR DESCRIPTION
to avoid potential build failure. Not yet reproducing in CI though.

Fixes #12458.