### PR TITLE
zstd: Use Meson to build

### DIFF
--- a/packages/zstd/build-meson-contrib-meson.build.patch
+++ b/packages/zstd/build-meson-contrib-meson.build.patch
@@ -1,0 +1,7 @@
+--- a/build/meson/contrib/meson.build
++++ b/build/meson/contrib/meson.build
+@@ -9,4 +9,3 @@
+ # #############################################################################
+ 
+ subdir('pzstd')
+-subdir('gen_html')

--- a/packages/zstd/build.sh
+++ b/packages/zstd/build.sh
@@ -3,17 +3,36 @@ TERMUX_PKG_DESCRIPTION="Zstandard compression"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.5.5"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/facebook/zstd/archive/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=98e9c3d949d1b924e28e01eccb7deed865eefebf25c2f21c702e5cd5b63b85e1
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="liblzma, zlib"
 TERMUX_PKG_BREAKS="zstd-dev"
 TERMUX_PKG_REPLACES="zstd-dev"
-TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-Ddefault_library=both
+-Dbin_programs=true
+-Dbin_tests=false
+-Dbin_contrib=true
+-Dzlib=enabled
+-Dlzma=enabled
+-Dlz4=disabled
+"
 
-termux_step_post_make_install() {
-	make -j $TERMUX_MAKE_PROCESSES -C contrib/pzstd
-	make -j $TERMUX_MAKE_PROCESSES -C contrib/pzstd install
+# Is this needed?
+TERMUX_PKG_RM_AFTER_INSTALL="
+bin/zstd-frugal
+"
+
+termux_step_pre_configure() {
+	TERMUX_PKG_SRCDIR+="/build/meson"
+
+	# SOVERSION suffix is needed for backward compatibility. Do not remove
+	# this (and the guard in the post-massage step) unless you know what
+	# you are doing. `zstd` is a dependency of `apt` to which something
+	# catastrophic could happen if you are careless.
+	export TERMUX_MESON_ENABLE_SOVERSION=1
 }
 
 termux_step_post_massage() {


### PR DESCRIPTION
to remove the custom post-make-install step for building pzstd.

CMake could be used instead, which however now has some subtle issue of symbol visibility which makes me prefer Meson. (See also #17335.)