### PR TITLE
termux_step_massage: enhance symbol checking 

### DIFF
--- a/scripts/build/termux_step_setup_variables.sh
+++ b/scripts/build/termux_step_setup_variables.sh
@@ -146,6 +146,7 @@ termux_step_setup_variables() {
 	TERMUX_PKG_EXTRA_CONFIGURE_ARGS=""
 	TERMUX_PKG_EXTRA_HOSTBUILD_CONFIGURE_ARGS=""
 	TERMUX_PKG_EXTRA_MAKE_ARGS=""
+	TERMUX_PKG_EXTRA_UNDEF_SYMBOLS_TO_CHECK="" # space-separated undefined symbols to check in termux_step_massaging
 	TERMUX_PKG_FORCE_CMAKE=false # if the package has autotools as well as cmake, then set this to prefer cmake
 	TERMUX_PKG_GIT_BRANCH="" # branch defaults to 'v$TERMUX_PKG_VERSION' unless this variable is defined
 	TERMUX_PKG_GO_USE_OLDER=false # set to true to use the older supported release of Go.
@@ -174,6 +175,7 @@ termux_step_setup_variables() {
 	TERMUX_PKG_SRCDIR=$TERMUX_TOPDIR/$TERMUX_PKG_NAME/src
 	TERMUX_PKG_SUGGESTS=""
 	TERMUX_PKG_TMPDIR=$TERMUX_TOPDIR/$TERMUX_PKG_NAME/tmp
+	TERMUX_PKG_UNDEF_SYMBOLS_FILES="" # maintainer acknowledges these files have undefined symbols will not result in broken packages, eg: all, *.elf, ./path/to/file. "error" to always print results as errors
 	TERMUX_PKG_SERVICE_SCRIPT=() # Fill with entries like: ("daemon name" 'script to execute'). Script is echoed with -e so can contain \n for multiple lines
 	TERMUX_PKG_GROUPS="" # https://wiki.archlinux.org/title/Pacman#Installing_package_groups
 	TERMUX_PKG_ON_DEVICE_BUILD_NOT_SUPPORTED=false # if the package does not support compilation on a device, then this package should not be compiled on devices

--- a/scripts/libc.map.txt
+++ b/scripts/libc.map.txt
@@ -1,0 +1,1823 @@
+LIBC {
+  global:
+    __assert;
+    __assert2;
+    __atomic_cmpxchg; # arm
+    __atomic_dec; # arm
+    __atomic_inc; # arm
+    __atomic_swap; # arm
+    __b64_ntop;
+    __b64_pton;
+    __cmsg_nxthdr; # introduced=21
+    __connect; # arm x86 introduced=21
+    __ctype_get_mb_cur_max; # introduced=21
+    __cxa_atexit;
+    __cxa_finalize;
+    __cxa_thread_atexit_impl; # introduced=23
+    __dn_comp;
+    __dn_count_labels;
+    __dn_skipname;
+    __epoll_pwait; # arm x86 introduced=21
+    __errno;
+    __exit; # arm x86 introduced=21
+    __fadvise64; # x86 introduced=21
+    __fbufsize; # introduced=23
+    __fcntl64; # arm x86
+    __FD_CLR_chk; # introduced=21
+    __FD_ISSET_chk; # introduced=21
+    __FD_SET_chk; # introduced=21
+    __fgets_chk; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    __flbf; # introduced=23
+    __fp_nquery;
+    __fp_query;
+    __fpclassify; # introduced=21
+    __fpclassifyd;
+    __fpclassifyf;
+    __fpclassifyl;
+    __fpending; # introduced=23
+    __fpurge; # introduced=23
+    __freadable; # introduced=23
+    __fsetlocking; # introduced=23
+    __fstatfs64; # arm x86
+    __fwritable; # introduced=23
+    __get_h_errno;
+    __getcpu; # arm x86 introduced-arm=12 introduced-x86=12
+    __getcwd; # arm x86
+    __getpid; # arm x86 introduced=21
+    __getpriority; # arm x86
+    __gnu_basename; # introduced=23
+    __gnu_strerror_r; # introduced=23
+    __hostalias;
+    __ioctl; # arm x86
+    __isfinite;
+    __isfinitef;
+    __isfinitel;
+    __isinf;
+    __isinff;
+    __isinfl;
+    __isnan; # introduced=21
+    __isnanf; # introduced=21
+    __isnanl;
+    __isnormal;
+    __isnormalf;
+    __isnormall;
+    __isthreaded; # arm x86 var
+    __libc_current_sigrtmax; # introduced=21
+    __libc_current_sigrtmin; # introduced=21
+    __libc_init;
+    __llseek; # arm x86
+    __loc_aton;
+    __loc_ntoa;
+    __memchr_chk; # introduced=23
+    __memcpy_chk; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    __memmove_chk; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    __memrchr_chk; # introduced=23
+    __memset_chk; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    __mmap2; # arm x86
+    __ns_format_ttl; # arm x86 introduced=22
+    __ns_get16; # arm x86 introduced=22
+    __ns_get32; # arm x86 introduced=22
+    __ns_initparse; # arm x86 introduced=22
+    __ns_makecanon; # arm x86 introduced=22
+    __ns_msg_getflag; # arm x86 introduced=22
+    __ns_name_compress; # arm x86 introduced=22
+    __ns_name_ntol; # arm x86 introduced=22
+    __ns_name_ntop; # arm x86 introduced=22
+    __ns_name_pack; # arm x86 introduced=22
+    __ns_name_pton; # arm x86 introduced=22
+    __ns_name_rollback; # arm x86 introduced=22
+    __ns_name_skip; # arm x86 introduced=22
+    __ns_name_uncompress; # arm x86 introduced=22
+    __ns_name_unpack; # arm x86 introduced=22
+    __ns_parserr; # arm x86 introduced=22
+    __ns_put16; # arm x86 introduced=22
+    __ns_put32; # arm x86 introduced=22
+    __ns_samename; # arm x86 introduced=22
+    __ns_skiprr; # arm x86 introduced=22
+    __ns_sprintrr; # arm x86 introduced=22
+    __ns_sprintrrf; # arm x86 introduced=22
+    __open_2; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    __openat; # arm x86
+    __openat_2; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    __p_cdname;
+    __p_cdnname;
+    __p_class;
+    __p_class_syms; # var
+    __p_fqname;
+    __p_fqnname;
+    __p_option;
+    __p_query;
+    __p_rcode;
+    __p_secstodate;
+    __p_time;
+    __p_type;
+    __p_type_syms; # var
+    __poll_chk; # introduced=23
+    __ppoll; # arm x86 introduced=21
+    __ppoll_chk; # introduced=23
+    __ppoll64_chk; # introduced=28
+    __pread64_chk; # introduced=23
+    __pread_chk; # introduced=23
+    __progname; # var
+    __pselect6; # arm x86 introduced=21
+    __pthread_cleanup_pop;
+    __pthread_cleanup_push;
+    __ptrace; # arm x86
+    __putlong;
+    __putshort;
+    __read_chk; # introduced=21
+    __readlink_chk; # introduced=23
+    __readlinkat_chk; # introduced=23
+    __reboot; # arm x86
+    __recvfrom_chk; # introduced=21
+    __register_atfork; # introduced=23
+    __res_close;
+    __res_dnok;
+    __res_hnok;
+    __res_hostalias;
+    __res_isourserver;
+    __res_mailok;
+    __res_nameinquery;
+    __res_nclose;
+    __res_ninit;
+    __res_nmkquery;
+    __res_nquery;
+    __res_nquerydomain;
+    __res_nsearch;
+    __res_nsend;
+    __res_ownok;
+    __res_queriesmatch;
+    __res_querydomain;
+    __res_send;
+    __res_send_setqhook;
+    __res_send_setrhook;
+    __rt_sigaction; # arm x86
+    __rt_sigpending; # arm x86 introduced=21
+    __rt_sigprocmask; # arm x86
+    __rt_sigsuspend; # arm x86 introduced=21
+    __rt_sigtimedwait; # arm x86
+    __sched_cpualloc; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    __sched_cpucount; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    __sched_cpufree; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    __sched_getaffinity; # arm x86 introduced=12
+    __set_thread_area; # x86
+    __set_tid_address; # arm x86 introduced=21
+    __set_tls; # arm
+    __sF; # var
+    __sigaction; # arm x86 introduced=21
+    __snprintf_chk; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    __socket; # arm x86 introduced=21
+    __sprintf_chk; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    __stack_chk_fail;
+    __stack_chk_guard; # var
+    __statfs64; # arm x86
+    __stpcpy_chk; # introduced=21
+    __stpncpy_chk; # introduced=21
+    __stpncpy_chk2; # introduced=21
+    __strcat_chk; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    __strchr_chk; # introduced-arm=18 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    __strcpy_chk; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    __strlcat_chk; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    __strlcpy_chk; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    __strlen_chk; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    __strncat_chk; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    __strncpy_chk; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    __strncpy_chk2; # introduced=21
+    __strrchr_chk; # introduced-arm=18 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    __sym_ntop;
+    __sym_ntos;
+    __sym_ston;
+    __system_property_area_serial; # introduced=23
+    __system_property_find;
+    __system_property_find_nth;
+    __system_property_foreach; # introduced-arm=19 introduced-arm64=21 introduced-x86=19 introduced-x86_64=21
+    __system_property_get;
+    __system_property_read;
+    __system_property_serial; # introduced-arm=19 introduced-arm64=21 introduced-x86=19 introduced-x86_64=21
+    __system_property_set; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    __timer_create; # arm x86
+    __timer_delete; # arm x86
+    __timer_getoverrun; # arm x86
+    __timer_gettime; # arm x86
+    __timer_settime; # arm x86
+    __umask_chk; # introduced-arm=18 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    __vsnprintf_chk; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    __vsprintf_chk; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    __waitid; # arm x86
+    _ctype_; # var
+    _Exit; # introduced=21
+    _exit;
+    _flushlbf; # introduced=23
+    _getlong;
+    _getshort;
+    _longjmp;
+    _resolv_delete_cache_for_net; # introduced=21
+    _resolv_flush_cache_for_net; # introduced=21
+    _resolv_set_nameservers_for_net; # introduced=21
+    _setjmp;
+    _tolower; # introduced=21
+    _tolower_tab_; # arm x86 var
+    _toupper; # introduced=21
+    _toupper_tab_; # arm x86 var
+    abort;
+    abs; # introduced-arm=19 introduced-arm64=21 introduced-x86=19 introduced-x86_64=21
+    accept;
+    accept4; # introduced=21
+    access;
+    acct;
+    alarm;
+    alphasort;
+    alphasort64; # introduced=21
+    android_set_abort_message; # introduced=21
+    arc4random;
+    arc4random_buf;
+    arc4random_uniform;
+    asctime;
+    asctime64; # arm x86
+    asctime64_r; # arm x86
+    asctime_r;
+    asprintf;
+    at_quick_exit; # introduced=21
+    atof; # introduced=21
+    atoi;
+    atol;
+    atoll;
+    basename;
+    basename_r; # arm x86
+    bind;
+    bindresvport;
+    brk;
+    bsearch;
+    btowc;
+    c16rtomb; # introduced=21
+    c32rtomb; # introduced=21
+    cacheflush; # arm
+    calloc;
+    capget;
+    capset;
+    cfgetispeed; # introduced=21
+    cfgetospeed; # introduced=21
+    cfmakeraw; # introduced=21
+    cfsetispeed; # introduced=21
+    cfsetospeed; # introduced=21
+    cfsetspeed; # introduced=21
+    chdir;
+    chmod;
+    chown;
+    chroot;
+    clearenv;
+    clearerr;
+    clearerr_unlocked; # introduced=23
+    clock;
+    clock_getcpuclockid; # introduced=23
+    clock_getres;
+    clock_gettime;
+    clock_nanosleep;
+    clock_settime;
+    clone; # introduced-arm=9 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    close;
+    closedir;
+    closelog;
+    connect;
+    creat;
+    creat64; # introduced=21
+    ctime;
+    ctime64; # arm x86
+    ctime64_r; # arm x86
+    ctime_r;
+    daemon;
+    daylight; # var
+    delete_module;
+    difftime;
+    dirfd;
+    dirname;
+    dirname_r; # arm x86
+    div;
+    dn_expand;
+    dprintf; # introduced=21
+    drand48;
+    dup;
+    dup2;
+    dup3; # introduced=21
+    duplocale; # introduced=21
+    endmntent; # introduced=21
+    endservent;
+    endutent;
+    environ; # var
+    epoll_create;
+    epoll_create1; # introduced=21
+    epoll_ctl;
+    epoll_pwait; # introduced=21
+    epoll_wait;
+    erand48;
+    err;
+    error; # introduced=23
+    error_at_line; # introduced=23
+    error_message_count; # var introduced=23
+    error_one_per_line; # var introduced=23
+    error_print_progname; # var introduced=23
+    errx;
+    ether_aton; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    ether_aton_r; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    ether_ntoa; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    ether_ntoa_r; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    eventfd;
+    eventfd_read;
+    eventfd_write;
+    execl;
+    execle;
+    execlp;
+    execv;
+    execve;
+    execvp;
+    execvpe; # introduced=21
+    exit;
+    faccessat;
+    fallocate; # introduced=21
+    fallocate64; # introduced=21
+    fchdir;
+    fchmod;
+    fchmodat;
+    fchown;
+    fchownat;
+    fclose;
+    fcntl;
+    fdatasync;
+    fdopen;
+    fdopendir;
+    fdprintf; # arm x86 versioned=28
+    feof;
+    feof_unlocked; # introduced=23
+    ferror;
+    ferror_unlocked; # introduced=23
+    fflush;
+    ffs; # introduced-arm=9 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    fgetc;
+    fgetln;
+    fgetpos;
+    fgets;
+    fgetwc;
+    fgetws;
+    fgetxattr;
+    fileno;
+    flistxattr;
+    flock;
+    flockfile;
+    fmemopen; # introduced=23
+    fnmatch;
+    fopen;
+    fork;
+    forkpty; # introduced=23
+    fpathconf;
+    fprintf;
+    fpurge;
+    fputc;
+    fputs;
+    fputwc;
+    fputws;
+    fread;
+    free;
+    freeaddrinfo;
+    freelocale; # introduced=21
+    fremovexattr;
+    freopen;
+    fscanf;
+    fseek;
+    fseeko;
+    fsetpos;
+    fsetxattr;
+    fstat;
+    fstat64; # introduced=21
+    fstatat;
+    fstatat64; # introduced=21
+    fstatfs;
+    fstatfs64; # introduced=21
+    fstatvfs; # introduced-arm=19 introduced-arm64=21 introduced-x86=19 introduced-x86_64=21
+    fstatvfs64; # introduced=21
+    fsync;
+    ftell;
+    ftello;
+    ftok;
+    ftruncate;
+    ftruncate64; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    ftrylockfile;
+    fts_children; # introduced=21
+    fts_close; # introduced=21
+    fts_open; # introduced=21
+    fts_read; # introduced=21
+    fts_set; # introduced=21
+    ftw; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    ftw64; # introduced=21
+    funlockfile;
+    funopen;
+    futimens; # introduced-arm=19 introduced-arm64=21 introduced-x86=19 introduced-x86_64=21
+    fwide;
+    fwprintf;
+    fwrite;
+    fwscanf;
+    gai_strerror;
+    get_avphys_pages; # introduced=23
+    get_nprocs; # introduced=23
+    get_nprocs_conf; # introduced=23
+    get_phys_pages; # introduced=23
+    getaddrinfo;
+    getauxval; # introduced-arm=18 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    getc;
+    getc_unlocked;
+    getchar;
+    getchar_unlocked;
+    getcwd;
+    getdelim; # introduced-arm=18 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    getegid;
+    getenv;
+    geteuid;
+    getgid;
+    getgrgid;
+    getgrnam;
+    getgrouplist;
+    getgroups;
+    gethostbyaddr;
+    gethostbyaddr_r; # introduced=23
+    gethostbyname;
+    gethostbyname2;
+    gethostbyname2_r; # introduced=23
+    gethostbyname_r;
+    gethostent;
+    gethostname;
+    getitimer;
+    getline; # introduced-arm=18 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    getlogin;
+    getmntent;
+    getmntent_r; # introduced=21
+    getnameinfo;
+    getnetbyaddr;
+    getnetbyname;
+    getopt;
+    getopt_long;
+    getopt_long_only;
+    getpagesize; # introduced=21
+    getpeername;
+    getpgid;
+    getpgrp;
+    getpid;
+    getppid;
+    getpriority;
+    getprogname; # introduced=21
+    getprotobyname;
+    getprotobynumber;
+    getpt;
+    getpwnam;
+    getpwnam_r; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    getpwuid;
+    getpwuid_r; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    getresgid;
+    getresuid;
+    getrlimit;
+    getrlimit64; # introduced=21
+    getrusage;
+    gets;
+    getservbyname;
+    getservbyport;
+    getservent;
+    getsid; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    getsockname;
+    getsockopt;
+    gettid;
+    gettimeofday;
+    getuid;
+    getutent;
+    getwc;
+    getwchar;
+    getxattr;
+    gmtime;
+    gmtime64; # arm x86
+    gmtime64_r; # arm x86
+    gmtime_r;
+    grantpt; # introduced=21
+    herror;
+    hstrerror;
+    htonl; # introduced=21
+    htons; # introduced=21
+    if_indextoname;
+    if_nametoindex;
+    imaxabs; # introduced-arm=19 introduced-arm64=21 introduced-x86=19 introduced-x86_64=21
+    imaxdiv; # introduced-arm=19 introduced-arm64=21 introduced-x86=19 introduced-x86_64=21
+    inet_addr;
+    inet_aton;
+    inet_lnaof; # introduced=21
+    inet_makeaddr; # introduced=21
+    inet_netof; # introduced=21
+    inet_network; # introduced=21
+    inet_nsap_addr;
+    inet_nsap_ntoa;
+    inet_ntoa;
+    inet_ntop;
+    inet_pton;
+    init_module;
+    initgroups;
+    initstate; # introduced=21
+    inotify_add_watch;
+    inotify_init;
+    inotify_init1; # introduced=21
+    inotify_rm_watch;
+    insque; # introduced=21
+    ioctl;
+    isalnum;
+    isalnum_l; # introduced=21
+    isalpha;
+    isalpha_l; # introduced=21
+    isascii;
+    isatty;
+    isblank;
+    isblank_l; # introduced=21
+    iscntrl;
+    iscntrl_l; # introduced=21
+    isdigit;
+    isdigit_l; # introduced=21
+    isfinite; # introduced=21
+    isfinitef; # introduced=21
+    isfinitel; # introduced=21
+    isgraph;
+    isgraph_l; # introduced=21
+    isinf; # introduced=21
+    isinff; # introduced=21
+    isinfl; # introduced=21
+    islower;
+    islower_l; # introduced=21
+    isnan;
+    isnanf;
+    isnanl; # introduced=21
+    isnormal; # introduced=21
+    isnormalf; # introduced=21
+    isnormall; # introduced=21
+    isprint;
+    isprint_l; # introduced=21
+    ispunct;
+    ispunct_l; # introduced=21
+    isspace;
+    isspace_l; # introduced=21
+    isupper;
+    isupper_l; # introduced=21
+    iswalnum;
+    iswalnum_l; # introduced=21
+    iswalpha;
+    iswalpha_l; # introduced=21
+    iswblank; # introduced=21
+    iswblank_l; # introduced=21
+    iswcntrl;
+    iswcntrl_l; # introduced=21
+    iswctype;
+    iswctype_l; # introduced=21
+    iswdigit;
+    iswdigit_l; # introduced=21
+    iswgraph;
+    iswgraph_l; # introduced=21
+    iswlower;
+    iswlower_l; # introduced=21
+    iswprint;
+    iswprint_l; # introduced=21
+    iswpunct;
+    iswpunct_l; # introduced=21
+    iswspace;
+    iswspace_l; # introduced=21
+    iswupper;
+    iswupper_l; # introduced=21
+    iswxdigit;
+    iswxdigit_l; # introduced=21
+    isxdigit;
+    isxdigit_l; # introduced=21
+    jrand48;
+    kill;
+    killpg;
+    klogctl;
+    labs; # introduced-arm=19 introduced-arm64=21 introduced-x86=19 introduced-x86_64=21
+    lchown;
+    lcong48; # introduced=23
+    ldexp;
+    ldiv;
+    lfind; # introduced=21
+    lgetxattr;
+    link;
+    linkat; # introduced=21
+    listen;
+    listxattr;
+    llabs; # introduced-arm=19 introduced-arm64=21 introduced-x86=19 introduced-x86_64=21
+    lldiv;
+    llistxattr;
+    localeconv; # introduced=21
+    localtime;
+    localtime64; # arm x86
+    localtime64_r; # arm x86
+    localtime_r;
+    login_tty; # introduced=23
+    longjmp;
+    lrand48;
+    lremovexattr;
+    lsearch; # introduced=21
+    lseek;
+    lseek64;
+    lsetxattr;
+    lstat;
+    lstat64; # introduced=21
+    madvise;
+    mallinfo;
+    malloc;
+    malloc_info; # introduced=23
+    malloc_usable_size; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    mbrlen;
+    mbrtoc16; # introduced=21
+    mbrtoc32; # introduced=21
+    mbrtowc;
+    mbsinit;
+    mbsnrtowcs; # introduced=21
+    mbsrtowcs;
+    mbstowcs; # introduced=21
+    mbtowc; # introduced=21
+    memalign;
+    memccpy;
+    memchr;
+    memcmp;
+    memcpy;
+    memmem;
+    memmove;
+    mempcpy; # introduced=23
+    memrchr;
+    memset;
+    mincore;
+    mkdir;
+    mkdirat;
+    mkdtemp;
+    mkfifo; # introduced=21
+    mkfifoat; # introduced=23
+    mknod;
+    mknodat; # introduced=21
+    mkostemp; # introduced=23
+    mkostemp64; # introduced=23
+    mkostemps; # introduced=23
+    mkostemps64; # introduced=23
+    mkstemp;
+    mkstemp64; # introduced=21
+    mkstemps;
+    mkstemps64; # introduced=23
+    mktemp;
+    mktime;
+    mktime64; # arm x86
+    mlock;
+    mlockall; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    mmap;
+    mmap64; # introduced=21
+    mount;
+    mprotect;
+    mrand48;
+    mremap;
+    msync;
+    munlock;
+    munlockall; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    munmap;
+    nanosleep;
+    newlocale; # introduced=21
+    nftw; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    nftw64; # introduced=21
+    nice;
+    nrand48;
+    ns_format_ttl; # arm64 x86_64 riscv64 introduced=22
+    ns_get16; # arm64 x86_64 riscv64 introduced=22
+    ns_get32; # arm64 x86_64 riscv64 introduced=22
+    ns_initparse; # arm64 x86_64 riscv64 introduced=22
+    ns_makecanon; # arm64 x86_64 riscv64 introduced=22
+    ns_msg_getflag; # arm64 x86_64 riscv64 introduced=22
+    ns_name_compress; # arm64 x86_64 riscv64 introduced=22
+    ns_name_ntol; # arm64 x86_64 riscv64 introduced=22
+    ns_name_ntop; # arm64 x86_64 riscv64 introduced=22
+    ns_name_pack; # arm64 x86_64 riscv64 introduced=22
+    ns_name_pton; # arm64 x86_64 riscv64 introduced=22
+    ns_name_rollback; # arm64 x86_64 riscv64 introduced=22
+    ns_name_skip; # arm64 x86_64 riscv64 introduced=22
+    ns_name_uncompress; # arm64 x86_64 riscv64 introduced=22
+    ns_name_unpack; # arm64 x86_64 riscv64 introduced=22
+    ns_parserr; # arm64 x86_64 riscv64 introduced=22
+    ns_put16; # arm64 x86_64 riscv64 introduced=22
+    ns_put32; # arm64 x86_64 riscv64 introduced=22
+    ns_samename; # arm64 x86_64 riscv64 introduced=22
+    ns_skiprr; # arm64 x86_64 riscv64 introduced=22
+    ns_sprintrr; # arm64 x86_64 riscv64 introduced=22
+    ns_sprintrrf; # arm64 x86_64 riscv64 introduced=22
+    nsdispatch;
+    ntohl; # introduced=21
+    ntohs; # introduced=21
+    open;
+    open64; # introduced=21
+    open_memstream; # introduced=23
+    open_wmemstream; # introduced=23
+    openat;
+    openat64; # introduced=21
+    opendir;
+    openlog;
+    openpty; # introduced=23
+    optarg; # var
+    opterr; # var
+    optind; # var
+    optopt; # var
+    optreset; # var
+    pathconf;
+    pause;
+    pclose;
+    perror;
+    personality;
+    pipe;
+    pipe2;
+    poll;
+    popen;
+    posix_fadvise; # introduced=21
+    posix_fadvise64; # introduced=21
+    posix_fallocate; # introduced=21
+    posix_fallocate64; # introduced=21
+    posix_madvise; # introduced=23
+    posix_memalign; # introduced=17
+    posix_openpt; # introduced=21
+    ppoll; # introduced=21
+    prctl;
+    pread;
+    pread64; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    printf;
+    prlimit; # arm64 x86_64 riscv64
+    prlimit64; # introduced=21
+    process_vm_readv; # introduced=23
+    process_vm_writev; # introduced=23
+    pselect;
+    psiginfo; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    psignal; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    pthread_atfork; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    pthread_attr_destroy;
+    pthread_attr_getdetachstate;
+    pthread_attr_getguardsize;
+    pthread_attr_getschedparam;
+    pthread_attr_getschedpolicy;
+    pthread_attr_getscope;
+    pthread_attr_getstack;
+    pthread_attr_getstacksize;
+    pthread_attr_init;
+    pthread_attr_setdetachstate;
+    pthread_attr_setguardsize;
+    pthread_attr_setschedparam;
+    pthread_attr_setschedpolicy;
+    pthread_attr_setscope;
+    pthread_attr_setstack;
+    pthread_attr_setstacksize;
+    pthread_cond_broadcast;
+    pthread_cond_destroy;
+    pthread_cond_init;
+    pthread_cond_signal;
+    pthread_cond_timedwait;
+    pthread_cond_timedwait_monotonic; # arm x86
+    pthread_cond_timedwait_monotonic_np; # introduced-arm=9 introduced-x86=9 introduced-arm64=28 introduced-x64_64=28
+    pthread_cond_timedwait_relative_np; # arm x86
+    pthread_cond_timeout_np; # arm x86
+    pthread_cond_wait;
+    pthread_condattr_destroy;
+    pthread_condattr_getclock; # introduced=21
+    pthread_condattr_getpshared;
+    pthread_condattr_init;
+    pthread_condattr_setclock; # introduced=21
+    pthread_condattr_setpshared;
+    pthread_create;
+    pthread_detach;
+    pthread_equal;
+    pthread_exit;
+    pthread_getattr_np;
+    pthread_getcpuclockid;
+    pthread_getschedparam;
+    pthread_getspecific;
+    pthread_gettid_np; # introduced=21
+    pthread_join;
+    pthread_key_create;
+    pthread_key_delete;
+    pthread_kill;
+    pthread_mutex_destroy;
+    pthread_mutex_init;
+    pthread_mutex_lock;
+    pthread_mutex_lock_timeout_np; # arm x86
+    pthread_mutex_timedlock; # introduced=21
+    pthread_mutex_trylock;
+    pthread_mutex_unlock;
+    pthread_mutexattr_destroy;
+    pthread_mutexattr_getpshared;
+    pthread_mutexattr_gettype;
+    pthread_mutexattr_init;
+    pthread_mutexattr_setpshared;
+    pthread_mutexattr_settype;
+    pthread_once;
+    pthread_rwlock_destroy;
+    pthread_rwlock_init;
+    pthread_rwlock_rdlock;
+    pthread_rwlock_timedrdlock;
+    pthread_rwlock_timedwrlock;
+    pthread_rwlock_tryrdlock;
+    pthread_rwlock_trywrlock;
+    pthread_rwlock_unlock;
+    pthread_rwlock_wrlock;
+    pthread_rwlockattr_destroy;
+    pthread_rwlockattr_getkind_np; # introduced=23
+    pthread_rwlockattr_getpshared;
+    pthread_rwlockattr_init;
+    pthread_rwlockattr_setkind_np; # introduced=23
+    pthread_rwlockattr_setpshared;
+    pthread_self;
+    pthread_setname_np;
+    pthread_setschedparam;
+    pthread_setspecific;
+    pthread_sigmask;
+    ptrace;
+    ptsname;
+    ptsname_r;
+    putc;
+    putc_unlocked;
+    putchar;
+    putchar_unlocked;
+    putenv;
+    puts;
+    pututline;
+    putw; # arm x86
+    putwc;
+    putwchar;
+    pvalloc; # arm x86 introduced=17
+    pwrite;
+    pwrite64; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    qsort;
+    quick_exit; # introduced=21
+    raise;
+    rand; # introduced=21
+    rand_r; # introduced=21
+    random; # introduced=21
+    read;
+    readahead;
+    readdir;
+    readdir64; # introduced=21
+    readdir64_r; # introduced=21
+    readdir_r;
+    readlink;
+    readlinkat; # introduced=21
+    readv;
+    realloc;
+    realpath;
+    reboot;
+    recv;
+    recvfrom;
+    recvmmsg; # introduced=21
+    recvmsg;
+    regcomp;
+    regerror;
+    regexec;
+    regfree;
+    remove;
+    removexattr;
+    remque; # introduced=21
+    rename;
+    renameat;
+    res_init;
+    res_mkquery;
+    res_query;
+    res_search;
+    rewind;
+    rewinddir;
+    rmdir;
+    sbrk;
+    scandir;
+    scandir64; # introduced=21
+    scanf;
+    sched_get_priority_max;
+    sched_get_priority_min;
+    sched_getaffinity; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    sched_getcpu; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    sched_getparam;
+    sched_getscheduler;
+    sched_rr_get_interval;
+    sched_setaffinity; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    sched_setparam;
+    sched_setscheduler;
+    sched_yield;
+    seed48;
+    seekdir; # introduced=23
+    select;
+    sem_close;
+    sem_destroy;
+    sem_getvalue;
+    sem_init;
+    sem_open;
+    sem_post;
+    sem_timedwait;
+    sem_trywait;
+    sem_unlink;
+    sem_wait;
+    send;
+    sendfile;
+    sendfile64; # introduced=21
+    sendmmsg; # introduced=21
+    sendmsg;
+    sendto;
+    setbuf;
+    setbuffer;
+    setegid;
+    setenv;
+    seteuid;
+    setfsgid; # introduced=21
+    setfsuid; # introduced=21
+    setgid;
+    setgroups;
+    sethostname; # introduced=23
+    setitimer;
+    setjmp;
+    setlinebuf;
+    setlocale;
+    setlogmask;
+    setmntent; # introduced=21
+    setns; # introduced=21
+    setpgid;
+    setpgrp;
+    setpriority;
+    setprogname; # introduced=21
+    setregid;
+    setresgid;
+    setresuid;
+    setreuid;
+    setrlimit;
+    setrlimit64; # introduced=21
+    setservent;
+    setsid;
+    setsockopt;
+    setstate; # introduced=21
+    settimeofday;
+    setuid;
+    setutent;
+    setvbuf;
+    setxattr;
+    shutdown;
+    sigaction;
+    sigaddset; # introduced=21
+    sigaltstack;
+    sigblock; # arm x86 arm64 x86_64
+    sigdelset; # introduced=21
+    sigemptyset; # introduced=21
+    sigfillset; # introduced=21
+    siginterrupt;
+    sigismember; # introduced=21
+    siglongjmp; # introduced-arm=9 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    signal; # introduced=21
+    signalfd; # introduced-arm=18 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    sigpending;
+    sigprocmask;
+    sigqueue; # introduced=23
+    sigsetjmp; # introduced-arm=9 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    sigsetmask; # arm x86 arm64 x86_64
+    sigsuspend;
+    sigtimedwait; # introduced=23
+    sigwait;
+    sigwaitinfo; # introduced=23
+    sleep;
+    snprintf;
+    socket;
+    socketpair;
+    splice; # introduced=21
+    sprintf;
+    srand; # introduced=21
+    srand48;
+    srandom; # introduced=21
+    sscanf;
+    stat;
+    stat64; # introduced=21
+    statfs;
+    statfs64; # introduced=21
+    statvfs; # introduced-arm=19 introduced-arm64=21 introduced-x86=19 introduced-x86_64=21
+    statvfs64; # introduced=21
+    stderr; # var introduced=23
+    stdin; # var introduced=23
+    stdout; # var introduced=23
+    stpcpy; # introduced=21
+    stpncpy; # introduced=21
+    strcasecmp;
+    strcasecmp_l; # introduced=23
+    strcasestr;
+    strcat;
+    strchr;
+    strcmp;
+    strcoll;
+    strcoll_l; # introduced=21
+    strcpy;
+    strcspn;
+    strdup;
+    strerror;
+    strerror_l; # introduced=23
+    strerror_r;
+    strftime;
+    strftime_l; # introduced=21
+    strlcat;
+    strlcpy;
+    strlen;
+    strncasecmp;
+    strncasecmp_l; # introduced=23
+    strncat;
+    strncmp;
+    strncpy;
+    strndup;
+    strnlen;
+    strpbrk;
+    strptime;
+    strrchr;
+    strsep;
+    strsignal;
+    strspn;
+    strstr;
+    strtod;
+    strtof; # introduced=21
+    strtoimax;
+    strtok;
+    strtok_r;
+    strtol;
+    strtold; # introduced=21
+    strtold_l; # introduced=21
+    strtoll;
+    strtoll_l; # introduced=21
+    strtoul;
+    strtoull;
+    strtoull_l; # introduced=21
+    strtoumax;
+    strxfrm;
+    strxfrm_l; # introduced=21
+    swapoff; # introduced-arm=19 introduced-arm64=21 introduced-x86=19 introduced-x86_64=21
+    swapon; # introduced-arm=19 introduced-arm64=21 introduced-x86=19 introduced-x86_64=21
+    swprintf;
+    swscanf;
+    symlink;
+    symlinkat; # introduced=21
+    sync;
+    sys_siglist; # var
+    sys_signame; # var
+    syscall;
+    sysconf;
+    sysinfo;
+    syslog;
+    system;
+    tcdrain; # introduced=21
+    tcflow; # introduced=21
+    tcflush; # introduced=21
+    tcgetattr; # introduced=21
+    tcgetpgrp;
+    tcgetsid; # introduced=21
+    tcsendbreak; # introduced=21
+    tcsetattr; # introduced=21
+    tcsetpgrp;
+    tdelete;
+    tdestroy;
+    tee; # introduced=21
+    telldir; # introduced=23
+    tempnam;
+    tfind;
+    tgkill;
+    time;
+    timegm; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    timegm64; # arm x86
+    timelocal; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    timelocal64; # arm x86
+    timer_create;
+    timer_delete;
+    timer_getoverrun;
+    timer_gettime;
+    timer_settime;
+    timerfd_create; # introduced-arm=19 introduced-arm64=21 introduced-x86=19 introduced-x86_64=21
+    timerfd_gettime; # introduced-arm=19 introduced-arm64=21 introduced-x86=19 introduced-x86_64=21
+    timerfd_settime; # introduced-arm=19 introduced-arm64=21 introduced-x86=19 introduced-x86_64=21
+    times;
+    timezone; # var
+    tmpfile;
+    tmpnam;
+    toascii;
+    tolower;
+    tolower_l; # introduced=21
+    toupper;
+    toupper_l; # introduced=21
+    towlower;
+    towlower_l; # introduced=21
+    towupper;
+    towupper_l; # introduced=21
+    truncate;
+    truncate64; # introduced=21
+    tsearch;
+    ttyname;
+    ttyname_r;
+    twalk; # introduced=21
+    tzname; # var
+    tzset;
+    umask;
+    umount;
+    umount2;
+    uname;
+    ungetc;
+    ungetwc;
+    unlink;
+    unlinkat;
+    unlockpt;
+    unsetenv;
+    unshare; # introduced-arm=17 introduced-arm64=21 introduced-x86=17 introduced-x86_64=21
+    uselocale; # introduced=21
+    usleep;
+    utime;
+    utimensat; # introduced-arm=12 introduced-arm64=21 introduced-x86=12 introduced-x86_64=21
+    utimes;
+    utmpname;
+    valloc; # arm x86
+    vasprintf;
+    vdprintf; # introduced=21
+    verr;
+    verrx;
+    vfdprintf; # arm x86 versioned=28
+    vfork;
+    vfprintf;
+    vfscanf;
+    vfwprintf;
+    vfwscanf; # introduced=21
+    vmsplice; # introduced=21
+    vprintf;
+    vscanf;
+    vsnprintf;
+    vsprintf;
+    vsscanf;
+    vswprintf;
+    vswscanf; # introduced=21
+    vsyslog;
+    vwarn;
+    vwarnx;
+    vwprintf;
+    vwscanf; # introduced=21
+    wait;
+    wait4; # introduced-arm=18 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    waitid;
+    waitpid;
+    warn;
+    warnx;
+    wcpcpy;
+    wcpncpy;
+    wcrtomb;
+    wcscasecmp;
+    wcscasecmp_l; # introduced=23
+    wcscat;
+    wcschr;
+    wcscmp;
+    wcscoll;
+    wcscoll_l; # introduced=21
+    wcscpy;
+    wcscspn;
+    wcsdup;
+    wcsftime;
+    wcslcat;
+    wcslcpy;
+    wcslen;
+    wcsncasecmp;
+    wcsncasecmp_l; # introduced=23
+    wcsncat;
+    wcsncmp;
+    wcsncpy;
+    wcsnlen;
+    wcsnrtombs; # introduced=21
+    wcspbrk;
+    wcsrchr;
+    wcsrtombs;
+    wcsspn;
+    wcsstr;
+    wcstod;
+    wcstof; # introduced=21
+    wcstoimax; # introduced=21
+    wcstok;
+    wcstol;
+    wcstold; # introduced=21
+    wcstold_l; # introduced=21
+    wcstoll; # introduced=21
+    wcstoll_l; # introduced=21
+    wcstombs; # introduced=21
+    wcstoul;
+    wcstoull; # introduced=21
+    wcstoull_l; # introduced=21
+    wcstoumax; # introduced=21
+    wcswidth;
+    wcsxfrm;
+    wcsxfrm_l; # introduced=21
+    wctob;
+    wctomb; # introduced=21
+    wctype;
+    wctype_l; # introduced=21
+    wcwidth;
+    wmemchr;
+    wmemcmp;
+    wmemcpy;
+    wmemmove;
+    wmempcpy; # introduced=23
+    wmemset;
+    wprintf;
+    write;
+    writev;
+    wscanf;
+  local:
+    *;
+};
+
+LIBC_N { # introduced-arm64=24 introduced-x86=24 introduced-x86_64=24
+  global:
+    __aeabi_atexit; # arm versioned=24
+    __aeabi_memclr; # arm versioned=24
+    __aeabi_memclr4; # arm versioned=24
+    __aeabi_memclr8; # arm versioned=24
+    __aeabi_memcpy; # arm versioned=24
+    __aeabi_memcpy4; # arm versioned=24
+    __aeabi_memcpy8; # arm versioned=24
+    __aeabi_memmove; # arm versioned=24
+    __aeabi_memmove4; # arm versioned=24
+    __aeabi_memmove8; # arm versioned=24
+    __aeabi_memset; # arm versioned=24
+    __aeabi_memset4; # arm versioned=24
+    __aeabi_memset8; # arm versioned=24
+    __fread_chk; # introduced=24
+    __fwrite_chk; # introduced=24
+    __getcwd_chk; # introduced=24
+    __gnu_Unwind_Find_exidx; # arm versioned=24
+    __pwrite_chk; # introduced=24
+    __pwrite64_chk; # introduced=24
+    __write_chk; # introduced=24
+    adjtimex; # introduced=24
+    clock_adjtime; # introduced=24
+    fgetpos64; # introduced=24
+    fileno_unlocked; # introduced=24
+    fopen64; # introduced=24
+    freeifaddrs; # introduced=24
+    freopen64; # introduced=24
+    fseeko64; # introduced=24
+    fsetpos64; # introduced=24
+    ftello64; # introduced=24
+    funopen64; # introduced=24
+    getgrgid_r; # introduced=24
+    getgrnam_r; # introduced=24
+    getifaddrs; # introduced=24
+    if_freenameindex; # introduced=24
+    if_nameindex; # introduced=24
+    in6addr_any; # var introduced=24
+    in6addr_loopback; # var introduced=24
+    lockf; # introduced=24
+    lockf64; # introduced=24
+    preadv; # introduced=24
+    preadv64; # introduced=24
+    prlimit; # arm x86 introduced=24
+    pthread_barrierattr_destroy; # introduced=24
+    pthread_barrierattr_getpshared; # introduced=24
+    pthread_barrierattr_init; # introduced=24
+    pthread_barrierattr_setpshared; # introduced=24
+    pthread_barrier_destroy; # introduced=24
+    pthread_barrier_init; # introduced=24
+    pthread_barrier_wait; # introduced=24
+    pthread_spin_destroy; # introduced=24
+    pthread_spin_init; # introduced=24
+    pthread_spin_lock; # introduced=24
+    pthread_spin_trylock; # introduced=24
+    pthread_spin_unlock; # introduced=24
+    pwritev; # introduced=24
+    pwritev64; # introduced=24
+    scandirat; # introduced=24
+    scandirat64; # introduced=24
+    strchrnul; # introduced=24
+    tmpfile64; # introduced=24
+} LIBC;
+
+LIBC_O {
+  global:
+    __sendto_chk; # introduced=26
+    __system_property_read_callback; # introduced=26
+    __system_property_wait; # introduced=26
+    bsd_signal; # arm x86 versioned=26
+    catclose; # introduced=26
+    catgets; # introduced=26
+    catopen; # introduced=26
+    ctermid; # introduced=26
+    endgrent; # introduced=26
+    endpwent; # introduced=26
+    futimes; # introduced=26
+    futimesat; # introduced=26
+    getdomainname; # introduced=26
+    getgrent; # introduced=26
+    getpwent; # introduced=26
+    getsubopt; # introduced=26
+    hasmntopt; # introduced=26
+    lutimes; # introduced=26
+    mallopt; # introduced=26
+    mblen; # introduced=26
+    msgctl; # introduced=26
+    msgget; # introduced=26
+    msgrcv; # introduced=26
+    msgsnd; # introduced=26
+    nl_langinfo; # introduced=26
+    nl_langinfo_l; # introduced=26
+    pthread_getname_np; # introduced=26
+    quotactl; # introduced=26
+    semctl; # introduced=26
+    semget; # introduced=26
+    semop; # introduced=26
+    semtimedop; # introduced=26
+    setdomainname; # introduced=26
+    setgrent; # introduced=26
+    setpwent; # introduced=26
+    shmat; # introduced=26
+    shmctl; # introduced=26
+    shmdt; # introduced=26
+    shmget; # introduced=26
+    sighold; # introduced=26
+    sigignore; # introduced=26
+    sigpause; # introduced=26
+    sigrelse; # introduced=26
+    sigset; # introduced=26
+    strtod_l; # introduced=26
+    strtof_l; # introduced=26
+    strtol_l; # introduced=26
+    strtoul_l; # introduced=26
+    sync_file_range; # introduced=26
+    towctrans; # introduced=26
+    towctrans_l; # introduced=26
+    wctrans; # introduced=26
+    wctrans_l; # introduced=26
+} LIBC_N;
+
+LIBC_P { # introduced=P
+  global:
+    __freading;
+    __free_hook;
+    __fseterr;
+    __fwriting;
+    __malloc_hook;
+    __memalign_hook;
+    __realloc_hook;
+    aligned_alloc;
+    endhostent;
+    endnetent;
+    endprotoent;
+    epoll_pwait64;
+    fexecve;
+    fflush_unlocked;
+    fgetc_unlocked;
+    fgets_unlocked;
+    fputc_unlocked;
+    fputs_unlocked;
+    fread_unlocked;
+    fwrite_unlocked;
+    getentropy;
+    getnetent;
+    getprotoent;
+    getrandom;
+    getlogin_r;
+    glob;
+    globfree;
+    hcreate;
+    hcreate_r;
+    hdestroy;
+    hdestroy_r;
+    hsearch;
+    hsearch_r;
+    iconv;
+    iconv_close;
+    iconv_open;
+    posix_spawn;
+    posix_spawnattr_destroy;
+    posix_spawnattr_getflags;
+    posix_spawnattr_getpgroup;
+    posix_spawnattr_getschedparam;
+    posix_spawnattr_getschedpolicy;
+    posix_spawnattr_getsigdefault;
+    posix_spawnattr_getsigdefault64;
+    posix_spawnattr_getsigmask;
+    posix_spawnattr_getsigmask64;
+    posix_spawnattr_init;
+    posix_spawnattr_setflags;
+    posix_spawnattr_setpgroup;
+    posix_spawnattr_setschedparam;
+    posix_spawnattr_setschedpolicy;
+    posix_spawnattr_setsigdefault;
+    posix_spawnattr_setsigdefault64;
+    posix_spawnattr_setsigmask;
+    posix_spawnattr_setsigmask64;
+    posix_spawn_file_actions_addclose;
+    posix_spawn_file_actions_adddup2;
+    posix_spawn_file_actions_addopen;
+    posix_spawn_file_actions_destroy;
+    posix_spawn_file_actions_init;
+    posix_spawnp;
+    ppoll64;
+    pselect64;
+    pthread_attr_getinheritsched;
+    pthread_attr_setinheritsched;
+    pthread_mutex_timedlock_monotonic_np;
+    pthread_mutexattr_getprotocol;
+    pthread_mutexattr_setprotocol;
+    pthread_rwlock_timedrdlock_monotonic_np;
+    pthread_rwlock_timedwrlock_monotonic_np;
+    pthread_setschedprio;
+    pthread_sigmask64;
+    sem_timedwait_monotonic_np;
+    sethostent;
+    setnetent;
+    setprotoent;
+    sigaction64;
+    sigaddset64;
+    sigdelset64;
+    sigemptyset64;
+    sigfillset64;
+    sigismember64;
+    signalfd64;
+    sigpending64;
+    sigprocmask64;
+    sigsuspend64;
+    sigtimedwait64;
+    sigwait64;
+    sigwaitinfo64;
+    strptime_l;
+    swab;
+    syncfs;
+    wcsftime_l;
+    wcstod_l;
+    wcstof_l;
+    wcstol_l;
+    wcstoul_l;
+} LIBC_O;
+
+LIBC_Q { # introduced=Q
+  global:
+    ___tls_get_addr; # x86
+    __aeabi_read_tp; # arm
+    __res_randomid;
+    __tls_get_addr; # arm riscv64 x86_64
+    android_fdsan_close_with_tag;
+    android_fdsan_create_owner_tag;
+    android_fdsan_exchange_owner_tag;
+    android_fdsan_get_error_level;
+    android_fdsan_get_owner_tag;
+    android_fdsan_get_tag_type;
+    android_fdsan_get_tag_value;
+    android_fdsan_set_error_level;
+    android_get_device_api_level;
+    getloadavg;
+    pthread_sigqueue;
+    reallocarray;
+    timespec_get;
+
+    # Used by libselinux
+    __system_properties_init; # apex
+
+    # Used by libmemunreachable
+    malloc_backtrace; # apex llndk
+    malloc_disable; # apex llndk
+    malloc_enable; # apex llndk
+    malloc_iterate; # apex llndk
+
+    # Used by libandroid_net
+    android_getaddrinfofornet; # apex
+
+    # Used by libandroid_runtime, libcutils, libmedia, and libmediautils
+    android_mallopt; # apex llndk
+} LIBC_P;
+
+LIBC_R { # introduced=R
+  global:
+    __mempcpy_chk;
+    __tls_get_addr; # arm64
+    call_once;
+    cnd_broadcast;
+    cnd_destroy;
+    cnd_init;
+    cnd_signal;
+    cnd_timedwait;
+    cnd_wait;
+    memfd_create;
+    mlock2;
+    mtx_destroy;
+    mtx_init;
+    mtx_lock;
+    mtx_timedlock;
+    mtx_trylock;
+    mtx_unlock;
+    pthread_cond_clockwait;
+    pthread_mutex_clocklock;
+    pthread_rwlock_clockrdlock;
+    pthread_rwlock_clockwrlock;
+    renameat2;
+    sem_clockwait;
+    statx;
+    thrd_create;
+    thrd_current;
+    thrd_detach;
+    thrd_equal;
+    thrd_exit;
+    thrd_join;
+    thrd_sleep;
+    thrd_yield;
+    tss_create;
+    tss_delete;
+    tss_get;
+    tss_set;
+
+    # Unwinder implementation
+    __aeabi_unwind_cpp_pr0; # arm
+    __aeabi_unwind_cpp_pr1; # arm
+    __aeabi_unwind_cpp_pr2; # arm
+    __deregister_frame; # arm64 x86 x86_64
+    __gnu_unwind_frame; # arm
+    __register_frame; # arm64 x86 x86_64
+    _Unwind_Backtrace;
+    _Unwind_Complete; # arm
+    _Unwind_DeleteException;
+    _Unwind_Find_FDE;
+    _Unwind_FindEnclosingFunction;
+    _Unwind_ForcedUnwind; # arm64 x86 x86_64
+    _Unwind_GetCFA;
+    _Unwind_GetDataRelBase;
+    _Unwind_GetGR;
+    _Unwind_GetIP;
+    _Unwind_GetIPInfo;
+    _Unwind_GetLanguageSpecificData;
+    _Unwind_GetRegionStart;
+    _Unwind_GetTextRelBase;
+    _Unwind_RaiseException;
+    _Unwind_Resume;
+    _Unwind_Resume_or_Rethrow;
+    _Unwind_SetGR;
+    _Unwind_SetIP;
+    _Unwind_VRS_Get; # arm
+    _Unwind_VRS_Pop; # arm
+    _Unwind_VRS_Set; # arm
+} LIBC_Q;
+
+LIBC_S { # introduced=S
+  global:
+    __libc_get_static_tls_bounds;
+    __libc_register_thread_exit_callback;
+    __libc_iterate_dynamic_tls;
+    __libc_register_dynamic_tls_listeners;
+    android_reset_stack_guards;
+    ffsl;
+    ffsll;
+    pidfd_getfd;
+    pidfd_open;
+    pidfd_send_signal;
+    process_madvise;
+} LIBC_R;
+
+LIBC_T { # introduced=Tiramisu
+  global:
+    backtrace;
+    backtrace_symbols;
+    backtrace_symbols_fd;
+    preadv2;
+    preadv64v2;
+    pwritev2;
+    pwritev64v2;
+} LIBC_S;
+
+LIBC_U { # introduced=UpsideDownCake
+  global:
+    __freadahead;
+    close_range;
+    copy_file_range;
+    memset_explicit;
+    posix_spawn_file_actions_addchdir_np;
+    posix_spawn_file_actions_addfchdir_np;
+} LIBC_T;
+
+LIBC_V { # introduced=VanillaIceCream
+  global:
+    android_crash_detail_register;
+    android_crash_detail_unregister;
+    android_crash_detail_replace_name;
+    android_crash_detail_replace_data;
+    epoll_pwait2;
+    epoll_pwait2_64;
+    _Fork;
+    localtime_rz;
+    mbsrtowcs_l;
+    mktime_z;
+    __riscv_flush_icache; # riscv64
+    __riscv_hwprobe; # riscv64
+    strerrorname_np;
+    tcgetwinsize;
+    tcsetwinsize;
+    timespec_getres;
+    tzalloc;
+    tzfree;
+    wcsrtombs_l;
+    __system_properties_zygote_reload; # apex
+} LIBC_U;
+
+LIBC_PRIVATE {
+  global:
+    __accept4; # arm x86
+    __adddf3; # arm
+    __addsf3; # arm
+    __aeabi_atexit; # arm
+    __aeabi_cdcmpeq; # arm
+    __aeabi_cdcmple; # arm
+    __aeabi_cdrcmple; # arm
+    __aeabi_cfcmpeq; # arm
+    __aeabi_cfcmple; # arm
+    __aeabi_cfrcmple; # arm
+    __aeabi_d2f; # arm
+    __aeabi_d2iz; # arm
+    __aeabi_d2uiz; # arm
+    __aeabi_dadd; # arm
+    __aeabi_dcmpeq; # arm
+    __aeabi_dcmpge; # arm
+    __aeabi_dcmpgt; # arm
+    __aeabi_dcmple; # arm
+    __aeabi_dcmplt; # arm
+    __aeabi_dcmpun; # arm
+    __aeabi_ddiv; # arm
+    __aeabi_dmul; # arm
+    __aeabi_drsub; # arm
+    __aeabi_dsub; # arm
+    __aeabi_f2d; # arm
+    __aeabi_f2iz; # arm
+    __aeabi_f2uiz; # arm
+    __aeabi_fadd; # arm
+    __aeabi_fcmpeq; # arm
+    __aeabi_fcmpge; # arm
+    __aeabi_fcmpgt; # arm
+    __aeabi_fcmple; # arm
+    __aeabi_fcmplt; # arm
+    __aeabi_fcmpun; # arm
+    __aeabi_fdiv; # arm
+    __aeabi_fmul; # arm
+    __aeabi_frsub; # arm
+    __aeabi_fsub; # arm
+    __aeabi_i2d; # arm
+    __aeabi_i2f; # arm
+    __aeabi_idiv; # arm
+    __aeabi_idiv0; # arm
+    __aeabi_idivmod; # arm
+    __aeabi_l2d; # arm
+    __aeabi_l2f; # arm
+    __aeabi_lasr; # arm
+    __aeabi_ldiv0; # arm
+    __aeabi_ldivmod; # arm
+    __aeabi_llsl; # arm
+    __aeabi_llsr; # arm
+    __aeabi_lmul; # arm
+    __aeabi_memclr; # arm
+    __aeabi_memclr4; # arm
+    __aeabi_memclr8; # arm
+    __aeabi_memcpy; # arm
+    __aeabi_memcpy4; # arm
+    __aeabi_memcpy8; # arm
+    __aeabi_memmove; # arm
+    __aeabi_memmove4; # arm
+    __aeabi_memmove8; # arm
+    __aeabi_memset; # arm
+    __aeabi_memset4; # arm
+    __aeabi_memset8; # arm
+    __aeabi_ui2d; # arm
+    __aeabi_ui2f; # arm
+    __aeabi_uidiv; # arm
+    __aeabi_uidivmod; # arm
+    __aeabi_ul2d; # arm
+    __aeabi_ul2f; # arm
+    __aeabi_uldivmod; # arm
+    __arm_fadvise64_64; # arm
+    __ashldi3; # arm
+    __ashrdi3; # arm
+    __bionic_brk; # arm x86
+    __bionic_libcrt_compat_symbols; # arm x86
+    __cmpdf2; # arm
+    __cmpsf2; # arm
+    __divdf3; # arm
+    __divdi3; # arm x86
+    __divsf3; # arm
+    __divsi3; # arm
+    __dso_handle; # arm
+    __eqdf2; # arm
+    __eqsf2; # arm
+    __extendsfdf2; # arm
+    __fixdfsi; # arm
+    __fixsfsi; # arm
+    __fixunsdfsi; # arm
+    __fixunssfsi; # arm
+    __floatdidf; # arm
+    __floatdisf; # arm
+    __floatsidf; # arm
+    __floatsisf; # arm
+    __floatundidf; # arm
+    __floatundisf; # arm
+    __floatunsidf; # arm
+    __floatunsisf; # arm
+    __futex_wait; # arm x86
+    __futex_wake; # arm x86
+    __gedf2; # arm
+    __gesf2; # arm
+    __get_thread; # arm x86
+    __get_tls; # arm x86
+    __getdents64; # arm x86
+    __gnu_ldivmod_helper; # arm
+    __gnu_uldivmod_helper; # arm
+    __gnu_Unwind_Find_exidx; # arm
+    __gtdf2; # arm
+    __gtsf2; # arm
+    __ledf2; # arm
+    __lesf2; # arm
+    __lshrdi3; # arm
+    __ltdf2; # arm
+    __ltsf2; # arm
+    __muldf3; # arm
+    __muldi3; # arm
+    __mulsf3; # arm
+    __nedf2; # arm
+    __nesf2; # arm
+    __open; # arm x86
+    __page_shift; # arm x86
+    __page_size; # arm x86
+    __popcount_tab; # arm
+    __popcountsi2; # arm x86
+    __pthread_gettid; # arm x86
+    __sclose; # arm x86
+    __sdidinit; # arm x86
+    __set_errno; # arm x86
+    __sflags; # arm x86
+    __sflush; # arm x86
+    __sfp; # arm x86
+    __sglue; # arm x86
+    __sinit; # arm x86
+    __smakebuf; # arm x86
+    __sread; # arm x86
+    __srefill; # arm x86
+    __srget; # arm x86
+    __sseek; # arm x86
+    __subdf3; # arm
+    __subsf3; # arm
+    __swbuf; # arm x86
+    __swrite; # arm x86
+    __swsetup; # arm x86
+    __truncdfsf2; # arm
+    __udivdi3; # arm x86
+    __udivsi3; # arm
+    __umoddi3; # x86
+    __unorddf2; # arm
+    __unordsf2; # arm
+    __wait4; # arm x86
+    _fwalk; # arm x86
+    android_getaddrinfofornetcontext;
+    android_gethostbyaddrfornet;
+    android_gethostbyaddrfornetcontext;
+    android_gethostbynamefornet;
+    android_gethostbynamefornetcontext;
+    android_run_on_all_threads;
+    android_unsafe_frame_pointer_chase;
+    arc4random_addrandom; # arm x86
+    arc4random_stir; # arm x86
+    atexit; # arm
+    bcopy; # arm x86
+    bzero; # arm x86
+    dlmalloc; # arm x86
+    dlmalloc_inspect_all; # arm x86
+    dlmalloc_trim; # arm x86
+    dlmalloc_usable_size; # arm x86
+    ftime; # arm x86
+    getdents; # arm x86
+    getdtablesize; # arm x86
+    index; # arm x86
+    issetugid; # arm x86
+    memswap; # arm x86
+    pthread_attr_getstackaddr; # arm x86
+    pthread_attr_setstackaddr; # arm x86
+    SHA1Final; # arm x86
+    SHA1Init; # arm x86
+    SHA1Transform; # arm x86
+    SHA1Update; # arm x86
+    strntoimax; # arm x86
+    strntoumax; # arm x86
+    strtotimeval; # arm x86
+    sysv_signal; # arm x86
+    tkill; # arm x86
+    wait3; # arm x86
+    wcswcs; # arm x86
+} LIBC_Q;
+
+LIBC_DEPRECATED {
+  global:
+    __system_property_wait_any;
+    free_malloc_leak_info; # arm
+    get_malloc_leak_info; # arm
+};
+
+LIBC_PLATFORM {
+  global:
+    __system_property_add;
+    __system_property_area__; # var
+    __system_property_area_init;
+    __system_property_set_filename;
+    __system_property_update;
+    android_fdsan_get_fd_table;
+    android_fdtrack_compare_exchange_hook; # llndk
+    android_fdtrack_get_enabled; # llndk
+    android_fdtrack_set_enabled; # llndk
+    android_fdtrack_set_globally_enabled; # llndk
+    android_net_res_stats_get_info_for_net;
+    android_net_res_stats_aggregate;
+    android_net_res_stats_get_usable_servers;
+} LIBC_Q;

--- a/scripts/libdl.map.txt
+++ b/scripts/libdl.map.txt
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2015 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+LIBC {
+  global:
+    android_dlopen_ext; # introduced=21
+    dl_iterate_phdr; # introduced-arm=21
+    dl_unwind_find_exidx; # arm
+    dladdr;
+    dlclose;
+    dlerror;
+    dlopen;
+    dlsym;
+  local:
+    *;
+};
+
+LIBC_N {
+  global:
+    android_get_application_target_sdk_version; # introduced=24 versioned=29
+    dlvsym; # introduced=24
+} LIBC;
+
+LIBC_OMR1 { # introduced=27
+  global:
+    __cfi_shadow_size;
+    __cfi_slowpath;
+    __cfi_slowpath_diag;
+} LIBC_N;
+
+LIBC_PLATFORM {
+  global:
+    android_get_LD_LIBRARY_PATH;
+    __cfi_init;
+    android_handle_signal;
+} LIBC_OMR1;

--- a/scripts/libm.map.txt
+++ b/scripts/libm.map.txt
@@ -1,0 +1,309 @@
+LIBC {
+  global:
+    __fe_dfl_env; # var
+    __signbit;
+    __signbitf;
+    __signbitl;
+    acos;
+    acosf;
+    acosh;
+    acoshf;
+    acoshl; # introduced=21
+    acosl; # introduced=21
+    asin;
+    asinf;
+    asinh;
+    asinhf;
+    asinhl; # introduced=21
+    asinl; # introduced=21
+    atan;
+    atan2;
+    atan2f;
+    atan2l; # introduced=21
+    atanf;
+    atanh;
+    atanhf;
+    atanhl; # introduced=21
+    atanl; # introduced=21
+    cabs; # introduced=23
+    cabsf; # introduced=23
+    cabsl; # introduced-arm=21 introduced-arm64=23 introduced-x86=21 introduced-x86_64=23
+    cacos; # introduced=23
+    cacosf; # introduced=23
+    cacosh; # introduced=23
+    cacoshf; # introduced=23
+    carg; # introduced=23
+    cargf; # introduced=23
+    cargl; # introduced=23
+    casin; # introduced=23
+    casinf; # introduced=23
+    casinh; # introduced=23
+    casinhf; # introduced=23
+    catan; # introduced=23
+    catanf; # introduced=23
+    catanh; # introduced=23
+    catanhf; # introduced=23
+    cbrt;
+    cbrtf;
+    cbrtl; # introduced=21
+    ccos; # introduced=23
+    ccosf; # introduced=23
+    ccosh; # introduced=23
+    ccoshf; # introduced=23
+    ceil;
+    ceilf;
+    ceill;
+    cexp; # introduced=23
+    cexpf; # introduced=23
+    cimag; # introduced=23
+    cimagf; # introduced=23
+    cimagl; # introduced=23
+    conj; # introduced=23
+    conjf; # introduced=23
+    conjl; # introduced=23
+    copysign;
+    copysignf;
+    copysignl;
+    cos;
+    cosf;
+    cosh;
+    coshf;
+    coshl; # introduced=21
+    cosl; # introduced=21
+    cproj; # introduced=23
+    cprojf; # introduced=23
+    cprojl; # introduced-arm=21 introduced-arm64=23 introduced-x86=21 introduced-x86_64=23
+    creal; # introduced=23
+    crealf; # introduced=23
+    creall; # introduced=23
+    csin; # introduced=23
+    csinf; # introduced=23
+    csinh; # introduced=23
+    csinhf; # introduced=23
+    csqrt; # introduced=23
+    csqrtf; # introduced=23
+    csqrtl; # introduced-arm=21 introduced-arm64=23 introduced-x86=21 introduced-x86_64=23
+    ctan; # introduced=23
+    ctanf; # introduced=23
+    ctanh; # introduced=23
+    ctanhf; # introduced=23
+    drem;
+    dremf;
+    erf;
+    erfc;
+    erfcf;
+    erfcl; # introduced=21
+    erff;
+    erfl; # introduced=21
+    exp;
+    exp2;
+    exp2f;
+    exp2l; # introduced=21
+    expf;
+    expl; # introduced=21
+    expm1;
+    expm1f;
+    expm1l; # introduced=21
+    fabs;
+    fabsf;
+    fabsl;
+    fdim;
+    fdimf;
+    fdiml;
+    feclearexcept; # introduced-arm=21 introduced-arm64=21 introduced-x86=9 introduced-x86_64=21
+    fedisableexcept; # introduced-arm=21 introduced-arm64=21 introduced-x86=9 introduced-x86_64=21
+    feenableexcept; # introduced-arm=21 introduced-arm64=21 introduced-x86=9 introduced-x86_64=21
+    fegetenv; # introduced-arm=21 introduced-arm64=21 introduced-x86=9 introduced-x86_64=21
+    fegetexcept; # introduced-arm=21 introduced-arm64=21 introduced-x86=9 introduced-x86_64=21
+    fegetexceptflag; # introduced-arm=21 introduced-arm64=21 introduced-x86=9 introduced-x86_64=21
+    fegetround; # introduced-arm=21 introduced-arm64=21 introduced-x86=9 introduced-x86_64=21
+    feholdexcept; # introduced-arm=21 introduced-arm64=21 introduced-x86=9 introduced-x86_64=21
+    feraiseexcept; # introduced-arm=21 introduced-arm64=21 introduced-x86=9 introduced-x86_64=21
+    fesetenv; # introduced-arm=21 introduced-arm64=21 introduced-x86=9 introduced-x86_64=21
+    fesetexceptflag; # introduced-arm=21 introduced-arm64=21 introduced-x86=9 introduced-x86_64=21
+    fesetround; # introduced-arm=21 introduced-arm64=21 introduced-x86=9 introduced-x86_64=21
+    fetestexcept; # introduced-arm=21 introduced-arm64=21 introduced-x86=9 introduced-x86_64=21
+    feupdateenv; # introduced-arm=21 introduced-arm64=21 introduced-x86=9 introduced-x86_64=21
+    finite;
+    finitef;
+    floor;
+    floorf;
+    floorl;
+    fma;
+    fmaf;
+    fmal; # introduced=21
+    fmax;
+    fmaxf;
+    fmaxl;
+    fmin;
+    fminf;
+    fminl;
+    fmod;
+    fmodf;
+    fmodl; # introduced=21
+    frexp;
+    frexpf;
+    frexpl; # introduced=21
+    gamma;
+    gamma_r;
+    gammaf;
+    gammaf_r;
+    hypot;
+    hypotf;
+    hypotl; # introduced=21
+    ilogb;
+    ilogbf;
+    ilogbl;
+    j0;
+    j0f;
+    j1;
+    j1f;
+    jn;
+    jnf;
+    ldexpf;
+    ldexpl;
+    lgamma;
+    lgamma_r;
+    lgammaf;
+    lgammaf_r;
+    lgammal; # introduced=21
+    lgammal_r; # introduced=23
+    llrint;
+    llrintf;
+    llrintl; # introduced=21
+    llround;
+    llroundf;
+    llroundl;
+    log;
+    log10;
+    log10f;
+    log10l; # introduced=21
+    log1p;
+    log1pf;
+    log1pl; # introduced=21
+    log2; # introduced-arm=18 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    log2f; # introduced-arm=18 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    log2l; # introduced-arm=18 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    logb;
+    logbf;
+    logbl; # introduced-arm=18 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    logf;
+    logl; # introduced=21
+    lrint;
+    lrintf;
+    lrintl; # introduced=21
+    lround;
+    lroundf;
+    lroundl;
+    modf;
+    modff;
+    modfl; # introduced=21
+    nan; # introduced-arm=13 introduced-arm64=21 introduced-x86=9 introduced-x86_64=21
+    nanf; # introduced-arm=13 introduced-arm64=21 introduced-x86=9 introduced-x86_64=21
+    nanl; # introduced-arm=13 introduced-arm64=21 introduced-x86=13 introduced-x86_64=21
+    nearbyint;
+    nearbyintf;
+    nearbyintl; # introduced=21
+    nextafter;
+    nextafterf;
+    nextafterl; # introduced=21
+    nexttoward; # introduced-arm=18 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    nexttowardf;
+    nexttowardl; # introduced-arm=18 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    pow;
+    powf;
+    powl; # introduced=21
+    remainder;
+    remainderf;
+    remainderl; # introduced=21
+    remquo;
+    remquof;
+    remquol; # introduced=21
+    rint;
+    rintf;
+    rintl; # introduced=21
+    round;
+    roundf;
+    roundl;
+    scalb;
+    scalbf;
+    scalbln; # introduced-arm=9 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    scalblnf; # introduced-arm=9 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    scalblnl; # introduced-arm=9 introduced-arm64=21 introduced-x86=18 introduced-x86_64=21
+    scalbn;
+    scalbnf;
+    scalbnl;
+    signgam; # var
+    significand;
+    significandf;
+    significandl; # introduced=21
+    sin;
+    sincos;
+    sincosf;
+    sincosl;
+    sinf;
+    sinh;
+    sinhf;
+    sinhl; # introduced=21
+    sinl; # introduced=21
+    sqrt;
+    sqrtf;
+    sqrtl; # introduced=21
+    tan;
+    tanf;
+    tanh;
+    tanhf;
+    tanhl; # introduced=21
+    tanl; # introduced=21
+    tgamma;
+    tgammaf; # introduced-arm=13 introduced-arm64=21 introduced-x86=9 introduced-x86_64=21
+    tgammal; # introduced=21
+    trunc;
+    truncf;
+    truncl;
+    y0;
+    y0f;
+    y1;
+    y1f;
+    yn;
+    ynf;
+  local:
+    *;
+};
+
+LIBC_O { # introduced=O
+  global:
+    cacoshl;
+    cacosl;
+    casinhl;
+    casinl;
+    catanhl;
+    catanl;
+    ccoshl;
+    ccosl;
+    cexpl;
+    clog;
+    clogf;
+    clogl;
+    cpow;
+    cpowf;
+    cpowl;
+    csinhl;
+    csinl;
+    ctanhl;
+    ctanl;
+} LIBC;
+
+LIBC_DEPRECATED { # arm platform-only
+  global: # arm
+    __aeabi_d2lz; # arm
+    __aeabi_d2ulz; # arm
+    __aeabi_f2lz; # arm
+    __aeabi_f2ulz; # arm
+    __aeabi_l2d; # arm
+    __fixdfdi; # arm
+    __fixsfdi; # arm
+    __fixunsdfdi; # arm
+    __fixunssfdi; # arm
+    __floatdidf; # arm
+} LIBC_O; # arm


### PR DESCRIPTION
The dummy package is not part of this PR. But it demonstrates how we can capture the issue early on.
The benefit is that we don't need to physically install packages on old devices to check the package can even be started or not.

I do not think we want to maintain libc.map.txt and a matching parser for the little effort so I pasted symbols into a function.

I have changed so that it checks all files instead of just "*.so" from lib dir only but I like to gather opinions from all first.

Old commit: https://github.com/termux/termux-packages/commit/d98409a91fbef3c22303cdd3af7490502e3d6d2d
Old CI: https://github.com/termux/termux-packages/actions/runs/6507027577/job/17673682012