### PR TITLE
chore(editorconfig): initial setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,35 @@
+[*]
+trim_trailing_whitespace = true
+
+[*.{patch,.diff,.patch.*}]
+trim_trailing_whitespace = false
+
+[*.sh]
+indent_style = tab
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[repo.json]
+indent_style = space
+indent_size = 2
+
+[Dockerfile]
+indent_style = tab
+
+[scripts/profile.json]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[ndk-patches/*.h]
+indent_style = tab


### PR DESCRIPTION
See https://editorconfig.org/. `.editorconfig` should help contributors
by not having them to set up configs on their own sides for their code
editor of choice. Editorconfig also has plugins for most commonly used
code editors
