### PR TITLE
termux_setup_meson: bump to 1.2.2

### DIFF
--- a/scripts/build/setup/termux_setup_meson.sh
+++ b/scripts/build/setup/termux_setup_meson.sh
@@ -1,6 +1,6 @@
 termux_setup_meson() {
 	termux_setup_ninja
-	local MESON_VERSION=1.1.0
+	local MESON_VERSION=1.2.2
 	local MESON_FOLDER
 
 	if [ "${TERMUX_PACKAGES_OFFLINE-false}" = "true" ]; then
@@ -16,7 +16,7 @@ termux_setup_meson() {
 		termux_download \
 			"https://github.com/mesonbuild/meson/releases/download/$MESON_VERSION/meson-$MESON_VERSION.tar.gz" \
 			"$MESON_TAR_FILE" \
-			d9616c44cd6c53689ff8f05fc6958a693f2e17c3472a8daf83cee55dabff829f
+			4a0f04de331fbc7af3b802a844fc8838f4ccd1ded1e792ba4f8f2faf8c5fe4d6
 		tar xf "$MESON_TAR_FILE" -C "$TERMUX_PKG_TMPDIR"
 		shopt -s nullglob
 		local f


### PR DESCRIPTION
This version is needed to cross compile some packages with llvm 17.