### PR TITLE
yazi: recommend `nerdfix`

### DIFF
--- a/packages/yazi/build.sh
+++ b/packages/yazi/build.sh
@@ -3,10 +3,12 @@ TERMUX_PKG_DESCRIPTION="Blazing fast terminal file manager written in Rust, base
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.2.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/sxyazi/yazi/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=ce830fc312fc7a9515abefbbc71c8d1a46515257e9d1c56165cf6ff2fa5404c7
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_SUGGESTS="nerdfix"
 
 termux_step_make() {
 	termux_setup_rust
@@ -16,15 +18,21 @@ termux_step_make() {
 termux_step_make_install() {
 	install -Dm700 -t $TERMUX_PREFIX/bin target/${CARGO_TARGET_NAME}/release/yazi
 
-	cd yazi-config/completions
-	install -Dm644 "${TERMUX_PKG_NAME}".bash "${TERMUX_PREFIX}"/share/bash-completion/completions/"${TERMUX_PKG_NAME}".bash
-	install -Dm644 _"${TERMUX_PKG_NAME}" "${TERMUX_PREFIX}"/share/zsh/site-functions/_"${TERMUX_PKG_NAME}"
-	install -Dm644 "${TERMUX_PKG_NAME}".fish "${TERMUX_PREFIX}"/share/fish/vendor_completions.d/"${TERMUX_PKG_NAME}".fish
+	install -Dm644 yazi-config/completions/"${TERMUX_PKG_NAME}".bash \
+		"${TERMUX_PREFIX}"/share/bash-completion/completions/"${TERMUX_PKG_NAME}".bash
+	install -Dm644 yazi-config/completions/_"${TERMUX_PKG_NAME}" \
+		"${TERMUX_PREFIX}"/share/zsh/site-functions/_"${TERMUX_PKG_NAME}"
+	install -Dm644 yazi-config/completions/"${TERMUX_PKG_NAME}".fish \
+		"${TERMUX_PREFIX}"/share/fish/vendor_completions.d/"${TERMUX_PKG_NAME}".fish
 }
 
 termux_step_create_debscripts() {
 	cat <<- POSTINST_EOF > ./postinst
 	#!$TERMUX_PREFIX/bin/sh
-	echo "Please change font from termux-styling addon"
+	echo "Use of a NerdFont is recommended for yazi."
+	echo "You can either select one from the Termux:Styling add-on"
+	echo "or manually install a NerdFont of your choice from:"
+	echo "https://github.com/ryanoasis/nerd-fonts/tree/master/patched-fonts"
+	echo "and replacing ~/.termux/font.ttf with it"
 	POSTINST_EOF
 }


### PR DESCRIPTION
Recommend `nerdfix` for dealing with obsolete NerdFont 2.x symbols.
I also took the opportunity to reword the post install recommendation,
and slightly cleaned up the build script.

I also plan to add a `TERMUX_PKG_SUGGESTS="nerdfix"` to other packages commonly used in conjunction with NerdFonts.
Below is a preliminary list of these packages.
- [x] `yazi`
- [ ] `eza`
- [ ] `neofetch`
- [x] `starship`
- [ ] `neovim` (NerdFonts are commonly used by plugins)
- [ ] `onefetch`
- [ ] `fastfetch`
- [ ] `bat`?
- [ ] `tmux`?
- [ ] Other (extensible) editors? (Emacs, Vim, Helix, Micro, O, etc...)