### PR TITLE
K9S: compile using the right ldflags

### DIFF
--- a/packages/k9s/build.sh
+++ b/packages/k9s/build.sh
@@ -3,20 +3,22 @@ TERMUX_PKG_DESCRIPTION="Kubernetes CLI To Manage Your Clusters In Style!"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="Krishna Kanhaiya @kcubeterm"
 TERMUX_PKG_VERSION="0.32.4"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/derailed/k9s/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=597fa2c547437070a8993d1fb6fce91d696bd3731d37230feace3a2d3bfdb198
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_BUILD_DEPEDNS="mesa"
 
 termux_step_make() {
         termux_setup_golang
+        local GOPKG="github.com/derailed/k9s"
+        local GOLDFLAGS="-w -s -X ${GOPKG}/cmd.version=${TERMUX_PKG_VERSION} -X ${GOPKG}/cmd.commit=${TERMUX_PKG_VERSION}"
         cd "$TERMUX_PKG_SRCDIR"
         mkdir -p "${TERMUX_PKG_BUILDDIR}/src/github.com/derailed"
         cp -a "${TERMUX_PKG_SRCDIR}" "${TERMUX_PKG_BUILDDIR}/src/github.com/derailed/k9s"
         cd "${TERMUX_PKG_BUILDDIR}/src/github.com/derailed/k9s"
 
         go get -d -v
-        go build
+        go build -ldflags "$GOLDFLAGS"
 }
 
 termux_step_make_install() {


### PR DESCRIPTION
Hello, the UI of k9s uses some compile-time definitions to show the version in the main panel. Without this fix it just shows `0.0.0` and it clutters the main panel with the "upgrade available" stuff.

I tested and compiled with this flag directly on my device and it looks good, but since this is my first PR any comment is welcome!

I also removed the dependencies line because 1. there was a typo so it was unused anyway and 2. I don't think "mesa" is a dependency for a TUI application.