### PR TITLE
qt5-qtbase: use posix ipc

### DIFF
--- a/x11-packages/qt5-qtbase/build.sh
+++ b/x11-packages/qt5-qtbase/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="A cross-platform application and UI framework"
 TERMUX_PKG_LICENSE="LGPL-3.0"
 TERMUX_PKG_MAINTAINER="Simeon Huang <symeon@librehat.com>"
 TERMUX_PKG_VERSION=5.15.10
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL="https://download.qt.io/official_releases/qt/5.15/${TERMUX_PKG_VERSION}/submodules/qtbase-everywhere-opensource-src-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=c0d06cb18d20f10bf7ad53552099e097ec39362d30a5d6f104724f55fa1c8fb9
-TERMUX_PKG_DEPENDS="dbus, double-conversion, freetype, glib, harfbuzz, krb5, libandroid-execinfo, libandroid-shmem, libandroid-sysv-semaphore, libc++, libice, libicu, libjpeg-turbo, libpng, libsm, libuuid, libx11, libxcb, libxi, libxkbcommon, openssl, pcre2, postgresql, ttf-dejavu, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm, zlib"
+TERMUX_PKG_DEPENDS="dbus, double-conversion, freetype, glib, harfbuzz, krb5, libandroid-execinfo, libandroid-shmem, libandroid-posix-semaphore, libc++, libice, libicu, libjpeg-turbo, libpng, libsm, libuuid, libx11, libxcb, libxi, libxkbcommon, openssl, pcre2, postgresql, ttf-dejavu, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm, zlib"
 # gtk3 dependency is a run-time dependency only for the gtk platformtheme subpackage
 TERMUX_PKG_BUILD_DEPENDS="gtk3"
 TERMUX_PKG_SUGGESTS="qt5-qmake"
@@ -113,7 +113,8 @@ termux_step_configure () {
         -system-libpng \
         -system-libjpeg \
         -system-sqlite \
-        -sql-sqlite
+        -sql-sqlite \
+        -posix-ipc
 
 }
 
