### PR TITLE
new package: freerdp

### DIFF
--- a/x11-packages/freerdp/0001-pthread_cancel.patch
+++ b/x11-packages/freerdp/0001-pthread_cancel.patch
@@ -1,0 +1,11 @@
+--- a/winpr/libwinpr/thread/thread.c
++++ b/winpr/libwinpr/thread/thread.c
+@@ -963,7 +963,7 @@
+ 	if (!run_mutex_fkt(pthread_mutex_lock, &thread->mutex))
+ 		return FALSE;
+ 
+-#ifndef ANDROID
++#ifndef __ANDROID__
+ 	pthread_cancel(thread->thread);
+ #else
+ 	WLog_ERR(TAG, "Function not supported on this platform!");

--- a/x11-packages/freerdp/0002-use-cross-wayland-scanner.patch
+++ b/x11-packages/freerdp/0002-use-cross-wayland-scanner.patch
@@ -1,0 +1,13 @@
+--- a/cmake/FindWayland.cmake
++++ b/cmake/FindWayland.cmake
+@@ -34,9 +34,7 @@
+     pkg_check_modules(XKBCOMMON_PC xkbcommon)
+ endif()
+ 
+-find_program(WAYLAND_SCANNER wayland-scanner
+-    HINTS "${WAYLAND_SCANNER_PC_PREFIX}/bin"
+-)
++find_program(WAYLAND_SCANNER wayland-scanner)
+ 
+ find_path(WAYLAND_INCLUDE_DIR wayland-client.h
+     HINTS ${WAYLAND_CLIENT_PC_INCLUDE_DIRS}

--- a/x11-packages/freerdp/0003-posix-shm.patch
+++ b/x11-packages/freerdp/0003-posix-shm.patch
@@ -1,0 +1,72 @@
+--- a/client/X11/xf_window.c
++++ b/client/X11/xf_window.c
+@@ -72,6 +72,69 @@
+ 
+ #include "xf_window.h"
+ 
++#ifdef __ANDROID__
++#include <alloca.h>
++#include <errno.h>
++static int shm_unlink(const char *name) {
++    size_t namelen;
++    char *fname;
++
++    /* Construct the filename.  */
++    while (name[0] == '/') ++name;
++
++    if (name[0] == '\0') {
++        /* The name "/" is not supported.  */
++        errno = EINVAL;
++        return -1;
++    }
++
++    namelen = strlen(name);
++    fname = (char *) alloca(sizeof("@TERMUX_PREFIX@/tmp/") - 1 + namelen + 1);
++    memcpy(fname, "@TERMUX_PREFIX@/tmp/", sizeof("@TERMUX_PREFIX@/tmp/") - 1);
++    memcpy(fname + sizeof("@TERMUX_PREFIX@/tmp/") - 1, name, namelen + 1);
++
++    return unlink(fname);
++}
++
++static int shm_open(const char *name, int oflag, mode_t mode) {
++    size_t namelen;
++    char *fname;
++    int fd;
++
++    /* Construct the filename.  */
++    while (name[0] == '/') ++name;
++
++    if (name[0] == '\0') {
++        /* The name "/" is not supported.  */
++        errno = EINVAL;
++        return -1;
++    }
++
++    namelen = strlen(name);
++    fname = (char *) alloca(sizeof("@TERMUX_PREFIX@/tmp/") - 1 + namelen + 1);
++    memcpy(fname, "@TERMUX_PREFIX@/tmp/", sizeof("@TERMUX_PREFIX@/tmp/") - 1);
++    memcpy(fname + sizeof("@TERMUX_PREFIX@/tmp/") - 1, name, namelen + 1);
++
++    fd = open(fname, oflag, mode);
++    if (fd != -1) {
++        /* We got a descriptor.  Now set the FD_CLOEXEC bit.  */
++        int flags = fcntl(fd, F_GETFD, 0);
++        flags |= FD_CLOEXEC;
++        flags = fcntl(fd, F_SETFD, flags);
++
++        if (flags == -1) {
++            /* Something went wrong.  We cannot return the descriptor.  */
++            int save_errno = errno;
++            close(fd);
++            fd = -1;
++            errno = save_errno;
++        }
++    }
++
++    return fd;
++}
++#endif
++
+ /* Extended Window Manager Hints: http://standards.freedesktop.org/wm-spec/wm-spec-1.3.html */
+ 
+ /* bit definitions for MwmHints.flags */

--- a/x11-packages/freerdp/0004-incompatible-function-pointer-types.patch
+++ b/x11-packages/freerdp/0004-incompatible-function-pointer-types.patch
@@ -1,0 +1,11 @@
+--- a/client/Wayland/wlfreerdp.c
++++ v/client/Wayland/wlfreerdp.c
+@@ -587,7 +587,7 @@
+ 	DeleteCriticalSection(&wlf->critical);
+ }
+ 
+-static void* uwac_event_clone(const void* val)
++static void* uwac_event_clone(void* val)
+ {
+ 	UwacEvent* copy;
+ 	UwacEvent* ev = (UwacEvent*)val;

--- a/x11-packages/freerdp/0005-fix-hardcoded-paths.patch
+++ b/x11-packages/freerdp/0005-fix-hardcoded-paths.patch
@@ -1,0 +1,95 @@
+--- a/winpr/libwinpr/path/shell.c
++++ b/winpr/libwinpr/path/shell.c
+@@ -107,7 +107,7 @@
+ 	path = GetEnvAlloc("TMPDIR");
+ 
+ 	if (!path)
+-		path = _strdup("/tmp");
++		path = _strdup("@TERMUX_PREFIX@/tmp");
+ 
+ #endif
+ 	return path;
+--- a/winpr/libwinpr/sspi/Schannel/schannel_openssl.c
++++ b/winpr/libwinpr/sspi/Schannel/schannel_openssl.c
+@@ -240,7 +240,7 @@
+ 	options |= SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS;
+ 	SSL_CTX_set_options(context->ctx, options);
+ 
+-	if (SSL_CTX_use_RSAPrivateKey_file(context->ctx, "/tmp/localhost.key", SSL_FILETYPE_PEM) <= 0)
++	if (SSL_CTX_use_RSAPrivateKey_file(context->ctx, "@TERMUX_PREFIX@/tmp/localhost.key", SSL_FILETYPE_PEM) <= 0)
+ 	{
+ 		WLog_ERR(TAG, "SSL_CTX_use_RSAPrivateKey_file failed");
+ 		goto out_rsa_key;
+@@ -254,7 +254,7 @@
+ 		goto out_ssl_new;
+ 	}
+ 
+-	if (SSL_use_certificate_file(context->ssl, "/tmp/localhost.crt", SSL_FILETYPE_PEM) <= 0)
++	if (SSL_use_certificate_file(context->ssl, "@TERMUX_PREFIX@/tmp/localhost.crt", SSL_FILETYPE_PEM) <= 0)
+ 	{
+ 		WLog_ERR(TAG, "SSL_use_certificate_file failed");
+ 		goto out_use_certificate;
+--- a/server/shadow/X11/x11_shadow.c
++++ b/server/shadow/X11/x11_shadow.c
+@@ -131,7 +131,7 @@
+ static BOOL x11_shadow_pam_get_service_name(SHADOW_PAM_AUTH_INFO* info)
+ {
+ 	size_t x;
+-	const char* base = "/etc/pam.d";
++	const char* base = "@TERMUX_PREFIX@/etc/pam.d";
+ 	const char* hints[] = { "lightdm", "gdm", "xdm", "login", "sshd" };
+ 
+ 	for (x = 0; x < ARRAYSIZE(hints); x++)
+--- a/winpr/libwinpr/timezone/timezone.c
++++ b/winpr/libwinpr/timezone/timezone.c
+@@ -89,7 +89,7 @@
+ 
+ static char* winpr_get_timezone_from_link(void)
+ {
+-	const char* links[] = { "/etc/localtime", "/etc/TZ" };
++	const char* links[] = { "@TERMUX_PREFIX@/etc/localtime", "@TERMUX_PREFIX@/etc/TZ" };
+ 	size_t x;
+ 	ssize_t len;
+ 	char buf[1024];
+@@ -233,7 +233,7 @@
+ #if defined(__FreeBSD__) || defined(__OpenBSD__)
+ 	fp = winpr_fopen("/var/db/zoneinfo", "r");
+ #else
+-	fp = winpr_fopen("/etc/timezone", "r");
++	fp = winpr_fopen("@TERMUX_PREFIX@/etc/timezone", "r");
+ #endif
+ 
+ 	if (NULL == fp)
+--- a/winpr/libwinpr/utils/sam.c
++++ b/winpr/libwinpr/utils/sam.c
+@@ -40,7 +40,7 @@
+ #ifdef _WIN32
+ #define WINPR_SAM_FILE "C:\\SAM"
+ #else
+-#define WINPR_SAM_FILE "/etc/winpr/SAM"
++#define WINPR_SAM_FILE "@TERMUX_PREFIX@/etc/winpr/SAM"
+ #endif
+ #define TAG WINPR_TAG("utils")
+ 
+--- a/winpr/libwinpr/registry/registry_reg.c
++++ b/winpr/libwinpr/registry/registry_reg.c
+@@ -36,7 +36,7 @@
+ #include "../log.h"
+ #define TAG WINPR_TAG("registry")
+ 
+-#define WINPR_HKLM_HIVE "/etc/winpr/HKLM.reg"
++#define WINPR_HKLM_HIVE "@TERMUX_PREFIX@/etc/winpr/HKLM.reg"
+ 
+ struct reg_data_type
+ {
+--- a/winpr/libwinpr/wtsapi/wtsapi.c
++++ b/winpr/libwinpr/wtsapi/wtsapi.c
+@@ -740,7 +740,7 @@
+ 
+ 	ini = IniFile_New();
+ 
+-	if (IniFile_ReadFile(ini, "/var/run/freerds.instance") < 0)
++	if (IniFile_ReadFile(ini, "@TERMUX_PREFIX@/var/run/freerds.instance") < 0)
+ 	{
+ 		IniFile_Free(ini);
+ 		WLog_ERR(TAG, "failed to parse freerds.instance");

--- a/x11-packages/freerdp/0006-read-timezone.patch
+++ b/x11-packages/freerdp/0006-read-timezone.patch
@@ -1,0 +1,19 @@
+--- a/winpr/libwinpr/timezone/timezone.c
++++ b/winpr/libwinpr/timezone/timezone.c
+@@ -232,6 +232,16 @@
+ 	char* tzid = NULL;
+ #if defined(__FreeBSD__) || defined(__OpenBSD__)
+ 	fp = winpr_fopen("/var/db/zoneinfo", "r");
++#elif defined(__TERMUX__)
++	fp = popen("getprop persist.sys.timezone", "r");
++
++	if (fp)
++	{
++		tzid = winpr_read_unix_timezone_identifier_from_file(fp);
++		pclose(fp);
++	}
++
++	return tzid;
+ #else
+ 	fp = winpr_fopen("@TERMUX_PREFIX@/etc/timezone", "r");
+ #endif

--- a/x11-packages/freerdp/build.sh
+++ b/x11-packages/freerdp/build.sh
@@ -1,0 +1,38 @@
+TERMUX_PKG_HOMEPAGE=http://www.freerdp.com/
+TERMUX_PKG_DESCRIPTION="A free remote desktop protocol library and clients"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=2.11.2
+TERMUX_PKG_SRCURL=https://github.com/FreeRDP/FreeRDP/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=674b5600bc2ae3e16e5b5a811c7d5b0daaff6198601ba278bd15b4cb9b281044
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="libandroid-shmem, libcairo, libjpeg-turbo, libusb, libwayland, libx11, libxcursor, libxdamage, libxext, libxfixes, libxi, libxinerama, libxkbcommon, libxkbfile, libxrandr, libxrender, libxv, openssl, pulseaudio, zlib"
+TERMUX_PKG_BUILD_DEPENDS="libwayland-cross-scanner, libwayland-protocols"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DANDROID_NO_TERMUX=OFF
+-DWITH_LIBSYSTEMD=OFF
+-DWITH_PULSE=ON
+-DWITH_OPENSLES=OFF
+-DWITH_OSS=OFF
+-DWITH_ALSA=OFF
+-DWITH_CUPS=OFF
+-DWITH_PCSC=OFF
+-DWITH_FFMPEG=OFF
+-DWITH_JPEG=ON
+-DWITH_OPENSSL=ON
+-DWITH_SERVER=ON
+"
+
+termux_step_post_get_source() {
+	find "$TERMUX_PKG_SRCDIR" -name CMakeLists.txt -o -name '*.cmake' | \
+		xargs -n 1 sed -i \
+		-e 's/\([^A-Za-z0-9_]ANDROID\)\([^A-Za-z0-9_]\)/\1_NO_TERMUX\2/g' \
+		-e 's/\([^A-Za-z0-9_]ANDROID\)$/\1_NO_TERMUX/g'
+}
+
+termux_step_pre_configure() {
+	export PATH="$TERMUX_PREFIX/opt/libwayland/cross/bin:$PATH"
+
+	CPPFLAGS+=" -D__USE_BSD"
+	LDFLAGS+=" -landroid-shmem"
+}


### PR DESCRIPTION
Add `freerdp`, a RDP client. Termux already has `xrdp` as RDP server, but no RDP client currently.

Also enable `freerdp-server` as it is the dependency of `weston` (a wayland compositor, will be added after this PR gets merged).

Tested on MIX2S with tigervnc.

![image](https://github.com/termux/termux-packages/assets/45286352/e653de77-1cc4-4018-9aa6-fd6aa36881d4)


