### PR TITLE
sdl2-image: Revbump to rebuild

### DIFF
--- a/x11-packages/sdl2-image/build.sh
+++ b/x11-packages/sdl2-image/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="ZLIB"
 TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.6.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/libsdl-org/SDL_image/releases/download/release-${TERMUX_PKG_VERSION}/SDL2_image-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=931c9be5bf1d7c8fae9b7dc157828b7eee874e23c7f24b44ba7eff6b4836312c
 TERMUX_PKG_DEPENDS="libjpeg-turbo, libjxl, libpng, libtiff, libwebp, sdl2"


### PR DESCRIPTION
due to SONAME change in libjpeg-turbo.