### PR TITLE
fix(main/frp): upgrade quic-go to 0.32.0

### DIFF
--- a/packages/frp/build.sh
+++ b/packages/frp/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A fast reverse proxy to expose a local server behind a N
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="2096779623 <admin@utermux.dev>"
 TERMUX_PKG_VERSION="0.46.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/fatedier/frp/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=af3e8d9d4144cf520cee2609cd45fb575afe711c03cc7441dc89d0402628a869
 # Depend on its subpackages.

--- a/packages/frp/upstream-upgrade-quic-go-to-0.32.0.patch
+++ b/packages/frp/upstream-upgrade-quic-go-to-0.32.0.patch
@@ -1,0 +1,167 @@
+From 6b3daffaf09bd5fecc55d5a0fdf6b1b91624a71c Mon Sep 17 00:00:00 2001
+From: fatedier <fatedier@gmail.com>
+Date: Thu, 2 Feb 2023 20:20:17 +0800
+Subject: [PATCH] upgrade quic-go and change import path (#3286)
+
+---
+ client/service.go    |  2 +-
+ go.mod               | 13 +++++++------
+ go.sum               | 26 ++++++++++++++------------
+ pkg/util/net/conn.go |  2 +-
+ server/service.go    |  2 +-
+ 5 files changed, 24 insertions(+), 21 deletions(-)
+
+diff --git a/client/service.go b/client/service.go
+index 99201f0bb..c8d92c6de 100644
+--- a/client/service.go
++++ b/client/service.go
+@@ -31,7 +31,7 @@ import (
+ 	"github.com/fatedier/golib/crypto"
+ 	libdial "github.com/fatedier/golib/net/dial"
+ 	fmux "github.com/hashicorp/yamux"
+-	quic "github.com/lucas-clemente/quic-go"
++	quic "github.com/quic-go/quic-go"
+ 
+ 	"github.com/fatedier/frp/assets"
+ 	"github.com/fatedier/frp/pkg/auth"
+diff --git a/go.mod b/go.mod
+index d518a612d..386aedb12 100644
+--- a/go.mod
++++ b/go.mod
+@@ -13,11 +13,11 @@ require (
+ 	github.com/gorilla/mux v1.8.0
+ 	github.com/gorilla/websocket v1.5.0
+ 	github.com/hashicorp/yamux v0.1.1
+-	github.com/lucas-clemente/quic-go v0.31.0
+ 	github.com/onsi/ginkgo v1.16.4
+ 	github.com/onsi/gomega v1.20.2
+ 	github.com/pires/go-proxyproto v0.6.2
+ 	github.com/prometheus/client_golang v1.13.0
++	github.com/quic-go/quic-go v0.32.0
+ 	github.com/rodaine/table v1.0.1
+ 	github.com/spf13/cobra v1.1.3
+ 	github.com/stretchr/testify v1.7.0
+@@ -47,8 +47,6 @@ require (
+ 	github.com/klauspost/cpuid/v2 v2.0.6 // indirect
+ 	github.com/klauspost/reedsolomon v1.9.15 // indirect
+ 	github.com/leodido/go-urn v1.2.1 // indirect
+-	github.com/marten-seemann/qtls-go1-18 v0.1.3 // indirect
+-	github.com/marten-seemann/qtls-go1-19 v0.1.1 // indirect
+ 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+ 	github.com/nxadm/tail v1.4.8 // indirect
+ 	github.com/onsi/ginkgo/v2 v2.2.0 // indirect
+@@ -57,16 +55,19 @@ require (
+ 	github.com/prometheus/client_model v0.2.0 // indirect
+ 	github.com/prometheus/common v0.37.0 // indirect
+ 	github.com/prometheus/procfs v0.8.0 // indirect
++	github.com/quic-go/qtls-go1-18 v0.2.0 // indirect
++	github.com/quic-go/qtls-go1-19 v0.2.0 // indirect
++	github.com/quic-go/qtls-go1-20 v0.1.0 // indirect
+ 	github.com/spf13/pflag v1.0.5 // indirect
+ 	github.com/templexxx/cpufeat v0.0.0-20180724012125-cef66df7f161 // indirect
+ 	github.com/templexxx/xor v0.0.0-20191217153810-f85b25db303b // indirect
+ 	github.com/tjfoc/gmsm v1.4.1 // indirect
+ 	golang.org/x/crypto v0.4.0 // indirect
+-	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
+-	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
++	golang.org/x/exp v0.0.0-20221205204356-47842c84f3db // indirect
++	golang.org/x/mod v0.6.0 // indirect
+ 	golang.org/x/sys v0.3.0 // indirect
+ 	golang.org/x/text v0.5.0 // indirect
+-	golang.org/x/tools v0.1.12 // indirect
++	golang.org/x/tools v0.2.0 // indirect
+ 	google.golang.org/appengine v1.6.7 // indirect
+ 	google.golang.org/protobuf v1.28.1 // indirect
+ 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
+diff --git a/go.sum b/go.sum
+index 347128716..521f06b2e 100644
+--- a/go.sum
++++ b/go.sum
+@@ -307,13 +307,7 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+ github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+ github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
+ github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
+-github.com/lucas-clemente/quic-go v0.31.0 h1:MfNp3fk0wjWRajw6quMFA3ap1AVtlU+2mtwmbVogB2M=
+-github.com/lucas-clemente/quic-go v0.31.0/go.mod h1:0wFbizLgYzqHqtlyxyCaJKlE7bYgE6JQ+54TLd/Dq2g=
+ github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+-github.com/marten-seemann/qtls-go1-18 v0.1.3 h1:R4H2Ks8P6pAtUagjFty2p7BVHn3XiwDAl7TTQf5h7TI=
+-github.com/marten-seemann/qtls-go1-18 v0.1.3/go.mod h1:mJttiymBAByA49mhlNZZGrH5u1uXYZJ+RW28Py7f4m4=
+-github.com/marten-seemann/qtls-go1-19 v0.1.1 h1:mnbxeq3oEyQxQXwI4ReCgW9DPoPR94sNlqWoDZnjRIE=
+-github.com/marten-seemann/qtls-go1-19 v0.1.1/go.mod h1:5HTDWtVudo/WFsHKRNuOhWlbdjrfs5JHrYb0wIJqGpI=
+ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+ github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+@@ -392,6 +386,14 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
+ github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
+ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
+ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
++github.com/quic-go/qtls-go1-18 v0.2.0 h1:5ViXqBZ90wpUcZS0ge79rf029yx0dYB0McyPJwqqj7U=
++github.com/quic-go/qtls-go1-18 v0.2.0/go.mod h1:moGulGHK7o6O8lSPSZNoOwcLvJKJ85vVNc7oJFD65bc=
++github.com/quic-go/qtls-go1-19 v0.2.0 h1:Cvn2WdhyViFUHoOqK52i51k4nDX8EwIh5VJiVM4nttk=
++github.com/quic-go/qtls-go1-19 v0.2.0/go.mod h1:ySOI96ew8lnoKPtSqx2BlI5wCpUVPT05RMAlajtnyOI=
++github.com/quic-go/qtls-go1-20 v0.1.0 h1:d1PK3ErFy9t7zxKsG3NXBJXZjp/kMLoIb3y/kV54oAI=
++github.com/quic-go/qtls-go1-20 v0.1.0/go.mod h1:JKtK6mjbAVcUTN/9jZpvLbGxvdWIKS8uT7EiStoU1SM=
++github.com/quic-go/quic-go v0.32.0 h1:lY02md31s1JgPiiyfqJijpu/UX/Iun304FI3yUqX7tA=
++github.com/quic-go/quic-go v0.32.0/go.mod h1:/fCsKANhQIeD5l76c2JFU+07gVE3KaA0FP+0zMWwfwo=
+ github.com/rodaine/table v1.0.1 h1:U/VwCnUxlVYxw8+NJiLIuCxA/xa6jL38MY3FYysVWWQ=
+ github.com/rodaine/table v1.0.1/go.mod h1:UVEtfBsflpeEcD56nF4F5AocNFta0ZuolpSVdPtlmP4=
+ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+@@ -478,8 +480,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
+ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
+ golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
+ golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
+-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
++golang.org/x/exp v0.0.0-20221205204356-47842c84f3db h1:D/cFflL63o2KSLJIwjlcIt8PR064j/xsmdEJL/YvY/o=
++golang.org/x/exp v0.0.0-20221205204356-47842c84f3db/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+ golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
+ golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+ golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
+@@ -505,8 +507,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
+-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
++golang.org/x/mod v0.6.0 h1:b9gGHsz9/HhJ3HF5DHQytPpuwocVTChQJK3AvoLRD5I=
++golang.org/x/mod v0.6.0/go.mod h1:4mET923SAdbXp2ki8ey+zGs1SLqsuM2Y0uvdZR/fUNI=
+ golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+@@ -748,8 +750,8 @@ golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+ golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+ golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+ golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+-golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
+-golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
++golang.org/x/tools v0.2.0 h1:G6AHpWxTMGY1KyEYoAQ5WTtIekUUvDNjan3ugu60JvE=
++golang.org/x/tools v0.2.0/go.mod h1:y4OqIKeOV/fWJetJ8bXPU1sEVniLMIyDAZWeHdV+NTA=
+ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+diff --git a/pkg/util/net/conn.go b/pkg/util/net/conn.go
+index a09da99e7..fb2ff6777 100644
+--- a/pkg/util/net/conn.go
++++ b/pkg/util/net/conn.go
+@@ -22,7 +22,7 @@ import (
+ 	"sync/atomic"
+ 	"time"
+ 
+-	quic "github.com/lucas-clemente/quic-go"
++	quic "github.com/quic-go/quic-go"
+ 
+ 	"github.com/fatedier/frp/pkg/util/xlog"
+ )
+diff --git a/server/service.go b/server/service.go
+index fc59b39c6..e2f849408 100644
+--- a/server/service.go
++++ b/server/service.go
+@@ -28,7 +28,7 @@ import (
+ 
+ 	"github.com/fatedier/golib/net/mux"
+ 	fmux "github.com/hashicorp/yamux"
+-	quic "github.com/lucas-clemente/quic-go"
++	quic "github.com/quic-go/quic-go"
+ 
+ 	"github.com/fatedier/frp/assets"
+ 	"github.com/fatedier/frp/pkg/auth"


### PR DESCRIPTION
![frps](https://user-images.githubusercontent.com/57583560/216748075-7e7b3eb5-8388-496a-b33b-c111f0d47921.png)
![frpc](https://user-images.githubusercontent.com/57583560/216748086-a2976b1f-d92e-46c3-9bf9-398d6c8aba60.png)

Part of #14915 .
