### PR TITLE
new package: zellij

### DIFF
--- a/packages/zellij/build.sh
+++ b/packages/zellij/build.sh
@@ -1,0 +1,34 @@
+TERMUX_PKG_HOMEPAGE="https://zellij.dev/"
+TERMUX_PKG_DESCRIPTION="A terminal workspace with batteries included"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="Jonathan Lei <me@xjonathan.dev>"
+TERMUX_PKG_VERSION="0.33.0"
+TERMUX_PKG_SRCURL="https://github.com/zellij-org/zellij/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256="63eaf8ca0c1235389281e3ee5f599b810de3921d220e500cb35c46ec9b5125ff"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+
+# wasmer doesn't support these platforms yet
+TERMUX_PKG_BLACKLISTED_ARCHES="arm, i686"
+
+termux_step_make() {
+	termux_setup_rust
+	cargo build --jobs ${TERMUX_MAKE_PROCESSES} --target ${CARGO_TARGET_NAME} --release
+}
+
+termux_step_make_install() {
+	install -Dm700 -t ${TERMUX_PREFIX}/bin target/${CARGO_TARGET_NAME}/release/zellij
+
+	install -Dm644 /dev/null ${TERMUX_PREFIX}/share/bash-completion/completions/zellij.bash
+	install -Dm644 /dev/null ${TERMUX_PREFIX}/share/zsh/site-functions/_zellij
+	install -Dm644 /dev/null ${TERMUX_PREFIX}/share/fish/vendor_completions.d/zellij.fish
+}
+
+termux_step_create_debscripts() {
+	cat <<-EOF >./postinst
+		#!${TERMUX_PREFIX}/bin/sh
+		zellij setup --generate-completion bash > ${TERMUX_PREFIX}/share/bash-completion/completions/zellij.bash
+		zellij setup --generate-completion zsh > ${TERMUX_PREFIX}/share/zsh/site-functions/_zellij
+		zellij setup --generate-completion fish > ${TERMUX_PREFIX}/share/fish/vendor_completions.d/zellij.fish
+	EOF
+}

