### PR TITLE
fix(main/zsh): zshrc double sourcing and dangling nomatch

### DIFF
--- a/packages/zsh/build.sh
+++ b/packages/zsh/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="LICENCE"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=5.9
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL="https://sourceforge.net/projects/zsh/files/zsh/$TERMUX_PKG_VERSION/zsh-$TERMUX_PKG_VERSION".tar.xz
 TERMUX_PKG_SHA256=9b8d1ecedd5b5e81fbf1918e876752a7dd948e05c1a0dba10ab863842d45acd5
 # Remove hard link to bin/zsh as Android does not support hard links:

--- a/packages/zsh/etc-zshrc
+++ b/packages/zsh/etc-zshrc
@@ -1,8 +1,5 @@
-. @TERMUX_PREFIX@/etc/profile
+emulate sh -c '. @TERMUX_PREFIX@/etc/profile'
 command_not_found_handler() {
 	@TERMUX_PREFIX@/libexec/termux/command-not-found $1
 }
-#set nomatch so *.sh would not error if no file is available
-setopt +o nomatch
-. @TERMUX_PREFIX@/etc/profile
 PS1='%# '


### PR DESCRIPTION
Fixes #18605