### PR TITLE
newsboat: re-add iconv dependency

### DIFF
--- a/packages/newsboat/build.sh
+++ b/packages/newsboat/build.sh
@@ -3,12 +3,13 @@ TERMUX_PKG_DESCRIPTION="RSS/Atom feed reader for the text console"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.30
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://newsboat.org/releases/${TERMUX_PKG_VERSION}/newsboat-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=e0ac957487d444cc6c4674e0dc82bbc8129b56a43ecd7ea9fc726c65e3b471d5
 TERMUX_PKG_DEPENDS="json-c, libandroid-glob, libandroid-support, libc++, libcurl, libsqlite, libxml2, ncurses, stfl"
 TERMUX_PKG_BUILD_DEPENDS="openssl"
 TERMUX_PKG_BUILD_IN_SRC=true
-TERMUX_PKG_RM_AFTER_INSTALL="share/locale"
+# TERMUX_PKG_RM_AFTER_INSTALL="share/locale"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="ac_cv_lib_bsd_main=no"
 TERMUX_PKG_CONFLICTS=newsbeuter
 TERMUX_PKG_REPLACES=newsbeuter
@@ -21,8 +22,6 @@ termux_step_pre_configure() {
 
 	# Used by newsboat Makefile:
 	export CARGO_BUILD_TARGET=$CARGO_TARGET_NAME
-
-	LDFLAGS+=" -liconv"
 
 	export PKG_CONFIG_ALLOW_CROSS=1
 }

--- a/packages/newsboat/rust-libnewsboat-src-utils.rs.patch
+++ b/packages/newsboat/rust-libnewsboat-src-utils.rs.patch
@@ -42,13 +42,10 @@
          }
      }
  
-@@ -987,7 +990,9 @@
-     let mut result = vec![];
+@@ -987,6 +990,7 @@
  
      let tocode_translit = translit(tocode, fromcode);
--
-+    
-+    result = tocode_translit.as_bytes().to_vec();
+ 
 +    /*
      // Illegal and incomplete multi-byte sequences will be replaced by this
      // placeholder. By default, we use an ASCII value for "question mark".


### PR DESCRIPTION
After it was (accidentally?) removed newsboat started having issues, see newsboat/newsboat#2299