### PR TITLE
Disable QEMU guest agent

### DIFF
--- a/packages/qemu-system-x86-64-headless/build.sh
+++ b/packages/qemu-system-x86-64-headless/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="A generic and open source machine emulator and virtualiz
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1:7.2.0
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://download.qemu.org/qemu-${TERMUX_PKG_VERSION:2}.tar.xz
 TERMUX_PKG_SHA256=5b49ce2687744dad494ae90a898c52204a3406e84d072482a1e1be854eeb2157
 TERMUX_PKG_DEPENDS="glib, libbz2, libcurl, libgmp, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libslirp, libspice-server, libssh, libusb, libusbredir, ncurses, pulseaudio, qemu-common, resolv-conf, zlib, zstd"
@@ -89,7 +89,7 @@ termux_step_configure() {
 		--enable-coroutine-pool \
 		--audio-drv-list=pa \
 		--enable-trace-backends=nop \
-		--enable-guest-agent \
+		--disable-guest-agent \
 		--enable-gnutls \
 		--enable-nettle \
 		--disable-sdl \

--- a/packages/qemu-system-x86-64-headless/qemu-common.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-common.subpackage.sh
@@ -3,7 +3,6 @@ TERMUX_SUBPKG_DEPENDS="glib, libbz2, libcap-ng, libcurl, libgmp, libgnutls, libn
 TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 
 TERMUX_SUBPKG_INCLUDE="
-bin/qemu-ga
 bin/qemu-pr-helper
 bin/qemu-storage-daemon
 libexec/virtfs-proxy-helper

--- a/x11-packages/qemu-system-x86-64/build.sh
+++ b/x11-packages/qemu-system-x86-64/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="A generic and open source machine emulator and virtualiz
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1:7.2.0
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://download.qemu.org/qemu-${TERMUX_PKG_VERSION:2}.tar.xz
 TERMUX_PKG_SHA256=5b49ce2687744dad494ae90a898c52204a3406e84d072482a1e1be854eeb2157
 TERMUX_PKG_DEPENDS="gdk-pixbuf, glib, gtk3, libbz2, libcairo, libcurl, libepoxy, libgmp, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libslirp, libspice-server, libssh, libusb, libusbredir, libx11, mesa, ncurses, pulseaudio, qemu-common, resolv-conf, sdl2, sdl2-image, virglrenderer, zlib, zstd"
@@ -104,7 +104,7 @@ termux_step_configure() {
 		--enable-coroutine-pool \
 		--audio-drv-list=pa,sdl \
 		--enable-trace-backends=nop \
-		--enable-guest-agent \
+		--disable-guest-agent \
 		--enable-gnutls \
 		--enable-nettle \
 		--enable-sdl \


### PR DESCRIPTION
As per documentation: https://www.qemu.org/docs/master/interop/qemu-ga.html

I don't think enabling guest agent would be necessary and it just generates `qemu-ga` binary for guests to communicate within the host, which in this case Android. I think communication still works without `qemu-ga` included in the host.

Let me know if there are other changes that is needed to be done!