### PR TITLE
libmp3lame, libmad: Fix installation of pc files

### DIFF
--- a/packages/libmad/build.sh
+++ b/packages/libmad/build.sh
@@ -22,8 +22,9 @@ termux_post_configure() {
 }
 
 termux_step_post_make_install() {
-	mkdir -p $TERMUX_PKG_CONFIG_LIBDIR
-	cat > $TERMUX_PKG_CONFIG_LIBDIR/mad.pc <<-EOF
+	local _pkgconfig_dir=$TERMUX_PREFIX/lib/pkgconfig
+	mkdir -p ${_pkgconfig_dir}
+	cat > ${_pkgconfig_dir}/mad.pc <<-EOF
 		prefix=$TERMUX_PREFIX
 		exec_prefix=\${prefix}
 		libdir=$TERMUX_PREFIX/lib

--- a/packages/libmp3lame/build.sh
+++ b/packages/libmp3lame/build.sh
@@ -10,8 +10,9 @@ TERMUX_PKG_BREAKS="libmp3lame-dev"
 TERMUX_PKG_REPLACES="libmp3lame-dev"
 
 termux_step_post_make_install() {
-	mkdir -p $TERMUX_PKG_CONFIG_LIBDIR
-	cat <<-EOF > $TERMUX_PKG_CONFIG_LIBDIR/lame.pc
+	local _pkgconfig_dir=$TERMUX_PREFIX/lib/pkgconfig
+	mkdir -p ${_pkgconfig_dir}
+	cat <<-EOF > ${_pkgconfig_dir}/lame.pc
 		prefix=$TERMUX_PREFIX
 		exec_prefix=\${prefix}
 		libdir=\${exec_prefix}/lib


### PR DESCRIPTION
Do not assume TERMUX_PKG_CONFIG_LIBDIR to be a single directory.

Fixes #16610.