### PR TITLE
bump(main/vulkan-loader-generic): 1.3.275

### DIFF
--- a/packages/vulkan-loader-generic/build.sh
+++ b/packages/vulkan-loader-generic/build.sh
@@ -2,32 +2,21 @@ TERMUX_PKG_HOMEPAGE=https://github.com/KhronosGroup/Vulkan-Loader
 TERMUX_PKG_DESCRIPTION="Vulkan Loader"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.3.271"
-TERMUX_PKG_SRCURL=https://github.com/KhronosGroup/Vulkan-Loader/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=348b6db7a8af4e46ffdd7f494f7fe994f572fc0b7473be98338a0a8a4a3d5725
+TERMUX_PKG_VERSION="1.3.275"
+TERMUX_PKG_SRCURL=https://github.com/KhronosGroup/Vulkan-Loader/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=96dee7d8ccb08f2518e2b82f7a8ce84ffee511c96b16c83259fff87b6ee45232
 TERMUX_PKG_BUILD_DEPENDS="vulkan-headers (=${TERMUX_PKG_VERSION}), libx11, libxcb, libxrandr"
 TERMUX_PKG_CONFLICTS="vulkan-loader-android"
 TERMUX_PKG_PROVIDES="vulkan-loader-android"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--DCMAKE_SYSTEM_NAME=Linux
--DVULKAN_HEADERS_INSTALL_DIR=$TERMUX_PREFIX
--DBUILD_TESTS=OFF
--DENABLE_WERROR=OFF
-"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+.\d+.\d+"
-
-termux_pkg_auto_update() {
-	# Get latest release tag:
-	local tag
-	tag="$(termux_github_api_get_tag "${TERMUX_PKG_SRCURL}" "${TERMUX_PKG_UPDATE_TAG_TYPE}")"
-	if grep -qP "^v${TERMUX_PKG_UPDATE_VERSION_REGEXP}\$" <<<"$tag"; then
-		termux_pkg_upgrade_version "$tag"
-	else
-		echo "WARNING: Skipping auto-update: Not a release($tag)"
-	fi
-}
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DBUILD_TESTS=OFF
+-DCMAKE_SYSTEM_NAME=Linux
+-DENABLE_WERROR=OFF
+-DVULKAN_HEADERS_INSTALL_DIR=$TERMUX_PREFIX
+"
 
 termux_step_pre_configure() {
 	CPPFLAGS+=" -Wno-typedef-redefinition"
@@ -40,7 +29,14 @@ termux_step_post_make_install() {
 	echo "INFO: ========== vulkan.pc =========="
 
 	# Lots of apps will search libvulkan.so.1
-	if [ ! -e $TERMUX_PREFIX/lib/libvulkan.so.1 ]; then
-		ln -sfr $TERMUX_PREFIX/lib/libvulkan.so{,.1}
+	local e=0
+	[ ! -e "$TERMUX_PREFIX"/lib/libvulkan.so ] && e=1
+	[ ! -e "$TERMUX_PREFIX"/lib/libvulkan.so.1 ] && e=1
+	if [[ "${e}" != 0 ]]; then
+		termux_error_exit "
+		Symlink check failed!
+		$(file "$TERMUX_PREFIX"/lib/libvulkan.so)
+		$(file "$TERMUX_PREFIX"/lib/libvulkan.so.1)
+		"
 	fi
 }


### PR DESCRIPTION
Fix https://github.com/termux/termux-packages/actions/runs/7428056920/job/20214798062#step:4:1714
```
INFO: Updating vulkan-loader-generic [Current version: 1.3.271]
WARNING: Skipping auto-update: Not a release(1.3.275)
```
Also changed to checking symlinks instead of making symlinks ourselves