### PR TITLE
CI: bootstrap generation: use termux/upload-release-action v4.2.0

### DIFF
--- a/.github/workflows/bootstrap_archives.yml
+++ b/.github/workflows/bootstrap_archives.yml
@@ -64,7 +64,7 @@ jobs:
           git push --tags
           echo "tag_name=$new_tag" >> $GITHUB_OUTPUT
       - name: Publish bootstrap zips to GitHub release
-        uses: termux/upload-release-action@v4.1.0
+        uses: termux/upload-release-action@v4.2.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: "*.zip"


### PR DESCRIPTION
Fixes warning in bootstrap generation action: 

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20 https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
```