### PR TITLE
snapcast-server: Fix build with Boost 1.81.0

### DIFF
--- a/packages/snapcast-server/snapcast-0.26.0-boost-1.81.0.patch
+++ b/packages/snapcast-server/snapcast-0.26.0-boost-1.81.0.patch
@@ -1,0 +1,52 @@
+From 853c3f622ff2262b56681ee04dd20b4266c72493 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Wed, 21 Dec 2022 11:31:29 +0000
+Subject: [PATCH] server/control_session_http: update for boost 1.81.0
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ server/control_session_http.cpp | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/server/control_session_http.cpp b/server/control_session_http.cpp
+index 385b3197..6522f5a9 100644
+--- a/server/control_session_http.cpp
++++ b/server/control_session_http.cpp
+@@ -127,8 +127,8 @@ boost::beast::string_view mime_type(boost::beast::string_view path)
+ std::string path_cat(boost::beast::string_view base, boost::beast::string_view path)
+ {
+     if (base.empty())
+-        return path.to_string();
+-    std::string result = base.to_string();
++        return static_cast<std::string>(path);
++    std::string result = static_cast<std::string>(base);
+     char constexpr path_separator = '/';
+     if (result.back() == path_separator)
+         result.resize(result.size() - 1);
+@@ -171,7 +171,7 @@ void ControlSessionHttp::handle_request(http::request<Body, http::basic_fields<A
+         res.set(http::field::server, HTTP_SERVER_NAME);
+         res.set(http::field::content_type, "text/html");
+         res.keep_alive(req.keep_alive());
+-        res.body() = why.to_string();
++        res.body() = static_cast<std::string>(why);
+         res.prepare_payload();
+         return res;
+     };
+@@ -182,7 +182,7 @@ void ControlSessionHttp::handle_request(http::request<Body, http::basic_fields<A
+         res.set(http::field::server, HTTP_SERVER_NAME);
+         res.set(http::field::content_type, "text/html");
+         res.keep_alive(req.keep_alive());
+-        res.body() = "The resource '" + target.to_string() + "' was not found.";
++        res.body() = "The resource '" + static_cast<std::string>(target) + "' was not found.";
+         res.prepare_payload();
+         return res;
+     };
+@@ -204,7 +204,7 @@ void ControlSessionHttp::handle_request(http::request<Body, http::basic_fields<A
+         res.set(http::field::server, HTTP_SERVER_NAME);
+         res.set(http::field::content_type, "text/html");
+         res.keep_alive(req.keep_alive());
+-        res.body() = "An error occurred: '" + what.to_string() + "'";
++        res.body() = "An error occurred: '" + static_cast<std::string>(what) + "'";
+         res.prepare_payload();
+         return res;
+     };


### PR DESCRIPTION
- [x] assimp
- [x] botan
- [x] crypto-monitor
- [x] enblend
- [x] libasio
- [x] libmsgpack-cxx
- [x] libosmium
- [x] libtins
- [x] mpd
- [x] mpdscribble
- [x] openbabel
- [x] poppler
- [ ] ~~snapcast-server~~
- [x] stuntman
- [x] taglib
- [x] abiword
- [x] ardour
- [x] fritzing
- [x] lyx
- [x] mumble-server
- [x] poppler-qt