### PR TITLE
build-bootstraps.sh: fix some issues

### DIFF
--- a/scripts/build-bootstraps.sh
+++ b/scripts/build-bootstraps.sh
@@ -119,7 +119,7 @@ extract_debs() {
 	for deb in *.deb; do
 
 		current_package_name="$(echo "$deb" | sed -E 's/^([^_]+).*/\1/' )"
-		current_package_arch="$(echo "$deb" | sed -E 's/.*_(.*).deb$/\1/' )"
+		current_package_arch="$(echo "$deb" | sed -E 's/.*_(aarch64|all|arm|i686|x86_64).deb$/\1/' )"
 		echo "current_package_name: '$current_package_name'"
 		echo "current_package_arch: '$current_package_arch'"
 


### PR DESCRIPTION
Fixes some found issues in build-bootstraps.sh script. Summary:

* No need to rebuild packages when packages were already built and architecture was switched using `--architecture` option. (/data/data is switched in same way as done by `build-package.sh` script)
* Extract deb files only for correct arch. Taken from https://github.com/termux/termux-packages/pull/10296/commits/7c5578cebb9782321152df76f2bfb2dcf6da78d7

Replaces this pull request: https://github.com/termux/termux-packages/pull/16898