### PR TITLE
rizin: add package

### DIFF
--- a/packages/rizin/build.sh
+++ b/packages/rizin/build.sh
@@ -1,0 +1,8 @@
+TERMUX_PKG_HOMEPAGE=https://rizin.re
+TERMUX_PKG_DESCRIPTION="UNIX-like reverse engineering framework and command-line toolset."
+TERMUX_PKG_LICENSE="GPL-3.0, LGPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=0.6.2
+TERMUX_PKG_SRCURL=https://github.com/rizinorg/rizin/archive/v$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SUGGESTS="python, apk-tools, apktool, apksigner"
+TERMUX_PKG_SHA256=ab4bd4c767940b28d683f664f27180665f98bfab2aa7972ba4c331e8bed30da8


### PR DESCRIPTION
This pull request adds support for rizin(fork of radare2), a UNIX-like reverse engineering framework and commandline toolset, to the android termux package. Rizin aims to provide a more user-friendly and modular interface, as well as faster development and bug fixes. With this package, termux users can easily install and use rizin on their android devices, and perform various tasks such as binary analysis, debugging, forensics, and exploitation. The package has been tested on several android versions and architectures and works as expected. I hope this contribution will be useful for the termux community and the rizin project.
Co-developed-by: Joshua Kahn @TomJo2000