### PR TITLE
nim: update to 1.6.8

### DIFF
--- a/packages/nim/build.sh
+++ b/packages/nim/build.sh
@@ -3,9 +3,9 @@ TERMUX_PKG_DESCRIPTION="Nim programming language compiler"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="copying.txt"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1.6.6
+TERMUX_PKG_VERSION=1.6.8
 TERMUX_PKG_SRCURL=https://nim-lang.org/download/nim-$TERMUX_PKG_VERSION.tar.xz
-TERMUX_PKG_SHA256=67b111ce6f3861503b9fcc1cae59fc34d0122566d3ecfef3a064a2174121a452
+TERMUX_PKG_SHA256=0f5b65cdb60f78af41cb075c238983689a1e1f7e25c819f179862c18a484cf57
 TERMUX_PKG_DEPENDS="clang, git, libandroid-glob, openssl-1.1"
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -40,7 +40,6 @@ termux_step_make() {
 	sed -i "s%\@LDFLAGS\@%${LDFLAGS}%g" config/nim.cfg
 	sed -i "s%\@CPPFLAGS\@%${CPPFLAGS}%g" config/nim.cfg
 
-	find -name "stdlib_osproc.nim.c" | xargs -n 1 sed -i 's',"/system/bin/sh\"\,\ 14","${TERMUX_PREFIX}/bin/sh\"\,\ 38",'g'
 	PATH=$TERMUX_PKG_HOSTBUILD_DIR/bin:$PATH
 
 	if [ $NIM_ARCH = "amd64" ]; then


### PR DESCRIPTION
Updates Nim to [1.6.8](https://nim-lang.org/blog/2022/09/27/version-168-released.html)