### PR TITLE
fix,scripts(toolchain_26b): add rpath flag to avoid adding CI paths to all package binaries

### DIFF
--- a/packages/util-linux/build.sh
+++ b/packages/util-linux/build.sh
@@ -10,7 +10,7 @@ Documentation/licenses/COPYING.BSD-4-Clause-UC
 Documentation/licenses/COPYING.ISC"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.39.3"
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=https://www.kernel.org/pub/linux/utils/util-linux/v${TERMUX_PKG_VERSION:0:4}/util-linux-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=7b6605e48d1a49f43cc4b4cfc59f313d0dd5402fa40b96810bd572e167dfed0f
 # libcrypt is required for only newgrp and sulogin, which are not built anyways

--- a/scripts/build/toolchain/termux_setup_toolchain_26b.sh
+++ b/scripts/build/toolchain/termux_setup_toolchain_26b.sh
@@ -67,7 +67,7 @@ termux_setup_toolchain_26b() {
 	# -static-openmp requires -fopenmp in LDFLAGS to work; hopefully this won't be problematic
 	# even when we don't have -fopenmp in CFLAGS / when we don't want to enable OpenMP
 	# We might also want to consider shipping libomp.so instead; since r21
-	LDFLAGS+=" -fopenmp -static-openmp"
+	LDFLAGS+=" -fopenmp -static-openmp -fno-openmp-implicit-rpath"
 
 	# Android 7 started to support DT_RUNPATH (but not DT_RPATH).
 	LDFLAGS+=" -Wl,--enable-new-dtags"


### PR DESCRIPTION
Bump `util-linux` to make sure it works, fixes #19299.