### PR TITLE
Git: recommend `openssh`

### DIFF
--- a/packages/git/build.sh
+++ b/packages/git/build.sh
@@ -3,10 +3,12 @@ TERMUX_PKG_DESCRIPTION="Fast, scalable, distributed revision control system"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.43.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/pub/software/scm/git/git-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=2234f37b453ff8e4672c21ad40d41cc7393c9a8dcdfe640bec7ac5b5358f30d2
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libcurl, libiconv, less, openssl, pcre2, zlib"
+TERMUX_PKG_RECOMMENDS="openssh"
 TERMUX_PKG_SUGGESTS="perl"
 
 ## This requires a working $TERMUX_PREFIX/bin/sh on the host building:


### PR DESCRIPTION
As with #19238, `git` itself should also recommend `openssh`
since it enables several features in Git, such as Pushing/Pulling over SSH,
and Commit/Tag/Push signing via SSH keys.

I believe `TERMUX_PKG_RECOMMENDS` is the right relation for the two.
Since:
> [`packages usually used with the current one`](https://github.com/termux/termux-packages/wiki/Creating-new-package#:~:text=TERMUX_PKG_RECOMMENDS)

Fits Git/OpenSSH's relation.