### PR TITLE
proton-bridge: bump to 2.3.0

### DIFF
--- a/packages/proton-bridge/build.sh
+++ b/packages/proton-bridge/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/ProtonMail/proton-bridge
 TERMUX_PKG_DESCRIPTION="ProtonMail Bridge application"
 TERMUX_PKG_LICENSE="GPL-3.0"
-TERMUX_PKG_VERSION=2.1.3
+TERMUX_PKG_VERSION=2.3.0
 TERMUX_PKG_SRCURL=https://github.com/ProtonMail/proton-bridge.git
 TERMUX_PKG_GIT_BRANCH=br-${TERMUX_PKG_VERSION}
 TERMUX_PKG_MAINTAINER="Radomír Polách <rp@t4d.cz>"


### PR DESCRIPTION
Needs to be updaed soon because Protonmail is dropping support for version <2.3.0 in beginning of 2023