### PR TITLE
fix(main/boinc): make benchmark LTO resistant

### DIFF
--- a/packages/boinc/build.sh
+++ b/packages/boinc/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Open-source software for volunteer computing"
 TERMUX_PKG_LICENSE="LGPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=7.20.5
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/BOINC/boinc/archive/client_release/${TERMUX_PKG_VERSION:0:4}/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=34f32398ee5981fb3216b103271f0051c807e57c3368eb00654e5bbf89dc5065
 TERMUX_PKG_DEPENDS="libandroid-execinfo, libandroid-shmem, libc++, libcurl, openssl, zlib"

--- a/packages/boinc/client-cpu_benchmark.h.patch
+++ b/packages/boinc/client-cpu_benchmark.h.patch
@@ -1,0 +1,28 @@
+diff -uNr boinc/client/cpu_benchmark.h boinc.mod/client/cpu_benchmark.h
+--- boinc/client/cpu_benchmark.h	2022-12-02 17:15:26.000000000 +0800
++++ boinc.mod/client/cpu_benchmark.h	2022-12-30 12:31:58.195989823 +0800
+@@ -24,8 +24,8 @@
+ #define BM_TYPE_FP       0
+ #define BM_TYPE_INT      1
+ 
+-extern int dhrystone(double& vax_mips, double& loops, double& cpu_time, double min_cpu_time);
+-extern int whetstone(double& flops, double& cpu_time, double min_cpu_time);
++extern volatile int dhrystone(double& vax_mips, double& loops, double& cpu_time, double min_cpu_time);
++extern volatile int whetstone(double& flops, double& cpu_time, double min_cpu_time);
+ extern void benchmark_wait_to_start(int which);
+ extern bool benchmark_time_to_stop(int which);
+ 
+@@ -38,11 +38,11 @@
+ #endif // ANDROID_NEON
+ 
+ namespace android_neon {
+-    int whetstone(double& flops, double& cpu_time, double min_cpu_time);
++    volatile int whetstone(double& flops, double& cpu_time, double min_cpu_time);
+ }
+ 
+ namespace android_vfp {
+-    int whetstone(double& flops, double& cpu_time, double min_cpu_time);
++    volatile int whetstone(double& flops, double& cpu_time, double min_cpu_time);
+ }
+ 
+ #endif // ANDROID

