### PR TITLE
libbsd: Fix `configure` for detecting `__progname`

### DIFF
--- a/packages/libbsd/__progname.patch
+++ b/packages/libbsd/__progname.patch
@@ -1,0 +1,24 @@
+https://github.com/termux/termux-packages/issues/15852
+
+--- a/configure
++++ b/configure
+@@ -16743,6 +16743,7 @@
+ printf %s "checking for __progname... " >&6; }
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <stdio.h>
+ extern char *__progname;
+ int
+ main (void)
+--- a/configure.ac
++++ b/configure.ac
+@@ -221,7 +221,8 @@
+ 
+ AC_MSG_CHECKING([for __progname])
+ AC_LINK_IFELSE(
+-	[AC_LANG_PROGRAM([[extern char *__progname;]],
++	[AC_LANG_PROGRAM([[#include <stdio.h>
++		extern char *__progname;]],
+ 	                 [[printf("%s", __progname);]])],
+ 	[AC_DEFINE([HAVE___PROGNAME], [1], [Define to 1 if you have __progname])
+ 	 AC_MSG_RESULT([yes])],


### PR DESCRIPTION
Reference: #15852.