### PR TITLE
chore(main/{apt,{root,x11}-repo}): use cloudflare proxy by default

### DIFF
--- a/packages/apt/build.sh
+++ b/packages/apt/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Front-end for the dpkg package manager"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.5.5
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://deb.debian.org/debian/pool/main/a/apt/apt_${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=711d22c529efca3e9943dad989e9715ebf097e630928daeedd2fbe587e0efd85
 # apt-key requires utilities from coreutils, findutils, gpgv, grep, sed.
@@ -71,10 +72,10 @@ termux_step_pre_configure() {
 
 termux_step_post_make_install() {
 	{
-		echo "# The main termux repository, behind cloudflare cache:"
-		echo "# deb https://packages-cf.termux.dev/apt/termux-main/ stable main"
-		echo "# The main termux repository:"
-		echo "deb https://packages.termux.dev/apt/termux-main/ stable main"
+		echo "# The main termux repository, with cloudflare cache"
+		echo "deb https://packages-cf.termux.dev/apt/termux-main/ stable main"
+		echo "# The main termux repository, without cloudflare cache"
+		echo "# deb https://packages.termux.dev/apt/termux-main/ stable main"
 	} > $TERMUX_PREFIX/etc/apt/sources.list
 
 	# apt-transport-tor

--- a/packages/root-repo/build.sh
+++ b/packages/root-repo/build.sh
@@ -3,13 +3,19 @@ TERMUX_PKG_DESCRIPTION="Package repository containing programs for rooted device
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
 TERMUX_PKG_VERSION=2.4
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_DEPENDS="termux-keyring"
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 
 termux_step_make_install() {
 	mkdir -p $TERMUX_PREFIX/etc/apt/sources.list.d
-	echo "deb https://packages.termux.dev/apt/termux-root root stable" > $TERMUX_PREFIX/etc/apt/sources.list.d/root.list
+	{
+		echo "# The root termux repository, with cloudflare cache"
+		echo "deb https://packages-cf.termux.dev/apt/termux-main/ root stable"
+		echo "# The root termux repository, without cloudflare cache"
+		echo "# deb https://packages.termux.dev/apt/termux-main/ root stable"
+	} > $TERMUX_PREFIX/etc/apt/sources.list.d/root.list
 }
 
 termux_step_create_debscripts() {

--- a/packages/x11-repo/build.sh
+++ b/packages/x11-repo/build.sh
@@ -3,13 +3,19 @@ TERMUX_PKG_DESCRIPTION="Package repository containing X11 programs and libraries
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=8.4
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_DEPENDS="termux-keyring"
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 
 termux_step_make_install() {
 	mkdir -p $TERMUX_PREFIX/etc/apt/sources.list.d
-	echo "deb https://packages.termux.dev/apt/termux-x11 x11 main" > $TERMUX_PREFIX/etc/apt/sources.list.d/x11.list
+	{
+		echo "# The x11 termux repository, with cloudflare cache"
+		echo "deb https://packages-cf.termux.dev/apt/termux-x11/ x11 main"
+		echo "# The x11 termux repository, without cloudflare cache"
+		echo "# deb https://packages.termux.dev/apt/termux-x11/ x11 main"
+	} > $TERMUX_PREFIX/etc/apt/sources.list.d/x11.list
 }
 
 termux_step_create_debscripts() {


### PR DESCRIPTION
Referencing to
https://github.com/termux/termux-tools/commit/311ac5c9824792945bb9cefccd185d5e3a38b86d.
This should hopefully help reduce the amount of bandwidth consumed by
out Hetzner instance.

Some rough statistics (proper ones would require some scripts to be run
on the server, I just got to lazy to write something that could work):

Cloudflare cached content accounts for only about 14.9% of the total
amount of requests. This change should increase this number in the long
run
