### PR TITLE
python: Refactor `build.sh` before bumping to 3.11.2

### DIFF
--- a/packages/python/build.sh
+++ b/packages/python/build.sh
@@ -1,6 +1,8 @@
 TERMUX_PKG_HOMEPAGE=https://python.org/
 TERMUX_PKG_DESCRIPTION="Python 3 programming language intended to enable clear programs"
-TERMUX_PKG_LICENSE="PythonPL"
+# License: PSF-2.0
+TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_LICENSE_FILE="LICENSE"
 TERMUX_PKG_MAINTAINER="@termux"
 _MAJOR_VERSION=3.11
 TERMUX_PKG_VERSION=${_MAJOR_VERSION}.1
@@ -8,9 +10,8 @@ TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://www.python.org/ftp/python/${TERMUX_PKG_VERSION}/Python-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=85879192f2cffd56cb16c092905949ebf3e5e394b7f764723529637901dfb58f
 TERMUX_PKG_DEPENDS="gdbm, libandroid-posix-semaphore, libandroid-support, libbz2, libcrypt, libexpat, libffi, liblzma, libsqlite, ncurses, ncurses-ui-libs, openssl, readline, zlib"
-TERMUX_PKG_RECOMMENDS="clang, make, pkg-config, python-pip"
+TERMUX_PKG_RECOMMENDS="python-pip"
 TERMUX_PKG_SUGGESTS="python-tkinter"
-# For python-pip, see https://github.com/termux/termux-packages/pull/13611.
 TERMUX_PKG_BREAKS="python2 (<= 2.7.15), python-dev"
 TERMUX_PKG_REPLACES="python-dev"
 # Let "python3" will be alias to this package.
@@ -68,6 +69,8 @@ termux_step_pre_configure() {
 	else
 		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-build-python=python$_MAJOR_VERSION"
 	fi
+
+	export LIBCRYPT_LIBS="-lcrypt"
 }
 
 termux_step_post_make_install() {

--- a/packages/python/python-ensurepip-wheels.subpackage.sh
+++ b/packages/python/python-ensurepip-wheels.subpackage.sh
@@ -1,0 +1,7 @@
+TERMUX_SUBPKG_DESCRIPTION="Wheels for Python ensurepip"
+TERMUX_SUBPKG_PLATFORM_INDEPENDENT=true
+TERMUX_SUBPKG_INCLUDE="
+lib/python${_MAJOR_VERSION}/ensurepip/_bundled/
+"
+TERMUX_SUBPKG_BREAKS="python (<< 3.11.1-3)"
+TERMUX_SUBPKG_REPLACES="python (<< 3.11.1-3)"

--- a/packages/python/python-tkinter.subpackage.sh
+++ b/packages/python/python-tkinter.subpackage.sh
@@ -1,11 +1,13 @@
 TERMUX_SUBPKG_DESCRIPTION="Tkinter support for Python 3"
-TERMUX_SUBPKG_DEPENDS="tk"
+TERMUX_SUBPKG_DEPENDS="tcl, tk"
 TERMUX_SUBPKG_INCLUDE="
 bin/idle*
 lib/python${_MAJOR_VERSION}/idlelib
 lib/python${_MAJOR_VERSION}/tkinter
 lib/python${_MAJOR_VERSION}/turtle.py
 lib/python${_MAJOR_VERSION}/turtledemo
-lib/python${_MAJOR_VERSION}/lib-dynload/_tkinter.cpython-${_MAJOR_VERSION/./}m.so
+lib/python${_MAJOR_VERSION}/lib-dynload/_tkinter.*.so
 lib/python${_MAJOR_VERSION}/__pycache__/turtle.*.pyc
 "
+TERMUX_SUBPKG_BREAKS="python (<< 3.11.1-3)"
+TERMUX_SUBPKG_REPLACES="python (<< 3.11.1-3)"


### PR DESCRIPTION
* Fix license (PythonPL was for CNRI Python)

* Adjust recommended packages (clang etc. are recommended by python-pip)

* Fix included files for python-tkinter

* Separate ensurepip wheels as subpackage (not needed by default now)

* Fix underlinking of `_crypt` extension (not just a refactoring though)

%ci:no-build