### PR TITLE
xcb-proto: Bump to 1.15.2

### DIFF
--- a/packages/xcb-proto/build.sh
+++ b/packages/xcb-proto/build.sh
@@ -3,15 +3,14 @@ TERMUX_PKG_HOMEPAGE=https://xcb.freedesktop.org/
 TERMUX_PKG_DESCRIPTION="XML-XCB protocol descriptions"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1.15
+TERMUX_PKG_VERSION=1.15.2
 TERMUX_PKG_SRCURL=https://xorg.freedesktop.org/archive/individual/proto/xcb-proto-$TERMUX_PKG_VERSION.tar.xz
-TERMUX_PKG_SHA256=d34c3b264e8365d16fa9db49179cfa3e9952baaf9275badda0f413966b65955f
+TERMUX_PKG_SHA256=7072beb1f680a2fe3f9e535b797c146d22528990c72f63ddb49d2f350a3653ed
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_CONFLICTS="xcbproto"
 TERMUX_PKG_REPLACES="xcbproto"
-
-termux_step_pre_configure() {
-	export PYTHON_VERSION=$(. $TERMUX_SCRIPTDIR/packages/python/build.sh; echo $_MAJOR_VERSION)
-	export PYTHON=python$PYTHON_VERSION
-	TERMUX_PKG_RM_AFTER_INSTALL="lib/${PYTHON}/site-packages/xcbgen/__pycache__"
-}
+_PYTHON_VERSION=$(. $TERMUX_SCRIPTDIR/packages/python/build.sh; echo $_MAJOR_VERSION)
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+PYTHON=python${_PYTHON_VERSION}
+am_cv_python_pythondir=$TERMUX_PREFIX/lib/python${_PYTHON_VERSION}/site-packages
+"

--- a/packages/xcb-proto/python-xcbgen.subpackage.sh
+++ b/packages/xcb-proto/python-xcbgen.subpackage.sh
@@ -1,0 +1,5 @@
+TERMUX_SUBPKG_INCLUDE="lib/python*"
+TERMUX_SUBPKG_DESCRIPTION="The xcbgen Python module"
+# Cannot depend on python due to circular dependency.
+TERMUX_SUBPKG_BREAKS="xcb-proto (<< 1.15.2)"
+TERMUX_SUBPKG_REPLACES="xcb-proto (<< 1.15.2)"


### PR DESCRIPTION
and separate python-xcbgen as a subpackage.