### PR TITLE
fix(main/libidn2): Disable symver aliases.

### DIFF
--- a/packages/libidn2/0000-disable-versioning-of-symbols.patch
+++ b/packages/libidn2/0000-disable-versioning-of-symbols.patch
@@ -1,0 +1,10 @@
+--- src/configure
++++ src/configure
+@@ -32898,8 +32898,6 @@
+ if ac_fn_c_try_compile "$LINENO"
+ then :
+
+-printf "%s\n" "#define HAVE_SYMVER_ALIAS_SUPPORT 1" >>confdefs.h
+-
+ fi
+ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext


### PR DESCRIPTION
Building `libidn2` currently fails at link:

```
make[3]: Entering directory '/home/builder/.termux-build/libidn2/build/lib'
  // snip
  CC       context.lo
  CCLD     libidn2.la
ld.lld: error: .libs/puny_encode.o: symbol _idn2_punycode_encode@IDN2_0.0.0 has undefined version IDN2_0.0.0
ld.lld: error: .libs/puny_decode.o: symbol _idn2_punycode_decode@IDN2_0.0.0 has undefined version IDN2_0.0.0
clang-17: error: linker command failed with exit code 1 (use -v to see invocation)
make[3]: *** [Makefile:1609: libidn2.la] Error 1
```

This fix is recommended here[0]. I couldn't figure out a cleaner way to
do this. It would have been a more stable patch against `config.ac`, but
`configure` is included in the source tarball and this seemed like the
lesser evil. I manually built all packages explicitly depending on
`libidn2` with this patch applied:

```
gnunet
gnurl
html-xml-utils
lftp
libcurl
libgmime
libgnutls
libknot
libpsl
msmtp
wget2
wget
whois
```

`gnunet` and `wget2` fail with an apparently unrelated issue:

```
ld.lld: error: version script assignment of 'LIBCTF_1.0' to symbol 'ctf_label_set' failed: symbol not defined
ld.lld: error: version script assignment of 'LIBCTF_1.0' to symbol 'ctf_label_get' failed: symbol not defined
```

`libgmime` hangs building `termux-am`. The rest build fine.

[0] https://www.mail-archive.com/help-libidn@gnu.org/msg01356.html
