### PR TITLE
new package: kbd

### DIFF
--- a/packages/kbd/build.sh
+++ b/packages/kbd/build.sh
@@ -1,0 +1,34 @@
+TERMUX_PKG_HOMEPAGE="https://kbd-project.org/"
+TERMUX_PKG_DESCRIPTION="KBD's showkey utility for examining keycodes"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=2.6.4
+TERMUX_PKG_SRCURL=https://mirrors.edge.kernel.org/pub/linux/utils/kbd/kbd-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=99b2a39e1c5475ffe8e1bb2004345cb8849c3cc1aedbe541beee2d45e270975f
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-vlock"
+
+# We're only keeping:
+# bin/showkey
+# share/doc/kbd/LICENSE
+# share/man/man1/showkey.1.gz
+
+TERMUX_PKG_RM_AFTER_INSTALL='
+bin/unicode_stop bin/kbd_mode bin/deallocvt bin/fgconsole bin/getkeycodes
+bin/setvtrgb bin/openvt bin/psfgettable bin/setmetamode bin/setleds
+bin/chvt bin/unicode_start bin/psfstriptable bin/dumpkeys bin/kbdrate
+bin/setfont bin/psfaddtable bin/mapscrn bin/kbdinfo bin/setkeycodes
+bin/showconsolefont bin/loadkeys bin/psfxtable bin/loadunimap
+
+share/man/man5 share/man/man8
+share/man/man1/loadkeys.1 share/man/man1/fgconsole.1
+share/man/man1/setmetamode.1 share/man/man1/psfstriptable.1
+share/man/man1/dumpkeys.1 share/man/man1/unicode_start.1
+share/man/man1/chvt.1 share/man/man1/psfaddtable.1
+share/man/man1/psfxtable.1 share/man/man1/unicode_stop.1
+share/man/man1/openvt.1 share/man/man1/psfgettable.1
+share/man/man1/kbd_mode.1 share/man/man1/deallocvt.1
+share/man/man1/setleds.1 share/man/man1/kbdinfo.1
+
+share/consolefonts share/consoletrans
+share/keymaps share/unimaps
+'

--- a/packages/kbd/resizecons.c.patch
+++ b/packages/kbd/resizecons.c.patch
@@ -1,0 +1,14 @@
+diff --git a/src/resizecons.c b/src/resizecons.c
+index 618ce8b..f613951 100644
+--- a/src/resizecons.c
++++ b/src/resizecons.c
+@@ -78,7 +78,8 @@
+ #include <stdio.h>
+ #include <errno.h>
+ #include <signal.h>
+-#include <sys/io.h>
++#include <sys/syscall.h>
++#define iopl(level) ((int)syscall(SYS_iopl, level))
+ #include <sys/ioctl.h>
+ #include <linux/vt.h>
+ 


### PR DESCRIPTION
I can write a proper package request for `kbd` later if wanted,
for now here's the cliff notes version.

## [`kbd`](https://repology.org/project/kbd/information)
Tools for configuring the console (keyboard, virtual terminals, etc.)
- Packaging todo list:
  > - [x] Builds locally
  > - [x] Builds on GitHub CI/CD
  > - [x] Works on-device (tested on: Android 10, aarch64)

I mainly just ported this for `showkey`,
most of the other commands in this package either aren't applicable or don't work on Termux.
I'll see if the ones related to VTs can be patched to work on Termux,
but I've been up 20 hours and I'm running on sugar and caffeine right now.

