### PR TITLE
gst-plugins-base: Revbump to rebuild

### DIFF
--- a/packages/gst-plugins-base/build.sh
+++ b/packages/gst-plugins-base/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="GStreamer base plug-ins"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.22.4
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=292424e82dea170528c42b456f62a89532bcabc0508f192e34672fb86f68e5b8
 TERMUX_PKG_DEPENDS="glib, graphene, gstreamer, libandroid-shmem, libjpeg-turbo, libogg, libopus, libpng, libtheora, libvorbis, libx11, libxcb, libxext, libxv, zlib"


### PR DESCRIPTION
due to SONAME change in libjpeg-turbo.