### PR TITLE
streamripper: Fix missing `strcpy` declaration

### DIFF
--- a/packages/streamripper/build.sh
+++ b/packages/streamripper/build.sh
@@ -3,9 +3,8 @@ TERMUX_PKG_DESCRIPTION="Records and splits streaming mp3 into tracks"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.64.6
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/sourceforge/streamripper/streamripper-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=c1d75f2e9c7b38fd4695be66eff4533395248132f3cc61f375196403c4d8de42
-TERMUX_PKG_DEPENDS="glib, libmad, libvorbis"
+TERMUX_PKG_DEPENDS="glib, libmad, libogg, libvorbis"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="ac_cv_lib_pthread_pthread_create=yes"
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false

--- a/packages/streamripper/lib-argv.c.patch
+++ b/packages/streamripper/lib-argv.c.patch
@@ -1,0 +1,13 @@
+--- a/lib/argv.c
++++ b/lib/argv.c
+@@ -52,6 +52,10 @@
+ 
+ /*  Routines imported from standard C runtime libraries. */
+ 
++#ifdef __ANDROID__
++# define ANSI_PROTOTYPES
++#endif
++
+ #ifdef ANSI_PROTOTYPES
+ 
+ #include <stddef.h>


### PR DESCRIPTION
Reference: #15852.