### PR TITLE
libt3{key,window}: Fix `configure` for strict C99

### DIFF
--- a/packages/libt3key/build.sh
+++ b/packages/libt3key/build.sh
@@ -9,7 +9,6 @@ TERMUX_PKG_DEPENDS="libt3config, ncurses"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--without-gettext"
 TERMUX_PKG_HOSTBUILD=true
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false
 
 termux_step_post_get_source() {
 	sed -i 's/ -s / /g' Makefile.in

--- a/packages/libt3key/config.pkg.patch
+++ b/packages/libt3key/config.pkg.patch
@@ -1,0 +1,12 @@
+https://github.com/termux/termux-packages/issues/15852
+
+--- a/config.pkg
++++ b/config.pkg
+@@ -144,6 +144,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <curses.h>
++#include <term.h>
+ 
+ int main(int argc, char *argv[]) {
+ 	int args[9], error, fd;

--- a/packages/libt3window/build.sh
+++ b/packages/libt3window/build.sh
@@ -8,7 +8,6 @@ TERMUX_PKG_SHA256=4c14d3f4f946637fd6c3fa23ef7511fa505880946e151406d5e16f645d24e7
 TERMUX_PKG_DEPENDS="libtranscript, libunistring, ncurses"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--without-gettext"
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false
 
 termux_step_post_get_source() {
 	sed -i 's/ -s / /g' Makefile.in

--- a/packages/libt3window/config.pkg.patch
+++ b/packages/libt3window/config.pkg.patch
@@ -1,0 +1,12 @@
+https://github.com/termux/termux-packages/issues/15852
+
+--- a/config.pkg
++++ b/config.pkg
+@@ -144,6 +144,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <curses.h>
++#include <term.h>
+ 
+ int main(int argc, char *argv[]) {
+ 	int args[9], error, fd;


### PR DESCRIPTION
Reference: #15852.