### PR TITLE
*: fix vulkan packages deps 2

### DIFF
--- a/packages/vulkan-extension-layer/build.sh
+++ b/packages/vulkan-extension-layer/build.sh
@@ -3,13 +3,12 @@ TERMUX_PKG_DESCRIPTION="Vulkan Tools and Utilities"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # This package and vulkan-headers should be updated at same time. Otherwise, they do not compile successfully.
-# Do not TERMUX_PKG_DEPENDS on vulkan-loader
 TERMUX_PKG_VERSION="1.3.257"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/KhronosGroup/Vulkan-ExtensionLayer/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=27227d904072228b44fea3e2b766fffb03fb0acc0864ac3c917ce399b0516676
-TERMUX_PKG_DEPENDS="libc++"
+TERMUX_PKG_DEPENDS="libc++, vulkan-loader"
 TERMUX_PKG_BUILD_DEPENDS="vulkan-headers (=${TERMUX_PKG_VERSION}), vulkan-loader-generic (=${TERMUX_PKG_VERSION})"
-TERMUX_PKG_RECOMMENDS="vulkan-loader"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DBUILD_TESTS=OFF
 -DVULKAN_HEADERS_INSTALL_DIR=$TERMUX_PREFIX

--- a/packages/vulkan-tools/build.sh
+++ b/packages/vulkan-tools/build.sh
@@ -3,13 +3,12 @@ TERMUX_PKG_DESCRIPTION="Vulkan Tools and Utilities"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # This package and vulkan-headers should be updated at same time. Otherwise, they do not compile successfully.
-# Do not TERMUX_PKG_DEPENDS on vulkan-loader
 TERMUX_PKG_VERSION="1.3.255"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/KhronosGroup/Vulkan-Tools/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=ccd9175eec671b9ebff2486d1fb3e3d2f318028bbc873378ff9e1382b432abc6
-TERMUX_PKG_DEPENDS="libc++, libx11, libxcb, libwayland"
+TERMUX_PKG_DEPENDS="libc++, libx11, libxcb, libwayland, vulkan-loader"
 TERMUX_PKG_BUILD_DEPENDS="libwayland-protocols, vulkan-headers (=${TERMUX_PKG_VERSION}), vulkan-loader-generic (=${TERMUX_PKG_VERSION})"
-TERMUX_PKG_RECOMMENDS="vulkan-loader"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
@@ -22,5 +21,3 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DVULKAN_HEADERS_INSTALL_DIR=${TERMUX_PREFIX}
 -DWAYLAND_SCANNER_EXECUTABLE=${TERMUX_PREFIX}/opt/libwayland/cross/bin/wayland-scanner
 "
-
-# https://github.com/KhronosGroup/Vulkan-Tools/blob/main/CMakeLists.txt


### PR DESCRIPTION
Follow up of #17297 but for Khronos packages that depends on vulkan-loader-generic (to avoid pollution from the other loader)

Drops TERMUX_PKG_RECOMMENDS and reinstate TERMUX_PKG_DEPENDS on vulkan-loader