### PR TITLE
bump(main/pacman): updating server links to repos and adding email to TERMUX_PKG_MAINTAINER

### DIFF
--- a/packages/pacman/build.sh
+++ b/packages/pacman/build.sh
@@ -1,9 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://archlinux.org/pacman/
 TERMUX_PKG_DESCRIPTION="A library-based package manager with dependency support"
 TERMUX_PKG_LICENSE="GPL-2.0"
-TERMUX_PKG_MAINTAINER="@Maxython"
+TERMUX_PKG_MAINTAINER="@Maxython <mixython@gmail.com>"
 TERMUX_PKG_VERSION=6.0.2
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://sources.archlinux.org/other/pacman/pacman-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=7d8e3e8c5121aec0965df71f59bedf46052c6cf14f96365c4411ec3de0a4c1a5
 TERMUX_PKG_DEPENDS="bash, libarchive, curl, gpgme, openssl, termux-licenses"

--- a/packages/pacman/pacman.conf.in.patch
+++ b/packages/pacman/pacman.conf.in.patch
@@ -64,16 +64,16 @@ diff -uNr pacman-6.0.2/etc/pacman.conf.in pacman-6.0.2/etc/pacman.conf.in.patch
 -#SigLevel = Optional TrustAll
 -#Server = file:///home/custompkgs
 +[main]
-+Server = https://s3.amazonaws.com/termux-pacman.us/main/$arch
++Server = https://service.termux-pacman.dev/main/$arch
 +
 +[x11]
-+Server = https://s3.amazonaws.com/termux-pacman.us/x11/$arch
++Server = https://service.termux-pacman.dev/x11/$arch
 +
 +[root]
-+Server = https://s3.amazonaws.com/termux-pacman.us/root/$arch
++Server = https://service.termux-pacman.dev/root/$arch
 +
 +[tur]
-+Server = https://s3.amazonaws.com/termux-pacman.us/tur/$arch
++Server = https://service.termux-pacman.dev/tur/$arch
 +
 +[tur-continuous]
-+Server = https://s3.amazonaws.com/termux-pacman.us/tur-continuous/$arch
++Server = https://service.termux-pacman.dev/tur-continuous/$arch


### PR DESCRIPTION
The `pacman` package manager now has a plain format domain with faster download speeds. The old links (`s3.amazonaws.com/termux-pacman.us/...`) will still work, but I recommend using the new ones.