### PR TITLE
liblxqt, lxqt-runner: Fix missing `pipe2` declaration

### DIFF
--- a/x11-packages/liblxqt/add_missing_wordexp.patch
+++ b/x11-packages/liblxqt/add_missing_wordexp.patch
@@ -13,7 +13,8 @@ diff -uNr src/CMakeLists.txt src.mod/CMakeLists.txt
 diff -uNr src/wordexp.c src.mod/wordexp.c
 --- src/wordexp.c	1970-01-01 00:00:00.000000000 +0000
 +++ src.mod/wordexp.c	2021-05-21 08:58:23.662102000 +0000
-@@ -0,0 +1,184 @@
+@@ -0,0 +1,185 @@
++#define __USE_GNU
 +// Copied from http://git.musl-libc.org/cgit/musl/plain/src/misc/wordexp.c
 +// pthread-related lines are removed because they're missing on Android
 +#include <wordexp.h>

--- a/x11-packages/liblxqt/build.sh
+++ b/x11-packages/liblxqt/build.sh
@@ -9,4 +9,3 @@ TERMUX_PKG_DEPENDS="libc++, qt5-qtbase, qt5-qtx11extras, kwindowsystem, libqtxdg
 TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt5-qtbase-cross-tools"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DBUILD_BACKLIGHT_LINUX_BACKEND=OFF"
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false

--- a/x11-packages/lxqt-runner/add_missing_wordexp.patch
+++ b/x11-packages/lxqt-runner/add_missing_wordexp.patch
@@ -20,7 +20,8 @@ diff -uNr src/CMakeLists.txt src.mod/CMakeLists.txt
 diff -uNr src/wordexp.c src.mod/wordexp.c
 --- src/wordexp.c	1970-01-01 00:00:00.000000000 +0000
 +++ src.mod/wordexp.c	2021-05-21 09:10:10.115178000 +0000
-@@ -0,0 +1,184 @@
+@@ -0,0 +1,185 @@
++#define __USE_GNU
 +// Copied from http://git.musl-libc.org/cgit/musl/plain/src/misc/wordexp.c
 +// pthread-related lines are removed because they're missing on Android
 +#include <wordexp.h>

--- a/x11-packages/lxqt-runner/build.sh
+++ b/x11-packages/lxqt-runner/build.sh
@@ -8,7 +8,6 @@ TERMUX_PKG_SHA256=1f9b61fef6420589b8d546c9b504364063e43de675b94020e215c35469852f
 TERMUX_PKG_DEPENDS="libc++, qt5-qtbase, libqtxdg, kwindowsystem, liblxqt, lxqt-globalkeys"
 TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt5-qtbase-cross-tools, qt5-qttools-cross-tools"
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false
 
 # TODO runner math depends on muparser
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DRUNNER_MATH=OFF"


### PR DESCRIPTION
Reference: #15852.