### PR TITLE
ci(actionlint): Setup actionlint for github workflow checks

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,17 @@
+name: Lint workflows
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color -shellcheck "shellcheck --exclude 'SC2086'"


### PR DESCRIPTION
[actionlint](https://github.com/rhysd/actionlint) can be quite nice in catching mistakes in github actions workflow files, especially as it runs [shellcheck](https://www.shellcheck.net/) on the shell scripts in `run` sections.

What do you think?

We need to whitelist the shellcheck [SC2086 - Double quote to prevent globbing and word splitting](https://www.shellcheck.net/wiki/SC2086) diagnostic for now, as we have quite a lot of it.