### PR TITLE
allow caching builds

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -462,7 +462,8 @@ while (($# >= 1)); do
 				termux_error_exit "./build-package.sh: option '-o' requires an argument"
 			fi
 			;;
-		-c) TERMUX_CONTINUE_BUILD=true;;
+		-c|--continue) TERMUX_CONTINUE_BUILD=true;;
+		-C|--cache) export TERMUX_CACHE_ENABLED=true;;
 		-*) termux_error_exit "./build-package.sh: illegal option '$1'";;
 		*) PACKAGE_LIST+=("$1");;
 	esac

--- a/packages/nodejs-lts/build.sh
+++ b/packages/nodejs-lts/build.sh
@@ -39,6 +39,10 @@ termux_step_configure() {
 	export CC_host=gcc
 	export CXX_host=g++
 	export LINK_host=g++
+	if [ "$TERMUX_CACHE_ENABLED" = true ]; then
+		CC_host="ccache gcc"
+		CXX_host="ccache g++"
+	fi
 
 	# See note above TERMUX_PKG_DEPENDS why we do not use a shared libuv
 	# When building with ninja, build.ninja is geenrated for both Debug and Release builds.

--- a/packages/nodejs/build.sh
+++ b/packages/nodejs/build.sh
@@ -63,6 +63,10 @@ termux_step_configure() {
 	export CC_host=gcc
 	export CXX_host=g++
 	export LINK_host=g++
+	if [ "$TERMUX_CACHE_ENABLED" = true ]; then
+		CC_host="ccache gcc"
+		CXX_host="ccache g++"
+	fi
 
 	LDFLAGS+=" -ldl"
 	# See note above TERMUX_PKG_DEPENDS why we do not use a shared libuv.

--- a/scripts/build/toolchain/termux_setup_toolchain_23c.sh
+++ b/scripts/build/toolchain/termux_setup_toolchain_23c.sh
@@ -181,6 +181,10 @@ termux_setup_toolchain_23c() {
 		fi
 	done
 
+	if [ "$TERMUX_CACHE_ENABLED" = "true" ]; then
+		sed -i 's|"$bin_dir/clang"|ccache "$bin_dir/clang"|g' \
+			$_TERMUX_TOOLCHAIN_TMPDIR/bin/*-{clang,clang++,cpp,gcc,g++}
+	fi
 	# Create a pkg-config wrapper. We use path to host pkg-config to
 	# avoid picking up a cross-compiled pkg-config later on.
 	local _HOST_PKGCONFIG

--- a/scripts/build/toolchain/termux_setup_toolchain_25c.sh
+++ b/scripts/build/toolchain/termux_setup_toolchain_25c.sh
@@ -166,6 +166,7 @@ termux_setup_toolchain_25c() {
 	cp $_TERMUX_TOOLCHAIN_TMPDIR/bin/armv7a-linux-androideabi-cpp \
 		$_TERMUX_TOOLCHAIN_TMPDIR/bin/arm-linux-androideabi-cpp
 
+
 	for HOST_PLAT in aarch64-linux-android armv7a-linux-androideabi i686-linux-android x86_64-linux-android arm-linux-androideabi; do
 		mv $_TERMUX_TOOLCHAIN_TMPDIR/bin/$HOST_PLAT-clang \
 			$_TERMUX_TOOLCHAIN_TMPDIR/bin/$HOST_PLAT-clang.no-16-porting
@@ -181,6 +182,14 @@ termux_setup_toolchain_25c() {
 				$_TERMUX_TOOLCHAIN_TMPDIR/bin/$HOST_PLAT-clang
 		fi
 	done
+
+	if [ "$TERMUX_CACHE_ENABLED" = "true" ]; then
+		sed -i 's|"$bin_dir/clang"|ccache "$bin_dir/clang"|g' \
+			$_TERMUX_TOOLCHAIN_TMPDIR/bin/*-{clang,clang++,cpp,gcc,g++}
+		sed -i 's|"$bin_dir/clang++"|ccache "$bin_dir/clang++"|g' \
+			$_TERMUX_TOOLCHAIN_TMPDIR/bin/*-{clang,clang++,cpp,gcc,g++}
+	fi
+
 
 	# Create a pkg-config wrapper. We use path to host pkg-config to
 	# avoid picking up a cross-compiled pkg-config later on.

--- a/scripts/setup-archlinux.sh
+++ b/scripts/setup-archlinux.sh
@@ -23,7 +23,10 @@ PACKAGES+=" intltool" # Used by qalc build.
 PACKAGES+=" jre8-openjdk-headless"
 PACKAGES+=" jq" # Required for parsing repo.json
 PACKAGES+=" re2c" # Needed by kphp-timelib
-PACKAGES+=" libjpeg-turbo" # Needed by ghostscript.
+PACKAGES+=" libjpeg-turbo" # Needed by ghostscript
+PACKAGES+=" lib32-icu"
+PACKAGES+=" lib32-openssl"
+PACKAGES+=" lib32-zlib"
 PACKAGES+=" libtool"
 PACKAGES+=" lua" # Needed to build luarocks package.
 PACKAGES+=" lzip"
@@ -61,3 +64,4 @@ echo
 echo "- ncurses5-compat-libs"
 echo "- makedepend"
 echo "- python2"
+echo "- lib32-c-ares"


### PR DESCRIPTION
With these changes I am able to build nodejs within 5 minutes on my 4-core machine with 4GB RAM. Just I need to have built nodejs once and then cache shows it's magic on subsequent compilations. A clean build takes around 2+ hours depending on what I am doing on my desktop, while the compilation is hapenning in the background. Hopefully this allows me to quickly test small changes without having to spin up GitHub Codespaces or get the CI burning for 2 hours straight. Especially helpful when trying to diagnose a small bug for which doing so is simply waste of resources.

Also since this works, we can probalby in future also cache builds on PRs to make the CI faster. Not sure about the master branch as things are moving quite fast there and bug fixes are pretty uncommon due to a recent commit's introducing a bug. Also GitHub has cache limits per repository, so it wouldn't be wise to do so.

ccache's cache doesn't take up much space either, for testing of this PR, it ended up using around 200M in total for single architecture, which is quite inflated than what it would actually use as I had run `./clean.sh` multiple times during the testing, which invalidates the cache for the target since the compiler binary is getting replaced.
