### PR TITLE
New package: xorg-server-xephyr

### DIFF
--- a/x11-packages/xorg-server/build.sh
+++ b/x11-packages/xorg-server/build.sh
@@ -8,7 +8,7 @@ TERMUX_PKG_SHA256=38aadb735650c8024ee25211c190bf8aad844c5f59632761ab1ef4c4d5aeb1
 TERMUX_PKG_DEPENDS="libandroid-shmem, libdrm, libpciaccess, libpixman, libx11, libxau, libxcvt, libxfont2, libxinerama, libxkbfile, libxshmfence, opengl, openssl, xkeyboard-config, xorg-protocol-txt, xorg-xkbcomp"
 
 # Needed for Xephyr
-TERMUX_PKG_BUILD_DEPENDS="xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util,wm"
+TERMUX_PKG_BUILD_DEPENDS="xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm"
 
 TERMUX_PKG_RECOMMENDS="xf86-video-dummy, xf86-input-void"
 TERMUX_PKG_NO_STATICSPLIT=true

--- a/x11-packages/xorg-server/build.sh
+++ b/x11-packages/xorg-server/build.sh
@@ -6,6 +6,10 @@ TERMUX_PKG_VERSION=21.1.8
 TERMUX_PKG_SRCURL=https://xorg.freedesktop.org/releases/individual/xserver/xorg-server-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=38aadb735650c8024ee25211c190bf8aad844c5f59632761ab1ef4c4d5aeb152
 TERMUX_PKG_DEPENDS="libandroid-shmem, libdrm, libpciaccess, libpixman, libx11, libxau, libxcvt, libxfont2, libxinerama, libxkbfile, libxshmfence, opengl, openssl, xkeyboard-config, xorg-protocol-txt, xorg-xkbcomp"
+
+# Needed for Xephyr
+TERMUX_PKG_BUILD_DEPENDS="xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util,wm"
+
 TERMUX_PKG_RECOMMENDS="xf86-video-dummy, xf86-input-void"
 TERMUX_PKG_NO_STATICSPLIT=true
 
@@ -50,7 +54,7 @@ ac_cv_path_RAWCPP=/usr/bin/cpp
 --disable-xnest
 --disable-xwayland
 --disable-xwin
---disable-kdrive
+--enable-kdrive
 --enable-xephyr
 --disable-libunwind
 --enable-xshmfence

--- a/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
+++ b/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
@@ -1,6 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="nested X server"
 TERMUX_SUBPKG_DEPEND_ON_PARENT="no"
-TERMUX_SUBPKG_DEPENDS="libandroid-shmem, libpixman, libxau, libxcb, libxdmcp, libxfont2, opengl, openssl, xorg-xkbcomp, xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm"
+TERMUX_SUBPKG_DEPENDS="libandroid-shmem, libpixman, libxau, libxcb, libxdmcp, libxfont2, opengl, openssl, xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm, xkeyboard-config, xorg-xkbcomp"
 TERMUX_SUBPKG_INCLUDE="
 bin/Xephyr
 share/man/man1/Xephyr.1.gz

--- a/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
+++ b/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
@@ -1,6 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="nested X server"
 TERMUX_SUBPKG_DEPEND_ON_PARENT="no"
-TERMUX_SUBPKG_DEPENDS="libandroid-shmem, libdrm, libpixman, libx11, libxau, libxfont2, opengl, openssl, xorg-protocol-txt, xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm"
+TERMUX_SUBPKG_DEPENDS="libandroid-shmem, libpixman, libxau, libxcb, libxdmcp, libxfont2, opengl, openssl, xorg-xkbcomp, xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm"
 TERMUX_SUBPKG_INCLUDE="
 bin/Xephyr
 share/man/man1/Xephyr.1.gz

--- a/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
+++ b/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
@@ -1,4 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="nested X server"
+TERMUX_SUBPKG_DEPEND_ON_PARENT="no"
 TERMUX_SUBPKG_DEPENDS="libandroid-shmem, libdrm, libpixman, libx11, libxau, libxfont2, opengl, openssl, xorg-protocol-txt, xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm"
 TERMUX_SUBPKG_INCLUDE="
 bin/Xephyr

