### PR TITLE
lvm2: configure --with-symvers=no

### DIFF
--- a/root-packages/lvm2/build.sh
+++ b/root-packages/lvm2/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="GPL-2.0, LGPL-2.1, BSD 2-Clause"
 TERMUX_PKG_LICENSE_FILE="COPYING, COPYING.BSD, COPYING.LIB"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.03.17
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/sourceware/lvm2/releases/LVM2.${TERMUX_PKG_VERSION}.tgz
 TERMUX_PKG_SHA256=7286cfa9651828c589389509546333b8da965dfa84a1a4c8ab3e681a47fabae7
 TERMUX_PKG_DEPENDS="libandroid-support, libaio, readline"
@@ -19,6 +20,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --with-default-run-dir=$TERMUX_PREFIX/var/run
 --with-default-locking-dir=$TERMUX_PREFIX/var/run/lock/lvm
 --with-confdir=$TERMUX_PREFIX/etc
+--with-symvers=no
 "
 
 termux_step_pre_configure() {


### PR DESCRIPTION
Otherwise we get errors like:

CANNOT LINK EXECUTABLE "cryptsetup": cannot find verneed/verdef for version index=32785 referenced by symbol "dm_bitset_parse_list" at "/data/data/com.termux/files/usr/lib/libdevmapper.so.1.02"

I mistakenly thought this issue was fixed in commit 650fcddc7ffe
("cryptsetup: bump after lvm2 update").

Fixes termux/termux-packages#13574