### PR TITLE
fix(scripts): `TERMUX_PYTHON_CROSSENV_PREFIX` should be architecture-specific

### DIFF
--- a/scripts/build/termux_step_setup_variables.sh
+++ b/scripts/build/termux_step_setup_variables.sh
@@ -134,7 +134,7 @@ termux_step_setup_variables() {
 	TERMUX_PKG_PYTHON_TARGET_DEPS="" # python modules to be installed via pip3
 	TERMUX_PKG_PYTHON_BUILD_DEPS="" # python modules to be installed via build-pip
 	TERMUX_PKG_PYTHON_COMMON_DEPS="" # python modules to be installed via pip3 or build-pip
-	TERMUX_PYTHON_CROSSENV_PREFIX=$TERMUX_TOPDIR/python-crossenv-prefix # python modules dependency location (only used in non-devices)
+	TERMUX_PYTHON_CROSSENV_PREFIX="$TERMUX_TOPDIR/python-crossenv-prefix-$TERMUX_ARCH" # python modules dependency location (only used in non-devices)
 	TERMUX_PYTHON_HOME=$TERMUX_PREFIX/lib/python${TERMUX_PYTHON_VERSION} # location of python libraries
 
 	unset CFLAGS CPPFLAGS LDFLAGS CXXFLAGS


### PR DESCRIPTION
`TERMUX_PYTHON_CROSSENV_PREFIX` should be architecture-specific. If we build `x86_64` pip package, then build `aarch64`, `python-crossenv` will still be `x86_64` and then error will occur.