### PR TITLE
photon-rss, ratt: Restore `termux_step_post_get_source`

### DIFF
--- a/packages/photon-rss/build.sh
+++ b/packages/photon-rss/build.sh
@@ -9,6 +9,18 @@ TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_MAKE_ARGS="PREFIX=$TERMUX_PREFIX"
 
+termux_step_post_get_source() {
+	git fetch --unshallow
+	git checkout $_COMMIT
+
+	local version="$(git log -1 --format=%cs | sed 's/-/./g')"
+	if [ "$version" != "$TERMUX_PKG_VERSION" ]; then
+		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
+		echo " is different from what is expected to be: \"$version\""
+		return 1
+	fi
+}
+
 termux_step_pre_configure() {
 	termux_setup_golang
 

--- a/packages/ratt/build.sh
+++ b/packages/ratt/build.sh
@@ -9,6 +9,18 @@ TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_MAKE_ARGS="PREFIX=$TERMUX_PREFIX"
 
+termux_step_post_get_source() {
+	git fetch --unshallow
+	git checkout $_COMMIT
+
+	local version="$(git log -1 --format=%cs | sed 's/-/./g')"
+	if [ "$version" != "$TERMUX_PKG_VERSION" ]; then
+		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
+		echo " is different from what is expected to be: \"$version\""
+		return 1
+	fi
+}
+
 termux_step_pre_configure() {
 	termux_setup_golang
 


### PR DESCRIPTION
as a follow-up of commit 3ec82277d7773e29aac53d525fdf519f74246bd4.

%ci:no-build