### PR TITLE
exercism: make the binary executable

### DIFF
--- a/packages/exercism/build.sh
+++ b/packages/exercism/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="A Go based command line tool for exercism.io"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.1.0"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL="https://github.com/exercism/cli/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz"
 TERMUX_PKG_SHA256=34653a6a45d49daef10db05672c9b4e36c3c30e09d57c3c0f737034d071ae4f6
 TERMUX_PKG_AUTO_UPDATE=true
@@ -16,7 +16,7 @@ termux_step_make() {
 }
 
 termux_step_post_make_install() {
-	install -Dm644 "$TERMUX_PKG_SRCDIR/exercism/exercism" \
+	install -Dm700 "$TERMUX_PKG_SRCDIR/exercism/exercism" \
 		"$TERMUX_PREFIX/bin/exercism"
 
 	# shell completions


### PR DESCRIPTION
After installation I found out that `exercism` binary is not executable, so here is the fix.