### PR TITLE
micro: use make build instead of quick-build

### DIFF
--- a/packages/micro/build.sh
+++ b/packages/micro/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_SRCURL=https://github.com/zyedidia/micro.git
 TERMUX_PKG_VERSION=2.0.11
+TERMUX_PKG_REVISION=1
 
 termux_step_make() {
 	return
@@ -20,7 +21,7 @@ termux_step_make_install() {
 	cp -R . $MICRO_SRC
 
 	cd $MICRO_SRC
-	make build-quick
+	make build
 	mv micro $TERMUX_PREFIX/bin/micro
 }
 


### PR DESCRIPTION
This ensures the runtime files are generated and properly embedded into the binary.

A user complained about syntax highlighting not working so I tried to look into what could be wrong and I found people discussing a similar issue in the arch linux packaging https://github.com/zyedidia/micro/issues/2521

v2.0.11 uses `go generate` to generate some files and those needs to be ran before the main build, the `build` target of the Makefile is essentially generate & quick-build