### PR TITLE
mdbook-presentation-preprocessor: Use Rust 1.68.2 to build

### DIFF
--- a/packages/mdbook-presentation-preprocessor/build.sh
+++ b/packages/mdbook-presentation-preprocessor/build.sh
@@ -7,6 +7,9 @@ TERMUX_PKG_SRCURL=https://github.com/FreeMasen/mdbook-presentation-preprocessor/
 TERMUX_PKG_SHA256=40d2c72052b45fc6c0b4f4d7179ed81114c6de13cfcecc793f30d500047a9e5c
 TERMUX_PKG_BUILD_IN_SRC=true
 
+# https://github.com/termux/termux-packages/issues/16755
+TERMUX_RUST_VERSION=1.68.2
+
 termux_step_make() {
 	termux_setup_rust
 	cargo build --jobs $TERMUX_MAKE_PROCESSES --target $CARGO_TARGET_NAME --release


### PR DESCRIPTION
for now.

Closes #16755.