### PR TITLE
enet: add package

### DIFF
--- a/packages/libenet/build.sh
+++ b/packages/libenet/build.sh
@@ -1,0 +1,11 @@
+TERMUX_PKG_HOMEPAGE=http://enet.bespin.org
+TERMUX_PKG_DESCRIPTION="ENet reliable UDP networking library"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@ravener"
+TERMUX_PKG_VERSION=1.3.17
+TERMUX_PKG_SRCURL=http://enet.bespin.org/download/enet-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=a38f0f194555d558533b8b15c0c478e946310022d0ec7b34334e19e4574dcedc
+
+termux_step_pre_configure() {
+	autoreconf -vfi
+}


### PR DESCRIPTION
ENet's purpose is to provide a relatively thin, simple and robust network communication layer on top of UDP (User Datagram Protocol).The primary feature it provides is optional reliable, in-order delivery of packets.

ENet omits certain higher level networking features such as authentication, lobbying, server discovery, encryption, or other similar tasks that are particularly application specific so that the library remains flexible, portable, and easily embeddable.

As an example of enet's use: [love2d](https://love2d.org) (which is also available in termux) already comes with it to allow games using it to implement networking. This package allows more flexibility to users allowing them to e.g write servers in different languages while still being protocol compatible with love2d's client, as an example.