### PR TITLE
libduckdb: enable various extensions

### DIFF
--- a/packages/libduckdb/CMakeLists.txt.patch
+++ b/packages/libduckdb/CMakeLists.txt.patch
@@ -1,24 +1,10 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -280,17 +280,16 @@ option(EXTENSION_STATIC_BUILD
+@@ -280,7 +280,6 @@ option(EXTENSION_STATIC_BUILD
  set(JEMALLOC_DEFAULT_BUILD FALSE)
  if(NOT CLANG_TIDY AND OS_NAME STREQUAL "linux")
    # build jemalloc by default for linux
 -  set(JEMALLOC_DEFAULT_BUILD TRUE)
  endif()
  
--option(BUILD_ICU_EXTENSION "Build the ICU extension." FALSE)
--option(BUILD_PARQUET_EXTENSION "Build the Parquet extension." FALSE)
-+option(BUILD_ICU_EXTENSION "Build the ICU extension." TRUE)
-+option(BUILD_PARQUET_EXTENSION "Build the Parquet extension." TRUE)
- option(BUILD_TPCH_EXTENSION "Build the TPC-H extension." FALSE)
- option(BUILD_TPCDS_EXTENSION "Build the TPC-DS extension." FALSE)
- option(BUILD_FTS_EXTENSION "Build the FTS extension." FALSE)
--option(BUILD_HTTPFS_EXTENSION "Build the HTTP File System extension." FALSE)
-+option(BUILD_HTTPFS_EXTENSION "Build the HTTP File System extension." TRUE)
- option(BUILD_VISUALIZER_EXTENSION "Build the profiler-output visualizer extension." FALSE)
--option(BUILD_JSON_EXTENSION "Build the JSON extension." FALSE)
-+option(BUILD_JSON_EXTENSION "Build the JSON extension." TRUE)
- option(BUILD_JEMALLOC_EXTENSION "Build the JEMalloc extension." ${JEMALLOC_DEFAULT_BUILD})
- option(BUILD_EXCEL_EXTENSION "Build the excel extension." FALSE)
- option(BUILD_INET_EXTENSION "Build the inet extension." FALSE)
+ option(BUILD_ICU_EXTENSION "Build the ICU extension." FALSE)

--- a/packages/libduckdb/CMakeLists.txt.patch
+++ b/packages/libduckdb/CMakeLists.txt.patch
@@ -1,10 +1,24 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -280,7 +280,6 @@ option(EXTENSION_STATIC_BUILD
+@@ -280,17 +280,16 @@ option(EXTENSION_STATIC_BUILD
  set(JEMALLOC_DEFAULT_BUILD FALSE)
  if(NOT CLANG_TIDY AND OS_NAME STREQUAL "linux")
    # build jemalloc by default for linux
 -  set(JEMALLOC_DEFAULT_BUILD TRUE)
  endif()
  
- option(BUILD_ICU_EXTENSION "Build the ICU extension." FALSE)
+-option(BUILD_ICU_EXTENSION "Build the ICU extension." FALSE)
+-option(BUILD_PARQUET_EXTENSION "Build the Parquet extension." FALSE)
++option(BUILD_ICU_EXTENSION "Build the ICU extension." TRUE)
++option(BUILD_PARQUET_EXTENSION "Build the Parquet extension." TRUE)
+ option(BUILD_TPCH_EXTENSION "Build the TPC-H extension." FALSE)
+ option(BUILD_TPCDS_EXTENSION "Build the TPC-DS extension." FALSE)
+ option(BUILD_FTS_EXTENSION "Build the FTS extension." FALSE)
+-option(BUILD_HTTPFS_EXTENSION "Build the HTTP File System extension." FALSE)
++option(BUILD_HTTPFS_EXTENSION "Build the HTTP File System extension." TRUE)
+ option(BUILD_VISUALIZER_EXTENSION "Build the profiler-output visualizer extension." FALSE)
+-option(BUILD_JSON_EXTENSION "Build the JSON extension." FALSE)
++option(BUILD_JSON_EXTENSION "Build the JSON extension." TRUE)
+ option(BUILD_JEMALLOC_EXTENSION "Build the JEMalloc extension." ${JEMALLOC_DEFAULT_BUILD})
+ option(BUILD_EXCEL_EXTENSION "Build the excel extension." FALSE)
+ option(BUILD_INET_EXTENSION "Build the inet extension." FALSE)

--- a/packages/libduckdb/build.sh
+++ b/packages/libduckdb/build.sh
@@ -3,9 +3,10 @@ TERMUX_PKG_DESCRIPTION="An in-process SQL OLAP database management system"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.7.1
+TERMUX_PKG_REVISION=1
 # we clone to retain the .git directory, to ensure the version in the built executable is correctly populated
 TERMUX_PKG_SRCURL=git+https://github.com/duckdb/duckdb
-TERMUX_PKG_DEPENDS="libc++"
+TERMUX_PKG_DEPENDS="libc++, openssl"
 
 termux_step_pre_configure() {
 	LDFLAGS+=" -llog"

--- a/packages/libduckdb/build.sh
+++ b/packages/libduckdb/build.sh
@@ -7,6 +7,12 @@ TERMUX_PKG_REVISION=1
 # we clone to retain the .git directory, to ensure the version in the built executable is correctly populated
 TERMUX_PKG_SRCURL=git+https://github.com/duckdb/duckdb
 TERMUX_PKG_DEPENDS="libc++, openssl"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DBUILD_ICU_EXTENSION=TRUE 
+-DBUILD_PARQUET_EXTENSION=TRUE 
+-DBUILD_HTTPFS_EXTENSION=TRUE 
+-DBUILD_JSON_EXTENSION=TRUE
+"
 
 termux_step_pre_configure() {
 	LDFLAGS+=" -llog"


### PR DESCRIPTION
Not sure if there's a way to set CMake flags instead? That would be much nicer than patching the CMakeLists.txt