### PR TITLE
fix(x11/mesa-demos): Use full path for data files

### DIFF
--- a/x11-packages/mesa-demos/build.sh
+++ b/x11-packages/mesa-demos/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="OpenGL demonstration and test programs"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Rafael Kitover <rkitover@gmail.com>"
 TERMUX_PKG_VERSION=9.0.0
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://mesa.freedesktop.org/archive/demos/mesa-demos-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=3046a3d26a7b051af7ebdd257a5f23bfeb160cad6ed952329cdff1e9f1ed496b
 TERMUX_PKG_DEPENDS="freeglut, glu, libx11, libxext, opengl"
@@ -11,6 +11,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dlibdrm=disabled
 -Dvulkan=disabled
 -Dwayland=disabled
+-Dwith-system-data-files=true
 "
 
 termux_step_pre_configure() {


### PR DESCRIPTION

    This change fixes the following error.

    ~ $ teapot
    Teapot V1.2
    Written by David Bucciarelli (tech.hmw@plus.it)
    ../data/tile.rgb: No such file or directory
    File not found
    Error reading a texture.
