### PR TITLE
addpkg(main): libandroid-complex-math, box86

### DIFF
--- a/packages/box86/CMakeLists.txt.patch
+++ b/packages/box86/CMakeLists.txt.patch
@@ -1,0 +1,37 @@
+diff -uNr box86/CMakeLists.txt box86.mod/CMakeLists.txt
+--- box86/CMakeLists.txt	2022-10-31 00:09:49.879470723 +0800
++++ box86.mod/CMakeLists.txt	2022-10-31 00:08:16.691470789 +0800
+@@ -622,7 +622,7 @@
+ add_dependencies(${BOX86} WRAPPERS)
+ add_dependencies(${BOX86} PRINTER)
+ if(ANDROID)
+-    target_link_libraries(${BOX86} c m dl)
++    target_link_libraries(${BOX86} c m dl android-complex-math android-glob android-spawn android-sysv-semaphore)
+ else()
+     #target_link_libraries(${BOX86} c m dl rt pthread resolv)
+     set_target_properties(${BOX86} PROPERTIES LINK_FLAGS "-Wl,--no-as-needed -lc -lm -ldl -lrt -lpthread -lresolv -Wl,--as-needed -pthread")
+@@ -633,14 +633,22 @@
+ 
+ if(${CMAKE_VERSION} VERSION_LESS "3.13")
+     if(NOT NOLOADADDR)
+-        set_target_properties(${BOX86} PROPERTIES LINK_FLAGS "-rdynamic -Wl,-Ttext-segment,${BOX86_ELF_ADDRESS}")
++        if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
++            set_target_properties(${BOX86} PROPERTIES LINK_FLAGS "-Wl,--image-base=${BOX86_ELF_ADDRESS}")
++        else()
++            set_target_properties(${BOX86} PROPERTIES LINK_FLAGS "-rdynamic -Wl,-Ttext-segment,${BOX86_ELF_ADDRESS}")
++        endif()
+     else()
+         set_target_properties(${BOX86} PROPERTIES LINK_FLAGS -rdynamic)
+     endif()
+ else()
+     target_link_options(${BOX86} PUBLIC -rdynamic)
+     if(NOT NOLOADADDR)
+-        target_link_options(${BOX86} PUBLIC -Wl,-Ttext-segment,${BOX86_ELF_ADDRESS})
++        if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
++            target_link_options(${BOX86} PUBLIC LINKER:--image-base=${BOX86_ELF_ADDRESS})
++        else()
++            target_link_options(${BOX86} PUBLIC -Wl,-Ttext-segment,${BOX86_ELF_ADDRESS})
++        endif()
+     endif()
+ endif()
+ 

