### PR TITLE
gst-plugins-good: Revbump to rebuild

### DIFF
--- a/packages/gst-plugins-good/build.sh
+++ b/packages/gst-plugins-good/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="GStreamer Good Plug-ins"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.22.4
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=d7120c1146a9d723d53d5bfe8074da2575a81f0598438752937f39bb7c833b6a
 TERMUX_PKG_DEPENDS="glib, gst-plugins-base, gstreamer, libandroid-shmem, libbz2, libcaca, libflac, libjpeg-turbo, libmp3lame, libnettle, libpng, libvpx, libx11, libxext, libxfixes, libxml2, pulseaudio, zlib"


### PR DESCRIPTION
due to SONAME change in libjpeg-turbo.