### PR TITLE
fix(scripts/Dockerfile): Make build more portable

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
 	useradd -u 1001 -U -m -s /bin/bash builder && \
 	echo "builder ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/builder && \
 	chmod 0440 /etc/sudoers.d/builder && \
+	chmod a+rx /tmp/*.sh /tmp/build/termux_download.sh && \
 	su - builder -c /tmp/setup-ubuntu.sh && \
 	su - builder -c /tmp/setup-android-sdk.sh && \
 	su - builder -c /tmp/setup-cgct.sh && \

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -316,6 +316,7 @@ fi
 $SUDO dpkg --add-architecture i386
 # Add ppa repo to be able to get openjdk-17 on ubuntu 22.04
 $SUDO cp $(dirname "$(realpath "$0")")/openjdk-r-ppa.gpg /etc/apt/trusted.gpg.d/
+$SUDO chmod a+r /etc/apt/trusted.gpg.d/openjdk-r-ppa.gpg
 echo "deb https://ppa.launchpadcontent.net/openjdk-r/ppa/ubuntu/ jammy main" | $SUDO tee /etc/apt/sources.list.d/openjdk-r-ubuntu-ppa-jammy.list > /dev/null
 $SUDO apt-get -yq update
 


### PR DESCRIPTION
This change fixes building the builder docker image also on systems that does not have an existing user with id 1001.