### PR TITLE
lrzsz: Fix missing `exit` declaration

### DIFF
--- a/packages/lrzsz/build.sh
+++ b/packages/lrzsz/build.sh
@@ -10,7 +10,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-syslog 
 --mandir=$TERMUX_PREFIX/share/man
 "
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false
 
 termux_step_pre_configure() {
 	autoreconf -vfi

--- a/packages/lrzsz/lib-long-options.c.patch
+++ b/packages/lrzsz/lib-long-options.c.patch
@@ -1,0 +1,12 @@
+https://github.com/termux/termux-packages/issues/15852
+
+--- a/lib/long-options.c
++++ b/lib/long-options.c
+@@ -22,6 +22,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include <stdlib.h>
+ #include <getopt.h>
+ #include "long-options.h"
+ 


### PR DESCRIPTION
Reference: #15852.