### PR TITLE
bump(main/zlib): 1.3

### DIFF
--- a/packages/zlib/build.sh
+++ b/packages/zlib/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.zlib.net/
 TERMUX_PKG_DESCRIPTION="Compression library implementing the deflate compression method found in gzip and PKZIP"
 TERMUX_PKG_LICENSE="ZLIB"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1.2.13
+TERMUX_PKG_VERSION=1.3
 TERMUX_PKG_SRCURL=https://www.zlib.net/zlib-$TERMUX_PKG_VERSION.tar.xz
-TERMUX_PKG_SHA256=d14c38e313afc35a9a8760dadf26042f51ea0f5d154b0630a31da0540107fb98
+TERMUX_PKG_SHA256=8a9ba2898e1d0d774eca6ba5b4627a11e5588ba85c8851336eb38de4683050a7
 TERMUX_PKG_BREAKS="ndk-sysroot (<< 19b-3), zlib-dev"
 TERMUX_PKG_REPLACES="ndk-sysroot (<< 19b-3), zlib-dev"
 


### PR DESCRIPTION
minor version bump due to finally dropping K&R support!
despite this not breaking ABI (i think), i might do some revbumps anyway? just in case things see the new version number and error out on principle