### PR TITLE
libwebp: Revbump to rebuild

### DIFF
--- a/packages/libwebp/build.sh
+++ b/packages/libwebp/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Library to encode and decode images in WebP format"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.3.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/webmproject/libwebp/archive/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=1c45f135a20c629c31cebcba62e2b399bae5d6e79851aa82ec6686acedcf6f65
 TERMUX_PKG_DEPENDS="giflib, libjpeg-turbo, libpng, libtiff"


### PR DESCRIPTION
due to SONAME change in libjpeg-turbo.