### PR TITLE
qemu-system-x86-64: Fix dependency

### DIFF
--- a/x11-packages/qemu-system-x86-64/build.sh
+++ b/x11-packages/qemu-system-x86-64/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1:7.2.0
 TERMUX_PKG_SRCURL=https://download.qemu.org/qemu-${TERMUX_PKG_VERSION:2}.tar.xz
 TERMUX_PKG_SHA256=5b49ce2687744dad494ae90a898c52204a3406e84d072482a1e1be854eeb2157
-TERMUX_PKG_DEPENDS="glib, gtk3, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libslirp, libspice-server, libssh, libusb, libusbredir, libx11, ncurses, pulseaudio, qemu-common, resolv-conf, sdl2, sdl2-image, zlib, zstd"
+TERMUX_PKG_DEPENDS="gdk-pixbuf, glib, gtk3, libbz2, libcairo, libcurl, libgmp, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libslirp, libspice-server, libssh, libusb, libusbredir, libx11, ncurses, pulseaudio, qemu-common, resolv-conf, sdl2, sdl2-image, zlib, zstd"
 
 # Required by configuration script, but I can't find any binary that uses it.
 TERMUX_PKG_BUILD_DEPENDS="libtasn1"

--- a/x11-packages/qemu-system-x86-64/qemu-system-aarch64.subpackage.sh
+++ b/x11-packages/qemu-system-x86-64/qemu-system-aarch64.subpackage.sh
@@ -1,7 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer"
-TERMUX_SUBPKG_DEPENDS="glib, gtk3, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libspice-server, libssh, libusb, libusbredir, libx11, ncurses, pulseaudio, qemu-common, resolv-conf, sdl2, sdl2-image, zlib, zstd"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
 TERMUX_SUBPKG_CONFLICTS="qemu-system-aarch64-headless"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 
 TERMUX_SUBPKG_INCLUDE="
 bin/qemu-system-aarch64

--- a/x11-packages/qemu-system-x86-64/qemu-system-arm.subpackage.sh
+++ b/x11-packages/qemu-system-x86-64/qemu-system-arm.subpackage.sh
@@ -1,7 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer"
-TERMUX_SUBPKG_DEPENDS="glib, gtk3, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libspice-server, libssh, libusb, libusbredir, libx11, ncurses, pulseaudio, qemu-common, resolv-conf, sdl2, sdl2-image, zlib, zstd"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
 TERMUX_SUBPKG_CONFLICTS="qemu-system-arm-headless"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 
 TERMUX_SUBPKG_INCLUDE="
 bin/qemu-system-arm

--- a/x11-packages/qemu-system-x86-64/qemu-system-i386.subpackage.sh
+++ b/x11-packages/qemu-system-x86-64/qemu-system-i386.subpackage.sh
@@ -1,7 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer"
-TERMUX_SUBPKG_DEPENDS="glib, gtk3, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libspice-server, libssh, libusb, libusbredir, libx11, ncurses, pulseaudio, qemu-common, resolv-conf, sdl2, sdl2-image, zlib, zstd"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
 TERMUX_SUBPKG_CONFLICTS="qemu-system-i386-headless"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 
 TERMUX_SUBPKG_INCLUDE="
 bin/qemu-system-i386

--- a/x11-packages/qemu-system-x86-64/qemu-system-m68k.subpackage.sh
+++ b/x11-packages/qemu-system-x86-64/qemu-system-m68k.subpackage.sh
@@ -1,7 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer"
-TERMUX_SUBPKG_DEPENDS="glib, gtk3, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libspice-server, libssh, libusb, libusbredir, libx11, ncurses, pulseaudio, qemu-common, resolv-conf, sdl2, sdl2-image, zlib, zstd"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
 TERMUX_SUBPKG_CONFLICTS="qemu-system-m68k-headless"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 
 TERMUX_SUBPKG_INCLUDE="
 bin/qemu-system-m68k

--- a/x11-packages/qemu-system-x86-64/qemu-system-ppc.subpackage.sh
+++ b/x11-packages/qemu-system-x86-64/qemu-system-ppc.subpackage.sh
@@ -1,7 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer"
-TERMUX_SUBPKG_DEPENDS="glib, gtk3, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libspice-server, libssh, libusb, libusbredir, libx11, ncurses, pulseaudio, qemu-common, resolv-conf, sdl2, sdl2-image, zlib, zstd"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
 TERMUX_SUBPKG_CONFLICTS="qemu-system-ppc-headless"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 
 TERMUX_SUBPKG_INCLUDE="
 bin/qemu-system-ppc

--- a/x11-packages/qemu-system-x86-64/qemu-system-ppc64.subpackage.sh
+++ b/x11-packages/qemu-system-x86-64/qemu-system-ppc64.subpackage.sh
@@ -1,7 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer"
-TERMUX_SUBPKG_DEPENDS="glib, gtk3, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libspice-server, libssh, libusb, libusbredir, libx11, ncurses, pulseaudio, qemu-common, resolv-conf, sdl2, sdl2-image, zlib, zstd"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
 TERMUX_SUBPKG_CONFLICTS="qemu-system-ppc64-headless"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 
 TERMUX_SUBPKG_INCLUDE="
 bin/qemu-system-ppc64

--- a/x11-packages/qemu-system-x86-64/qemu-system-riscv32.subpackage.sh
+++ b/x11-packages/qemu-system-x86-64/qemu-system-riscv32.subpackage.sh
@@ -1,7 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer"
-TERMUX_SUBPKG_DEPENDS="glib, gtk3, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libspice-server, libssh, libusb, libusbredir, libx11, ncurses, pulseaudio, qemu-common, resolv-conf, sdl2, sdl2-image, zlib, zstd"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
 TERMUX_SUBPKG_CONFLICTS="qemu-system-riscv32-headless"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 
 TERMUX_SUBPKG_INCLUDE="
 bin/qemu-system-riscv32

--- a/x11-packages/qemu-system-x86-64/qemu-system-riscv64.subpackage.sh
+++ b/x11-packages/qemu-system-x86-64/qemu-system-riscv64.subpackage.sh
@@ -1,7 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer"
-TERMUX_SUBPKG_DEPENDS="glib, gtk3, libbz2, libc++, libcurl, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libspice-server, libssh, libusb, libusbredir, libx11, ncurses, pulseaudio, qemu-common, resolv-conf, sdl2, sdl2-image, zlib, zstd"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
 TERMUX_SUBPKG_CONFLICTS="qemu-system-riscv64-headless"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 
 TERMUX_SUBPKG_INCLUDE="
 bin/qemu-system-riscv64


### PR DESCRIPTION
libslirp dep was missing from qemu-system-* subpackages.

There is a plan to further modify this package soon, so:

%ci:no-build