### PR TITLE
chore: do not hardcode repository information in `scripts/proporties.sh`

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1,5 +1,20 @@
 {
-  "packages":      { "name" : "termux-main", "distribution" : "stable" },
-  "root-packages": { "name" : "termux-root", "distribution" : "root" },
-  "x11-packages":  { "name" : "termux-x11",  "distribution" : "x11" }
+  "packages": {
+    "name": "termux-main",
+    "distribution": "stable",
+    "component": "main",
+    "url": "https://packages-cf.termux.dev/apt/termux-main"
+  },
+  "root-packages": {
+    "name": "termux-root",
+    "distribution": "root",
+    "component": "stable",
+    "url": "https://packages-cf.termux.dev/apt/termux-root"
+  },
+  "x11-packages": {
+    "name": "termux-x11",
+    "distribution": "x11",
+    "component": "main",
+    "url": "https://packages-cf.termux.dev/apt/termux-x11"
+  }
 }

--- a/scripts/properties.sh
+++ b/scripts/properties.sh
@@ -43,23 +43,19 @@ TERMUX_PREFIX="${TERMUX_BASE_DIR}/usr"
 TERMUX_REPO_PACKAGE="com.termux"
 
 # Termux repo urls.
-TERMUX_REPO_URL=(
-	https://packages-cf.termux.dev/apt/termux-main
-	https://packages-cf.termux.dev/apt/termux-root
-	https://packages-cf.termux.dev/apt/termux-x11
-)
+TERMUX_REPO_URL=()
+TERMUX_REPO_DISTRIBUTION=()
+TERMUX_REPO_COMPONENT=()
 
-TERMUX_REPO_DISTRIBUTION=(
-	stable
-	root
-	x11
-)
-
-TERMUX_REPO_COMPONENT=(
-	main
-	stable
-	main
-)
+for url in $(jq -r '.[] | .url' ${TERMUX_SCRIPTDIR}/repo.json); do
+	TERMUX_REPO_URL+=("$url")
+done
+for distribution in $(jq -r '.[] | .distribution' ${TERMUX_SCRIPTDIR}/repo.json); do
+	TERMUX_REPO_DISTRIBUTION+=("$distribution")
+done
+for component in $(jq -r '.[] | .component' ${TERMUX_SCRIPTDIR}/repo.json); do
+	TERMUX_REPO_COMPONENT+=("$component")
+done
 
 # Allow to override setup.
 for f in "${HOME}/.config/termux/termuxrc.sh" "${HOME}/.termux/termuxrc.sh" "${HOME}/.termuxrc"; do


### PR DESCRIPTION
Should have been done during the initial migration to monorepo itself, but anyways.

Requesting a review from @licy183 , one of the maintainers of TUR
