### PR TITLE
new package: vnstat

### DIFF
--- a/root-packages/vnstat/build.sh
+++ b/root-packages/vnstat/build.sh
@@ -1,0 +1,19 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/vergoh/vnstat
+TERMUX_PKG_DESCRIPTION="A console-based network traffic monitor"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@Denzy7"
+TERMUX_PKG_VERSION=2.12
+TERMUX_PKG_SRCURL=https://github.com/vergoh/vnstat/releases/download/v${TERMUX_PKG_VERSION}/vnstat-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=b7386b12fc1fc6f47fab31f208b12eda61862e63e229e84e95a6fa80406d2852
+TERMUX_PKG_DEPENDS="libsqlite"
+TERMUX_PKG_SERVICE_SCRIPT=("vnstat" "exec su -c \"PATH=\$PATH $TERMUX_PREFIX/bin/vnstatd -n 2>&1\"")
+
+# from docker root package: https://github.com/termux/termux-packages/blob/master/root-packages/docker/build.sh
+termux_step_post_make_install() {
+	mkdir -p $TERMUX_PREFIX/var/service/vnstat/
+	{
+		echo "#!$TERMUX_PREFIX/bin/sh"
+		echo "su -c pkill vnstatd"
+	} > $TERMUX_PREFIX/var/service/vnstat/finish
+	chmod u+x $TERMUX_PREFIX/var/service/vnstat/finish
+}

--- a/root-packages/vnstat/cfg-vnstat.conf.patch
+++ b/root-packages/vnstat/cfg-vnstat.conf.patch
@@ -1,0 +1,26 @@
+diff --git a/cfg/vnstat.conf b/cfg/vnstat.conf
+index f68cad4..306aefc 100644
+--- a/cfg/vnstat.conf
++++ b/cfg/vnstat.conf
+@@ -8,7 +8,7 @@
+ ;Interface ""
+ 
+ # location of the database directory
+-;DatabaseDir "/var/lib/vnstat"
++;DatabaseDir "@TERMUX_PREFIX@/var/lib/vnstat"
+ 
+ # locale (LC_ALL) ("-" = use system locale)
+ ;Locale "-"
+@@ -168,10 +168,10 @@
+ ;UpdateFileOwner 1
+ 
+ # file used for logging if UseLogging is set to 1
+-;LogFile "/var/log/vnstat/vnstat.log"
++;LogFile "@TERMUX_PREFIX@/var/log/vnstat/vnstat.log"
+ 
+ # file used as daemon pid / lock file
+-;PidFile "/var/run/vnstat/vnstat.pid"
++;PidFile "@TERMUX_PREFIX@/var/run/vnstat/vnstat.pid"
+ 
+ # 1 = 64-bit, 0 = 32-bit, -1 = old style logic, -2 = automatic detection
+ ;64bitInterfaceCounters -2

--- a/root-packages/vnstat/src-common.h.patch
+++ b/root-packages/vnstat/src-common.h.patch
@@ -1,0 +1,24 @@
+diff --git a/src/common.h b/src/common.h
+index c528a5d..8e782c0 100644
+--- a/src/common.h
++++ b/src/common.h
+@@ -64,7 +64,7 @@ and most can be changed later from the config file.
+ #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+ #define DATABASEDIR "/var/db/vnstat"
+ #else
+-#define DATABASEDIR "/var/lib/vnstat"
++#define DATABASEDIR "@TERMUX_PREFIX@/var/lib/vnstat"
+ #endif
+ #endif
+ 
+@@ -259,8 +259,8 @@ and most can be changed later from the config file.
+ #define USELOGGING 2
+ #define CREATEDIRS 1
+ #define UPDATEFILEOWNER 1
+-#define LOGFILE "/var/log/vnstat/vnstat.log"
+-#define PIDFILE "/var/run/vnstat/vnstat.pid"
++#define LOGFILE "@TERMUX_PREFIX@/var/log/vnstat/vnstat.log"
++#define PIDFILE "@TERMUX_PREFIX@/var/run/vnstat/vnstat.pid"
+ #define IS64BIT -2
+ #define WALDB 0
+ #define WALDBCHECKPOINTINTERVALMINS 240

--- a/root-packages/vnstat/src-daemon.c.patch
+++ b/root-packages/vnstat/src-daemon.c.patch
@@ -1,0 +1,25 @@
+diff --git a/src/daemon.c b/src/daemon.c
+index 98c9f5b..46dd2ea 100644
+--- a/src/daemon.c
++++ b/src/daemon.c
+@@ -11,6 +11,20 @@
+ #include "id.h"
+ #include "daemon.h"
+ 
++/*
++ * Bionic implemention from initial aosp commit :)))
++ * https://android.googlesource.com/platform/bionic/+/a799b53f10e5a6fd51fef4436cfb7ec99836a516/libc/unistd/getdtablesize.c
++ */
++#include <sys/resource.h>
++int getdtablesize()
++{
++    struct rlimit r;
++    if (getrlimit(RLIMIT_NOFILE, &r) < 0) {
++        return sysconf(_SC_OPEN_MAX);
++    }
++    return r.rlim_cur;
++}
++
+ void daemonize(void)
+ {
+ 	int i;

--- a/root-packages/vnstat/vnstati.subpackage.sh
+++ b/root-packages/vnstat/vnstati.subpackage.sh
@@ -1,0 +1,3 @@
+TERMUX_SUBPKG_DESCRIPTION="Image output for vnstat"
+TERMUX_SUBPKG_DEPENDS="libgd"
+TERMUX_SUBPKG_INCLUDE="bin/vnstati"


### PR DESCRIPTION
vnstatd needs to be run as root since it reads /sys/class/net. vnstat also needs root since it reads databse from vnstatd. vnstati pulls in libgd as dependency which depends on x11 libs (can be added as seperate package?)