### PR TITLE
packages.yml: fix regexp on big packages

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -181,7 +181,7 @@ jobs:
         done
 
         if [ ! -z "$packages" ]; then
-          if grep -qP "(^|\s)${packages// /($|\s)|(^|\s)}($|\s)" ./scripts/big-pkgs.list; then
+          if grep -qP "(^|\\s)${packages// /($|\\s)|(^|\\s)}($|\\s)" ./scripts/big-pkgs.list; then
             ./scripts/setup-ubuntu.sh
             sudo apt install ninja-build
             sudo apt purge -yq $(dpkg -l | grep '^ii' | awk '{ print $2 }' | grep -P '(aspnetcore|cabal-|dotnet-|ghc-|libmono|php)') \


### PR DESCRIPTION
The origin one will not work properly, all of the packages will build on the VM rather than our Docker image.

Tested with Github Action.

"libc++": https://github.com/termux/termux-packages/actions/runs/6953220058/job/18918023611

"libllvm": https://github.com/termux/termux-packages/actions/runs/6953227022

"libc++ libllvm": https://github.com/termux/termux-packages/actions/runs/6953255561/job/18918102357
