### PR TITLE
Update NextTrace

### DIFF
--- a/root-packages/nexttrace-enhanced/build.sh
+++ b/root-packages/nexttrace-enhanced/build.sh
@@ -1,11 +1,11 @@
-TERMUX_PKG_HOMEPAGE=https://github.com/OwO-Network/nexttrace-enhanced
+TERMUX_PKG_HOMEPAGE=https://github.com/nxtrace/Ntrace-V1
 TERMUX_PKG_DESCRIPTION="An open source visual routing tool that pursues light weight"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.3.2-beta.1"
+TERMUX_PKG_VERSION="1.2.0.1"
 TERMUX_PKG_REVISION=2
-TERMUX_PKG_SRCURL=https://github.com/OwO-Network/nexttrace-enhanced/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=b651a3af52fcd34f149537ea5486f394b30a8bb840d112861048400ee69cf76c
+TERMUX_PKG_SRCURL=https://github.com/nxtrace/Ntrace-V1/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=eaca3cadd415a7b4435db56d8eaec93b9f7f56dfc3867cdf22368f65ad76494e
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 


### PR DESCRIPTION
Hello, I am the developer of NextTrace. First of all, I am very grateful to termux for integrating NextTrace.
But I see that you joined the v0.3.2-beta.1 version of NextTrace-enhanced. Unfortunately, this version uses our old version of the API. The old version of the API will stop running within a year, and v0.3.2-beta.1 will not be available at that time. I hope you can consider upgrading the integrated NextTrace version to our latest v1.2.0.1. Thank you.

NextTrace's announcement on stopping the maintenance of the old version of API：https://github.com/nxtrace/Ntrace-core/issues/159
NextTrace v1.2.0.1：https://github.com/nxtrace/Ntrace-V1/tree/v1.2.0.1