### PR TITLE
qt5-qtwebengine: fix build dependencies

### DIFF
--- a/x11-packages/qt5-qtwebengine/build.sh
+++ b/x11-packages/qt5-qtwebengine/build.sh
@@ -7,7 +7,7 @@ TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=git+https://github.com/qt/qtwebengine
 TERMUX_PKG_GIT_BRANCH=v$TERMUX_PKG_VERSION-lts
 TERMUX_PKG_DEPENDS="fontconfig, dbus, libc++, libjpeg-turbo, libminizip, libnss, libpng, libre2, libsnappy, libvpx, libwebp, libx11, libxml2, libxslt, libxkbfile, qt5-qtbase, qt5-qtdeclarative, zlib"
-TERMUX_PKG_BUILD_DEPENDS="qt5-qtbase-cross-tools, qt5-qtdeclarative-cross-tools"
+TERMUX_PKG_BUILD_DEPENDS="libdrm, qt5-qtbase-cross-tools, qt5-qtdeclarative-cross-tools"
 TERMUX_PKG_NO_STATICSPLIT=true
 
 termux_step_pre_configure() {


### PR DESCRIPTION
Add missing dependencies libdrm for qtwebengine. But IMO this will not affect many users because libdrm will be installed if they use mesa as opengl provider. So I'd like to skip the ci.

Closes #15955