### PR TITLE
mruby: Fix missing `clog` declaration

### DIFF
--- a/packages/mruby/build.sh
+++ b/packages/mruby/build.sh
@@ -7,7 +7,6 @@ TERMUX_PKG_SRCURL=https://github.com/mruby/mruby/archive/${TERMUX_PKG_VERSION}.z
 TERMUX_PKG_SHA256=64a0dd8b65825f2e7cdac6699e818648dc73bfdfc68aa1bfd58417a35315e5cc
 TERMUX_PKG_DEPENDS="libandroid-complex-math, readline"
 TERMUX_PKG_BUILD_IN_SRC=true
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false
 
 termux_step_make() {
 	export CC_FOR_TARGET="$CC"

--- a/packages/mruby/mrbgems-mruby-cmath-src-cmath.c.patch
+++ b/packages/mruby/mrbgems-mruby-cmath-src-cmath.c.patch
@@ -1,0 +1,15 @@
+https://github.com/termux/termux-packages/issues/15852
+
+--- a/mrbgems/mruby-cmath/src/cmath.c
++++ b/mrbgems/mruby-cmath/src/cmath.c
+@@ -17,6 +17,10 @@
+ 
+ #include <complex.h>
+ 
++#if defined __ANDROID__ && __ANDROID_API__ < 26
++double complex clog(double complex);
++#endif
++
+ mrb_value mrb_complex_new(mrb_state *mrb, mrb_float real, mrb_float imag);
+ void mrb_complex_get(mrb_state *mrb, mrb_value cpx, mrb_float*, mrb_float*);
+ 


### PR DESCRIPTION
Reference: #15852.