### PR TITLE
fix(main/kcptun): Break dependency cycle by merging subpackages

### DIFF
--- a/packages/kcptun/build.sh
+++ b/packages/kcptun/build.sh
@@ -5,8 +5,8 @@ TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="20230811"
 TERMUX_PKG_SRCURL=https://github.com/xtaci/kcptun/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=dd88c7ddb85cc74ff22940ba2dc22f65d3b6737153b225d611abb801a0694c4d
-# Depend on its subpackages.
-TERMUX_PKG_DEPENDS="kcptun-client, kcptun-server"
+TERMUX_PKG_REPLACES="kcptun-client, kcptun-server"
+TERMUX_PKG_BREAKS="kcptun-client, kcptun-server"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 

--- a/packages/kcptun/kcptun-client.subpackage.sh
+++ b/packages/kcptun/kcptun-client.subpackage.sh
@@ -1,2 +1,0 @@
-TERMUX_SUBPKG_DESCRIPTION="kcptun client"
-TERMUX_SUBPKG_INCLUDE="bin/kcptun-client"

--- a/packages/kcptun/kcptun-server.subpackage.sh
+++ b/packages/kcptun/kcptun-server.subpackage.sh
@@ -1,2 +1,0 @@
-TERMUX_SUBPKG_DESCRIPTION="kcptun server"
-TERMUX_SUBPKG_INCLUDE="bin/kcptun-server"


### PR DESCRIPTION
Currently kcptun have two subpackages: kcptun-client and kcptun-server

There is a cyclic dependency between these: kcptun depends on each subpackage, and each subpackage depends on kcptun.

This makes scripts/buildorder.py (used by build-all.sh) error out.

And there is also no point in this current package split, as all three packages will always be installed together due to the cyclic dependency. So let's remove the subpackage split.