### PR TITLE
fix(main/perl): link against libm

### DIFF
--- a/packages/perl/build.sh
+++ b/packages/perl/build.sh
@@ -11,6 +11,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 # - subversion
 TERMUX_PKG_VERSION=(5.38.2
                     388d0eedbfc3864bbbf7ad7f965064d99cac5aaa)
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=(a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e
                    a975c196075623f0dc94f57d00633b0d18ed08e3d85a3ea19d34ece4ec1a94c1)
 TERMUX_PKG_SRCURL=(http://www.cpan.org/src/5.0/perl-${TERMUX_PKG_VERSION}.tar.gz
@@ -65,7 +66,8 @@ termux_step_configure() {
 			-Duseshrplib \
 			-Duseithreads \
 			-Dusemultiplicity \
-			-Doptimize="-O2"
+			-Doptimize="-O2" \
+                        --with-libs="-lm"
 	)
 }
 


### PR DESCRIPTION
To fix build errors like:

    aarch64-linux-android-clang --sysroot=/home/builder/.termux-build/_cache/android-r26b-api-24-v2/sysroot -Wl,-rpath,/data/data/com.termux/files/usr/lib/perl5/5.38.2/aarch64-android/CORE -Wl,-E -o perl perlmain.o libperl.so
    ld.lld: error: undefined reference due to --no-allow-shlib-undefined: pow
    >>> referenced by libperl.so