### PR TITLE
workflows: Use `TERMUXBOT2_TOKEN`

### DIFF
--- a/.github/workflows/command_not_found.yml
+++ b/.github/workflows/command_not_found.yml
@@ -19,10 +19,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-          token: ${{ secrets.GH_API_KEY }}
+          token: ${{ secrets.TERMUXBOT2_TOKEN }}
       - name: Revbump main/command-not-found
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.TERMUXBOT2_TOKEN }}
         run: |
           git config --global user.name "Termux Github Actions"
           git config --global user.email "contact@termux.dev"

--- a/.github/workflows/package_updates.yml
+++ b/.github/workflows/package_updates.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_API_KEY }}
+          token: ${{ secrets.TERMUXBOT2_TOKEN }}
       - name: Process package updates
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.TERMUXBOT2_TOKEN }}
           BUILD_PACKAGES: "true"
           GIT_COMMIT_PACKAGES: "true"
           GIT_PUSH_PACKAGES: "true"


### PR DESCRIPTION
instead of `GH_API_KEY`.

I'm not sure if this works.

Ref: #14993