### PR TITLE
termux_setup_python_crossenv: Fix `PYTHONPATH`

### DIFF
--- a/scripts/build/setup/python-crossenv-PYTHONPATH.patch
+++ b/scripts/build/setup/python-crossenv-PYTHONPATH.patch
@@ -1,0 +1,22 @@
+--- a/crossenv/__init__.py
++++ b/crossenv/__init__.py
+@@ -695,6 +695,8 @@
+         # Also: 'stdlib' might not be accurate if build-python is in a build
+         # directory.
+         stdlib = os.path.abspath(os.path.dirname(os.__file__))
++        stdlib_dynload = os.path.join(stdlib, 'lib-dynload')
++        build_site_dir = os.path.join(context.build_env_dir, 'lib', pyver, 'site-packages')
+ 
+         context.sentinel = random.randint(0,0xffffffff)
+ 
+--- a/crossenv/scripts/pywrapper.py.tmpl
++++ b/crossenv/scripts/pywrapper.py.tmpl
+@@ -17,7 +17,7 @@
+ os.environ['_PYTHON_SYSCONFIGDATA_NAME']={{repr(sysconfig_name)}}
+ os.environ['PYTHONHOME']={{repr(self.host_home)}}
+ oldpath = os.environ.get('PYTHONPATH')
+-newpath = os.pathsep.join([{{repr(context.lib_path)}}, {{repr(stdlib)}}])
++newpath = os.pathsep.join([{{repr(context.lib_path)}}, {{repr(build_site_dir)}}, {{repr(stdlib)}}, {{repr(stdlib_dynload)}}])
+ if oldpath:
+     path = os.pathsep.join([newpath, oldpath])
+ else:


### PR DESCRIPTION
in cross-python.

~~Not sure if really needed though.~~