### PR TITLE
new package: weston

### DIFF
--- a/packages/libseat/build.sh
+++ b/packages/libseat/build.sh
@@ -1,0 +1,11 @@
+TERMUX_PKG_HOMEPAGE=https://sr.ht/~kennylevinsen/seatd/
+TERMUX_PKG_DESCRIPTION="Reference implementation of a wayland compositor"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.8.0"
+TERMUX_PKG_SRCURL=https://github.com/kennylevinsen/seatd/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=a562a44ee33ccb20954a1c1ec9a90ecb2db7a07ad6b18d0ac904328efbcf65a0
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-Ddefaultpath=$TERMUX_PREFIX/var/run/seatd.sock
+"

--- a/x11-packages/weston/0001-neatvnc-0.7.0.patch
+++ b/x11-packages/weston/0001-neatvnc-0.7.0.patch
@@ -1,0 +1,32 @@
+https://gitlab.freedesktop.org/wayland/weston/-/commit/8895b15f3dfc555a869e310ff6e16ff5dced1336
+--- a/libweston/backend-vnc/meson.build
++++ b/libweston/backend-vnc/meson.build
+@@ -3,7 +3,7 @@ if not get_option('backend-vnc')
+ endif
+ 
+ config_h.set('BUILD_VNC_COMPOSITOR', '1')
+-dep_neatvnc = dependency('neatvnc', version: ['>= 0.6.0', '< 0.7.0'], required: false, fallback: ['neatvnc', 'neatvnc_dep'])
++dep_neatvnc = dependency('neatvnc', version: ['>= 0.7.0', '< 0.8.0'], required: false, fallback: ['neatvnc', 'neatvnc_dep'])
+ if not dep_neatvnc.found()
+ 	error('VNC backend requires neatvnc which was not found. Or, you can use \'-Dbackend-vnc=false\'.')
+ endif
+--- a/libweston/backend-vnc/vnc.c
++++ b/libweston/backend-vnc/vnc.c
+@@ -1248,8 +1248,15 @@ vnc_backend_create(struct weston_compositor *compositor,
+ 		goto err_output;
+ 	}
+ 
+-	ret = nvnc_enable_auth(backend->server, config->server_key,
+-			       config->server_cert, vnc_handle_auth,
++	ret = nvnc_set_tls_creds(backend->server, config->server_key,
++				 config->server_cert);
++	if (ret) {
++		weston_log("Failed set TLS credentials\n");
++		goto err_output;
++	}
++
++	ret = nvnc_enable_auth(backend->server, NVNC_AUTH_REQUIRE_AUTH |
++			       NVNC_AUTH_REQUIRE_ENCRYPTION, vnc_handle_auth,
+ 			       NULL);
+ 	if (ret) {
+ 		weston_log("Failed to enable TLS support\n");

--- a/x11-packages/weston/0002-drop-deps-libinput.patch
+++ b/x11-packages/weston/0002-drop-deps-libinput.patch
@@ -1,0 +1,128 @@
+--- a/meson.build
++++ b/meson.build
+@@ -139,7 +139,6 @@
+ dep_wayland_server = dependency('wayland-server', version: '>= 1.20.0')
+ dep_wayland_client = dependency('wayland-client', version: '>= 1.20.0')
+ dep_pixman = dependency('pixman-1', version: '>= 0.25.2')
+-dep_libinput = dependency('libinput', version: '>= 1.2.0')
+ dep_libevdev = dependency('libevdev')
+ dep_libm = cc.find_library('m')
+ dep_libdl = cc.find_library('dl')
+--- a/compositor/meson.build
++++ b/compositor/meson.build
+@@ -12,7 +12,6 @@
+ deps_weston = [
+ 	dep_libshared,
+ 	dep_libweston_public,
+-	dep_libinput,
+ 	dep_libevdev,
+ 	dep_libdl,
+ 	dep_threads,
+--- a/libweston/meson.build
++++ b/libweston/meson.build
+@@ -217,27 +217,6 @@
+ )
+ dep_session_helper = declare_dependency(link_with: lib_session_helper)
+ 
+-
+-lib_libinput_backend = static_library(
+-	'libinput-backend',
+-	[
+-		'libinput-device.c',
+-		'libinput-seat.c',
+-		tablet_unstable_v2_server_protocol_h
+-	],
+-	dependencies: [
+-		dep_libweston_private,
+-		dep_libinput,
+-		dependency('libudev', version: '>= 136')
+-	],
+-	include_directories: common_inc,
+-	install: false
+-)
+-dep_libinput_backend = declare_dependency(
+-	link_with: lib_libinput_backend,
+-	include_directories: include_directories('.')
+-)
+-
+ dep_vertex_clipping = declare_dependency(
+ 	sources: 'vertex-clipping.c',
+ 	include_directories: include_directories('.')
+--- a/compositor/main.c
++++ b/compositor/main.c
+@@ -41,7 +41,9 @@
+ #include <sys/stat.h>
+ #include <sys/wait.h>
+ #include <sys/socket.h>
++#ifndef __ANDROID__
+ #include <libinput.h>
++#endif
+ #include <libevdev/libevdev.h>
+ #include <linux/input.h>
+ #include <sys/time.h>
+@@ -1038,6 +1040,7 @@
+ 	return 0;
+ }
+ 
++#ifndef __ANDROID__
+ static int
+ save_touch_device_calibration(struct weston_compositor *compositor,
+ 			      struct weston_touch_device *device,
+@@ -1095,6 +1098,7 @@
+ 
+ 	return ret;
+ }
++#endif
+ 
+ static int
+ weston_compositor_init_config(struct weston_compositor *ec,
+@@ -1153,12 +1157,14 @@
+ 			compositor->use_color_manager = true;
+ 	}
+ 
++#ifndef __ANDROID__
+ 	/* weston.ini [libinput] */
+ 	s = weston_config_get_section(config, "libinput", NULL, NULL);
+ 	weston_config_section_get_bool(s, "touchscreen_calibrator", &cal, 0);
+ 	if (cal)
+ 		weston_compositor_enable_touch_calibrator(ec,
+ 						save_touch_device_calibration);
++#endif
+ 
+ 	return 0;
+ }
+@@ -1873,6 +1879,7 @@
+ 						&wet->heads_changed_listener);
+ }
+ 
++#ifndef __ANDROID__
+ static void
+ configure_input_device_accel(struct weston_config_section *s,
+ 		struct libinput_device *device)
+@@ -2074,6 +2081,7 @@
+ 
+ 	configure_input_device_scroll(s, device);
+ }
++#endif
+ 
+ static int
+ drm_backend_output_configure(struct weston_output *output,
+@@ -2923,6 +2931,7 @@
+ load_drm_backend(struct weston_compositor *c, int *argc, char **argv,
+ 		 struct weston_config *wc, enum weston_renderer_type renderer)
+ {
++#ifndef __ANDROID__
+ 	struct weston_drm_backend_config config = {{ 0, }};
+ 	struct weston_config_section *section;
+ 	struct wet_compositor *wet = to_wet_compositor(c);
+@@ -2990,6 +2999,10 @@
+ 	free(config.specific_device);
+ 
+ 	return ret;
++#else
++	weston_log("error: drm_backend is not avaiable on Android.\n");
++	abort();
++#endif
+ }
+ 
+ static int

--- a/x11-packages/weston/0003-drop-deps-pam.patch
+++ b/x11-packages/weston/0003-drop-deps-pam.patch
@@ -1,0 +1,37 @@
+--- a/libweston/meson.build
++++ b/libweston/meson.buil
+@@ -90,7 +90,7 @@
+ 	dep_egl = dependency('', required: false)
+ endif
+ 
+-if get_option('backend-vnc')
++if get_option('backend-vnc') and host_machine.system() != 'android'
+ 	dep_pam = dependency('pam', required: false)
+ 	if not dep_pam.found()
+ 		dep_pam = cc.find_library('pam')
+--- a/pam/meson.build
++++ b/pam/meson.build
+@@ -1,4 +1,4 @@
+-if not get_option('backend-vnc')
++if not get_option('backend-vnc') or host_machine.system() == 'android'
+ 	subdir_done()
+ endif
+ 
+--- a/libweston/backend-vnc/vnc.c
++++ b/libweston/backend-vnc/vnc.c
+@@ -1090,6 +1090,7 @@
+ 	nvnc_set_userdata(backend->server, backend, NULL);
+ 	nvnc_set_name(backend->server, "Weston VNC backend");
+ 
++#ifndef __ANDROID__
+ 	if (!nvnc_has_auth()) {
+ 		weston_log("Neat VNC built without TLS support\n");
+ 		goto err_output;
+@@ -1117,6 +1118,7 @@
+ 	}
+ 
+ 	weston_log("TLS support activated\n");
++#endif
+ 
+ 	ret = weston_plugin_api_register(compositor, WESTON_VNC_OUTPUT_API_NAME,
+ 					 &api, sizeof(api));

--- a/x11-packages/weston/0004-drop-deps-libudev.patch
+++ b/x11-packages/weston/0004-drop-deps-libudev.patch
@@ -1,0 +1,11 @@
+--- a/clients/meson.build
++++ b/clients/meson.build
+@@ -77,7 +77,7 @@
+ 			dep_libshared,
+ 			dep_pixman,
+ 			dep_libdrm,
+-			dependency('libudev', version: '>= 136'),
++			dependency('libudev', version: '>= 136', required: simple_build_all or simple_clients_enabled.contains('dmabuf-feedback')),
+ 			# gbm_bo_get_fd_for_plane() from 21.1.0
+ 			dependency('gbm', version: '>= 21.1.1',
+ 				required: simple_build_all or simple_clients_enabled.contains('dmabuf-feedback'),

--- a/x11-packages/weston/0005-use-cross-wayland-scanner.patch
+++ b/x11-packages/weston/0005-use-cross-wayland-scanner.patch
@@ -1,0 +1,9 @@
+--- a/protocol/meson.build
++++ b/protocol/meson.build
+@@ -1,5 +1,5 @@
+ dep_scanner = dependency('wayland-scanner', native: true)
+-prog_scanner = find_program(dep_scanner.get_variable(pkgconfig: 'wayland_scanner'))
++prog_scanner = find_program('wayland-scanner')
+ 
+ dep_wp = dependency('wayland-protocols', version: '>= 1.31',
+ 	fallback: ['wayland-protocols', 'wayland_protocols'])

--- a/x11-packages/weston/0006-progname.patch
+++ b/x11-packages/weston/0006-progname.patch
@@ -1,0 +1,49 @@
+--- a/shared/xalloc.h
++++ b/shared/xalloc.h
+@@ -42,6 +42,10 @@
+ 	static const char oommsg[] = ": out of memory\n";
+ 	size_t written __attribute__((unused));
+ 
++#ifdef __ANDROID__
++	const char *program_invocation_short_name = getprogname();
++#endif
++
+ 	if (p)
+ 		return p;
+ 
+--- a/clients/touch-calibrator.c
++++ b/clients/touch-calibrator.c
+@@ -870,6 +870,10 @@
+ {
+ 	va_list argp;
+ 
++#ifdef __ANDROID__
++	const char *program_invocation_short_name = getprogname();
++#endif
++
+ 	va_start(argp, fmt);
+ 	fprintf(stderr, "%s error: ", program_invocation_short_name);
+ 	vfprintf(stderr, fmt, argp);
+@@ -879,6 +883,9 @@
+ static void
+ help(void)
+ {
++#ifdef __ANDROID__
++	const char *program_invocation_short_name = getprogname();
++#endif
+ 	fprintf(stderr, "Compute a touchscreen calibration matrix for "
+ 		"a Wayland compositor by\n"
+ 		"having the user touch points on the screen.\n\n");
+--- a/clients/desktop-shell.c
++++ b/clients/desktop-shell.c
+@@ -1172,6 +1172,10 @@
+ 	struct weston_config_section *s;
+ 	char *type;
+ 
++#ifdef __ANDROID__
++	const char *program_invocation_short_name = getprogname();
++#endif
++
+ 	background = xzalloc(sizeof *background);
+ 	background->owner = output;
+ 	background->base.configure = background_configure;

--- a/x11-packages/weston/0007-fix-include.patch
+++ b/x11-packages/weston/0007-fix-include.patch
@@ -1,0 +1,28 @@
+--- a/shared/signal.h
++++ b/shared/signal.h
+@@ -23,6 +23,10 @@
+ #ifndef WESTON_SIGNAL_H
+ #define WESTON_SIGNAL_H
+ 
++#ifdef __ANDROID__
++#include_next <signal.h>
++#endif
++
+ #include <wayland-server-core.h>
+ 
+ #ifdef  __cplusplus
+--- a/libweston/input.c
++++ b/libweston/input.c
+@@ -34,7 +34,12 @@
+ #include <sys/mman.h>
+ #include <assert.h>
+ #include <unistd.h>
++#ifndef __ANDROID__
+ #include <values.h>
++#else
++#include <limits.h>
++#include <float.h>
++#endif
+ #include <fcntl.h>
+ #include <limits.h>
+ #include <errno.h>

--- a/x11-packages/weston/0008-drop-tests.patch
+++ b/x11-packages/weston/0008-drop-tests.patch
@@ -1,0 +1,11 @@
+--- a/meson.build
++++ b/meson.build
+@@ -173,7 +173,7 @@
+ subdir('pipewire')
+ subdir('clients')
+ subdir('wcap')
+-subdir('tests')
++# subdir('tests')
+ subdir('data')
+ subdir('man')
+ subdir('pam')

--- a/x11-packages/weston/build.sh
+++ b/x11-packages/weston/build.sh
@@ -1,0 +1,31 @@
+TERMUX_PKG_HOMEPAGE=https://gitlab.freedesktop.org/wayland/weston
+TERMUX_PKG_DESCRIPTION="Reference implementation of a wayland compositor"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="12.0.2"
+TERMUX_PKG_SRCURL=https://gitlab.freedesktop.org/wayland/weston/-/archive/${TERMUX_PKG_VERSION}/weston-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=d2fb2f993891c5d4b09dcbf1fc9826cf8c615fa2219aea555422976761f28499
+TERMUX_PKG_DEPENDS="freerdp, libaml, libandroid-shmem, libcairo, libcairo, libevdev, libglvnd, libneatvnc, libseat, libwayland, libwebp, libxcb, libxcursor, libxkbcommon, littlecms, pango, xcb-util-cursor"
+TERMUX_PKG_BUILD_DEPENDS="libwayland-cross-scanner, libwayland-protocols"
+# XXX: Do not depend on gbm
+TERMUX_PKG_ANTI_BUILD_DEPENDS="mesa"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-Dbackend-drm=false
+-Dbackend-drm-screencast-vaapi=false
+-Dremoting=false
+-Dpipewire=false
+-Drenderer-gl=true
+-Dbackend-pipewire=false
+-Dbackend-default=headless
+-Dxwayland-path=$TERMUX_PREFIX/bin/Xwayland
+-Dsystemd=false
+-Dsimple-clients=damage,shm,touch
+-Ddemo-clients=false
+"
+
+termux_step_pre_configure() {
+	export PATH="$TERMUX_PREFIX/opt/libwayland/cross/bin:$PATH"
+
+	export LDFLAGS+=" -landroid-shmem"
+}


### PR DESCRIPTION
Add `weston`, a basic wayland compositor. It provides native RDP and VNC support, and can provide wayland session inside X11 or wayland.

Tested on MIX2S with both VNC backend and RDP backend.

![image](https://github.com/termux/termux-packages/assets/45286352/0be7d66d-4eb9-4fa8-9879-c4d608df26ed)

![image](https://github.com/termux/termux-packages/assets/45286352/68f2913a-140d-4388-8d6b-dbc6cea70c37)
