### PR TITLE
mutt: configure with --enable-debug and ac_cv_func_fget{c,s}_unlocked=no 

### DIFF
--- a/packages/mutt/build.sh
+++ b/packages/mutt/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_DESCRIPTION="Mail client with patches from neomutt"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.2.10
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=ftp://ftp.mutt.org/pub/mutt/mutt-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=4d773f22422f79096f7b94b57bee45654ad9a25165dbb36463c58295b4cd3d88
 TERMUX_PKG_DEPENDS="libandroid-support, ncurses, gdbm, openssl, libsasl, mime-support, zlib, libiconv"
@@ -25,6 +26,15 @@ mutt_cv_c99_vsnprintf=yes
 --without-idn
 --with-sasl
 --with-ssl
+"
+
+# fget{c,s}_unlocked were added in API level 28.
+# AC_CHECK_FUNCS(fget{c,s}_unlocked) finds them in libc, even though
+# it is not defined in stdio.h, so we need to override the check or
+# else compilation on device fails
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+="
+ac_cv_func_fgetc_unlocked=no
+ac_cv_func_fgets_unlocked=no
 "
 
 if $TERMUX_DEBUG_BUILD; then

--- a/packages/mutt/build.sh
+++ b/packages/mutt/build.sh
@@ -14,6 +14,7 @@ mutt_cv_c99_snprintf=yes
 mutt_cv_c99_vsnprintf=yes
 --disable-gpgme
 --enable-compressed
+--enable-debug
 --enable-hcache
 --enable-imap
 --enable-pop


### PR DESCRIPTION
--enable-debug makes it easier to debug issues, and ac_cv_func_fget{c,s}_unlocked=no is necessary for compilation on device to work