### PR TITLE
deadbeef: Set `_FILE_OFFSET_BITS=64`

### DIFF
--- a/x11-packages/deadbeef/build.sh
+++ b/x11-packages/deadbeef/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="ZLIB, GPL-2.0, LGPL-2.1, BSD 3-Clause, MIT"
 TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.9.5
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/deadbeef/deadbeef-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=74c4478edccfee8a978d4adbeeb208f049bef63982f4df19ee208aaad8a6cd26
 TERMUX_PKG_DEPENDS="atk, dbus, ffmpeg, gdk-pixbuf, glib, gtk3, harfbuzz, libblocksruntime, libc++, libcairo, libcurl, libdispatch, libflac, libiconv, libjansson, libmad, libogg, libsamplerate, libsndfile, libvorbis, libwavpack, libx11, libzip, mpg123, opusfile, pango, pulseaudio, zlib"
@@ -19,6 +19,7 @@ ax_cv_c_flags__msse2=no
 termux_step_pre_configure() {
 	autoreconf -fi
 
+	CPPFLAGS+=" -D_FILE_OFFSET_BITS=64"
 	LDFLAGS+=" -lm $($CC -print-libgcc-file-name)"
 
 	rm -rf intl


### PR DESCRIPTION
Fix build for 32-bit arches:

```
/home/builder/.termux-build/deadbeef/src/external/mp4p/src/mp4pfile.c:49:16:
 error: incompatible function pointer types assigning to
 'off_t (*)(struct mp4p_file_callbacks_s *)' (aka 'long (*)(struct mp4p_file_callbacks_s *)')
 from
 'int64_t (mp4p_file_callbacks_t *)' (aka 'long long (struct mp4p_file_callbacks_s *)')
 [-Werror,-Wincompatible-function-pointer-types]
    file->tell = _file_tell;
               ^ ~~~~~~~~~~
```

Reference: #15852.