### PR TITLE
fix(main/rclone): Adds a 'v' at the beginning of the version string (#19013)

### DIFF
--- a/packages/rclone/build.sh
+++ b/packages/rclone/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="rsync for cloud storage"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.65.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/rclone/rclone/releases/download/v${TERMUX_PKG_VERSION}/rclone-v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=904b906cc465dd679a00487497e3891d33fca6b6e25c184400bccfb248344f39
 TERMUX_PKG_AUTO_UPDATE=true
@@ -16,7 +17,7 @@ termux_step_make_install() {
 	ln -sf "$PWD" .gopath/src/github.com/rclone/rclone
 	export GOPATH="$PWD/.gopath"
 
-	go build -v -ldflags "-X github.com/rclone/rclone/fs.Version=${TERMUX_PKG_VERSION}-termux" -tags noselfupdate -o rclone
+	go build -v -ldflags "-X github.com/rclone/rclone/fs.Version=v${TERMUX_PKG_VERSION}-termux" -tags noselfupdate -o rclone
 
 	# XXX: Fix read-only files which prevents removal of src dir.
 	chmod u+w -R .


### PR DESCRIPTION
proposed fix for #19013