### PR TITLE
Give the github tag fetcher regex filter powers.

### DIFF
--- a/packages/neovim/build.sh
+++ b/packages/neovim/build.sh
@@ -8,7 +8,7 @@ TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/neovim/neovim/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=39d79107c54d2f3babcad2cd157c399241c04f6e75e98c18e8afaf2bb5e82937
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+\.\d+"
+TERMUX_PKG_UPDATE_VERSION_REGEXP="^\d+\.\d+\.\d+$"
 TERMUX_PKG_DEPENDS="libiconv, libuv, luv, libmsgpack, libandroid-support, libvterm (>= 1:0.3-0), libtermkey, libluajit, libunibilium, libtreesitter"
 TERMUX_PKG_HOSTBUILD=true
 
@@ -26,13 +26,9 @@ TERMUX_PKG_CONFFILES="share/nvim/sysinit.vim"
 termux_pkg_auto_update() {
 	# Get the latest release tag:
 	local tag
-	tag="$(termux_github_api_get_tag "${TERMUX_PKG_SRCURL}")"
-	# check if this is not a numbered release:
-	if grep -qP "^${TERMUX_PKG_UPDATE_VERSION_REGEXP}\$" <<<"$tag"; then
-		termux_pkg_upgrade_version "$tag"
-	else
-		echo "WARNING: Skipping auto-update: Not a numbered release($tag)"
-	fi
+	tag="$(termux_github_api_get_tag "${TERMUX_PKG_SRCURL}" \
+		latest-regex "${TERMUX_PKG_UPDATE_VERSION_REGEXP}")"
+	termux_pkg_upgrade_version "$tag"
 }
 
 _patch_luv() {

--- a/scripts/updates/api/termux_github_api_get_tag.sh
+++ b/scripts/updates/api/termux_github_api_get_tag.sh
@@ -2,7 +2,7 @@
 termux_github_api_get_tag() {
 	if [[ -z "$1" ]]; then
 		termux_error_exit <<-EndOfUsage
-			Usage: ${FUNCNAME[0]} PKG_SRCURL [TAG_TYPE]
+			Usage: ${FUNCNAME[0]} PKG_SRCURL [TAG_TYPE [FILTER_REGEX]]
 			Returns the latest tag of the given package.
 		EndOfUsage
 	fi
@@ -14,6 +14,7 @@ termux_github_api_get_tag() {
 
 	local PKG_SRCURL="$1"
 	local TAG_TYPE="${2:-}"
+	local FILTER_REGEX="${3:-}"
 
 	local project
 	project="$(echo "${PKG_SRCURL}" | cut -d'/' -f4-5)"
@@ -27,6 +28,11 @@ termux_github_api_get_tag() {
 			# Get the latest release tag.
 			TAG_TYPE="latest-release-tag"
 		fi
+	fi
+	if [[ -n "${FILTER_REGEX}" && "${TAG_TYPE}" != "latest-regex" ]]; then
+		termux_error_exit <<-EndOfError
+		ERROR: You can only specify a regex with TAG_TYPE="latest-regex"
+		EndOfError
 	fi
 
 	local jq_filter
@@ -71,6 +77,9 @@ termux_github_api_get_tag() {
 	elif [[ "${TAG_TYPE}" == "latest-release-tag" ]]; then
 		api_url="${api_url}/repos/${project}/releases/latest"
 		jq_filter=".tag_name"
+	elif [[ "${TAG_TYPE}" == "latest-regex" ]]; then
+		api_url="${api_url}/repos/${project}/releases"
+		jq_filter=".[].tag_name"
 	else
 		termux_error_exit <<-EndOfError
 			ERROR: Invalid TAG_TYPE: '${TAG_TYPE}'.
@@ -88,17 +97,29 @@ termux_github_api_get_tag() {
 
 	local tag_name
 	if [[ "${http_code}" == "200" ]]; then
-		if jq --exit-status --raw-output "${jq_filter}" <<<"${response}" >/dev/null; then
-			tag_name="$(jq --exit-status --raw-output "${jq_filter}" <<<"${response}")"
+		if [[ "${FILTER_REGEX}" ]]; then
+			if jq --exit-status --raw-output "${jq_filter}" <<<"${response}" >/dev/null; then
+				tag_name="$(jq --exit-status --raw-output "${jq_filter}" <<<"${response}" \
+					| sed 's/^v//' | grep -P "${FILTER_REGEX}" | head -n 1)"
+				if [[ -z "${tag_name}" ]]; then
+					termux_error_exit "ERROR: No tags matched regex '${FILTER_REGEX}' in '${response}'"
+				fi
+			else
+				termux_error_exit "ERROR: Failed to parse tag name from: '${response}'"
+			fi
 		else
-			termux_error_exit "ERROR: Failed to parse tag name from: '${response}'"
+			if jq --exit-status --raw-output "${jq_filter}" <<<"${response}" >/dev/null; then
+				tag_name="$(jq --exit-status --raw-output "${jq_filter}" <<<"${response}")"
+			else
+				termux_error_exit "ERROR: Failed to parse tag name from: '${response}'"
+			fi
 		fi
 	elif [[ "${http_code}" == "404" ]]; then
 		if jq --exit-status "has(\"message\") and .message == \"Not Found\"" <<<"${response}"; then
 			termux_error_exit <<-EndOfError
 				ERROR: No '${TAG_TYPE}' found (${api_url}).
 					Try using '$(
-					if [ ${TAG_TYPE} = "newest-tag" ]; then
+					if [ "${TAG_TYPE}" = "newest-tag" ]; then
 						echo "latest-release-tag"
 					else
 						echo "newest-tag"


### PR DESCRIPTION
At time of commit, we have neovim 0.9.0 and haven't automatically picked
up 0.9.2. This turned out to be because neomvim has some floating tags
(`nightly`) and (`stable`) and `stable` was the latest tag offered by
the api.

Since we already have a regex for the tag, we can give it to the fetcher
and use it as a filter. I updated neovim for this usage and confirmed
that we now detect 0.9.2 as an auto-update with
`scripts/bin/update-packages`.
