### PR TITLE
Update opencv-python.subpackage.sh

### DIFF
--- a/packages/opencv/opencv-python.subpackage.sh
+++ b/packages/opencv/opencv-python.subpackage.sh
@@ -1,7 +1,7 @@
 TERMUX_SUBPKG_INCLUDE="lib/python*"
 TERMUX_SUBPKG_DESCRIPTION="Python bindings for OpenCV"
 TERMUX_SUBPKG_DEPENDS="python, python-numpy"
-
+TERMUX_SUBPKG_VERSION=4.8.0.74
 termux_step_create_subpkg_debscripts() {
 	_NUMPY_VERSION=$(. $TERMUX_SCRIPTDIR/packages/python-numpy/build.sh; echo $TERMUX_PKG_VERSION)
 

--- a/packages/opencv/opencv-python.subpackage.sh
+++ b/packages/opencv/opencv-python.subpackage.sh
@@ -1,7 +1,7 @@
 TERMUX_SUBPKG_INCLUDE="lib/python*"
 TERMUX_SUBPKG_DESCRIPTION="Python bindings for OpenCV"
 TERMUX_SUBPKG_DEPENDS="python, python-numpy"
-TERMUX_SUBPKG_VERSION=4.8.0.74
+TERMUX_SUBPKG_DEPEND_ON_PARENT="unversioned"
 termux_step_create_subpkg_debscripts() {
 	_NUMPY_VERSION=$(. $TERMUX_SCRIPTDIR/packages/python-numpy/build.sh; echo $TERMUX_PKG_VERSION)
 


### PR DESCRIPTION
# Proposed Fix for OpenCV Version Conflict in Termux

## Problem
When attempting to install other Python modules that require `opencv-python` in Termux, a conflict arises between the version specified by PIP and the version of OpenCV present. The conflict arises because PIP has a version `4.8.0.74`, but OpenCV only has version `4.8.0`.

## Solution
To resolve this version conflict, I propose the following fix:

1. **Add Separate Version Variable in Python OpenCV**:
   - Introduce a separate version variable, for example, `TERMUX_SUBPKG_VERSION=4.8.0.74`, in the Python OpenCV package for Termux.
   - This new variable will help differentiate the Python package version from the actual OpenCV version.
   - By having this separate version variable, PIP can work smoothly without any version ambiguity.