### PR TITLE
tree-wide: Add informal SHA256 checksum verification

### DIFF
--- a/packages/2048-c/build.sh
+++ b/packages/2048-c/build.sh
@@ -1,10 +1,11 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/mevdschee/2048.c
 TERMUX_PKG_DESCRIPTION="Console version of the game '2048' for GNU/Linux"
 TERMUX_PKG_LICENSE="MIT"
-_COMMIT=6c04517bb59c28f3831585da338f021bc2ea86d6
 TERMUX_PKG_MAINTAINER="@termux"
+_COMMIT=6c04517bb59c28f3831585da338f021bc2ea86d6
 TERMUX_PKG_VERSION=2022.10.23
 TERMUX_PKG_SRCURL=git+https://github.com/mevdschee/2048.c
+TERMUX_PKG_SHA256=ffa0f524a6c05f42613101e8b0c5881b489631d343ac1a5f615cc746fc34a857
 TERMUX_PKG_GIT_BRANCH=main
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_GROUPS="games"
@@ -18,5 +19,10 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }

--- a/packages/astra-sm/build.sh
+++ b/packages/astra-sm/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=44bcd2852b7f315233267f639730e0e21b9b6c22
 TERMUX_PKG_VERSION=2019.06.19
 TERMUX_PKG_SRCURL=git+https://github.com/OpenVisionE2/astra-sm
+TERMUX_PKG_SHA256=635bcda7c024adee99c540bcae10cba16946c54108817ac2f3a6f36305b29e85
 TERMUX_PKG_GIT_BRANCH=staging
 TERMUX_PKG_DEPENDS="libdvbcsa, liblua53"
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -25,6 +26,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/ceu-lang/build.sh
+++ b/packages/ceu-lang/build.sh
@@ -6,6 +6,7 @@ TERMUX_PKG_SRCURL="git+https://github.com/ceu-lang/ceu"
 TERMUX_PKG_GIT_BRANCH="master"
 _COMMIT="5e0c8d3004ad98658ffe82823ad8303a8d371064"
 TERMUX_PKG_VERSION="2019.07.17"
+TERMUX_PKG_SHA256=bc3417d7a2a568d33ea01097bdfab6d34bb89da4b6191c169140a21cfefa5301
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_BUILD_DEPENDS="lua53, lua-lpeg"
 TERMUX_PKG_DEPENDS="lua53, lua-lpeg, liblua53"
@@ -19,5 +20,10 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }

--- a/packages/chibicc/build.sh
+++ b/packages/chibicc/build.sh
@@ -6,6 +6,7 @@ _COMMIT=90d1f7f199cc55b13c7fdb5839d1409806633fdb
 TERMUX_PKG_VERSION=2020.12.07
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/rui314/chibicc
+TERMUX_PKG_SHA256=9cb136d4713c8003122e8b637730a15808dd102dc2b54a5f96f33053a34a8171
 TERMUX_PKG_GIT_BRANCH=main
 TERMUX_PKG_DEPENDS="binutils-is-llvm | binutils, libandroid-glob"
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -20,6 +21,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/chromaprint/build.sh
+++ b/packages/chromaprint/build.sh
@@ -6,6 +6,7 @@ _COMMIT=aa67c95b9e486884a6d3ee8b0c91207d8c2b0551
 _COMMIT_DATE=20221217
 TERMUX_PKG_VERSION=1.5.1-p${_COMMIT_DATE}
 TERMUX_PKG_SRCURL=git+https://github.com/acoustid/chromaprint
+TERMUX_PKG_SHA256=5a880f6e976fdbbfbc1d5487d27cf59fba7398c675c6cb5069aaf3d3cff716a7
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="ffmpeg, libc++"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
@@ -25,5 +26,10 @@ termux_step_post_get_source() {
 		echo -n " different from what is expected to be; should end"
 		echo " with \"${pdate}\"."
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }

