### PR TITLE
chore(libblocksruntime): Fix package dependency cycle

### DIFF
--- a/packages/libdispatch/build.sh
+++ b/packages/libdispatch/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="The libdispatch project, for concurrency on multicore ha
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@finagolfin"
 TERMUX_PKG_VERSION="1:5.8"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/apple/swift-corelibs-libdispatch/archive/swift-${TERMUX_PKG_VERSION:2}-RELEASE.tar.gz
 TERMUX_PKG_SHA256=391d2bcaea22c4aa980400c3a29b3d9991641aa62253b693c0b79c302eafd5a0
 TERMUX_PKG_DEPENDS="libc++, libblocksruntime"

--- a/packages/libdispatch/libblocksruntime.subpackage.sh
+++ b/packages/libdispatch/libblocksruntime.subpackage.sh
@@ -1,2 +1,3 @@
 TERMUX_SUBPKG_INCLUDE="include/Block.h lib/libBlocksRuntime.so"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 TERMUX_SUBPKG_DESCRIPTION="LLVM Blocks runtime library"


### PR DESCRIPTION
The libblocksruntime has been split out from libdispatch to allow packages to depend only on libblocksruntime and not the whole libdispatch. But for this to work we need

TERMUX_SUBPKG_DEPEND_ON_PARENT=no

Otherwise there is a dependency cycle between libdispatch and libblocksruntime, so they are always installed together