### PR TITLE
postgis: Fix missing `bzero` declaration

### DIFF
--- a/packages/postgis/build.sh
+++ b/packages/postgis/build.sh
@@ -6,7 +6,6 @@ TERMUX_PKG_VERSION=3.3.2
 TERMUX_PKG_SRCURL=https://download.osgeo.org/postgis/source/postgis-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=9a2a219da005a1730a39d1959a1c7cec619b1efb009b65be80ffc25bad299068
 TERMUX_PKG_DEPENDS="gdal, json-c, libc++, libgeos, libiconv, libprotobuf-c, libxml2, pcre2, postgresql, proj"
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false
 
 # both configure script and Makefile(s) look for files in current
 # directory rather than srcdir, so need to build in source

--- a/packages/postgis/liblwgeom-ptarray.c.patch
+++ b/packages/postgis/liblwgeom-ptarray.c.patch
@@ -1,0 +1,12 @@
+https://github.com/termux/termux-packages/issues/15852
+
+--- a/liblwgeom/ptarray.c
++++ b/liblwgeom/ptarray.c
+@@ -26,6 +26,7 @@
+ 
+ #include <stdio.h>
+ #include <string.h>
++#include <strings.h>
+ #include <stdlib.h>
+ 
+ #include "../postgis_config.h"


### PR DESCRIPTION
Reference: #15852.