### PR TITLE
libnl: Fix missing `getsubopt` definition

### DIFF
--- a/packages/libnl/build.sh
+++ b/packages/libnl/build.sh
@@ -3,11 +3,10 @@ TERMUX_PKG_DESCRIPTION="Collection of libraries providing APIs to netlink protoc
 TERMUX_PKG_LICENSE="LGPL-2.1, GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.7.0"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/thom311/libnl/releases/download/libnl${TERMUX_PKG_VERSION//./_}/libnl-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=9fe43ccbeeea72c653bdcf8c93332583135cda46a79507bfd0a483bb57f65939
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+.\d+.\d+"
 TERMUX_PKG_BREAKS="libnl-dev"
 TERMUX_PKG_REPLACES="libnl-dev"
@@ -34,5 +33,23 @@ termux_step_post_get_source() {
 }
 
 termux_step_pre_configure() {
+	local _inc="$TERMUX_PKG_SRCDIR/_getsubopt/include"
+	rm -rf "${_inc}"
+	mkdir -p "${_inc}"
+	cp "$TERMUX_PKG_BUILDER_DIR/getsubopt.h" "${_inc}"
+
+	CPPFLAGS+=" -I${_inc}"
+
+	local _lib="$TERMUX_PKG_BUILDDIR/_getsubopt/lib"
+	rm -rf "${_lib}"
+	mkdir -p "${_lib}"
+	pushd "${_lib}"/..
+	$CC $CFLAGS $CPPFLAGS "$TERMUX_PKG_BUILDER_DIR/getsubopt.c" \
+		-fvisibility=hidden -c -o ./getsubopt.o
+	$AR cru "${_lib}"/libgetsubopt.a ./getsubopt.o
+	popd
+
+	LDFLAGS+=" -L${_lib} -l:libgetsubopt.a"
+
 	CFLAGS+=" -Dsockaddr_storage=__kernel_sockaddr_storage"
 }

--- a/packages/libnl/getsubopt.c
+++ b/packages/libnl/getsubopt.c
@@ -1,0 +1,89 @@
+/*
+ * Android c-library does not have getsubopt,
+ * so code lifted from uClibc
+ * http://git.uclibc.org/uClibc/tree/libc/unistd/getsubopt.c
+ */
+
+/* Parse comma separate list into words.
+   Copyright (C) 1996, 1997, 1999, 2004 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Ulrich Drepper <drepper@cygnus.com>, 1996.
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, write to the Free
+   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307 USA.  */
+
+
+#include <stdlib.h>
+#include <string.h>
+
+char *strchrnul(const char *s, int c)
+{
+    char *result;
+
+    result = strchr( s, c );
+
+    if( !result )
+    {
+        result = (char *)s + strlen( s );
+    }
+
+    return( result );
+}
+
+/* Parse comma separated suboption from *OPTIONP and match against
+   strings in TOKENS.  If found return index and set *VALUEP to
+   optional value introduced by an equal sign.  If the suboption is
+   not part of TOKENS return in *VALUEP beginning of unknown
+   suboption.  On exit *OPTIONP is set to the beginning of the next
+   token or at the terminating NUL character.  */
+int
+getsubopt (char **optionp, char *const *tokens, char **valuep)
+{
+  char *endp, *vstart;
+  int cnt;
+
+  if (**optionp == '\0')
+    return -1;
+
+  /* Find end of next token.  */
+  endp = strchrnul (*optionp, ',');
+
+  /* Find start of value.  */
+  vstart = memchr (*optionp, '=', endp - *optionp);
+  if (vstart == NULL)
+    vstart = endp;
+
+  /* Try to match the characters between *OPTIONP and VSTART against
+     one of the TOKENS.  */
+  for (cnt = 0; tokens[cnt] != NULL; ++cnt)
+    if (strncmp (*optionp, tokens[cnt], vstart - *optionp) == 0
+    && tokens[cnt][vstart - *optionp] == '\0')
+      {
+    /* We found the current option in TOKENS.  */
+    *valuep = vstart != endp ? vstart + 1 : NULL;
+
+    if (*endp != '\0')
+      *endp++ = '\0';
+    *optionp = endp;
+
+    return cnt;
+      }
+
+  /* The current suboption does not match any option.  */
+  *valuep = *optionp;
+
+  if (*endp != '\0')
+    *endp++ = '\0';
+  *optionp = endp;
+
+  return -1;
+}

--- a/packages/libnl/getsubopt.h
+++ b/packages/libnl/getsubopt.h
@@ -1,0 +1,16 @@
+#ifndef _GETSUBOPT_H
+#define _GETSUBOPT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined __ANDROID__ && __ANDROID_API__ < 26
+int getsubopt(char **, char *const *, char **);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _GETSUBOPT_H */

--- a/packages/libnl/getsubopt.patch
+++ b/packages/libnl/getsubopt.patch
@@ -1,0 +1,10 @@
+--- a/src/lib/route.c
++++ b/src/lib/route.c
+@@ -12,6 +12,7 @@
+ 
+ #include <netlink/cli/utils.h>
+ #include <netlink/cli/route.h>
++#include "getsubopt.h"
+ 
+ struct rtnl_route *nl_cli_route_alloc(void)
+ {


### PR DESCRIPTION
Reference #15852.

Actually `libnl-cli` was broken for Android API `< 26` due to this.