### PR TITLE
auto-update: Exclude epoch in version comparison

### DIFF
--- a/scripts/updates/utils/termux_pkg_upgrade_version.sh
+++ b/scripts/updates/utils/termux_pkg_upgrade_version.sh
@@ -35,7 +35,7 @@ termux_pkg_upgrade_version() {
 
 	if [[ "${SKIP_VERSION_CHECK}" != "--skip-version-check" ]]; then
 		if ! termux_pkg_is_update_needed \
-			"${TERMUX_PKG_VERSION}" "${EPOCH}${LATEST_VERSION}"; then
+			"${TERMUX_PKG_VERSION#*:}" "${LATEST_VERSION}"; then
 			echo "INFO: No update needed. Already at version '${LATEST_VERSION}'."
 			return 0
 		fi


### PR DESCRIPTION
to avoid warnings like

```
/usr/lib/python3/dist-packages/pkg_resources/__init__.py:116: PkgResourcesDeprecationWarning: 2:0.8.3 is an invalid version and will not be supported in a future release
```