### PR TITLE
mdbook-cat-prep: Use Rust 1.68.2 to build

### DIFF
--- a/packages/mdbook-cat-prep/build.sh
+++ b/packages/mdbook-cat-prep/build.sh
@@ -9,6 +9,9 @@ TERMUX_PKG_SRCURL=git+https://github.com/gjk-cat/cat-prep
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_BUILD_IN_SRC=true
 
+# https://github.com/termux/termux-packages/issues/16756
+TERMUX_RUST_VERSION=1.68.2
+
 termux_step_post_get_source() {
 	git fetch --unshallow
 	git checkout $_COMMIT


### PR DESCRIPTION
for now.

Closes #16756.