### PR TITLE
new package: libcwidget, aptitude

### DIFF
--- a/packages/aptitude/0001-fix-ftbfs-with-gcc-10.patch
+++ b/packages/aptitude/0001-fix-ftbfs-with-gcc-10.patch
@@ -1,0 +1,14 @@
+Description: Fix FTBFS with GCC 10
+Author: Axel Beckert <abe@debian.org>
+Bug-Debian: https://bugs.debian.org/966875
+
+--- a/src/generic/views/download_progress.h
++++ b/src/generic/views/download_progress.h
+@@ -29,6 +29,7 @@
+ #include <optional>
+ #include <string>
+ #include <vector>
++#include <sstream>
+ 
+ namespace aptitude
+ {

--- a/packages/aptitude/0002-apt_2.1.19_compatibility.patch
+++ b/packages/aptitude/0002-apt_2.1.19_compatibility.patch
@@ -1,0 +1,19 @@
+Description: Fix FTBFS regression from StrToNum fixes in APT 2.1.19
+Author: David Kalnischkies <david@kalnischkies.de>
+Author: Axel Beckert <abe@debian.org>
+Bug-Debian: https://bugs.debian.org/982716
+
+--- a/src/generic/apt/aptitude_resolver.cc
++++ b/src/generic/apt/aptitude_resolver.cc
+@@ -673,7 +673,10 @@
+   else
+     {
+       unsigned long score_tweak = 0;
+-      if(!StrToNum(action.c_str(), score_tweak, action.size()))
++      char * endptr;
++      errno = 0;
++      score_tweak = strtol(action.c_str(), &endptr, 10);
++      if (errno != 0 || *endptr != '\0')
+ 	{
+ 	  // TRANSLATORS: actions ("approve", etc.) are keywords and should
+ 	  // not be translated

--- a/packages/aptitude/0003-fix-FTBFS-1011681.patch
+++ b/packages/aptitude/0003-fix-FTBFS-1011681.patch
@@ -1,0 +1,15 @@
+Description: Fix FTBFS due missing unistd.h include
+ Probably caused by a more recent C/C++ compiler
+Bug-Debian: https://bugs.debian.org/1011681
+Author: Axel Beckert <abe@debian.org>
+
+--- a/src/generic/apt/dpkg.cc
++++ b/src/generic/apt/dpkg.cc
+@@ -35,6 +35,7 @@
+ #include <sys/types.h>
+ #include <sys/wait.h>
+ #include <fcntl.h>
++#include <unistd.h>
+ 
+ using namespace std;
+ 

--- a/packages/aptitude/0004-fix-bashism-related-issue-with-fixman-scripts.patch
+++ b/packages/aptitude/0004-fix-bashism-related-issue-with-fixman-scripts.patch
@@ -1,0 +1,18 @@
+Description: Fix bashism-related issue with fixman i18n scripts
+ Simply calling them as script instead of forking them seems to do the trick.
+Author: Axel Beckert <abe@debian.org>
+Bug-Debian: https://bugs.debian.org/999383
+
+diff --git a/buildlib/docbook.mk b/buildlib/docbook.mk
+index 9ec1b433..de03f0b4 100644
+--- a/buildlib/docbook.mk
++++ b/buildlib/docbook.mk
+@@ -129,7 +129,7 @@ docbook-man-stamp: $(DOCBOOK_XML) aptitude-man.xsl aptitude-common.xsl
+ 	@if [ -x "$(srcdir)/fixman" ]; then \
+ 	  for i in $(DOCBOOK_MANS); do \
+ 	    echo "$(srcdir)/fixman $$i"; \
+-	    . $(srcdir)/fixman $$i; \
++	    $(srcdir)/fixman $$i; \
+           done; \
+         fi
+ 	touch docbook-man-stamp

--- a/packages/aptitude/0005-fix-ftbfs-with-gcc-12.patch
+++ b/packages/aptitude/0005-fix-ftbfs-with-gcc-12.patch
@@ -1,0 +1,34 @@
+From 3b135b1a8a575a3cf0718c697e546ea192dfb88d Mon Sep 17 00:00:00 2001
+From: Paul Wise <pabs@debian.org>
+Date: Sun, 24 Jul 2022 16:40:28 +0800
+Subject: [PATCH] Declare operator<< functions used by cppunit before they are
+ used.
+
+Solves a build failure with GCC 12 and clang.
+
+Fixes: https://bugs.debian.org/1012895
+---
+ tests/test_parsers.cc | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/tests/test_parsers.cc b/tests/test_parsers.cc
+index 1bcc8e31..afb046f6 100644
+--- a/tests/test_parsers.cc
++++ b/tests/test_parsers.cc
+@@ -20,6 +20,14 @@
+ 
+ #include <generic/util/parsers.h>
+ 
++// These are used by cppunit so they must be declared early.
++
++template<typename T>
++std::ostream &operator<<(std::ostream &out, const std::optional<T> &o);
++
++template<typename T>
++std::ostream &operator<<(std::ostream &out, const std::vector<T> &v);
++
+ #include <cppunit/extensions/HelperMacros.h>
+ 
+ #include <boost/fusion/container/generation/make_vector.hpp>
+-- 
+2.36.1

--- a/packages/aptitude/0100-fix-hardcoded-paths.patch
+++ b/packages/aptitude/0100-fix-hardcoded-paths.patch
@@ -1,0 +1,185 @@
+diff -uNr a/configure b/configure
+--- a/configure
++++ b/configure
+@@ -10766,7 +10766,7 @@
+ 	  STATEDIR="$enableval"
+ 	fi
+ else
+-  STATEDIR="/var/lib/aptitude"
++  STATEDIR="@TERMUX_PREFIX@/var/lib/aptitude"
+ fi
+ 
+ 
+@@ -10780,7 +10780,7 @@
+ 	  LOCKFILE="$enableval"
+ 	fi
+ else
+-  LOCKFILE="/var/lock/aptitude"
++  LOCKFILE="@TERMUX_PREFIX@/var/lock/aptitude"
+ fi
+ 
+ 
+diff -uNr a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
+@@ -633,7 +633,7 @@
+ 	else
+ 	  STATEDIR="$enableval"
+ 	fi,
+-	STATEDIR="/var/lib/aptitude")
++	STATEDIR="@TERMUX_PREFIX@/var/lib/aptitude")
+ 
+ AC_ARG_WITH(lock-loc,
+ 	AS_HELP_STRING([--with-lock-loc], [use the given location for storing state (default /var/lock/aptitude)]),
+@@ -643,7 +643,7 @@
+ 	else
+ 	  LOCKFILE="$enableval"
+ 	fi,
+-	LOCKFILE="/var/lock/aptitude")
++	LOCKFILE="@TERMUX_PREFIX@/var/lock/aptitude")
+ 
+ AC_ARG_ENABLE(aptitude,
+ 	AS_HELP_STRING([--disable-aptitude], [don't compile the program itself]),
+diff -uNr a/src/apt_options.cc b/src/apt_options.cc
+--- a/src/apt_options.cc
++++ b/src/apt_options.cc
+@@ -348,7 +348,7 @@
+ 		 "be interpreted as a shell command that is to "
+ 		 "receive the log on standard input."),
+ 	      PACKAGE "::Log",
+-	      "/var/log/aptitude"),
++	      "@TERMUX_PREFIX@/var/log/aptitude"),
+   option_item(N_("Use localized messages and dates in the log"),
+ 	      N_("If this option is enabled, aptitude will use the "
+ 		 "user's locale for messages and dates in the log "
+diff -uNr a/src/cmdline/cmdline_changelog.cc b/src/cmdline/cmdline_changelog.cc
+--- a/src/cmdline/cmdline_changelog.cc
++++ b/src/cmdline/cmdline_changelog.cc
+@@ -288,9 +288,9 @@
+ void do_cmdline_changelog(const vector<string> &packages,
+                           const std::shared_ptr<terminal_metrics> &term_metrics)
+ {
+-  const char *pager="/usr/bin/sensible-pager";
++  const char *pager="@TERMUX_PREFIX@/bin/sensible-pager";
+ 
+-  if(access("/usr/bin/sensible-pager", X_OK)!=0)
++  if(access("@TERMUX_PREFIX@/bin/sensible-pager", X_OK)!=0)
+     {
+       _error->Warning(_("Can't execute sensible-pager, is this a working Debian system?"));
+ 
+diff -uNr a/src/generic/apt/log.cc b/src/generic/apt/log.cc
+--- a/src/generic/apt/log.cc
++++ b/src/generic/apt/log.cc
+@@ -230,7 +230,7 @@
+ {
+   vector<string> logs;
+ 
+-  string main_log = aptcfg->Find(PACKAGE "::Log", "/var/log/" PACKAGE);
++  string main_log = aptcfg->Find(PACKAGE "::Log", "@TERMUX_PREFIX@/var/log/" PACKAGE);
+ 
+   if(!main_log.empty())
+     logs.push_back(main_log);
+diff -uNr a/src/generic/apt/matching/match.cc b/src/generic/apt/matching/match.cc
+--- a/src/generic/apt/matching/match.cc
++++ b/src/generic/apt/matching/match.cc
+@@ -384,7 +384,7 @@
+ 	  {
+             const std::string filename =
+               aptcfg->FindFile("Apt-Xapian-Index::Index",
+-                               "/var/lib/apt-xapian-index/index");
++                               "@TERMUX_PREFIX@/var/lib/apt-xapian-index/index");
+             db.reset(new Xapian::Database(filename));
+ 	  }
+ 	catch(...)
+diff -uNr a/src/generic/apt/pkg_changelog.cc b/src/generic/apt/pkg_changelog.cc
+--- a/src/generic/apt/pkg_changelog.cc
++++ b/src/generic/apt/pkg_changelog.cc
+@@ -515,7 +515,7 @@
+ 				// the changelog exists by trying to stat it.
+ 				struct stat buf;
+ 
+-				std::string changelog_file = "/usr/share/doc/";
++				std::string changelog_file = "@TERMUX_PREFIX@/share/doc/";
+ 				changelog_file += pkg.Name();
+ 				changelog_file += "/changelog.Debian";
+ 
+diff -uNr a/src/generic/apt/resolver_manager.cc b/src/generic/apt/resolver_manager.cc
+--- a/src/generic/apt/resolver_manager.cc
++++ b/src/generic/apt/resolver_manager.cc
+@@ -497,7 +497,7 @@
+ 	  // Should I close open fds here?
+ 
+ 	  // Should I allow tar to be found on the path?
+-	  execl("/bin/tar", "/bin/tar", "czf",
++	  execl("@TERMUX_PREFIX@/bin/tar", "@TERMUX_PREFIX@/bin/tar", "czf",
+ 		resolver_trace_file.c_str(),
+ 		"-C",
+ 		trace_dir.c_str(),
+diff -uNr a/src/generic/apt/tags.cc b/src/generic/apt/tags.cc
+--- a/src/generic/apt/tags.cc
++++ b/src/generic/apt/tags.cc
+@@ -196,7 +196,7 @@
+ static bool load_tags_from_debtags(OpProgress *progress)
+ {
+   const string filename(aptcfg->FindFile("Debtags::Package-Tags",
+-                                         "/var/lib/debtags/package-tags"));
++                                         "@TERMUX_PREFIX@/var/lib/debtags/package-tags"));
+   _error->PushToStack(); // Ignore no-such-file errors.
+   FileFd F(filename, FileFd::ReadOnly);
+   _error->RevertToStack();
+@@ -353,7 +353,7 @@
+   tag_descriptions = new tag_description_map;
+ 
+   _error->PushToStack(); // Ignore no-such-file errors.
+-  FileFd F(aptcfg->FindFile("DebTags::Vocabulary", "/var/lib/debtags/vocabulary"),
++  FileFd F(aptcfg->FindFile("DebTags::Vocabulary", "@TERMUX_PREFIX@/var/lib/debtags/vocabulary"),
+ 	   FileFd::ReadOnly);
+   _error->RevertToStack();
+ 
+diff -uNr a/src/generic/apt/tasks.cc b/src/generic/apt/tasks.cc
+--- a/src/generic/apt/tasks.cc
++++ b/src/generic/apt/tasks.cc
+@@ -492,6 +492,7 @@
+   const char *descdirs[] =
+     {"/usr/share/tasksel/descs",
+      "/usr/local/share/tasksel/descs",
++     "@TERMUX_PREFIX@/share/tasksel/descs",
+      NULL};
+   vector<string> descfiles;
+   for(const char **it = descdirs; *it != NULL; ++it)
+diff -uNr a/src/gtk/changelog.cc b/src/gtk/changelog.cc
+--- a/src/gtk/changelog.cc
++++ b/src/gtk/changelog.cc
+@@ -65,7 +65,7 @@
+       std::string URL = cw::util::ssprintf("http://bugs.debian.org/%s", bug_number.c_str());
+ 
+       std::vector<std::string> arguments;
+-      arguments.push_back("/usr/bin/sensible-browser");
++      arguments.push_back("@TERMUX_PREFIX@/bin/sensible-browser");
+       arguments.push_back(URL);
+ 
+       Glib::spawn_async(".", arguments);
+diff -uNr a/src/gtk/filesview.cc b/src/gtk/filesview.cc
+--- a/src/gtk/filesview.cc
++++ b/src/gtk/filesview.cc
+@@ -297,7 +297,7 @@
+ 		     ver.VerStr());
+       }
+ 
+-    Glib::ustring fileslistname = Glib::ustring("/var/lib/dpkg/info/")
++    Glib::ustring fileslistname = Glib::ustring("@TERMUX_PREFIX@/var/lib/dpkg/info/")
+     + Glib::ustring(ver.ParentPkg().Name()) + Glib::ustring(".list");
+ 
+     std::ifstream fileslist(fileslistname.c_str());
+diff -uNr a/src/gtk/gui.cc b/src/gtk/gui.cc
+--- a/src/gtk/gui.cc
++++ b/src/gtk/gui.cc
+@@ -363,7 +363,7 @@
+ 	  saw_any_output(false)
+       {
+ 	std::vector<std::string> arguments;
+-	arguments.push_back("/usr/bin/diff");
++	arguments.push_back("@TERMUX_PREFIX@/bin/diff");
+ 	arguments.push_back("-u");
+ 	arguments.push_back(existing_file);
+ 	arguments.push_back(new_file);

--- a/packages/aptitude/0101-do-not-link-against-stdc++fs.patch
+++ b/packages/aptitude/0101-do-not-link-against-stdc++fs.patch
@@ -1,0 +1,12 @@
+diff -uNr a/src/Makefile.am b/src/Makefile.am
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -14,7 +14,7 @@
+ 
+ localedir = $(datadir)/locale
+ AM_CPPFLAGS = -I$(top_builddir) -I$(srcdir) -I$(top_srcdir) -I$(top_srcdir)/src
+-FILESYSTEM_LDFLAGS = -lstdc++fs
++FILESYSTEM_LDFLAGS = 
+ DEFS = -DLOCALEDIR=\"$(localedir)\" @DEFS@
+ 
+ bin_PROGRAMS=aptitude

--- a/packages/aptitude/0102-non-static-member-access-in-nested-type.patch
+++ b/packages/aptitude/0102-non-static-member-access-in-nested-type.patch
@@ -1,0 +1,13 @@
+error: use of non-static data member 'graph' of 'generic_problem_resolver' from nested type 'do_process_promotion'
+
+--- a/src/generic/problemresolver/problemresolver.h
++++ b/src/generic/problemresolver/problemresolver.h
+@@ -1722,7 +1722,7 @@
+ 
+     void active(int step_num) const
+     {
+-      step &s = graph.get_step(step_num);
++      step &s = resolver.graph.get_step(step_num);
+       resolver.increase_effective_step_cost(s, p);
+       resolver.graph.schedule_promotion_propagation(step_num, p);
+     }

--- a/packages/aptitude/0103-fill-some-functions-from-libintl.h.patch
+++ b/packages/aptitude/0103-fill-some-functions-from-libintl.h.patch
@@ -1,0 +1,24 @@
+--- a/src/aptitude.h
++++ b/src/aptitude.h
+@@ -32,9 +32,7 @@
+ 
+ #if ENABLE_NLS
+ # include <libintl.h>
+-# include <cwidget/generic/util/transcode.h>
+ # define _(Text) gettext (Text)
+-# define W_(Text) cwidget::util::transcode (gettext (Text) )
+ # define N_(Text) Text
+ 
+ /** Strips everything up to and including the first pipe character
+@@ -69,8 +67,11 @@
+ }
+ # define gettext(Text) Text
+ # define dgettext(Domain, Text) Text
++# define ngettext(Msg1, Msg2, Count) ((Count == 1) ? Msg1 : Msg2)
+ #endif
+ 
++#include <cwidget/generic/util/transcode.h>
++#define W_(Text) cwidget::util::transcode (gettext (Text) )
+ 
+ // This is used to store the location of the binary as determined by
+ // argv[0].

--- a/packages/aptitude/0104-fill-rpmatch.patch
+++ b/packages/aptitude/0104-fill-rpmatch.patch
@@ -1,0 +1,17 @@
+--- a/src/cmdline/cmdline_prompt.cc
++++ b/src/cmdline/cmdline_prompt.cc
+@@ -62,6 +62,14 @@
+ using aptitude::why::make_cmdline_why_callbacks;
+ using aptitude::why::why_callbacks;
+ 
++// https://github.com/coreutils/gnulib/blob/2a5409cf2ac62ed273589c72bb8ae0031f06a219/lib/rpmatch.c#L126
++int
++rpmatch (const char *response)
++{
++  /* Test against "^[yY]" and "^[nN]", hardcoded to avoid requiring regex */
++  return (*response == 'y' || *response == 'Y' ? 1
++          : *response == 'n' || *response == 'N' ? 0 : -1);
++}
+ 
+ static string reason_string_list(set<reason> &reasons)
+ {

--- a/packages/aptitude/0105-add-namespace-to-ptr_fun.patch
+++ b/packages/aptitude/0105-add-namespace-to-ptr_fun.patch
@@ -1,0 +1,13 @@
+--- a/src/ui.cc
++++ b/src/ui.cc
+@@ -694,8 +694,8 @@
+ 	{
+ 	  really_quit_active = true;
+ 	  prompt_yesno(_("Really quit Aptitude?"), false,
+-		       cw::util::arg(sigc::bind(ptr_fun(do_really_quit_answer), true)),
+-		       cw::util::arg(sigc::bind(ptr_fun(do_really_quit_answer), false)));
++		       cw::util::arg(sigc::bind(sigc::ptr_fun(do_really_quit_answer), true)),
++		       cw::util::arg(sigc::bind(sigc::ptr_fun(do_really_quit_answer), false)));
+ 	}
+     }
+   else

--- a/packages/aptitude/0106-cxx11-narrowing.patch
+++ b/packages/aptitude/0106-cxx11-narrowing.patch
@@ -1,0 +1,13 @@
+--- a/src/pkg_columnizer.cc
++++ b/src/pkg_columnizer.cc
+@@ -71,8 +71,8 @@
+   {30, false, false},   // origin
+   {10, true, true},     // archive
+   {9, false, false},    // sizechange
+-  {strlen(PACKAGE), false, false},  // progname
+-  {strlen(VERSION), false, false},  // progver
++  {static_cast<unsigned int>(strlen(PACKAGE)), false, false},  // progname
++  {static_cast<unsigned int>(strlen(VERSION)), false, false},  // progver
+   {12, false, false},   // brokencount
+   {16, false, false},   // diskusage, example (max): "Disk: -2,587 kB "
+   {22, false, false},   // downloadsize, example (max): " DL: 2,586 kB/2,587 kB"

--- a/packages/aptitude/0107-char-array-initialization.patch
+++ b/packages/aptitude/0107-char-array-initialization.patch
@@ -1,0 +1,13 @@
+--- a/src/pkg_columnizer.cc
++++ b/src/pkg_columnizer.cc
+@@ -397,8 +397,8 @@
+       break;
+     case diskusage:
+       {
+-	size_t bufsize = 256;
+-	char buf[bufsize] = "";
++	const size_t bufsize = 256;
++	char buf[bufsize] = {};
+ 	if (apt_cache_file && ((*apt_cache_file)->UsrSize() != 0))
+ 	  {
+ 	    char sign = ((*apt_cache_file)->UsrSize() > 0) ? '+' : '-';

--- a/packages/aptitude/build.sh
+++ b/packages/aptitude/build.sh
@@ -1,0 +1,34 @@
+TERMUX_PKG_HOMEPAGE=https://wiki.debian.org/Aptitude
+TERMUX_PKG_DESCRIPTION="terminal-based package manager"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=0.8.13
+TERMUX_PKG_SRCURL=http://deb.debian.org/debian/pool/main/a/aptitude/aptitude_$TERMUX_PKG_VERSION.orig.tar.xz
+TERMUX_PKG_SHA256=0ef50cb5de27215dd30de74dd9b46b318f017bd0ec3f5c4735df7ac0beb40248
+TERMUX_PKG_DEPENDS="apt, boost, libcwidget, libsigc++-2.0, libsqlite, libxapian, ncurses"
+TERMUX_PKG_BUILD_DEPENDS="boost-headers, googletest"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--disable-tests
+--disable-docs
+--disable-boost-lib-checks
+--with-boost=$TERMUX_PREFIX
+--with-package-state-loc=$TERMUX_PREFIX/var/lib/aptitude
+--with-lock-loc=$TERMUX_PREFIX/var/lock/aptitude
+--disable-nls
+"
+
+termux_step_pre_configure() {
+	CXXFLAGS+=" -DNCURSES_WIDECHAR=1"
+}
+
+termux_step_create_debscripts() {
+	cat <<- EOF > postrm
+	#!$TERMUX_PREFIX/bin/sh
+	case "\$1" in
+	purge)
+		rm -fr $TERMUX_PREFIX/var/lib/aptitude
+		rm -f $TERMUX_PREFIX/var/log/aptitude $TERMUX_PREFIX/var/log/aptitude.[0-9].gz
+		;;
+	esac
+	EOF
+}

--- a/packages/libcwidget/0001-pthread_cancel.patch
+++ b/packages/libcwidget/0001-pthread_cancel.patch
@@ -1,0 +1,52 @@
+--- a/src/cwidget/generic/threads/threads.h
++++ b/src/cwidget/generic/threads/threads.h
+@@ -25,6 +25,8 @@
+ #ifndef THREADS_H
+ #define THREADS_H
+ 
++#include <stdatomic.h>
++
+ #include <errno.h>
+ #include <cwidget/generic/util/exception.h>
+ 
+@@ -120,6 +122,8 @@
+       }
+ 
+     public:
++      atomic_bool request_cancel;
++
+       /** \brief Stores the attributes with which a thread is to be
+        * created.
+        *
+@@ -157,7 +161,7 @@
+        */
+       template<typename F>
+       thread(const F &thunk, const attr &a = attr())
+-	:joined(false)
++	:joined(false), request_cancel(ATOMIC_VAR_INIT(false))
+       {
+ 	// Create a thunk on the heap to pass to the new thread.
+ 	F *tmp = new F(thunk);
+@@ -192,7 +196,7 @@
+       /** Cancel this thread. */
+       void cancel()
+       {
+-	pthread_cancel(tid);
++	atomic_store(&request_cancel, true);
+       }
+     };
+ 
+--- a/src/cwidget/toplevel.cc
++++ b/src/cwidget/toplevel.cc
+@@ -480,9 +480,9 @@
+ 	    FD_ZERO(&selectfds);
+ 	    FD_SET(0, &selectfds);
+ 
+-	    pthread_testcancel();
++	    if (atomic_load(&instancet->request_cancel)) pthread_exit(NULL);
+ 	    int result = select(1, &selectfds, NULL, NULL, &timeout);
+-	    pthread_testcancel();	// Workaround for Linux threads suckage.
++	    if (atomic_load(&instancet->request_cancel)) pthread_exit(NULL);
+ 	    // See pthread_cancel(3).
+ 
+ 	    if(result != 1)

--- a/packages/libcwidget/0002-replace-Wterminate-with-Wexceptions.patch
+++ b/packages/libcwidget/0002-replace-Wterminate-with-Wexceptions.patch
@@ -1,0 +1,22 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -114,7 +114,7 @@
+ 
+ 
+ dnl Default to -Werror, but add an easy flag to disable it.
+-WERROR="-Werror -Wno-terminate"
++WERROR="-Werror -Wno-exceptions"
+ 
+ AC_ARG_ENABLE(dynamic-backtrace,
+ 	AS_HELP_STRING([--enable-dynamic-backtrace], [Modify the executable so that it can generate a backtrace for uncaught exceptions.  Will double the size of the stripped binary.]),
+--- a/configure
++++ b/configure
+@@ -19307,7 +19307,7 @@
+ 
+ 
+ 
+-WERROR="-Werror -Wno-terminate"
++WERROR="-Werror -Wno-exceptions"
+ 
+ # Check whether --enable-dynamic-backtrace was given.
+ if test "${enable_dynamic_backtrace+set}" = set; then :

--- a/packages/libcwidget/build.sh
+++ b/packages/libcwidget/build.sh
@@ -1,0 +1,18 @@
+TERMUX_PKG_HOMEPAGE=https://salsa.debian.org/cwidget-team/
+TERMUX_PKG_DESCRIPTION="high-level terminal interface library for C++"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=0.5.18
+TERMUX_PKG_SRCURL=http://deb.debian.org/debian/pool/main/c/cwidget/cwidget_$TERMUX_PKG_VERSION.orig.tar.xz
+TERMUX_PKG_SHA256=a2fb48ff86e41fe15072e6d87b9467ff3af57329586f4548d9f25cf50491c9fc
+TERMUX_PKG_DEPENDS="ncurses, libiconv, libsigc++-2.0"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-werror"
+
+termux_step_pre_configure() {
+	CXXFLAGS+=" -DNCURSES_WIDECHAR=1"
+	LDFLAGS+=" -liconv"
+
+	if [ $TERMUX_ARCH = aarch64 ] || [ $TERMUX_ARCH = arm ]; then
+		LDFLAGS+=" $($CC -print-libgcc-file-name)"
+	fi
+}


### PR DESCRIPTION
This package was added in TUR about half year ago by [kawanakaiku](https://github.com/kawanakaiku) because this package cannot be compiled with clang (I guess). I applied some patches and now it is able to be compiled with clang. So I think it's time to add this package to main repository.

Comments about the `pthread_cancel` patch: Customized signal handler cannot be used in this package because it blocks all signals when creating a thread.

Closes #865
