### PR TITLE
liblog4c: Fix implicit declaration of function

### DIFF
--- a/packages/liblog4c/build.sh
+++ b/packages/liblog4c/build.sh
@@ -6,7 +6,6 @@ TERMUX_PKG_VERSION=1.2.4
 TERMUX_PKG_SRCURL=http://prdownloads.sourceforge.net/log4c/log4c-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=5991020192f52cc40fa852fbf6bbf5bd5db5d5d00aa9905c67f6f0eadeed48ea
 TERMUX_PKG_DEPENDS="libexpat"
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false
 
 termux_step_pre_configure() {
 	autoreconf -fi

--- a/packages/liblog4c/src-sd-malloc.h.patch
+++ b/packages/liblog4c/src-sd-malloc.h.patch
@@ -1,9 +1,10 @@
 --- a/src/sd/malloc.h
 +++ b/src/sd/malloc.h
-@@ -8,6 +8,7 @@
+@@ -8,6 +8,8 @@
  #ifndef __sd_malloc_h
  #define __sd_malloc_h
  
++#include_next <malloc.h>
 +#include <stdint.h>
  #include <stddef.h>
  #include <stdlib.h>


### PR DESCRIPTION
declared in system `<malloc.h>`.

Reference: #15852.