### PR TITLE
qemu-system-x86-64-headless: Fix dependency

### DIFF
--- a/packages/qemu-system-x86-64-headless/build.sh
+++ b/packages/qemu-system-x86-64-headless/build.sh
@@ -3,9 +3,10 @@ TERMUX_PKG_DESCRIPTION="A generic and open source machine emulator and virtualiz
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1:7.2.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://download.qemu.org/qemu-${TERMUX_PKG_VERSION:2}.tar.xz
 TERMUX_PKG_SHA256=5b49ce2687744dad494ae90a898c52204a3406e84d072482a1e1be854eeb2157
-TERMUX_PKG_DEPENDS="glib, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libslirp, libspice-server, libssh, libusb, libusbredir, ncurses, pulseaudio, qemu-common, resolv-conf, zlib, zstd"
+TERMUX_PKG_DEPENDS="glib, libbz2, libcurl, libgmp, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libslirp, libspice-server, libssh, libusb, libusbredir, ncurses, pulseaudio, qemu-common, resolv-conf, zlib, zstd"
 
 # Required by configuration script, but I can't find any binary that uses it.
 TERMUX_PKG_BUILD_DEPENDS="libtasn1"

--- a/packages/qemu-system-x86-64-headless/qemu-common.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-common.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="A set common files used by the QEMU emulators"
-TERMUX_SUBPKG_DEPENDS="glib, libgcrypt"
+TERMUX_SUBPKG_DEPENDS="glib, libbz2, libcap-ng, libcurl, libgmp, libgnutls, libnettle, libnfs, libpixman, libssh, zlib, zstd"
 TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 
 TERMUX_SUBPKG_INCLUDE="

--- a/packages/qemu-system-x86-64-headless/qemu-system-aarch64-headless.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-system-aarch64-headless.subpackage.sh
@@ -1,6 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer (headless)"
-TERMUX_SUBPKG_DEPENDS="glib, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libspice-server, libssh, libusb, libusbredir, ncurses, pulseaudio, qemu-common, resolv-conf, zlib, zstd"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=no
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
 
 TERMUX_SUBPKG_INCLUDE="
 bin/qemu-system-aarch64

--- a/packages/qemu-system-x86-64-headless/qemu-system-arm-headless.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-system-arm-headless.subpackage.sh
@@ -1,6 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer (headless)"
-TERMUX_SUBPKG_DEPENDS="glib, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libspice-server, libssh, libusb, libusbredir, ncurses, pulseaudio, qemu-common, resolv-conf, zlib, zstd"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=no
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
 
 TERMUX_SUBPKG_INCLUDE="
 bin/qemu-system-arm

--- a/packages/qemu-system-x86-64-headless/qemu-system-i386-headless.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-system-i386-headless.subpackage.sh
@@ -1,6 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer (headless)"
-TERMUX_SUBPKG_DEPENDS="glib, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libspice-server, libssh, libusb, libusbredir, ncurses, pulseaudio, qemu-common, resolv-conf, zlib, zstd"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=no
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
 
 TERMUX_SUBPKG_INCLUDE="
 bin/qemu-system-i386

--- a/packages/qemu-system-x86-64-headless/qemu-system-m68k-headless.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-system-m68k-headless.subpackage.sh
@@ -1,6 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer (headless)"
-TERMUX_SUBPKG_DEPENDS="glib, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libspice-server, libssh, libusb, libusbredir, ncurses, pulseaudio, qemu-common, resolv-conf, zlib, zstd"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=no
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
 
 TERMUX_SUBPKG_INCLUDE="
 bin/qemu-system-m68k

--- a/packages/qemu-system-x86-64-headless/qemu-system-ppc-headless.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-system-ppc-headless.subpackage.sh
@@ -1,6 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer (headless)"
-TERMUX_SUBPKG_DEPENDS="glib, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libspice-server, libssh, libusb, libusbredir, ncurses, pulseaudio, qemu-common, resolv-conf, zlib, zstd"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=no
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
 
 TERMUX_SUBPKG_INCLUDE="
 bin/qemu-system-ppc

--- a/packages/qemu-system-x86-64-headless/qemu-system-ppc64-headless.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-system-ppc64-headless.subpackage.sh
@@ -1,6 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer (headless)"
-TERMUX_SUBPKG_DEPENDS="glib, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libspice-server, libssh, libusb, libusbredir, ncurses, pulseaudio, qemu-common, resolv-conf, zlib, zstd"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=no
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
 
 TERMUX_SUBPKG_INCLUDE="
 bin/qemu-system-ppc64

--- a/packages/qemu-system-x86-64-headless/qemu-system-riscv32-headless.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-system-riscv32-headless.subpackage.sh
@@ -1,6 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer (headless)"
-TERMUX_SUBPKG_DEPENDS="glib, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libspice-server, libssh, libusb, libusbredir, ncurses, pulseaudio, qemu-common, resolv-conf, zlib, zstd"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=no
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
 
 TERMUX_SUBPKG_INCLUDE="
 bin/qemu-system-riscv32

