### PR TITLE
bump(main/nodejs-lts): v18.16.0

### DIFF
--- a/packages/nodejs-lts/build.sh
+++ b/packages/nodejs-lts/build.sh
@@ -1,11 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://nodejs.org/
 TERMUX_PKG_DESCRIPTION="Open Source, cross-platform JavaScript runtime environment"
 TERMUX_PKG_LICENSE="MIT"
-TERMUX_PKG_MAINTAINER="Yaksh Bariya <yakshbari4@gmail.com>"
-TERMUX_PKG_VERSION=18.14.1
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_MAINTAINER="Yaksh Bariya <thunder-coding@termux.dev>"
+TERMUX_PKG_VERSION=18.16.0
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=eec353438266fd0aef53a9446be10b32ee6e74d08e32dd5454b382ff6793da04
+TERMUX_PKG_SHA256=33d81a233e235a509adda4a4f2209008d04591979de6b3f0f67c1c906093f118
 # Note that we do not use a shared libuv to avoid an issue with the Android
 # linker, which does not use symbols of linked shared libraries when resolving
 # symbols on dlopen(). See https://github.com/termux/termux-packages/issues/462.

--- a/packages/nodejs-lts/deps-uv-uv.gyp.patch
+++ b/packages/nodejs-lts/deps-uv-uv.gyp.patch
@@ -18,14 +18,6 @@
          'conditions': [
            ['OS == "linux"', {
              'defines': [ '_POSIX_C_SOURCE=200112' ],
-@@ -256,7 +256,6 @@
-         }],
-         [ 'OS=="android"', {
-           'sources': [
--            'src/unix/android-ifaddrs.c',
-             'src/unix/linux-core.c',
-             'src/unix/linux-inotify.c',
-             'src/unix/linux-syscalls.c',
 @@ -267,6 +266,7 @@
              'src/unix/random-sysctl-linux.c',
              'src/unix/epoll.c',

--- a/packages/nodejs-lts/node.gyp.patch
+++ b/packages/nodejs-lts/node.gyp.patch
@@ -1,6 +1,6 @@
---- ./node.gyp.orig	2023-02-02 02:40:18.000000000 +0530
-+++ ./node.gyp	2023-02-10 18:36:40.392625869 +0530
-@@ -157,7 +157,8 @@
+--- ./node.gyp.orig	2023-04-12 09:39:19.000000000 +0530
++++ ./node.gyp	2023-05-11 17:50:13.676999154 +0530
+@@ -158,7 +158,8 @@
        ],
  
        'sources': [
@@ -10,15 +10,7 @@
        ],
  
        'dependencies': [
-@@ -458,6 +459,7 @@
- 
-       'include_dirs': [
-         'src',
-+        'deps/cares/src/lib',
-         '<(SHARED_INTERMEDIATE_DIR)' # for node_natives.h
-       ],
-       'dependencies': [
-@@ -1125,309 +1127,6 @@
+@@ -1131,311 +1132,6 @@
          } ],
        ]
      }, # specialize_node_d
@@ -110,6 +102,7 @@
 -        'node_dtrace_ustack',
 -        'node_dtrace_provider',
 -        'deps/simdutf/simdutf.gyp:simdutf',
+-        'deps/ada/ada.gyp:ada',
 -      ],
 -
 -      'includes': [
@@ -150,7 +143,6 @@
 -        'test/cctest/test_sockaddr.cc',
 -        'test/cctest/test_traced_value.cc',
 -        'test/cctest/test_util.cc',
--        'test/cctest/test_url.cc',
 -      ],
 -
 -      'conditions': [
@@ -209,6 +201,7 @@
 -        'node_dtrace_header',
 -        'node_dtrace_ustack',
 -        'node_dtrace_provider',
+-        'deps/ada/ada.gyp:ada',
 -      ],
 -
 -      'includes': [
@@ -278,6 +271,7 @@
 -        '<(node_lib_target_name)',
 -        'deps/histogram/histogram.gyp:histogram',
 -        'deps/uvwasi/uvwasi.gyp:uvwasi',
+-        'deps/ada/ada.gyp:ada',
 -      ],
 -
 -      'includes': [

--- a/packages/nodejs-lts/test-parallel-test-child-process-uid-gid.js.patch
+++ b/packages/nodejs-lts/test-parallel-test-child-process-uid-gid.js.patch
@@ -1,0 +1,13 @@
+--- ./test/parallel/test-child-process-uid-gid.js.orig	2023-04-29 17:23:04.494870309 +0530
++++ ./test/parallel/test-child-process-uid-gid.js	2023-04-29 17:42:33.075531699 +0530
+@@ -4,6 +4,10 @@
+ const spawn = require('child_process').spawn;
+ const expectedError = common.isWindows ? /\bENOTSUP\b/ : /\bEPERM\b/;
+ 
++if (process.platform === 'android') {
++  common.skip('We are patching node to not use setuid/setgid with child_process.spawn in anyway');
++}
++
+ if (common.isIBMi)
+   common.skip('IBMi has a different behavior');
+ 


### PR DESCRIPTION
Also update my email address to termux.dev one

Logs of test run, as run in termux-docker. Note that for aarch64 and arm, the tests were run using QEMU and has a bunch of false-positives. The PR will be merged after running those tests on an actual arm device.

[test-result-aarch64.txt](https://github.com/termux/termux-packages/files/11458283/test-result-aarch64.txt)
[test-result-i686.txt](https://github.com/termux/termux-packages/files/11458285/test-result-i686.txt)
[test-result-x86_64.txt](https://github.com/termux/termux-packages/files/11458288/test-result-x86_64.txt)
[test-result-arm.txt](https://github.com/termux/termux-packages/files/11458289/test-result-arm.txt)
