### PR TITLE
fix(main/kubectl): Use make to build kubectl

### DIFF
--- a/packages/kubectl/build.sh
+++ b/packages/kubectl/build.sh
@@ -34,12 +34,12 @@ termux_step_make() {
 	#chmod +w "$TERMUX_PKG_SRCDIR"/_output
 	#rm -rf "$TERMUX_PKG_SRCDIR"/_output
 
-	cd "$TERMUX_PKG_SRCDIR"/cmd/kubectl
-	go build .
+	make -C "$TERMUX_PKG_SRCDIR" \
+		WHAT=cmd/kubectl
 }
 
 termux_step_make_install() {
-	install -Dm700 "$TERMUX_PKG_SRCDIR"/cmd/kubectl/kubectl \
+	install -Dm700 "$TERMUX_PKG_SRCDIR"/_output/bin/kubectl \
 		"$TERMUX_PREFIX"/bin/kubectl
 
 	#mkdir -p "$TERMUX_PREFIX"/share/man/man1


### PR DESCRIPTION
This will fix version command:

```
$ _output/bin/kubectl version --client --short
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default. Client Version: v1.27.3
Kustomize Version: v5.0.1
```