### PR TITLE
scripts: Provide hooks triggered by failure in configure

### DIFF
--- a/scripts/build/configure/termux_step_configure_autotools.sh
+++ b/scripts/build/configure/termux_step_configure_autotools.sh
@@ -113,5 +113,10 @@ termux_step_configure_autotools() {
 		$ENABLE_SHARED \
 		$ENABLE_STATIC \
 		$LIBEXEC_FLAG \
-		$QUIET_BUILD
+		$QUIET_BUILD \
+		|| (termux_step_configure_autotools_failure_hook && false)
+}
+
+termux_step_configure_autotools_failure_hook() {
+	false
 }

--- a/scripts/build/configure/termux_step_configure_cmake.sh
+++ b/scripts/build/configure/termux_step_configure_cmake.sh
@@ -47,5 +47,10 @@ termux_step_configure_cmake() {
 		-DDOXYGEN_EXECUTABLE= \
 		-DBUILD_TESTING=OFF \
 		"${CMAKE_ADDITIONAL_ARGS[@]}" \
-		$TERMUX_PKG_EXTRA_CONFIGURE_ARGS
+		$TERMUX_PKG_EXTRA_CONFIGURE_ARGS \
+		|| (termux_step_configure_cmake_failure_hook && false)
+}
+
+termux_step_configure_cmake_failure_hook() {
+	false
 }

--- a/scripts/build/configure/termux_step_configure_meson.sh
+++ b/scripts/build/configure/termux_step_configure_meson.sh
@@ -8,5 +8,10 @@ termux_step_configure_meson() {
 		--libdir lib \
 		--buildtype minsize \
 		--strip \
-		$TERMUX_PKG_EXTRA_CONFIGURE_ARGS
+		$TERMUX_PKG_EXTRA_CONFIGURE_ARGS \
+		|| (termux_step_configure_meson_failure_hook && false)
+}
+
+termux_step_configure_meson_failure_hook() {
+	false
 }


### PR DESCRIPTION
In response to commit ae454e2ef4faf9676974104328e1261f3aa97c70.