--- a/packages/zellij/cargo-lock.patch
+++ b/packages/zellij/cargo-lock.patch
@@ -1,0 +1,1154 @@
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -8,7 +8,7 @@ version = "0.17.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+ dependencies = [
+- "gimli 0.26.1",
++ "gimli",
+ ]
+ 
+ [[package]]
+@@ -17,6 +17,17 @@ version = "1.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+ 
++[[package]]
++name = "ahash"
++version = "0.7.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
++dependencies = [
++ "getrandom 0.2.7",
++ "once_cell",
++ "version_check",
++]
++
+ [[package]]
+ name = "aho-corasick"
+ version = "0.7.18"
+@@ -226,24 +237,21 @@ dependencies = [
+  "cfg-if 1.0.0",
+  "libc",
+  "miniz_oxide",
+- "object 0.28.4",
++ "object",
+  "rustc-demangle",
+ ]
+ 
+ [[package]]
+-name = "base64"
+-version = "0.13.0"
++name = "base-x"
++version = "0.2.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
++checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+ 
+ [[package]]
+-name = "bincode"
+-version = "1.3.3"
++name = "base64"
++version = "0.13.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+-dependencies = [
+- "serde",
+-]
++checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+ 
+ [[package]]
+ name = "bitflags"
+@@ -313,6 +321,27 @@ version = "0.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+ 
++[[package]]
++name = "bytecheck"
++version = "0.6.9"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "d11cac2c12b5adc6570dad2ee1b87eff4955dac476fe12d81e5fdd352e52406f"
++dependencies = [
++ "bytecheck_derive",
++ "ptr_meta",
++]
++
++[[package]]
++name = "bytecheck_derive"
++version = "0.6.9"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "syn",
++]
++
+ [[package]]
+ name = "byteorder"
+ version = "1.4.3"
+@@ -358,7 +387,7 @@ dependencies = [
+  "libc",
+  "num-integer",
+  "num-traits",
+- "time",
++ "time 0.1.44",
+  "winapi",
+ ]
+ 
+@@ -472,12 +501,31 @@ dependencies = [
+  "winapi",
+ ]
+ 
++[[package]]
++name = "const_fn"
++version = "0.4.9"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
++
+ [[package]]
+ name = "core-foundation-sys"
+ version = "0.8.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+ 
++[[package]]
++name = "corosensei"
++version = "0.1.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "9847f90f32a50b0dcbd68bc23ff242798b13080b97b0569f6ed96a45ce4cf2cd"
++dependencies = [
++ "autocfg",
++ "cfg-if 1.0.0",
++ "libc",
++ "scopeguard",
++ "windows-sys 0.33.0",
++]
++
+ [[package]]
+ name = "cpufeatures"
+ version = "0.2.2"
+@@ -489,62 +537,56 @@ dependencies = [
+ 
+ [[package]]
+ name = "cranelift-bforest"
+-version = "0.68.0"
++version = "0.82.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9221545c0507dc08a62b2d8b5ffe8e17ac580b0a74d1813b496b8d70b070fbd0"
++checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
+ dependencies = [
+  "cranelift-entity",
+ ]
+ 
+ [[package]]
+ name = "cranelift-codegen"
+-version = "0.68.0"
++version = "0.82.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7e9936ea608b6cd176f107037f6adbb4deac933466fc7231154f96598b2d3ab1"
++checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
+ dependencies = [
+- "byteorder",
+  "cranelift-bforest",
+  "cranelift-codegen-meta",
+  "cranelift-codegen-shared",
+  "cranelift-entity",
+- "gimli 0.22.0",
++ "gimli",
+  "log",
+  "regalloc",
+  "smallvec",
+  "target-lexicon",
+- "thiserror",
+ ]
+ 
+ [[package]]
+ name = "cranelift-codegen-meta"
+-version = "0.68.0"
++version = "0.82.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4ef2b2768568306540f4c8db3acce9105534d34c4a1e440529c1e702d7f8c8d7"
++checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
+ dependencies = [
+  "cranelift-codegen-shared",
+- "cranelift-entity",
+ ]
+ 
+ [[package]]
+ name = "cranelift-codegen-shared"
+-version = "0.68.0"
++version = "0.82.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6759012d6d19c4caec95793f052613e9d4113e925e7f14154defbac0f1d4c938"
++checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
+ 
+ [[package]]
+ name = "cranelift-entity"
+-version = "0.68.0"
++version = "0.82.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "86badbce14e15f52a45b666b38abe47b204969dd7f8fb7488cb55dd46b361fa6"
+-dependencies = [
+- "serde",
+-]
++checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
+ 
+ [[package]]
+ name = "cranelift-frontend"
+-version = "0.68.0"
++version = "0.82.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b608bb7656c554d0a4cf8f50c7a10b857e80306f6ff829ad6d468a7e2323c8d8"
++checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
+ dependencies = [
+  "cranelift-codegen",
+  "log",
+@@ -788,6 +830,12 @@ dependencies = [
+  "winapi",
+ ]
+ 
++[[package]]
++name = "discard"
++version = "1.0.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
++
+ [[package]]
+ name = "either"
+ version = "1.6.1"
+@@ -800,6 +848,26 @@ version = "0.3.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+ 
++[[package]]
++name = "enum-iterator"
++version = "0.7.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
++dependencies = [
++ "enum-iterator-derive",
++]
++
++[[package]]
++name = "enum-iterator-derive"
++version = "0.7.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "syn",
++]
++
+ [[package]]
+ name = "enumset"
+ version = "1.0.11"
+@@ -1007,7 +1075,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "8e1d3b771574f62d0548cee0ad9057857e9fc25d7a3335f140c84f6acd0bf601"
+ dependencies = [
+  "cfg-if 0.1.10",
+- "serde",
+ ]
+ 
+ [[package]]
+@@ -1073,21 +1140,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "gimli"
+-version = "0.22.0"
++version = "0.26.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
++checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+ dependencies = [
+  "fallible-iterator",
+  "indexmap",
+  "stable_deref_trait",
+ ]
+ 
+-[[package]]
+-name = "gimli"
+-version = "0.26.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+-
+ [[package]]
+ name = "gloo-timers"
+ version = "0.2.4"
+@@ -1105,6 +1166,18 @@ name = "hashbrown"
+ version = "0.11.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
++dependencies = [
++ "ahash",
++]
++
++[[package]]
++name = "hashbrown"
++version = "0.12.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
++dependencies = [
++ "ahash",
++]
+ 
+ [[package]]
+ name = "heck"
+@@ -1172,7 +1245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+ dependencies = [
+  "autocfg",
+- "hashbrown",
++ "hashbrown 0.11.2",
+  "serde",
+ ]
+ 
+@@ -1305,9 +1378,9 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+ 
+ [[package]]
+ name = "libloading"
+-version = "0.6.7"
++version = "0.7.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
++checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+ dependencies = [
+  "cfg-if 1.0.0",
+  "winapi",
+@@ -1398,6 +1471,27 @@ dependencies = [
+  "winapi",
+ ]
+ 
++[[package]]
++name = "loupe"
++version = "0.1.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "9b6a72dfa44fe15b5e76b94307eeb2ff995a8c5b283b55008940c02e0c5b634d"
++dependencies = [
++ "indexmap",
++ "loupe-derive",
++ "rustversion",
++]
++
++[[package]]
++name = "loupe-derive"
++version = "0.1.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c0fbfc88337168279f2e9ae06e157cfed4efd3316e14dc96ed074d4f2e6c5952"
++dependencies = [
++ "quote",
++ "syn",
++]
++
+ [[package]]
+ name = "mach"
+ version = "0.3.2"
+@@ -1427,9 +1521,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+ 
+ [[package]]
+ name = "memmap2"
+-version = "0.2.3"
++version = "0.5.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
++checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+ dependencies = [
+  "libc",
+ ]
+@@ -1648,22 +1742,15 @@ dependencies = [
+  "libc",
+ ]
+ 
+-[[package]]
+-name = "object"
+-version = "0.22.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
+-dependencies = [
+- "crc32fast",
+- "indexmap",
+-]
+-
+ [[package]]
+ name = "object"
+ version = "0.28.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+ dependencies = [
++ "crc32fast",
++ "hashbrown 0.11.2",
++ "indexmap",
+  "memchr",
+ ]
+ 
+@@ -1779,7 +1866,7 @@ dependencies = [
+  "libc",
+  "redox_syscall",
+  "smallvec",
+- "windows-sys",
++ "windows-sys 0.36.1",
+ ]
+ 
+ [[package]]
+@@ -2006,6 +2093,12 @@ dependencies = [
+  "version_check",
+ ]
+ 
++[[package]]
++name = "proc-macro-hack"
++version = "0.5.19"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
++
+ [[package]]
+ name = "proc-macro2"
+ version = "1.0.39"
+@@ -2015,6 +2108,26 @@ dependencies = [
+  "unicode-ident",
+ ]
+ 
++[[package]]
++name = "ptr_meta"
++version = "0.1.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
++dependencies = [
++ "ptr_meta_derive",
++]
++
++[[package]]
++name = "ptr_meta_derive"
++version = "0.1.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "syn",
++]
++
+ [[package]]
+ name = "quote"
+ version = "1.0.18"
+@@ -2151,9 +2264,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "regalloc"
+-version = "0.0.31"
++version = "0.0.34"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
++checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
+ dependencies = [
+  "log",
+  "rustc-hash",
+@@ -2179,9 +2292,9 @@ checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+ 
+ [[package]]
+ name = "region"
+-version = "2.2.0"
++version = "3.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
++checksum = "76e189c2369884dce920945e2ddf79b3dff49e071a167dd1817fa9c4c00d512e"
+ dependencies = [
+  "bitflags",
+  "libc",
+@@ -2198,6 +2311,40 @@ dependencies = [
+  "winapi",
+ ]
+ 
++[[package]]
++name = "rend"
++version = "0.3.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
++dependencies = [
++ "bytecheck",
++]
++
++[[package]]
++name = "rkyv"
++version = "0.7.39"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "cec2b3485b07d96ddfd3134767b8a447b45ea4eb91448d0a35180ec0ffd5ed15"
++dependencies = [
++ "bytecheck",
++ "hashbrown 0.12.3",
++ "ptr_meta",
++ "rend",
++ "rkyv_derive",
++ "seahash",
++]
++
++[[package]]
++name = "rkyv_derive"
++version = "0.7.39"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "6eaedadc88b53e36dd32d940ed21ae4d850d5916f2581526921f553a72ac34c4"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "syn",
++]
++
+ [[package]]
+ name = "rmp"
+ version = "0.8.11"
+@@ -2232,6 +2379,21 @@ version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+ 
++[[package]]
++name = "rustc_version"
++version = "0.2.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
++dependencies = [
++ "semver 0.9.0",
++]
++
++[[package]]
++name = "rustversion"
++version = "1.0.9"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
++
+ [[package]]
+ name = "ryu"
+ version = "1.0.10"
+@@ -2244,15 +2406,36 @@ version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+ 
++[[package]]
++name = "seahash"
++version = "4.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
++
++[[package]]
++name = "semver"
++version = "0.9.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
++dependencies = [
++ "semver-parser 0.7.0",
++]
++
+ [[package]]
+ name = "semver"
+ version = "0.11.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+ dependencies = [
+- "semver-parser",
++ "semver-parser 0.10.2",
+ ]
+ 
++[[package]]
++name = "semver-parser"
++version = "0.7.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
++
+ [[package]]
+ name = "semver-parser"
+ version = "0.10.2"
+@@ -2336,6 +2519,21 @@ dependencies = [
+  "opaque-debug 0.2.3",
+ ]
+ 
++[[package]]
++name = "sha1"
++version = "0.6.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
++dependencies = [
++ "sha1_smol",
++]
++
++[[package]]
++name = "sha1_smol"
++version = "1.0.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
++
+ [[package]]
+ name = "sha2"
+ version = "0.9.9"
+@@ -2464,6 +2662,15 @@ version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+ 
++[[package]]
++name = "standback"
++version = "0.2.17"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
++dependencies = [
++ "version_check",
++]
++
+ [[package]]
+ name = "status-bar"
+ version = "0.1.0"
+@@ -2480,6 +2687,55 @@ dependencies = [
+  "zellij-tile-utils",
+ ]
+ 
++[[package]]
++name = "stdweb"
++version = "0.4.20"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
++dependencies = [
++ "discard",
++ "rustc_version",
++ "stdweb-derive",
++ "stdweb-internal-macros",
++ "stdweb-internal-runtime",
++ "wasm-bindgen",
++]
++
++[[package]]
++name = "stdweb-derive"
++version = "0.5.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "serde",
++ "serde_derive",
++ "syn",
++]
++
++[[package]]
++name = "stdweb-internal-macros"
++version = "0.2.9"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
++dependencies = [
++ "base-x",
++ "proc-macro2",
++ "quote",
++ "serde",
++ "serde_derive",
++ "serde_json",
++ "sha1",
++ "syn",
++]
++
++[[package]]
++name = "stdweb-internal-runtime"
++version = "0.1.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
++
+ [[package]]
+ name = "strider"
+ version = "0.2.0"
+@@ -2599,9 +2855,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "target-lexicon"
+-version = "0.11.2"
++version = "0.12.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "422045212ea98508ae3d28025bc5aaa2bd4a9cdaecd442a08da2ee620ee9ea95"
++checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+ 
+ [[package]]
+ name = "tempfile"
+@@ -2683,7 +2939,7 @@ dependencies = [
+  "pest_derive",
+  "phf 0.10.1",
+  "regex",
+- "semver",
++ "semver 0.11.0",
+  "sha2",
+  "signal-hook 0.1.17",
+  "siphasher",
+@@ -2758,6 +3014,44 @@ dependencies = [
+  "winapi",
+ ]
+ 
++[[package]]
++name = "time"
++version = "0.2.27"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
++dependencies = [
++ "const_fn",
++ "libc",
++ "standback",
++ "stdweb",
++ "time-macros",
++ "version_check",
++ "winapi",
++]
++
++[[package]]
++name = "time-macros"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
++dependencies = [
++ "proc-macro-hack",
++ "time-macros-impl",
++]
++
++[[package]]
++name = "time-macros-impl"
++version = "0.1.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
++dependencies = [
++ "proc-macro-hack",
++ "proc-macro2",
++ "quote",
++ "standback",
++ "syn",
++]
++
+ [[package]]
+ name = "tinyvec"
+ version = "1.6.0"
+@@ -3094,68 +3388,87 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasmer"
+-version = "1.0.2"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a70cfae554988d904d64ca17ab0e7cd652ee5c8a0807094819c1ea93eb9d6866"
++checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
+ dependencies = [
+- "cfg-if 0.1.10",
++ "cfg-if 1.0.0",
+  "indexmap",
++ "js-sys",
++ "loupe",
+  "more-asserts",
+  "target-lexicon",
+  "thiserror",
++ "wasm-bindgen",
++ "wasmer-artifact",
+  "wasmer-compiler",
+  "wasmer-compiler-cranelift",
+  "wasmer-derive",
+  "wasmer-engine",
+- "wasmer-engine-jit",
+- "wasmer-engine-native",
++ "wasmer-engine-dylib",
++ "wasmer-engine-universal",
+  "wasmer-types",
+  "wasmer-vm",
+  "wat",
+  "winapi",
+ ]
+ 
++[[package]]
++name = "wasmer-artifact"
++version = "2.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "7aaf9428c29c1d8ad2ac0e45889ba8a568a835e33fd058964e5e500f2f7ce325"
++dependencies = [
++ "enumset",
++ "loupe",
++ "thiserror",
++ "wasmer-compiler",
++ "wasmer-types",
++]
++
+ [[package]]
+ name = "wasmer-compiler"
+-version = "1.0.2"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6b7732a9cab472bd921d5a0c422f45b3d03f62fa2c40a89e0770cef6d47e383e"
++checksum = "e67a6cd866aed456656db2cfea96c18baabbd33f676578482b85c51e1ee19d2c"
+ dependencies = [
+  "enumset",
++ "loupe",
++ "rkyv",
+  "serde",
+  "serde_bytes",
+  "smallvec",
+  "target-lexicon",
+  "thiserror",
+  "wasmer-types",
+- "wasmer-vm",
+  "wasmparser",
+ ]
+ 
+ [[package]]
+ name = "wasmer-compiler-cranelift"
+-version = "1.0.2"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "48cb9395f094e1d81534f4c5e330ed4cdb424e8df870d29ad585620284f5fddb"
++checksum = "48be2f9f6495f08649e4f8b946a2cbbe119faf5a654aa1457f9504a99d23dae0"
+ dependencies = [
+  "cranelift-codegen",
++ "cranelift-entity",
+  "cranelift-frontend",
+- "gimli 0.22.0",
++ "gimli",
++ "loupe",
+  "more-asserts",
+  "rayon",
+- "serde",
+  "smallvec",
++ "target-lexicon",
+  "tracing",
+  "wasmer-compiler",
+  "wasmer-types",
+- "wasmer-vm",
+ ]
+ 
+ [[package]]
+ name = "wasmer-derive"
+-version = "1.0.2"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d8b86dcd2c3efdb8390728a2b56f762db07789aaa5aa872a9dc776ba3a7912ed"
++checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
+ dependencies = [
+  "proc-macro-error",
+  "proc-macro2",
+@@ -3165,13 +3478,14 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasmer-engine"
+-version = "1.0.2"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "efe4667d6bd888f26ae8062a63a9379fa697415b4b4e380f33832e8418fd71b5"
++checksum = "3f98f010978c244db431b392aeab0661df7ea0822343334f8f2a920763548e45"
+ dependencies = [
+  "backtrace",
+- "bincode",
++ "enumset",
+  "lazy_static",
++ "loupe",
+  "memmap2",
+  "more-asserts",
+  "rustc-demangle",
+@@ -3179,57 +3493,81 @@ dependencies = [
+  "serde_bytes",
+  "target-lexicon",
+  "thiserror",
++ "wasmer-artifact",
+  "wasmer-compiler",
+  "wasmer-types",
+  "wasmer-vm",
+ ]
+ 
+ [[package]]
+-name = "wasmer-engine-jit"
+-version = "1.0.2"
++name = "wasmer-engine-dylib"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "26770be802888011b4a3072f2a282fc2faa68aa48c71b3db6252a3937a85f3da"
++checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
+ dependencies = [
+- "bincode",
+- "cfg-if 0.1.10",
+- "region",
++ "cfg-if 1.0.0",
++ "enum-iterator",
++ "enumset",
++ "leb128",
++ "libloading",
++ "loupe",
++ "object",
++ "rkyv",
+  "serde",
+- "serde_bytes",
++ "tempfile",
++ "tracing",
++ "wasmer-artifact",
+  "wasmer-compiler",
+  "wasmer-engine",
++ "wasmer-object",
+  "wasmer-types",
+  "wasmer-vm",
+- "winapi",
++ "which",
+ ]
+ 
+ [[package]]
+-name = "wasmer-engine-native"
+-version = "1.0.2"
++name = "wasmer-engine-universal"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2bb4083a6c69f2cd4b000b82a80717f37c6cc2e536aee3a8ffe9af3edc276a8b"
++checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
+ dependencies = [
+- "bincode",
+- "cfg-if 0.1.10",
++ "cfg-if 1.0.0",
++ "enumset",
+  "leb128",
+- "libloading",
+- "serde",
+- "tempfile",
+- "tracing",
++ "loupe",
++ "region",
++ "rkyv",
+  "wasmer-compiler",
+  "wasmer-engine",
+- "wasmer-object",
++ "wasmer-engine-universal-artifact",
+  "wasmer-types",
+  "wasmer-vm",
+- "which",
++ "winapi",
++]
++
++[[package]]
++name = "wasmer-engine-universal-artifact"
++version = "2.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
++dependencies = [
++ "enum-iterator",
++ "enumset",
++ "loupe",
++ "rkyv",
++ "thiserror",
++ "wasmer-artifact",
++ "wasmer-compiler",
++ "wasmer-types",
+ ]
+ 
+ [[package]]
+ name = "wasmer-object"
+-version = "1.0.2"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "abf8e0c12b82ff81ebecd30d7e118be5fec871d6de885a90eeb105df0a769a7b"
++checksum = "8d831335ff3a44ecf451303f6f891175c642488036b92ceceb24ac8623a8fa8b"
+ dependencies = [
+- "object 0.22.0",
++ "object",
+  "thiserror",
+  "wasmer-compiler",
+  "wasmer-types",
+@@ -3237,60 +3575,94 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasmer-types"
+-version = "1.0.2"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c7f4ac28c2951cd792c18332f03da523ed06b170f5cf6bb5b1bdd7e36c2a8218"
++checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
+ dependencies = [
+- "cranelift-entity",
++ "backtrace",
++ "enum-iterator",
++ "indexmap",
++ "loupe",
++ "more-asserts",
++ "rkyv",
+  "serde",
+  "thiserror",
+ ]
+ 
++[[package]]
++name = "wasmer-vfs"
++version = "2.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "9302eae3edc53cb540c2d681e7f16d8274918c1ce207591f04fed351649e97c0"
++dependencies = [
++ "libc",
++ "thiserror",
++ "tracing",
++]
++
+ [[package]]
+ name = "wasmer-vm"
+-version = "1.0.2"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a7635ba0b6d2fd325f588d69a950ad9fa04dddbf6ad08b6b2a183146319bf6ae"
++checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
+ dependencies = [
+  "backtrace",
+  "cc",
+- "cfg-if 0.1.10",
++ "cfg-if 1.0.0",
++ "corosensei",
++ "enum-iterator",
+  "indexmap",
++ "lazy_static",
+  "libc",
++ "loupe",
++ "mach",
+  "memoffset",
+  "more-asserts",
+  "region",
++ "rkyv",
++ "scopeguard",
+  "serde",
+  "thiserror",
++ "wasmer-artifact",
+  "wasmer-types",
+  "winapi",
+ ]
+ 
+ [[package]]
+ name = "wasmer-wasi"
+-version = "1.0.2"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "aaf3ec2503b6b12034cf066deb923805952f821223b881acb746df83e284c03e"
++checksum = "fadbe31e3c1b6f3e398ad172b169152ae1a743ae6efd5f9ffb34019983319d99"
+ dependencies = [
+- "bincode",
+- "byteorder",
++ "cfg-if 1.0.0",
+  "generational-arena",
+  "getrandom 0.2.7",
+  "libc",
+- "serde",
+  "thiserror",
+- "time",
+  "tracing",
+- "typetag",
++ "wasm-bindgen",
+  "wasmer",
++ "wasmer-vfs",
++ "wasmer-wasi-types",
+  "winapi",
+ ]
+ 
++[[package]]
++name = "wasmer-wasi-types"
++version = "2.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "22dc83aadbdf97388de3211cb6f105374f245a3cf2a5c65a16776e7a087a8468"
++dependencies = [
++ "byteorder",
++ "time 0.2.27",
++ "wasmer-types",
++]
++
+ [[package]]
+ name = "wasmparser"
+-version = "0.65.0"
++version = "0.83.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "87cc2fe6350834b4e528ba0901e7aa405d78b89dc1fa3145359eb4de0e323fcf"
++checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
+ 
+ [[package]]
+ name = "wast"
+@@ -3420,43 +3792,86 @@ version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+ 
++[[package]]
++name = "windows-sys"
++version = "0.33.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "43dbb096663629518eb1dfa72d80243ca5a6aca764cae62a2df70af760a9be75"
++dependencies = [
++ "windows_aarch64_msvc 0.33.0",
++ "windows_i686_gnu 0.33.0",
++ "windows_i686_msvc 0.33.0",
++ "windows_x86_64_gnu 0.33.0",
++ "windows_x86_64_msvc 0.33.0",
++]
++
+ [[package]]
+ name = "windows-sys"
+ version = "0.36.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+ dependencies = [
+- "windows_aarch64_msvc",
+- "windows_i686_gnu",
+- "windows_i686_msvc",
+- "windows_x86_64_gnu",
+- "windows_x86_64_msvc",
++ "windows_aarch64_msvc 0.36.1",
++ "windows_i686_gnu 0.36.1",
++ "windows_i686_msvc 0.36.1",
++ "windows_x86_64_gnu 0.36.1",
++ "windows_x86_64_msvc 0.36.1",
+ ]
+ 
++[[package]]
++name = "windows_aarch64_msvc"
++version = "0.33.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
++
+ [[package]]
+ name = "windows_aarch64_msvc"
+ version = "0.36.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+ 
++[[package]]
++name = "windows_i686_gnu"
++version = "0.33.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
++
+ [[package]]
+ name = "windows_i686_gnu"
+ version = "0.36.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+ 
++[[package]]
++name = "windows_i686_msvc"
++version = "0.33.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
++
+ [[package]]
+ name = "windows_i686_msvc"
+ version = "0.36.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+ 
++[[package]]
++name = "windows_x86_64_gnu"
++version = "0.33.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
++
+ [[package]]
+ name = "windows_x86_64_gnu"
+ version = "0.36.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+ 
++[[package]]
++name = "windows_x86_64_msvc"
++version = "0.33.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
++
+ [[package]]
+ name = "windows_x86_64_msvc"
+ version = "0.36.1"
+@@ -3520,7 +3935,7 @@ dependencies = [
+  "highway",
+  "insta",
+  "log",
+- "semver",
++ "semver 0.11.0",
+  "serde_json",
+  "sixel-image",
+  "sixel-tokenizer",

--- a/packages/zellij/etc-path.patch
+++ b/packages/zellij/etc-path.patch
@@ -1,0 +1,11 @@
+--- a/zellij-utils/src/consts.rs
++++ b/zellij-utils/src/consts.rs
+@@ -13,7 +13,7 @@ pub const DEFAULT_SCROLL_BUFFER_SIZE: usize = 10_000;
+ pub static SCROLL_BUFFER_SIZE: OnceCell<usize> = OnceCell::new();
+ pub static DEBUG_MODE: OnceCell<bool> = OnceCell::new();
+ 
+-pub const SYSTEM_DEFAULT_CONFIG_DIR: &str = "/etc/zellij";
++pub const SYSTEM_DEFAULT_CONFIG_DIR: &str = "@TERMUX_PREFIX@/etc/zellij";
+ pub const SYSTEM_DEFAULT_DATA_DIR_PREFIX: &str = system_default_data_dir();
+ 
+ const fn system_default_data_dir() -> &'static str {

--- a/packages/zellij/wasmer.patch
+++ b/packages/zellij/wasmer.patch
@@ -1,0 +1,34 @@
+--- a/zellij-server/Cargo.toml
++++ b/zellij-server/Cargo.toml
+@@ -18,8 +18,8 @@ daemonize = "0.4.1"
+ serde_json = "1.0"
+ unicode-width = "0.1.8"
+ url = "2.2.2"
+-wasmer = "1.0.0"
+-wasmer-wasi = "1.0.0"
++wasmer = "2.3.0"
++wasmer-wasi = "2.3.0"
+ cassowary = "0.3.0"
+ zellij-utils = { path = "../zellij-utils/", version = "0.33.0" }
+ log = "0.4.17"
+--- a/zellij-server/src/logging_pipe.rs
++++ b/zellij-server/src/logging_pipe.rs
+@@ -114,7 +114,6 @@ impl Seek for LoggingPipe {
+     }
+ }
+ 
+-#[typetag::serde]
+ impl WasiFile for LoggingPipe {
+     fn last_accessed(&self) -> u64 {
+         0
+--- a/zellij-server/src/panes/grid.rs
++++ b/zellij-server/src/panes/grid.rs
+@@ -2563,7 +2563,7 @@ impl Perform for Grid {
+             };
+             if first_intermediate_is_questionmark {
+                 let query_type = params_iter.next();
+-                let is_query = params_iter.next() == Some(&[1]);
++                let is_query = matches!(params_iter.next(), Some(&[1]));
+                 if is_query {
+                     // XTSMGRAPHICS
+                     match query_type {


### PR DESCRIPTION
Resolves #11857.

This PR adds [Zellij](https://github.com/zellij-org/zellij) to the package registry. I have to include a relatively large patch for the `Cargo.lock` file thanks to the `wasmer` dependency version bump. The patches were generated using https://github.com/zellij-org/zellij/pull/1833. No patch would be needed after the PR merges, which is expected to happen before next release.