### PR TITLE
bump(main/llvm-mingw-w64{,-ucrt,-libcompiler-rt}):

### DIFF
--- a/packages/llvm-mingw-w64-libcompiler-rt/build.sh
+++ b/packages/llvm-mingw-w64-libcompiler-rt/build.sh
@@ -3,9 +3,9 @@ TERMUX_PKG_DESCRIPTION="Compiler runtime libraries for LLVM-MinGW"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@licy183"
 # Bump llvm-mingw-w64* to the same version in one PR.
-TERMUX_PKG_VERSION="20231031"
+TERMUX_PKG_VERSION="20240320"
 TERMUX_PKG_SRCURL=https://github.com/mstorsjo/llvm-mingw/releases/download/$TERMUX_PKG_VERSION/llvm-mingw-$TERMUX_PKG_VERSION-ucrt-ubuntu-20.04-x86_64.tar.xz
-TERMUX_PKG_SHA256=95a4fb16425ce3234a2bf94c6d7c6c1fbf6833a4fa80d84c82ccf2ad533f0737
+TERMUX_PKG_SHA256=45461bc1634fda1d1ceaa09a476a3a279454d4e237c2d1723787c9be66e57141
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_NO_STATICSPLIT=true
@@ -13,8 +13,9 @@ TERMUX_PKG_NO_STATICSPLIT=true
 termux_step_make_install() {
 	# Install compier-rt libraries
 	local LLVM_MAJOR_VERSION=$(. $TERMUX_SCRIPTDIR/packages/libllvm/build.sh; echo $LLVM_MAJOR_VERSION)
+	rm -rf $TERMUX_PREFIX/lib/clang/$LLVM_MAJOR_VERSION/lib/windows
 	mkdir -p $TERMUX_PREFIX/lib/clang/$LLVM_MAJOR_VERSION/lib/windows
-	mv $TERMUX_PKG_SRCDIR/lib/clang/*/lib/windows $TERMUX_PREFIX/lib/clang/$LLVM_MAJOR_VERSION/lib/
+	mv $TERMUX_PKG_SRCDIR/lib/clang/$LLVM_MAJOR_VERSION/lib/windows $TERMUX_PREFIX/lib/clang/$LLVM_MAJOR_VERSION/lib/
 }
 
 termux_step_install_license() {

--- a/packages/llvm-mingw-w64-ucrt/build.sh
+++ b/packages/llvm-mingw-w64-ucrt/build.sh
@@ -3,15 +3,16 @@ TERMUX_PKG_DESCRIPTION="MinGW-w64 runtime for LLVM-MinGW"
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_MAINTAINER="@licy183"
 # Bump llvm-mingw-w64* to the same version in one PR.
-TERMUX_PKG_VERSION="20231031"
+TERMUX_PKG_VERSION="20240320"
 TERMUX_PKG_SRCURL=https://github.com/mstorsjo/llvm-mingw/releases/download/$TERMUX_PKG_VERSION/llvm-mingw-$TERMUX_PKG_VERSION-ucrt-ubuntu-20.04-x86_64.tar.xz
-TERMUX_PKG_SHA256=95a4fb16425ce3234a2bf94c6d7c6c1fbf6833a4fa80d84c82ccf2ad533f0737
+TERMUX_PKG_SHA256=45461bc1634fda1d1ceaa09a476a3a279454d4e237c2d1723787c9be66e57141
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_NO_STATICSPLIT=true
 
 termux_step_make_install() {
 	mkdir -p $TERMUX_PREFIX/opt/llvm-mingw-w64
+	rm -rf $TERMUX_PREFIX/opt/llvm-mingw-w64/{aarch64,armv7,i686,x86_64,generic}-w64-mingw32
 	mv $TERMUX_PKG_SRCDIR/{aarch64,armv7,i686,x86_64,generic}-w64-mingw32 $TERMUX_PREFIX/opt/llvm-mingw-w64
 }
 

--- a/packages/llvm-mingw-w64/build.sh
+++ b/packages/llvm-mingw-w64/build.sh
@@ -3,17 +3,20 @@ TERMUX_PKG_DESCRIPTION="MinGW-w64 toolchain based on LLVM"
 TERMUX_PKG_LICENSE="ISC"
 TERMUX_PKG_MAINTAINER="@licy183"
 # Bump llvm-mingw-w64* to the same version in one PR.
-TERMUX_PKG_VERSION="20231031"
+TERMUX_PKG_VERSION="20240320"
 TERMUX_PKG_SRCURL=https://github.com/mstorsjo/llvm-mingw/releases/download/$TERMUX_PKG_VERSION/llvm-mingw-$TERMUX_PKG_VERSION-ucrt-ubuntu-20.04-x86_64.tar.xz
-TERMUX_PKG_SHA256=95a4fb16425ce3234a2bf94c6d7c6c1fbf6833a4fa80d84c82ccf2ad533f0737
+TERMUX_PKG_SHA256=45461bc1634fda1d1ceaa09a476a3a279454d4e237c2d1723787c9be66e57141
 TERMUX_PKG_AUTO_UPDATE=false
-TERMUX_PKG_DEPENDS="clang, llvm, llvm-tools, llvm-mingw-w64-libcompiler-rt, llvm-mingw-w64-ucrt"
+_LLVM_MAJOR_VERSION=$(. $TERMUX_SCRIPTDIR/packages/libllvm/build.sh; echo $LLVM_MAJOR_VERSION)
+_LLVM_MAJOR_VERSION_NEXT=$((_LLVM_MAJOR_VERSION + 1))
+TERMUX_PKG_DEPENDS="clang (<< ${_LLVM_MAJOR_VERSION_NEXT}), llvm (<< ${_LLVM_MAJOR_VERSION_NEXT}), llvm-tools (<< ${_LLVM_MAJOR_VERSION_NEXT}), llvm-mingw-w64-libcompiler-rt, llvm-mingw-w64-ucrt"
 TERMUX_PKG_RECOMMENDS="llvm-mingw-w64-tools"
 TERMUX_PKG_CONFLICTS="mingw-w64"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_NO_STATICSPLIT=true
 
 termux_step_make_install() {
+	rm -rf $TERMUX_PREFIX/opt/llvm-mingw-w64/bin
 	mkdir -p $TERMUX_PREFIX/opt/llvm-mingw-w64/bin
 	cd $TERMUX_PKG_SRCDIR/bin
 


### PR DESCRIPTION
Update to `20240320`, and rebuild against LLVM 18.

Also for some reason `llvm-mingw-w64-ucrt` won't build unless I manually make it remove:
- `$TERMUX_PREFIX/opt/llvm-mingw-w64` and
- `$TERMUX_PREFIX/lib/clang/18/lib/windows`

I have no idea what's going on with that.
I'm hoping that's just a local issue.