### PR TITLE
gst-plugins-bad: Revbump to rebuild

### DIFF
--- a/packages/gst-plugins-bad/build.sh
+++ b/packages/gst-plugins-bad/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="GStreamer Bad Plug-ins"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.22.4
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=eaaf53224565eaabd505ca39c6d5769719b45795cf532ce1ceb60e1b2ebe99ac
 TERMUX_PKG_DEPENDS="game-music-emu, glib, gst-plugins-base, gstreamer, libaom, libass, libbz2, libcairo, libcurl, libopus, librsvg, libsndfile, libsrt, libx11, libxml2 (>= 2.11.4-2), littlecms, openal-soft, openjpeg, openssl, pango"


### PR DESCRIPTION
due to SONAME change in libxml2.