--- a/packages/cloneit/build.sh
+++ b/packages/cloneit/build.sh
@@ -6,6 +6,7 @@ _COMMIT=62c433f0b1c54a977d585f3b84b8c43213095474
 _COMMIT_DATE=2022.10.24
 TERMUX_PKG_VERSION=${_COMMIT_DATE//./}
 TERMUX_PKG_SRCURL=git+https://github.com/alok8bb/cloneit
+TERMUX_PKG_SHA256=61b2631109817bd468d5b8ab6411206fff75df13bafb45e53558139eea46c0cb
 TERMUX_PKG_GIT_BRANCH="master"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_BUILD_DEPENDS="openssl-1.1" 	
@@ -19,6 +20,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified commit date \"$_COMMIT_DATE\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/crypto-monitor/build.sh
+++ b/packages/crypto-monitor/build.sh
@@ -6,6 +6,7 @@ _COMMIT=86fd7de705babc2cef1e920e39ec439f5aa9c336
 TERMUX_PKG_VERSION=2021.02.22
 TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=git+https://github.com/edghyhdz/crypto_monitor
+TERMUX_PKG_SHA256=df67d1a0de5f547cab78dbc977609d1b24f5c2ed8e3fc0619734d3e36ac4a1bc
 TERMUX_PKG_GIT_BRANCH=main
 TERMUX_PKG_DEPENDS="libc++, libcurl, ncurses-ui-libs, openssl"
 TERMUX_PKG_BUILD_DEPENDS="boost, boost-headers"
@@ -20,6 +21,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/dnstop/build.sh
+++ b/packages/dnstop/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=2ec80df727aee31bbaaf9cccd8adbd16ca539bb3
 TERMUX_PKG_VERSION=2022.10.19
 TERMUX_PKG_SRCURL=git+https://github.com/measurement-factory/dnstop
+TERMUX_PKG_SHA256=5b3e58944a0ff03e9836133c974387269f47d4ef8fdeb7100faa66f74ed56624
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="libpcap, ncurses"
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -19,6 +20,12 @@ termux_step_post_get_source() {
 		echo " is different from what is expected to be: \"$version\""
 		return 1
 	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
+	fi
+
 	sed -i "s/@VERSION@/$version/g" dnstop.c
 }
 

--- a/packages/go-findimagedupes/build.sh
+++ b/packages/go-findimagedupes/build.sh
@@ -6,6 +6,7 @@ _COMMIT=47ca1d51be2bc1d437261d82157b84fe977ec934
 TERMUX_PKG_VERSION=2022.07.22
 TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=git+https://gitlab.com/opennota/findimagedupes
+TERMUX_PKG_SHA256=9232ececc4918e07255591512b18ac4cc1bcad0fbf43f095cd59af4ee95d3cf8
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="file, libc++, libheif, libjpeg-turbo, libpng, libtiff"
 TERMUX_PKG_CONFLICTS="findimagedupes"
@@ -20,6 +21,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/hummin/build.sh
+++ b/packages/hummin/build.sh
@@ -6,6 +6,7 @@ _COMMIT=b117aef9c64348b1ef262a99316f1e51328efe18
 TERMUX_PKG_VERSION=2021.05.18
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://gitlab.com/trantor/hummin
+TERMUX_PKG_SHA256=a59bdd3b08cf50786fe08d94edd1d35223f14e63bf4850a99ce394753b5405d3
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_BUILD_IN_SRC=true
 
@@ -18,6 +19,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/jbig2enc/build.sh
+++ b/packages/jbig2enc/build.sh
@@ -6,6 +6,7 @@ _COMMIT=ea6a40a2cbf05efb00f3418f2d0ad71232565beb
 TERMUX_PKG_VERSION=2019.09.08
 TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=git+https://github.com/agl/jbig2enc
+TERMUX_PKG_SHA256=58ed481b772f795147ec79dde335de79e361bf5eafa9068b0afa267151bcb486
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="giflib, leptonica, libc++, libjpeg-turbo, libpng, libtiff, libwebp, python, zlib"
 
@@ -18,6 +19,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/libflann/build.sh
+++ b/packages/libflann/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=f9caaf609d8b8cb2b7104a85cf59eb92c275a25d
 TERMUX_PKG_VERSION=2022.10.27
 TERMUX_PKG_SRCURL=git+https://github.com/flann-lib/flann
+TERMUX_PKG_SHA256=ed889b301be373af6575d655e03e327039aa2923f70cb619a4d57fd931682630
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="libc++, liblz4"
 TERMUX_PKG_BUILD_DEPENDS="libhdf5-static"
@@ -25,5 +26,10 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }

