### PR TITLE
fix(termux_repology_api_get_latest_version.sh): return "Already up to date" for all repology update requests in the case if repology is unavailable or other error

### DIFF
--- a/scripts/updates/api/termux_repology_api_get_latest_version.sh
+++ b/scripts/updates/api/termux_repology_api_get_latest_version.sh
@@ -20,7 +20,8 @@ termux_repology_api_get_latest_version() {
 		find /usr/lib/python3.* -name EXTERNALLY-MANAGED -print -quit | grep -q . || 
 			pip3 install bs4 requests >/dev/null # Install python dependencies.
 		python3 "${TERMUX_SCRIPTDIR}"/scripts/updates/api/dump-repology-data \
-			"${TERMUX_REPOLOGY_DATA_FILE}" >/dev/null
+			"${TERMUX_REPOLOGY_DATA_FILE}" >/dev/null || \
+   				echo "{}" > ${TERMUX_REPOLOGY_DATA_FILE}
 	fi
 
 	local PKG_NAME="$1"


### PR DESCRIPTION
https://github.com/termux/termux-packages/issues/18690#issuecomment-1855014477