### PR TITLE
pcsx-rearmed: Refactor `build.sh`

### DIFF
--- a/x11-packages/pcsx-rearmed/build.sh
+++ b/x11-packages/pcsx-rearmed/build.sh
@@ -12,9 +12,8 @@ TERMUX_PKG_BUILD_DEPENDS="mesa-dev, binutils-cross"
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_pre_configure() {
-	CFLAGS+=" -I$TERMUX_PREFIX/include"
+	CFLAGS+=" $CPPFLAGS"
 	if [ "$TERMUX_ARCH" = "arm" ]; then
-		CFLAGS+=" -fno-integrated-as"
 		termux_setup_no_integrated_as
 	fi
 }
@@ -24,9 +23,9 @@ termux_step_configure() {
 }
 
 termux_step_make_install() {
-	install -Dm755 pcsx ${PREFIX}/bin/pcsx
-	mkdir -p ${PREFIX}/etc/pcsx ${PREFIX}/lib/pcsx_plugins
-	cp -r frontend/pandora/skin ${PREFIX}/etc/pcsx/
-	install -m755 plugins/*.so ${PREFIX}/lib/pcsx_plugins/
-	ln -fs ../../lib/pcsx_plugins ${PREFIX}/etc/pcsx/plugins
+	install -Dm755 pcsx $TERMUX_PREFIX/bin/pcsx
+	mkdir -p $TERMUX_PREFIX/etc/pcsx $TERMUX_PREFIX/lib/pcsx_plugins
+	cp -r frontend/pandora/skin $TERMUX_PREFIX/etc/pcsx/
+	install -m755 plugins/*.so $TERMUX_PREFIX/lib/pcsx_plugins/
+	ln -fs ../../lib/pcsx_plugins $TERMUX_PREFIX/etc/pcsx/plugins
 }


### PR DESCRIPTION
Use of `PREFIX` is not standard. `TERMUX_PREFIX` should be used instead.

%ci:no-build