--- a/packages/librnnoise/build.sh
+++ b/packages/librnnoise/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=7f449bf8bd3b933891d12c30112268c4090e4d59
 TERMUX_PKG_VERSION=2021.03.12
 TERMUX_PKG_SRCURL=git+https://gitlab.xiph.org/xiph/rnnoise
+TERMUX_PKG_SHA256=e78ca58aeed18f0f7558bbb18f517326e4216a1f8aceb0d88dc4f77ca38cfd9d
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-examples
@@ -20,6 +21,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/libtvision/build.sh
+++ b/packages/libtvision/build.sh
@@ -6,6 +6,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=7cdc0c8d45bdc94fbbc0f0cb349904dbaf8efb56
 TERMUX_PKG_VERSION=2022.12.06
 TERMUX_PKG_SRCURL=git+https://github.com/magiblot/tvision
+TERMUX_PKG_SHA256=f3c9606933fcc182011d26657d0c3f41bed59a90113f9ff34467467e3eedf711
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="libc++, ncurses"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
@@ -23,5 +24,10 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }

--- a/packages/libupscaledb/build.sh
+++ b/packages/libupscaledb/build.sh
@@ -7,6 +7,7 @@ _COMMIT_DATE=2021.08.20
 TERMUX_PKG_VERSION=2.2.1p${_COMMIT_DATE//./}
 TERMUX_PKG_REVISION=7
 TERMUX_PKG_SRCURL=git+https://github.com/cruppstahl/upscaledb
+TERMUX_PKG_SHA256=83e26f9f099897f347129470b494487bddf96c3d09ab4747251135d47d8b4256
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_DEPENDS="boost, libc++, libsnappy, openssl, zlib"
@@ -29,6 +30,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified commit date \"$_COMMIT_DATE\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/mazter/build.sh
+++ b/packages/mazter/build.sh
@@ -7,6 +7,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=a02de683f93a61690d1a4f3b845f654f5e026484
 TERMUX_PKG_VERSION=2022.08.13
 TERMUX_PKG_SRCURL="git+https://github.com/Canop/mazter"
+TERMUX_PKG_SHA256=1196209325408a2335d989e056893c02cea48fcf0da8eacac264679b5f7304cb
 TERMUX_PKG_GIT_BRANCH=main
 TERMUX_PKG_BUILD_IN_SRC=true
 
@@ -19,5 +20,10 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }

--- a/packages/mfcuk/build.sh
+++ b/packages/mfcuk/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=b333a7925a3be80d9496c88c9fef816777827a83
 TERMUX_PKG_VERSION=2018.07.14
 TERMUX_PKG_SRCURL=git+https://github.com/nfc-tools/mfcuk
+TERMUX_PKG_SHA256=1ceec471a8cd0cfb50dd19e022f7f019bb2892285c9354403c98d5b0f94ef9af
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="libnfc"
 
@@ -17,6 +18,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/mktorrent/build.sh
+++ b/packages/mktorrent/build.sh
@@ -6,6 +6,7 @@ _COMMIT=de7d011b35458de1472665f50b96c9cf6c303f39
 _COMMIT_DATE=20210130
 TERMUX_PKG_VERSION=1.1-p${_COMMIT_DATE}
 TERMUX_PKG_SRCURL=git+https://github.com/Rudde/mktorrent
