### PR TITLE
python-numpy: bump to 1.26.0

### DIFF
--- a/packages/python-numpy/build.sh
+++ b/packages/python-numpy/build.sh
@@ -2,13 +2,13 @@ TERMUX_PKG_HOMEPAGE=https://numpy.org/
 TERMUX_PKG_DESCRIPTION="The fundamental package for scientific computing with Python"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.25.2"
+TERMUX_PKG_VERSION="1.26.0"
 TERMUX_PKG_SRCURL=git+https://github.com/numpy/numpy
 TERMUX_PKG_DEPENDS="libc++, libopenblas, python"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="latest-release-tag"
-TERMUX_PKG_PYTHON_COMMON_DEPS="wheel, pybind11, Cython, pythran"
+TERMUX_PKG_PYTHON_COMMON_DEPS="'setuptools==59.2.0', 'wheel==0.38.1', 'Cython>=0.29.34,<3.1'"
 TERMUX_PKG_RM_AFTER_INSTALL="
 bin/
 "
@@ -17,7 +17,8 @@ termux_step_post_get_source() {
 	# numpy has switched to use meson-python by default, 
 	# but meson-python hasn't supported cross compiling.
 	# See mesonbuild/meson-python#321
-	rm -f meson.build
+	rm -f meson.build pyproject.toml
+	mv pyproject.toml.setuppy pyproject.toml
 }
 
 termux_step_pre_configure() {

--- a/packages/python-numpy/numpy-distutils-core.py.patch
+++ b/packages/python-numpy/numpy-distutils-core.py.patch
@@ -1,0 +1,21 @@
+When building without meson, `setup.py` generates a weird verion string `1.26.1.26.0`.
+
+Numpy's code has a logical error when doing some code clean-up in commit [1].
+This causes the abnormal version string `1.26.01.26.0`, and then `setuptools`
+normalized this string as `1.26.1.26.0`.
+
+See also:
+[1] https://github.com/numpy/numpy/commit/a880c68752c47a63577e55689275b5fb9d6595a3
+[2] https://github.com/numpy/numpy/pull/24196#discussion_r1291739515
+--- a/numpy/distutils/core.py
++++ b/numpy/distutils/core.py
+@@ -65,7 +65,8 @@
+         elif isinstance(dv, dict):
+             _dict_append(dv, **v)
+         elif is_string(dv):
+-            d[k] = dv + v
++            assert is_string(v)
++            d[k] = v
+         else:
+             raise TypeError(repr(type(dv)))
+ 


### PR DESCRIPTION
- [x] Builds locally (aarch64)
- [x] Builds on GitHub CI/CD
- [x] Works on-device (Tests on aarch64, arm, x86_64 and i686)

Closes #17835 