### PR TITLE
addpkg(main/sabnzbd): v3.7.2

### DIFF
--- a/packages/python-sabyenc3/build.sh
+++ b/packages/python-sabyenc3/build.sh
@@ -1,0 +1,17 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/sabnzbd/sabctools
+TERMUX_PKG_DESCRIPTION="C implementations of functions for use within SABnzbd"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=5.4.4
+TERMUX_PKG_SRCURL=https://github.com/sabnzbd/sabctools/releases/download/v${TERMUX_PKG_VERSION}/sabyenc3-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=b06d12028f832fc941b92bc034231318324663b0b31f821c31da95b18a948d8e
+TERMUX_PKG_DEPENDS="python"
+TERMUX_PKG_BUILD_DEPENDS="libcpufeatures"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_PYTHON_COMMON_DEPS="wheel"
+
+termux_step_pre_configure() {
+	export CXXFLAGS+=" -fPIC -I$TERMUX_PREFIX/include/ndk_compat"
+	export CFLAGS+=" -I$TERMUX_PREFIX/include/ndk_compat"
+	export LDFLAGS+=" -l:libndk_compat.a"
+}

--- a/packages/sabnzbd/build.sh
+++ b/packages/sabnzbd/build.sh
@@ -1,0 +1,31 @@
+TERMUX_PKG_HOMEPAGE=https://sabnzbd.org/
+TERMUX_PKG_DESCRIPTION="Fully automated Usenet Binary Downloader"
+TERMUX_PKG_LICENSE="GPL-2.0, GPL-3.0"
+TERMUX_PKG_LICENSE_FILE="LICENSE.txt, GPL2.txt, GPL3.txt"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=3.7.2
+TERMUX_PKG_SRCURL=https://github.com/sabnzbd/sabnzbd/releases/download/${TERMUX_PKG_VERSION}/SABnzbd-${TERMUX_PKG_VERSION}-src.tar.gz
+TERMUX_PKG_SHA256=01250ecd09cdb50da8be8829e4f44f33f0bf1bcf1fcff136ad6045e5f4a2a172
+TERMUX_PKG_DEPENDS="python, python-cryptography, python-sabyenc3, termux-tools, par2, unrar, p7zip, unzip"
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_SERVICE_SCRIPT=("sabnzbd" 'exec sabnzbd -d 2>&1')
+TERMUX_PKG_PYTHON_TARGET_DEPS="'cheetah3==3.2.6.post1', 'cffi==1.15.1', 'pycparser==2.21', 'feedparser==6.0.10', 'configobj==5.0.6', 'cheroot==9.0.0', 'six==1.16.0', 'cherrypy==18.8.0', 'jaraco.functools==3.5.2', 'jaraco.collections==3.8.0', 'jaraco.text==3.8.1', 'jaraco.classes==3.2.3', 'jaraco.context==4.2.0', 'more-itertools==9.0.0', 'zc.lockfile==2.0', 'python-dateutil==2.8.2', 'tempora==5.2.0', 'pytz==2022.7', 'sgmllib3k==1.0.0', 'portend==3.1.0', 'chardet==5.1.0', 'PySocks==1.7.1', 'puremagic==1.14', 'guessit==3.5.0', 'babelfish==0.6.0', 'rebulk==3.1.0'"
+
+termux_step_make_install() {
+	local sabnzbd="${TERMUX_PREFIX}/share/sabnzbd"
+	mkdir -p "${sabnzbd}"
+	cp -r email icons interfaces locale po sabnzbd scripts tools "${sabnzbd}"
+	find "${sabnzbd}" -type d -exec chmod 700 {} \;
+	find "${sabnzbd}" -type f -exec chmod 600 {} \;
+	install -Dm700 SABnzbd.py "${TERMUX_PREFIX}/bin/sabnzbd"
+	install -Dm600 linux/sabnzbd.bash-completion "${TERMUX_PREFIX}/share/bash-completion/completions/sabnzbd"
+}
+
+termux_step_create_debscripts() {
+	cat <<- EOF > ./postinst
+	#!$TERMUX_PREFIX/bin/sh
+	echo "Installing dependencies through pip..."
+	pip3 install ${TERMUX_PKG_PYTHON_TARGET_DEPS//, / }
+	EOF
+}

--- a/packages/sabnzbd/prog_dir.patch
+++ b/packages/sabnzbd/prog_dir.patch
@@ -1,0 +1,42 @@
+diff --git a/SABnzbd.py b/SABnzbd.py
+index ffd999892..662358479 100755
+--- a/SABnzbd.py
++++ b/SABnzbd.py
+@@ -16,6 +16,7 @@
+ # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ 
+ import sys
++sys.path.insert(0,"@TERMUX_PREFIX@/share/sabnzbd")
+ 
+ if sys.hexversion < 0x03070000:
+     print("Sorry, requires Python 3.7 or above")
+@@ -366,19 +367,7 @@ def fix_webname(name):
+ 
+ def get_user_profile_paths():
+     """Get the default data locations on Windows"""
+-    if sabnzbd.DAEMON:
+-        # In daemon mode, do not try to access the user profile
+-        # just assume that everything defaults to the program dir
+-        sabnzbd.DIR_LCLDATA = sabnzbd.DIR_PROG
+-        sabnzbd.DIR_HOME = sabnzbd.DIR_PROG
+-        if sabnzbd.WIN32:
+-            # Ignore Win32 "logoff" signal
+-            # This should work, but it doesn't
+-            # Instead the signal_handler will ignore the "logoff" signal
+-            # signal.signal(5, signal.SIG_IGN)
+-            pass
+-        return
+-    elif sabnzbd.WIN32:
++    if sabnzbd.WIN32:
+         try:
+             path = shell.SHGetFolderPath(0, shellcon.CSIDL_LOCAL_APPDATA, None, 0)
+             sabnzbd.DIR_LCLDATA = os.path.join(path, DEF_WORKDIR)
+@@ -965,7 +954,7 @@ def main():
+ 
+     sabnzbd.MY_FULLNAME = os.path.normpath(os.path.abspath(sabnzbd.MY_FULLNAME))
+     sabnzbd.MY_NAME = os.path.basename(sabnzbd.MY_FULLNAME)
+-    sabnzbd.DIR_PROG = os.path.dirname(sabnzbd.MY_FULLNAME)
++    sabnzbd.DIR_PROG = "@TERMUX_PREFIX@/share/sabnzbd"
+     sabnzbd.DIR_INTERFACES = real_path(sabnzbd.DIR_PROG, DEF_INTERFACES)
+     sabnzbd.DIR_LANGUAGE = real_path(sabnzbd.DIR_PROG, DEF_LANGUAGE)
+     org_dir = os.getcwd()

--- a/packages/sabnzbd/webbrowser.patch
+++ b/packages/sabnzbd/webbrowser.patch
@@ -1,0 +1,28 @@
+diff --git a/sabnzbd/panic.py b/sabnzbd/panic.py
+index 6e4b61f72..017dc9407 100644
+--- a/sabnzbd/panic.py
++++ b/sabnzbd/panic.py
+@@ -24,10 +24,7 @@ import logging
+ import tempfile
+ import ctypes
+ 
+-try:
+-    import webbrowser
+-except ImportError:
+-    webbrowser = None
++import subprocess
+ 
+ import sabnzbd
+ import sabnzbd.cfg as cfg
+@@ -240,10 +237,7 @@ def launch_a_browser(url, force=False):
+     try:
+         if url and not url.startswith("http"):
+             url = "file:///%s" % url
+-        if webbrowser:
+-            webbrowser.open(url, 2, 1)
+-        else:
+-            logging.info("Not showing panic message in webbrowser, no support found")
++        subprocess.call(["termux-open-url", url])
+     except:
+         logging.warning(T("Cannot launch the browser, probably not found"))
+         logging.info("Traceback: ", exc_info=True)


### PR DESCRIPTION
SABnzbd is an alternative to NZBGet, which is also packaged in Termux but is now abandoned by the upstream developer.

`python-sabyenc3` is a dependency for SABnzbd, it contains native (C) code and doesn't compile without patching.

In addition to the sabyenc3 dependency, it includes various enhancements like service definition for `termux-services`, patch to support `termux-open-url`, placing of `bash-completion` file etc. Before finilizing this package, I inspected and sourced ideas from packaging of SABnzbd on Arch Linux, RHEL 8 and Ubuntu.