+TERMUX_PKG_SHA256=2e1c61fceaef47f0fdf68d73580edea104ab044040c339f844d44fe119507d78
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_BUILD_IN_SRC=true
 
@@ -19,5 +20,10 @@ termux_step_post_get_source() {
 		echo -n " different from what is expected to be; should end"
 		echo " with \"${pdate}\"."
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }

--- a/packages/pforth/build.sh
+++ b/packages/pforth/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=d553430f9a04a09e3002868067763538f28e0cfa
 TERMUX_PKG_VERSION=20221211
 TERMUX_PKG_SRCURL=git+https://github.com/philburk/pforth
+TERMUX_PKG_SHA256=57f04445a91b23eda19f6bc1201ac1f6bc8662ff58baffd73faec4766038a588
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -18,6 +19,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/photon-rss/build.sh
+++ b/packages/photon-rss/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=02e0faa0a40f4772e996b58ec203337f7c0dd51c
 TERMUX_PKG_VERSION=2022.12.01
 TERMUX_PKG_SRCURL=git+https://git.sr.ht/~ghost08/photon
+TERMUX_PKG_SHA256=a832e72b66c8edc45af2b1f7a68e484879d8c1f3f5c980faafeb46073a469a1d
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_MAKE_ARGS="PREFIX=$TERMUX_PREFIX"
@@ -18,6 +19,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/picocom/build.sh
+++ b/packages/picocom/build.sh
@@ -7,6 +7,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=1acf1ddabaf3576b4023c4f6f09c5a3e4b086fb8
 TERMUX_PKG_VERSION=2018.04.12
 TERMUX_PKG_SRCURL=git+https://github.com/npat-efault/picocom
+TERMUX_PKG_SHA256=51340c2f57638117e1ddb40a29d6acc8692df07ce44bf9cc8fa70417847bb1a7
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_BUILD_IN_SRC=true
 
@@ -19,6 +20,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/pipes.sh/build.sh
+++ b/packages/pipes.sh/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@Efreak"
 _COMMIT=581792d4e0ea51e15889ba14a85db1bc9727b83d
 TERMUX_PKG_VERSION=2018.04.22
 TERMUX_PKG_SRCURL=git+https://github.com/pipeseroni/pipes.sh
+TERMUX_PKG_SHA256=d28a4f49acf31fd5a2d18684d6b6f7a8fca735d98919149e32ce65598091a9b6
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS=bash
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
@@ -18,6 +19,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/rappel/build.sh
+++ b/packages/rappel/build.sh
@@ -6,6 +6,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=b848fce5e3759f3cbeda55e3cd8dcd7321525a44
 TERMUX_PKG_VERSION=2022.11.07
 TERMUX_PKG_SRCURL=git+https://github.com/yrp604/rappel
+TERMUX_PKG_SHA256=e3dfe84e88b7711918555e40cb88f723ee99f197795193cd5620367b29f4a56e
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="binutils-is-llvm | binutils, libedit"
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -22,6 +23,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/ratt/build.sh
+++ b/packages/ratt/build.sh
@@ -6,6 +6,7 @@ _COMMIT=ff3adafce8ce29bd98221a65f87e7e10f2c7ba25
 TERMUX_PKG_VERSION=2022.10.30
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://git.sr.ht/~ghost08/ratt
+TERMUX_PKG_SHA256=caacb0f19581bc06380be3fff8387aa32ee098394921f3ac75c1e18d6fe913c3
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_MAKE_ARGS="PREFIX=$TERMUX_PREFIX"
@@ -19,6 +20,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/rdircd/build.sh
+++ b/packages/rdircd/build.sh
@@ -6,6 +6,7 @@ _COMMIT=6e5f541361a1bdecd8f8aab7060cb4fb3d0b1869
 TERMUX_PKG_VERSION=2022.12.28
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/mk-fg/reliable-discord-client-irc-daemon
+TERMUX_PKG_SHA256=77fd6d3c7f0005c689c4ed3ee6522ed32fcfeb9aeb3289995b95e2f40adbad80
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="python, python-pip"
 TERMUX_PKG_PYTHON_TARGET_DEPS="aiohttp"
