### PR TITLE
fix(rust): patch unsupported dlopen flag

### DIFF
--- a/packages/rust/build.sh
+++ b/packages/rust/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Systems programming language focused on safety, speed an
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.66.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/rustc-$TERMUX_PKG_VERSION-src.tar.xz
 TERMUX_PKG_SHA256=0dc176e34fae9871f855a6ba4cb30fa19d69c5b4428d29281a07419c4950715c
 _LLVM_MAJOR_VERSION=$(. $TERMUX_SCRIPTDIR/packages/libllvm/build.sh; echo $LLVM_MAJOR_VERSION)

--- a/packages/rust/dlopen.patch
+++ b/packages/rust/dlopen.patch
@@ -1,0 +1,13 @@
+--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib.rs
++++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib.rs
+@@ -71,9 +71,8 @@ fn load_library(file: &Path) -> Result<Library, libloading::Error> {
+     use std::os::raw::c_int;
+ 
+     const RTLD_NOW: c_int = 0x00002;
+-    const RTLD_DEEPBIND: c_int = 0x00008;
+ 
+-    unsafe { UnixLibrary::open(Some(file), RTLD_NOW | RTLD_DEEPBIND).map(|lib| lib.into()) }
++    unsafe { UnixLibrary::open(Some(file), RTLD_NOW).map(|lib| lib.into()) }
+ }
+ 
+ #[derive(Debug)]


### PR DESCRIPTION
`rust-analyzer` uses an [unsupported](https://github.com/termux/termux-packages/wiki/Common-porting-problems#dlopen-and-rtld_-flags) `dlopen` flag `RTLD_DEEPBIND`, causing many proc macros (e.g. `tokio::main`) to get errors and not expanded, resulting in an inferior Rust development experience on Termux - `rust-analyzer` doesn't even work on a `#[tokio::main]` hello-world application.

This PR fixes the issue by removing the flag for good.

Instead of patching `rust-analyzer`, I'm patching the `rust` package first, because the `rust` package ships a `rust-analyzer-proc-macro-srv` binary, which is used by `rust-analyzer` by default (RA falls back to using itself only when it cannot find the preinstalled srv binary), no matter how `rust-analyzer` itself is installed.

Tested on my phone, proc macros work good with the patched `rust` package.