### PR TITLE
new package: nerdfix

### DIFF
--- a/packages/nerdfix/build.sh
+++ b/packages/nerdfix/build.sh
@@ -1,0 +1,23 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/loichyan/nerdfix
+TERMUX_PKG_DESCRIPTION="nerdfix helps you to find/fix obsolete Nerd Font icons in your project."
+TERMUX_PKG_LICENSE="Apache-2.0, MIT"
+TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
+TERMUX_PKG_VERSION=0.4.0
+TERMUX_PKG_SRCURL=https://github.com/loichyan/nerdfix/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=72e835aeb349495be87e92f74f405b43dac982ec137cfd7e180e72146b6f6fb7
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+	# do not pin the version of the rust toolchain
+	rm -f rust-toolchain
+	termux_setup_rust
+}
+
+termux_step_make() {
+	cargo build --jobs $TERMUX_MAKE_PROCESSES --target $CARGO_TARGET_NAME --release
+}
+
+termux_step_make_install() {
+	install -Dm755 -t $TERMUX_PREFIX/bin target/${CARGO_TARGET_NAME}/release/nerdfix
+}
+

--- a/packages/starship/build.sh
+++ b/packages/starship/build.sh
@@ -3,12 +3,14 @@ TERMUX_PKG_DESCRIPTION="A minimal, blazing fast, and extremely customizable prom
 TERMUX_PKG_LICENSE="ISC"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.16.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/starship/starship/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=133888e190ce1563927e16ee693da3026d2e668d975ac373f853e030743775c5
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_DEPENDS="zlib"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--all-features"
+TERMUX_PKG_SUGGESTS="nerdfix"
 
 termux_step_pre_configure() {
 	termux_setup_rust


### PR DESCRIPTION
Adds the [`nerdfix`](https://github.com/loichyan/nerdfix) utility for replacing obsolete NerdFont glyphs.

It would probably be prudent to package an interactive utility for replacing obsolete NerdFont 2.3.x glyphs, considering termux/termux-styling just updated the fonts to NerdFonts 3.0.2
- termux/termux-styling#212

`nerdfix` is [already packaged](https://repology.org/project/nerdfix/versions) on the AUR, Homebrew and Nixpkgs.

I have chosen to package the latest commit [`76bf959`](https://github.com/loichyan/nerdfix/commits/main) as of today,
as there are several improvements over the 0.3.1 release from May.

I think it would be better to put this package in the main repo rather than the TUR
as it makes sense to set it as a `TERMUX_PKG_SUGGESTS`
for packages often used in conjunction with NerdFonts, such as `starship`.
(If I missed other such packages please suggest them.)

---

#### PR checklist
- [x] Builds locally (all architectures
- [x] Builds on CI/CD
- [x] Add as a `TERMUX_PKG_SUGGESTS` to relavant packages
  - [x] `starship`
- [x] Tested on-device (Android 10, Aarch64)
