### PR TITLE
fakeroot: Bump to 1.30.1

### DIFF
--- a/packages/fakeroot/build.sh
+++ b/packages/fakeroot/build.sh
@@ -1,15 +1,17 @@
-TERMUX_PKG_HOMEPAGE=http://packages.debian.org/fakeroot
+TERMUX_PKG_HOMEPAGE=https://packages.qa.debian.org/f/fakeroot.html
 TERMUX_PKG_DESCRIPTION="Tool for simulating superuser privileges (with tcp ipc)"
-TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1.25.3
+TERMUX_PKG_VERSION=1.30.1
 TERMUX_PKG_SRCURL=https://deb.debian.org/debian/pool/main/f/fakeroot/fakeroot_${TERMUX_PKG_VERSION}.orig.tar.gz
-TERMUX_PKG_SHA256=8e903683357f7f5bcc31b879fd743391ad47691d4be33d24a76be3b6c21e956c
+TERMUX_PKG_SHA256=32ebb1f421aca0db7141c32a8c104eb95d2b45c393058b9435fbf903dd2b6a75
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-ipc=tcp"
 TERMUX_PKG_BUILD_DEPENDS="libcap"
 
 termux_step_pre_configure() {
 	autoreconf -vfi
+
+	CPPFLAGS+=" -D_ID_T"
 }
 
 termux_step_post_make_install() {

--- a/packages/fakeroot/dont-wrap-while-environ-is-null.patch
+++ b/packages/fakeroot/dont-wrap-while-environ-is-null.patch
@@ -1,0 +1,27 @@
+Workaround for https://github.com/termux/termux-packages/issues/3148.
+
+--- a/libfakeroot.c
++++ b/libfakeroot.c
+@@ -699,6 +699,22 @@ int WRAP_FSTAT FSTAT_ARG(int ver,
+ 			int fd,
+ 			struct stat *st){
+ 
++#ifdef __ANDROID__
++  static int initialized = 0;
++  if (!initialized) {
++    if (environ == NULL) {
++      void *libc_handle = dlopen("libc.so", RTLD_NOW);
++      if (libc_handle == NULL)
++        __builtin_abort();
++      int (*libc_impl)(int, struct stat *) = dlsym(libc_handle, "fstat");
++      if (libc_impl == NULL)
++        __builtin_abort();
++      return libc_impl(fd, st);
++    } else {
++      initialized = 1;
++    }
++  }
++#endif
+ 
+   int r;
+ 


### PR DESCRIPTION
and add workaround for

```
libfakeroot: FAKEROOTKEY not defined in environment
```

on some Android version. (#3148)

I have confirmed that this works on my Android 8.1.0 (API 27) environment. Does this work on other Android versions that are affected? (Not sure but I guess Android 9 (API 28) is affected too.)