### PR TITLE
experimental dri3 support for turnip kgsl on Termux:X11

### DIFF
--- a/packages/mesa-vulkan-icd-freedreno-dri3/build.sh
+++ b/packages/mesa-vulkan-icd-freedreno-dri3/build.sh
@@ -1,0 +1,53 @@
+TERMUX_PKG_HOMEPAGE=https://www.mesa3d.org
+TERMUX_PKG_DESCRIPTION="An open-source implementation of the OpenGL specification"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_LICENSE_FILE="docs/license.rst"
+TERMUX_PKG_MAINTAINER="xMeM <haooy@outlook.com>"
+TERMUX_PKG_VERSION="23.3.2"
+TERMUX_PKG_SRCURL=https://archive.mesa3d.org/mesa-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=3cfcb81fa16f89c56abe3855d2637d396ee4e03849b659000a6b8e5f57e69adc
+TERMUX_PKG_DEPENDS="libandroid-shmem, libc++, libdrm, libx11, libxcb, libxshmfence, libwayland, vulkan-loader-generic, zlib, zstd"
+TERMUX_PKG_BUILD_DEPENDS="libwayland-protocols, libxrandr, xorgproto"
+TERMUX_PKG_CONFLICTS="mesa-vulkan-icd-freedreno"
+
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--cmake-prefix-path $TERMUX_PREFIX
+-Dcpp_rtti=false
+-Dgbm=disabled
+-Dopengl=false
+-Dllvm=disabled
+-Dshared-llvm=disabled
+-Dplatforms=x11,wayland
+-Dgallium-drivers=
+-Dxmlconfig=disabled
+-Dvulkan-drivers=freedreno
+-Dfreedreno-kmds=msm,kgsl
+"
+
+TERMUX_PKG_BLACKLISTED_ARCHES="i686, x86_64"
+
+termux_step_pre_configure() {
+	termux_setup_cmake
+
+	CPPFLAGS+=" -D__USE_GNU"
+	LDFLAGS+=" -landroid-shmem"
+
+	_WRAPPER_BIN=$TERMUX_PKG_BUILDDIR/_wrapper/bin
+	mkdir -p $_WRAPPER_BIN
+	if [ "$TERMUX_ON_DEVICE_BUILD" = "false" ]; then
+		sed 's|@CMAKE@|'"$(command -v cmake)"'|g' \
+			$TERMUX_PKG_BUILDER_DIR/cmake-wrapper.in \
+			> $_WRAPPER_BIN/cmake
+		chmod 0700 $_WRAPPER_BIN/cmake
+		sed "s|^export PKG_CONFIG_LIBDIR=|export PKG_CONFIG_LIBDIR=${TERMUX_PREFIX}/opt/libwayland/cross/lib/x86_64-linux-gnu/pkgconfig:|" \
+			"${TERMUX_STANDALONE_TOOLCHAIN}/bin/pkg-config" \
+			> "${_WRAPPER_BIN}/pkg-config"
+		chmod +x "${_WRAPPER_BIN}/pkg-config"
+		export PKG_CONFIG="${_WRAPPER_BIN}/pkg-config"
+	fi
+	export PATH=$_WRAPPER_BIN:$PATH
+}
+
+termux_step_post_configure() {
+	rm -f $_WRAPPER_BIN/cmake
+}

--- a/packages/mesa-vulkan-icd-freedreno-dri3/cmake-wrapper.in
+++ b/packages/mesa-vulkan-icd-freedreno-dri3/cmake-wrapper.in
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+if [ -e CMakeLists.txt ]; then
+	sed -i '1s|^|project(foo LANGUAGES C CXX)\n|' CMakeLists.txt
+fi
+
+for f in "$@"; do
+	case "${f}" in
+		-DCMAKE_TOOLCHAIN_FILE=* )
+			sed -i "${f#-DCMAKE_TOOLCHAIN_FILE=}" \
+				-e 's|\(set(CMAKE_SYSTEM_NAME\) "Android")|\1 "Linux")|g'
+			;;
+	esac
+done
+
+exec @CMAKE@ "$@"