@@ -21,6 +22,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/robotfindskitten/build.sh
+++ b/packages/robotfindskitten/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=58155f8d3459e30ad393e2d7c23ad0c8eeb96df2
 TERMUX_PKG_VERSION=2022.05.21
 TERMUX_PKG_SRCURL=git+https://github.com/noncombatant/robotfindskitten
+TERMUX_PKG_SHA256=58d9403ba1d3303b68a8fe82357d2c5ca69bf45c032670bf9b28d8c4a149496d
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="ncurses"
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -20,6 +21,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/rxfetch/build.sh
+++ b/packages/rxfetch/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@PeroSar"
 _COMMIT=84fd56a34deb2bf3a439511df6ad49ba42fa6a0e
 TERMUX_PKG_VERSION=2022.12.16
 TERMUX_PKG_SRCURL=git+https://github.com/mangeshrex/rxfetch
+TERMUX_PKG_SHA256=29ed08073013c6183859e44f92eaf95af21b78f0a3dc1afa344fd509dc242839
 TERMUX_PKG_GIT_BRANCH=main
 TERMUX_PKG_DEPENDS="bash"
 TERMUX_PKG_CONFLICTS="rxfetch-termux"
@@ -21,6 +22,11 @@ termux_step_post_get_source() {
 		echo "Error: Expected version: $ver"
 		echo "Found version: $TERMUX_PKG_VERSION"
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/slashtime/build.sh
+++ b/packages/slashtime/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=6a6c2ce075f085f9892cd6d89e423c811f21a4a8
 TERMUX_PKG_VERSION=2022.04.20
 TERMUX_PKG_SRCURL=git+https://github.com/istathar/slashtime
+TERMUX_PKG_SHA256=c14a5adfe836436fb6e485eb8cf25f9fb031dd2a7c32f646414b00e6a5a0b077
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="perl"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
@@ -19,6 +20,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/slugify/build.sh
+++ b/packages/slugify/build.sh
@@ -1,10 +1,11 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/benlinton/slugify
 TERMUX_PKG_DESCRIPTION="Bash command that converts filenames and directories to a web friendly format"
 TERMUX_PKG_LICENSE="MIT"
-_COMMIT=4528e8ecc2de14f76dfc76d045635beed138fb39
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_SRCURL=git+https://github.com/benlinton/slugify
+_COMMIT=4528e8ecc2de14f76dfc76d045635beed138fb39
 TERMUX_PKG_VERSION=2016.01.23
+TERMUX_PKG_SRCURL=git+https://github.com/benlinton/slugify
+TERMUX_PKG_SHA256=f629ae6fb1ed2b3e51497502528996e36c135cfc81a8fc659fdc4ab73a6a4077
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -19,6 +20,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/snake/build.sh
+++ b/packages/snake/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="Tipz Team @TipzTeam"
 _COMMIT=a57f7f8aa8c77fcce2dabafca1a5ec4b96825231
 TERMUX_PKG_VERSION=2022.11.07
 TERMUX_PKG_SRCURL=git+https://github.com/gogakoreli/snake
+TERMUX_PKG_SHA256=3fc981af52289eaac169944de362e20d4fe6260a41158f5a8a44741e1522b89b
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="libc++"
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -19,6 +20,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/tenki-php/build.sh
+++ b/packages/tenki-php/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=cb07deb9d8c8fc5849f8752f6f0605f72f96fd9b
 TERMUX_PKG_VERSION=2022.05.26
 TERMUX_PKG_SRCURL=git+https://github.com/dmpop/tenki
+TERMUX_PKG_SHA256=7bdea2d3e09709d6562503833c4cd995aa40303a14c75f6a4338dfd40750d2ca
 TERMUX_PKG_GIT_BRANCH=main
 TERMUX_PKG_DEPENDS="apache2, php"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
@@ -18,6 +19,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/tome2/build.sh
+++ b/packages/tome2/build.sh
@@ -6,6 +6,7 @@ _COMMIT=1e26568b084104edd2a696e86118a3e71c78d61e
 TERMUX_PKG_VERSION=2022.12.27
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/tome2/tome2
+TERMUX_PKG_SHA256=e18ab63c74f8650b8348cbc82af923e44a42f2d4a2621f993ee7e789f461a61a
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="boost, libc++, libx11, ncurses"
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -20,6 +21,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/vgmtools/build.sh
+++ b/packages/vgmtools/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=a993f82c609f259bc4f53e0f965a171cb5cf9420
 TERMUX_PKG_VERSION=2022.12.28
 TERMUX_PKG_SRCURL=git+https://github.com/vgmrips/vgmtools
+TERMUX_PKG_SHA256=dc5fbcb6a9be12fa4c3a3a6601a146972843a09c0609c3bbebb5c09e076f195d
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="libandroid-glob, libc++, zlib"
 
@@ -17,6 +18,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/vobsub2srt/build.sh
+++ b/packages/vobsub2srt/build.sh
@@ -6,6 +6,7 @@ _COMMIT=0ba6e25e078a040195d7295e860cc9064bef7c2c
 TERMUX_PKG_VERSION=2017.12.18
 TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=git+https://github.com/ruediger/VobSub2SRT
+TERMUX_PKG_SHA256=20cb64627124e4f22e44e5e48d00148683e0a9b6317f3d4d8783b689cd09a7f7
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="libc++, tesseract"
 TERMUX_PKG_FORCE_CMAKE=true
@@ -19,5 +20,10 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }

