### PR TITLE
ndk-sysroot: Add workaround for case-insensitive filesystem

### DIFF
--- a/packages/ndk-sysroot/postinst.in
+++ b/packages/ndk-sysroot/postinst.in
@@ -1,0 +1,7 @@
+#!@TERMUX_PREFIX@/bin/sh
+
+for f in @NF_SUPPL_FILES@; do
+	if [ ! -e "@TERMUX_PREFIX@/${f}" ]; then
+		ln -sf "@NF_SUPPL_PREFIX@/${f}" "@TERMUX_PREFIX@/${f}"
+	fi
+done

--- a/packages/ndk-sysroot/prerm.in
+++ b/packages/ndk-sysroot/prerm.in
@@ -1,0 +1,7 @@
+#!@TERMUX_PREFIX@/bin/sh
+
+for f in @NF_SUPPL_FILES@; do
+	if [ -L "@TERMUX_PREFIX@/${f}" ]; then
+		rm -f "@TERMUX_PREFIX@/${f}"
+	fi
+done


### PR DESCRIPTION
Ref #13188

Not for merge until tested on case-insensitive filesystems.