### PR TITLE
mailsync: Fix implicit int in `configure`

### DIFF
--- a/packages/mailsync/acinclude-ac_with_md5.m4.patch
+++ b/packages/mailsync/acinclude-ac_with_md5.m4.patch
@@ -1,0 +1,13 @@
+https://github.com/termux/termux-packages/issues/15852
+
+--- a/acinclude/ac_with_md5.m4
++++ b/acinclude/ac_with_md5.m4
+@@ -26,7 +26,7 @@
+ 
+     void md5_init (MD5CONTEXT *ctx);
+ 
+-    main(int argc,char **argv) {
++    int main(int argc,char **argv) {
+      #include "linkage.c"
+      md5_init(NULL);
+     }


### PR DESCRIPTION
Reference: #15852.