### PR TITLE
chore(main/libpopt): drop libpopt.la file

### DIFF
--- a/packages/libpopt/build.sh
+++ b/packages/libpopt/build.sh
@@ -3,12 +3,13 @@ TERMUX_PKG_DESCRIPTION="Library for parsing cmdline parameters"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.19
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=http://ftp.rpm.org/popt/releases/popt-1.x/popt-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=c25a4838fc8e4c1c8aacb8bd620edb3084a3d63bf8987fdad3ca2758c63240f9
 TERMUX_PKG_DEPENDS="libandroid-glob"
 TERMUX_PKG_BREAKS="libpopt-dev"
 TERMUX_PKG_REPLACES="libpopt-dev"
+TERMUX_PKG_RM_AFTER_INSTALL="lib/libpopt.la"
 
 termux_step_pre_configure() {
 	LDFLAGS+=" -landroid-glob"


### PR DESCRIPTION
We have pkgconfig scripts so should be no need for .la file.  In fact, trying to build a static library that uses libpopt becomes difficult with libpopt.la, due to it declaring that libandroid-glob.so is a dependency (seemingly for both libpopt.so and libpopt.a).