### PR TITLE
mariadb: Fix detection of `select()`

### DIFF
--- a/packages/mariadb/configure.cmake.patch
+++ b/packages/mariadb/configure.cmake.patch
@@ -1,0 +1,12 @@
+https://github.com/termux/termux-packages/issues/15852
+
+--- a/configure.cmake
++++ b/configure.cmake
+@@ -578,6 +578,7 @@
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <netdb.h>
++#include <sys/select.h>
+ #endif
+ int main()
+ {


### PR DESCRIPTION
Reference: #15852.