### PR TITLE
addpkg(main/bc-gh): GNU- and BSD-compatible Unix dc and POSIX bc

### DIFF
--- a/packages/bc-gh/build.sh
+++ b/packages/bc-gh/build.sh
@@ -1,0 +1,32 @@
+TERMUX_PKG_HOMEPAGE=https://git.gavinhoward.com/gavin/bc
+TERMUX_PKG_DESCRIPTION="Unix dc and POSIX bc with GNU and BSD extensions"
+TERMUX_PKG_LICENSE="BSD 2-Clause"
+TERMUX_PKG_MAINTAINER="Gavin D. Howard <gavin@gavinhoward.com>"
+TERMUX_PKG_VERSION=6.6.0
+TERMUX_PKG_SRCURL=https://github.com/gavinhoward/bc/releases/download/${TERMUX_PKG_VERSION}/bc-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=37efb9ad2a7d3683ab1f7c49d8787473a5241feb222d2e4ae73d1b133f82db0c
+TERMUX_PKG_DEPENDS="readline"
+
+termux_step_configure() {
+	cd $TERMUX_PKG_BUILDDIR
+	# Without NLS_PATH set like this, bc will complain that the
+	# locale files will not be in the right place.
+	#
+	# GEN_HOST=0 prevents the need for a host compiler.
+	#
+	# The --predefined-build-type makes bc and dc act like the GNU
+	# bc and dc by default, although users can change that at
+	# runtime.
+	NLS_PATH=$TERMUX_PREFIX/share/locale/%L/%N GEN_HOST=0 EXECSUFFIX=-gh \
+		$TERMUX_PKG_SRCDIR/configure.sh \
+		--predefined-build-type=GNU --enable-readline \
+		--disable-nls --prefix=$TERMUX_PREFIX
+}
+
+termux_step_make_install() {
+	install -Dm700 -T bin/bc $TERMUX_PREFIX/bin/bc-gh
+	ln -sf ./bc-gh $TERMUX_PREFIX/bin/dc-gh
+	chmod 700 $TERMUX_PREFIX/bin/dc-gh
+	install -Dm600 manuals/bc.1 $TERMUX_PREFIX/share/man/man1/bc-gh.1
+	install -Dm600 manuals/dc.1 $TERMUX_PREFIX/share/man/man1/dc-gh.1
+}


### PR DESCRIPTION
This commit/PR is a request to consider changing the bc implementation to the one by Gavin Howard. I understand if this PR is ultimately rejected.

That said, the bc/dc by Gavin Howard (me) is IMO a better option than the GNU bc/dc for these reasons:

* It is already used by the upstream Android Open Source Project. [1]
* It is permissively licensed.
* It implements the POSIX bc standard better.
* It can be made to imitate the GNU bc/dc exactly, barring differences between the GNU bc and the POSIX standard. This includes all GNU extensions and command-line options.
* It can *also* be made to imitate the BSD bc/dc exactly, barring differences between the BSD bc and the POSIX standard. This means that my bc can be a bridge for Android users used to the BSD bc/dc.
* It is being actively maintained, and I respond to bug reports. [2]
* It is *much* faster. [3]
* It has many more extensions, most of which are math-related. [4] [5]
* I am prepared to be the maintainer of this package like I maintain the Gentoo package, [6] though I am willing to let others maintain it.

I see two possible disadvantages:

* My bc/dc is takes more space.
* The GNU bc/dc is more well-known.

However, I don't think these are problems.

On aarch64, the size of the package is under 300 kB. This includes the manuals. Total space use would be about 1.2 MB. The extra space is also partially offset by having no dependency on flex.

Yes, the GNU bc/dc is more well-known, but I have tested my bc against the GNU bc from the beginning and achieved near-perfect compatibility. There have been few reports of discrepancies, and any reported discrepancies have been fixed if they do not violate the POSIX standard. This bc is also faster and has more extensions.

It is also becoming a standard itself. It has been the system bc for FreeBSD since 13.0 (April 2021), [7] and it became the system bc in Mac OSX starting with Ventura. [8] It is also supported in several Linux distros as the default or as a first-class alternative to the GNU bc.

My bc/dc also has built-in history support, but it can also use both readline and libedit instead. I chose readline for this package since the GNU bc already used it, but if the built-in history is used, then this bc has no runtime dependencies.

Now, for notes on the commit.

I put myself as the maintainer. It may be wrong because I couldn't find any examples that were not "@termux". The homepage is my self-hosted Gitea, but I use the GitHub link for ease.

I use a direct configure.sh call because it's a hand-coded script (not autotools) and does not recognize some default options.

I use an install step because I have a script from the musl project that installs, but I saw that policy was to use the `install` program.

The LICENSE.md file is not part of the install, so I added the step to install it.

Finally, this bc uses a raw Makefile (generated by configure.sh), but both together *do* support out-of-source builds.

[1]: https://android.googlesource.com/platform/external/bc/
[2]: https://github.com/gavinhoward/bc/issues/67
[3]: https://git.gavinhoward.com/gavin/bc#performance
[4]: https://git.gavinhoward.com/gavin/bc#extensions
[5]: https://git.gavinhoward.com/gavin/bc/src/branch/master/manuals/bc/A.1.md#extended-library
[6]: https://github.com/gentoo/gentoo/blob/master/sci-calculators/bc-gh/metadata.xml#L4-L7
[7]: https://man.freebsd.org/cgi/man.cgi?query=bc&sektion=1&manpath=FreeBSD+13.0-RELEASE#end
[8]: https://github.com/apple-oss-distributions/bc/tree/main/bc