--- a/packages/box86/build.sh
+++ b/packages/box86/build.sh
@@ -1,0 +1,88 @@
+TERMUX_PKG_HOMEPAGE=https://ptitseb.github.io/box86/
+TERMUX_PKG_DESCRIPTION="Linux Userspace x86 Emulator"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+_COMMIT=91609788d412e58e38ecdb1cc64eb8b6216429f2
+_COMMIT_DATE=20221029
+_COMMIT_TIME=144816
+TERMUX_PKG_VERSION="0.2.6.20221029.144816g916097"
+TERMUX_PKG_SRCURL=https://github.com/ptitSeb/box86.git
+TERMUX_PKG_GIT_BRANCH=master
+TERMUX_PKG_DEPENDS="libandroid-complex-math, libandroid-glob, libandroid-spawn, libandroid-sysv-semaphore"
+TERMUX_PKG_AUTO_UPDATE=true
+
+# box86 is for arm only
+TERMUX_PKG_BLACKLISTED_ARCHES="aarch64, i686, x86_64"
+
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DANDROID=ON
+-DARM_DYNAREC=ON
+"
+
+# this should only be used until release new version
+termux_pkg_auto_update() {
+	local latest_commit_date_tz latest_commit_date latest_commit_time latest_version
+	local latest_commit=$(curl -s https://api.github.com/repos/ptitSeb/box86/commits | jq .[].sha | head -1 | sed -e 's|\"||g')
+
+	if [ -z "${latest_commit}" ]; then
+		echo "WARN: Unable to get latest commit from upstream. Try again later." >&2
+		return 0
+	fi
+
+	if [ "${latest_commit}" = "${_COMMIT}" ]; then
+		echo "INFO: No update needed. Already at version '${TERMUX_PKG_VERSION}'."
+		return 0
+	fi
+
+	latest_commit_date_tz=$(curl -s "https://api.github.com/repos/ptitSeb/box86/commits/${latest_commit}" | jq .commit.committer.date | sed -e 's|\"||g')
+
+	if [ -z "${latest_commit_date_tz}" ]; then
+		termux_error_exit "ERROR: Unable to get latest commit date info"
+	fi
+
+	latest_commit_date=$(echo "${latest_commit_date_tz}" | sed -e 's|\(.*\)T\(.*\)Z|\1|' -e 's|\-||g')
+	latest_commit_time=$(echo "${latest_commit_date_tz}" | sed -e 's|\(.*\)T\(.*\)Z|\2|' -e 's|\:||g')
+
+	# always check this in case upstream change the version format
+	latest_version="0.2.6.${latest_commit_date}.${latest_commit_time}g${latest_commit:0:8}"
+
+	# rough estimate weekly push
+	local current_date=$(date "+%Y%m%d")
+	local current_date_diff=$((current_date-_COMMIT_DATE))
+	if [ "${current_date_diff}" -lt 7 ]; then
+		echo "INFO: Queuing updates after 7 days since last push, currently its ${current_date_diff}"
+		return 0
+	fi
+
+	if ! dpkg --compare-versions "${latest_version}" gt "${TERMUX_PKG_VERSION}"; then
+		termux_error_exit "ERROR: Resulting latest version is not counted as update to the current version (${latest_version} < ${TERMUX_PKG_VERSION})"
+	fi
+
+	# unlikely to happen
+	if [ "${latest_commit_date}" -lt "${_COMMIT_DATE}" ]; then
+		termux_error_exit "ERROR: Upstream is older than current package version. Please report to upstream."
+	elif [ "${latest_commit_date}" -eq "${_COMMIT_DATE}" ] && [ "${latest_commit_time}" -lt "${_COMMIT_TIME}" ]; then
+		termux_error_exit "ERROR: Upstream is older than current package version. Please report to upstream."
+	fi
+
+	sed -i "${TERMUX_PKG_BUILDER_DIR}/build.sh" -e "s|^_COMMIT=.*|_COMMIT=${latest_commit}|"
+	sed -i "${TERMUX_PKG_BUILDER_DIR}/build.sh" -e "s|^_COMMIT_DATE=.*|_COMMIT_DATE=${latest_commit_date}|"
+	sed -i "${TERMUX_PKG_BUILDER_DIR}/build.sh" -e "s|^_COMMIT_TIME=.*|_COMMIT_TIME=${latest_commit_time}|"
+
+	# maybe save a few ms as we already done version check
+	termux_pkg_upgrade_version "${latest_version}" --skip-version-check
+}
+
+termux_step_post_get_source() {
+	git fetch --unshallow
+	git checkout "${_COMMIT}"
+}
+
+termux_step_pre_configure() {
+	export CFLAGS="${CFLAGS/-Oz/-O2}"
+}
+
+termux_step_make_install() {
+	install -Dm755 -t "${TERMUX_PREFIX}/bin" "${TERMUX_PKG_BUILDDIR}/box86"
+}
+

--- a/packages/box86/src_dynarec_dynablock.c.patch
+++ b/packages/box86/src_dynarec_dynablock.c.patch
@@ -1,0 +1,37 @@
+diff -uNr box86/src/dynarec/dynablock.c box86.mod/src/dynarec/dynablock.c
+--- box86/src/dynarec/dynablock.c	2022-10-31 00:09:49.883470723 +0800
++++ box86.mod/src/dynarec/dynablock.c	2022-10-31 00:08:16.999470789 +0800
+@@ -299,12 +299,21 @@
+ }
+ 
+ //TODO: move this to dynrec_arm.c and track allocated structure to avoid memory leak
++#ifdef ANDROID
++static __thread jmp_buf dynarec_jmpbuf;
++
++void cancelFillBlock()
++{
++    longjmp(dynarec_jmpbuf, 1);
++}
++#else
+ static __thread struct __jmp_buf_tag dynarec_jmpbuf;
+ 
+ void cancelFillBlock()
+ {
+     longjmp(&dynarec_jmpbuf, 1);
+ }
++#endif
+ 
+ /* 
+     return NULL if block is not found / cannot be created. 
+@@ -343,7 +352,11 @@
+     block->x86_addr = (void*)addr;
+     if(need_lock)
+         pthread_mutex_lock(&my_context->mutex_dyndump);
++#ifdef ANDROID
++    if(sigsetjmp(dynarec_jmpbuf, 1)) {
++#else
+     if(sigsetjmp(&dynarec_jmpbuf, 1)) {
++#endif
+         printf_log(LOG_INFO, "FillBlock at %p triggered a segfault, cancelling\n", (void*)addr);
+         if(need_lock)
+             pthread_mutex_unlock(&my_context->mutex_dyndump);

--- a/packages/libandroid-complex-math/LICENSE
+++ b/packages/libandroid-complex-math/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2010 The NetBSD Foundation, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/packages/libandroid-complex-math/build.sh
+++ b/packages/libandroid-complex-math/build.sh
@@ -1,0 +1,31 @@
+TERMUX_PKG_HOMEPAGE=https://android.googlesource.com/platform/bionic/+/refs/heads/master/libm/upstream-netbsd/lib/libm/complex
+TERMUX_PKG_DESCRIPTION="A shared library providing libm complex math functions"
+TERMUX_PKG_LICENSE="BSD 2-Clause"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=0.1
+TERMUX_PKG_SKIP_SRC_EXTRACT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+# https://android.googlesource.com/platform/bionic/+/9ee6adb003eb5a9855ff6c47f9c150b415a11299
+# https://android.googlesource.com/platform/bionic/+/refs/tags/android-8.1.0_r81/libm/upstream-netbsd/lib/libm/complex/
+# https://android.googlesource.com/platform/bionic/+/master/libm/libm.map.txt
+# https://android.googlesource.com/platform/bionic/+/master/docs/status.md#libm
+
+# Use the full NetBSD implementation as is from Android O
+# instead of matching the latest Android implementation which is a mix of FreeBSD and NetBSD
+
+termux_step_pre_configure() {
+	CPPFLAGS+=" -D__USE_GNU"
+	CFLAGS+=" -fPIC"
+}
+
+termux_step_make() {
+	$CC $CFLAGS $CPPFLAGS -c $TERMUX_PKG_BUILDER_DIR/upstream-netbsd/lib/libm/complex/*.c
+	$CC $CFLAGS -shared $LDFLAGS -o libandroid-complex-math.so *.o
+	$AR cru libandroid-complex-math.a *.o
+	cp -f $TERMUX_PKG_BUILDER_DIR/LICENSE $TERMUX_PKG_SRCDIR/
+}
+
+termux_step_make_install() {
+	install -Dm644 -t $TERMUX_PREFIX/lib libandroid-complex-math.{a,so}
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/cacoshl.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/cacoshl.c
@@ -1,0 +1,45 @@
+/* $NetBSD: cacoshl.c,v 1.1 2014/10/10 00:48:18 christos Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <complex.h>
+
+long double complex
+cacoshl(long double complex z)
+{
+	long double complex w;
+
+#if 0 /* does not give the principal value */
+	w = I * cacosl(z);
+#else
+	w = clogl(z + csqrtl(z + 1) * csqrtl(z - 1));
+#endif
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/cacosl.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/cacosl.c
@@ -1,0 +1,45 @@
+/* $NetBSD: cacosl.c,v 1.1 2014/10/10 00:48:18 christos Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+#include <math.h>
+#include "cephes_subrl.h"
+
+long double complex
+cacosl(long double complex z)
+{
+	long double complex w;
+
+	w = casinl(z);
+	w = (M_PI_2L - creall(w)) - cimagl(w) * I;
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/casinhl.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/casinhl.c
@@ -1,0 +1,42 @@
+/* $NetBSD: casinhl.c,v 1.1 2014/10/10 00:48:18 christos Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+
+long double complex
+casinhl(long double complex z)
+{
+	long double complex w;
+
+	w = -1.0L * I * casinl(z * I);
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/casinl.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/casinl.c
@@ -1,0 +1,120 @@
+/* $NetBSD: casinl.c,v 1.1 2014/10/10 00:48:18 christos Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+#include <math.h>
+
+#ifdef __weak_alias
+__weak_alias(casinl, _casinl)
+#endif
+
+long double complex
+casinl(long double complex z)
+{
+	long double complex w;
+	long double complex ca, ct, zz, z2;
+	long double x, y;
+
+	x = creall(z);
+	y = cimagl(z);
+
+#if 0 /* MD: test is incorrect, casin(>1) is defined */
+	if (y == 0.0L) {
+		if (fabsl(x) > 1.0L) {
+			w = M_PI_2L + 0.0L * I;
+#if 0
+			mtherr ("casinl", DOMAIN);
+#endif
+		} else {
+			w = asinl(x) + 0.0L * I;
+		}
+		return w;
+	}
+#endif
+
+/* Power series expansion */
+/*
+b = cabsl(z);
+if( b < 0.125L )
+{
+z2.r = (x - y) * (x + y);
+z2.i = 2.0L * x * y;
+
+cn = 1.0L;
+n = 1.0L;
+ca.r = x;
+ca.i = y;
+sum.r = x;
+sum.i = y;
+do
+	{
+	ct.r = z2.r * ca.r  -  z2.i * ca.i;
+	ct.i = z2.r * ca.i  +  z2.i * ca.r;
+	ca.r = ct.r;
+	ca.i = ct.i;
+
+	cn *= n;
+	n += 1.0;
+	cn /= n;
+	n += 1.0;
+	b = cn/n;
+
+	ct.r *= b;
+	ct.i *= b;
+	sum.r += ct.r;
+	sum.i += ct.i;
+	b = fabsl(ct.r) + fabsl(ct.i);
+	}
+while( b > MACHEPL );
+w->r = sum.r;
+w->i = sum.i;
+return;
+}
+*/
+
+
+	ca = x + y * I;
+	ct = ca * I;
+	/* sqrtl( 1 - z*z) */
+	/* cmull( &ca, &ca, &zz ) */
+	/*x * x  -  y * y */
+	zz = (x - y) * (x + y) + (2.0L * x * y) * I;
+
+	zz = 1.0L - creall(zz) - cimagl(zz) * I;
+	z2 = csqrtl(zz);
+
+	zz = ct + z2;
+	zz = clogl(zz);
+	/* multiply by 1/i = -i */
+	w = zz * (-1.0L * I);
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/catanhl.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/catanhl.c
@@ -1,0 +1,42 @@
+/* $NetBSD: catanhl.c,v 1.3 2014/10/10 12:43:15 christos Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+
+long double complex
+catanhl(long double complex z)
+{
+	long double complex w;
+
+	w = -1.0L * I * catanl(z * I);
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/catanl.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/catanl.c
@@ -1,0 +1,80 @@
+/* $NetBSD: catanl.c,v 1.1 2014/10/10 00:48:18 christos Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+#include <math.h>
+#include <float.h>
+#include "cephes_subrl.h"
+
+#ifdef __weak_alias
+__weak_alias(catanl, _catanl)
+#endif
+
+#define MAXNUM LDBL_MAX
+
+long double complex
+catanl(long double complex z)
+{
+	long double complex w;
+	long double a, t, x, x2, y;
+
+	x = creall(z);
+	y = cimagl(z);
+
+	if ((x == 0.0L) && (y > 1.0L))
+		goto ovrf;
+
+	x2 = x * x;
+	a = 1.0L - x2 - (y * y);
+	if (a == 0.0)
+		goto ovrf;
+
+	t = 0.5L * atan2l(2.0L * x, a);
+	w = _redupil(t);
+
+	t = y - 1.0L;
+	a = x2 + (t * t);
+	if (a == 0.0L)
+		goto ovrf;
+
+	t = y + 1.0L;
+	a = (x2 + (t * t))/a;
+	w = w + (0.25L * logl(a)) * I;
+	return w;
+
+ovrf:
+#if 0
+	mtherr ("catanl", OVERFLOW);
+#endif
+	w = MAXNUM + MAXNUM * I;
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/ccoshl.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/ccoshl.c
@@ -1,0 +1,46 @@
+/* $NetBSD: ccoshl.c,v 1.1 2014/10/10 00:48:18 christos Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+#include <math.h>
+
+long double complex
+ccoshl(long double complex z)
+{
+	long double complex w;
+	long double x, y;
+
+	x = creall(z);
+	y = cimagl(z);
+	w = coshl(x) * cosl(y) + (sinhl(x) * sinl(y)) * I;
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/ccosl.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/ccosl.c
@@ -1,0 +1,46 @@
+/* $NetBSD: ccosl.c,v 1.1 2014/10/10 00:48:18 christos Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+#include <math.h>
+#include "cephes_subrl.h"
+
+long double complex
+ccosl(long double complex z)
+{
+	long double complex w;
+	long double ch, sh;
+
+	_cchshl(cimagl(z), &ch, &sh);
+	w = cosl(creall(z)) * ch - (sinl(creall(z)) * sh) * I;
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/cephes_subrl.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/cephes_subrl.c
@@ -1,0 +1,129 @@
+/* $NetBSD: cephes_subrl.c,v 1.2 2014/10/10 14:06:40 christos Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+#include <math.h>
+#include "cephes_subrl.h"
+
+/* calculate cosh and sinh */
+
+void
+_cchshl(long double x, long double *c, long double *s)
+{
+	long double e, ei;
+
+	if (fabsl(x) <= 0.5L) {
+		*c = coshl(x);
+		*s = sinhl(x);
+	} else {
+		e = expl(x);
+		ei = 0.5L / e;
+		e = 0.5L * e;
+		*s = e - ei;
+		*c = e + ei;
+	}
+}
+
+/* Program to subtract nearest integer multiple of PI */
+
+/* extended precision value of PI: */
+static const long double DP1 = 3.14159265358979323829596852490908531763125L;
+static const long double DP2 = 1.6667485837041756656403424829301998703007e-19L;
+#ifndef __vax__
+static const long double DP3 = 1.8830410776607851167459095484560349402753e-39L;
+#define MACHEPL 1.1e-38L
+#else
+static const long double DP3 = 0L;
+#define MACHEPL 1.1e-19L
+#endif
+
+long double
+_redupil(long double x)
+{
+	long double t;
+	long long i;
+
+	t = x / M_PIL;
+	if (t >= 0.0L)
+		t += 0.5L;
+	else
+		t -= 0.5L;
+
+	i = t;	/* the multiple */
+	t = i;
+	t = ((x - t * DP1) - t * DP2) - t * DP3;
+	return t;
+}
+
+/* Taylor series expansion for cosh(2y) - cos(2x) */
+
+long double
+_ctansl(long double complex z)
+{
+	long double f, x, x2, y, y2, rn, t;
+	long double d;
+
+	x = fabsl(2.0L * creall(z));
+	y = fabsl(2.0L * cimagl(z));
+
+	x = _redupil(x);
+
+	x = x * x;
+	y = y * y;
+	x2 = 1.0;
+	y2 = 1.0;
+	f = 1.0;
+	rn = 0.0;
+	d = 0.0;
+	do {
+		rn += 1.0L;
+		f *= rn;
+		rn += 1.0L;
+		f *= rn;
+		x2 *= x;
+		y2 *= y;
+		t = y2 + x2;
+		t /= f;
+		d += t;
+
+		rn += 1.0L;
+		f *= rn;
+		rn += 1.0L;
+		f *= rn;
+		x2 *= x;
+		y2 *= y;
+		t = y2 - x2;
+		t /= f;
+		d += t;
+	} while (fabsl(t/d) > MACHEPL);
+	return d;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/cephes_subrl.h
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/cephes_subrl.h
@@ -1,0 +1,9 @@
+/* $NetBSD: cephes_subrl.h,v 1.1 2014/10/10 00:48:18 christos Exp $ */
+
+void _cchshl(long double, long double *, long double *);
+long double _redupil(long double);
+long double _ctansl(long double complex);
+
+#define	M_PIL	3.14159265358979323846264338327950280e+00L
+#define	M_PI_2L	1.57079632679489661923132169163975140e+00L
+

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/cexpl.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/cexpl.c
@@ -1,0 +1,47 @@
+/* $NetBSD: cexpl.c,v 1.1 2014/10/10 00:48:18 christos Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+#include <math.h>
+
+long double complex
+cexpl(long double complex z)
+{
+	long double complex w;
+	long double r, x, y;
+
+	x = creall(z);
+	y = cimagl(z);
+	r = expl(x);
+	w = r * cosl(y) + r * sinl(y) * I;
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/clog.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/clog.c
@@ -1,0 +1,47 @@
+/* $NetBSD: clog.c,v 1.1 2007/08/20 16:01:35 drochner Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+#include <math.h>
+
+double complex
+clog(double complex z)
+{
+	double complex w;
+	double p, rr;
+
+	rr = cabs(z);
+	p = log(rr);
+	rr = atan2(cimag(z), creal(z));
+	w = p + rr * I;
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/clogf.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/clogf.c
@@ -1,0 +1,47 @@
+/* $NetBSD: clogf.c,v 1.1 2007/08/20 16:01:35 drochner Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+#include <math.h>
+
+float complex
+clogf(float complex z)
+{
+	float complex w;
+	float p, rr;
+
+	rr = cabsf(z);
+	p = logf(rr);
+	rr = atan2f(cimagf(z), crealf(z));
+	w = p + rr * I;
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/clogl.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/clogl.c
@@ -1,0 +1,47 @@
+/* $NetBSD: clogl.c,v 1.1 2014/10/10 00:48:18 christos Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+#include <math.h>
+
+long double complex
+clogl(long double complex z)
+{
+	long double complex w;
+	long double p, rr;
+
+	rr = cabsl(z);
+	p = logl(rr);
+	rr = atan2l(cimagl(z), creall(z));
+	w = p + rr * I;
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/cpow.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/cpow.c
@@ -1,0 +1,57 @@
+/* $NetBSD: cpow.c,v 1.1 2007/08/20 16:01:35 drochner Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+#include <math.h>
+
+double complex
+cpow(double complex a, double complex z)
+{
+	double complex w;
+	double x, y, r, theta, absa, arga;
+
+	x = creal(z);
+	y = cimag(z);
+	absa = cabs(a);
+	if (absa == 0.0) {
+		return (0.0 + 0.0 * I);
+	}
+	arga = carg(a);
+	r = pow(absa, x);
+	theta = x * arga;
+	if (y != 0.0) {
+		r = r * exp(-y * arga);
+		theta = theta + y * log(absa);
+	}
+	w = r * cos(theta) + (r * sin(theta)) * I;
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/cpowf.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/cpowf.c
@@ -1,0 +1,57 @@
+/* $NetBSD: cpowf.c,v 1.1 2007/08/20 16:01:36 drochner Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+#include <math.h>
+
+float complex
+cpowf(float complex a, float complex z)
+{
+	float complex w;
+	float x, y, r, theta, absa, arga;
+
+	x = crealf(z);
+	y = cimagf(z);
+	absa = cabsf(a);
+	if (absa == 0.0f) {
+		return (0.0f + 0.0f * I);
+	}
+	arga = cargf(a);
+	r = powf(absa, x);
+	theta = x * arga;
+	if (y != 0.0f) {
+		r = r * expf(-y * arga);
+		theta = theta + y * logf(absa);
+	}
+	w = r * cosf(theta) + (r * sinf(theta)) * I;
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/cpowl.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/cpowl.c
@@ -1,0 +1,57 @@
+/* $NetBSD: cpowl.c,v 1.1 2014/10/10 00:48:18 christos Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+#include <math.h>
+
+long double complex
+cpowl(long double complex a, long double complex z)
+{
+	long double complex w;
+	long double x, y, r, theta, absa, arga;
+
+	x = creall(z);
+	y = cimagl(z);
+	absa = cabsl(a);
+	if (absa == 0.0L) {
+		return (0.0L + 0.0L * I);
+	}
+	arga = cargl(a);
+	r = powl(absa, x);
+	theta = x * arga;
+	if (y != 0.0L) {
+		r = r * expl(-y * arga);
+		theta = theta + y * logl(absa);
+	}
+	w = r * cosl(theta) + (r * sinl(theta)) * I;
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/csinhl.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/csinhl.c
@@ -1,0 +1,46 @@
+/* $NetBSD: csinhl.c,v 1.1 2014/10/10 00:48:18 christos Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+#include <math.h>
+
+long double complex
+csinhl(long double complex z)
+{
+	long double complex w;
+	long double x, y;
+
+	x = creall(z);
+	y = cimagl(z);
+	w = sinhl(x) * cosl(y) + (coshl(x) * sinl(y)) * I;
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/csinl.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/csinl.c
@@ -1,0 +1,46 @@
+/* $NetBSD: csinl.c,v 1.1 2014/10/10 00:48:18 christos Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+#include <math.h>
+#include "cephes_subrl.h"
+
+long double complex
+csinl(long double complex z)
+{
+	long double complex w;
+	long double ch, sh;
+
+	_cchshl(cimagl(z), &ch, &sh);
+	w = sinl(creall(z)) * ch + (cosl(creall(z)) * sh) * I;
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/ctanhl.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/ctanhl.c
@@ -1,0 +1,48 @@
+/* $NetBSD: ctanhl.c,v 1.1 2014/10/10 00:48:18 christos Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+#include <math.h>
+
+long double complex
+ctanhl(long double complex z)
+{
+	long double complex w;
+	long double x, y, d;
+
+	x = creall(z);
+	y = cimagl(z);
+	d = coshl(2.0L * x) + cosl(2.0L * y);
+	w = sinhl(2.0L * x) / d  +  (sinl(2.0L * y) / d) * I;
+
+	return w;
+}

--- a/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/ctanl.c
+++ b/packages/libandroid-complex-math/upstream-netbsd/lib/libm/complex/ctanl.c
@@ -1,0 +1,59 @@
+/* $NetBSD: ctanl.c,v 1.1 2014/10/10 00:48:18 christos Exp $ */
+
+/*-
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software written by Stephen L. Moshier.
+ * It is redistributed by the NetBSD Foundation by permission of the author.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../src/namespace.h"
+#include <complex.h>
+#include <math.h>
+#include <float.h>
+#include "cephes_subrl.h"
+
+#define MAXNUM LDBL_MAX
+
+long double complex
+ctanl(long double complex z)
+{
+	long double complex w;
+	long double d;
+
+	d = cosl(2.0L * creall(z)) + coshl(2.0L * cimagl(z));
+
+	if (fabsl(d) < 0.25L)
+		d = _ctansl(z);
+
+	if (d == 0.0L) {
+		/* mtherr ("ctan", OVERFLOW); */
+		w = MAXNUM + MAXNUM * I;
+		return w;
+	}
+
+	w = sinl(2.0L * creall(z)) / d + (sinhl(2.0L * cimagl(z)) / d) * I;
+	return w;
+}


### PR DESCRIPTION
Closes #7672

Notes:
1. Unfortunately the box86 here is nothing more than a tech demo that allows running binaries created using `clang --target=i686-linux-android` on an arm(32) Android device. It is still not a replacement for qemu-i386 (and never will, I think, due to how box86 works). There's still other issues for a proot + box86 integration that I am not willing to dig for now.
2. If you are thinking running Steam with this, you will be disappointed. There's way too many missing global symbols issues in bionic libc to allow full fledged glibc programs to run in box86 way, which wraps calls on the fly, I think. Prepare to maintain a long list of wrapped calls for a lot of libs if you really want to improve this box86.
3. You are better off with a `proot + Linux distro (arm) + box86` solution near term as everything is glibc based.
4. Feel free for others to pick up and improve.
5. box64 will be unavailable unless somebody managed to compile and even then will have the same issues listed above (and also aarch64 only).
6. I never understand how box86 is useful for Android anyway, let alone stock Android without Termux libs to back it up.