### PR TITLE
mate-applet-brisk-menu: Adjust dependency

### DIFF
--- a/x11-packages/mate-applet-brisk-menu/build.sh
+++ b/x11-packages/mate-applet-brisk-menu/build.sh
@@ -6,4 +6,4 @@ TERMUX_PKG_REVISION=2
 TERMUX_PKG_MAINTAINER="Yisus7u7 <dev.yisus@hotmail.com>"
 TERMUX_PKG_SRCURL=http://deb.debian.org/debian/pool/main/b/brisk-menu/brisk-menu_$TERMUX_PKG_VERSION.orig.tar.xz
 TERMUX_PKG_SHA256=5a87f4dcf7365e81a571128bf0b8199eb06a6fcd7e15ec7739be0ccff1326488
-TERMUX_PKG_DEPENDS="dconf, libnotify, libxml2, glib, gtk3, mate-panel, mate-menus"
+TERMUX_PKG_DEPENDS="dconf, glib, gtk3, libnotify, libx11, mate-menus, mate-panel"


### PR DESCRIPTION
* Add libx11

* Remove libxml2 as unused

%ci:no-build