### PR TITLE
gnome-font-viewer: Adapt to gnome-desktop API change

### DIFF
--- a/x11-packages/gnome-font-viewer/build.sh
+++ b/x11-packages/gnome-font-viewer/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Stick to GTK 3 for now.
 _MAJOR_VERSION=41
 TERMUX_PKG_VERSION=${_MAJOR_VERSION}.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://download.gnome.org/sources/gnome-font-viewer/${_MAJOR_VERSION}/gnome-font-viewer-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=5dd410331be070e4e034397f2754980e073851d50a2119f2fbf96adc6fe2e876
 TERMUX_PKG_DEPENDS="fontconfig, freetype, gdk-pixbuf, glib, gnome-desktop3, gtk3, harfbuzz, libcairo, libhandy, pango"

--- a/x11-packages/gnome-font-viewer/fix-build-against-gnome-desktop-42.0.patch
+++ b/x11-packages/gnome-font-viewer/fix-build-against-gnome-desktop-42.0.patch
@@ -1,0 +1,28 @@
+--- a/src/font-view.c
++++ b/src/font-view.c
+@@ -207,7 +207,7 @@
+ 
+     factory = gnome_desktop_thumbnail_factory_new (GNOME_DESKTOP_THUMBNAIL_SIZE_LARGE);
+     pixbuf = gnome_desktop_thumbnail_factory_generate_thumbnail
+-        (factory, thumb_uri, g_file_info_get_content_type (info));
++        (factory, thumb_uri, g_file_info_get_content_type (info), NULL, NULL);
+ 
+     mtime = g_file_info_get_attribute_uint64 (info, G_FILE_ATTRIBUTE_TIME_MODIFIED);
+     if (pixbuf != NULL) {
+@@ -216,12 +216,14 @@
+                                                      128 * scale_factor,
+                                                      GDK_INTERP_BILINEAR);
+         gnome_desktop_thumbnail_factory_save_thumbnail (factory, pixbuf,
+-                                                        thumb_uri, (time_t) mtime);
++                                                        thumb_uri, (time_t) mtime,
++                                                        NULL, NULL);
+         g_object_unref (pixbuf);
+         pixbuf = scaled;
+     } else {
+         gnome_desktop_thumbnail_factory_create_failed_thumbnail (factory,
+-                                                                 thumb_uri, (time_t) mtime);
++                                                                 thumb_uri, (time_t) mtime,
++                                                                 NULL, NULL);
+     }
+ 
+     return g_steal_pointer (&pixbuf);


### PR DESCRIPTION
Fixes #12457.