### PR TITLE
renameutils: Add missing `getsubopt` declaration

### DIFF
--- a/packages/renameutils/add-missing-functions.patch
+++ b/packages/renameutils/add-missing-functions.patch
@@ -93,3 +93,55 @@ diff -uNr renameutils-0.12.0/src/editformats/Makefile.in renameutils-0.12.0.mod/
  
  all: all-am
  
+--- a/src/editformats/destination-only.c
++++ b/src/editformats/destination-only.c
+@@ -36,6 +36,8 @@
+ #include "xalloc.h"		/* Gnulib */
+ #include "qcmd.h"
+ 
++#include "getsubopt.h"
++
+ static bool parse_options(char *options);
+ static char *option_generator(const char *text, int state);
+ static void output(FILE *out, LList *files);
+--- a/src/editformats/dual-column.c
++++ b/src/editformats/dual-column.c
+@@ -43,6 +43,8 @@
+ #include "xalloc.h"			/* Gnulib */
+ #include "qcmd.h"
+ 
++#include "getsubopt.h"
++
+ static void reset_options();
+ static bool parse_options(char *options);
+ static char *option_generator(const char *text, int state);
+--- a/src/editformats/single-column.c
++++ b/src/editformats/single-column.c
+@@ -36,6 +36,8 @@
+ #include "common/llist.h"
+ #include "qcmd.h"
+ 
++#include "getsubopt.h"
++
+ static bool parse_options(char *options);
+ static char *option_generator(const char *text, int state);
+ static void output(FILE *out, LList *files);
+--- a/src/getsubopt.h
++++ b/src/getsubopt.h
+@@ -0,0 +1,16 @@
++#ifndef _GETSUBOPT_H
++#define _GETSUBOPT_H
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++#if defined __ANDROID__ && __ANDROID_API__ < 26
++int getsubopt(char **, char *const *, char **);
++#endif
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /* _GETSUBOPT_H */

--- a/packages/renameutils/build.sh
+++ b/packages/renameutils/build.sh
@@ -7,7 +7,6 @@ TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://savannah.nongnu.org/download/renameutils/renameutils-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=cbd2f002027ccf5a923135c3f529c6d17fabbca7d85506a394ca37694a9eb4a3
 TERMUX_PKG_DEPENDS="libandroid-wordexp, readline"
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false
 
 termux_step_pre_configure() {
 	LDFLAGS+=" -landroid-wordexp"


### PR DESCRIPTION
Reference: #15852.