--- a/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
+++ b/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="nested X server"
-TERMUX_SUBPKG_DEPENDS="libandroid-shmem, libdrm, libpixman, libx11, libxau, libxfont2, libxkbfile, opengl, openssl, xkeyboard-config, xorg-protocol-txt, xorg-xkbcomp, xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm"
+TERMUX_SUBPKG_DEPENDS="libandroid-shmem, libdrm, libpixman, libx11, libxau, libxfont2, opengl, openssl, xkeyboard-config, xorg-protocol-txt, xorg-xkbcomp, xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm"
 TERMUX_SUBPKG_INCLUDE="
 bin/Xephyr
 share/doc/xorg-server-xephyr/LICENSE

--- a/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
+++ b/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="nested X server"
-TERMUX_SUBPKG_DEPENDS="libandroid-shmem, libdrm, libpixman, libx11, libxau, libxfont2, opengl, openssl, xkeyboard-config, xorg-protocol-txt, xorg-xkbcomp, xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm"
+TERMUX_SUBPKG_DEPENDS="libandroid-shmem, libdrm, libpixman, libx11, libxau, libxfont2, opengl, openssl, xorg-protocol-txt, xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm"
 TERMUX_SUBPKG_INCLUDE="
 bin/Xephyr
 share/doc/xorg-server-xephyr/LICENSE

--- a/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
+++ b/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="nested X server"
-TERMUX_SUBPKG_DEPENDS="libandroid-shmem, libdrm, libpixman, libx11, libxau, libxfont2, libxkbfile, libxshmfence, opengl, openssl, xkeyboard-config, xorg-protocol-txt, xorg-xkbcomp, xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util,wm"
+TERMUX_SUBPKG_DEPENDS="libandroid-shmem, libdrm, libpixman, libx11, libxau, libxfont2, libxkbfile, opengl, openssl, xkeyboard-config, xorg-protocol-txt, xorg-xkbcomp, xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util,wm"
 TERMUX_SUBPKG_INCLUDE="
 bin/Xephyr
 share/doc/xorg-server-xephyr/LICENSE

--- a/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
+++ b/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
@@ -1,5 +1,5 @@
 TERMUX_SUBPKG_DESCRIPTION="nested X server"
-TERMUX_SUBPKG_DEPENDS="libandroid-shmem, libdrm, libpixman, libx11, libxau, libxfont2, libxkbfile, opengl, openssl, xkeyboard-config, xorg-protocol-txt, xorg-xkbcomp, xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util,wm"
+TERMUX_SUBPKG_DEPENDS="libandroid-shmem, libdrm, libpixman, libx11, libxau, libxfont2, libxkbfile, opengl, openssl, xkeyboard-config, xorg-protocol-txt, xorg-xkbcomp, xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm"
 TERMUX_SUBPKG_INCLUDE="
 bin/Xephyr
 share/doc/xorg-server-xephyr/LICENSE

--- a/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
+++ b/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
@@ -1,0 +1,7 @@
+TERMUX_SUBPKG_DESCRIPTION="nested X server"
+TERMUX_SUBPKG_DEPENDS="libandroid-shmem, libdrm, libpixman, libx11, libxau, libxfont2, libxkbfile, libxshmfence, opengl, openssl, xkeyboard-config, xorg-protocol-txt, xorg-xkbcomp, xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util,wm"
+TERMUX_SUBPKG_INCLUDE="
+bin/Xephyr
+share/doc/xorg-server-xephyr/LICENSE
+share/man/man1/Xephyr.1.gz
+"

--- a/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
+++ b/x11-packages/xorg-server/xorg-server-xephyr.subpackage.sh
@@ -2,6 +2,5 @@ TERMUX_SUBPKG_DESCRIPTION="nested X server"
 TERMUX_SUBPKG_DEPENDS="libandroid-shmem, libdrm, libpixman, libx11, libxau, libxfont2, opengl, openssl, xorg-protocol-txt, xcb-util, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm"
 TERMUX_SUBPKG_INCLUDE="
 bin/Xephyr
-share/doc/xorg-server-xephyr/LICENSE
 share/man/man1/Xephyr.1.gz
 "


### PR DESCRIPTION
Resolves #17388 

License file wasn't included as it is already part of `xorg-server` package? Added this as subpackage since it only takes to just enable kdrive and xephyr.