### PR TITLE
bump(main/nodejs): v20.3.1

### DIFF
--- a/packages/nodejs/build.sh
+++ b/packages/nodejs/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://nodejs.org/
 TERMUX_PKG_DESCRIPTION="Open Source, cross-platform JavaScript runtime environment"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Yaksh Bariya <thunder-coding@termux.dev>"
-TERMUX_PKG_VERSION=20.2.0
+TERMUX_PKG_VERSION=20.3.1
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=22523df2316c35569714ff1f69b053c2e286ced460898417dee46945efcdf989
+TERMUX_PKG_SHA256=12a82db306697959b4389b351a5f97848986b1313f9901b0e0b3d8cf4f3f9991
 # Note that we do not use a shared libuv to avoid an issue with the Android
 # linker, which does not use symbols of linked shared libraries when resolving
 # symbols on dlopen(). See https://github.com/termux/termux-packages/issues/462.

--- a/packages/nodejs/deps-uv-uv.gyp.patch
+++ b/packages/nodejs/deps-uv-uv.gyp.patch
@@ -1,15 +1,23 @@
---- ./deps/uv/uv.gyp.orig	2022-11-14 07:56:05.000000000 +0530
-+++ ./deps/uv/uv.gyp	2022-11-25 18:51:25.022527139 +0530
-@@ -40,7 +40,7 @@
-     {
+--- ./deps/uv/uv.gyp.orig	2023-06-20 18:41:27.000000000 +0530
++++ ./deps/uv/uv.gyp	2023-06-23 19:59:00.665947296 +0530
+@@ -137,7 +137,6 @@
+     'uv_sources_android': [
+       'src/unix/linux.c',
+       'src/unix/procfs-exepath.c',
+-      'src/unix/pthread-fixes.c',
+       'src/unix/random-getentropy.c',
+       'src/unix/random-getrandom.c',
+       'src/unix/random-sysctl-linux.c',
+@@ -157,7 +156,7 @@
        'target_name': 'libuv',
+       'toolsets': ['host', 'target'],
        'type': '<(uv_library)',
 -      'include_dirs': [
 +      'include_dirs+': [
          'include',
          'src/',
        ],
-@@ -55,7 +55,7 @@
+@@ -172,7 +171,7 @@
            '<@(shared_unix_defines)',
            '<@(shared_zos_defines)',
          ],
@@ -18,11 +26,19 @@
          'conditions': [
            ['OS == "linux"', {
              'defines': [ '_POSIX_C_SOURCE=200112' ],
-@@ -267,6 +267,7 @@
-             'src/unix/random-sysctl-linux.c',
-             'src/unix/epoll.c',
+@@ -305,6 +304,7 @@
+             '_XOPEN_SOURCE=500',
+             '_REENTRANT',
            ],
 +          'defines': [ '__USE_GNU' ],
            'link_settings': {
-             'libraries': [ '-ldl' ],
-           },
+             'libraries': [
+               '-lkstat',
+@@ -399,7 +399,6 @@
+         }],
+         ['OS=="zos"', {
+           'sources': [
+-            'src/unix/pthread-fixes.c',
+             'src/unix/os390.c',
+             'src/unix/os390-syscalls.c'
+           ]

--- a/packages/nodejs/node.gyp.patch
+++ b/packages/nodejs/node.gyp.patch
@@ -1,6 +1,6 @@
---- ./node.gyp.orig	2023-05-16 12:28:21.000000000 +0530
-+++ ./node.gyp	2023-05-27 19:10:17.150845679 +0530
-@@ -466,7 +466,8 @@
+--- ./node.gyp.orig	2023-06-20 18:41:28.000000000 +0530
++++ ./node.gyp	2023-06-23 19:40:03.398406378 +0530
+@@ -469,7 +469,8 @@
        ],
  
        'sources': [
@@ -10,7 +10,7 @@
        ],
  
        'dependencies': [
-@@ -761,6 +762,7 @@
+@@ -764,6 +765,7 @@
        'include_dirs': [
          'src',
          'deps/postject',
@@ -18,7 +18,7 @@
          '<(SHARED_INTERMEDIATE_DIR)' # for node_natives.h
        ],
        'dependencies': [
-@@ -947,294 +949,6 @@
+@@ -950,235 +952,6 @@
          },
        ],
      }, # node_lib_target_name
@@ -129,6 +129,7 @@
 -          'sources': [
 -            'test/cctest/test_crypto_clienthello.cc',
 -            'test/cctest/test_node_crypto.cc',
+-            'test/cctest/test_node_crypto_env.cc',
 -            'test/cctest/test_quic_cid.cc',
 -            'test/cctest/test_quic_tokens.cc',
 -          ]
@@ -250,6 +251,13 @@
 -        }],
 -      ]
 -    }, # overlapped-checker
+     {
+       'target_name': 'node_js2c',
+       'type': 'executable',
+@@ -1209,66 +982,6 @@
+         }],
+       ]
+     },
 -    {
 -      'target_name': 'node_mksnapshot',
 -      'type': 'executable',


### PR DESCRIPTION
v20.3.1 also contains a security fix which will be merged ONLY after I run the test suite. Users who need the security fix should use the LTS release anyway.

An update for the LTS release will be fixed soon on master branch, after I ensure that it's building for aarch64
