### PR TITLE
*: Remove `share/pkgconfig` hack

### DIFF
--- a/packages/xorg-util-macros/build.sh
+++ b/packages/xorg-util-macros/build.sh
@@ -1,14 +1,12 @@
 # X11 package
 TERMUX_PKG_HOMEPAGE=https://xorg.freedesktop.org/
 TERMUX_PKG_DESCRIPTION="X.Org Autotools macros"
-TERMUX_PKG_LICENSE="MIT"
+# License: HPND
+TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.19.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://xorg.freedesktop.org/releases/individual/util/util-macros-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=0f812e6e9d2786ba8f54b960ee563c0663ddbe2434bf24ff193f5feab1f31971
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
-
-termux_step_post_make_install() {
-	mkdir -p ${TERMUX_PREFIX}/lib/pkgconfig
-	mv ${TERMUX_PREFIX}/share/pkgconfig/xorg-macros.pc ${TERMUX_PREFIX}/lib/pkgconfig/
-}

--- a/packages/xtrans/build.sh
+++ b/packages/xtrans/build.sh
@@ -1,16 +1,13 @@
 # X11 package
 TERMUX_PKG_HOMEPAGE=https://xorg.freedesktop.org/
 TERMUX_PKG_DESCRIPTION="X transport library"
-TERMUX_PKG_LICENSE="MIT"
+# Licenses: MIT, HPND
+TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.4.0
-TERMUX_PKG_REVISION=8
+TERMUX_PKG_REVISION=9
 TERMUX_PKG_SRCURL=https://xorg.freedesktop.org/releases/individual/lib/xtrans-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=377c4491593c417946efcd2c7600d1e62639f7a8bbca391887e2c4679807d773
 TERMUX_PKG_NO_DEVELSPLIT=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
-
-termux_step_post_make_install() {
-	mkdir -p ${TERMUX_PREFIX}/lib/pkgconfig
-	mv ${TERMUX_PREFIX}/share/pkgconfig/xtrans.pc ${TERMUX_PREFIX}/lib/pkgconfig
-}

--- a/packages/yajl/build.sh
+++ b/packages/yajl/build.sh
@@ -3,17 +3,9 @@ TERMUX_PKG_DESCRIPTION="Yet Another JSON Library"
 TERMUX_PKG_LICENSE="ISC"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.1.0
-TERMUX_PKG_REVISION=6
+TERMUX_PKG_REVISION=7
 TERMUX_PKG_SRCURL=https://github.com/lloyd/yajl/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=3fb73364a5a30efe615046d07e6db9d09fd2b41c763c5f7d3bfb121cd5c5ac5a
 TERMUX_PKG_BREAKS="yajl-dev"
 TERMUX_PKG_REPLACES="yajl-dev"
 TERMUX_PKG_FORCE_CMAKE=true
-
-termux_step_post_make_install() {
-	# Fix location of 'yajl.pc'.
-	mkdir -p "${TERMUX_PREFIX}"/lib/pkgconfig
-	mv -f \
-		"${TERMUX_PREFIX}"/share/pkgconfig/yajl.pc \
-		"${TERMUX_PREFIX}"/lib/pkgconfig/yajl.pc
-}

--- a/x11-packages/xbitmaps/build.sh
+++ b/x11-packages/xbitmaps/build.sh
@@ -1,18 +1,12 @@
 TERMUX_PKG_HOMEPAGE=https://xorg.freedesktop.org/
 TERMUX_PKG_DESCRIPTION="X.org Bitmap files"
-TERMUX_PKG_LICENSE="MIT"
+# License: HPND
+TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.1.2
-TERMUX_PKG_REVISION=30
+TERMUX_PKG_REVISION=31
 TERMUX_PKG_SRCURL=https://xorg.freedesktop.org/releases/individual/data/xbitmaps-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=b9f0c71563125937776c8f1f25174ae9685314cbd130fb4c2efce811981e07ee
-TERMUX_PKG_BUILD_DEPENDS="xorg-util-macros"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_NO_DEVELSPLIT=true
-
-termux_step_post_make_install() {
-	if [ -f "${TERMUX_PREFIX}/share/pkgconfig/xbitmaps.pc" ]; then
-		mkdir -p "${TERMUX_PREFIX}/lib/pkgconfig" || exit 1
-		mv -f "${TERMUX_PREFIX}/share/pkgconfig/xbitmaps.pc" "${TERMUX_PREFIX}/lib/pkgconfig/xbitmaps.pc" || exit 1
-	fi
-}


### PR DESCRIPTION
after commit 3f1be51372b6f33762eac18c3096e3b240cb056a.

On-device `pkg-config` searches `$PREFIX/share/pkgconfig` by default.

%ci:no-build