### PR TITLE
new packages: xf86-video-dummy and xf86-input-void. Added default config for Xorg.

### DIFF
--- a/x11-packages/xf86-input-void/build.sh
+++ b/x11-packages/xf86-input-void/build.sh
@@ -1,0 +1,10 @@
+TERMUX_PKG_HOMEPAGE=https://xorg.freedesktop.org/
+TERMUX_PKG_DESCRIPTION="X.org void input driver"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=1.4.2
+TERMUX_PKG_SRCURL=https://xorg.freedesktop.org/releases/individual/driver/xf86-input-void-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=a211d8e21ce0e2ed8af5b8a2e8d4409d70c9c7e5ee528f5e6002ad279bf07885
+TERMUX_PKG_DEPENDS="xorg-server"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_NO_STATICSPLIT=true

--- a/x11-packages/xf86-video-dummy/build.sh
+++ b/x11-packages/xf86-video-dummy/build.sh
@@ -1,0 +1,11 @@
+TERMUX_PKG_HOMEPAGE=https://xorg.freedesktop.org/
+TERMUX_PKG_DESCRIPTION="X.org dummy video driver"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+# Please, do not update it to 0.4.0.
+TERMUX_PKG_VERSION=0.3.8
+TERMUX_PKG_SRCURL=https://xorg.freedesktop.org/releases/individual/driver/xf86-video-dummy-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=ee5ad51e80c8cc90d4c76ac3dec2269a3c769f4232ed418b29d60d618074631b
+TERMUX_PKG_DEPENDS="xorg-server"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_NO_STATICSPLIT=true

--- a/x11-packages/xorg-server/build.sh
+++ b/x11-packages/xorg-server/build.sh
@@ -3,11 +3,12 @@ TERMUX_PKG_DESCRIPTION="Xorg server"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=21.1.7
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://xorg.freedesktop.org/releases/individual/xserver/xorg-server-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=d9c60b2dd0ec52326ca6ab20db0e490b1ff4f566f59ca742d6532e92795877bb
 TERMUX_PKG_DEPENDS="libandroid-shmem, libdrm, libpciaccess, libpixman, libx11, libxau, libxcvt, libxfont2, libxinerama, libxkbfile, libxshmfence, opengl, openssl, xkeyboard-config, xorg-protocol-txt, xorg-xkbcomp"
-TERMUX_PKG_BUILD_DEPENDS="mesa-dev"
+TERMUX_PKG_RECOMMENDS="xf86-video-dummy, xf86-input-void"
+TERMUX_PKG_NO_STATICSPLIT=true
 
 # Provided by xorg-protocol-txt (subpackage of xorg-server-xvfb):
 TERMUX_PKG_RM_AFTER_INSTALL="lib/xorg/protocol.txt"
@@ -81,6 +82,7 @@ termux_step_pre_configure() {
 
 termux_step_post_make_install () {
 	rm -f "${TERMUX_PREFIX}/usr/share/X11/xkb/compiled"
+	install -Dm644 -t "$TERMUX_PREFIX/etc/X11/" "${TERMUX_PKG_BUILDER_DIR}/xorg.conf" 
 }
 
 ## The following is required for package 'tigervnc'.

--- a/x11-packages/xorg-server/xorg.conf
+++ b/x11-packages/xorg-server/xorg.conf
@@ -1,0 +1,49 @@
+# Just some default xorg.conf
+
+Section "ServerFlags"
+  Option "DontVTSwitch" "true"
+  Option "AllowMouseOpenFail" "true"
+  Option "PciForceNone" "true"
+  Option "AutoEnableDevices" "false"
+  Option "AutoAddDevices" "false"
+EndSection
+
+Section "InputDevice"
+  Identifier "NoMouse"
+  Option "CorePointer" "true"
+  Driver "void"
+EndSection
+
+Section "InputDevice"
+  Identifier "NoKeyboard"
+  Option "CoreKeyboard" "true"
+  Driver "void"
+EndSection
+
+Section "Device"
+  Identifier "Videocard0"
+  Driver "dummy"
+  VideoRam 4096000
+EndSection
+
+Section "Monitor"
+  Identifier "Monitor0"
+EndSection
+
+Section "Screen"
+  Identifier "Screen0"
+  Device "Videocard0"
+  Monitor "Monitor0"
+  DefaultDepth 24
+  SubSection "Display"
+    Viewport 0 0
+    Depth 24
+  EndSubSection
+EndSection
+
+Section "ServerLayout"
+  Identifier   "dummy_layout"
+  Screen       "screen0"
+  InputDevice  "NoMouse"
+  InputDevice  "NoKeyboard"
+EndSection


### PR DESCRIPTION
xorg-server with default modules (dummy and void) is needed to make termux-x11 work with existing server. Xvfb is slow, Xwayland needs compositor and does not support multiple resolutions. Xorg is enough good for this.