### PR TITLE
termux_step_configure_meson.sh: Add setup option with meson command

### DIFF
--- a/scripts/build/configure/termux_step_configure_meson.sh
+++ b/scripts/build/configure/termux_step_configure_meson.sh
@@ -9,6 +9,7 @@ termux_step_configure_meson() {
 	fi
 
 	CC=gcc CXX=g++ CFLAGS= CXXFLAGS= CPPFLAGS= LDFLAGS= $TERMUX_MESON \
+		setup \
 		$TERMUX_PKG_SRCDIR \
 		$TERMUX_PKG_BUILDDIR \
 		--$(test "${TERMUX_PKG_MESON_NATIVE}" = "true" && echo "native-file" || echo "cross-file") $TERMUX_MESON_CROSSFILE \


### PR DESCRIPTION

    This commit fixes the following warning with meson newer than 0.64.0 version.

    WARNING: Running the setup command as `meson [options]' instead of `meson setup [options]' is ambiguous and deprecated.
