### PR TITLE
scripts/buildorder.py: improving dependency retrieval

### DIFF
--- a/scripts/build/termux_step_get_dependencies.sh
+++ b/scripts/build/termux_step_get_dependencies.sh
@@ -123,7 +123,7 @@ termux_run_build-package() {
 		fi
 	fi
 	TERMUX_BUILD_IGNORE_LOCK=true ./build-package.sh \
- 		$(test "${TERMUX_INSTALL_DEPS}" = "true" && echo "-I" || true) \
+ 		$(test "${TERMUX_INSTALL_DEPS}" = "true" && echo "-I" || echo "-s") \
  		$(test "${TERMUX_FORCE_BUILD_DEPENDENCIES}" = "true" && echo "-F" || true) \
    		$(test "${TERMUX_WITHOUT_DEPVERSION_BINDING}" = "true" && echo "-w") \
      		--format $TERMUX_PACKAGE_FORMAT --library $set_library "${PKG_DIR}"


### PR DESCRIPTION
This change adds two values ​​to configure how package dependencies are retrieved:
- `TERMUX_PKG_SEPARATE_SUB_DEPENDS` - this value allows to avoid adding dependencies from `*.subpackage.sh`
- `TERMUX_PKG_ONLY_INSTALLING` - if some package requests a package with this value, then this package must be installed and not compiled, otherwise it will be ignored (designed to avoid circular dependencies)

These values ​​will work in a package if this package is requested from another package as a dependency. In other cases they are ignored.