### PR TITLE
updpkg(main/fdupes): 2.3.0

### DIFF
--- a/packages/fdupes/build.sh
+++ b/packages/fdupes/build.sh
@@ -1,11 +1,12 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/adrianlopezroche/fdupes
 TERMUX_PKG_DESCRIPTION="Duplicates file detector"
-TERMUX_PKG_LICENSE="BSD"
+TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="2.2.1"
+TERMUX_PKG_VERSION="2.3.0"
 TERMUX_PKG_SRCURL=https://github.com/adrianlopezroche/fdupes/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=7d12e9d28c6a5dc46ff3a37fafd65b4b84f5c19dddf630beec8d67bc158fa265
+TERMUX_PKG_SHA256=8f38d21eb53e27a43f6652f0c6fa80c673f18466760281e812e84f56c1d359e3
 TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_BUILD_DEPENDS="libsqlite"
 TERMUX_PKG_DEPENDS="ncurses, pcre2"
 
 termux_step_pre_configure() {


### PR DESCRIPTION
`fdupes` now has a build time dependency on `libsqlite`
I also noticed the License is actually MIT, not BSD.

PR Checklist:
- [x] Builds locally (all architectures)
- [x] Tested on device (Fairphone 5, Android 13, AArch64)
- [x] Builds on CI