### PR TITLE
fix(main/nushell): disable `--features=dataframe` for `i686` as it's not building on *GitHub*

### DIFF
--- a/packages/nushell/build.sh
+++ b/packages/nushell/build.sh
@@ -26,7 +26,7 @@ termux_step_pre_configure() {
 		echo "INPUT(-l:libunwind.a)" >libgcc.so
 		popd
 	fi
-	if [ $TERMUX_ARCH != "arm" ]; then
+	if [ $TERMUX_ARCH != "i686" && $TERMUX_ARCH != "arm" ]; then
 		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --features=dataframe"
 	fi
 


### PR DESCRIPTION
The build failed for i686 at <https://github.com/termux/termux-packages/actions/runs/7186452137/job/19571862993>.

See <https://github.com/nushell/nushell/pull/9542>. This had similar issues due to `simd-json`. They just skipped it with the *Rust* flags `--exclude=nu-cmd-dataframe`.