### PR TITLE
netcat-openbsd: Fix missing `explicit_bzero` declaration

### DIFF
--- a/packages/netcat-openbsd/build.sh
+++ b/packages/netcat-openbsd/build.sh
@@ -7,7 +7,6 @@ TERMUX_PKG_SRCURL=https://salsa.debian.org/debian/netcat-openbsd/-/archive/debia
 TERMUX_PKG_SHA256=25fb463ba60d2c54f3f44ddd45d122e9a95b9cc2a2f4dfb264b5b2d0adfc9265
 TERMUX_PKG_DEPENDS="libbsd"
 TERMUX_PKG_BUILD_IN_SRC=true
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false
 
 termux_step_pre_configure() {
 	local p

--- a/packages/netcat-openbsd/debian-patches-port-to-linux-with-libbsd.patch
+++ b/packages/netcat-openbsd/debian-patches-port-to-linux-with-libbsd.patch
@@ -19,3 +19,18 @@ diff -uNr netcat-openbsd-debian-1.218-5/debian/patches/port-to-linux-with-libbsd
  +# define IPTOS_LOWDELAY 0x10
  +# define IPTOS_THROUGHPUT 0x08
  +# define IPTOS_RELIABILITY 0x04
+@@ -355,12 +355,13 @@
+ index 7c7448c..8db10d4 100644
+ --- a/socks.c
+ +++ b/socks.c
+-@@ -38,7 +38,7 @@
++@@ -38,7 +38,8 @@
+  #include <string.h>
+  #include <unistd.h>
+  #include <resolv.h>
+ -#include <readpassphrase.h>
+ +#include <bsd/readpassphrase.h>
+++#include <bsd/string.h>
+  #include "atomicio.h"
+  
+  #define SOCKS_PORT	"1080"


### PR DESCRIPTION
Reference: #15852.