### PR TITLE
ndk-multilib: Exclude native stubs for shared libs

### DIFF
--- a/packages/ndk-multilib/build.sh
+++ b/packages/ndk-multilib/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Version should be equal to TERMUX_NDK_{VERSION_NUM,REVISION} in
 # scripts/properties.sh
 TERMUX_PKG_VERSION=25c
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://dl.google.com/android/repository/android-ndk-r${TERMUX_PKG_VERSION}-linux.zip
 TERMUX_PKG_SHA256=769ee342ea75f80619d985c2da990c48b3d8eaf45f48783a2d48870d04b46108
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
@@ -21,9 +22,10 @@ prepare_libs() {
 	fi
 
 	mkdir -p $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib
+	mkdir -p $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/opt/ndk-multilib/$SUFFIX/lib
 	local BASEDIR=toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/$SUFFIX/
 	cp $BASEDIR/${TERMUX_PKG_API_LEVEL}/*.o $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib
-	cp $BASEDIR/${TERMUX_PKG_API_LEVEL}/lib{c,dl,log,m}.so $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib
+	cp $BASEDIR/${TERMUX_PKG_API_LEVEL}/lib{c,dl,log,m}.so $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/opt/ndk-multilib/$SUFFIX/lib
 	cp $BASEDIR/libc++_shared.so $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib
 	cp $BASEDIR/lib{c,dl,m,c++_static,c++abi}.a $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib
 	echo 'INPUT(-lc++_static -lc++abi)' > $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib/libc++_shared.a
@@ -55,3 +57,18 @@ termux_step_make_install() {
 	prepare_libs "x86_64" "x86_64-linux-android"
 	add_cross_compiler_rt
 }
+
+termux_step_create_debscripts() {
+	local f
+	for f in postinst prerm; do
+		sed -e "s|@TERMUX_PREFIX@|${TERMUX_PREFIX}|g" \
+			-e "s|@TERMUX_PACKAGE_FORMAT@|${TERMUX_PACKAGE_FORMAT}|g" \
+			$TERMUX_PKG_BUILDER_DIR/postinst-header.in > "${f}"
+	done
+	sed 's|@COMMAND@|ln -sf "'$TERMUX_PREFIX'/opt/ndk-multilib/$triple/lib/$so" "'$TERMUX_PREFIX'/\$triple/lib"|' \
+		$TERMUX_PKG_BUILDER_DIR/postinst-alien.in >> postinst
+	sed 's|@COMMAND@|rm -f "'$TERMUX_PREFIX'/$triple/lib/$so"|' \
+		$TERMUX_PKG_BUILDER_DIR/postinst-alien.in >> prerm
+	chmod 0700 postinst prerm
+}
+

--- a/packages/ndk-multilib/ndk-multilib-native-stubs.subpackage.sh
+++ b/packages/ndk-multilib/ndk-multilib-native-stubs.subpackage.sh
@@ -1,0 +1,17 @@
+TERMUX_SUBPKG_DESCRIPTION="Install native stubs for shared libs from NDK"
+TERMUX_SUBPKG_INCLUDE=""
+
+termux_step_create_subpkg_debscripts() {
+	local f
+	for f in postinst prerm; do
+		sed -e "s|@TERMUX_PREFIX@|${TERMUX_PREFIX}|g" \
+			-e "s|@TERMUX_PACKAGE_FORMAT@|${TERMUX_PACKAGE_FORMAT}|g" \
+			$TERMUX_PKG_BUILDER_DIR/postinst-header.in > "${f}"
+	done
+	sed 's|@COMMAND@|ln -sf "'$TERMUX_PREFIX'/opt/ndk-multilib/$triple/lib/$so" "'$TERMUX_PREFIX'/\$triple/lib"|' \
+		$TERMUX_PKG_BUILDER_DIR/postinst-native.in >> postinst
+	sed 's|@COMMAND@|rm -f "'$TERMUX_PREFIX'/$triple/lib/$so"|' \
+		$TERMUX_PKG_BUILDER_DIR/postinst-native.in >> prerm
+	chmod 0700 postinst prerm
+}
+

--- a/packages/ndk-multilib/postinst-alien.in
+++ b/packages/ndk-multilib/postinst-alien.in
@@ -1,0 +1,11 @@
+
+for triple in aarch64-linux-android arm-linux-androideabi i686-linux-android x86_64-linux-android; do
+	if [ x"$native_triple" = x"$triple" ]; then
+		continue
+	fi
+	for so in libc.so libdl.so liblog.so libm.so; do
+		@COMMAND@
+	done
+done
+
+exit 0

--- a/packages/ndk-multilib/postinst-header.in
+++ b/packages/ndk-multilib/postinst-header.in
@@ -1,0 +1,18 @@
+#!@TERMUX_PREFIX@/bin/sh
+
+pkg_format="@TERMUX_PACKAGE_FORMAT@"
+pkg_arch=unknown
+case "$pkg_format" in
+	debian ) pkg_arch=$(dpkg --print-architecture) ;;
+	pacman ) pkg_arch=$(pacman-conf Architecture) ;;
+	* ) echo "Warning: unknown package format: $pkg_format" ;;
+esac
+native_triple=unknown
+case "$pkg_arch" in
+	aarch64 ) native_triple=aarch64-linux-android ;;
+	arm ) native_triple=arm-linux-androideabi ;;
+	i686 ) native_triple=i686-linux-android ;;
+	x86_64 ) native_triple=x86_64-linux-android ;;
+	* ) echo "Warning: unknown arch: $pkg_arch" ;;
+esac
+

--- a/packages/ndk-multilib/postinst-native.in
+++ b/packages/ndk-multilib/postinst-native.in
@@ -1,0 +1,11 @@
+
+triple="$native_triple"
+if [ x"$triple" = x"unknown" ]; then
+	echo "Error: cannot determine the native architecture."
+	exit 1
+fi
+for so in libc.so libdl.so liblog.so libm.so; do
+	@COMMAND@
+done
+
+exit 0


### PR DESCRIPTION
which are now installed with subpackage named ndk-multilib-native-stubs.