### PR TITLE
webkit2gtk-4.1: Do not use `pthread_getname_np()`

### DIFF
--- a/x11-packages/webkit2gtk-4.1/pas_thread_local_cache.c.patch
+++ b/x11-packages/webkit2gtk-4.1/pas_thread_local_cache.c.patch
@@ -1,0 +1,11 @@
+--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
++++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
+@@ -214,6 +214,8 @@ static void dump_thread_diagnostics(pthr
+ #endif
+ #if PAS_PLATFORM(PLAYSTATION)
+     getname_result = pthread_get_name_np(thread, thread_name);
++#elif defined __ANDROID__ && __ANDROID_API__ < 26
++    getname_result = -1;
+ #else
+     getname_result = pthread_getname_np(thread, thread_name, sizeof(thread_name));
+ #endif


### PR DESCRIPTION
that is not available until API 26.

Reference: #15852.