### PR TITLE
chore(libltdl): Fix package dependency cycle

### DIFF
--- a/packages/libtool/build.sh
+++ b/packages/libtool/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Generic library support script hiding the complexity of 
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.4.7
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/libtool/libtool-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=04e96c2404ea70c590c546eba4202a4e12722c640016c12b9b2f1ce3d481e9a8
 TERMUX_PKG_DEPENDS="bash, grep, sed, libltdl"

--- a/packages/libtool/libltdl.subpackage.sh
+++ b/packages/libtool/libltdl.subpackage.sh
@@ -1,2 +1,3 @@
 TERMUX_SUBPKG_INCLUDE="lib/libltdl.so"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 TERMUX_SUBPKG_DESCRIPTION="Library for dlopening libraries"


### PR DESCRIPTION
The libltdl has been split out from libtool to allow packages to depend only on libltdl and not the whole libtool. But for this to work we need

TERMUX_SUBPKG_DEPEND_ON_PARENT=no

Otherwise there is a dependency cycle between libtool and libltdl, so they are always installed together