### PR TITLE
wireless-tools: Fix missing `bzero` declaration

### DIFF
--- a/root-packages/wireless-tools/iwlib.c.patch
+++ b/root-packages/wireless-tools/iwlib.c.patch
@@ -1,0 +1,10 @@
+--- a/iwlib.c
++++ b/iwlib.c
+@@ -12,6 +12,7 @@
+ /***************************** INCLUDES *****************************/
+ 
+ #include "iwlib-private.h"		/* Private header */
++#include <strings.h>
+ 
+ /************************ CONSTANTS & MACROS ************************/
+ 


### PR DESCRIPTION
Reference: #15852.