### PR TITLE
apr-util: Revbump to rebuild

### DIFF
--- a/packages/apr-util/build.sh
+++ b/packages/apr-util/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Apache Portable Runtime Utility Library"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.6.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://downloads.apache.org/apr/apr-util-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=2b74d8932703826862ca305b094eef2983c27b39d5c9414442e9976a9acf1983
 TERMUX_PKG_DEPENDS="apr, libcrypt, libexpat, libiconv, libuuid"


### PR DESCRIPTION
due to SONAME change in libexpat.