--- a/packages/mesa-vulkan-icd-freedreno-dri3/fix-for-anon-file.patch
+++ b/packages/mesa-vulkan-icd-freedreno-dri3/fix-for-anon-file.patch
@@ -1,0 +1,16 @@
+Fallback to `@TERMUX_PREFIX@/tmp` if env `XDG_RUNTIME_DIR` is not set.
+
+--- a/src/util/anon_file.c
++++ b/src/util/anon_file.c
+@@ -136,6 +136,11 @@
+    char *name;
+ 
+    path = getenv("XDG_RUNTIME_DIR");
++#ifdef __TERMUX__
++   if (!path) {
++      path = "@TERMUX_PREFIX@/tmp";
++   }
++#endif
+    if (!path) {
+       errno = ENOENT;
+       return -1;

--- a/packages/mesa-vulkan-icd-freedreno-dri3/fix-for-getprogname.patch
+++ b/packages/mesa-vulkan-icd-freedreno-dri3/fix-for-getprogname.patch
@@ -1,0 +1,20 @@
+--- a/src/util/u_process.c
++++ b/src/util/u_process.c
+@@ -103,7 +103,7 @@
+ {
+    return strdup(program_invocation_short_name);
+ }
+-#elif defined(__FreeBSD__) || defined(__DragonFly__) || defined(__APPLE__) || defined(ANDROID) || defined(__NetBSD__)
++#elif defined(__FreeBSD__) || defined(__DragonFly__) || defined(__APPLE__) || defined(__ANDROID__) || defined(__NetBSD__)
+ #if defined(__NetBSD__)
+ #    include <sys/param.h>
+ #endif
+@@ -170,7 +170,7 @@
+ #endif
+ 
+ #if defined(GET_PROGRAM_NAME_NOT_AVAILABLE)
+-#if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__UCLIBC__) || defined(ANDROID)
++#if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__UCLIBC__) || defined(__ANDROID__)
+ /* This is a hack. It's said to work on OpenBSD, NetBSD and GNU.
+  * Rogelio M.Serrano Jr. reported it's also working with UCLIBC. It's
+  * used as a last resort, if there is no documented facility available. */

--- a/packages/mesa-vulkan-icd-freedreno-dri3/meson.build.patch
+++ b/packages/mesa-vulkan-icd-freedreno-dri3/meson.build.patch
@@ -1,0 +1,11 @@
+--- a/meson.build
++++ b/meson.build
+@@ -1377,7 +1377,7 @@
+   endif
+ endif
+ 
+-foreach h : ['xlocale.h', 'linux/futex.h', 'endian.h', 'dlfcn.h', 'sys/shm.h',
++foreach h : ['linux/futex.h', 'endian.h', 'dlfcn.h', 'sys/shm.h',
+              'cet.h', 'pthread_np.h', 'renderdoc_app.h', 'sys/inotify.h']
+   if cc.check_header(h)
+     pre_args += '-DHAVE_@0@'.format(h.to_upper().underscorify())

--- a/packages/mesa-vulkan-icd-freedreno-dri3/src-gallium-drivers-llvmpipe-lp_screen.c.patch
+++ b/packages/mesa-vulkan-icd-freedreno-dri3/src-gallium-drivers-llvmpipe-lp_screen.c.patch
@@ -1,0 +1,15 @@
+Disable multithreading by default because it seems to introduce a significant
+overhead when enabled.
+
+--- a/src/gallium/drivers/llvmpipe/lp_screen.c
++++ b/src/gallium/drivers/llvmpipe/lp_screen.c
+@@ -1092,6 +1092,9 @@
+    screen->num_threads = debug_get_num_option("LP_NUM_THREADS",
+                                               screen->num_threads);
+    screen->num_threads = MIN2(screen->num_threads, LP_MAX_THREADS);
++#if defined __ANDROID__
++   screen->num_threads = 0;
++#endif
+ 
+    lp_build_init(); /* get lp_native_vector_width initialised */
+ 

--- a/packages/mesa-vulkan-icd-freedreno-dri3/tu_kgsl_export_dmabuf.patch
+++ b/packages/mesa-vulkan-icd-freedreno-dri3/tu_kgsl_export_dmabuf.patch
@@ -1,0 +1,192 @@
+diff --git a/src/freedreno/vulkan/tu_device.cc b/src/freedreno/vulkan/tu_device.cc
+index f892fcedcb3..0a5c4dd7a49 100644
+--- a/src/freedreno/vulkan/tu_device.cc
++++ b/src/freedreno/vulkan/tu_device.cc
+@@ -2624,6 +2624,14 @@ tu_AllocateMemory(VkDevice _device,
+       uint64_t client_address = 0;
+       BITMASK_ENUM(tu_bo_alloc_flags) alloc_flags = TU_BO_ALLOC_NO_FLAGS;
+ 
++      const VkExportMemoryAllocateInfo *export_info = vk_find_struct_const(
++         pAllocateInfo->pNext, EXPORT_MEMORY_ALLOCATE_INFO);
++      if (export_info && (export_info->handleTypes &
++                          (VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT |
++                           VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT))) {
++         alloc_flags |= TU_BO_ALLOC_SHAREABLE;
++      }
++
+       const VkMemoryOpaqueCaptureAddressAllocateInfo *replay_info =
+          vk_find_struct_const(pAllocateInfo->pNext,
+                               MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO);
+diff --git a/src/freedreno/vulkan/tu_knl.h b/src/freedreno/vulkan/tu_knl.h
+index 78cb442dc93..264000c5ea8 100644
+--- a/src/freedreno/vulkan/tu_knl.h
++++ b/src/freedreno/vulkan/tu_knl.h
+@@ -21,6 +21,7 @@ enum tu_bo_alloc_flags
+    TU_BO_ALLOC_ALLOW_DUMP = 1 << 0,
+    TU_BO_ALLOC_GPU_READ_ONLY = 1 << 1,
+    TU_BO_ALLOC_REPLAYABLE = 1 << 2,
++   TU_BO_ALLOC_SHAREABLE = 1 << 3,
+ };
+ 
+ /* Define tu_timeline_sync type based on drm syncobj for a point type
+@@ -53,6 +54,7 @@ struct tu_bo {
+    uint32_t bo_list_idx;
+ 
+    bool implicit_sync : 1;
++   int dmabuf_fd;
+ };
+ 
+ struct tu_knl {
+diff --git a/src/freedreno/vulkan/tu_knl_kgsl.cc b/src/freedreno/vulkan/tu_knl_kgsl.cc
+index 0c2f16c496c..6a484d83a47 100644
+--- a/src/freedreno/vulkan/tu_knl_kgsl.cc
++++ b/src/freedreno/vulkan/tu_knl_kgsl.cc
+@@ -11,6 +11,7 @@
+ #include <stdint.h>
+ #include <sys/ioctl.h>
+ #include <sys/mman.h>
++#include <linux/dma-heap.h>
+ 
+ #include "msm_kgsl.h"
+ #include "vk_util.h"
+@@ -18,6 +19,7 @@
+ #include "util/u_debug.h"
+ #include "util/u_vector.h"
+ #include "util/libsync.h"
++#include "util/os_file.h"
+ #include "util/timespec.h"
+ 
+ #include "tu_cmd_buffer.h"
+@@ -67,6 +69,57 @@ kgsl_submitqueue_close(struct tu_device *dev, uint32_t queue_id)
+    safe_ioctl(dev->physical_device->local_fd, IOCTL_KGSL_DRAWCTXT_DESTROY, &req);
+ }
+ 
++static int
++dmabuf_alloc(uint64_t size)
++{
++   int ret;
++   int dma_heap = open("/dev/dma_heap/system", O_RDONLY);
++
++   if (dma_heap < 0) {
++      int ion_heap = open("/dev/ion", O_RDONLY);
++
++      if (ion_heap < 0)
++         return -1;
++
++      struct ion_allocation_data {
++         __u64 len;
++         __u32 heap_id_mask;
++         __u32 flags;
++         __u32 fd;
++         __u32 unused;
++      } alloc_data = {
++         .len = size,
++         /* ION_HEAP_SYSTEM | ION_SYSTEM_HEAP_ID */
++         .heap_id_mask = (1U << 0) | (1U << 25),
++         .flags = 0, /* uncached */
++      };
++
++      ret = safe_ioctl(ion_heap, _IOWR('I', 0, struct ion_allocation_data),
++                      &alloc_data);
++
++      close(ion_heap);
++
++      if (ret)
++         return -1;
++
++      return alloc_data.fd;
++   } else {
++      struct dma_heap_allocation_data alloc_data = {
++         .len = size,
++         .fd_flags = O_RDWR | O_CLOEXEC,
++      };
++
++      ret = safe_ioctl(dma_heap, DMA_HEAP_IOCTL_ALLOC, &alloc_data);
++
++      close(dma_heap);
++
++      if (ret)
++         return -1;
++
++      return alloc_data.fd;
++   }
++}
++
+ static VkResult
+ kgsl_bo_init(struct tu_device *dev,
+              struct tu_bo **out_bo,
+@@ -78,6 +131,21 @@ kgsl_bo_init(struct tu_device *dev,
+ {
+    assert(client_iova == 0);
+ 
++   if (flags & TU_BO_ALLOC_SHAREABLE) {
++      int fd = dmabuf_alloc(size);
++
++      if (fd < 0) {
++         return vk_errorf(dev, VK_ERROR_OUT_OF_DEVICE_MEMORY,
++                       "DMABUF_ALLOC failed (%s)", strerror(errno));
++      }
++
++      VkResult res = tu_bo_init_dmabuf(dev, out_bo, size, fd);
++
++      close(fd);
++
++      return res;
++   }
++
+    struct kgsl_gpumem_alloc_id req = {
+       .size = size,
+    };
+@@ -113,6 +181,7 @@ kgsl_bo_init(struct tu_device *dev,
+       .iova = req.gpuaddr,
+       .name = tu_debug_bos_add(dev, req.mmapsize, name),
+       .refcnt = 1,
++      .dmabuf_fd = -1,
+    };
+ 
+    *out_bo = bo;
+@@ -162,6 +231,7 @@ kgsl_bo_init_dmabuf(struct tu_device *dev,
+       .iova = info_req.gpuaddr,
+       .name = tu_debug_bos_add(dev, info_req.size, "dmabuf"),
+       .refcnt = 1,
++      .dmabuf_fd = os_dupfd_cloexec(fd),
+    };
+ 
+    *out_bo = bo;
+@@ -172,9 +242,7 @@ kgsl_bo_init_dmabuf(struct tu_device *dev,
+ static int
+ kgsl_bo_export_dmabuf(struct tu_device *dev, struct tu_bo *bo)
+ {
+-   tu_stub();
+-
+-   return -1;
++   return os_dupfd_cloexec(bo->dmabuf_fd);
+ }
+ 
+ static VkResult
+@@ -183,6 +251,15 @@ kgsl_bo_map(struct tu_device *dev, struct tu_bo *bo)
+    if (bo->map)
+       return VK_SUCCESS;
+ 
++   if (bo->dmabuf_fd != -1) {
++      void *map = mmap(0, bo->size, PROT_READ | PROT_WRITE, MAP_SHARED, bo->dmabuf_fd, 0);
++
++      if (map != MAP_FAILED) {
++         bo->map = map;
++         return VK_SUCCESS;
++      }
++   }
++
+    uint64_t offset = bo->gem_handle << 12;
+    void *map = mmap(0, bo->size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                     dev->physical_device->local_fd, offset);
+@@ -210,6 +287,9 @@ kgsl_bo_finish(struct tu_device *dev, struct tu_bo *bo)
+    if (bo->map)
+       munmap(bo->map, bo->size);
+ 
++   if (bo->dmabuf_fd != -1)
++      close(bo->dmabuf_fd);
++
+    struct kgsl_gpumem_free_id req = {
+       .id = bo->gem_handle
+    };

--- a/packages/mesa-vulkan-icd-freedreno-dri3/virgl-socket-path.patch
+++ b/packages/mesa-vulkan-icd-freedreno-dri3/virgl-socket-path.patch
@@ -1,0 +1,11 @@
+--- a/src/virtio/vtest/vtest_protocol.h
++++ b/src/virtio/vtest/vtest_protocol.h
+@@ -25,7 +25,7 @@
+ #ifndef VTEST_PROTOCOL
+ #define VTEST_PROTOCOL
+ 
+-#define VTEST_DEFAULT_SOCKET_NAME "/tmp/.virgl_test"
++#define VTEST_DEFAULT_SOCKET_NAME "@TERMUX_PREFIX@/tmp/.virgl_test"
+ 
+ #ifdef VIRGL_RENDERER_UNSTABLE_APIS
+ #define VTEST_PROTOCOL_VERSION 3

--- a/packages/mesa-vulkan-icd-freedreno-dri3/wsi-no-pthread_cancel.patch
+++ b/packages/mesa-vulkan-icd-freedreno-dri3/wsi-no-pthread_cancel.patch
@@ -1,0 +1,86 @@
+--- src/src/vulkan/wsi/wsi_common_display.c	2023-02-09 00:05:36.000000000 +0300
++++ src/src/vulkan/wsi/wsi_common_display.c.patch	2023-02-17 22:26:52.517688447 +0300
+@@ -167,6 +167,12 @@
+ 
+ static uint64_t fence_sequence;
+ 
++#ifdef __ANDROID__
++static void thread_signal_handler (int signum) {
++   pthread_exit (0);
++}
++#endif
++
+ ICD_DEFINE_NONDISP_HANDLE_CASTS(wsi_display_mode, VkDisplayModeKHR)
+ ICD_DEFINE_NONDISP_HANDLE_CASTS(wsi_display_connector, VkDisplayKHR)
+ 
+@@ -1267,7 +1273,9 @@
+       .events = POLLIN
+    };
+ 
++#ifndef __ANDROID__
+    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
++#endif
+    for (;;) {
+       int ret = poll(&pollfd, 1, -1);
+       if (ret > 0) {
+@@ -1295,9 +1303,22 @@
+ static void
+ wsi_display_stop_wait_thread(struct wsi_display *wsi)
+ {
++#ifdef __ANDROID__
++   struct sigaction actions;
++   memset (&actions, 0, sizeof (actions));
++   sigemptyset (&actions.sa_mask);
++   actions.sa_flags = 0;
++   actions.sa_handler = thread_signal_handler;
++   sigaction (SIGUSR2, &actions, NULL);
++#endif
++
+    pthread_mutex_lock(&wsi->wait_mutex);
+    if (wsi->wait_thread) {
++#ifndef __ANDROID__
+       pthread_cancel(wsi->wait_thread);
++#else
++      pthread_kill(wsi->wait_thread, SIGUSR2);
++#endif
+       pthread_join(wsi->wait_thread, NULL);
+       wsi->wait_thread = 0;
+    }
+@@ -2075,7 +2096,9 @@
+ 
+    int udev_fd = udev_monitor_get_fd(mon);
+ 
++#ifndef __ANDROID__
+    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
++#endif
+ 
+    for (;;) {
+       nfds_t nfds = 1;
+@@ -2198,6 +2221,15 @@
+    struct wsi_display *wsi =
+       (struct wsi_display *) wsi_device->wsi[VK_ICD_WSI_PLATFORM_DISPLAY];
+ 
++#ifdef __ANDROID__
++   struct sigaction actions;
++   memset (&actions, 0, sizeof (actions));
++   sigemptyset (&actions.sa_mask);
++   actions.sa_flags = 0;
++   actions.sa_handler = thread_signal_handler;
++   sigaction (SIGUSR2, &actions, NULL);
++#endif
++
+    if (wsi) {
+       wsi_for_each_connector(connector, wsi) {
+          wsi_for_each_display_mode(mode, connector) {
+@@ -2209,7 +2241,11 @@
+       wsi_display_stop_wait_thread(wsi);
+ 
+       if (wsi->hotplug_thread) {
++#ifndef __ANDROID__
+          pthread_cancel(wsi->hotplug_thread);
++#else
++         pthread_kill(wsi->hotplug_thread, SIGUSR2);
++#endif
+          pthread_join(wsi->hotplug_thread, NULL);
+       }
+ 

--- a/packages/mesa-vulkan-icd-freedreno-dri3/wsi-termux-x11.patch
+++ b/packages/mesa-vulkan-icd-freedreno-dri3/wsi-termux-x11.patch
@@ -1,0 +1,92 @@
+diff --git a/src/vulkan/wsi/wsi_common_x11.c b/src/vulkan/wsi/wsi_common_x11.c
+index b7724c028ea..a9595291c37 100644
+--- a/src/vulkan/wsi/wsi_common_x11.c
++++ b/src/vulkan/wsi/wsi_common_x11.c
+@@ -439,7 +439,7 @@ wsi_x11_get_connection(struct wsi_device *wsi_dev,
+ 
+ static const VkFormat formats[] = {
+    VK_FORMAT_R5G6B5_UNORM_PACK16,
+-   VK_FORMAT_B8G8R8A8_SRGB,
++   // VK_FORMAT_B8G8R8A8_SRGB,
+    VK_FORMAT_B8G8R8A8_UNORM,
+    VK_FORMAT_A2R10G10B10_UNORM_PACK32,
+ };
+@@ -1417,7 +1417,6 @@ x11_acquire_next_image_poll_find_index(struct x11_swapchain *chain, uint32_t *im
+    for (uint32_t i = 0; i < chain->base.image_count; i++) {
+       if (!chain->images[i].busy) {
+          /* We found a non-busy image */
+-         xshmfence_await(chain->images[i].shm_fence);
+          *image_index = i;
+          chain->images[i].busy = true;
+          chain->present_poll_acquire_count++;
+@@ -1573,7 +1572,6 @@ x11_acquire_next_image_from_queue(struct x11_swapchain *chain,
+    }
+ 
+    assert(image_index < chain->base.image_count);
+-   xshmfence_await(chain->images[image_index].shm_fence);
+ 
+    *image_index_out = image_index;
+ 
+@@ -1616,8 +1614,6 @@ x11_present_to_x11_dri3(struct x11_swapchain *chain, uint32_t image_index,
+       options |= XCB_PRESENT_OPTION_SUBOPTIMAL;
+ #endif
+ 
+-   xshmfence_reset(image->shm_fence);
+-
+    ++chain->sent_image_count;
+    assert(chain->sent_image_count <= chain->base.image_count);
+ 
+@@ -2196,14 +2192,23 @@ x11_image_init(VkDevice device_h, struct x11_swapchain *chain,
+          return VK_ERROR_OUT_OF_HOST_MEMORY;
+ 
+       cookie =
+-         xcb_dri3_pixmap_from_buffer_checked(chain->conn,
+-                                             image->pixmap,
+-                                             chain->window,
+-                                             image->base.sizes[0],
+-                                             pCreateInfo->imageExtent.width,
+-                                             pCreateInfo->imageExtent.height,
+-                                             image->base.row_pitches[0],
+-                                             chain->depth, bpp, fd);
++         xcb_dri3_pixmap_from_buffers_checked(chain->conn,
++                                              image->pixmap,
++                                              chain->window,
++                                              image->base.num_planes,
++                                              pCreateInfo->imageExtent.width,
++                                              pCreateInfo->imageExtent.height,
++                                              image->base.row_pitches[0],
++                                              image->base.offsets[0],
++                                              0,
++                                              0,
++                                              0,
++                                              0,
++                                              0,
++                                              0,
++                                              chain->depth, bpp,
++                                              1274,
++                                              &fd);
+    }
+ 
+    error = xcb_request_check(chain->conn, cookie);
+@@ -2212,6 +2217,10 @@ x11_image_init(VkDevice device_h, struct x11_swapchain *chain,
+       goto fail_image;
+    }
+ 
++   image->sync_fence = 0;
++   image->busy = false;
++   return VK_SUCCESS;
++
+ out_fence:
+    fence_fd = xshmfence_alloc_shm();
+    if (fence_fd < 0)
+@@ -2254,10 +2263,6 @@ x11_image_finish(struct x11_swapchain *chain,
+    xcb_void_cookie_t cookie;
+ 
+    if (!chain->base.wsi->sw || chain->has_mit_shm) {
+-      cookie = xcb_sync_destroy_fence(chain->conn, image->sync_fence);
+-      xcb_discard_reply(chain->conn, cookie.sequence);
+-      xshmfence_unmap_shm(image->shm_fence);
+-
+       cookie = xcb_free_pixmap(chain->conn, image->pixmap);
+       xcb_discard_reply(chain->conn, cookie.sequence);
+ 


### PR DESCRIPTION
Only available on turnip with kgsl enabled.
Requires latest Termux:X11 build.
Thanks to twaik for the idea and implemented dri3 support for Termux:X11.