### PR TITLE
libtranscript: Fix `configure` for strict C99

### DIFF
--- a/packages/libtranscript/build.sh
+++ b/packages/libtranscript/build.sh
@@ -8,7 +8,6 @@ TERMUX_PKG_SRCURL=https://os.ghalkes.nl/dist/libtranscript-${TERMUX_PKG_VERSION}
 TERMUX_PKG_SHA256=1f8c19f257da5d6fad0ed9a7e5bd2442819e910a19907c38e115116a3955f5fa
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--without-gettext"
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false
 
 termux_step_post_get_source() {
 	sed -i 's/ -s / /g' Makefile.in

--- a/packages/libtranscript/config.pkg.patch
+++ b/packages/libtranscript/config.pkg.patch
@@ -1,0 +1,21 @@
+https://github.com/termux/termux-packages/issues/15852
+
+--- a/config.pkg
++++ b/config.pkg
+@@ -66,6 +66,7 @@
+ #include <sys/types.h>
+ #include <stdint.h>
+ #include <dirent.h>
++#include <stdio.h>
+ 
+ int main(int argc, char *argv[]) {
+ 	DIR *dir;
+@@ -74,7 +75,7 @@
+ 
+ 	dir = opendir(".");
+ 	entry = readdir(dir);
+-	puts(entry->d_name[0]);
++	puts(entry->d_name);
+ 	closedir(dir);
+ 	return 0;
+ }


### PR DESCRIPTION
Reference: #15852.