--- a/packages/weechat-matrix-rs/build.sh
+++ b/packages/weechat-matrix-rs/build.sh
@@ -6,6 +6,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=ca23e1745e6e2ba235550360e1def1457e2f3857
 TERMUX_PKG_VERSION=2022.10.04
 TERMUX_PKG_SRCURL="git+https://github.com/poljar/weechat-matrix-rs"
+TERMUX_PKG_SHA256=61d4d307167f274c1ee165a7021d5cda330a2331eb89e8add2f027becf8cae0c
 TERMUX_PKG_GIT_BRANCH=main
 TERMUX_PKG_DEPENDS="weechat, openssl"
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -21,6 +22,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/wiz/build.sh
+++ b/packages/wiz/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=a174205e1694ab225c11813d3a3ab9e81742869d
 TERMUX_PKG_VERSION=2022.06.02
 TERMUX_PKG_SRCURL=git+https://github.com/wiz-lang/wiz
+TERMUX_PKG_SHA256=9404438d6026ef90523388d2ec0ffa1ce03481b16c562b8ff4aa2c40357556ec
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="libc++"
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -19,5 +20,10 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }

--- a/packages/xpup/build.sh
+++ b/packages/xpup/build.sh
@@ -6,6 +6,7 @@ _COMMIT=3c408621ad9b5693323acd7d1b455f78444e0c5f
 TERMUX_PKG_VERSION=2021.12.26
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/ericchiang/xpup
+TERMUX_PKG_SHA256=080e5bba8556f488dfecfbfcc39b1c8e476cb1a2128f09d3f29f0aa7e7f52278
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_BUILD_IN_SRC=true
 
@@ -18,6 +19,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/packages/zzuf/build.sh
+++ b/packages/zzuf/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=a7111e51eac3086264fcca0c7026de22b5ab55c7
 TERMUX_PKG_VERSION=2022.05.29
 TERMUX_PKG_SRCURL=git+https://github.com/samhocevar/zzuf
