### PR TITLE
tree-wide: Cleanup dummy `lib{rt,pthread}` hack

### DIFF
--- a/x11-packages/deadbeef/build.sh
+++ b/x11-packages/deadbeef/build.sh
@@ -26,13 +26,6 @@ termux_step_pre_configure() {
 		all:
 		install:
 	EOF
-
-	_NEED_DUMMY_LIBPTHREAD_A=
-	_LIBPTHREAD_A=$TERMUX_PREFIX/lib/libpthread.a
-	if [ ! -e $_LIBPTHREAD_A ]; then
-		_NEED_DUMMY_LIBPTHREAD_A=true
-		echo '!<arch>' > $_LIBPTHREAD_A
-	fi
 }
 
 termux_step_post_configure() {
@@ -40,10 +33,6 @@ termux_step_post_configure() {
 }
 
 termux_step_post_make_install() {
-	if [ $_NEED_DUMMY_LIBPTHREAD_A ]; then
-		rm -f $_LIBPTHREAD_A
-	fi
-
 	cd $TERMUX_PKG_SRCDIR
 	local f
 	for f in $(find plugins -name COPYING); do

--- a/x11-packages/handbrake/build.sh
+++ b/x11-packages/handbrake/build.sh
@@ -23,21 +23,8 @@ termux_step_pre_configure() {
 	sed -i -E '/(\/contrib|contrib\/)/d' make/include/main.defs
 
 	LDFLAGS+=" -liconv -lx265"
-
-	_NEED_DUMMY_LIBPTHREAD_A=
-	_LIBPTHREAD_A=$TERMUX_PREFIX/lib/libpthread.a
-	if [ ! -e $_LIBPTHREAD_A ]; then
-		_NEED_DUMMY_LIBPTHREAD_A=true
-		echo '!<arch>' > $_LIBPTHREAD_A
-	fi
 }
 
 termux_step_configure() {
 	$TERMUX_PKG_SRCDIR/configure $TERMUX_PKG_EXTRA_CONFIGURE_ARGS
-}
-
-termux_step_post_make_install() {
-	if [ $_NEED_DUMMY_LIBPTHREAD_A ]; then
-		rm -f $_LIBPTHREAD_A
-	fi
 }

--- a/x11-packages/kitty/build.sh
+++ b/x11-packages/kitty/build.sh
@@ -26,13 +26,6 @@ termux_step_post_get_source() {
 
 termux_step_pre_configure() {
 	CFLAGS+=" $CPPFLAGS"
-
-	_NEED_DUMMY_LIBRT_A=
-	_LIBRT_A=$TERMUX_PREFIX/lib/librt.a
-	if [ ! -e $_LIBRT_A ]; then
-		_NEED_DUMMY_LIBRT_A=true
-		echo '!<arch>' > $_LIBRT_A
-	fi
 }
 
 termux_step_make() {
@@ -43,10 +36,4 @@ termux_step_make() {
 
 termux_step_make_install() {
 	cp -rT linux-package $TERMUX_PREFIX
-}
-
-termux_step_post_make_install() {
-	if [ $_NEED_DUMMY_LIBRT_A ]; then
-		rm -f $_LIBRT_A
-	fi
 }

--- a/x11-packages/raylib/build.sh
+++ b/x11-packages/raylib/build.sh
@@ -15,18 +15,3 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DUSE_EXTERNAL_GLFW=ON
 -DOPENGL_VERSION=2.1
 "
-
-termux_step_pre_configure() {
-	_NEED_DUMMY_LIBPTHREAD_A=
-	_LIBPTHREAD_A=$TERMUX_PREFIX/lib/libpthread.a
-	if [ ! -e $_LIBPTHREAD_A ]; then
-		_NEED_DUMMY_LIBPTHREAD_A=true
-		echo '!<arch>' > $_LIBPTHREAD_A
-	fi
-}
-
-termux_step_post_make_install() {
-	if [ $_NEED_DUMMY_LIBPTHREAD_A ]; then
-		rm -f $_LIBPTHREAD_A
-	fi
-}

--- a/x11-packages/sfml/build.sh
+++ b/x11-packages/sfml/build.sh
@@ -11,27 +11,3 @@ TERMUX_PKG_DEPENDS="freetype, libc++, libflac, libogg, libvorbis, libx11, libxra
 termux_step_post_get_source() {
 	cp src/SFML/Window/Android/JoystickImpl.{cpp,hpp} src/SFML/Window/Unix/
 }
-
-termux_step_pre_configure() {
-	_NEED_DUMMY_LIBPTHREAD_A=
-	_LIBPTHREAD_A=$TERMUX_PREFIX/lib/libpthread.a
-	if [ ! -e $_LIBPTHREAD_A ]; then
-		_NEED_DUMMY_LIBPTHREAD_A=true
-		echo '!<arch>' > $_LIBPTHREAD_A
-	fi
-	_NEED_DUMMY_LIBRT_A=
-	_LIBRT_A=$TERMUX_PREFIX/lib/librt.a
-	if [ ! -e $_LIBRT_A ]; then
-		_NEED_DUMMY_LIBRT_A=true
-		echo '!<arch>' > $_LIBRT_A
-	fi
-}
-
-termux_step_post_make_install() {
-	if [ $_NEED_DUMMY_LIBPTHREAD_A ]; then
-		rm -f $_LIBPTHREAD_A
-	fi
-	if [ $_NEED_DUMMY_LIBRT_A ]; then
-		rm -f $_LIBRT_A
-	fi
-}


### PR DESCRIPTION
after commit af18f1dac0b561d5a54cbdad4aa6c90491ef71f5.

%ci:no-build