### PR TITLE
enchance(main/libandroid-support): remove pre-depends on dpkg

### DIFF
--- a/packages/libandroid-support/build.sh
+++ b/packages/libandroid-support/build.sh
@@ -3,14 +3,13 @@ TERMUX_PKG_DESCRIPTION="Library extending the Android C library (Bionic) for add
 TERMUX_PKG_LICENSE="Apache-2.0, MIT"
 TERMUX_PKG_VERSION=(28
 		    3)
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_LICENSE_FILE="LICENSE.txt, wcwidth-${TERMUX_PKG_VERSION[1]}/LICENSE.txt"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_SRCURL=(https://github.com/termux/libandroid-support/archive/v${TERMUX_PKG_VERSION[0]}.tar.gz
 		   https://github.com/termux/wcwidth/archive/v${TERMUX_PKG_VERSION[1]}.tar.gz)
 TERMUX_PKG_SHA256=(ef35260994ffa3bd054be66068dfc28934c823ac8de2394796d94d1cd5de3be4
 		   d38062a53edb2545b9988be41bd8d217f803fa985158b7cadf95d804761dd1f6)
-TERMUX_PKG_PRE_DEPENDS="dpkg (>= 1.19.4-3)"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_ESSENTIAL=true
 


### PR DESCRIPTION
It was added to fix a particular package dependency issue when libiconv was added (see termux/termux-packages#3762).  It is however not correct, libandroid-support does not (pre-)depend on dpkg and specifying that it does can lead to cyclic dependency issues.

Remove this workaround since it by now has been several years since the original issue was fixed.

Fixes termux/termux-packages#13913