--- a/packages/boinc/client-dhrystone.cpp.patch
+++ b/packages/boinc/client-dhrystone.cpp.patch
@@ -1,0 +1,80 @@
+diff -uNr boinc/client/dhrystone.cpp boinc.mod/client/dhrystone.cpp
+--- boinc/client/dhrystone.cpp	2022-12-02 17:15:26.000000000 +0800
++++ boinc.mod/client/dhrystone.cpp	2022-12-30 13:13:10.679988055 +0800
+@@ -63,20 +63,20 @@
+  */
+ 
+ 
+-void Proc_0();
+-void Proc_1(DS_DATA&, Rec_Pointer PtrParIn);
+-void Proc_2(DS_DATA&, One_Fifty *IntParIO);
+-void Proc_3(DS_DATA&, Rec_Pointer *PtrParOut);
+-void Proc_4(DS_DATA&);
+-void Proc_5(DS_DATA&);
+-void Proc_6(DS_DATA&, Enumeration EnumParIn, Enumeration *EnumParOut);
+-void Proc_7(One_Fifty IntParI1, One_Fifty IntParI2, One_Fifty *IntParOut);
+-void Proc_8(DS_DATA&, Arr_1_Dim Array1Par, Arr_2_Dim Array2Par, One_Fifty IntParI1, One_Fifty IntParI2);
++volatile void Proc_0();
++volatile void Proc_1(DS_DATA&, Rec_Pointer PtrParIn);
++volatile void Proc_2(DS_DATA&, One_Fifty *IntParIO);
++volatile void Proc_3(DS_DATA&, Rec_Pointer *PtrParOut);
++volatile void Proc_4(DS_DATA&);
++volatile void Proc_5(DS_DATA&);
++volatile void Proc_6(DS_DATA&, Enumeration EnumParIn, Enumeration *EnumParOut);
++volatile void Proc_7(One_Fifty IntParI1, One_Fifty IntParI2, One_Fifty *IntParOut);
++volatile void Proc_8(DS_DATA&, Arr_1_Dim Array1Par, Arr_2_Dim Array2Par, One_Fifty IntParI1, One_Fifty IntParI2);
+ Enumeration  Func_1(DS_DATA&, Capital_Letter , Capital_Letter );
+ bool      Func_2(DS_DATA&, Str_30 , Str_30 );
+ bool Func_3(Enumeration EnumParIn);
+ 
+-int dhrystone(
++volatile int dhrystone(
+    double& Vax_Mips, double& int_loops, double& int_time, double min_cpu_time
+ ){
+         One_Fifty       Int_1_Loc;
+@@ -181,7 +181,7 @@
+     return 0;
+ }
+ 
+-void Proc_1(DS_DATA& dd, REG Rec_Pointer Ptr_Val_Par)
++volatile void Proc_1(DS_DATA& dd, REG Rec_Pointer Ptr_Val_Par)
+ {
+   REG Rec_Pointer Next_Record = Ptr_Val_Par->Ptr_Comp;
+                                         /* == Ptr_Glob_Next */
+@@ -210,7 +210,7 @@
+     structassign (*Ptr_Val_Par, *Ptr_Val_Par->Ptr_Comp);
+ }
+ 
+-void Proc_2(DS_DATA& dd, One_Fifty *Int_Par_Ref)
++volatile void Proc_2(DS_DATA& dd, One_Fifty *Int_Par_Ref)
+ {
+   One_Fifty  Int_Loc;
+   Enumeration   Enum_Loc=Ident_1;
+@@ -227,7 +227,7 @@
+   while (Enum_Loc != Ident_1); /* true */
+ }
+ 
+-void Proc_3(DS_DATA& dd, Rec_Pointer *Ptr_Ref_Par)
++volatile void Proc_3(DS_DATA& dd, Rec_Pointer *Ptr_Ref_Par)
+ {
+   if (Ptr_Glob != NULL)
+     /* then, executed */
+@@ -235,7 +235,7 @@
+   Proc_7 (10, Int_Glob, &Ptr_Glob->variant.var_1.Int_Comp);
+ }
+ 
+-void Proc_4(DS_DATA& dd)
++volatile void Proc_4(DS_DATA& dd)
+ {
+   bool Bool_Loc;
+ 
+@@ -244,7 +244,7 @@
+   Ch_2_Glob = 'B';
+ }
+ 
+-void Proc_5(DS_DATA& dd)
++volatile void Proc_5(DS_DATA& dd)
+ {
+         Ch_1_Glob = 'A';
+         Bool_Glob = FALSE;
+

--- a/packages/boinc/client-whetstone.cpp.patch
+++ b/packages/boinc/client-whetstone.cpp.patch
@@ -1,0 +1,46 @@
+diff -uNr boinc/client/whetstone.cpp boinc.mod/client/whetstone.cpp
+--- boinc/client/whetstone.cpp	2022-12-02 17:15:26.000000000 +0800
++++ boinc.mod/client/whetstone.cpp	2022-12-30 12:50:30.379989028 +0800
+@@ -54,12 +54,12 @@
+ // don't do away with their computation.
+ // suggested by Ben Herndon
+ //
+-double extern_array[12];
++volatile double extern_array[12];
+ 
+ // #pragma intrinsic (sin, cos, tan, atan, sqrt, exp, log)
+ 
+ 
+-void pa(SPDP e[4], SPDP t, SPDP t2)
++volatile void pa(SPDP e[4], SPDP t, SPDP t2)
+       {
+      long j;
+      for(j=0;j<6;j++)
+@@ -73,7 +73,7 @@
+      return;
+ }
+ 
+-void po(SPDP e1[4], long j, long k, long l)
++volatile void po(SPDP e1[4], long j, long k, long l)
+       {
+      e1[j] = e1[k];
+      e1[k] = e1[l];
+@@ -81,7 +81,7 @@
+      return;
+ }
+ 
+-void p3(SPDP *x, SPDP *y, SPDP *z, SPDP t, SPDP t1, SPDP t2)
++volatile void p3(SPDP *x, SPDP *y, SPDP *z, SPDP t, SPDP t1, SPDP t2)
+       {
+      *x = *y;
+      *y = *z;
+@@ -93,7 +93,7 @@
+ 
+ // return an error if CPU time is less than min_cpu_time
+ //
+-int whetstone(double& flops, double& cpu_time, double min_cpu_time) {
++volatile int whetstone(double& flops, double& cpu_time, double min_cpu_time) {
+     long n1,n2,n3,n4,n5,n6,n7,n8,i,ix,n1mult;
+     SPDP x,y,z;
+     long j,k,l, jjj;
+


### PR DESCRIPTION
My poor attempt on fixing this issue by slapping `volatile` in the code which actually works.
I dont understand why this does not happen on Fedora which supposedly turn on LTO everywhere...