### PR TITLE
dnote: add tag fts5 and remove post installation script

### DIFF
--- a/packages/dnote/build.sh
+++ b/packages/dnote/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A simple command line notebook for programmers"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="Ravener <ravener.anime@gmail.com>"
 TERMUX_PKG_VERSION=1:0.12.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/dnote/dnote/archive/refs/tags/cli-v${TERMUX_PKG_VERSION:2}.tar.gz
 TERMUX_PKG_SHA256=2b2c276f3b381a853e155ed2eab7007c5b5f2ec927b3d882d5605f2650b15085
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -16,23 +17,15 @@ termux_step_pre_configure() {
 
 termux_step_make() {
 	cd "$TERMUX_PKG_SRCDIR"
-	go build -o dnote -ldflags "-X main.versionTag=${TERMUX_PKG_VERSION:2}" pkg/cli/main.go
+	go build -o dnote -ldflags "-X main.versionTag=${TERMUX_PKG_VERSION:2}" -tags fts5 pkg/cli/main.go
 }
 
 termux_step_make_install() {
 	install -Dm700 $TERMUX_PKG_SRCDIR/dnote $TERMUX_PREFIX/bin/dnote
-	install -Dm644 /dev/null "${TERMUX_PREFIX}/share/bash-completion/completions/dnote.bash"
-	install -Dm644 /dev/null "${TERMUX_PREFIX}/share/zsh/site-functions/_dnote"
-	install -Dm644 /dev/null "${TERMUX_PREFIX}/share/fish/vendor_completions.d/dnote.fish"
-}
-
-termux_step_create_debscripts() {
-	cat <<- EOF > ./postinst
-		#!${TERMUX_PREFIX}/bin/sh
-		dnote completion bash > ${TERMUX_PREFIX}/share/bash-completion/completions/dnote.bash
-		dnote completion zsh > ${TERMUX_PREFIX}/share/zsh/site-functions/_dnote
-		dnote completion fish > ${TERMUX_PREFIX}/share/fish/vendor_completions.d/dnote.fish
-	EOF
+	install -Dm600 "$TERMUX_PKG_SRCDIR"/pkg/cli/dnote-completion.bash \
+		"$TERMUX_PREFIX"/share/bash-completion/completions/dnote
+	install -Dm600 "$TERMUX_PKG_SRCDIR"/pkg/cli/dnote-completion.zsh \
+		"$TERMUX_PREFIX"/share/zsh/site-functions/_dnote
 }
 
 termux_step_install_license() {


### PR DESCRIPTION
Fixes #12784

I was missing `-tags fts5` for the build command.

And regarding the post installation script, I'm not sure why @2096779623 added it, I just kept it like that but now that I checked, there's no such command as `dnote completions` so I completely removed the shell completion stuff.