### PR TITLE
ttyd: Avoid downloading and building xxd

### DIFF
--- a/packages/ttyd/build.sh
+++ b/packages/ttyd/build.sh
@@ -3,16 +3,9 @@ TERMUX_PKG_DESCRIPTION="Command-line tool for sharing terminal over the web"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.7.4"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/tsl0922/ttyd/archive/$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=300d8cef4b0b32b0ec30d7bf4d3721a5d180e22607f9467a95ab7b6d9652ca9b
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="json-c, libcap, libuv, libwebsockets, openssl, zlib"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DCMAKE_XXD=$TERMUX_PKG_TMPDIR/xxd"
-
-termux_step_pre_configure() {
-	termux_download \
-		https://raw.githubusercontent.com/vim/vim/v8.1.0427/src/xxd/xxd.c \
-		$TERMUX_PKG_CACHEDIR/xxd.c \
-		021b38e02cd31951a80ef5185271d71f2def727eb8ff65b7a07aecfbd688b8e1
-	gcc $TERMUX_PKG_CACHEDIR/xxd.c -o $TERMUX_PKG_TMPDIR/xxd
-}


### PR DESCRIPTION
ttyd does not use xxd during the build since 2020, so this can be removed: https://github.com/tsl0922/ttyd/commit/0e728e61ce28a36072b164a43badc8830e1f0d2e