### PR TITLE
openssh: Keep also the LD_PRELOAD environment variable

### DIFF
--- a/packages/openssh/build.sh
+++ b/packages/openssh/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Secure shell for logging into a remote machine"
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=9.4p1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://fastly.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=3608fd9088db2163ceb3e600c85ab79d0de3d221e59192ea1923e23263866a85
 TERMUX_PKG_DEPENDS="krb5, ldns, libandroid-support, libedit, openssh-sftp-server, openssl, termux-auth, zlib"

--- a/packages/openssh/session.c.patch
+++ b/packages/openssh/session.c.patch
@@ -74,7 +74,7 @@ diff -uNr openssh-9.3p1/session.c openssh-9.3p1.mod/session.c
  
  
 +#ifdef __ANDROID__
-+	char const* envs_to_keep[] = {"ASEC_MOUNTPOINT", "BOOTCLASSPATH", "DEX2OATBOOTCLASSPATH", "EXTERNAL_STORAGE", "LANG", "PATH", "PREFIX", "SYSTEMSERVERCLASSPATH", "TMPDIR"};
++	char const* envs_to_keep[] = {"ASEC_MOUNTPOINT", "BOOTCLASSPATH", "DEX2OATBOOTCLASSPATH", "EXTERNAL_STORAGE", "LANG", "PATH", "PREFIX", "SYSTEMSERVERCLASSPATH", "TMPDIR", "LD_PRELOAD"};
 +	for (i = 0; i < (sizeof(envs_to_keep) / sizeof(envs_to_keep[0])); i++) {
 +		char const* env_to_keep_name = envs_to_keep[i];
 +		char const* env_to_keep_value = getenv(env_to_keep_name);


### PR DESCRIPTION
This makes things work better when ssh:ing in and directly executing some script which can have a shebang (`#!/bin/sh`) that needs `termux-exec`.

It's also necessary for the proposed changed to `termux-exec`, to avoid executing ELF files directly: https://github.com/termux/termux-exec/pull/24