### PR TITLE
new package: jwm

### DIFF
--- a/x11-packages/jwm/build.sh
+++ b/x11-packages/jwm/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE=http://joewing.net/projects/jwm/
+TERMUX_PKG_DESCRIPTION="Joe's Window Manager is a light-weight X11 window manager"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
+TERMUX_PKG_VERSION=2.4.3
+TERMUX_PKG_SRCURL=https://github.com/joewing/jwm/releases/download/v${TERMUX_PKG_VERSION}/jwm-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=ee3b4ee0c452ef31fcb9303ab50aaf496cf5bdf7b5f1fdc9a1251b7175ca67ab
+TERMUX_PKG_DEPENDS="libcairo,librsvg,pango,libjpeg-turbo,libpng,libxext,libxrender,libxmu,libxinerama,libxpm"
+TERMUX_PKG_BUILD_IN_SRC=true


### PR DESCRIPTION
New package: `jwm` - Joe's Window Manager.

`jwm` is a [widely packaged](https://repology.org/project/jwm/information), lightweight window manager for X11.
All necessary dependencies are already packaged.
The `.deb`'s range between 84 to 100KB.

PR checklist:
- [x] Builds Locally
- [x] Builds on CI/CD

<details><summary>Tested on-device (Android 10, Aarch64)</summary>
<p>

![JWM running on Termux:X11](https://github.com/termux/termux-packages/assets/43716232/9618f380-c754-4291-921b-0d15b4b6ca32)

</p>
</details>

I am uncertain if the listed dependencies are all required at runtime.
The [documentation](http://joewing.net/projects/jwm/#:~:text=can%20use) isn't entirely clear on that point.