### PR TITLE
diffstat: Use alternative source URL

### DIFF
--- a/packages/diffstat/build.sh
+++ b/packages/diffstat/build.sh
@@ -3,7 +3,8 @@ TERMUX_PKG_DESCRIPTION="Displays a histogram of changes to a file"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.64
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://invisible-mirror.net/archives/diffstat/diffstat-${TERMUX_PKG_VERSION}.tgz
+TERMUX_PKG_SRCURL=https://ftp-osl.osuosl.org/pub/gentoo/distfiles/diffstat-${TERMUX_PKG_VERSION}.tgz
+# invisible-mirror.net is not suitable for CI due to bad responsiveness.
+#TERMUX_PKG_SRCURL=https://invisible-mirror.net/archives/diffstat/diffstat-${TERMUX_PKG_VERSION}.tgz
 #TERMUX_PKG_SRCURL=https://invisible-island.net/datafiles/release/diffstat.tar.gz
 TERMUX_PKG_SHA256=b8aee38d9d2e1d05926e6b55810a9d2c2dd407f24d6a267387563a4436e3f7fc


### PR DESCRIPTION
once again.

invisible-mirror.net is not suitable for CI due to bad responsiveness.

%ci:no-build