### PR TITLE
packages.yml: change location indicating "large" packages

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -177,7 +177,7 @@ jobs:
         done
 
         if [ ! -z "$packages" ]; then
-          if grep -qP '(^|\s)(clvk|dart|libllvm|rust|rustc-nightly|swift|tinygo|wasmer|zig|firefox|bionic-host)($|\s)' <<< "$packages"; then
+          if grep -qP "(^|\s)$packages($|\s)" ./scripts/big-pkgs.list; then
             ./scripts/setup-ubuntu.sh
             sudo apt install ninja-build
             sudo apt purge -yq $(dpkg -l | grep '^ii' | awk '{ print $2 }' | grep -P '(aspnetcore|cabal-|dotnet-|ghc-|libmono|php)') \

--- a/scripts/big-pkgs.list
+++ b/scripts/big-pkgs.list
@@ -1,0 +1,11 @@
+clvk
+dart
+libllvm
+rust
+rustc-nightly
+swift
+tinygo
+wasmer
+zig
+firefox
+bionic-host


### PR DESCRIPTION
Due to the fact that we specify “large” packages in `packages.yml`, this is not added in the git repo mirror termux-pacman/termux-packages since `packages.yml` is static (that is, any changes are ignored).