### PR TITLE
tree-wide: make python packages use termux_setup_python_pip (part 2)

### DIFF
--- a/packages/2ping/build.sh
+++ b/packages/2ping/build.sh
@@ -3,34 +3,14 @@ TERMUX_PKG_DESCRIPTION="A bi-directional ping utility"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=4.5.1
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://github.com/rfinnie/2ping/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=0f85dc21be1266daccfbba903819ca8935ebdbe002b1e0305bfda258af44fdcd
 TERMUX_PKG_DEPENDS="python"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_PYTHON_COMMON_DEPS="wheel"
 
-_PYTHON_VERSION=$(. $TERMUX_SCRIPTDIR/packages/python/build.sh; echo $_MAJOR_VERSION)
-
-termux_step_pre_configure() {
-	termux_setup_python_crossenv
-	pushd $TERMUX_PYTHON_CROSSENV_SRCDIR
-	_CROSSENV_PREFIX=$TERMUX_PKG_BUILDDIR/python-crossenv-prefix
-	python${_PYTHON_VERSION} -m crossenv \
-		$TERMUX_PREFIX/bin/python${_PYTHON_VERSION} \
-		${_CROSSENV_PREFIX}
-	popd
-	. ${_CROSSENV_PREFIX}/bin/activate
-	build-pip install wheel
-}
-
-termux_step_make() {
-	:
-}
-
-termux_step_make_install() {
-	export PYTHONPATH=$TERMUX_PREFIX/lib/python${_PYTHON_VERSION}/site-packages
-	pip install --no-deps . --prefix $TERMUX_PREFIX
-
+termux_step_post_make_install() {
 	install -Dm600 -t $TERMUX_PREFIX/share/man/man1 doc/2ping.1
 }

--- a/packages/python-apt/build.sh
+++ b/packages/python-apt/build.sh
@@ -7,24 +7,4 @@ TERMUX_PKG_SRCURL=https://ftp.debian.org/debian/pool/main/p/python-apt/python-ap
 TERMUX_PKG_SHA256=07ece069cdc9f5523a405f46ab5437260dca5e34909601c4540f160c476bb982
 TERMUX_PKG_DEPENDS="apt, build-essential, libc++, python, texinfo"
 TERMUX_PKG_BUILD_IN_SRC=true
-
-_PYTHON_VERSION=$(. $TERMUX_SCRIPTDIR/packages/python/build.sh; echo $_MAJOR_VERSION)
-
-termux_step_pre_configure() {
-	termux_setup_python_crossenv
-	pushd $TERMUX_PYTHON_CROSSENV_SRCDIR
-	_CROSSENV_PREFIX=$TERMUX_PKG_BUILDDIR/python-crossenv-prefix
-	python${_PYTHON_VERSION} -m crossenv \
-		$TERMUX_PREFIX/bin/python${_PYTHON_VERSION} \
-		${_CROSSENV_PREFIX}
-	popd
-	. ${_CROSSENV_PREFIX}/bin/activate
-	build-pip install wheel
-
-	LDFLAGS+=" -lpython${_PYTHON_VERSION}"
-}
-
-termux_step_make_install() {
-	DEBVER=$TERMUX_PKG_VERSION \
-		python setup.py install --force --prefix $TERMUX_PREFIX
-}
+TERMUX_PKG_PYTHON_COMMON_DEPS="wheel"

--- a/packages/python-cryptography/build.sh
+++ b/packages/python-cryptography/build.sh
@@ -11,41 +11,25 @@ TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="openssl, python"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
-
-_PYTHON_VERSION=$(. $TERMUX_SCRIPTDIR/packages/python/build.sh; echo $_MAJOR_VERSION)
+TERMUX_PKG_PYTHON_COMMON_DEPS="wheel, cffi, setuptools-rust"
+TERMUX_PKG_PYTHON_TARGET_DEPS="'cffi>=1.12'"
 
 termux_step_post_get_source() {
 	echo "Applying openssl-libs.diff"
-	sed "s%@PYTHON_VERSION@%$_PYTHON_VERSION%g" \
+	sed "s%@PYTHON_VERSION@%$TERMUX_PYTHON_VERSION%g" \
 		$TERMUX_PKG_BUILDER_DIR/openssl-libs.diff | patch --silent -p1
 }
 
-termux_step_pre_configure() {
+termux_step_configure() {
 	termux_setup_rust
-
-	termux_setup_python_crossenv
-	pushd $TERMUX_PYTHON_CROSSENV_SRCDIR
-	_CROSSENV_PREFIX=$TERMUX_PKG_BUILDDIR/python-crossenv-prefix
-	python${_PYTHON_VERSION} -m crossenv \
-		$TERMUX_PREFIX/bin/python${_PYTHON_VERSION} \
-		${_CROSSENV_PREFIX}
-	popd
-	. ${_CROSSENV_PREFIX}/bin/activate
-
-	build-pip install wheel cffi setuptools-rust
-}
-
-termux_step_make_install() {
 	export CARGO_BUILD_TARGET=${CARGO_TARGET_NAME}
-	export PYO3_CROSS_LIB_DIR=$TERMUX_PREFIX/lib
-	export PYTHONPATH=$TERMUX_PREFIX/lib/python${_PYTHON_VERSION}/site-packages
-	pip install --no-deps . --prefix $TERMUX_PREFIX
+        export PYO3_CROSS_LIB_DIR=$TERMUX_PREFIX/lib
 }
 
 termux_step_create_debscripts() {
 	cat <<- EOF > ./postinst
 	#!$TERMUX_PREFIX/bin/sh
 	echo "Installing dependencies through pip..."
-	pip3 install --no-binary cffi 'cffi>=1.12'
+	pip3 install --no-binary $TERMUX_PKG_PYTHON_TARGET_DEPS
 	EOF
 }


### PR DESCRIPTION
This happened because I didn't separate the packages correctly.

Close #14586