### PR TITLE
Adding libdeflate to htslib build

### DIFF
--- a/packages/htslib/build.sh
+++ b/packages/htslib/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.17
 TERMUX_PKG_SRCURL=https://github.com/samtools/htslib/releases/download/${TERMUX_PKG_VERSION}/htslib-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=763779288c40f07646ec7ad98b96c378c739171d162ad98398868783b721839f
-TERMUX_PKG_DEPENDS="libbz2, liblzma, zlib"
+TERMUX_PKG_DEPENDS="libbz2, liblzma, zlib, libdeflate"
 
 # error: assigning to 'uint8x8_t' (vector of 8 'uint8_t' values) from incompatible type 'int'
 TERMUX_PKG_BLACKLISTED_ARCHES="arm"


### PR DESCRIPTION
Libdeflate makes htslib faster. Usually htslib is built with libdeflate. 