### PR TITLE
libcoinor-{osi-utils}: Bump and fix c++17/ndk26 compatibility

### DIFF
--- a/packages/libcoinor-osi/build.sh
+++ b/packages/libcoinor-osi/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://github.com/coin-or/Osi
 TERMUX_PKG_DESCRIPTION="An abstract base class to a generic linear programming (LP) solver"
 TERMUX_PKG_LICENSE="EPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1:0.108.7
+TERMUX_PKG_VERSION=1:0.108.8
 TERMUX_PKG_SRCURL=https://github.com/coin-or/Osi/archive/refs/tags/releases/${TERMUX_PKG_VERSION#*:}.tar.gz
-TERMUX_PKG_SHA256=f1bc53a498585f508d3f8d74792440a30a83c8bc934d0c8ecf8cd8bc0e486228
+TERMUX_PKG_SHA256=8b01a49190cb260d4ce95aa7e3948a56c0917b106f138ec0a8544fadca71cf6a
 TERMUX_PKG_DEPENDS="libc++, libcoinor-utils"
 
 termux_step_pre_configure() {

--- a/packages/libcoinor-utils/build.sh
+++ b/packages/libcoinor-utils/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://github.com/coin-or/CoinUtils
 TERMUX_PKG_DESCRIPTION="An open-source collection of classes and helper functions for COIN-OR projects"
 TERMUX_PKG_LICENSE="EPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1:2.11.6
+TERMUX_PKG_VERSION=1:2.11.9
 TERMUX_PKG_SRCURL=https://github.com/coin-or/CoinUtils/archive/refs/tags/releases/${TERMUX_PKG_VERSION#*:}.tar.gz
-TERMUX_PKG_SHA256=6ea31d5214f7eb27fa3ffb2bdad7ec96499dd2aaaeb4a7d0abd90ef852fc79ca
+TERMUX_PKG_SHA256=15d572ace4cd3b7c8ce117081b65a2bd5b5a4ebaba54fadc99c7a244160f88b8
 TERMUX_PKG_DEPENDS="libc++"
 
 termux_step_pre_configure() {

--- a/packages/libcoinor-utils/no-register.patch
+++ b/packages/libcoinor-utils/no-register.patch
@@ -1,0 +1,57 @@
+diff -u -r ../orig-src/CoinUtils/src/CoinOslC.h ./CoinUtils/src/CoinOslC.h
+--- ../orig-src/CoinUtils/src/CoinOslC.h	2023-04-24 13:28:57.000000000 +0000
++++ ./CoinUtils/src/CoinOslC.h	2023-10-02 13:05:06.967278569 +0000
+@@ -34,30 +34,30 @@
+ extern "C" {
+ #endif
+ 
+-int c_ekkbtrn(register const EKKfactinfo *fact,
++int c_ekkbtrn(const EKKfactinfo *fact,
+   double *dwork1,
+   int *mpt, int first_nonzero);
+-int c_ekkbtrn_ipivrw(register const EKKfactinfo *fact,
++int c_ekkbtrn_ipivrw(const EKKfactinfo *fact,
+   double *dwork1,
+   int *mpt, int ipivrw, int *spare);
+ 
+-int c_ekketsj(register /*const*/ EKKfactinfo *fact,
++int c_ekketsj(/*const*/ EKKfactinfo *fact,
+   double *dwork1,
+   int *mpt2, double dalpha, int orig_nincol,
+   int npivot, int *nuspikp,
+   const int ipivrw, int *spare);
+-int c_ekkftrn(register const EKKfactinfo *fact,
++int c_ekkftrn(const EKKfactinfo *fact,
+   double *dwork1,
+   double *dpermu, int *mpt, int numberNonZero);
+ 
+-int c_ekkftrn_ft(register EKKfactinfo *fact,
++int c_ekkftrn_ft(EKKfactinfo *fact,
+   double *dwork1, int *mpt, int *nincolp);
+-void c_ekkftrn2(register EKKfactinfo *fact, double *dwork1,
++void c_ekkftrn2(EKKfactinfo *fact, double *dwork1,
+   double *dpermu1, int *mpt1, int *nincolp,
+   double *dwork1_ft, int *mpt_ft, int *nincolp_ft);
+ 
+-int c_ekklfct(register EKKfactinfo *fact);
+-int c_ekkslcf(register const EKKfactinfo *fact);
++int c_ekklfct(EKKfactinfo *fact);
++int c_ekkslcf(const EKKfactinfo *fact);
+ inline void c_ekkscpy(int n, const int *marr1, int *marr2)
+ {
+   CoinMemcpyN(marr1, n, marr2);
+diff -u -r ../orig-src/CoinUtils/src/CoinOslFactorization2.cpp ./CoinUtils/src/CoinOslFactorization2.cpp
+--- ../orig-src/CoinUtils/src/CoinOslFactorization2.cpp	2023-04-24 13:28:57.000000000 +0000
++++ ./CoinUtils/src/CoinOslFactorization2.cpp	2023-10-02 13:03:37.519841028 +0000
+@@ -21,9 +21,9 @@
+ extern int ets_count;
+ extern int ets_check;
+ #endif
+-#define COIN_REGISTER register
++#define COIN_REGISTER
+ #define COIN_REGISTER2
+-#define COIN_REGISTER3 register
++#define COIN_REGISTER3
+ #ifdef COIN_USE_RESTRICT
+ #define COIN_RESTRICT2 __restrict
+ #else


### PR DESCRIPTION
See https://github.com/termux/termux-packages/pull/17863