### PR TITLE
add(main,x11): new package jadx,jadx-gui

### DIFF
--- a/packages/jadx/build.sh
+++ b/packages/jadx/build.sh
@@ -1,0 +1,25 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/skylot/jadx
+TERMUX_PKG_DESCRIPTION="Dex to Java decompiler"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_LICENSE_FILE="LICENSE, NOTICE"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="1.4.7"
+TERMUX_PKG_SRCURL=https://github.com/skylot/jadx/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=4afdd130f7ec60e88996b73d7c84c51b402cc36b4bf117bdc6289254027726cf
+TERMUX_PKG_DEPENDS="openjdk-17"
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make() {
+        export JADX_VERSION="$TERMUX_PKG_VERSION"
+        ./gradlew clean dist
+
+        sed -i "s#CLASSPATH=\$APP_HOME/share/jadx-$TERMUX_PKG_VERSION-all.jar#CLASSPATH=$TERMUX_PREFIX/share/java/jadx-$TERMUX_PKG_VERSION-all.jar#g" "$TERMUX_PKG_SRCDIR"/build/jadx/bin/jadx
+}
+termux_step_make_install() {
+	install -Dm755 -t $TERMUX_PREFIX/bin build/jadx/bin/jadx
+
+        rm -rf $TERMUX_PREFIX/share/java/
+        mkdir -p $TERMUX_PREFIX/share/java/
+        install -Dm700 -t $TERMUX_PREFIX/share/java build/jadx/lib/*
+}

--- a/x11-packages/jadx-gui/build.sh
+++ b/x11-packages/jadx-gui/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/skylot/jadx
+TERMUX_PKG_DESCRIPTION="Dex to Java decompiler"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_LICENSE_FILE="LICENSE, NOTICE"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="1.4.7"
+TERMUX_PKG_SRCURL=https://github.com/skylot/jadx/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=4afdd130f7ec60e88996b73d7c84c51b402cc36b4bf117bdc6289254027726cf
+TERMUX_PKG_DEPENDS="openjdk-17, jadx"
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make() {
+        export JADX_VERSION="${TERMUX_PKG_VERSION}"
+        ./gradlew clean dist
+
+        sed -i "s#CLASSPATH=\$APP_HOME/share/jadx-$TERMUX_PKG_VERSION-all.jar#CLASSPATH=$TERMUX_PREFIX/share/java/jadx-$TERMUX_PKG_VERSION-all.jar#g" "$TERMUX_PKG_SRCDIR"/build/jadx/bin/jadx-gui
+}
+termux_step_make_install() {
+	install -Dm755 -t $TERMUX_PREFIX/bin build/jadx/bin/jadx-gui
+}


### PR DESCRIPTION
Close #16591 .
It provides [pre-built version](https://github.com/skylot/jadx/releases/download/v1.4.7/jadx-1.4.7.zip), but I've run into [some issues](https://github.com/2096779623/termux-packages/actions/runs/5187186160/jobs/9349250865#step:6:1216), it would be great if someone could solve it.