### PR TITLE
New package: 7zip

### DIFF
--- a/packages/7zip/build.sh
+++ b/packages/7zip/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://www.7-zip.org
 TERMUX_PKG_DESCRIPTION="7-Zip file archiver with a high compression ratio"
 TERMUX_PKG_LICENSE="LGPL-2.1, BSD 3-Clause"
+TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=22.01
 TERMUX_PKG_SRCURL=https://www.7-zip.org/a/7z${TERMUX_PKG_VERSION//./}-src.tar.xz
 TERMUX_PKG_SHA256=393098730c70042392af808917e765945dc2437dee7aae3cfcc4966eb920fbc5

--- a/packages/7zip/build.sh
+++ b/packages/7zip/build.sh
@@ -1,0 +1,56 @@
+TERMUX_PKG_HOMEPAGE=https://www.7-zip.org
+TERMUX_PKG_DESCRIPTION="7-Zip file archiver with a high compression ratio"
+TERMUX_PKG_LICENSE="LGPL-2.1, BSD 3-Clause"
+TERMUX_PKG_VERSION=22.01
+TERMUX_PKG_SRCURL=https://www.7-zip.org/a/7z${TERMUX_PKG_VERSION//./}-src.tar.xz
+TERMUX_PKG_SHA256=393098730c70042392af808917e765945dc2437dee7aae3cfcc4966eb920fbc5
+TERMUX_PKG_BUILD_IN_SRC=true
+
+# The original "termux_extract_src_archive" always strips the first components
+# but the source of 7zip is directly under the root directory of the tar file
+termux_extract_src_archive() {
+	local file="$TERMUX_PKG_CACHEDIR/$(basename "$TERMUX_PKG_SRCURL")"
+	mkdir -p "$TERMUX_PKG_SRCDIR"
+	tar -xf "$file" -C "$TERMUX_PKG_SRCDIR"
+}
+
+termux_step_pre_configure() {
+	if [ "$TERMUX_ARCH" = 'aarch64' ]; then
+		CFLAGS+=' -march=armv8.1-a+crypto'
+		CXXFLAGS+=' -march=armv8.1-a+crypto'
+	fi
+	# from https://build.opensuse.org/package/view_file/openSUSE:Factory/7zip/7zip.spec?rev=5
+	# Remove carriage returns from docs
+	sed -i -e 's/\r$//g' DOC/*.txt
+	# Remove executable perms from docs
+	chmod -x DOC/*.txt
+	# Remove -Werror to make build succeed
+	sed -i -e 's/-Werror//' CPP/7zip/7zip_gcc.mak
+}
+
+termux_step_make() {
+	# from https://git.alpinelinux.org/aports/tree/community/7zip/APKBUILD?id=b4601c88f608662c75422311b7ca3c26fab4b1f4
+	cd CPP/7zip/Bundles/Alone2
+	mkdir -p b/c
+	# TODO: enable asm
+	# DISABLE_RAR: RAR codec is non-free
+	# -D_GNU_SOURCE: broken sched.h defines
+	make \
+		CC="$CC $CFLAGS $LDFLAGS -D_GNU_SOURCE" \
+		CXX="$CXX $CXXFLAGS $LDFLAGS -D_GNU_SOURCE" \
+		DISABLE_RAR=1 \
+		--file ../../cmpl_clang.mak \
+		--jobs "$TERMUX_MAKE_PROCESSES"
+}
+
+termux_step_make_install() {
+	install -Dm0755 \
+		-t "$TERMUX_PREFIX"/bin \
+		"$TERMUX_PKG_BUILDDIR"/CPP/7zip/Bundles/Alone2/b/c/7zz
+	install -Dm0644 \
+		-t "$TERMUX_PREFIX"/share/doc/"$TERMUX_PKG_NAME" \
+		"$TERMUX_PKG_BUILDDIR"/DOC/{7zC,7zFormat,lzma,Methods,readme,src-history}.txt
+	install -Dm0644 \
+		-t "$TERMUX_PREFIX"/share/licenses/"$TERMUX_PKG_NAME" \
+		"$TERMUX_PKG_BUILDDIR"/DOC/{copying,License}.txt
+}

--- a/packages/7zip/disable_hardware_acceleration_support_on_arm.patch
+++ b/packages/7zip/disable_hardware_acceleration_support_on_arm.patch
@@ -1,0 +1,159 @@
+From: YOKOTA Hiroshi <yokota.hgml@gmail.com>
+Date: Tue, 14 Sep 2021 23:51:04 +0900
+Subject: Disable hardware acceleration support on armel
+
+Use "__ARM_ARCH" to split "armel" and "armhf"
+
+__ARM_ARCH:
+  armel = 5
+  armhf = 7
+---
+ C/Aes.c                   | 2 ++
+ C/AesOpt.c                | 2 ++
+ C/Sha1.c                  | 2 ++
+ C/Sha1Opt.c               | 2 ++
+ C/Sha256.c                | 2 ++
+ C/Sha256Opt.c             | 2 ++
+ CPP/7zip/Crypto/MyAes.cpp | 2 ++
+ 7 files changed, 14 insertions(+)
+
+diff --git a/C/Aes.c b/C/Aes.c
+index 9ad66c5..2af4298 100755
+--- a/C/Aes.c
++++ b/C/Aes.c
+@@ -56,6 +56,7 @@ static Byte InvS[256];
+ #ifdef MY_CPU_X86_OR_AMD64
+   #define USE_HW_AES
+ #elif defined(MY_CPU_ARM_OR_ARM64) && defined(MY_CPU_LE)
++ #if (__ARM_ARCH > 7)
+   #if defined(__clang__)
+     #if (__clang_major__ >= 8) // fix that check
+       #define USE_HW_AES
+@@ -69,6 +70,7 @@ static Byte InvS[256];
+       #define USE_HW_AES
+     #endif
+   #endif
++ #endif
+ #endif
+ 
+ #ifdef USE_HW_AES
+diff --git a/C/AesOpt.c b/C/AesOpt.c
+index 1bdc9a8..60058bc 100755
+--- a/C/AesOpt.c
++++ b/C/AesOpt.c
+@@ -508,6 +508,7 @@ VAES_COMPAT_STUB (AesCtr_Code_HW)
+ 
+ #elif defined(MY_CPU_ARM_OR_ARM64) && defined(MY_CPU_LE)
+ 
++ #if (__ARM_ARCH > 7)
+   #if defined(__clang__)
+     #if (__clang_major__ >= 8) // fix that check
+       #define USE_HW_AES
+@@ -521,6 +522,7 @@ VAES_COMPAT_STUB (AesCtr_Code_HW)
+       #define USE_HW_AES
+     #endif
+   #endif
++ #endif
+ 
+ #ifdef USE_HW_AES
+ 
+diff --git a/C/Sha1.c b/C/Sha1.c
+index 7adeb44..b6ee739 100755
+--- a/C/Sha1.c
++++ b/C/Sha1.c
+@@ -33,6 +33,7 @@ This code is based on public domain code of Steve Reid from Wei Dai's Crypto++ l
+     #endif
+   #endif
+ #elif defined(MY_CPU_ARM_OR_ARM64)
++ #if (__ARM_ARCH > 7)
+   #ifdef _MSC_VER
+     #if _MSC_VER >= 1910 && _MSC_VER >= 1929 && _MSC_FULL_VER >= 192930037
+       #define _SHA_SUPPORTED
+@@ -46,6 +47,7 @@ This code is based on public domain code of Steve Reid from Wei Dai's Crypto++ l
+       #define _SHA_SUPPORTED
+     #endif
+   #endif
++ #endif
+ #endif
+ 
+ void MY_FAST_CALL Sha1_UpdateBlocks(UInt32 state[5], const Byte *data, size_t numBlocks);
+diff --git a/C/Sha1Opt.c b/C/Sha1Opt.c
+index dcedfbc..574d469 100755
+--- a/C/Sha1Opt.c
++++ b/C/Sha1Opt.c
+@@ -214,6 +214,7 @@ void MY_FAST_CALL Sha1_UpdateBlocks_HW(UInt32 state[5], const Byte *data, size_t
+ 
+ #elif defined(MY_CPU_ARM_OR_ARM64)
+ 
++ #if (__ARM_ARCH > 7)
+   #if defined(__clang__)
+     #if (__clang_major__ >= 8) // fix that check
+       #define USE_HW_SHA
+@@ -227,6 +228,7 @@ void MY_FAST_CALL Sha1_UpdateBlocks_HW(UInt32 state[5], const Byte *data, size_t
+       #define USE_HW_SHA
+     #endif
+   #endif
++ #endif
+ 
+ #ifdef USE_HW_SHA
+ 
+diff --git a/C/Sha256.c b/C/Sha256.c
+index c03b75a..e997ad4 100755
+--- a/C/Sha256.c
++++ b/C/Sha256.c
+@@ -33,6 +33,7 @@ This code is based on public domain code from Wei Dai's Crypto++ library. */
+     #endif
+   #endif
+ #elif defined(MY_CPU_ARM_OR_ARM64)
++ #if (__ARM_ARCH > 7)
+   #ifdef _MSC_VER
+     #if _MSC_VER >= 1910
+       #define _SHA_SUPPORTED
+@@ -46,6 +47,7 @@ This code is based on public domain code from Wei Dai's Crypto++ library. */
+       #define _SHA_SUPPORTED
+     #endif
+   #endif
++ #endif
+ #endif
+ 
+ void MY_FAST_CALL Sha256_UpdateBlocks(UInt32 state[8], const Byte *data, size_t numBlocks);
+diff --git a/C/Sha256Opt.c b/C/Sha256Opt.c
+index cc8c53e..b13cf7b 100755
+--- a/C/Sha256Opt.c
++++ b/C/Sha256Opt.c
+@@ -214,6 +214,7 @@ void MY_FAST_CALL Sha256_UpdateBlocks_HW(UInt32 state[8], const Byte *data, size
+ 
+ #elif defined(MY_CPU_ARM_OR_ARM64)
+ 
++ #if (__ARM_ARCH > 7)
+   #if defined(__clang__)
+     #if (__clang_major__ >= 8) // fix that check
+       #define USE_HW_SHA
+@@ -227,6 +228,7 @@ void MY_FAST_CALL Sha256_UpdateBlocks_HW(UInt32 state[8], const Byte *data, size
+       #define USE_HW_SHA
+     #endif
+   #endif
++ #endif
+ 
+ #ifdef USE_HW_SHA
+ 
+diff --git a/CPP/7zip/Crypto/MyAes.cpp b/CPP/7zip/Crypto/MyAes.cpp
+index 7e7cced..0df7b2f 100755
+--- a/CPP/7zip/Crypto/MyAes.cpp
++++ b/CPP/7zip/Crypto/MyAes.cpp
+@@ -86,6 +86,7 @@ STDMETHODIMP CAesCoder::SetInitVector(const Byte *data, UInt32 size)
+ #ifdef MY_CPU_X86_OR_AMD64
+   #define USE_HW_AES
+ #elif defined(MY_CPU_ARM_OR_ARM64) && defined(MY_CPU_LE)
++ #if (__ARM_ARCH > 7)
+   #if defined(__clang__)
+     #if (__clang_major__ >= 8) // fix that check
+       #define USE_HW_AES
+@@ -99,6 +100,7 @@ STDMETHODIMP CAesCoder::SetInitVector(const Byte *data, UInt32 size)
+       #define USE_HW_AES
+     #endif
+   #endif
++ #endif
+ #endif
+ 
+ #endif

--- a/packages/7zip/guard_armv8_feature_from_old_architectures.patch
+++ b/packages/7zip/guard_armv8_feature_from_old_architectures.patch
@@ -1,0 +1,25 @@
+From: YOKOTA Hiroshi <yokota.hgml@gmail.com>
+Date: Wed, 13 Oct 2021 07:59:13 +0900
+Subject: Guard ARM v8 feature from old architecture
+
+Forwarded: not-needed
+---
+ C/7zCrc.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/C/7zCrc.c b/C/7zCrc.c
+index c7ec353..230d8a5 100755
+--- a/C/7zCrc.c
++++ b/C/7zCrc.c
+@@ -81,8 +81,9 @@ UInt32 MY_FAST_CALL CrcUpdateT1(UInt32 v, const void *data, size_t size, const U
+         #define USE_ARM64_CRC
+     #endif
+     #endif
+-  #elif (defined(__clang__) && (__clang_major__ >= 3)) \
+-     || (defined(__GNUC__) && (__GNUC__ > 4))
++  #elif ( (defined(__clang__) && (__clang_major__ >= 3)) ||	 \
++          (defined(__GNUC__)  && (__GNUC__ > 4)        )    ) && \
++        (__ARM_ARCH >= 8)
+       #if !defined(__ARM_FEATURE_CRC32)
+         #define __ARM_FEATURE_CRC32 1
+           #if (!defined(__clang__) || (__clang_major__ > 3)) // fix these numbers

--- a/packages/7zip/remove_pthread.patch
+++ b/packages/7zip/remove_pthread.patch
@@ -1,0 +1,24 @@
+diff -ru a/C/7zip_gcc_c.mak b/C/7zip_gcc_c.mak
+--- a/C/7zip_gcc_c.mak	2022-07-15 10:00:00.000000000 +0200
++++ b/C/7zip_gcc_c.mak	2022-11-10 22:05:33.101451700 +0100
+@@ -108,7 +108,7 @@
+ 
+ # LOCAL_LIBS=-lpthread
+ # LOCAL_LIBS_DLL=$(LOCAL_LIBS) -ldl
+-LIB2 = -lpthread -ldl
++LIB2 = -ldl
+ 
+ DEL_OBJ_EXE = -$(RM) $(PROGPATH) $(PROGPATH_STATIC) $(OBJS)
+ 
+diff -ru a/CPP/7zip/7zip_gcc.mak b/CPP/7zip/7zip_gcc.mak
+--- a/CPP/7zip/7zip_gcc.mak	2022-07-15 14:00:00.000000000 +0200
++++ b/CPP/7zip/7zip_gcc.mak	2022-11-10 22:05:39.648159700 +0100
+@@ -131,7 +131,7 @@
+ 
+ # LOCAL_LIBS=-lpthread
+ # LOCAL_LIBS_DLL=$(LOCAL_LIBS) -ldl
+-LIB2 = -lpthread -ldl
++LIB2 = -ldl
+ 
+ 
+ endif


### PR DESCRIPTION
Termux currently provides a quite up-to-date fork of the 7-Zip port p7zip (https://github.com/jinfeihan57/p7zip), since the original p7zip hasn't been updated since 2016.

Since 2021 there is however an official version of 7-Zip for Linux. This new version is slowly finding its way into some well-known distros:
- Alpine: https://pkgs.alpinelinux.org/packages?name=7zip
- Arch: https://aur.archlinux.org/packages/7-zip
- Debian: https://packages.debian.org/bullseye-backports/7zip
- OpenSUSE: https://software.opensuse.org/package/7zip
- Ubuntu: https://packages.ubuntu.com/jammy/7zip

Therefore, it would be nice to have this new, official version on Termux too :)

Most distros use "7zip" as the name of the package (as opposed to "7-Zip").

The build process generates an executable called "7zz", so there should be no conflicts with the executables provided by the p7zip package ("7z", "7za").

There is a bit of confusion about the license, as different distros list different licenses; clarification might be necessary:
- Alpine: LGPL-2.0-only (does not build the RAR component)
- Arch: LGPL, BSD, custom:unRAR
- Debian: LGPL-2.1+, BSD-3-clause, public-domain (does not build the RAR component)
- OpenSUSE: LGPL-2.1-or-later , BSD-3-Clause (does not build the RAR component)
- Ubuntu: LGPL-2.1+, BSD-3-clause, public-domain (does not build the RAR component)

The following patches are taken from Debian:
- disable_hardware_acceleration_support_on_arm.patch: https://sources.debian.org/patches/7zip/22.01%2Bdfsg-2~bpo11%2B1/0003-Disable-hardware-acceleration-support-on-armel.patch/
  - modified: #if (__ARM_ARCH >= 7) => #if (__ARM_ARCH > 7)
- guard_armv8_feature_from_old_architectures.patch: https://sources.debian.org/patches/7zip/22.01%2Bdfsg-2~bpo11%2B1/0004-Guard-ARM-v8-feature-from-old-architecture.patch/

All architectures build successfully but I can only test aarch64. I think that there might be problems because building aarch64 requires using "-march=armv8.1-a+crypto", which I haven't seen used in any other package. Maybe the crypto features should be disabled for aarch64 like they are for arm.

I haven't even tried to build using the assembler optimizations, as most distros do not either.
