### PR TITLE
mumble-server: Bump to 1.5.517

### DIFF
--- a/x11-packages/mumble-server/build.sh
+++ b/x11-packages/mumble-server/build.sh
@@ -2,33 +2,24 @@ TERMUX_PKG_HOMEPAGE=https://www.mumble.info/
 TERMUX_PKG_DESCRIPTION="Server module for Mumble, an open source voice-chat software"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1.4.287
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION=1.5.517
 TERMUX_PKG_SRCURL=git+https://github.com/mumble-voip/mumble
-TERMUX_PKG_DEPENDS="libc++, libcap, libdns-sd, libprotobuf, openssl-1.1, qt5-qtbase"
+TERMUX_PKG_DEPENDS="libc++, libcap, libdns-sd, libprotobuf, openssl, qt5-qtbase"
 TERMUX_PKG_BUILD_DEPENDS="boost, boost-headers, qt5-qtbase-cross-tools"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dclient=OFF
 -Dice=OFF
 -Doverlay=OFF
 -Dwarnings-as-errors=OFF
--DOPENSSL_INCLUDE_DIR=$TERMUX_PREFIX/include/openssl-1.1
--DOPENSSL_LIBRARIES=$TERMUX_PREFIX/lib/openssl-1.1
--DOPENSSL_CRYPTO_LIBRARY=$TERMUX_PREFIX/lib/openssl-1.1/libcrypto.so.1.1
--DOPENSSL_SSL_LIBRARY=$TERMUX_PREFIX/lib/openssl-1.1/libssl.so.1.1
+"
+TERMUX_PKG_RM_AFTER_INSTALL="
+etc/systemd
 "
 
 termux_step_pre_configure() {
 	termux_setup_protobuf
 
 	LDFLAGS+=" -lcap"
-
-	CFLAGS="-I$TERMUX_PREFIX/include/openssl-1.1 $CFLAGS"
-	CPPFLAGS="-I$TERMUX_PREFIX/include/openssl-1.1 $CPPFLAGS"
-	CXXFLAGS="-I$TERMUX_PREFIX/include/openssl-1.1 $CXXFLAGS"
-	LDFLAGS="-L$TERMUX_PREFIX/lib/openssl-1.1 -Wl,-rpath=$TERMUX_PREFIX/lib/openssl-1.1 $LDFLAGS"
-	
-
 }
 
 termux_step_post_configure() {
@@ -40,9 +31,7 @@ termux_step_post_configure() {
 
 termux_step_post_make_install() {
 	ln -sfT mumble-server $TERMUX_PREFIX/bin/murmurd
-	cd $TERMUX_PKG_SRCDIR/scripts
-	install -Dm600 -t $TERMUX_PREFIX/etc/dbus-1/system.d murmur.conf
-	install -Dm600 -t $TERMUX_PREFIX/etc murmur.ini
-	install -Dm700 -t $TERMUX_PREFIX/bin mumble-server-user-wrapper
-	install -Dm600 -t $TERMUX_PREFIX/share/doc/mumble-server/examples murmur.ini
+	install -Dm600 -t $TERMUX_PREFIX/share/doc/mumble-server/examples \
+		$TERMUX_PKG_SRCDIR/auxiliary_files/mumble-server.ini
+	chmod 0700 $TERMUX_PREFIX/bin/mumble-server-user-wrapper
 }

--- a/x11-packages/mumble-server/scripts-mumble-server-user-wrapper.patch
+++ b/x11-packages/mumble-server/scripts-mumble-server-user-wrapper.patch
@@ -1,9 +1,9 @@
---- a/scripts/mumble-server-user-wrapper
-+++ b/scripts/mumble-server-user-wrapper
+--- a/auxiliary_files/run_scripts/mumble-server-user-wrapper.in
++++ b/auxiliary_files/run_scripts/mumble-server-user-wrapper.in
 @@ -6,7 +6,7 @@
  # Mumble source tree or at <https://www.mumble.info/LICENSE>.
  
- DIR=$HOME/murmur
+ DIR=$HOME/mumble-server
 -SYSDIR=/usr/share/doc/mumble-server/examples
 +SYSDIR=@TERMUX_PREFIX@/share/doc/mumble-server/examples
  
@@ -13,28 +13,28 @@
  DBUSFILE=$DIR/.dbus.sh
  
  if [ $DO_KILL == 1 ]; then
--	if pkill -U $UID -u $EUID -o -x -f "/usr/sbin/murmurd -ini $DIR/murmur.ini"; then
-+	if pkill -U $UID -u $EUID -o -x -f "@TERMUX_PREFIX@/bin/murmurd -ini $DIR/murmur.ini"; then
+-	if pkill -U $UID -u $EUID -o -x -f "/usr/sbin/@MUMBLE_SERVER_BINARY_NAME@ -ini $DIR/mumble-server.ini"; then
++	if pkill -U $UID -u $EUID -o -x -f "@TERMUX_PREFIX@/bin/@MUMBLE_SERVER_BINARY_NAME@ -ini $DIR/mumble-server.ini"; then
  		echo "Termination signal sent"
  	else
- 		echo "Murmur process not found; not terminated"
+ 		echo "Mumble server process not found; not terminated"
 @@ -82,11 +82,11 @@
  
  if [ "X$SETPW" != "X" ]; then
  	echo "Setting superuser password to \"$SETPW\""
--	/usr/sbin/murmurd -ini $DIR/murmur.ini -supw $SETPW
-+	@TERMUX_PREFIX@/bin/murmurd -ini $DIR/murmur.ini -supw $SETPW
+-	/usr/sbin/@MUMBLE_SERVER_BINARY_NAME@ -ini $DIR/mumble-server.ini -supw $SETPW
++	@TERMUX_PREFIX@/bin/@MUMBLE_SERVER_BINARY_NAME@ -ini $DIR/mumble-server.ini -supw $SETPW
  	exit 0
  fi
  
--PID=$(pgrep -U $UID -u $EUID -o -x -f "/usr/sbin/murmurd -ini $DIR/murmur.ini")
-+PID=$(pgrep -U $UID -u $EUID -o -x -f "@TERMUX_PREFIX@/bin/murmurd -ini $DIR/murmur.ini")
+-PID=$(pgrep -U $UID -u $EUID -o -x -f "/usr/sbin/@MUMBLE_SERVER_BINARY_NAME@ -ini $DIR/mumble-server.ini")
++PID=$(pgrep -U $UID -u $EUID -o -x -f "@TERMUX_PREFIX@/bin/@MUMBLE_SERVER_BINARY_NAME@ -ini $DIR/mumble-server.ini")
  
  if [ $DO_STATUS == 1 ]; then
  	if [ "X$PID" != "X" ]; then
 @@ -117,4 +117,4 @@
  fi
  
- echo "Starting Murmur"
--exec /usr/sbin/murmurd -ini $DIR/murmur.ini
-+exec @TERMUX_PREFIX@/bin/murmurd -ini $DIR/murmur.ini
+ echo "Starting Mumble server"
+-exec /usr/sbin/@MUMBLE_SERVER_BINARY_NAME@ -ini $DIR/mumble-server.ini
++exec @TERMUX_PREFIX@/bin/@MUMBLE_SERVER_BINARY_NAME@ -ini $DIR/mumble-server.ini


### PR DESCRIPTION
an RC but significant as the first version that supports OpenSSL 3.0.