### PR TITLE
php: Bump to 8.2.0

### DIFF
--- a/packages/php/build.sh
+++ b/packages/php/build.sh
@@ -3,10 +3,9 @@ TERMUX_PKG_DESCRIPTION="Server-side, HTML-embedded scripting language"
 TERMUX_PKG_LICENSE="PHP-3.01"
 TERMUX_PKG_LICENSE_FILE=LICENSE
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=8.1.13
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION=8.2.0
 TERMUX_PKG_SRCURL=https://github.com/php/php-src/archive/php-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=03e3cba9e8f3a559203cfb0145204d38cdfdbf4b674aadf8b62e548c5b937287
+TERMUX_PKG_SHA256=e6e9d2dd5b7981ecaefcebda330dde40b884f05d1431c7c86ea1a7ee5aaad649
 # Build native php for phar to build (see pear-Makefile.frag.patch):
 TERMUX_PKG_HOSTBUILD=true
 # Build the native php without xml support as we only need phar:
@@ -19,6 +18,7 @@ TERMUX_PKG_SERVICE_SCRIPT=("php-fpm" "mkdir -p $TERMUX_ANDROID_HOME/.php\nif [ -
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 ac_cv_func_res_nsearch=no
+ac_cv_phpdbg_userfaultfd_writefault=no
 --enable-bcmath
 --enable-calendar
 --enable-exif
@@ -57,12 +57,29 @@ ac_cv_func_res_nsearch=no
 "
 
 termux_step_host_build() {
+	# PatchELF packaged in Ubuntu is too old.
+	local PATCHELF_BUILD_SH=$TERMUX_SCRIPTDIR/packages/patchelf/build.sh
+	local PATCHELF_SRCURL=$(bash -c ". $PATCHELF_BUILD_SH; echo \$TERMUX_PKG_SRCURL")
+	local PATCHELF_SHA256=$(bash -c ". $PATCHELF_BUILD_SH; echo \$TERMUX_PKG_SHA256")
+	local PATCHELF_TARFILE=$TERMUX_PKG_CACHEDIR/$(basename $PATCHELF_SRCURL)
+	termux_download $PATCHELF_SRCURL $PATCHELF_TARFILE $PATCHELF_SHA256
+	local PATCHELF_SRCDIR=$TERMUX_PKG_HOSTBUILD_DIR/_patchelf
+	mkdir -p $PATCHELF_SRCDIR
+	tar xf $PATCHELF_TARFILE -C $PATCHELF_SRCDIR --strip-components=1
+	pushd $PATCHELF_SRCDIR
+	./bootstrap.sh
+	./configure
+	make -j $TERMUX_MAKE_PROCESSES
+	popd
+
 	(cd "$TERMUX_PKG_SRCDIR" && ./buildconf --force)
 	"$TERMUX_PKG_SRCDIR/configure" ${TERMUX_PKG_EXTRA_HOSTBUILD_CONFIGURE_ARGS}
 	make -j "$TERMUX_MAKE_PROCESSES"
 }
 
 termux_step_pre_configure() {
+	export PATH=$TERMUX_PKG_HOSTBUILD_DIR/_patchelf/src:$PATH
+
 	LDFLAGS+=" -lresolv_wrapper -landroid-glob -llog $($CC -print-libgcc-file-name)"
 
 	export PATH=$PATH:$TERMUX_PKG_HOSTBUILD_DIR/sapi/cli/
@@ -118,4 +135,16 @@ termux_step_post_make_install() {
 	done
 
 	sed -i 's/SED=.*/SED=sed/' $TERMUX_PREFIX/bin/phpize
+
+	# Shared extensions for PHP/Apache
+	mkdir -p $TERMUX_PREFIX/lib/php-apache
+	local f
+	for f in opcache ldap pdo_pgsql pgsql sodium; do
+		local so=$TERMUX_PREFIX/lib/php-apache/${f}.so
+		rm -f ${so}
+		cp -T $TERMUX_PREFIX/lib/php/${f}.so ${so}
+		patchelf --set-rpath $TERMUX_PREFIX/libexec/apache2:$TERMUX_PREFIX/lib \
+			--add-needed libphp.so \
+			${so}
+	done
 }

--- a/packages/php/ext-standard-php_fopen_wrapper.c.patch
+++ b/packages/php/ext-standard-php_fopen_wrapper.c.patch
@@ -6,7 +6,7 @@ diff -u -r ../php-5.6.16/ext/standard/php_fopen_wrapper.c ./ext/standard/php_fop
 @@ -312,7 +312,7 @@
  		}
  
- #if HAVE_UNISTD_H
+ #ifdef HAVE_UNISTD_H
 -		dtablesize = getdtablesize();
 +		dtablesize = sysconf(_SC_OPEN_MAX);
  #else

--- a/packages/php/php-apache-ldap.subpackage.sh
+++ b/packages/php/php-apache-ldap.subpackage.sh
@@ -1,0 +1,3 @@
+TERMUX_SUBPKG_INCLUDE="lib/php-apache/ldap.so"
+TERMUX_SUBPKG_DEPENDS="openldap, php-apache"
+TERMUX_SUBPKG_DESCRIPTION="LDAP module for PHP/Apache"

--- a/packages/php/php-apache-opcache.subpackage.sh
+++ b/packages/php/php-apache-opcache.subpackage.sh
@@ -1,0 +1,3 @@
+TERMUX_SUBPKG_INCLUDE="lib/php-apache/opcache.so"
+TERMUX_SUBPKG_DEPENDS="php-apache"
+TERMUX_SUBPKG_DESCRIPTION="OPcache module for PHP/Apache"

--- a/packages/php/php-apache-pgsql.subpackage.sh
+++ b/packages/php/php-apache-pgsql.subpackage.sh
@@ -1,0 +1,3 @@
+TERMUX_SUBPKG_INCLUDE="lib/php-apache/pgsql.so lib/php-apache/pdo_pgsql.so"
+TERMUX_SUBPKG_DEPENDS="php-apache, postgresql"
+TERMUX_SUBPKG_DESCRIPTION="PostgreSQL modules for PHP/Apache"

--- a/packages/php/php-apache-sodium.subpackage.sh
+++ b/packages/php/php-apache-sodium.subpackage.sh
@@ -1,0 +1,3 @@
+TERMUX_SUBPKG_INCLUDE="lib/php-apache/sodium.so"
+TERMUX_SUBPKG_DEPENDS="libsodium, php-apache"
+TERMUX_SUBPKG_DESCRIPTION="Sodium module for PHP/Apache"

--- a/packages/php/php-apache.subpackage.sh
+++ b/packages/php/php-apache.subpackage.sh
@@ -1,3 +1,15 @@
 TERMUX_SUBPKG_DESCRIPTION="Apache 2.0 Handler module for PHP"
 TERMUX_SUBPKG_DEPENDS="apache2, apr-util"
 TERMUX_SUBPKG_INCLUDE="libexec/apache2/libphp.so"
+
+termux_step_create_subpkg_debscripts() {
+	cat <<- EOF > ./postinst
+	#!$TERMUX_PREFIX/bin/sh
+	echo
+	echo "    Extensions for PHP/Apache are packaged under the name of 'php-apache-*'"
+	echo "    and are installed under the directory '\\\$PREFIX/lib/php-apache/'."
+	echo
+	echo "    (Extensions under '\\\$PREFIX/lib/php/' will not work with PHP/Apache.)"
+	echo
+	EOF
+}


### PR DESCRIPTION
This is a "major" bump including <a href="https://www.php.net/manual/en/migration82.incompatible.php">backward-incompatible changes</a>. Tests requested.

~~Include a workaround tip for #13256 in postinst message of `php-apache`.~~

Extensions for PHP/Apache are packaged under the name of `php-apache-*` and are installed under the directory `$PREFIX/lib/php-apache/`.

(Extensions under `$PREFIX/lib/php/` will not work with PHP/Apache.)

Closes #13256.