### PR TITLE
proxychains-ng: bump to 4.17

### DIFF
--- a/packages/proxychains-ng/build.sh
+++ b/packages/proxychains-ng/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://github.com/rofl0r/proxychains-ng
 TERMUX_PKG_DESCRIPTION="A hook preloader that allows to redirect TCP traffic of existing dynamically linked programs through one or more SOCKS or HTTP proxies"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=4.16
+TERMUX_PKG_VERSION=4.17
 TERMUX_PKG_SRCURL=https://github.com/rofl0r/proxychains-ng/archive/v$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_SHA256=5f66908044cc0c504f4a7e618ae390c9a78d108d3f713d7839e440693f43b5e7
+TERMUX_PKG_SHA256=1a2dc68fcbcb2546a07a915343c1ffc75845f5d9cc3ea5eb3bf0b62a66c0196f
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
 

--- a/packages/proxychains-ng/libproxychains.c.patch
+++ b/packages/proxychains-ng/libproxychains.c.patch
@@ -9,14 +9,3 @@
  	INIT();
  	PFUNC();
  
-@@ -729,8 +729,8 @@
- }
- 
- HOOKFUNC(int, getnameinfo, const struct sockaddr *sa, socklen_t salen,
--	           char *host, socklen_t hostlen, char *serv,
--	           socklen_t servlen, int flags)
-+	           char *host, size_t hostlen, char *serv,
-+	           size_t servlen, int flags)
- {
- 	INIT();
- 	PFUNC();


### PR DESCRIPTION
Closes #19036 