### PR TITLE
anacron: Fix missing `exit` declaration

### DIFF
--- a/packages/anacron/build.sh
+++ b/packages/anacron/build.sh
@@ -7,7 +7,6 @@ TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/anacron/anacron-${TERMUX_PKG
 TERMUX_PKG_SHA256=5ceee6f22cd089bdaf1c0841200dbe5726babaf9e2c432bb17c1fc95da5ca99f
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_MAKE_ARGS="PREFIX=$TERMUX_PREFIX"
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false
 
 termux_step_post_get_source() {
 	cp $TERMUX_PKG_BUILDER_DIR/obstack.h ./

--- a/packages/anacron/log.c.patch
+++ b/packages/anacron/log.c.patch
@@ -1,0 +1,10 @@
+--- a/log.c
++++ b/log.c
+@@ -37,6 +37,7 @@
+ #include <unistd.h>
+ #include <syslog.h>
+ #include <stdio.h>
++#include <stdlib.h>
+ #include <stdarg.h>
+ #include <errno.h>
+ #include <signal.h>

--- a/packages/anacron/main.c.patch
+++ b/packages/anacron/main.c.patch
@@ -1,0 +1,10 @@
+--- a/main.c
++++ b/main.c
+@@ -24,6 +24,7 @@
+ 
+ #include <time.h>
+ #include <stdio.h>
++#include <stdlib.h>
+ #include <unistd.h>
+ #include <signal.h>
+ #include <fcntl.h>


### PR DESCRIPTION
Reference: #15852.