### PR TITLE
libmad: enable SOVERSION suffix

### DIFF
--- a/packages/libmad/build.sh
+++ b/packages/libmad/build.sh
@@ -3,31 +3,19 @@ TERMUX_PKG_DESCRIPTION="MAD is a high-quality MPEG audio decoder"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.16.4"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://codeberg.org/tenacityteam/libmad/archive/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=f4eb229452252600ce48f3c2704c9e6d97b789f81e31c37b0c67dd66f445ea35
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BREAKS="libmad-dev"
 TERMUX_PKG_REPLACES="libmad-dev"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+"
 
-termux_post_configure() {
-	cd $TERMUX_PKG_SRCDIR
-	sed -i -e 's/-force-mem//g' Makefile
-}
-
-termux_step_post_make_install() {
-	local _pkgconfig_dir=$TERMUX_PREFIX/lib/pkgconfig
-	mkdir -p ${_pkgconfig_dir}
-	cat > ${_pkgconfig_dir}/mad.pc <<-EOF
-		prefix=$TERMUX_PREFIX
-		exec_prefix=\${prefix}
-		libdir=$TERMUX_PREFIX/lib
-		includedir=\${prefix}/include
-
-		Name: mad
-		Description: MPEG Audio Decoder
-		Requires:
-		Version: $TERMUX_PKG_VERSION
-		Libs: -L\${libdir} -lmad
-		Cflags: -I\${includedir}
-	EOF
+termux_step_post_massage() {
+	local _GUARD_FILE="lib/libmad.so.0"
+	if [ ! -e "${_GUARD_FILE}" ]; then
+		termux_error_exit "Error: file ${_GUARD_FILE} not found."
+	fi
 }


### PR DESCRIPTION
`libmad` switch the building system to cmake since 0.16.0, the SOVERSION suffix is disabled at the same time. Enable this SOVERSION again to avoid revbump revdeps.

Closes #18227
