### PR TITLE
imlib2: Revbump to rebuild

### DIFF
--- a/packages/imlib2/build.sh
+++ b/packages/imlib2/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="COPYING, COPYING-PLAIN"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.11.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/enlightenment/imlib2-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=f712b6bb9dcad46d8b8f4ad52610dcbbaebb4cc80b5fd12f93124d3a380fa6bf
 TERMUX_PKG_DEPENDS="freetype, gdk-pixbuf, giflib, glib, libandroid-shmem, libbz2, libcairo, libheif, libid3tag, libjpeg-turbo, libjxl, liblzma, libpng, librsvg, libtiff, libwebp, libx11, libxcb, libxext, openjpeg, zlib"


### PR DESCRIPTION
due to SONAME change in libjpeg-turbo.