### PR TITLE
weechat: fix `thread_cancel` patch

### DIFF
--- a/packages/weechat/build.sh
+++ b/packages/weechat/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 # `weechat-python-plugin` depends on libpython${TERMUX_PYTHON_VERSION}.so.
 # Please revbump and rebuild when bumping TERMUX_PYTHON_VERSION.
 TERMUX_PKG_VERSION="4.2.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.weechat.org/files/src/weechat-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=253ddf086f6c845031a2dd294b1552851d6b04cc08a2f9da4aedfb3e2f91bdcd
 TERMUX_PKG_DEPENDS="libandroid-support, libcurl, libgcrypt, libgnutls, libiconv, ncurses, zlib, zstd"

--- a/packages/weechat/src-core-hook-wee-hook-url.c.patch
+++ b/packages/weechat/src-core-hook-wee-hook-url.c.patch
@@ -11,6 +11,45 @@
  #include "../weechat.h"
  #include "../wee-hashtable.h"
  #include "../wee-hook.h"
+@@ -126,6 +126,24 @@
+  * URL transfer (in a separate thread).
+  */
+ 
++static void thread_testcancel (void *args)
++{
++#ifndef __ANDROID__
++    (void) args;
++    pthread_test_cancel ();
++#else
++    if (!atomic_flag_test_and_set ((atomic_flag *) args))
++    {
++        pthread_exit (NULL);
++    }
++#endif
++}
++
++int
++weeurl_download_internal (const char *url, struct t_hashtable *options,
++                 struct t_hashtable *output, void (thread_testcancel_func)(void *args),
++                 void *thread_test_cancel_args);
++
+ void *
+ hook_url_transfer_thread (void *hook_pointer)
+ {
+@@ -137,9 +150,11 @@
+ 
+     pthread_cleanup_push (&hook_url_thread_cleanup, hook);
+ 
+-    url_rc = weeurl_download (HOOK_URL(hook, url),
++    url_rc = weeurl_download_internal (HOOK_URL(hook, url),
+                               HOOK_URL(hook, options),
+-                              HOOK_URL(hook, output));
++                              HOOK_URL(hook, output),
++                              thread_testcancel,
++                              &HOOK_URL(hook, thread_cancel));
+ 
+     if (url_rc != 0)
+     {
 @@ -205,7 +209,11 @@
                  HOOK_URL(hook, url),
                  ((float)HOOK_URL(hook, timeout)) / 1000);

--- a/packages/weechat/src-core-wee-url.c.patch
+++ b/packages/weechat/src-core-wee-url.c.patch
@@ -1,0 +1,48 @@
+--- a/src/core/wee-url.c
++++ b/src/core/wee-url.c
+@@ -1337,8 +1337,9 @@
+  */
+ 
+ int
+-weeurl_download (const char *url, struct t_hashtable *options,
+-                 struct t_hashtable *output)
++weeurl_download_internal (const char *url, struct t_hashtable *options,
++                 struct t_hashtable *output, void (thread_testcancel_func)(void *args),
++                 void *thread_test_cancel_args)
+ {
+     CURL *curl;
+     struct t_url_file url_file[2];
+@@ -1374,7 +1375,9 @@
+         goto end;
+     }
+ 
++    if (thread_testcancel_func != NULL) thread_testcancel_func (thread_test_cancel_args);
+     curl = curl_easy_init ();
++    if (thread_testcancel_func != NULL) thread_testcancel_func (thread_test_cancel_args);
+     if (!curl)
+     {
+         snprintf (url_error, sizeof (url_error), "%s", _("not enough memory"));
+@@ -1452,7 +1455,9 @@
+     curl_easy_setopt (curl, CURLOPT_ERRORBUFFER, url_error);
+ 
+     /* perform action! */
++    if (thread_testcancel_func != NULL) thread_testcancel_func (thread_test_cancel_args);
+     curl_rc = curl_easy_perform (curl);
++    if (thread_testcancel_func != NULL) thread_testcancel_func (thread_test_cancel_args);
+     if (curl_rc == CURLE_OK)
+     {
+         if (output)
+@@ -1516,6 +1521,13 @@
+     return rc;
+ }
+ 
++int
++weeurl_download (const char *url, struct t_hashtable *options,
++                 struct t_hashtable *output)
++{
++    return weeurl_download_internal (url, options, output, NULL, NULL);
++}
++
+ /*
+  * Adds an URL option in an infolist.
+  *


### PR DESCRIPTION
The original patch for `pthread_cancel` will not work properly, because no cancellation is requested during the running process of the thread.

This patch will also not **always** work as expected. There are many cancellation points existing in `curl_easy_init` and `curl_easy_perform`, but we have no control to there functions. 
