### PR TITLE
ffmpeg enable amr encoding support

### DIFF
--- a/packages/ffmpeg/build.sh
+++ b/packages/ffmpeg/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="Tools and libraries to manipulate a wide range of multim
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=6.0
-TERMUX_PKG_REVISION=5
+TERMUX_PKG_REVISION=6
 TERMUX_PKG_SRCURL=https://www.ffmpeg.org/releases/ffmpeg-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082
-TERMUX_PKG_DEPENDS="freetype, game-music-emu, libaom, libandroid-glob, libass, libbluray, libbz2, libdav1d, libgnutls, libiconv, liblzma, libmp3lame, libopus, librav1e, libsoxr, libsrt, libssh, libtheora, libvorbis, libvpx, libvidstab, libwebp, libx264, libx265, libxml2, libzimg, littlecms, ocl-icd, xvidcore, zlib"
+TERMUX_PKG_DEPENDS="freetype, game-music-emu, libaom, libandroid-glob, libass, libbluray, libbz2, libdav1d, libgnutls, libiconv, liblzma, libmp3lame, libopencore-amr, libopus, librav1e, libsoxr, libsrt, libssh, libtheora, libvo-amrwbenc, libvorbis, libvpx, libvidstab, libwebp, libx264, libx265, libxml2, libzimg, littlecms, ocl-icd, xvidcore, zlib"
 TERMUX_PKG_BUILD_DEPENDS="opencl-headers"
 TERMUX_PKG_CONFLICTS="libav"
 TERMUX_PKG_BREAKS="ffmpeg-dev"
@@ -68,6 +68,7 @@ termux_step_configure() {
 		--enable-cross-compile \
 		--enable-gnutls \
 		--enable-gpl \
+		--enable-version3 \
 		--enable-jni \
 		--enable-lcms2 \
 		--enable-libaom \
@@ -77,6 +78,8 @@ termux_step_configure() {
 		--enable-libfreetype \
 		--enable-libgme \
 		--enable-libmp3lame \
+		--enable-libopencore-amrnb \
+		--enable-libopencore-amrwb \
 		--enable-libopus \
 		--enable-librav1e \
 		--enable-libsoxr \
@@ -84,6 +87,7 @@ termux_step_configure() {
 		--enable-libssh \
 		--enable-libtheora \
 		--enable-libvidstab \
+		--enable-libvo-amrwbenc \
 		--enable-libvorbis \
 		--enable-libvpx \
 		--enable-libwebp \

--- a/packages/libvo-amrwbenc/build.sh
+++ b/packages/libvo-amrwbenc/build.sh
@@ -1,0 +1,8 @@
+TERMUX_PKG_HOMEPAGE=https://sourceforge.net/projects/opencore-amr
+TERMUX_PKG_DESCRIPTION="VisualOn AMR-WB encoder library"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_LICENSE_FILE="COPYING"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=0.1.3
+TERMUX_PKG_SRCURL=https://sourceforge.net/projects/opencore-amr/files/vo-amrwbenc/vo-amrwbenc-${TERMUX_PKG_VERSION}.tar.gz/download
+TERMUX_PKG_SHA256=5652b391e0f0e296417b841b02987d3fd33e6c0af342c69542cbb016a71d9d4e


### PR DESCRIPTION
Close #17586 

ffmpeg will need to upgrade to GPLv3 properly

which previously has been GPLv2 falsely advertised as GPLv3 in the package