### PR TITLE
scripts: fixes for when building with static dependencies

### DIFF
--- a/root-packages/lvm2/build.sh
+++ b/root-packages/lvm2/build.sh
@@ -11,6 +11,8 @@ TERMUX_PKG_DEPENDS="libaio, libandroid-support, libblkid, readline"
 TERMUX_PKG_BREAKS="libdevmapper-dev"
 TERMUX_PKG_REPLACES="libdevmapper-dev"
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_NO_STATICSPLIT=true
+
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --enable-pkgconfig
 --disable-selinux

--- a/scripts/build/termux_extract_dep_info.sh
+++ b/scripts/build/termux_extract_dep_info.sh
@@ -12,14 +12,10 @@ termux_extract_dep_info() {
 			TERMUX_PKG_PLATFORM_INDEPENDENT=false
 			source ${PKG_DIR}/build.sh
 			TERMUX_SUBPKG_PLATFORM_INDEPENDENT=$TERMUX_PKG_PLATFORM_INDEPENDENT
-			if [ "$TERMUX_INSTALL_DEPS" = "false" ] || \
-				   [ "$TERMUX_PKG_NO_STATICSPLIT" = "true" ] || \
-				   [ "${PKG/-static/}-static" != "${PKG}" ]; then
-				if [ -f "${PKG_DIR}/${PKG}.subpackage.sh" ]; then
-					source ${PKG_DIR}/${PKG}.subpackage.sh
-				elif [ -f "${PKG_DIR}/${PKG/-glibc/}.subpackage.sh" ]; then
-					source ${PKG_DIR}/${PKG/-glibc/}.subpackage.sh
-				fi
+			if [ -f "${PKG_DIR}/${PKG}.subpackage.sh" ]; then
+				source ${PKG_DIR}/${PKG}.subpackage.sh
+			elif [ -f "${PKG_DIR}/${PKG/-glibc/}.subpackage.sh" ]; then
+				source ${PKG_DIR}/${PKG/-glibc/}.subpackage.sh
 			fi
 			if [ "$TERMUX_SUBPKG_PLATFORM_INDEPENDENT" = "true" ]; then
 				echo all

--- a/scripts/build/termux_extract_dep_info.sh
+++ b/scripts/build/termux_extract_dep_info.sh
@@ -17,7 +17,7 @@ termux_extract_dep_info() {
 				   [ "${PKG/-static/}-static" != "${PKG}" ]; then
 				if [ -f "${PKG_DIR}/${PKG}.subpackage.sh" ]; then
 					source ${PKG_DIR}/${PKG}.subpackage.sh
-				else
+				elif [ -f "${PKG_DIR}/${PKG/-glibc/}.subpackage.sh" ]; then
 					source ${PKG_DIR}/${PKG/-glibc/}.subpackage.sh
 				fi
 			fi

--- a/scripts/build/termux_step_finish_build.sh
+++ b/scripts/build/termux_step_finish_build.sh
@@ -5,7 +5,7 @@ termux_step_finish_build() {
 	mkdir -p "$TERMUX_BUILT_PACKAGES_DIRECTORY"
 	echo "$TERMUX_PKG_FULLVERSION" > "$TERMUX_BUILT_PACKAGES_DIRECTORY/$TERMUX_PKG_NAME"
 
-	for subpackage in "$TERMUX_PKG_BUILDER_DIR"/*.subpackage.sh; do
+	for subpackage in "$TERMUX_PKG_BUILDER_DIR"/*.subpackage.sh "$TERMUX_PKG_TMPDIR"/*subpackage.sh; do
 		local subpkg_name="$(basename $subpackage | sed 's@\.subpackage\.sh@@g')"
 		echo "$TERMUX_PKG_FULLVERSION" > "$TERMUX_BUILT_PACKAGES_DIRECTORY/${subpkg_name}"
 	done

--- a/scripts/buildorder.py
+++ b/scripts/buildorder.py
@@ -113,6 +113,7 @@ class TermuxPackage(object):
         self.excluded_arches = parse_build_file_excluded_arches(build_sh_path)
         self.only_installing = parse_build_file_variable_bool(build_sh_path, 'TERMUX_PKG_ONLY_INSTALLING')
         self.separate_subdeps = parse_build_file_variable_bool(build_sh_path, 'TERMUX_PKG_SEPARATE_SUB_DEPENDS')
+        self.no_static = parse_build_file_variable_bool(build_sh_path, 'TERMUX_PKG_NO_STATICSPLIT')
 
         if os.getenv('TERMUX_ON_DEVICE_BUILD') == "true" and termux_pkg_library == "bionic":
             always_deps = ['libc++']
@@ -132,8 +133,10 @@ class TermuxPackage(object):
 
             self.subpkgs.append(subpkg)
 
-        subpkg = TermuxSubPackage(self.dir + '/' + self.name + '-static' + '.subpackage.sh', self, virtual=True)
-        self.subpkgs.append(subpkg)
+        if not self.no_static:
+            # if no_static is true then there can be no static subpackage
+            subpkg = TermuxSubPackage(self.dir + '/' + self.name + '-static' + '.subpackage.sh', self, virtual=True)
+            self.subpkgs.append(subpkg)
 
         self.needed_by = set()  # Populated outside constructor, reverse of deps.
 


### PR DESCRIPTION
This series contain first few changes to make it possible/easier to build packages that contain (only) static binaries.