### PR TITLE
Update OVMF/EDK2

### DIFF
--- a/packages/ovmf/build.sh
+++ b/packages/ovmf/build.sh
@@ -2,17 +2,22 @@ TERMUX_PKG_HOMEPAGE=https://www.tianocore.org/
 TERMUX_PKG_DESCRIPTION="Open Virtual Machine Firmware"
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_MAINTAINER="@termux"
-_ED2K_VERSION=20221117gitfff6d81270b5
-_FEDORA_REPO_VERSION=14.fc39
+_ED2K_VERSION=20231122
+_FEDORA_REPO_VERSION=16.fc40
 TERMUX_PKG_VERSION=$_ED2K_VERSION-$_FEDORA_REPO_VERSION
 TERMUX_PKG_SRCURL=(https://kojipkgs.fedoraproject.org/packages/edk2/$_ED2K_VERSION/$_FEDORA_REPO_VERSION/noarch/edk2-aarch64-$TERMUX_PKG_VERSION.noarch.rpm
 		   https://kojipkgs.fedoraproject.org/packages/edk2/$_ED2K_VERSION/$_FEDORA_REPO_VERSION/noarch/edk2-arm-$TERMUX_PKG_VERSION.noarch.rpm
 		   https://kojipkgs.fedoraproject.org/packages/edk2/$_ED2K_VERSION/$_FEDORA_REPO_VERSION/noarch/edk2-ovmf-ia32-$TERMUX_PKG_VERSION.noarch.rpm
-		   https://kojipkgs.fedoraproject.org/packages/edk2/$_ED2K_VERSION/$_FEDORA_REPO_VERSION/noarch/edk2-ovmf-$TERMUX_PKG_VERSION.noarch.rpm)
+		   https://kojipkgs.fedoraproject.org/packages/edk2/$_ED2K_VERSION/$_FEDORA_REPO_VERSION/noarch/edk2-ovmf-$TERMUX_PKG_VERSION.noarch.rpm
+                   https://kojipkgs.fedoraproject.org/packages/edk2/$_ED2K_VERSION/$_FEDORA_REPO_VERSION/noarch/edk2-experimental-$TERMUX_PKG_VERSION.noarch.rpm
+		   https://kojipkgs.fedoraproject.org/packages/edk2/$_ED2K_VERSION/$_FEDORA_REPO_VERSION/noarch/edk2-ovmf-xen-$TERMUX_PKG_VERSION.noarch.rpm
+                   https://kojipkgs.fedoraproject.org/packages/edk2/$_EDK2_VERSION/$_FEDORA_REPO_VERSION/noarch/edk2-riscv64-$TERMUX_PKG_VERSION.noarch.rpm)
+## Is it worth removing legacy arm version of edk2 because todays emulating are beyond to aarch64, riscv64 and riscv128.
 TERMUX_PKG_SHA256=(deeea32e2ee7ffdd3a0b8a4a215dba50a0553128f7a21c27ec0929ed7a06d3e5
 		   dcc58da8c71fec992229ac629248802ffa71c4ef84ffa5b2df32dcf0fe56f6e4
 		   08ade311bde8b6a80b6aa138746949a6972a62c2976e0965a9be7127afac94f9
 		   5d4013dbdb7838227f3863514b61079a696e34f41492c66f437ec1a38afb06ea)
+## Help us update SHA256-SUMS
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 


### PR DESCRIPTION
enhance(main/ovmf): (add more architectures, bump package version)

Commit [`8b233cd`](https://github.com/termux/termux-packages/pull/19262/commits/8b233cde0db328b9adc7f8d7ce80733ffecc59f8)
Updated build.sh, added more artifact links, bumped version to [latest stable](https://kojipkgs.fedoraproject.org/packages/edk2/20231122/16.fc40/noaarch). 

[Fixes (termux/repo) #19259]
[Closes (termux/repo) #19259, #19262]