### PR TITLE
repo.json: change where `pkg_format` locates

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1,21 +1,23 @@
 {
-  "pkg_format": "debian",
   "packages": {
     "name": "termux-main",
     "distribution": "stable",
     "component": "main",
-    "url": "https://packages-cf.termux.dev/apt/termux-main"
+    "url": "https://packages-cf.termux.dev/apt/termux-main",
+    "pkg_format": "debian"
   },
   "root-packages": {
     "name": "termux-root",
     "distribution": "root",
     "component": "stable",
-    "url": "https://packages-cf.termux.dev/apt/termux-root"
+    "url": "https://packages-cf.termux.dev/apt/termux-root",
+    "pkg_format": "debian"
   },
   "x11-packages": {
     "name": "termux-x11",
     "distribution": "x11",
     "component": "main",
-    "url": "https://packages-cf.termux.dev/apt/termux-x11"
+    "url": "https://packages-cf.termux.dev/apt/termux-x11",
+    "pkg_format": "debian"
   }
 }


### PR DESCRIPTION
IIUC, the keys in `repo.json` should be the path where repos locates in the script folder, so `pkg_format` should not be a key.

Ref: https://github.com/termux/termux-packages/commit/14492acf7d976b74087dfb570a77475566598b14

CC @Maxython (as the maintainer of `termux-pacman`)
