### PR TITLE
enhance(x11/gtk3): add broadway backend

### DIFF
--- a/x11-packages/gtk3/broadway-server.patch
+++ b/x11-packages/gtk3/broadway-server.patch
@@ -1,0 +1,28 @@
+--- a/gdk/broadway/broadway-server.c	2022-12-12 14:17:52.598502580 +0000
++++ b/gdk/broadway/broadway-server.c	2022-12-12 14:18:54.758683298 +0000
+@@ -829,9 +829,6 @@
+   void *ptr;
+   char *filename = NULL;
+
+-  fd = shm_open (name, O_RDONLY, 0600);
+-  if (fd == -1)
+-    {
+       filename = g_build_filename (g_get_tmp_dir (), name, NULL);
+       fd = open (filename, O_RDONLY);
+       if (fd == -1)
+@@ -841,7 +838,6 @@
+
+ 	  return NULL;
+ 	}
+-    }
+
+   ptr = mmap (0, size, PROT_READ, MAP_SHARED, fd, 0);
+
+@@ -852,8 +848,6 @@
+       unlink (filename);
+       g_free (filename);
+     }
+-  else
+-    shm_unlink (name);
+
+   return ptr;

--- a/x11-packages/gtk3/build.sh
+++ b/x11-packages/gtk3/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="GObject-based multi-platform GUI toolkit"
 TERMUX_PKG_LICENSE="LGPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.24.35
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://gitlab.gnome.org/GNOME/gtk/-/archive/$TERMUX_PKG_VERSION/gtk-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=8b08020b183729fbc14c959c46124de10e43563334f4811a283ded0e8ba5463e
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -19,6 +20,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --enable-xcomposite
 --enable-xdamage
 --enable-x11-backend
+--enable-broadway-backend
 --disable-wayland-backend
 "
 TERMUX_PKG_RM_AFTER_INSTALL="share/glib-2.0/schemas/gschemas.compiled"

--- a/x11-packages/gtk3/gdkbroadway-server.patch
+++ b/x11-packages/gtk3/gdkbroadway-server.patch
@@ -1,0 +1,45 @@
+--- a/gdk/broadway/gdkbroadway-server.c.org	2022-12-12 14:29:27.452591178 +0000
++++ b/gdk/broadway/gdkbroadway-server.c	2022-12-12 14:30:43.176824600 +0000
+@@ -533,9 +533,6 @@
+   void *ptr;
+   int res;
+
+-  fd = shm_open(name, O_RDWR|O_CREAT|O_EXCL, 0600);
+-  if (fd == -1)
+-    {
+       if (errno == EEXIST)
+ 	return NULL;
+
+@@ -551,9 +548,6 @@
+ 	}
+       else
+ 	*is_shm = FALSE;
+-    }
+-  else
+-    *is_shm = TRUE;
+
+   res = ftruncate (fd, size);
+   g_assert (res != -1);
+@@ -564,8 +558,6 @@
+     {
+       if (filename)
+ 	unlink (filename);
+-      else
+-	shm_unlink (name);
+       g_error ("Not enough shared memory for window surface");
+     }
+ #endif
+@@ -680,14 +672,9 @@
+ #ifdef G_OS_UNIX
+
+   munmap (data->data, data->data_size);
+-  if (data->is_shm)
+-    shm_unlink (data->name);
+-  else
+-    {
+       char *filename = g_build_filename (g_get_tmp_dir (), data->name, NULL);
+       unlink (filename);
+       g_free (filename);
+-    }
+
+ #elif defined(G_OS_WIN32)


### PR DESCRIPTION
Hello,

This PR enables building gtk3 with the broadway backend.    
This backend allows to display GTK applications in a browser using HTML. It thus allows launching GTK application from termux without relying on an X server and using a browser to use the application.  
Please have a look here for more information: https://docs.gtk.org/gtk3/broadway.html.    

I can successfully build gtk3 using docker, and launch gtk3-demo via broadway, but it probably needs a bit more testing.