### PR TITLE
new package: libsass, python-libsass

### DIFF
--- a/packages/libsass/build.sh
+++ b/packages/libsass/build.sh
@@ -1,0 +1,18 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/sass/libsass
+TERMUX_PKG_DESCRIPTION="Sass compiler written in C++"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=3.6.5
+TERMUX_PKG_SRCURL=https://github.com/sass/libsass/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=89d8f2c46ae2b1b826b58ce7dde966a176bac41975b82e84ad46b01a55080582
+TERMUX_PKG_DEPENDS="libc++"
+
+termux_step_pre_configure() {
+	autoreconf -fi
+
+	if [ "${TERMUX_PKG_SRCURL:0:4}" != "git+" ] && [ ! -e VERSION ]; then
+		echo "${TERMUX_PKG_VERSION#*:}" > VERSION
+	fi
+
+	LDFLAGS+=" $($CC -print-libgcc-file-name)"
+}

--- a/packages/python-libsass/build.sh
+++ b/packages/python-libsass/build.sh
@@ -1,0 +1,14 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/sass/libsass-python
+TERMUX_PKG_DESCRIPTION="A straightforward binding of libsass for Python"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=0.22.0
+TERMUX_PKG_SRCURL=https://github.com/sass/libsass-python/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=f26d466918496fbce0890a3c388c78ee25ef9165a7affc591f846d0f8f1a671e
+TERMUX_PKG_DEPENDS="libsass, python"
+TERMUX_PKG_PYTHON_COMMON_DEPS="wheel"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+	export SYSTEM_SASS=1
+}

--- a/packages/python-libsass/setup.py.patch
+++ b/packages/python-libsass/setup.py.patch
@@ -1,0 +1,15 @@
+--- a/setup.py
++++ b/setup.py
+@@ -15,10 +15,10 @@
+ 
+ MACOS_FLAG = ['-mmacosx-version-min=10.7']
+ FLAGS_POSIX = [
+-    '-fPIC', '-std=gnu++0x', '-Wall', '-Wno-parentheses', '-Werror=switch',
++    '-fPIC', '-Wall', '-Wno-parentheses', '-Werror=switch',
+ ]
+ FLAGS_CLANG = ['-c', '-O3'] + FLAGS_POSIX + ['-stdlib=libc++']
+-LFLAGS_POSIX = ['-fPIC',  '-lstdc++']
++LFLAGS_POSIX = ['-fPIC']
+ LFLAGS_CLANG = ['-fPIC', '-stdlib=libc++']
+ 
+ sources = ['_sass.c']


### PR DESCRIPTION
Dependency of repomaker requested in #15940.

The libsass Python module fails to install through pip without patching: https://bugs.gentoo.org/881339.