### PR TITLE
moria: add prerm script

### DIFF
--- a/packages/moria/build.sh
+++ b/packages/moria/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Rogue-like game with an infinite dungeon"
 TERMUX_PKG_LICENSE="GPL-3.0-or-later"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=5.7.15
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=https://github.com/dungeons-of-moria/umoria/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=97f76a68b856dd5df37c20fc57c8a51017147f489e8ee8866e1764778b2e2d57
 TERMUX_PKG_DEPENDS="libc++, ncurses"
@@ -11,8 +11,19 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-Dbuild_dir=$TERMUX_PKG_BUILDDIR"
 TERMUX_PKG_GROUPS="games"
 
 termux_step_create_debscripts() {
-	# Create scores file in a debscript, so an update to the package wouldn't erease any scores
-	echo "mkdir -p $TERMUX_PREFIX/lib/games/moria/" > postinst
-	echo "touch $TERMUX_PREFIX/lib/games/moria/scores.dat" >> postinst
+	# Create scores file in a debscript, so an update to the package wouldn't erase any scores
+	echo "#!$TERMUX_PREFIX/bin/sh" > postinst
+	echo "DIR=$TERMUX_PREFIX/lib/games/moria" >> postinst
+	echo "mkdir -p \$DIR" >> postinst
+	echo "touch \$DIR/scores.dat" >> postinst
 	chmod 0755 postinst
+
+	# https://github.com/termux/termux-packages/issues/1401
+	echo "#!$TERMUX_PREFIX/bin/sh" > prerm
+	echo "cd $TERMUX_PREFIX/lib/games/moria || exit" >> prerm
+	echo "case \$1 in" >> prerm
+	echo "purge|remove)" >> prerm
+	echo "rm -f game.sav scores.dat" >> prerm
+	echo "esac" >> prerm
+	chmod 0755 prerm
 }


### PR DESCRIPTION
Fixes #1401

I initially tried to change the current `postinst` into `termux_step_post_massage` and use `TERMUX_PKG_CONFFILES` for `game.sav` and `scores.dat` to let package manager to deal with cleaning and directory sharing between packages

But it is less ideal as everytime you upgrade will be greeted with:
```
Configuration file '/data/data/com.termux/files/usr/lib/games/moria/scores.dat'
 ==> File on system created by you or by a script.
 ==> File also in package provided by package maintainer.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** scores.dat (Y/I/N/O/D/Z) [default=N] ?
```
Showing the difference is not intuitive as its comparing binary and empty files. It also doesn't help if user press Y when the default is N. So end up scrapping that idea.

Since the directory is no longer shared with other packages, change into using the simpler `prerm` method.