### PR TITLE
minimodem: Fix missing `bzero` declaration

### DIFF
--- a/packages/minimodem/build.sh
+++ b/packages/minimodem/build.sh
@@ -9,7 +9,6 @@ TERMUX_PKG_DEPENDS="fftw, libsndfile, pulseaudio"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --without-alsa
 "
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false
 
 termux_step_pre_configure() {
 	autoreconf -fi

--- a/packages/minimodem/src-fsk.c.patch
+++ b/packages/minimodem/src-fsk.c.patch
@@ -1,0 +1,10 @@
+--- a/src/fsk.c
++++ b/src/fsk.c
+@@ -20,6 +20,7 @@
+ 
+ #include <stdlib.h>
+ #include <string.h>
++#include <strings.h>
+ #include <math.h>	// fabsf, hypotf
+ #include <float.h>	// FLT_EPSILON
+ #include <errno.h>


### PR DESCRIPTION
Reference: #15852.