### PR TITLE
bump(main/v2ray): 5.8.0

### DIFF
--- a/packages/v2ray/build.sh
+++ b/packages/v2ray/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://www.v2fly.org/
 TERMUX_PKG_DESCRIPTION="A platform for building proxies to bypass network restrictions"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=5.7.0
+TERMUX_PKG_VERSION=5.8.0
 TERMUX_PKG_SRCURL=git+https://github.com/v2fly/v2ray-core
 TERMUX_PKG_BUILD_IN_SRC=true
 


### PR DESCRIPTION
This also fixes the build, as 5.7.0 cannot be built with go 1.21.