### PR TITLE
links: Revbump to rebuild

### DIFF
--- a/packages/links/build.sh
+++ b/packages/links/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_DESCRIPTION="Links is a text and graphics mode WWW browser"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.29
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=http://links.twibright.com/download/links-$TERMUX_PKG_VERSION.tar.bz2
 TERMUX_PKG_SHA256=22aa96c0b38e1a6f8f7ed9d7a4167a47fc37246097759ef6059ecf8f9ead7998
 TERMUX_PKG_DEPENDS="brotli, fontconfig, freetype, glib, libbz2, libcairo, libevent, libjpeg-turbo, liblzma, libpng, librsvg, libtiff, libwebp, libx11, openssl, zlib, zstd"


### PR DESCRIPTION
due to SONAME change in libjpeg-turbo.