### PR TITLE
Disable package uploads

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -244,6 +244,7 @@ jobs:
       env:
         REPOSITORY_URL: https://packages.termux.dev/aptly-api
       run: |
+        exit 1
         GITHUB_SHA=${{ github.sha }}
         APTLY_API_AUTH=${{ secrets.APTLY_API_AUTH }}
         GPG_PASSPHRASE=${{ secrets.GPG_PASSPHRASE }}
@@ -294,6 +295,7 @@ jobs:
       env:
         REPOSITORY_URL: https://aptly-api.grimler.se
       run: |
+        exit 1
         GITHUB_SHA=${{ github.sha }}
         APTLY_API_AUTH=${{ secrets.APTLY_API_AUTH }}
 

--- a/scripts/properties.sh
+++ b/scripts/properties.sh
@@ -40,9 +40,9 @@ TERMUX_REPO_PACKAGE="com.termux"
 
 # Termux repo urls.
 TERMUX_REPO_URL=(
-	https://packages-cf.termux.dev/apt/termux-main
-	https://packages-cf.termux.dev/apt/termux-root
-	https://packages-cf.termux.dev/apt/termux-x11
+        https://grimler.se/termux/termux-main
+        https://grimler.se/termux/termux-root
+        https://grimler.se/termux/termux-x11
 )
 
 TERMUX_REPO_DISTRIBUTION=(


### PR DESCRIPTION
As mentioned in termux/termux-packages#13804 package uploads will be disabled for maybe 2 h to allow for migration from fosshost to a new vps. 

This PR will be merged at 2022-12-10 09:00 UTC+0.