### PR TITLE
new package: angle-android

### DIFF
--- a/x11-packages/angle-android/args.gn.in
+++ b/x11-packages/angle-android/args.gn.in
@@ -1,0 +1,11 @@
+target_os = "android"
+target_cpu = "@TARGET_OS@"
+is_component_build = false
+is_debug = false
+angle_assert_always_on = true   # Recommended for debugging. Turn off for performance.
+angle_enable_gl = @ENABLE_GL@
+angle_enable_vulkan = @ENABLE_VULKAN@
+android32_ndk_api_level = @TERMUX_PKG_API_LEVEL@
+android64_ndk_api_level = @TERMUX_PKG_API_LEVEL@
+angle_build_tests = false
+angle_use_vulkan_null_display = @USE_VULKAN_NULL@

--- a/x11-packages/angle-android/build.sh
+++ b/x11-packages/angle-android/build.sh
@@ -1,0 +1,156 @@
+TERMUX_PKG_HOMEPAGE=https://chromium.googlesource.com/angle/angle
+TERMUX_PKG_DESCRIPTION="A conformant OpenGL ES implementation for Windows, Mac, Linux, iOS and Android"
+TERMUX_PKG_LICENSE="BSD 3-Clause, Apache-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+_COMMIT_DATE=2023.7.11
+_COMMIT=75e647193aeb1a78dad27bd5dc8f0199262800d1
+_COMMIT_POSISION=21474
+TERMUX_PKG_SRCURL=git+https://chromium.googlesource.com/angle/angle
+TERMUX_PKG_VERSION="2.1.$_COMMIT_POSISION-${_COMMIT:0:8}"
+
+TERMUX_PKG_HOSTBUILD=true
+
+termux_step_get_source() {
+	# Check whether we need to get source
+	if [ -f "$TERMUX_PKG_CACHEDIR/.angle-source-fetched" ]; then
+		local _fetched_source_version=$(cat $TERMUX_PKG_CACHEDIR/.angle-source-fetched)
+		if [ "$_fetched_source_version" = "$TERMUX_PKG_VERSION" ]; then
+			echo "[INFO]: Use pre-fetched source (version $_fetched_source_version)."
+			ln -sfr $TERMUX_PKG_CACHEDIR/tmp-checkout/angle $TERMUX_PKG_SRCDIR
+			return
+		fi
+	fi
+
+	# Fetch depot_tools
+	if [ ! -f "$TERMUX_PKG_CACHEDIR/.depot_tools-fetched" ];then
+		git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git $TERMUX_PKG_CACHEDIR/depot_tools
+		touch "$TERMUX_PKG_CACHEDIR/.depot_tools-fetched"
+	fi
+	export PATH="$TERMUX_PKG_CACHEDIR/depot_tools:$PATH"
+	export DEPOT_TOOLS_UPDATE=0
+
+	# Get source
+	rm -rf "$TERMUX_PKG_CACHEDIR/tmp-checkout"
+	mkdir -p "$TERMUX_PKG_CACHEDIR/tmp-checkout"
+	pushd "$TERMUX_PKG_CACHEDIR/tmp-checkout"
+	gclient config --verbose --unmanaged ${TERMUX_PKG_SRCURL#git+}
+	echo "" >> .gclient
+	echo 'target_os = ["android"]' >> .gclient
+	gclient sync --verbose --revision $_COMMIT
+
+	# Check commit posision
+	cd angle
+	local _real_commit_posision="$(git rev-list HEAD --count)"
+	if [ "$_real_commit_posision" != "$_COMMIT_POSISION" ]; then
+		termux_error_exit "Please update commit posision. Expected: $_COMMIT_POSISION, current: $_real_commit_posision."
+	fi
+	popd
+
+	echo "$TERMUX_PKG_VERSION" > "$TERMUX_PKG_CACHEDIR/.angle-source-fetched"
+	ln -sfr $TERMUX_PKG_CACHEDIR/tmp-checkout/angle $TERMUX_PKG_SRCDIR
+}
+
+termux_step_host_build() {
+	cd $TERMUX_PKG_HOSTBUILD_DIR
+
+	termux_setup_ninja
+	export PATH="$TERMUX_PKG_CACHEDIR/depot_tools:$PATH"
+	export DEPOT_TOOLS_UPDATE=0
+
+	local _target_os=
+	if [ "$TERMUX_ARCH" = "aarch64" ] || [ "$TERMUX_ARCH" = "arm" ]; then
+		_target_os="arm64"
+	elif [ "$TERMUX_ARCH" = "x86_64" ] || [ "$TERMUX_ARCH" = "i686" ]; then
+		_target_os="x64"
+	else
+		termux_error_exit "Unsupported arch: $TERMUX_ARCH"
+	fi
+
+	# Build with Android's GL
+	mkdir -p out/android
+	sed -e"s|@TARGET_OS@|$_target_os|g" \
+		-e "s|@ENABLE_GL@|true|g" \
+		-e "s|@ENABLE_VULKAN@|false|g" \
+		-e "s|@USE_VULKAN_NULL@|false|g" \
+		-e "s|@TERMUX_PKG_API_LEVEL@|$TERMUX_PKG_API_LEVEL|g" \
+		$TERMUX_PKG_BUILDER_DIR/args.gn.in > out/android/args.gn
+	pushd $TERMUX_PKG_SRCDIR
+	gn gen $TERMUX_PKG_HOSTBUILD_DIR/out/android --export-compile-commands
+	popd
+	ninja -C out/android
+	mkdir -p build/gl
+	cp out/android/apks/AngleLibraries.apk build/gl/
+	pushd build/gl
+	unzip AngleLibraries.apk
+	popd
+
+	# Build with Android's Vulkan
+	mkdir -p out/android
+	sed -e"s|@TARGET_OS@|$_target_os|g" \
+		-e "s|@ENABLE_GL@|false|g" \
+		-e "s|@ENABLE_VULKAN@|true|g" \
+		-e "s|@USE_VULKAN_NULL@|false|g" \
+		-e "s|@TERMUX_PKG_API_LEVEL@|$TERMUX_PKG_API_LEVEL|g" \
+		$TERMUX_PKG_BUILDER_DIR/args.gn.in > out/android/args.gn
+	pushd $TERMUX_PKG_SRCDIR
+	gn gen $TERMUX_PKG_HOSTBUILD_DIR/out/android --export-compile-commands
+	popd
+	ninja -C out/android
+	mkdir -p build/vulkan
+	cp out/android/apks/AngleLibraries.apk build/vulkan/
+	pushd build/vulkan
+	unzip AngleLibraries.apk
+	popd
+
+	# Build with Android's Vulkan null display
+	mkdir -p out/android
+	sed -e "s|@TARGET_OS@|$_target_os|g" \
+		-e "s|@ENABLE_GL@|false|g" \
+		-e "s|@ENABLE_VULKAN@|true|g" \
+		-e "s|@USE_VULKAN_NULL@|true|g" \
+		-e "s|@TERMUX_PKG_API_LEVEL@|$TERMUX_PKG_API_LEVEL|g" \
+		$TERMUX_PKG_BUILDER_DIR/args.gn.in > out/android/args.gn
+	pushd $TERMUX_PKG_SRCDIR
+	gn gen $TERMUX_PKG_HOSTBUILD_DIR/out/android --export-compile-commands
+	popd
+	ninja -C out/android
+	mkdir -p build/vulkan-null
+	cp out/android/apks/AngleLibraries.apk build/vulkan-null/
+	pushd build/vulkan-null
+	unzip AngleLibraries.apk
+	popd
+}
+
+termux_step_configure() {
+	# Remove this marker all the time, as this package is architecture-specific
+	rm -rf $TERMUX_HOSTBUILD_MARKER
+}
+
+termux_step_configure() {
+	:
+}
+
+termux_step_make() {
+	:
+}
+
+termux_step_make_install() {
+	local _lib_dir=
+	if [ "$TERMUX_ARCH" = "arm" ]; then
+		_lib_dir="armeabi-v7a"
+	elif [ "$TERMUX_ARCH" = "i686" ]; then
+		_lib_dir="x86"
+	elif [ "$TERMUX_ARCH" = "x86_64" ]; then
+		_lib_dir="x86_64"
+	elif [ "$TERMUX_ARCH" = "aarch64" ]; then
+		_lib_dir="arm64-v8a"
+	else
+		termux_error_exit "Unsupported arch: $TERMUX_ARCH"
+	fi
+
+	local _type
+	for _type in gl vulkan vulkan-null; do
+		mkdir -p $TERMUX_PREFIX/opt/angle-android/$_type
+		cp -v $TERMUX_PKG_HOSTBUILD_DIR/build/$_type/lib/$_lib_dir/*.so $TERMUX_PREFIX/opt/angle-android/$_type/
+	done
+}

--- a/x11-packages/virglrenderer-android/build.sh
+++ b/x11-packages/virglrenderer-android/build.sh
@@ -4,11 +4,12 @@ TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@licy183"
 TERMUX_PKG_VERSION=(0.10.4)
 TERMUX_PKG_VERSION+=(1.5.10) # libepoxy version
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=(https://gitlab.freedesktop.org/virgl/virglrenderer/-/archive/virglrenderer-${TERMUX_PKG_VERSION[0]}/virglrenderer-virglrenderer-${TERMUX_PKG_VERSION[0]}.tar.gz)
 TERMUX_PKG_SRCURL+=(https://github.com/anholt/libepoxy/archive/refs/tags/${TERMUX_PKG_VERSION[1]}.tar.gz)
 TERMUX_PKG_SHA256=(fd9a1b12473f4cda8d87e6ba1a6e5714a24355e16b69ed85df5c21bf48f797fa)
 TERMUX_PKG_SHA256+=(a7ced37f4102b745ac86d6a70a9da399cc139ff168ba6b8002b4d8d43c900c15)
+TERMUX_PKG_DEPENDS="angle-android"
 
 TERMUX_PKG_HOSTBUILD=true
 
@@ -66,8 +67,6 @@ termux_step_host_build() {
         -Degl_without_gbm=true \
         -Dplatforms=egl
 	ninja -C virglrenderer-build install -j $TERMUX_MAKE_PROCESSES
-
-	# TODO: Build angle?
 }
 
 termux_step_configure() {
@@ -80,7 +79,10 @@ termux_step_make() {
 }
 
 termux_step_make_install() {
-	ln -sfr $TERMUX_PREFIX/opt/virglrenderer-android/bin/virgl_test_server $TERMUX_PREFIX/bin/virgl_test_server_android
+	sed "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|g" \
+		$TERMUX_PKG_BUILDER_DIR/virgl_test_server_android.in > \
+		$TERMUX_PREFIX/bin/virgl_test_server_android
+	chmod +x $TERMUX_PREFIX/bin/virgl_test_server_android
 }
 
 termux_step_install_license() {

--- a/x11-packages/virglrenderer-android/virgl_test_server_android.in
+++ b/x11-packages/virglrenderer-android/virgl_test_server_android.in
@@ -1,0 +1,22 @@
+#!@TERMUX_PREFIX@/bin/sh
+
+_additional_ld_lib_path=""
+
+case "$1" in
+	--angle-gl)
+		_additional_ld_lib_path="@TERMUX_PREFIX@/opt/angle-android/gl"
+	;;
+	--angle-vulkan)
+		_additional_ld_lib_path="@TERMUX_PREFIX@/opt/angle-android/vulkan"
+	;;
+	--angle-vulkan-null)
+		_additional_ld_lib_path="@TERMUX_PREFIX@/opt/angle-android/vulkan-null"
+	;;
+esac
+
+if [ x"$_additional_ld_lib_path" != x"" ]; then
+	export LD_LIBRARY_PATH="$_additional_ld_lib_path:$LD_LIBRARY_PATH"
+	export EPOXY_USE_ANGLE=1
+fi
+
+exec @TERMUX_PREFIX@/opt/virglrenderer-android/bin/virgl_test_server


### PR DESCRIPTION
Running virgl straightly over Android's GL may cause error due to the lack of extensions and differences between Android's GLs. ANGLE can translate OpenGL operations to other OpenGL or vulkan, so it may solve some running issues for virglrenderer-android.

Tested on `Adreno 660` and `Mali G610`.

Related issue: #16763, #17406
