### PR TITLE
coreutils: Add workaround for undeclared `gethostid`

### DIFF
--- a/packages/coreutils/build.sh
+++ b/packages/coreutils/build.sh
@@ -10,7 +10,6 @@ TERMUX_PKG_DEPENDS="libandroid-support, libgmp, libiconv"
 TERMUX_PKG_BREAKS="chroot, busybox (<< 1.30.1-4)"
 TERMUX_PKG_REPLACES="chroot, busybox (<< 1.30.1-4)"
 TERMUX_PKG_ESSENTIAL=true
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false
 
 # pinky has no usage on Android.
 # df does not work either, let system binary prevail.

--- a/packages/coreutils/src-hostid.c.patch
+++ b/packages/coreutils/src-hostid.c.patch
@@ -1,0 +1,14 @@
+https://github.com/termux/termux-packages/issues/15852
+
+--- a/src/hostid.c
++++ b/src/hostid.c
+@@ -73,6 +73,9 @@
+       usage (EXIT_FAILURE);
+     }
+ 
++#ifdef __ANDROID__
++# define gethostid() (0L)
++#endif
+   id = gethostid ();
+ 
+   /* POSIX says gethostid returns a "32-bit identifier" but is silent


### PR DESCRIPTION
Reference: #15852.