### PR TITLE
scripts: create lib{util,rt,pthread}.so in termux_step_start_build

### DIFF
--- a/scripts/build/termux_step_extract_into_massagedir.sh
+++ b/scripts/build/termux_step_extract_into_massagedir.sh
@@ -4,7 +4,7 @@ termux_step_extract_into_massagedir() {
 	# Build diff tar with what has changed during the build:
 	cd $TERMUX_PREFIX
 	tar -N "$TERMUX_BUILD_TS_FILE" \
-		--exclude='lib/libutil.so' --exclude='tmp' \
+		--exclude='tmp' \
 		-czf "$TARBALL_ORIG" .
 
 	# Extract tar in order to massage it

--- a/scripts/build/termux_step_setup_toolchain.sh
+++ b/scripts/build/termux_step_setup_toolchain.sh
@@ -6,10 +6,10 @@ termux_step_setup_toolchain() {
 	# toolchain setup to ensure that everyone gets an updated
 	# toolchain
 	if [ "${TERMUX_NDK_VERSION}" = 25c ]; then
-		TERMUX_STANDALONE_TOOLCHAIN+="-v0"
+		TERMUX_STANDALONE_TOOLCHAIN+="-v1"
 		termux_setup_toolchain_25c
 	elif [ "${TERMUX_NDK_VERSION}" = 23c ]; then
-		TERMUX_STANDALONE_TOOLCHAIN+="-v3"
+		TERMUX_STANDALONE_TOOLCHAIN+="-v4"
 		termux_setup_toolchain_23c
 	else
 		termux_error_exit "We do not have a setup_toolchain function for NDK version $TERMUX_NDK_VERSION"

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -103,4 +103,11 @@ termux_step_start_build() {
 			7c29143b9cffb3a9a580f39a7966b2bb36c5fc099da6f4c98dcdedacb14f08a2
 		chmod u+x "$TERMUX_ELF_CLEANER"
 	fi
+
+	# On Android 7, libutil functionality is provided by libc.
+	# But many programs still may search for libutil.
+	if [ ! -f $TERMUX_PREFIX/lib/libutil.so ]; then
+		mkdir -p "$TERMUX_PREFIX/lib"
+		echo 'INPUT(-lc)' > $TERMUX_PREFIX/lib/libutil.so
+	fi
 }

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -104,10 +104,13 @@ termux_step_start_build() {
 		chmod u+x "$TERMUX_ELF_CLEANER"
 	fi
 
-	# On Android 7, libutil functionality is provided by libc.
-	# But many programs still may search for libutil.
-	if [ ! -f $TERMUX_PREFIX/lib/libutil.so ]; then
-		mkdir -p "$TERMUX_PREFIX/lib"
-		echo 'INPUT(-lc)' > $TERMUX_PREFIX/lib/libutil.so
-	fi
+	# Some packages search for libutil, libpthread and librt even
+	# though this functionality is provided by libc.  Provide
+	# library stubs so that such configure checks succeed.
+	mkdir -p "$TERMUX_PREFIX/lib"
+	for lib in libutil.so libpthread.so librt.so; do
+		if [ ! -f $TERMUX_PREFIX/lib/$lib ]; then
+			echo 'INPUT(-lc)' > $TERMUX_PREFIX/lib/$lib
+		fi
+	done
 }

--- a/scripts/build/toolchain/termux_setup_toolchain_23c.sh
+++ b/scripts/build/toolchain/termux_setup_toolchain_23c.sh
@@ -113,13 +113,6 @@ termux_setup_toolchain_23c() {
 	export ac_cv_func_sigsetmask=no
 	export ac_cv_c_bigendian=no
 
-	# On Android 7, libutil functionality is provided by libc.
-	# But many programs still may search for libutil.
-	if [ ! -f $TERMUX_PREFIX/lib/libutil.so ]; then
-		mkdir -p "$TERMUX_PREFIX/lib"
-		echo 'INPUT(-lc)' > $TERMUX_PREFIX/lib/libutil.so
-	fi
-
 	if [ "$TERMUX_ON_DEVICE_BUILD" = "true" ] || [ -d $TERMUX_STANDALONE_TOOLCHAIN ]; then
 		return
 	fi

--- a/scripts/build/toolchain/termux_setup_toolchain_25c.sh
+++ b/scripts/build/toolchain/termux_setup_toolchain_25c.sh
@@ -15,6 +15,7 @@ termux_setup_toolchain_25c() {
 	export READELF=llvm-readelf
 	export STRIP=llvm-strip
 	export NM=llvm-nm
+	export CXXFILT=llvm-cxxfilt
 
 	export TERMUX_HASKELL_LLVM_BACKEND="-fllvm --ghc-option=-fllvm"
 	if [ "${TERMUX_ARCH}" = "i686" ]; then

--- a/scripts/build/toolchain/termux_setup_toolchain_25c.sh
+++ b/scripts/build/toolchain/termux_setup_toolchain_25c.sh
@@ -114,13 +114,6 @@ termux_setup_toolchain_25c() {
 	export ac_cv_func_sigsetmask=no
 	export ac_cv_c_bigendian=no
 
-	# On Android 7, libutil functionality is provided by libc.
-	# But many programs still may search for libutil.
-	if [ ! -f $TERMUX_PREFIX/lib/libutil.so ]; then
-		mkdir -p "$TERMUX_PREFIX/lib"
-		echo 'INPUT(-lc)' > $TERMUX_PREFIX/lib/libutil.so
-	fi
-
 	if [ "$TERMUX_ON_DEVICE_BUILD" = "true" ] || [ -d $TERMUX_STANDALONE_TOOLCHAIN ]; then
 		return
 	fi

--- a/scripts/setup-termux.sh
+++ b/scripts/setup-termux.sh
@@ -19,6 +19,7 @@ PACKAGES+=" autoconf"
 PACKAGES+=" automake"
 PACKAGES+=" bc"
 PACKAGES+=" bison"
+PACKAGES+=" bsdtar"                     # Needed to create pacman packages
 PACKAGES+=" cmake"
 PACKAGES+=" ed"
 PACKAGES+=" flex"
@@ -42,7 +43,7 @@ PACKAGES+=" texinfo"
 PACKAGES+=" uuid-utils"
 PACKAGES+=" valac"
 PACKAGES+=" xmlto"                      # Needed by git's manpage generation
-PACKAGES+=" bsdtar"          # Needed to create pacman packages
+PACKAGES+=" zip"
 
 apt update
 apt dist-upgrade -y


### PR DESCRIPTION
Currently we create only libutil.so in our setup_toolchain scripts. Several packages have pthread patches that should no longer be needed if we create libpthread.so.

This makes environment on device slightly more similar to docker builds also, on device we have these libraries in ndk-sysroot.

These changes allows us to simplify openjdk build script a bit. Will push that with a %ci:no-build tag after this is merged.