### PR TITLE
addpkg(root/v4l-utils): 1.22.1

### DIFF
--- a/root-packages/rpi-v4l-utils/0001-removed-contrib-building.patch
+++ b/root-packages/rpi-v4l-utils/0001-removed-contrib-building.patch
@@ -1,0 +1,59 @@
+From ad6cdbea1a3a6c7cd1f03397ce948204f8741fee Mon Sep 17 00:00:00 2001
+From: Simon Hafner <hafnersimon@gmail.com>
+Date: Fri, 11 Nov 2022 16:47:26 +0100
+Subject: [PATCH] removed contrib building
+
+---
+ Makefile.am      |  2 +-
+ android-config.h | 12 ++++++------
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 3c3d3ce6..8725c032 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -4,7 +4,7 @@ ACLOCAL_AMFLAGS = -I m4
+ SUBDIRS = v4l-utils-po libdvbv5-po lib
+ 
+ if WITH_V4LUTILS
+-SUBDIRS += utils contrib
++SUBDIRS += utils
+ endif
+ 
+ EXTRA_DIST = android-config.h bootstrap.sh doxygen_libdvbv5.cfg include COPYING.libv4l \
+diff --git a/android-config.h b/android-config.h
+index e82a847e..bef061a0 100644
+--- a/android-config.h
++++ b/android-config.h
+@@ -59,22 +59,22 @@
+ /* #undef ICONV_CONST */
+ 
+ /* ir-keytable preinstalled tables directory */
+-#define IR_KEYTABLE_SYSTEM_DIR "/lib/udev/rc_keymaps"
++#define IR_KEYTABLE_SYSTEM_DIR "/data/data/com.termux/files/usr/lib/udev/rc_keymaps"
+ 
+ /* ir-keytable user defined tables directory */
+-#define IR_KEYTABLE_USER_DIR "/system/etc/rc_keymaps"
++#define IR_KEYTABLE_USER_DIR "/data/data/com.termux/files/usr/system/etc/rc_keymaps"
+ 
+ /* libv4l1 private lib directory */
+-#define LIBV4L1_PRIV_DIR "/system/lib/libv4l"
++#define LIBV4L1_PRIV_DIR "/data/data/com.termux/files/usr/system/lib/libv4l"
+ 
+ /* libv4l2 plugin directory */
+-#define LIBV4L2_PLUGIN_DIR "/system/lib/libv4l/plugins"
++#define LIBV4L2_PLUGIN_DIR "/data/data/com.termux/files/usr/system/lib/libv4l/plugins"
+ 
+ /* libv4l2 private lib directory */
+-#define LIBV4L2_PRIV_DIR "/system/lib/libv4l"
++#define LIBV4L2_PRIV_DIR "/data/data/com.termux/files/usr/system/lib/libv4l"
+ 
+ /* libv4lconvert private lib directory */
+-#define LIBV4LCONVERT_PRIV_DIR "/system/lib/libv4l"
++#define LIBV4LCONVERT_PRIV_DIR "/data/data/com.termux/files/usr/system/lib/libv4l"
+ 
+ /* Define to the sub-directory in which libtool stores uninstalled libraries.
+    */
+-- 
+2.38.1
+

--- a/root-packages/rpi-v4l-utils/build.sh
+++ b/root-packages/rpi-v4l-utils/build.sh
@@ -1,0 +1,36 @@
+TERMUX_PKG_HOMEPAGE=https://linuxtv.org
+
+TERMUX_PKG_DESCRIPTION="Userspace tools and conversion library for Video 4 Linux"
+
+TERMUX_PKG_LICENSE="GPL-2.0"
+
+TERMUX_PKG_MAINTAINER="@reactormonk"
+
+TERMUX_PKG_VERSION=20.0
+
+TERMUX_PKG_SRCURL=https://github.com/lineage-rpi/android_external_v4l-utils/archive/refs/heads/lineage-20.0.zip
+
+TERMUX_PKG_SHA256=2d39e98fafd3180299f17ae2bb58f6e665202b07e6a0a8f872936a02fec081af
+
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--without-libudev --with-udevdir=/data/data/com.termux/files/lib/udev"
+
+TERMUX_PKG_DEPENDS="argp,libandroid-glob,ndk-multilib"
+
+termux_step_pre_configure() {
+    CFLAGS+=" -DANDROID"
+    CPPFLAGS+=" -DANDROID"
+    mv android-config.h include/
+#     sed --in-place -e "s/-lrt//" configure.ac
+    shopt -s globstar
+    sed --in-place -e "s/-lrt//" -- **/Makefile.am
+    sed --in-place -e "s/-lrt//" -- **/*.pc.in
+    sed --in-place -e "s/-lrt//" -- **/*.pro
+    sed --in-place -e "s/-lpthread//" -- **/Makefile.am
+    shopt -u globstar
+
+#     # borrowed from memcached
+#     # cp $TERMUX_PKG_BUILDER_DIR/getsubopt.c $TERMUX_PKG_SRCDIR
+#     # cp $TERMUX_PKG_BUILDER_DIR/getsubopt.h $TERMUX_PKG_SRCDIR
+
+    autoreconf -fi
+}


### PR DESCRIPTION
Adding `v4l-utils`. Root sounds like the right folder, as the interaction is quite low-level, and most will require root. Lotsa utils here might not even work correctly, as the Android API for a lot of devices is different, but the video4linux for USB should work at least.

Requested in https://github.com/termux/termux-packages/issues/5019