+TERMUX_PKG_SHA256=a49c6704adf58d39d90fd27503d5b9748a7481ba70d92a0f4b8f9c480e9fd6ce
 TERMUX_PKG_GIT_BRANCH=master
 
 termux_step_post_get_source() {
@@ -16,6 +17,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/root-packages/open-zwave/build.sh
+++ b/root-packages/open-zwave/build.sh
@@ -6,6 +6,7 @@ _COMMIT=3fff11d246a0d558d26110e1db6bd634a1b347c0
 _COMMIT_DATE=20221117
 TERMUX_PKG_VERSION=1.6-p${_COMMIT_DATE}
 TERMUX_PKG_SRCURL=git+https://github.com/OpenZWave/open-zwave
+TERMUX_PKG_SHA256=d1077d3cf7fae3b61de5789321561b17a2bae4705d3016273d65785683bfc062
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="libc++"
 # XXX: libusb is not linked against (unexpectedly?)
@@ -22,6 +23,11 @@ termux_step_post_get_source() {
 		echo -n " different from what is expected to be; should end"
 		echo " with \"${pdate}\"."
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/x11-packages/awesome/build.sh
+++ b/x11-packages/awesome/build.sh
@@ -6,6 +6,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=ee0663459922a41f57fa2cc936da80d5857eedc9
 TERMUX_PKG_VERSION=2022.12.18
 TERMUX_PKG_SRCURL=git+https://github.com/awesomeWM/awesome
+TERMUX_PKG_SHA256=c934dbc49b7b47655e9c2e435a533664036a62d2adc1249cc362bded1bdf965b
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="dbus, gdk-pixbuf, glib, libcairo, liblua54, libx11, libxcb, libxdg-basedir, libxkbcommon, lua-lgi, pango, startup-notification, xcb-util, xcb-util-cursor, xcb-util-keysyms, xcb-util-wm, xcb-util-xrm"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
@@ -22,6 +23,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/x11-packages/olivia/build.sh
+++ b/x11-packages/olivia/build.sh
@@ -7,6 +7,7 @@ _COMMIT=4048134f7df91dc9368147d9aac25f408d6ecb59
 TERMUX_PKG_VERSION=2022.10.20
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/keshavbhatt/olivia
+TERMUX_PKG_SHA256=71994c6c9821f7bdf3560c308e3b0b1b27799b497f0ca9cf93969fbf998289ea
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="coreutils, libc++, mpv, python, qt5-qtbase, qt5-qtwebkit, socat, taglib, wget"
 TERMUX_PKG_BUILD_DEPENDS="qt5-qtbase-cross-tools"
@@ -24,6 +25,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/x11-packages/phantomjs/build.sh
+++ b/x11-packages/phantomjs/build.sh
@@ -7,6 +7,7 @@ _COMMIT=0a0b0facb16acfbabb7804822ecaf4f4b9dce3d2
 TERMUX_PKG_VERSION=2020.07.13
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/ariya/phantomjs
+TERMUX_PKG_SHA256=5603bfc300c6bf712db3d8e7dea6b0f8d97eb470b8ab589e9cec3b290ed56d57
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="libc++, qt5-qtbase, qt5-qtwebkit"
 TERMUX_PKG_BUILD_DEPENDS="qt5-qtbase-cross-tools"
@@ -21,5 +22,10 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }

--- a/x11-packages/sdl-image/build.sh
+++ b/x11-packages/sdl-image/build.sh
@@ -7,6 +7,7 @@ _COMMIT_DATE=20220527
 TERMUX_PKG_VERSION=1.2.12-p${_COMMIT_DATE}
 TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=git+https://github.com/libsdl-org/SDL_image
+TERMUX_PKG_SHA256=ef86f404ff0dc42e66b10209f5b881b66ff594fc0dcce3730083ad829ffe5d73
 TERMUX_PKG_GIT_BRANCH=SDL-1.2
 TERMUX_PKG_DEPENDS="libjpeg-turbo, libpng, libtiff, libwebp, sdl"
 
@@ -20,5 +21,10 @@ termux_step_post_get_source() {
 		echo -n " different from what is expected to be; should end"
 		echo " with \"${pdate}\"."
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }

--- a/x11-packages/sdl-mixer/build.sh
+++ b/x11-packages/sdl-mixer/build.sh
@@ -7,6 +7,7 @@ _COMMIT_DATE=20221010
 TERMUX_PKG_VERSION=1.2.12-p${_COMMIT_DATE}
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/libsdl-org/SDL_mixer
+TERMUX_PKG_SHA256=473a39b04f1a2ec29a22e3eafaafeee9704129f117044d17c591646648b540cd
 TERMUX_PKG_GIT_BRANCH=SDL-1.2
 TERMUX_PKG_DEPENDS="libflac, libvorbis, sdl"
 
@@ -20,5 +21,10 @@ termux_step_post_get_source() {
 		echo -n " different from what is expected to be; should end"
 		echo " with \"${pdate}\"."
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }

--- a/x11-packages/sdl-net/build.sh
+++ b/x11-packages/sdl-net/build.sh
@@ -7,6 +7,7 @@ _COMMIT_DATE=20221115
 TERMUX_PKG_VERSION=1.2.8-p${_COMMIT_DATE}
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/libsdl-org/SDL_net
+TERMUX_PKG_SHA256=9e48bf33b6702b9a570cc8819b69d2aec0d5cfbf410f0ac4ede8e189e216023f
 TERMUX_PKG_GIT_BRANCH=SDL-1.2
 TERMUX_PKG_DEPENDS="sdl"
 TERMUX_PKG_CONFLICTS="libsdl-net"
@@ -22,5 +23,10 @@ termux_step_post_get_source() {
 		echo -n " different from what is expected to be; should end"
 		echo " with \"${pdate}\"."
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }

--- a/x11-packages/sdl-ttf/build.sh
+++ b/x11-packages/sdl-ttf/build.sh
@@ -7,6 +7,7 @@ _COMMIT_DATE=20220526
 TERMUX_PKG_VERSION=2.0.11-p${_COMMIT_DATE}
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/libsdl-org/SDL_ttf
+TERMUX_PKG_SHA256=9e603ae3ee9363808e5eacf671f35ab92001ece21dc7d3eb1fb6209fa5c38ad4
 TERMUX_PKG_GIT_BRANCH=SDL-1.2
 TERMUX_PKG_DEPENDS="freetype, sdl"
 
@@ -20,6 +21,11 @@ termux_step_post_get_source() {
 		echo -n " different from what is expected to be; should end"
 		echo " with \"${pdate}\"."
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 

--- a/x11-packages/simulide/build.sh
+++ b/x11-packages/simulide/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=4bf26bc839147551a00938aa2949012681a3e046
 TERMUX_PKG_VERSION=2021.11.04
 TERMUX_PKG_SRCURL=git+https://github.com/SimulIDE/SimulIDE
+TERMUX_PKG_SHA256=253fb33e504d2735f425d2bcefed384c3d090feb413920735dbff0415d27620a
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="libc++, libelf, qt5-qtbase, qt5-qtmultimedia, qt5-qtscript, qt5-qtserialport, qt5-qtsvg"
 TERMUX_PKG_BUILD_DEPENDS="qt5-qtbase-cross-tools, qt5-qttools-cross-tools"
@@ -19,6 +20,11 @@ termux_step_post_get_source() {
 		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
 		echo " is different from what is expected to be: \"$version\""
 		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
 	fi
 }
 


### PR DESCRIPTION
for packages with custom `git checkout` command.

To avoid obvious mistakes.