### PR TITLE
bash: Fix `getconf` loadable

### DIFF
--- a/packages/bash/build.sh
+++ b/packages/bash/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _MAIN_VERSION=5.2
 _PATCH_VERSION=15
 TERMUX_PKG_VERSION=${_MAIN_VERSION}.${_PATCH_VERSION}
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/bash/bash-${_MAIN_VERSION}.tar.gz
 TERMUX_PKG_SHA256=a139c166df7ff4471c5e0733051642ee5556c1cc8a4a78f145583c5c81ab32fb
 TERMUX_PKG_DEPENDS="libandroid-support, libiconv, readline (>= 8.0), termux-tools"
@@ -12,7 +13,6 @@ TERMUX_PKG_RECOMMENDS="command-not-found, bash-completion"
 TERMUX_PKG_BREAKS="bash-dev"
 TERMUX_PKG_REPLACES="bash-dev"
 TERMUX_PKG_ESSENTIAL=true
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false
 TERMUX_PKG_BUILD_IN_SRC=true
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-multibyte --without-bash-malloc --with-installed-readline"

--- a/packages/bash/examples-loadables-getconf.c.patch
+++ b/packages/bash/examples-loadables-getconf.c.patch
@@ -12,3 +12,26 @@ diff -uNr bash-5.2/examples/loadables/getconf.c bash-5.2.mod/examples/loadables/
  
      /* LFS */
  #ifdef _CS_LFS_CFLAGS
+@@ -1072,6 +1074,7 @@
+ 	printf ("%ld\n", value);
+       return (EXECUTION_SUCCESS);
+ 
++#ifndef __ANDROID__
+     case CONFSTR:
+       errno = 0;
+       clen = confstr (cn, (char *) NULL, 0);
+@@ -1092,10 +1095,14 @@
+ 	printf ("%.*s\n", (int) clen, cvalue);
+       free (cvalue);
+       return (EXECUTION_SUCCESS);
++#endif
+ 
+     case CONSTANT:
+       return (getconf_internal (c, all));
+ 
++#ifdef __ANDROID__
++    case CONFSTR:
++#endif
+     case UNDEFINED:
+       builtin_error ("%s: undefined", c->name);
+       return (EXECUTION_FAILURE);


### PR DESCRIPTION
`confstr` is not available to Android.

Reference: #15852.