### PR TITLE
tidy: Bump to 5.9.14-next

### DIFF
--- a/packages/php/build.sh
+++ b/packages/php/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_LICENSE_FILE=LICENSE
 TERMUX_PKG_MAINTAINER="@termux"
 # Please revbump php-* extensions along with "minor" bump (e.g. 8.1.x to 8.2.0)
 TERMUX_PKG_VERSION=8.2.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/php/php-src/archive/php-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=afd375e6cf41099ca1d87734382b84df75425fcd30f591dd6de379ebbe652451
 # Build native php for phar to build (see pear-Makefile.frag.patch):

--- a/packages/tidy/build.sh
+++ b/packages/tidy/build.sh
@@ -3,11 +3,12 @@ TERMUX_PKG_DESCRIPTION="A tool to tidy down your HTML code to a clean style"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="README/LICENSE.md"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=5.8.0
-TERMUX_PKG_REVISION=1
+# Using unstable API version due to CVE-2021-33391.
+# Please revbump revdeps to rebuild when bumping version.
+TERMUX_PKG_VERSION=5.9.14-next
 TERMUX_PKG_SRCURL=https://github.com/htacg/tidy-html5/archive/${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=59c86d5b2e452f63c5cdb29c866a12a4c55b1741d7025cf2f3ce0cde99b0660e
-TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_SHA256=83cc9d9cdfa59bfe400dc745dea14eb1e1be4ca088facfb911eac8b78e75f2b4
+TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_DEPENDS="libxslt"
 TERMUX_PKG_BREAKS="tidy-dev"
 TERMUX_PKG_REPLACES="tidy-dev"
@@ -16,7 +17,7 @@ TERMUX_PKG_HOSTBUILD=true
 termux_step_post_get_source() {
 	# Do not forget to bump revision of reverse dependencies and rebuild them
 	# after SOVERSION is changed.
-	local _SOVERSION=58
+	local _SOVERSION=
 
 	local _MAJOR=$(echo ${TERMUX_PKG_VERSION#*:} | cut -d . -f 1)
 	local _MINOR=$(echo ${TERMUX_PKG_VERSION#*:} | cut -d . -f 2)


### PR DESCRIPTION
To fix CVE-2021-33391.