### PR TITLE
python-numpy: Remove dep on libandroid-complex-math

### DIFF
--- a/packages/python-numpy/build.sh
+++ b/packages/python-numpy/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.24.1"
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/numpy/numpy
-TERMUX_PKG_DEPENDS="libandroid-complex-math, libc++, libopenblas, python"
+TERMUX_PKG_DEPENDS="libc++, libopenblas, python"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="latest-release-tag"
@@ -14,8 +14,8 @@ TERMUX_PKG_RM_AFTER_INSTALL="
 bin/
 "
 
-LDFLAGS+="-landroid-complex-math -lm"
-
 termux_step_pre_configure() {
 	export MATHLIB="m"
+
+	LDFLAGS+=" -lm"
 }


### PR DESCRIPTION
The issue described in commit b3b1092640bcb575b14a5f2207026378e3c0fa38 is resolved upstream in version 1.24.1.

See also: https://github.com/numpy/numpy/issues/22850

%ci:no-build