### PR TITLE
fix,enhance(x11/deadbeef): enable gme plugin

### DIFF
--- a/x11-packages/deadbeef/build.sh
+++ b/x11-packages/deadbeef/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="ZLIB, GPL-2.0, LGPL-2.1, BSD 3-Clause, MIT"
 TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.9.6"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/deadbeef/deadbeef-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=9d77b3d8afdeab5027d24bd18e9cfc04ce7d6ab3ddc043cc8e84c82b41b79c04
 TERMUX_PKG_AUTO_UPDATE=true
@@ -11,7 +12,6 @@ TERMUX_PKG_DEPENDS="atk, dbus, ffmpeg, gdk-pixbuf, glib, gtk3, harfbuzz, libbloc
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 ax_cv_c_flags__msse2=no
 --disable-ffap
---disable-gme
 --disable-gtk2
 --disable-sid
 "
@@ -19,7 +19,7 @@ ax_cv_c_flags__msse2=no
 termux_step_pre_configure() {
 	autoreconf -fi
 
-	CPPFLAGS+=" -D_FILE_OFFSET_BITS=64"
+	CPPFLAGS+=" -Wno-implicit-function-declaration -D_FILE_OFFSET_BITS=64"
 	LDFLAGS+=" -lm $($CC -print-libgcc-file-name)"
 
 	rm -rf intl

--- a/x11-packages/deadbeef/plugins_gme.patch
+++ b/x11-packages/deadbeef/plugins_gme.patch
@@ -1,0 +1,29 @@
+diff --git a/plugins/gme/cgme.c b/plugins/gme/cgme.c
+index 6e200745a..db097bb93 100644
+--- a/plugins/gme/cgme.c
++++ b/plugins/gme/cgme.c
+@@ -294,11 +294,13 @@ cgme_read (DB_fileinfo_t *_info, char *bytes, int size) {
+ 
+     // FIXME: it makes more sense to call gme_set_fade on init and configchanged
+     if (playForever && info->fade_set) {
+-        gme_set_fade(info->emu, -1, 0);
++        // PATCH: Changed in gme 0.6.4
++        gme_set_fade(info->emu, 0);
+         info->fade_set = 0;
+     }
+     else if (!playForever && !info->fade_set && conf_fadeout > 0 && info->duration >= conf_fadeout && _info->readpos >= info->duration - conf_fadeout) {
+-        gme_set_fade(info->emu, (int)(_info->readpos * 1000), conf_fadeout * 1000);
++        // PATCH: Changed in gme 0.6.4
++        gme_set_fade(info->emu, conf_fadeout * 1000);
+         info->fade_set = 1;
+     }
+ 
+@@ -562,7 +564,7 @@ static DB_decoder_t plugin = {
+     .plugin.id = "stdgme",
+     .plugin.name = "Game-Music-Emu player",
+     .plugin.descr = "chiptune/game music player based on GME library",
+-    .plugin.copyright = 
++    .plugin.copyright =
+         "Game_Music_Emu plugin for DeaDBeeF\n"
+         "Copyright (C) 2009-2015 Oleksiy Yakovenko <waker@users.sourceforge.net>\n"
+         "\n"


### PR DESCRIPTION
Patches the `gme` plugin to use `gme_set_fade_msecs` which replicates the previous behavior of the `gme_set_fade` function used by the plugin.

See upstream commit: https://github.com/libgme/game-music-emu/commit/65d238684960ac08174682eea93b4fb391cfe84c

Closes #19331

> [!NOTE]
> Checklist:
> - [x] Builds locally
> - [x] Builds on CI
> - [x] Tested on device