### PR TITLE
libspice-server: Revbump to rebuild

### DIFF
--- a/packages/libspice-server/build.sh
+++ b/packages/libspice-server/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Implements the server side of the SPICE protocol"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.15.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.spice-space.org/download/releases/spice-server/spice-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=ada9af67ab321916bd7eb59e3d619a4a7796c08a28c732edfc7f02fc80b1a37a
 TERMUX_PKG_DEPENDS="glib, gst-plugins-base, gstreamer, libc++, libiconv, libjpeg-turbo, liblz4, libopus, liborc, libpixman, libsasl, libspice-protocol, openssl, zlib"


### PR DESCRIPTION
due to SONAME change in libjpeg-turbo.