### PR TITLE
add(main): new package dnote

### DIFF
--- a/packages/dnote/build.sh
+++ b/packages/dnote/build.sh
@@ -42,14 +42,13 @@ termux_step_create_debscripts() {
 		dnote completion bash > ${TERMUX_PREFIX}/share/bash-completion/completions/dnote.bash
 		dnote completion zsh > ${TERMUX_PREFIX}/share/zsh/site-functions/_dnote
 		dnote completion fish > ${TERMUX_PREFIX}/share/fish/vendor_completions.d/dnote.fish
-                
 	EOF
 }
 
 termux_step_install_license() {
 	install -Dm600 -t "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}" \
 		"${TERMUX_PKG_SRCDIR}/licenses/GPLv3.txt"
-    install -Dm600 -t "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}" \
+        install -Dm600 -t "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}" \
 		"${TERMUX_PKG_SRCDIR}/licenses/AGPLv3.txt"
         install -Dm600 -t "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}" \
 		"${TERMUX_PKG_SRCDIR}/LICENSE"

--- a/packages/dnote/build.sh
+++ b/packages/dnote/build.sh
@@ -1,0 +1,56 @@
+TERMUX_PKG_HOMEPAGE=https://www.getdnote.com/
+TERMUX_PKG_DESCRIPTION="A simple command line notebook for programmers"
+TERMUX_PKG_LICENSE="AGPL-V3,GPL-3.0"
+TERMUX_PKG_MAINTAINER="2096779623 <admin@utermux.dev>"
+TERMUX_PKG_VERSION=2.0.1
+TERMUX_PKG_SRCURL=https://github.com/dnote/dnote/archive/refs/tags/server-v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=28cc3bf93b3849b9a4a5e65e531f8a34d6be6048427d924c56ab8c7887676bad
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="dnote-server,dnote-client,postgresql"
+
+termux_step_pre_configure() {
+        termux_setup_nodejs
+        termux_setup_golang
+
+        go mod download
+        # build assets for dnote-server:
+        cd "$TERMUX_PKG_SRCDIR/pkg/server/assets"
+        npm update && npm i
+}
+
+termux_step_make() {
+        cd "$TERMUX_PKG_SRCDIR"
+        export GOOS=android
+        $TERMUX_PKG_SRCDIR/scripts/cli/build.sh ${TERMUX_PKG_VERSION}
+        $TERMUX_PKG_SRCDIR/scripts/server/build.sh ${TERMUX_PKG_VERSION}
+
+}
+
+termux_step_make_install() {
+        install -Dm700 $TERMUX_PKG_SRCDIR/build/server/android-$GOARCH/dnote-server "$TERMUX_PREFIX/bin/dnote-server"
+        install -Dm700 $TERMUX_PKG_SRCDIR/build/cli/android-$GOARCH/dnote "$TERMUX_PREFIX/bin/dnote"
+
+        install -Dm644 /dev/null "${TERMUX_PREFIX}/share/bash-completion/completions/dnote.bash"
+	install -Dm644 /dev/null "${TERMUX_PREFIX}/share/zsh/site-functions/_dnote"
+	install -Dm644 /dev/null "${TERMUX_PREFIX}/share/fish/vendor_completions.d/dnote.fish"
+}
+
+termux_step_create_debscripts() {
+	cat <<- EOF > ./postinst
+		#!${TERMUX_PREFIX}/bin/sh
+		dnote completion bash > ${TERMUX_PREFIX}/share/bash-completion/completions/dnote.bash
+		dnote completion zsh > ${TERMUX_PREFIX}/share/zsh/site-functions/_dnote
+		dnote completion fish > ${TERMUX_PREFIX}/share/fish/vendor_completions.d/dnote.fish
+                
+	EOF
+}
+
+termux_step_install_license() {
+	install -Dm600 -t "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}" \
+		"${TERMUX_PKG_SRCDIR}/licenses/GPLv3.txt"
+    install -Dm600 -t "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}" \
+		"${TERMUX_PKG_SRCDIR}/licenses/AGPLv3.txt"
+        install -Dm600 -t "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}" \
+		"${TERMUX_PKG_SRCDIR}/LICENSE"
+}

--- a/packages/dnote/cli-build.sh.patch
+++ b/packages/dnote/cli-build.sh.patch
@@ -1,0 +1,41 @@
+diff -uNr dnote-server-v2.0.1/scripts/cli/build.sh dnote-server-v2.0.1.mod/scripts/cli/build.sh
+--- dnote-server-v2.0.1/scripts/cli/build.sh	2022-05-09 19:37:02.000000000 +0800
++++ dnote-server-v2.0.1.mod/scripts/cli/build.sh	2022-10-29 18:03:03.282780947 +0800
+@@ -76,37 +76,9 @@
+     if [ "$platform" == "windows" ]; then
+       flags+=("-buildmode=exe")
+     fi
+-
+-    xgo \
+-      -go "$goVersion" \
+-      -targets="$platform/$arch" \
+-      -ldflags "$ldflags" \
+-      -dest="$destDir" \
+-      -out="cli" \
+-      "${flags[@]}" \
+-      -tags "$tags" \
+-      -pkg pkg/cli \
+-      .
+   fi
+-
+-  popd
+-
+   binaryName=$(get_binary_name "$platform")
+   mv "$destDir/cli-${platform}-"* "$destDir/$binaryName"
+-
+-  # build tarball
+-  tarballName="dnote_${version}_${platform}_${arch}.tar.gz"
+-  tarballPath="$outputDir/$tarballName"
+-
+-  cp "$projectDir/licenses/GPLv3.txt" "$destDir"
+-  cp "$basedir/README.md" "$destDir"
+-  tar -C "$destDir" -zcvf "$tarballPath" "."
+-  rm -rf "$destDir"
+-
+-  # calculate checksum
+-  pushd "$outputDir"
+-  shasum -a 256 "$tarballName" >> "$outputDir/dnote_${version}_checksums.txt"
+-  popd
+ }
+ 
+ if [ -z "$GOOS" ] && [ -z "$GOARCH" ]; then

