### PR TITLE
libllvm: Exclude lldb from 32-bit arches

### DIFF
--- a/packages/libllvm/lldb.subpackage.sh
+++ b/packages/libllvm/lldb.subpackage.sh
@@ -8,3 +8,6 @@ TERMUX_SUBPKG_DESCRIPTION="LLVM-based debugger"
 TERMUX_SUBPKG_DEPENDS="clang, libc++, libedit, libxml2, python, ncurses-ui-libs"
 TERMUX_SUBPKG_BREAKS="lldb-dev, lldb-static"
 TERMUX_SUBPKG_REPLACES="lldb-dev, lldb-static"
+
+# https://github.com/termux/termux-packages/issues/8880
+TERMUX_SUBPKG_EXCLUDED_ARCHES="arm, i686"


### PR DESCRIPTION
Ref #8880