### PR TITLE
fix(main/amber): Break dependency cycle by merging subpackages

### DIFF
--- a/packages/amber/ambr.subpackage.sh
+++ b/packages/amber/ambr.subpackage.sh
@@ -1,2 +1,0 @@
-TERMUX_SUBPKG_DESCRIPTION="amber replace"
-TERMUX_SUBPKG_INCLUDE="bin/ambr"

--- a/packages/amber/ambs.subpackage.sh
+++ b/packages/amber/ambs.subpackage.sh
@@ -1,2 +1,0 @@
-TERMUX_SUBPKG_DESCRIPTION="amber search"
-TERMUX_SUBPKG_INCLUDE="bin/ambs"

--- a/packages/amber/build.sh
+++ b/packages/amber/build.sh
@@ -3,11 +3,12 @@ TERMUX_PKG_DESCRIPTION="A code search / replace tool"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.5.9
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/dalance/amber/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=bf974e997fffa0d54463fc85e44f054563372ca4dade50099fb6ecec0ca8c483
 TERMUX_PKG_BUILD_IN_SRC=true
-# Depend on its subpackages.
-TERMUX_PKG_DEPENDS="ambr,ambs"
+TERMUX_PKG_REPLACES="amr, ambs"
+TERMUX_PKG_BREAKS="amr, ambs"
 TERMUX_PKG_AUTO_UPDATE=true
 
 termux_step_make() {


### PR DESCRIPTION
Currently amber have two subpackages: ambr and ambs

There is a cyclic dependency between these: ambr depends each subpackage, and each subpackage depends on ambr.

This makes scripts/buildorder.py (used by build-all.sh) error out.

And there is also no point in this current package split, as all three packages will always be installed together due to the cyclic dependency. So let's remove the subpackage split.