### PR TITLE
enhance(recoll): configure without --disable-python-module

### DIFF
--- a/packages/recoll/build.sh
+++ b/packages/recoll/build.sh
@@ -5,10 +5,13 @@ TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.33.1
 TERMUX_PKG_SRCURL=http://www.lesbonscomptes.com/recoll/recoll-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=025dec0b9745e1ddacd86ee5478f9c52b2da2e5c307f831aaa5b2c7f9d7e8db9
-TERMUX_PKG_DEPENDS="aspell, libxapian, libxslt, zlib"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" --disable-userdoc --disable-python-module --disable-python-chm --disable-x11mon --disable-qtgui"
-
+TERMUX_PKG_DEPENDS="aspell, libxapian, libxslt, zlib, python"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" --disable-userdoc --disable-python-chm --disable-x11mon --disable-qtgui"
+TERMUX_PKG_REVISION=1
 
 termux_step_pre_configure() {
 	LDFLAGS+=" $($CC -print-libgcc-file-name)"
+	CXXFLAGS+=" -fPIC"
+	_PYTHON_VERSION=$(source $TERMUX_SCRIPTDIR/packages/python/build.sh; echo $_MAJOR_VERSION)
+	CPPFLAGS+=" -I${TERMUX_PREFIX}/include/python${_PYTHON_VERSION}/"
 }


### PR DESCRIPTION
This PR builds on #12299 to enable Python support in the recoll package. Hopefully also fixes https://github.com/koniu/recoll-webui/issues/86.