### PR TITLE
addpkg(main/signify): Lightweight cryptographic signing and verifying tool

### DIFF
--- a/packages/signify/Makefile.patch
+++ b/packages/signify/Makefile.patch
@@ -1,0 +1,12 @@
+diff -uNr signify-31/Makefile signify-31.mod/Makefile
+--- signify-31/Makefile	2022-03-13 21:29:52.000000000 +0000
++++ signify-31.mod/Makefile	2023-06-10 15:30:29.000000000 +0000
+@@ -148,6 +148,8 @@
+ signify: $O $(LIBBSD_DEPS)
+ 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBBSD_LDFLAGS) $(LDLIBS)
+ 
++sha2.o: override CFLAGS += -DBYTE_ORDER=LITTLE_ENDIAN
++signify.o: override CFLAGS += -Wno-implicit-function-declaration
+ zsig.o signify.o bcrypt_pbkdf.o: override CFLAGS += -Wno-pointer-sign
+ 
+ clean-signify:

--- a/packages/signify/build.sh
+++ b/packages/signify/build.sh
@@ -1,0 +1,10 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/aperezdc/signify
+TERMUX_PKG_DESCRIPTION="Lightweight cryptographic signing and verifying tool"
+TERMUX_PKG_LICENSE="ISC"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=31
+TERMUX_PKG_SRCURL=https://github.com/aperezdc/signify/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=8111af7424f4cc69dab5cd43a14ccd607ca2d171ac77dd3ae288264a53254e5f
+TERMUX_PKG_DEPENDS="libbsd"
+TERMUX_PKG_BUILD_DEPENDS="libbsd"
+TERMUX_PKG_BUILD_IN_SRC=true

--- a/packages/signify/signify.c.patch
+++ b/packages/signify/signify.c.patch
@@ -1,0 +1,12 @@
+diff -uNr signify-31/signify.c signify-31.mod/signify.c
+--- signify-31/signify.c	2022-03-13 21:29:52.000000000 +0000
++++ signify-31.mod/signify.c	2023-06-10 15:53:46.000000000 +0000
+@@ -505,7 +505,7 @@
+ readpubkey(const char *pubkeyfile, struct pubkey *pubkey,
+     const char *sigcomment, const char *keytype)
+ {
+-	const char *safepath = "/etc/signify";
++	const char *safepath = "@TERMUX_PREFIX@/etc/signify";
+ 	char keypath[PATH_MAX];
+ 
+ 	if (!pubkeyfile) {


### PR DESCRIPTION
[Homepage](https://github.com/aperezdc/signify)
[Debian package](https://packages.debian.org/sid/utils/signify-openbsd)

I'm not really sure if patches are correct. I would prefer to define `BYTE_ORDER` in included headers and not to disable compiler warning.

<!-- Unfortunately I failed to build it in termux docker. First `sha2.c` required defining `BYTE_ORDER`:
```
aarch64-linux-android-clang  -fstack-protector-strong -Oz  -DLIBBSD_OVERLAY -isystem /data/data/com.termux/files/usr/include/bsd -Wall  -I/data/data/com.termux/files/usr/include -include compat.h -DBUNDLED_BZERO=1  -c -o sha2.o sha2.c
sha2.c:90:2: error: Define BYTE_ORDER to be equal to either LITTLE_ENDIAN or BIG_ENDIAN
#error Define BYTE_ORDER to be equal to either LITTLE_ENDIAN or BIG_ENDIAN
 ^
1 error generated.
make: *** [<builtin>: sha2.o] Error 1
```
I tried to add some includes like `# include <sys/endian.h>` to it but none helped until I hard-coded `#define BYTE_ORDER BIG_ENDIAN`.
Then I failed with `signify.c` which couldn't find `htonl`/`ntohl` in headers:
```
aarch64-linux-android-clang  -fstack-protector-strong -Oz  -DLIBBSD_OVERLAY -isystem /data/data/com.termux/files/usr/include/bsd -Wall -Wno-pointer-sign  -I/data/data/com.termux/files/usr/include -include compat.h -DBUNDLED_BZERO=1  -c -o signify.o signify.c
signify.c:328:21: error: implicit declaration of function 'htonl' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        enckey.kdfrounds = htonl(rounds);
                           ^
aarch64-linux-android-clang  -fstack-protector-strong -Oz  -DLIBBSD_OVERLAY -isystem /data/data/com.termux/files/usr/include/bsd -Wall -Wno-pointer-sign  -I/data/data/com.termux/files/usr/include -include compat.h -DBUNDLED_BZERO=1  -c -o zsig.o zsig.c
signify.c:417:11: error: implicit declaration of function 'ntohl' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        rounds = ntohl(enckey.kdfrounds);
                 ^
2 errors generated.
make: *** [<builtin>: signify.o] Error 1
```
I tried some includes like `arpa/inet.h` but none helped. That is far beyond my knowledge :(

Maybe someone could suggest any ways how to fix the build. -->