### PR TITLE
new package: opengl

### DIFF
--- a/packages/opengl/build.sh
+++ b/packages/opengl/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/termux/termux-packages
+TERMUX_PKG_DESCRIPTION="A metapackage for OpenGL implementation"
+TERMUX_PKG_LICENSE="Public Domain"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=0.1
+TERMUX_PKG_SKIP_SRC_EXTRACT=true
+TERMUX_PKG_DEPENDS="libglvnd, mesa"
+TERMUX_PKG_METAPACKAGE=true
+TERMUX_PKG_PLATFORM_INDEPENDENT=true


### PR DESCRIPTION
to be specified as a dependency of packages that require `lib/libGL.so` and friends.

Currently `lib/libGL.so` is provided by `libglvnd` package. Depending on `libglvnd`, however, would not work, because `libglvnd` does not depend on any provider of OpenGL implementation (`mesa` is a recommendation.) At least one provider should be hard-depended on, not only recommended.

See also #14785.