### PR TITLE
new package: virglrenderer-android

### DIFF
--- a/x11-packages/virglrenderer-android/0001-meson-add-new-option-egl_without_gbm-to-enable-build.patch.beforehostbuild
+++ b/x11-packages/virglrenderer-android/0001-meson-add-new-option-egl_without_gbm-to-enable-build.patch.beforehostbuild
@@ -1,0 +1,132 @@
+From 2da3dd9c2f8e1b594394a4a38da00f17dbb922c8 Mon Sep 17 00:00:00 2001
+From: CosineMath <boat_jvm@qq.com>
+Date: Tue, 21 Sep 2021 23:49:00 +0800
+Subject: [PATCH 1/6] meson: add new option 'egl_without_gbm' to enable
+ building without libgbm. Enable building without libdrm.
+
+---
+ config.h.meson    |  2 ++
+ meson.build       | 23 +++++++++++++++++++----
+ meson_options.txt |  7 +++++++
+ src/meson.build   |  9 +++++++--
+ 4 files changed, 35 insertions(+), 6 deletions(-)
+
+diff --git a/config.h.meson b/config.h.meson
+index b25a86b2..63130a14 100644
+--- a/config.h.meson
++++ b/config.h.meson
+@@ -55,3 +55,5 @@
+ #mesondefine PIPE_ARCH_S390
+ #mesondefine PIPE_ARCH_ARM
+ #mesondefine PIPE_ARCH_AARCH64
++#mesondefine EGL_WITHOUT_GBM
++#mesondefine HAVE_LIBDRM
+diff --git a/meson.build b/meson.build
+index ddb74daa..5aa99b53 100644
+--- a/meson.build
++++ b/meson.build
+@@ -66,7 +66,7 @@ add_project_arguments(cc.get_supported_arguments(flags), language : 'c')
+ 
+ prog_python = import('python').find_installation('python3')
+ 
+-libdrm_dep = dependency('libdrm', version : '>=2.4.50')
++libdrm_dep = dependency('libdrm', version : '>=2.4.50', required : false)
+ thread_dep = dependency('threads')
+ epoxy_dep = dependency('epoxy', version: '>= 1.5.4')
+ m_dep = cc.find_library('m', required : false)
+@@ -183,6 +183,10 @@ if get_option('buildtype') == 'debug'
+    add_global_arguments('-DDEBUG=1', language : 'c')
+ endif
+ 
++if libdrm_dep.found()
++  conf_data.set('HAVE_LIBDRM', 1)
++endif
++
+ platforms = get_option('platforms')
+ 
+ require_egl = platforms.contains('egl')
+@@ -195,8 +199,13 @@ with_glx = require_glx or auto_egl_glx
+ have_egl = false
+ have_glx = false
+ 
++egl_without_gbm = get_option('egl_without_gbm')
++
+ with_minigbm_allocation = get_option('minigbm_allocation')
+ if with_minigbm_allocation
++   if egl_without_gbm
++      error('Cannot build gbm allocation without gbm')
++   endif
+    conf_data.set('ENABLE_MINIGBM_ALLOCATION', 1)
+    _gbm_ver = '18.0.0'
+ else
+@@ -205,8 +214,14 @@ endif
+ 
+ if with_egl
+    if cc.has_header('epoxy/egl.h', dependencies: epoxy_dep) and epoxy_dep.get_pkgconfig_variable('epoxy_has_egl') == '1'
+-      gbm_dep = dependency('gbm', version: '>= ' + _gbm_ver, required: require_egl)
+-      have_egl = gbm_dep.found()
++      if egl_without_gbm
++         gbm_dep = dependency('', required : false)
++         have_egl = true
++         conf_data.set('EGL_WITHOUT_GBM', 1)
++      else
++         gbm_dep = dependency('gbm', version: '>= ' + _gbm_ver, required: require_egl)
++         have_egl = gbm_dep.found()
++      endif
+       if (have_egl)
+          conf_data.set('HAVE_EPOXY_EGL_H', 1)
+       else
+@@ -316,7 +331,7 @@ summary({'prefix': get_option('prefix'),
+         'libdir': get_option('libdir'),
+         }, section: 'Directories')
+ summary({'c_args': (' ').join(get_option('c_args')),
+-        'egl': have_egl,
++        'egl': (have_egl ? 'yes' : 'no') + (egl_without_gbm ? ' (no gbm)' : ''),
+         'glx': have_glx,
+         'minigbm_alloc': with_minigbm_allocation,
+         'venus': with_venus,
+diff --git a/meson_options.txt b/meson_options.txt
+index cb774064..3e43e676 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -31,6 +31,13 @@ option(
+   description : 'Platforms support, set to auto to enable all.'
+ )
+ 
++option(
++  'egl_without_gbm',
++  type : 'boolean',
++  value : 'false',
++  description : 'Build egl platform without gbm'
++)
++
+ option(
+   'minigbm_allocation',
+   type : 'boolean',
+diff --git a/src/meson.build b/src/meson.build
+index d78ac8c9..e9c97f72 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -64,12 +64,17 @@ virglrenderer_sources = [
+ ]
+ 
+ vrend_winsys_egl_sources = [
+-   'vrend_winsys_gbm.c',
+-   'vrend_winsys_gbm.h',
+    'vrend_winsys_egl.c',
+    'vrend_winsys_egl.h',
+ ]
+ 
++if not egl_without_gbm
++   vrend_winsys_egl_sources += [
++      'vrend_winsys_gbm.c',
++      'vrend_winsys_gbm.h',
++   ]
++endif
++
+ vrend_winsys_glx_sources = [
+    'vrend_winsys_glx.c',
+    'vrend_winsys_glx.h',
+-- 
+2.34.1
+

--- a/x11-packages/virglrenderer-android/0002-android-build-and-use-egl-platform-on-Android-withou.patch.beforehostbuild
+++ b/x11-packages/virglrenderer-android/0002-android-build-and-use-egl-platform-on-Android-withou.patch.beforehostbuild
@@ -1,0 +1,223 @@
+From 821cefb965d8c05e2791b031eb6448bd67d36572 Mon Sep 17 00:00:00 2001
+From: CosineMath <boat_jvm@qq.com>
+Date: Wed, 22 Sep 2021 00:11:10 +0800
+Subject: [PATCH 2/6] android: build and use egl platform on Android without
+ libdrm and libgbm.
+
+---
+ src/vrend_renderer.c   |  2 +-
+ src/vrend_renderer.h   |  5 +++++
+ src/vrend_winsys.c     | 14 +++++++++-----
+ src/vrend_winsys.h     |  2 ++
+ src/vrend_winsys_egl.c | 21 ++++++++++++++++-----
+ 5 files changed, 33 insertions(+), 11 deletions(-)
+
+diff --git a/src/vrend_renderer.c b/src/vrend_renderer.c
+index 4b7ee369..78dbe4b9 100644
+--- a/src/vrend_renderer.c
++++ b/src/vrend_renderer.c
+@@ -12283,7 +12283,7 @@ vrend_renderer_pipe_resource_set_type(struct vrend_context *ctx,
+ 
+    /* resource is still untyped */
+    if (!res->pipe_resource) {
+-#ifdef HAVE_EPOXY_EGL_H
++#if defined(HAVE_EPOXY_EGL_H) && !defined(EGL_WITHOUT_GBM)
+       const struct vrend_renderer_resource_create_args create_args = {
+          .target = PIPE_TEXTURE_2D,
+          .format = args->format,
+diff --git a/src/vrend_renderer.h b/src/vrend_renderer.h
+index 2aedf50e..c8ca418c 100644
+--- a/src/vrend_renderer.h
++++ b/src/vrend_renderer.h
+@@ -32,7 +32,12 @@
+ #include "vrend_debug.h"
+ #include "vrend_tweaks.h"
+ #include "vrend_iov.h"
++#ifdef EGL_WITHOUT_GBM
++#define VIRGL_GBM_MAX_PLANES 4
++#include "virglrenderer.h"
++#else
+ #include "vrend_winsys_gbm.h"
++#endif
+ #include "virgl_hw.h"
+ #include <epoxy/gl.h>
+ 
+diff --git a/src/vrend_winsys.c b/src/vrend_winsys.c
+index 6a73b7fd..eea16ec8 100644
+--- a/src/vrend_winsys.c
++++ b/src/vrend_winsys.c
+@@ -52,6 +52,7 @@ int vrend_winsys_init(uint32_t flags, int preferred_fd)
+ {
+    if (flags & VIRGL_RENDERER_USE_EGL) {
+ #ifdef HAVE_EPOXY_EGL_H
++#ifndef EGL_WITHOUT_GBM
+       /*
+        * If the user specifies a preferred DRM fd and we can't use it, fail. If the user doesn't
+        * specify an fd, it's possible to initialize EGL without one.
+@@ -59,15 +60,16 @@ int vrend_winsys_init(uint32_t flags, int preferred_fd)
+       gbm = virgl_gbm_init(preferred_fd);
+       if (preferred_fd > 0 && !gbm)
+          return -1;
+-
++#endif
+       egl = virgl_egl_init(gbm, flags & VIRGL_RENDERER_USE_SURFACELESS,
+                            flags & VIRGL_RENDERER_USE_GLES);
+       if (!egl) {
++#ifndef EGL_WITHOUT_GBM
+          if (gbm) {
+             virgl_gbm_fini(gbm);
+             gbm = NULL;
+          }
+-
++#endif
+          return -1;
+       }
+ 
+@@ -99,10 +101,12 @@ void vrend_winsys_cleanup(void)
+       virgl_egl_destroy(egl);
+       egl = NULL;
+       use_context = CONTEXT_NONE;
++#ifndef EGL_WITHOUT_GBM
+       if (gbm) {
+          virgl_gbm_fini(gbm);
+          gbm = NULL;
+       }
++#endif
+    } else if (use_context == CONTEXT_EGL_EXTERNAL) {
+       free(egl);
+       egl = NULL;
+@@ -201,7 +205,7 @@ int vrend_winsys_has_gl_colorspace(void)
+ 
+ int vrend_winsys_get_fourcc_for_texture(uint32_t tex_id, uint32_t format, int *fourcc)
+ {
+-#ifdef HAVE_EPOXY_EGL_H
++#if defined(HAVE_EPOXY_EGL_H) && !defined(EGL_WITHOUT_GBM)
+    if (use_context == CONTEXT_EGL)
+       return virgl_egl_get_fourcc_for_texture(egl, tex_id, format, fourcc);
+ #else
+@@ -214,7 +218,7 @@ int vrend_winsys_get_fourcc_for_texture(uint32_t tex_id, uint32_t format, int *f
+ 
+ int vrend_winsys_get_fd_for_texture(uint32_t tex_id, int *fd)
+ {
+-#ifdef HAVE_EPOXY_EGL_H
++#if defined(HAVE_EPOXY_EGL_H) && !defined(EGL_WITHOUT_GBM)
+    if (!egl)
+       return -1;
+ 
+@@ -228,7 +232,7 @@ int vrend_winsys_get_fd_for_texture(uint32_t tex_id, int *fd)
+ 
+ int vrend_winsys_get_fd_for_texture2(uint32_t tex_id, int *fd, int *stride, int *offset)
+ {
+-#ifdef HAVE_EPOXY_EGL_H
++#if defined(HAVE_EPOXY_EGL_H) && !defined(EGL_WITHOUT_GBM)
+    if (!egl)
+       return -1;
+ 
+diff --git a/src/vrend_winsys.h b/src/vrend_winsys.h
+index 5e605403..61891817 100644
+--- a/src/vrend_winsys.h
++++ b/src/vrend_winsys.h
+@@ -28,7 +28,9 @@
+ #include "config.h"
+ 
+ #ifdef HAVE_EPOXY_EGL_H
++#ifndef EGL_WITHOUT_GBM
+ #include "vrend_winsys_gbm.h"
++#endif
+ #include "vrend_winsys_egl.h"
+ #endif
+ 
+diff --git a/src/vrend_winsys_egl.c b/src/vrend_winsys_egl.c
+index 4b38d5ea..68adaa43 100644
+--- a/src/vrend_winsys_egl.c
++++ b/src/vrend_winsys_egl.c
+@@ -36,7 +36,9 @@
+ #include <poll.h>
+ #include <stdbool.h>
+ #include <unistd.h>
++#ifdef HAVE_LIBDRM
+ #include <xf86drm.h>
++#endif
+ 
+ #include "util/u_memory.h"
+ 
+@@ -44,7 +46,9 @@
+ #include "vrend_winsys.h"
+ #include "vrend_winsys_egl.h"
+ #include "virgl_hw.h"
++#ifndef EGL_WITHOUT_GBM
+ #include "vrend_winsys_gbm.h"
++#endif
+ #include "virgl_util.h"
+ 
+ #define EGL_KHR_SURFACELESS_CONTEXT            BIT(0)
+@@ -297,13 +301,15 @@ struct virgl_egl *virgl_egl_init(struct virgl_gbm *gbm, bool surfaceless, bool g
+ 
+    if (surfaceless)
+       conf_att[1] = EGL_PBUFFER_BIT;
++#ifndef EGL_WITHOUT_GBM
+    else if (!gbm)
+       goto fail;
+ 
+    egl->gbm = gbm;
++#endif
+    egl->different_gpu = false;
+    const char *client_extensions = eglQueryString (NULL, EGL_EXTENSIONS);
+-
++#ifndef EGL_WITHOUT_GBM
+ #ifdef ENABLE_MINIGBM_ALLOCATION
+    if (virgl_egl_get_display(egl)) {
+      /* Make -Wdangling-else happy. */
+@@ -325,15 +331,16 @@ struct virgl_egl *virgl_egl_init(struct virgl_gbm *gbm, bool surfaceless, bool g
+    } else {
+       egl->egl_display = eglGetDisplay((EGLNativeDisplayType)egl->gbm->device);
+    }
+-
++#endif
+    if (!egl->egl_display) {
++#ifndef EGL_WITHOUT_GBM
+       /*
+        * Don't fallback to the default display if the fd provided by (*get_drm_fd)
+        * can't be used.
+        */
+       if (egl->gbm && egl->gbm->fd < 0)
+          goto fail;
+-
++#endif
+       egl->egl_display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+       if (!egl->egl_display)
+          goto fail;
+@@ -430,8 +437,12 @@ struct virgl_egl *virgl_egl_init_external(EGLDisplay egl_display)
+       return NULL;
+    }
+ 
++#ifndef EGL_WITHOUT_GBM
+    gbm = virgl_gbm_init(-1);
+    egl->gbm = gbm;
++#else
++   egl->gbm = NULL;
++#endif
+ 
+    return egl;
+ }
+@@ -470,7 +481,7 @@ virgl_renderer_gl_context virgl_egl_get_current_context(UNUSED struct virgl_egl
+    EGLContext egl_ctx = eglGetCurrentContext();
+    return (virgl_renderer_gl_context)egl_ctx;
+ }
+-
++#ifndef EGL_WITHOUT_GBM
+ int virgl_egl_get_fourcc_for_texture(struct virgl_egl *egl, uint32_t tex_id, uint32_t format, int *fourcc)
+ {
+    int ret = EINVAL;
+@@ -569,7 +580,7 @@ int virgl_egl_get_fd_for_texture(struct virgl_egl *egl, uint32_t tex_id, int *fd
+    eglDestroyImageKHR(egl->egl_display, image);
+    return ret;
+ }
+-
++#endif
+ bool virgl_has_egl_khr_gl_colorspace(struct virgl_egl *egl)
+ {
+    return has_bit(egl->extension_bits, EGL_KHR_GL_COLORSPACE);
+-- 
+2.34.1
+

--- a/x11-packages/virglrenderer-android/0003-test-angle.patch.beforehostbuild
+++ b/x11-packages/virglrenderer-android/0003-test-angle.patch.beforehostbuild
@@ -1,0 +1,46 @@
+diff --git a/src/dispatch_common.c b/src/dispatch_common.c
+--- a/libepoxy/src/dispatch_common.c
++++ b/libepoxy/src/dispatch_common.c
+@@ -179,10 +179,38 @@
+ #define GLES1_LIB "libGLESv1_CM.so"
+ #define GLES2_LIB "libGLESv2.so"
+ #elif defined(__ANDROID__)
+-#define GLX_LIB "libGLESv2.so"
+-#define EGL_LIB "libEGL.so"
+-#define GLES1_LIB "libGLESv1_CM.so"
+-#define GLES2_LIB "libGLESv2.so"
++static inline const char *__android_get_glx_libraries() {
++    if (getenv("EPOXY_USE_ANGLE")) {
++        return "libGLESv2_angle.so";
++    } else {
++        return "libGLESv2.so";
++    }
++}
++static inline const char *__android_get_egl_libraries() {
++    if (getenv("EPOXY_USE_ANGLE")) {
++        return "libEGL_angle.so";
++    } else {
++        return "libEGL.so";
++    }
++}
++static inline const char *__android_get_gles1_libraries() {
++    if (getenv("EPOXY_USE_ANGLE")) {
++        return "libGLESv1_CM_angle.so";
++    } else {
++        return "libGLESv1_CM.so";
++    }
++}
++static inline const char *__android_get_gles2_libraries() {
++    if (getenv("EPOXY_USE_ANGLE")) {
++        return "libGLESv2_angle.so";
++    } else {
++        return "libGLESv2.so";
++    }
++}
++#define GLX_LIB __android_get_glx_libraries()
++#define EGL_LIB __android_get_egl_libraries()
++#define GLES1_LIB __android_get_gles1_libraries()
++#define GLES2_LIB __android_get_gles2_libraries()
+ #elif defined(_WIN32)
+ #define EGL_LIB "libEGL.dll"
+ #define GLES1_LIB "libGLES_CM.dll"

--- a/x11-packages/virglrenderer-android/0004-Assume-no-shm-on-Host.patch.beforehostbuild
+++ b/x11-packages/virglrenderer-android/0004-Assume-no-shm-on-Host.patch.beforehostbuild
@@ -1,0 +1,14 @@
+diff --git a/vtest/vtest_shm.c b/vtest/vtest_shm.c
+--- a/vtest/vtest_shm.c
++++ b/vtest/vtest_shm.c
+@@ -68,6 +68,10 @@ int vtest_new_shm(uint32_t handle, size_t size)
+ 
+ int vtest_shm_check(void)
+ {
++#ifdef __ANDROID__
++    // On Android, sendmsg with fd seems not to work.
++    return 0;
++#endif
+     int mfd = memfd_create("test", MFD_ALLOW_SEALING);
+ 
+     if (mfd >= 0) {

--- a/x11-packages/virglrenderer-android/0005-Enable-debug-for-EGL.patch.beforehostbuild
+++ b/x11-packages/virglrenderer-android/0005-Enable-debug-for-EGL.patch.beforehostbuild
@@ -1,0 +1,36 @@
+diff --git a/src/vrend_winsys_egl.c b/src/vrend_winsys_egl.c
+--- a/src/vrend_winsys_egl.c
++++ b/src/vrend_winsys_egl.c
+@@ -351,14 +351,14 @@ struct virgl_egl *virgl_egl_init(struct virgl_gbm *gbm, bool surfaceless, bool g
+       goto fail;
+ 
+    extensions = eglQueryString(egl->egl_display, EGL_EXTENSIONS);
+-#ifdef VIRGL_EGL_DEBUG
++// #ifdef VIRGL_EGL_DEBUG
+    vrend_printf( "EGL major/minor: %d.%d\n", major, minor);
+    vrend_printf( "EGL version: %s\n",
+            eglQueryString(egl->egl_display, EGL_VERSION));
+    vrend_printf( "EGL vendor: %s\n",
+            eglQueryString(egl->egl_display, EGL_VENDOR));
+    vrend_printf( "EGL extensions: %s\n", extensions);
+-#endif
++// #endif
+ 
+    if (virgl_egl_init_extensions(egl, extensions))
+       goto fail;
+@@ -424,13 +424,13 @@ struct virgl_egl *virgl_egl_init_external(EGLDisplay egl_display)
+    egl->egl_display = egl_display;
+ 
+    extensions = eglQueryString(egl->egl_display, EGL_EXTENSIONS);
+-#ifdef VIRGL_EGL_DEBUG
++// #ifdef VIRGL_EGL_DEBUG
+    vrend_printf( "EGL version: %s\n",
+            eglQueryString(egl->egl_display, EGL_VERSION));
+    vrend_printf( "EGL vendor: %s\n",
+            eglQueryString(egl->egl_display, EGL_VENDOR));
+    vrend_printf( "EGL extensions: %s\n", extensions);
+-#endif
++// #endif
+ 
+    if (virgl_egl_init_extensions(egl, extensions)) {
+       free(egl);

--- a/x11-packages/virglrenderer-android/0006-Disable-feature-feat_dual_src_blend.patch.beforehostbuild
+++ b/x11-packages/virglrenderer-android/0006-Disable-feature-feat_dual_src_blend.patch.beforehostbuild
@@ -1,0 +1,27 @@
+diff --git a/src/vrend_renderer.c b/src/vrend_renderer.c
+--- a/src/vrend_renderer.c
++++ b/src/vrend_renderer.c
+@@ -386,6 +386,14 @@ static struct global_renderer_state vrend_state;
+ 
+ static inline bool has_feature(enum features_id feature_id)
+ {
++#ifdef __ANDROID__
++   // On Adreno, this feature cannot be used.
++   // Maybe related to https://gitlab.freedesktop.org/virgl/virglrenderer/-/issues/223 
++   // and https://developer.qualcomm.com/forum/qdn-forums/software/adreno-gpu-sdk/34738
++   if (feature_id == feat_dual_src_blend) {
++      return false;
++   }
++#endif
+    int slot = feature_id / 64;
+    uint64_t mask = 1ull << (feature_id & 63);
+    bool retval = vrend_state.features[slot] & mask ? true : false;
+@@ -7444,7 +7452,7 @@ struct vrend_context *vrend_create_context(int id, uint32_t nlen, const char *de
+    grctx->shader_cfg.has_es31_compat = has_feature(feat_gles31_compatibility);
+    grctx->shader_cfg.has_conservative_depth = has_feature(feat_conservative_depth);
+    grctx->shader_cfg.use_integer = vrend_state.use_integer;
+-   grctx->shader_cfg.has_dual_src_blend = has_feature(feat_dual_src_blend);
++   grctx->shader_cfg.has_dual_src_blend = false;
+    grctx->shader_cfg.has_fbfetch_coherent = has_feature(feat_framebuffer_fetch);
+    grctx->shader_cfg.has_cull_distance = has_feature(feat_cull_distance);
+    grctx->shader_cfg.has_nopersective = has_feature(feat_shader_noperspective_interpolation);

--- a/x11-packages/virglrenderer-android/0007-Ensure-EGL-and-GLES.patch.beforehostbuild
+++ b/x11-packages/virglrenderer-android/0007-Ensure-EGL-and-GLES.patch.beforehostbuild
@@ -1,0 +1,17 @@
+diff --git a/vtest/vtest_server.c b/vtest/vtest_server.c
+--- a/vtest/vtest_server.c
++++ b/vtest/vtest_server.c
+@@ -254,6 +254,13 @@ static void vtest_server_parse_args(int argc, char **argv)
+       server.multi_clients = false;
+    }
+ 
++#ifdef __ANDROID__
++   // On Android, ensure that EGL and GLES is used.
++   server.use_egl_surfaceless = true;
++   server.use_glx = false;
++   server.use_gles = true;
++#endif
++
+    server.ctx_flags = VIRGL_RENDERER_USE_EGL;
+    if (server.use_glx) {
+       if (server.use_egl_surfaceless || server.use_gles) {

--- a/x11-packages/virglrenderer-android/0008-Change-vtest-socket-path.patch.beforehostbuild
+++ b/x11-packages/virglrenderer-android/0008-Change-vtest-socket-path.patch.beforehostbuild
@@ -1,0 +1,12 @@
+diff --git a/vtest/vtest_protocol.h b/vtest/vtest_protocol.h
+--- a/vtest/vtest_protocol.h
++++ b/vtest/vtest_protocol.h
+@@ -25,7 +25,7 @@
+ #ifndef VTEST_PROTOCOL
+ #define VTEST_PROTOCOL
+ 
+-#define VTEST_DEFAULT_SOCKET_NAME "/tmp/.virgl_test"
++#define VTEST_DEFAULT_SOCKET_NAME "@TERMUX_PREFIX@/tmp/.virgl_test"
+ 
+ #ifdef VIRGL_RENDERER_UNSTABLE_APIS
+ #define VTEST_PROTOCOL_VERSION 3

--- a/x11-packages/virglrenderer-android/build.sh
+++ b/x11-packages/virglrenderer-android/build.sh
@@ -1,0 +1,89 @@
+TERMUX_PKG_HOMEPAGE=https://virgil3d.github.io/
+TERMUX_PKG_DESCRIPTION="A virtual 3D GPU for use inside qemu virtual machines over OpenGLES libraries on Android"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@licy183"
+TERMUX_PKG_VERSION=(0.10.4)
+TERMUX_PKG_VERSION+=(1.5.10) # libepoxy version
+TERMUX_PKG_SRCURL=(https://gitlab.freedesktop.org/virgl/virglrenderer/-/archive/virglrenderer-${TERMUX_PKG_VERSION[0]}/virglrenderer-virglrenderer-${TERMUX_PKG_VERSION[0]}.tar.gz)
+TERMUX_PKG_SRCURL+=(https://github.com/anholt/libepoxy/archive/refs/tags/${TERMUX_PKG_VERSION[1]}.tar.gz)
+TERMUX_PKG_SHA256=(fd9a1b12473f4cda8d87e6ba1a6e5714a24355e16b69ed85df5c21bf48f797fa)
+TERMUX_PKG_SHA256+=(a7ced37f4102b745ac86d6a70a9da399cc139ff168ba6b8002b4d8d43c900c15)
+
+TERMUX_PKG_HOSTBUILD=true
+
+termux_step_post_get_source() {
+	mv libepoxy-${TERMUX_PKG_VERSION[1]} libepoxy
+}
+
+termux_step_host_build() {
+	# This packages should use the Android NDK toolchain to compile, not
+	# our custom toolchain, so I'd like to compile it in the hostbuild step.
+	export PATH="$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
+	export CCTERMUX_HOST_PLATFORM=$TERMUX_HOST_PLATFORM$TERMUX_PKG_API_LEVEL
+	if [ $TERMUX_ARCH = arm ]; then
+		CCTERMUX_HOST_PLATFORM=armv7a-linux-androideabi$TERMUX_PKG_API_LEVEL
+	fi
+
+	local _INSTALL_PREFIX=$TERMUX_PREFIX/opt/$TERMUX_PKG_NAME
+
+	PKG_CONFIG="$TERMUX_PKG_TMPDIR/host-build-pkg-config"
+	local _HOST_PKGCONFIG=$(command -v pkg-config)
+	cat > $PKG_CONFIG <<-HERE
+		#!/bin/sh
+		export PKG_CONFIG_DIR=
+		export PKG_CONFIG_LIBDIR=$_INSTALL_PREFIX/lib/pkgconfig
+		exec $_HOST_PKGCONFIG "\$@"
+	HERE
+	chmod +x $PKG_CONFIG
+
+	AR=$(command -v llvm-ar)
+	CC=$(command -v $CCTERMUX_HOST_PLATFORM-clang)
+	CXX=$(command -v $CCTERMUX_HOST_PLATFORM-clang++)
+	LD=$(command -v ld.lld)
+	CFLAGS=""
+	CPPFLAGS=""
+	CXXFLAGS=""
+	LDFLAGS="-Wl,-rpath=\$ORIGIN/../lib"
+	STRIP=$(command -v llvm-strip)
+	termux_setup_meson
+
+	# Compile libepoxy
+	mkdir -p libepoxy-build
+	$TERMUX_MESON $TERMUX_PKG_SRCDIR/libepoxy libepoxy-build \
+        --cross-file $TERMUX_MESON_CROSSFILE \
+        --prefix=$_INSTALL_PREFIX \
+		--libdir lib \
+        -Degl=yes -Dglx=no -Dx11=false
+	ninja -C libepoxy-build install -j $TERMUX_MAKE_PROCESSES
+
+	# Compile virglrenderer
+	mkdir -p virglrenderer-build
+	$TERMUX_MESON $TERMUX_PKG_SRCDIR virglrenderer-build \
+        --cross-file $TERMUX_MESON_CROSSFILE \
+        --prefix=$_INSTALL_PREFIX \
+		--libdir lib \
+        -Degl_without_gbm=true \
+        -Dplatforms=egl
+	ninja -C virglrenderer-build install -j $TERMUX_MAKE_PROCESSES
+
+	# TODO: Build angle?
+}
+
+termux_step_configure() {
+	# Remove this marker all the time, as this package is architecture-specific
+	rm -rf $TERMUX_HOSTBUILD_MARKER
+}
+
+termux_step_make() {
+	:
+}
+
+termux_step_make_install() {
+	ln -sfr $TERMUX_PREFIX/opt/virglrenderer-android/bin/virgl_test_server $TERMUX_PREFIX/bin/virgl_test_server_android
+}
+
+termux_step_install_license() {
+	mkdir -p $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME
+	cp $TERMUX_PKG_SRCDIR/COPYING $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/COPYING-virglrenderer
+	cp $TERMUX_PKG_SRCDIR/libepoxy/COPYING $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/COPYING-libepoxy
+}


### PR DESCRIPTION
This package contains a virgl test server using the OpenGLES driver of Android native. This package is tested on Adreno 630 (Xiaomi MIX2s) and Adreno 650 (Xiaomi MIX4) and works fine. It doesn't work on Bluestacks because the GLES driver Bluestacks provided doesn't have some feature.

To test this package, start the server in one session and run graphic tests in another session.

For example

Session 1:
```
virgl_test_server_android
```

Session 2:
```
vncserver :1
DISPLAY=:1 GALLIUM_DRIVER=virpipe glmark2
```

Closes #14517