### PR TITLE
perl: build with -O2

### DIFF
--- a/packages/perl/build.sh
+++ b/packages/perl/build.sh
@@ -65,7 +65,8 @@ termux_step_configure() {
 			-Dar="$ORIG_AR" \
 			-Duseshrplib \
 			-Duseithreads \
-			-Dusemultiplicity
+			-Dusemultiplicity \
+			-Doptimize="-O2"
 	)
 }
 


### PR DESCRIPTION
Closes #18340.

Output of `perl -V` now includes -O2:
```
Summary of my perl5 (revision 5 version 38 subversion 0) configuration:
   
  Platform:
    osname=android
    osvers=current
    archname=aarch64-android
    uname=''
    config_args='--target=aarch64-linux-android --with-cc=aarch64-linux-android-clang --with-ranlib=llvm-ranlib -Dosname=android -Dsysroot=-I/data/data/com.termux/files -Dprefix=/data/data/com.termux/files/usr -Dsh=/data/data/com.termux/files/usr/bin/sh -Dld=aarch64-linux-android-clang -Wl,-rpath=/data/data/com.termux/files/usr/lib -Wl,--enable-new-dtags -Dar=llvm-ar -Duseshrplib -Duseithreads -Dusemultiplicity -Doptimize=-O2 --keeplog --mode=target --target=aarch64-linux-android --targetarch=aarch64-unknown-linux-android'
(snip)
```

On my Quest 3, speed of an empty is loop goes down from 7.678 seconds to 1.769 seconds:
```
meta-quest-3:~/tmp/perl$ time perl -e 'for (1..100_000_000) {}'

real	0m1.769s
user	0m1.641s
sys	0m0.028s
```