### PR TITLE
add(main): new package navidrome

### DIFF
--- a/packages/navidrome/build.sh
+++ b/packages/navidrome/build.sh
@@ -1,0 +1,46 @@
+TERMUX_PKG_HOMEPAGE=https://www.navidrome.org/
+TERMUX_PKG_DESCRIPTION="🎧☁️ Modern Music Server and Streamer compatible with Subsonic/Airsonic"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="2096779623 <admin@utermux.dev>"
+TERMUX_PKG_VERSION=0.49.3
+TERMUX_PKG_SRCURL=https://github.com/navidrome/navidrome/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=ab48eadeb74f64456b612655941bac4eb95a0f546bfee473baa316319fb4a17a
+TERMUX_PKG_DEPENDS="taglib, ffmpeg"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+
+termux_step_make() {
+        rm -f Makefile
+
+        termux_setup_golang
+        termux_setup_nodejs
+
+        local GO_VERSION=$(grep "^go " $TERMUX_PKG_SRCDIR/go.mod | cut -f 2 -d ' ')
+        local NODE_VERSION=$(. $TERMUX_SCRIPTDIR/packages/golang/build.sh; echo $TERMUX_PKG_VERSION)
+        local GIT_SHA=$(git ls-remote https://github.com/navidrome/navidrome refs/tags/v$TERMUX_PKG_VERSION | head -c 7)
+        export GIT_TAG="v$TERMUX_PKG_VERSION"
+        # Build frontend
+        cd $TERMUX_PKG_SRCDIR/ui
+        npm ci && npm run build
+
+        # Build backend
+        cd $TERMUX_PKG_SRCDIR
+        go build -o navidrome -ldflags="-X github.com/navidrome/navidrome/consts.gitSha=$GIT_SHA -X github.com/navidrome/navidrome/consts.gitTag=$GIT_TAG-SNAPSHOT" -tags=netgo
+}
+
+termux_step_make_install() {
+        install -Dm755 -t "${TERMUX_PREFIX}"/bin ${TERMUX_PKG_SRCDIR}/navidrome
+
+        install -Dm644 /dev/null "${TERMUX_PREFIX}/share/bash-completion/completions/navidrome.bash"
+	install -Dm644 /dev/null "${TERMUX_PREFIX}/share/zsh/site-functions/_navidrome"
+	install -Dm644 /dev/null "${TERMUX_PREFIX}/share/fish/vendor_completions.d/navidrome.fish"
+}
+
+termux_step_create_debscripts() {
+	cat <<- EOF > ./postinst
+		#!${TERMUX_PREFIX}/bin/sh
+		navidrome completion bash -n > ${TERMUX_PREFIX}/share/bash-completion/completions/navidrome.bash
+		navidrome completion zsh -n > ${TERMUX_PREFIX}/share/zsh/site-functions/_navidrome
+		navidrome completion fish -n > ${TERMUX_PREFIX}/share/fish/vendor_completions.d/navidrome.fish
+	EOF
+}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/57583560/229139227-7dd43ba2-0404-41f0-bf3a-6c2bc863e290.png)

```bash
~ $ navidrome 
 _   _             _     _
| \ | |           (_)   | |
|  \| | __ ___   ___  __| |_ __ ___  _ __ ___   ___
| . ` |/ _` \ \ / / |/ _` | '__/ _ \| '_ ` _ \ / _ \
| |\  | (_| |\ V /| | (_| | | | (_) | | | | | |  __/
\_| \_/\__,_| \_/ |_|\__,_|_|  \___/|_| |_| |_|\___|
                  Version: 0.49.3-SNAPSHOT (8b93962)

INFO[0000] goose: no migrations to run. current version: 20230209181414 
INFO[0000] Starting signaler                            
INFO[0000] Setting Session Timeout                       value=24h
ERRO[0000] Agent not available. Check configuration      name=spotify
INFO[0000] Creating Image cache                          maxSize="100 MB" path=cache/images
INFO[0000] Finished initializing cache                   cache=Image elapsedTime=6.4ms maxSize=100MB
INFO[0000] Configuring Media Folder                      name="Music Library" path=music
INFO[0000] Starting scheduler                           
INFO[0000] Scheduling periodic scan                      schedule="@every 1m"
INFO[0000] Login rate limit set                          requestLimit=5 windowLength=20s
INFO[0000] Found ffmpeg                                  path=/data/data/com.termux/files/usr/bin/ffmpeg
INFO[0000] Spotify integration is not enabled: missing ID/Secret 
INFO[0000] Mounting Native API routes                    path=/api
ERRO[0000] Agent not available. Check configuration      name=spotify
INFO[0000] Creating Transcoding cache                    maxSize="100 MB" path=cache/transcoding
INFO[0000] Finished initializing cache                   cache=Transcoding elapsedTime=1.1ms maxSize=100MB
INFO[0000] Mounting Subsonic API routes                  path=/rest
ERRO[0000] Agent not available. Check configuration      name=spotify
INFO[0000] Mounting Public Endpoints routes              path=/share
INFO[0000] Mounting LastFM Auth routes                   path=/api/lastfm
INFO[0000] Mounting ListenBrainz Auth routes             path=/api/listenbrainz
INFO[0000] Mounting Background images routes             path=/backgrounds
INFO[0000] Mounting WebUI routes                         path=/app
INFO[0000] Navidrome server is ready!                    address="0.0.0.0:4533" startupTime=58.5ms
INFO[0002] Finished processing changed folder            deleted=0 dir=music elapsed=84.1ms updated=1
INFO[0002] Finished processing Music Folder              added=1 deleted=0 elapsed=94.5ms folder=music playlistsImported=0 updated=0
```