### PR TITLE
hstr: Add NULL check

### DIFF
--- a/packages/hstr/build.sh
+++ b/packages/hstr/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Shell history suggest box for bash and zsh"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.5
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/dvorka/hstr/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=7f5933fc07d55d09d5f7f9a6fbfdfc556d8a7d8575c3890ac1e672adabd2bec4
 TERMUX_PKG_DEPENDS="ncurses, readline"

--- a/packages/hstr/src-hstr_utils.c.patch
+++ b/packages/hstr/src-hstr_utils.c.patch
@@ -1,0 +1,18 @@
+--- a/src/hstr_utils.c
++++ b/src/hstr_utils.c
+@@ -154,6 +154,7 @@
+     char *b=buffer;
+     if(access(PROC_HOSTNAME, F_OK) != -1) {
+         FILE *file = fopen(PROC_HOSTNAME, "r");
++        if (file == NULL) goto fail;
+         b=fgets(buffer, bufferSize, file);
+         fclose(file);
+         if(b) {
+@@ -161,6 +162,7 @@
+             return;
+         }
+     }
++fail:
+     strcpy(buffer, "localhost");
+ }
+ 


### PR DESCRIPTION
for return value of `fopen("/proc/sys/kernel/hostname", "r")`.

Fixes #13697.