### PR TITLE
whois: Fix missing `crypt` declaration

### DIFF
--- a/packages/whois/build.sh
+++ b/packages/whois/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="An intelligent Whois client"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="5.5.16"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://ftp.debian.org/debian/pool/main/w/whois/whois_${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=0a818f56c4bb909cf8665766cb683931de52901d6a33627d51b1005add3cdb27
 TERMUX_PKG_DEPENDS="libcrypt, libiconv, libidn2"
@@ -14,8 +15,8 @@ HAVE_ICONV=1
 "
 
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_ENABLE_CLANG16_PORTING=false
 
 termux_step_pre_configure() {
+	CPPFLAGS+=" -DHAVE_CRYPT_H"
 	LDFLAGS+=" -liconv"
 }


### PR DESCRIPTION
Reference: #15852.