### PR TITLE
mupdf: Revbump to rebuild

### DIFF
--- a/packages/mupdf/build.sh
+++ b/packages/mupdf/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Lightweight PDF and XPS viewer (library)"
 TERMUX_PKG_LICENSE="AGPL-V3"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.22.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mupdf.com/downloads/archive/mupdf-${TERMUX_PKG_VERSION}-source.tar.gz
 TERMUX_PKG_SHA256=54c66af4e6ef8cea9867cc0320ef925d561b42919ea0d4f89db5c9ef485bbeb7
 TERMUX_PKG_DEPENDS="freetype, gumbo-parser, harfbuzz, jbig2dec, leptonica, libc++, libjpeg-turbo, openjpeg, tesseract, zlib"


### PR DESCRIPTION
due to SONAME change in libjpeg-turbo.