@@ -128,7 +129,7 @@ termux_step_post_make_install() {
 
         "${TERMUX_PREFIX}/opt/qt/cross/bin/qmake" \
             -spec "${TERMUX_PKG_SRCDIR}/mkspecs/termux-cross" \
-            DEFINES+="QT_NO_SYSTEMSEMAPHORE"
+            DEFINES+="QT_POSIX_IPC"
 
         make -j "${TERMUX_MAKE_PROCESSES}"
         install -Dm644 ../../../lib/libQt5Bootstrap.a "${TERMUX_PREFIX}/lib/libQt5Bootstrap.a"

--- a/x11-packages/qt5-qtbase/qmake.conf
+++ b/x11-packages/qt5-qtbase/qmake.conf
@@ -23,7 +23,7 @@ QMAKE_STRIP             = @TERMUX_STRIP@
 
 QMAKE_CFLAGS           += @TERMUX_CFLAGS@
 QMAKE_CXXFLAGS         += @TERMUX_CXXFLAGS@
-QMAKE_LFLAGS           += @TERMUX_LDFLAGS@ -landroid-shmem -landroid-sysv-semaphore
+QMAKE_LFLAGS           += @TERMUX_LDFLAGS@ -landroid-shmem -landroid-posix-semaphore
 QMAKE_LFLAGS_SHLIB     += -shared
 QMAKE_LFLAGS_PLUGIN    += -shared
 

--- a/x11-packages/qt5-qtbase/use_posix_ipc.patch
+++ b/x11-packages/qt5-qtbase/use_posix_ipc.patch
@@ -1,0 +1,97 @@
+`shm_open` and `shm_unlink` are implemented as static functions, do not check them
+in configure step.
+--- a/src/corelib/configure.json
++++ b/src/corelib/configure.json
+@@ -463,11 +463,9 @@
+             "test": {
+                 "include": [ "sys/types.h", "sys/mman.h", "semaphore.h", "fcntl.h" ],
+                 "main": [
+-                    "sem_close(sem_open(\"test\", O_CREAT | O_EXCL, 0666, 0));",
+-                    "shm_open(\"test\", O_RDWR | O_CREAT | O_EXCL, 0666);",
+-                    "shm_unlink(\"test\");"
++                    "sem_close(sem_open(\"test\", O_CREAT | O_EXCL, 0666, 0));"
+                 ],
+-                "qmake": "linux: LIBS += -lpthread -lrt"
++                "qmake": "linux: LIBS += -lpthread -lrt -landroid-posix-semaphore"
+             }
+         },
+         "linkat": {
+--- a/src/corelib/kernel/qsharedmemory_p.h
++++ b/src/corelib/kernel/qsharedmemory_p.h
+@@ -72,7 +72,7 @@
+ # include "private/qobject_p.h"
+ #endif
+ 
+-#if !defined(Q_OS_WIN) && !defined(Q_OS_ANDROID) && !defined(Q_OS_INTEGRITY) && !defined(Q_OS_RTEMS)
++#if !defined(Q_OS_WIN) && !defined(Q_OS_ANDROID) && !defined(Q_OS_INTEGRITY) && !defined(Q_OS_RTEMS) && !defined(QT_POSIX_IPC)
+ #  include <sys/sem.h>
+ #endif
+ 
+--- a/src/corelib/kernel/qsharedmemory_posix.cpp
++++ b/src/corelib/kernel/qsharedmemory_posix.cpp
+@@ -59,6 +59,65 @@
+ 
+ #include "private/qcore_unix_p.h"
+ 
++static int shm_unlink(const char *name) {
++    size_t namelen;
++    char *fname;
++
++    /* Construct the filename.  */
++    while (name[0] == '/') ++name;
++
++    if (name[0] == '\0') {
++        /* The name "/" is not supported.  */
++        errno = EINVAL;
++        return -1;
++    }
++
++    namelen = strlen(name);
++    fname = (char *) alloca(sizeof("@TERMUX_PREFIX@/tmp/") - 1 + namelen + 1);
++    memcpy(fname, "@TERMUX_PREFIX@/tmp/", sizeof("@TERMUX_PREFIX@/tmp/") - 1);
++    memcpy(fname + sizeof("@TERMUX_PREFIX@/tmp/") - 1, name, namelen + 1);
++
++    return unlink(fname);
++}
++
++static int shm_open(const char *name, int oflag, mode_t mode) {
++    size_t namelen;
++    char *fname;
++    int fd;
++
++    /* Construct the filename.  */
++    while (name[0] == '/') ++name;
++
++    if (name[0] == '\0') {
++        /* The name "/" is not supported.  */
++        errno = EINVAL;
++        return -1;
++    }
++
++    namelen = strlen(name);
++    fname = (char *) alloca(sizeof("@TERMUX_PREFIX@/tmp/") - 1 + namelen + 1);
++    memcpy(fname, "@TERMUX_PREFIX@/tmp/", sizeof("@TERMUX_PREFIX@/tmp/") - 1);
++    memcpy(fname + sizeof("@TERMUX_PREFIX@/tmp/") - 1, name, namelen + 1);
++
++    fd = open(fname, oflag, mode);
++    if (fd != -1) {
++        /* We got a descriptor.  Now set the FD_CLOEXEC bit.  */
++        int flags = fcntl(fd, F_GETFD, 0);
++        flags |= FD_CLOEXEC;
++        flags = fcntl(fd, F_SETFD, flags);
++
++        if (flags == -1) {
++            /* Something went wrong.  We cannot return the descriptor.  */
++            int save_errno = errno;
++            close(fd);
++            fd = -1;
++            errno = save_errno;
++        }
++    }
++
++    return fd;
++}
++
+ QT_BEGIN_NAMESPACE
+ 
+ int QSharedMemoryPrivate::handle()


### PR DESCRIPTION
SysV semaphore doesn't seem to work since Android 8.0, use POSIX semaphore instead.

Closes #17780 