### PR TITLE
firefox: bump to 123.0.1

### DIFF
--- a/x11-packages/firefox/0018-fix-include-dir-for-cpufeatures.patch
+++ b/x11-packages/firefox/0018-fix-include-dir-for-cpufeatures.patch
@@ -1,14 +1,3 @@
---- a/third_party/aom/aom_ports/arm_cpudetect.c
-+++ b/third_party/aom/aom_ports/arm_cpudetect.c
-@@ -88,7 +88,7 @@
- }
- 
- #elif defined(__ANDROID__) /* end _MSC_VER */
--#include <cpu-features.h>
-+#include <ndk_compat/cpu-features.h>
- 
- int aom_arm_cpu_caps(void) {
-   int flags;
 --- a/gfx/cairo/libpixman/src/pixman-arm.c
 +++ b/gfx/cairo/libpixman/src/pixman-arm.c
 @@ -96,7 +96,7 @@

--- a/x11-packages/firefox/0024-fix-missing-include-for-macro-MOZ_TRY-in-TimeZone.cpp.patch
+++ b/x11-packages/firefox/0024-fix-missing-include-for-macro-MOZ_TRY-in-TimeZone.cpp.patch
@@ -1,0 +1,10 @@
+--- a/intl/components/src/TimeZone.cpp
++++ b/intl/components/src/TimeZone.cpp
+@@ -4,6 +4,7 @@
+ 
+ #include "mozilla/intl/TimeZone.h"
+ 
++#include "mozilla/Try.h"
+ #include "mozilla/Vector.h"
+ 
+ #include <algorithm>

--- a/x11-packages/firefox/0025-disable-native-https-dns-resolve.patch
+++ b/x11-packages/firefox/0025-disable-native-https-dns-resolve.patch
@@ -1,0 +1,32 @@
+It uses `android_res_nquery`, but this function only got added in API level 29
+
+--- a/netwerk/dns/nsHostResolver.cpp
++++ b/netwerk/dns/nsHostResolver.cpp
+@@ -237,6 +237,8 @@
+   // native HTTPS records on Win 11 for now.
+   sNativeHTTPSSupported = StaticPrefs::network_dns_native_https_query_win10() ||
+                           mozilla::IsWin11OrLater();
++#elif defined(__TERMUX__)
++  sNativeHTTPSSupported = false;
+ #elif defined(MOZ_WIDGET_ANDROID)
+   // android_res_nquery only got added in API level 29
+   sNativeHTTPSSupported = jni::GetAPIVersion() >= 29;
+--- a/netwerk/dns/moz.build
++++ b/netwerk/dns/moz.build
+@@ -59,15 +59,7 @@
+     "nsEffectiveTLDService.cpp",  # Excluded from UNIFIED_SOURCES due to special build flags.
+ ]
+ 
+-if CONFIG["MOZ_WIDGET_TOOLKIT"] == "windows":
+-    SOURCES += ["PlatformDNSWin.cpp"]
+-elif CONFIG["OS_TARGET"] == "Linux" or CONFIG["MOZ_WIDGET_TOOLKIT"] == "cocoa":
+-    SOURCES += ["PlatformDNSUnix.cpp"]
+-    OS_LIBS += ["resolv"]
+-elif CONFIG["MOZ_WIDGET_TOOLKIT"] == "android":
+-    SOURCES += ["PlatformDNSAndroid.cpp"]
+-else:
+-    DEFINES["MOZ_NO_HTTPS_IMPL"] = 1
++DEFINES["MOZ_NO_HTTPS_IMPL"] = 1
+ 
+ UNIFIED_SOURCES += [
+     "ChildDNSService.cpp",

--- a/x11-packages/firefox/0026-partially-disable-unified-builds.patch
+++ b/x11-packages/firefox/0026-partially-disable-unified-builds.patch
@@ -1,0 +1,11 @@
+--- a/layout/style/moz.build
++++ b/layout/style/moz.build
+@@ -171,7 +171,7 @@
+     "StylePreloadKind.h",
+ ]
+ 
+-UNIFIED_SOURCES += [
++SOURCES += [
+     "AnimationCollection.cpp",
+     "AttributeStyles.cpp",
+     "CachedInheritingStyles.cpp",

--- a/x11-packages/firefox/build.sh
+++ b/x11-packages/firefox/build.sh
@@ -2,12 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://www.mozilla.org/firefox
 TERMUX_PKG_DESCRIPTION="Mozilla Firefox web browser"
 TERMUX_PKG_LICENSE="MPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="121.0.1"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION="123.0.1"
 TERMUX_PKG_SRCURL=https://ftp.mozilla.org/pub/firefox/releases/${TERMUX_PKG_VERSION}/source/firefox-${TERMUX_PKG_VERSION}.source.tar.xz
-TERMUX_PKG_SHA256=b3a4216e01eaeb9a7c6ef4659d8dcd956fbd90a78a8279ee3a598881e63e49ce
+TERMUX_PKG_SHA256=d5dcb955b65e0f164a90cac0760724486e36e896221b98f244801dfd045d741c
 # ffmpeg and pulseaudio are dependencies through dlopen(3):
-TERMUX_PKG_DEPENDS="ffmpeg, fontconfig, freetype, gdk-pixbuf, glib, gtk3, libandroid-shmem, libc++, libcairo, libevent, libffi, libice, libicu, libjpeg-turbo, libnspr, libnss, libpixman, libsm, libvpx, libwebp, libx11, libxcb, libxcomposite, libxdamage, libxext, libxfixes, libxrandr, libxtst, pango, pulseaudio, zlib"
+TERMUX_PKG_DEPENDS="ffmpeg, fontconfig, freetype, gdk-pixbuf, glib, gtk3, libandroid-shmem, libandroid-spawn, libc++, libcairo, libevent, libffi, libice, libicu, libjpeg-turbo, libnspr, libnss, libpixman, libsm, libvpx, libwebp, libx11, libxcb, libxcomposite, libxdamage, libxext, libxfixes, libxrandr, libxtst, pango, pulseaudio, zlib"
 TERMUX_PKG_BUILD_DEPENDS="binutils-cross, libcpufeatures, libice, libsm"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
@@ -71,7 +70,7 @@ termux_step_pre_configure() {
 
 	# https://reviews.llvm.org/D141184
 	CXXFLAGS+=" -U__ANDROID__ -D_LIBCPP_HAS_NO_C11_ALIGNED_ALLOC"
-	LDFLAGS+=" -landroid-shmem -llog"
+	LDFLAGS+=" -landroid-shmem -landroid-spawn -llog"
 
 	if [ "$TERMUX_ARCH" = "arm" ]; then
 		termux_setup_no_integrated_as
@@ -98,7 +97,7 @@ END
 }
 
 termux_step_make() {
-	./mach build
+	./mach build --keep-going
 	./mach buildsymbols
 }
 

--- a/x11-packages/firefox/mozconfig.cfg
+++ b/x11-packages/firefox/mozconfig.cfg
@@ -21,6 +21,7 @@ ac_add_options --with-system-zlib
 
 # Features
 ac_add_options --enable-audio-backends=pulseaudio
+ac_add_options --enable-default-toolkit=cairo-gtk3-x11-only
 ac_add_options --enable-minify=properties
 ac_add_options --enable-mobile-optimize
 ac_add_options --enable-printing


### PR DESCRIPTION
Hope that disabling `unified build` will not make it reach the CI limit of 6 hours.

Depends on #19436 

Closes #19053