--- a/packages/qemu-system-x86-64-headless/qemu-system-riscv64-headless.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-system-riscv64-headless.subpackage.sh
@@ -1,6 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer (headless)"
-TERMUX_SUBPKG_DEPENDS="glib, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libspice-server, libssh, libusb, libusbredir, ncurses, pulseaudio, qemu-common, resolv-conf, zlib, zstd"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=no
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
 
 TERMUX_SUBPKG_INCLUDE="
 bin/qemu-system-riscv64

--- a/packages/qemu-system-x86-64-headless/qemu-user-aarch64.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-user-aarch64.subpackage.sh
@@ -1,4 +1,4 @@
 TERMUX_SUBPKG_DESCRIPTION="QEMU Linux user mode emulator"
-TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libc++, libgnutls, libpixman"
+TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libgnutls, libpixman"
 TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 TERMUX_SUBPKG_INCLUDE="bin/qemu-aarch64"

--- a/packages/qemu-system-x86-64-headless/qemu-user-arm.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-user-arm.subpackage.sh
@@ -1,4 +1,4 @@
 TERMUX_SUBPKG_DESCRIPTION="QEMU Linux user mode emulator"
-TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libc++, libgnutls, libpixman"
+TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libgnutls, libpixman"
 TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 TERMUX_SUBPKG_INCLUDE="bin/qemu-arm"

--- a/packages/qemu-system-x86-64-headless/qemu-user-i386.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-user-i386.subpackage.sh
@@ -1,4 +1,4 @@
 TERMUX_SUBPKG_DESCRIPTION="QEMU Linux user mode emulator"
-TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libc++, libgnutls, libpixman"
+TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libgnutls, libpixman"
 TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 TERMUX_SUBPKG_INCLUDE="bin/qemu-i386"

--- a/packages/qemu-system-x86-64-headless/qemu-user-m68k.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-user-m68k.subpackage.sh
@@ -1,4 +1,4 @@
 TERMUX_SUBPKG_DESCRIPTION="QEMU Linux user mode emulator"
-TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libc++, libgnutls, libpixman"
+TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libgnutls, libpixman"
 TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 TERMUX_SUBPKG_INCLUDE="bin/qemu-m68k"

--- a/packages/qemu-system-x86-64-headless/qemu-user-ppc.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-user-ppc.subpackage.sh
@@ -1,4 +1,4 @@
 TERMUX_SUBPKG_DESCRIPTION="QEMU Linux user mode emulator"
-TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libc++, libgnutls, libpixman"
+TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libgnutls, libpixman"
 TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 TERMUX_SUBPKG_INCLUDE="bin/qemu-ppc"

--- a/packages/qemu-system-x86-64-headless/qemu-user-ppc64.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-user-ppc64.subpackage.sh
@@ -1,4 +1,4 @@
 TERMUX_SUBPKG_DESCRIPTION="QEMU Linux user mode emulator"
-TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libc++, libgnutls, libpixman"
+TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libgnutls, libpixman"
 TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 TERMUX_SUBPKG_INCLUDE="bin/qemu-ppc64"

--- a/packages/qemu-system-x86-64-headless/qemu-user-riscv32.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-user-riscv32.subpackage.sh
@@ -1,4 +1,4 @@
 TERMUX_SUBPKG_DESCRIPTION="QEMU Linux user mode emulator"
-TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libc++, libgnutls, libpixman"
+TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libgnutls, libpixman"
 TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 TERMUX_SUBPKG_INCLUDE="bin/qemu-riscv32"

--- a/packages/qemu-system-x86-64-headless/qemu-user-riscv64.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-user-riscv64.subpackage.sh
@@ -1,4 +1,4 @@
 TERMUX_SUBPKG_DESCRIPTION="QEMU Linux user mode emulator"
-TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libc++, libgnutls, libpixman"
+TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libgnutls, libpixman"
 TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 TERMUX_SUBPKG_INCLUDE="bin/qemu-riscv64"

--- a/packages/qemu-system-x86-64-headless/qemu-user-x86-64.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-user-x86-64.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="QEMU Linux user mode emulator"
-TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libc++, libgnutls, libpixman"
+TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libgnutls, libpixman"
 TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 TERMUX_SUBPKG_BREAKS="qemu-user-x86_64"
 TERMUX_SUBPKG_REPLACES="qemu-user-x86_64"

--- a/packages/qemu-system-x86-64-headless/qemu-utils.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-utils.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="A set of utilities for working with the QEMU emulators"
-TERMUX_SUBPKG_DEPENDS="glib, libbz2, libcap-ng, libcurl, libgnutls, libnettle, libnfs, libpixman, libssh, zlib, zstd"
+TERMUX_SUBPKG_DEPENDS="glib, libbz2, libcurl, libgmp, libgnutls, libnettle, libnfs, libpixman, libssh, zlib, zstd"
 TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 
 TERMUX_SUBPKG_INCLUDE="


### PR DESCRIPTION
* libslirp dep was missing from qemu-system-*-headless subpackages. Use TERMUX_SUBPKG_DEPEND_ON_PARENT=deps to avoid this type of bug.

* qemu-user-* subpackages do not depend on libc++.

(And more.)