### PR TITLE
zellij: Bump to 0.35.1

### DIFF
--- a/packages/zellij/build.sh
+++ b/packages/zellij/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE="https://zellij.dev/"
 TERMUX_PKG_DESCRIPTION="A terminal workspace with batteries included"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Jonathan Lei <me@xjonathan.dev>"
-TERMUX_PKG_VERSION="0.34.4"
+TERMUX_PKG_VERSION="0.35.1"
 TERMUX_PKG_SRCURL="https://github.com/zellij-org/zellij/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256=687e30a3e6916cdd7189ab04ff4b170bc5e09edd937637f0388b3f8432d0fc49
+TERMUX_PKG_SHA256=fa92982ea3b1481a1c50065f9d1c3eff2e47ac0deee071ca4752a18424aeb93e
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 

--- a/packages/zellij/prefix.patch
+++ b/packages/zellij/prefix.patch
@@ -1,16 +1,16 @@
 --- a/zellij-server/src/pty.rs
 +++ b/zellij-server/src/pty.rs
-@@ -445,8 +445,8 @@ impl Pty {
-     }
-     pub fn get_default_terminal(&self, cwd: Option<PathBuf>) -> TerminalAction {
-         let shell = PathBuf::from(env::var("SHELL").unwrap_or_else(|_| {
--            log::warn!("Cannot read SHELL env, falling back to use /bin/sh");
--            "/bin/sh".to_string()
-+            log::warn!("Cannot read SHELL env, falling back to use @TERMUX_PREFIX@/bin/sh");
-+            "@TERMUX_PREFIX@/bin/sh".to_string()
-         }));
-         if !shell.exists() {
-             panic!("Cannot find shell {}", shell.display());
+@@ -466,8 +466,8 @@ impl Pty {
+             },
+             None => {
+                 let shell = PathBuf::from(env::var("SHELL").unwrap_or_else(|_| {
+-                    log::warn!("Cannot read SHELL env, falling back to use /bin/sh");
+-                    "/bin/sh".to_string()
++                    log::warn!("Cannot read SHELL env, falling back to use @TERMUX_PREFIX@/bin/sh");
++                    "@TERMUX_PREFIX@/bin/sh".to_string()
+                 }));
+                 TerminalAction::RunCommand(RunCommand {
+                     args: vec![],
 --- a/zellij-utils/src/consts.rs
 +++ b/zellij-utils/src/consts.rs
 @@ -13,7 +13,7 @@ pub const DEFAULT_SCROLL_BUFFER_SIZE: usize = 10_000;


### PR DESCRIPTION
Zellij just released a new verions [v0.35.1](https://github.com/zellij-org/zellij/releases/tag/v0.35.1), this PR bumps the registery package version.