### PR TITLE
bump(main/mympd): 12.1.0

### DIFF
--- a/packages/mympd/CMakeLists.txt.patch
+++ b/packages/mympd/CMakeLists.txt.patch
@@ -16,7 +16,16 @@
  find_package(OpenSSL REQUIRED)
  
  # check dependencies versions
-@@ -238,7 +236,7 @@
+@@ -169,6 +167,8 @@
+   endif()
+   message("Searching for lua")
+   find_package(Lua)
++  set(LUA_LIBRARIES "lua5.4")
++  set(LUA_FOUND TRUE)
+   if(LUA_FOUND)
+     if(NOT LUA_VERSION_STRING VERSION_GREATER_EQUAL "5.3.0")
+       message("Lua is disabled because a version lower than 5.3.0 was found")
+@@ -238,7 +238,7 @@
  configure_file(contrib/initscripts/mympd.sysVinit.in contrib/initscripts/mympd.sysVinit @ONLY)
  configure_file(contrib/initscripts/mympd.openrc.in contrib/initscripts/mympd.openrc @ONLY)
  
@@ -25,7 +34,7 @@
    # set strict global compile flags
    add_compile_options(
      "-fdata-sections"
-@@ -329,8 +327,7 @@
+@@ -329,8 +329,7 @@
      add_compile_options("-g")
    endif()
    # IPO/LTO support

--- a/packages/mympd/build.sh
+++ b/packages/mympd/build.sh
@@ -2,10 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://jcorporation.github.io/myMPD/
 TERMUX_PKG_DESCRIPTION="A standalone and lightweight web-based MPD client"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=12.0.4
+TERMUX_PKG_VERSION=12.1.0
 TERMUX_PKG_SRCURL=https://github.com/jcorporation/myMPD/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=97bae393ea9d447d2b69d5231e37a91cd2549c7ec4ee87bcae4dcfa64becdf3c
-TERMUX_PKG_DEPENDS="libflac, libid3tag, openssl, pcre2, resolv-conf"
+TERMUX_PKG_SHA256=1937a021c32b635402a0ac89d9d4957fcf936297c48642a812d4bac89d3947f0
+TERMUX_PKG_DEPENDS="libflac, libid3tag, openssl, pcre2, resolv-conf, liblua54"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DMATH_LIB=m
 "


### PR DESCRIPTION
added a new dependency:

* liblua54

with modified patches:

* CMakeLists.txt.patch

so that mympd is fully functioned(enable lua).
It turns out the compiling process succeed in my docker.

If the build would fail, do:

1. Remove the lines 19-27( *@@ -169,6......found")* ) in **CMakeLists.txt.patch**
2. Remove the dependency(liblua54) that means remove the text( *, liblua54* ) that is positioning from 8,68 to 8,77 in **build.sh**

so that mympd is functioned as it is as before in termux.

Thanks!