--- a/packages/dnote/dnote-client.subpackage.sh
+++ b/packages/dnote/dnote-client.subpackage.sh
@@ -1,0 +1,2 @@
+TERMUX_SUBPKG_DESCRIPTION="dnote server"
+TERMUX_SUBPKG_INCLUDE="bin/dnote, share/doc/${TERMUX_PKG_NAME}/GPLv3.txt"

--- a/packages/dnote/dnote-server.subpackage.sh
+++ b/packages/dnote/dnote-server.subpackage.sh
@@ -1,0 +1,2 @@
+TERMUX_SUBPKG_DESCRIPTION="dnote server"
+TERMUX_SUBPKG_INCLUDE="bin/dnote-server, share/doc/${TERMUX_PKG_NAME}/AGPLv3.txt"

--- a/packages/dnote/server-build.sh.patch
+++ b/packages/dnote/server-build.sh.patch
@@ -1,0 +1,35 @@
+diff -uNr dnote-server-v2.0.1/scripts/server/build.sh dnote-server-v2.0.1.mod/scripts/server/build.sh
+--- dnote-server-v2.0.1/scripts/server/build.sh	2022-05-09 19:37:02.000000000 +0800
++++ dnote-server-v2.0.1.mod/scripts/server/build.sh	2022-10-29 17:44:33.332781370 +0800
+@@ -26,8 +26,8 @@
+ fi
+ 
+ build() {
+-  platform=$1
+-  arch=$2
++  platform=android
++  arch=$GOARCH
+ 
+   pushd "$basedir"
+ 
+@@ -46,20 +46,8 @@
+ 
+   popd
+ 
+-  # build tarball
+-  tarballName="dnote_server_${version}_${platform}_${arch}.tar.gz"
+-  tarballPath="$outputDir/$tarballName"
+-
+   cp "$projectDir/licenses/AGPLv3.txt" "$destDir"
+   cp "$basedir/README.md" "$destDir"
+-  tar -C "$destDir" -zcvf "$tarballPath" "."
+-  rm -rf "$destDir"
+-
+-  # calculate checksum
+-  pushd "$outputDir"
+-  shasum -a 256 "$tarballName" >> "$outputDir/dnote_${version}_checksums.txt"
+-  popd
+-
+ }
+ 
+ build linux amd64


### PR DESCRIPTION
# how to test
## server
```bash
mkdir -p $PREFIX/var/lib/postgresql
initdb $PREFIX/var/lib/postgresql
pg_ctl -D $PREFIX/var/lib/postgresql start
createdb dnote
DBHost=localhost DBPort=5432 DBName=dnote DBUser=postgres DBPassword="" DBSkipSSL=true WebURL=localhost:3000 dnote-server start
```

## client
```bash
mkdir -p $HOME/.dnote
# your editor here
echo editor: "nano" > ~/.dnote/dnoterc
echo apiEndpoint: http://localhost:3000/api >> ~/.dnote/dnoterc
# Open http://localhost:3000 in your browser then register an account first
dnote login
```

# log
## server
```bash
~ $ DBHost=localhost DBPort=5432 DBName=dnote DBUser=postgres DBPassword="" DBSkipSSL=true WebURL=localhost:3000 dnote-server start

2022/10/29 11:31:21 Performed 0 migrations
2022/10/29 11:31:21 Started background tasks
2022/10/29 11:31:21 Dnote version 2.0.1 is running on port 3000
{"duration":"54ms","level":"info","method":"GET","msg":"incoming request","origin":"","remoteAddr":"192.168.1.99:49506","statusCode":200,"ts":"2022-10-29T11:32:02.428597833Z","ts_unix":1667043122,"uri":"/","userAgent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.139 Safari/537.36"}
{"duration":"373ms","level":"info","method":"POST","msg":"incoming request","origin":"","remoteAddr":"127.0.0.1:39152","statusCode":200,"ts":"2022-10-29T11:33:06.031708642Z","ts_unix":1667043186,"uri":"/api/v3/signin","userAgent":"Go-http-client/1.1"}
```
## client
```bash
~ $ dnote login
  Welcome to Dnote Pro (http://localhost:3000)
  [?] email: admin@utermux.dev
  [?] password: 
  ✔ logged in
~ $ dnote add a
  ✔ added to a
  • book name: a
  • created at: Oct 29, 2022 11:33am (UTC)
  • note id: 1
  • note uuid: b8b66d6c-4a6d-473d-8817-84651bf06131

------------------------content------------------------
test

-------------------------------------------------------

```

* I don't know what software to use as the SMTP server, this is optional.