### PR TITLE
fix(x11/weston): hardcoded paths

### DIFF
--- a/x11-packages/weston/0009-fix-hardcoded-paths.patch
+++ b/x11-packages/weston/0009-fix-hardcoded-paths.patch
@@ -1,0 +1,41 @@
+--- a/xwayland/launcher.c
++++ b/xwayland/launcher.c
+@@ -78,9 +78,9 @@
+ {
+ 	char path[256];
+ 
+-	snprintf(path, sizeof path, "/tmp/.X%d-lock", wxs->display);
++	snprintf(path, sizeof path, "@TERMUX_PREFIX@/tmp/.X%d-lock", wxs->display);
+ 	unlink(path);
+-	snprintf(path, sizeof path, "/tmp/.X11-unix/X%d", wxs->display);
++	snprintf(path, sizeof path, "@TERMUX_PREFIX@/tmp/.X11-unix/X%d", wxs->display);
+ 	unlink(path);
+ 	if (wxs->client) {
+ 		wl_client_destroy(wxs->client);
+@@ -111,7 +111,7 @@
+ 
+ 	addr.sun_family = AF_LOCAL;
+ 	name_size = snprintf(addr.sun_path, sizeof addr.sun_path,
+-			     "%c/tmp/.X11-unix/X%d", 0, display);
++			     "%c@TERMUX_PREFIX@/tmp/.X11-unix/X%d", 0, display);
+ 	size = offsetof(struct sockaddr_un, sun_path) + name_size;
+ 	if (bind(fd, (struct sockaddr *) &addr, size) < 0) {
+ 		weston_log("failed to bind to @%s: %s\n", addr.sun_path + 1,
+@@ -141,7 +141,7 @@
+ 
+ 	addr.sun_family = AF_LOCAL;
+ 	name_size = snprintf(addr.sun_path, sizeof addr.sun_path,
+-			     "/tmp/.X11-unix/X%d", display) + 1;
++			     "@TERMUX_PREFIX@/tmp/.X11-unix/X%d", display) + 1;
+ 	size = offsetof(struct sockaddr_un, sun_path) + name_size;
+ 	unlink(addr.sun_path);
+ 	if (bind(fd, (struct sockaddr *) &addr, size) < 0) {
+@@ -169,7 +169,7 @@
+ 	int fd, size;
+ 	pid_t other;
+ 
+-	snprintf(lockfile, lsize, "/tmp/.X%d-lock", display);
++	snprintf(lockfile, lsize, "@TERMUX_PREFIX@/tmp/.X%d-lock", display);
+ 	fd = open(lockfile, O_WRONLY | O_CLOEXEC | O_CREAT | O_EXCL, 0444);
+ 	if (fd < 0 && errno == EEXIST) {
+ 		fd = open(lockfile, O_CLOEXEC | O_RDONLY);

--- a/x11-packages/weston/build.sh
+++ b/x11-packages/weston/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Reference implementation of a wayland compositor"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="13.0.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://gitlab.freedesktop.org/wayland/weston/-/archive/${TERMUX_PKG_VERSION}/weston-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=a4848b7cc510e3e88c9f2fcc808fd44c51fae622f13242f801a7c5107983335c
 TERMUX_PKG_DEPENDS="freerdp, libaml, libandroid-shmem, libcairo, libcairo, libevdev, libglvnd, libneatvnc, libseat, libwayland, libwebp, libxcb, libxcursor, libxkbcommon, littlecms, pango, xcb-util-cursor"


### PR DESCRIPTION
Fix
```
$ XDG_RUNTIME_DIR=$TMPDIR weston --backend=vnc --xwayland
...
[06:10:33.382] failed to create lock file /tmp/.X0-lock: No such file or directory
```