### PR TITLE
addpkg(main/rpm): 4.18.1

### DIFF
--- a/packages/rpm/build.sh
+++ b/packages/rpm/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE=https://rpm.org/
+TERMUX_PKG_DESCRIPTION="RPM Package Manager"
+TERMUX_PKG_LICENSE="GPL-2.0, LGPL-2.0"
+TERMUX_PKG_LICENSE_FILE="COPYING"
+TERMUX_PKG_MAINTAINER="@termux"
+_MAJOR_VERSION=4.18
+TERMUX_PKG_VERSION=${_MAJOR_VERSION}.1
+TERMUX_PKG_SRCURL=https://ftp.osuosl.org/pub/rpm/releases/rpm-${_MAJOR_VERSION}.x/rpm-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_SHA256=37f3b42c0966941e2ad3f10fde3639824a6591d07197ba8fd0869ca0779e1f56
+TERMUX_PKG_DEPENDS="file, libandroid-spawn, libarchive, libbz2, libgcrypt, libiconv, liblua54, liblzma, libpopt, libsqlite, readline, zlib, zstd"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--disable-static
+--disable-openmp
+"
+
+termux_step_pre_configure() {
+	export LUA_CFLAGS="-I$TERMUX_PREFIX/include/lua5.4"
+	export LUA_LIBS="-L$TERMUX_PREFIX/lib/liblua5.4.so"
+	LDFLAGS+=" -llua5.4 -landroid-spawn $($CC -print-libgcc-file-name)"
+}

--- a/packages/rpm/errno.patch
+++ b/packages/rpm/errno.patch
@@ -1,0 +1,13 @@
+diff --git a/misc/fts.c b/misc/fts.c
+index dc5480c50..6836a9939 100644
+--- a/misc/fts.c
++++ b/misc/fts.c
+@@ -80,7 +80,7 @@ static char sccsid[] = "@(#)fts.c	8.6 (Berkeley) 8/14/94";
+ #include <dirent.h>
+ #include <errno.h>
+ #include "misc/rpmfts.h"
+-#   define __set_errno(val) (*__errno_location ()) = (val)
++#   define __set_errno(val) (*__errno ()) = (val)
+ #   define __open	open
+ #   define __close	close
+ #   define __fchdir	fchdir

--- a/packages/rpm/goto_declaration.patch
+++ b/packages/rpm/goto_declaration.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/fsm.c b/lib/fsm.c
+index b2e5fe525..e0db49316 100644
+--- a/lib/fsm.c
++++ b/lib/fsm.c
+@@ -1014,7 +1014,7 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
+                     rc = RPMERR_UNKNOWN_FILETYPE;
+             }
+ 
+-setmeta:
++setmeta:;
+ 	    /* Special files require path-based ops */
+ 	    int mayopen = S_ISREG(fp->sb.st_mode) || S_ISDIR(fp->sb.st_mode);
+ 	    if (!rc && fd == -1 && mayopen) {


### PR DESCRIPTION
Having `rpm` in Termux should provide means to quickly inspect RPM files locally, outside RPM based distros. For example `mc` integrates with `rpm` and allows browsing RPM archives.