### PR TITLE
properties.sh: Bump build-tools to 33.0.1

### DIFF
--- a/packages/apksigner/build.sh
+++ b/packages/apksigner/build.sh
@@ -2,7 +2,8 @@ TERMUX_PKG_HOMEPAGE=https://developer.android.com/studio/command-line/apksigner
 TERMUX_PKG_DESCRIPTION="APK signing tool from Android SDK"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=${TERMUX_ANDROID_BUILD_TOOLS_VERSION}
+# Do not use the TERMUX_ANDROID_BUILD_TOOLS_VERSION variable when specifying:
+TERMUX_PKG_VERSION=33.0.1
 TERMUX_PKG_DEPENDS="openjdk-17"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
@@ -13,10 +14,15 @@ termux_step_pre_configure() {
 	if $TERMUX_ON_DEVICE_BUILD; then
 		termux_error_exit "Package '$TERMUX_PKG_NAME' is not available for on-device builds."
 	fi
+
+	# Version guard
+	if [ "${TERMUX_PKG_VERSION#*:}" != "${TERMUX_ANDROID_BUILD_TOOLS_VERSION}" ]; then
+		termux_error_exit "Version mismatch between TERMUX_PKG_VERSION and TERMUX_ANDROID_BUILD_TOOLS_VERSION."
+	fi
 }
 
 termux_step_make_install() {
-	install -Dm600 $ANDROID_HOME/build-tools/${TERMUX_PKG_VERSION}/lib/apksigner.jar \
+	install -Dm600 $ANDROID_HOME/build-tools/${TERMUX_ANDROID_BUILD_TOOLS_VERSION}/lib/apksigner.jar \
 		$TERMUX_PREFIX/share/java/apksigner.jar
 	cat <<- EOF > $TERMUX_PREFIX/bin/apksigner
 	#!${TERMUX_PREFIX}/bin/sh

--- a/packages/d8/build.sh
+++ b/packages/d8/build.sh
@@ -2,7 +2,8 @@ TERMUX_PKG_HOMEPAGE=https://developer.android.com/studio/command-line/d8
 TERMUX_PKG_DESCRIPTION="DEX bytecode compiler from Android SDK"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=${TERMUX_ANDROID_BUILD_TOOLS_VERSION}
+# Do not use the TERMUX_ANDROID_BUILD_TOOLS_VERSION variable when specifying:
+TERMUX_PKG_VERSION=33.0.1
 TERMUX_PKG_DEPENDS="openjdk-17"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
@@ -13,10 +14,15 @@ termux_step_pre_configure() {
 	if $TERMUX_ON_DEVICE_BUILD; then
 		termux_error_exit "Package '$TERMUX_PKG_NAME' is not available for on-device builds."
 	fi
+
+	# Version guard
+	if [ "${TERMUX_PKG_VERSION#*:}" != "${TERMUX_ANDROID_BUILD_TOOLS_VERSION}" ]; then
+		termux_error_exit "Version mismatch between TERMUX_PKG_VERSION and TERMUX_ANDROID_BUILD_TOOLS_VERSION."
+	fi
 }
 
 termux_step_make_install() {
-	install -Dm600 $ANDROID_HOME/build-tools/${TERMUX_PKG_VERSION}/lib/d8.jar \
+	install -Dm600 $ANDROID_HOME/build-tools/${TERMUX_ANDROID_BUILD_TOOLS_VERSION}/lib/d8.jar \
 		$TERMUX_PREFIX/share/java/d8.jar
 
 	cat <<- EOF > $TERMUX_PREFIX/bin/d8

--- a/scripts/properties.sh
+++ b/scripts/properties.sh
@@ -4,7 +4,11 @@
 # or sourcing any other script in our build directories.
 
 TERMUX_SDK_REVISION=9123335
-TERMUX_ANDROID_BUILD_TOOLS_VERSION=33.0.0
+TERMUX_ANDROID_BUILD_TOOLS_VERSION=33.0.1
+# when changing the above:
+# change TERMUX_PKG_VERSION (and remove TERMUX_PKG_REVISION if necessary) in:
+#   apksigner, d8
+# and trigger rebuild of them
 : "${TERMUX_NDK_VERSION_NUM:="25"}"
 : "${TERMUX_NDK_REVISION:="b"}"
 TERMUX_NDK_VERSION=$TERMUX_NDK_VERSION_NUM$TERMUX_NDK_REVISION


### PR DESCRIPTION
Also stops ~~directly specifying `$TERMUX_ANDROID_BUILD_TOOLS_VERSION` in~~ using the `TERMUX_ANDROID_BUILD_TOOLS_VERSION` variable when specifying `TERMUX_PKG_VERSION`. Ref: #2486.