### PR TITLE
tint2: Bump to 17.1.3

### DIFF
--- a/x11-packages/tint2/build.sh
+++ b/x11-packages/tint2/build.sh
@@ -1,11 +1,10 @@
-TERMUX_PKG_HOMEPAGE=https://gitlab.com/o9000/tint2
+TERMUX_PKG_HOMEPAGE=https://gitlab.com/nick87720z/tint2
 TERMUX_PKG_DESCRIPTION="Lightweight panel, Highly customizable"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=17.0.2
-TERMUX_PKG_REVISION=5
-TERMUX_PKG_SRCURL=https://gitlab.com/o9000/tint2/-/archive/${TERMUX_PKG_VERSION}/tint2-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=f87f147e176d32f31f12fc1737f75f54c4c6f77961c6a2615ef9d64cb29ce24c
+TERMUX_PKG_VERSION=17.1.3
+TERMUX_PKG_SRCURL=https://gitlab.com/nick87720z/tint2/-/archive/v${TERMUX_PKG_VERSION}/tint2-v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=283e193c3bed452e9d2ecbc64c21303ca3e3cc8a5f0a1e16550cbdae97514a23
 TERMUX_PKG_DEPENDS="gdk-pixbuf, glib, gtk3, imlib2, libandroid-shmem, libandroid-wordexp, libcairo, librsvg, libx11, libxcomposite, libxdamage, libxext, libxinerama, libxrandr, libxrender, pango, startup-notification"
 TERMUX_PKG_BUILD_IN_SRC=true
 

--- a/x11-packages/tint2/src-battery-dummy.c.patch
+++ b/x11-packages/tint2/src-battery-dummy.c.patch
@@ -1,0 +1,10 @@
+--- a/src/battery/dummy.c
++++ b/src/battery/dummy.c
+@@ -41,6 +41,6 @@
+ char *battery_os_tooltip()
+ {
+     char *text;
+-    strdup_static(text, "Operating System not supported")
++    strdup_static(text, "Operating System not supported");
+     return text;
+ }


### PR DESCRIPTION
Migrate to using active fork.