### PR TITLE
tracepath: Remove `traceroute`

### DIFF
--- a/packages/tracepath/build.sh
+++ b/packages/tracepath/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Tool to trace the network path to a remote host"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="20221126"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/iputils/iputils/archive/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=745ea711fe06d5c57d470d21acce3c3ab866eb6afb69379a16c6d60b89bd4311
 TERMUX_PKG_AUTO_UPDATE=true
@@ -33,9 +34,6 @@ termux_step_make_install() {
 		tracepath.xml
 	cp tracepath.8 $MANDIR/
 
-	# Setup traceroute as an alias for tracepath, since traceroute
-	# requires root which most Termux user does not have, and tracepath
-	# is probably good enough for most:
-	(cd $TERMUX_PREFIX/bin && ln -f -s tracepath traceroute)
-	(cd $MANDIR && ln -f -s tracepath.8 traceroute.8)
+	# `traceroute` command is now provided by the package of the same name.
+	# Please do not make `traceroute` an alias of `tracepath`.
 }

--- a/packages/traceroute/build.sh
+++ b/packages/traceroute/build.sh
@@ -3,8 +3,10 @@ TERMUX_PKG_DESCRIPTION="A new modern implementation of traceroute(8) utility for
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.1.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/project/traceroute/traceroute/traceroute-${TERMUX_PKG_VERSION}/traceroute-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=507c268f2977b4e218ce73e7ebed45ba0d970a8ca4995dd9cbb1ffe8e99b5b1f
+TERMUX_PKG_CONFLICTS="tracepath (<< 20221126-1)"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_MAKE_ARGS="prefix=$TERMUX_PREFIX -e"
 


### PR DESCRIPTION
which is now provided by the package of the same name.

* traceroute: Declare conflict with older tracepath

that provided `traceroute` command as an alias of `tracepath`.

Fixes #16562.