### PR TITLE
poppler: Revbump to rebuild

### DIFF
--- a/packages/poppler/build.sh
+++ b/packages/poppler/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # Please align the version with `poppler-qt` package.
 TERMUX_PKG_VERSION=23.05.0
+TERMUX_PKG_REVISION=1
 # Do not forget to bump revision of reverse dependencies and rebuild them
 # when SOVERSION is changed.
 _POPPLER_SOVERSION=128


### PR DESCRIPTION
due to SONAME change in libjpeg-turbo.