### PR TITLE
enhance(scripts/Dockerfile): Split out cgct installation

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -29,6 +29,8 @@ jobs:
         cd ./scripts
         docker build --tag termux/package-builder:latest .
         docker tag termux/package-builder:latest ghcr.io/termux/package-builder:latest
+        docker build --tag termux/package-builder-cgct:latest --file Dockerfile.cgct .
+        docker tag termux/package-builder-cgct:latest ghcr.io/termux/package-builder-cgct:latest
     - name: Login to GHCR
       if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'termux/termux-packages'
       uses: docker/login-action@v3
@@ -48,14 +50,16 @@ jobs:
         # ghcr.io seem to be unstable sometimes. It may suddenly drop connection
         # during docker push when some layers are already uploaded. The workaround
         # is to retry again 1 or 2 more times.
-        for t in 1 2 3; do
-          if docker push "ghcr.io/termux/package-builder:latest"; then
-            break
-          else
-            if [ "$t" = "3" ]; then
-              exit 1
+        for image in package-builder package-builder-cgct; do
+          for t in 1 2 3; do
+            if docker push "ghcr.io/termux/${image}:latest"; then
+              break
+            else
+              if [ "$t" = "3" ]; then
+                echo "Giving up after 3 attempts"
+                exit 1
+              fi
+              sleep 20
             fi
-          fi
+          done
         done
-
-        docker push termux/package-builder:latest

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update && \
 	chmod a+rx /tmp/*.sh /tmp/build/termux_download.sh && \
 	su - builder -c /tmp/setup-ubuntu.sh && \
 	su - builder -c /tmp/setup-android-sdk.sh && \
-	su - builder -c /tmp/setup-cgct.sh && \
 	# Removed unused parts to make a smaller Docker image:
 	apt-get remove -yq --autoremove lsb-release software-properties-common && \
 	apt-get clean && \

--- a/scripts/Dockerfile.cgct
+++ b/scripts/Dockerfile.cgct
@@ -1,0 +1,10 @@
+# First, build the base image (see Dockerfile) if necessary
+# - if that is not built locally, the remote image will be pulled.
+# Then, build with:
+#	docker build -t ghcr.io/termux/package-builder-cgct --file Dockerfile.cgct .
+# Push to GitHub registry with:
+#	docker push ghcr.io/termux/package-builder-cgct
+# This is done after changing this file or any of the
+# scripts/setup-{ubuntu,android-sdk,cgct}.sh setup scripts.
+FROM ghcr.io/termux/package-builder
+RUN /tmp/setup-cgct.sh


### PR DESCRIPTION
Avoiding the cgct installation shrinks builder image size with 1.5 GB.

For cgct builds, switch from:

        ghcr.io/termux/package-builder:latest

to:

        ghcr.io/termux/package-builder-cgct:latest