### PR TITLE
dcmtk: Adjust dependency

### DIFF
--- a/packages/dcmtk/build.sh
+++ b/packages/dcmtk/build.sh
@@ -5,11 +5,12 @@ TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_LICENSE_FILE="COPYRIGHT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.6.7"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL="https://github.com/DCMTK/dcmtk/archive/refs/tags/DCMTK-$TERMUX_PKG_VERSION.tar.gz"
 TERMUX_PKG_SHA256=17705dcdb2047d1266bb4e92dbf4aa6d4967819e8e3e94f39b7df697661b4860
-TERMUX_PKG_DEPENDS="libc++, libiconv, libjpeg-turbo, libpng, libtiff, libxml2, openssl, zlib"
-TERMUX_PKG_BUILD_DEPENDS="libsndfile"
+TERMUX_PKG_DEPENDS="libc++, libiconv, libpng, libtiff, libxml2, openssl, zlib"
+# As of 3.6.7, libsndfile and openjpeg are detected but not linked against
+TERMUX_PKG_BUILD_DEPENDS="libsndfile, openjpeg"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DDCMTK_NO_TRY_RUN=ON


### PR DESCRIPTION
libjpeg-turbo are not linked against, not even detected by build system.