### PR TITLE
gforth: Fix alignment of magic in `*.fi`

### DIFF
--- a/packages/gforth/build.sh
+++ b/packages/gforth/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="The Forth implementation of the GNU project"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.7.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://ftp.gnu.org/gnu/gforth/gforth-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=2f62f2233bf022c23d01c920b1556aa13eab168e3236b13352ac5e9f18542bb0
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -40,4 +41,30 @@ termux_step_pre_configure() {
 termux_step_post_configure() {
 	sed -i -e 's:\.\(/gforth-ditc\):'$TERMUX_PKG_HOSTBUILD_DIR'\1:g' \
 		Makefile
+}
+
+termux_step_post_massage() {
+	# Alignment of magic can be broken by shebang fix:
+	# https://github.com/termux/termux-packages/issues/14648
+	local f
+	for f in $(find ./lib/gforth ./share/gforth -type f -name '*.fi'); do
+		if [ $(head -c 2 "${f}") != '#!' ]; then
+			continue
+		fi
+		local c1=$(head -n 1 "${f}" | wc -c)
+		local c2=$(tail -c +$((c1+1)) "${f}" | head -c 16 | \
+				sed -n 's/Gforth3.*//p' | wc -c)
+		local p=$(( (8-(c1+c2)%8)%8 ))
+		if [ ${p} -ne 0 ]; then
+			echo "Fixing alignment of magic in ${f}"
+			head -c ${c1} "${f}" > "${f}".new
+			local i
+			for i in $(seq ${p}); do
+				echo -n " " >> "${f}".new
+			done
+			tail -c +$((c1+1)) "${f}" >> "${f}".new
+			rm -f "${f}"
+			mv "${f}".new "${f}"
+		fi
+	done
 }

--- a/scripts/build/termux_step_massage.sh
+++ b/scripts/build/termux_step_massage.sh
@@ -36,7 +36,7 @@ termux_step_massage() {
 	if [ "$TERMUX_PKG_NO_SHEBANG_FIX" != "true" ]; then
 		# Fix shebang paths:
 		while IFS= read -r -d '' file; do
-			if head -c 100 "$file" | grep -E "^#!.*/bin/.*" | grep -q -E -v "^#! ?/system"; then
+			if head -c 100 "$file" | head -n 1 | grep -E "^#!.*/bin/.*" | grep -q -E -v "^#! ?/system"; then
 				sed --follow-symlinks -i -E "1 s@^#\!(.*)/bin/(.*)@#\!$TERMUX_PREFIX/bin/\2@" "$file"
 			fi
 		done < <(find -L . -type f -print0)

--- a/scripts/build/termux_step_massage.sh
+++ b/scripts/build/termux_step_massage.sh
@@ -36,8 +36,9 @@ termux_step_massage() {
 	if [ "$TERMUX_PKG_NO_SHEBANG_FIX" != "true" ]; then
 		# Fix shebang paths:
 		while IFS= read -r -d '' file; do
-			head -c 100 "$file" | grep -E "^#!.*/bin/.*" | grep -q -E -v "^#! ?/system" &&
+			if head -c 100 "$file" | grep -E "^#!.*/bin/.*" | grep -q -E -v "^#! ?/system"; then
 				sed --follow-symlinks -i -E "1 s@^#\!(.*)/bin/(.*)@#\!$TERMUX_PREFIX/bin/\2@" "$file"
+			fi
 		done < <(find -L . -type f -print0)
 	fi
 


### PR DESCRIPTION
Also fixes logic of shebang fix in `termux_step_massage`.