### PR TITLE
fish: fix hardcoded paths for apt completions file

### DIFF
--- a/packages/fish/apt-autocompletion-sources-paths.patch
+++ b/packages/fish/apt-autocompletion-sources-paths.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -uNr fish-3.7.1/share/completions/apt.fish fish-3.7.1.mod/share/completions/apt.fish
+--- fish-3.7.1/share/completions/apt.fish	2024-03-19 11:40:45.000000000 +0800
++++ fish-3.7.1.mod/share/completions/apt.fish	2024-04-02 19:37:37.743032486 +0800
+@@ -28,7 +28,7 @@
+     # but /etc/apt/sources.list.d/ may or may not contain any files so using a fish
+     # wildcard glob may complain loudly if no files match the pattern so we use `find`.
+     # The trailing `sort -u` is largely decorative.
+-    cat (find /etc/apt/sources.list /etc/apt/sources.list.d/ -name "*.list") | string replace -rf '^\s*deb *(?:\[.*?\])? (?:[^ ]+) +([^ ]+) .*' '$1' | sort -u
++    cat (find @TERMUX_PREFIX@/etc/apt/sources.list @TERMUX_PREFIX@/etc/apt/sources.list.d/ -name "*.list") | string replace -rf '^\s*deb *(?:\[.*?\])? (?:[^ ]+) +([^ ]+) .*' '$1' | sort -u
+ end
+ 
+ complete -c apt -f

--- a/packages/fish/build.sh
+++ b/packages/fish/build.sh
@@ -3,12 +3,13 @@ TERMUX_PKG_DESCRIPTION="The user-friendly command line shell"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.7.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/fish-shell/fish-shell/releases/download/$TERMUX_PKG_VERSION/fish-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=614c9f5643cd0799df391395fa6bbc3649427bb839722ce3b114d3bbc1a3b250
 TERMUX_PKG_AUTO_UPDATE=true
 # fish calls 'tput' from ncurses-utils, at least when cancelling (Ctrl+C) a command line.
 # man is needed since fish calls apropos during command completion.
-TERMUX_PKG_DEPENDS="libc++, ncurses, libandroid-support, ncurses-utils, man, bc, pcre2, libandroid-spawn"
+TERMUX_PKG_DEPENDS="bc, libandroid-support, libandroid-spawn, libc++, ncurses, ncurses-utils, man, pcre2"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DBUILD_DOCS=OFF
@@ -20,7 +21,6 @@ termux_step_pre_configure() {
 
 termux_step_post_make_install() {
 	cat >> $TERMUX_PREFIX/etc/fish/config.fish <<HERE
-
 function __fish_command_not_found_handler --on-event fish_command_not_found
 	$TERMUX_PREFIX/libexec/termux/command-not-found \$argv[1]
 end

--- a/packages/fish/share-functions-__fish_print_apt_packages.fish.patch
+++ b/packages/fish/share-functions-__fish_print_apt_packages.fish.patch
@@ -1,0 +1,19 @@
+--- a/share/functions/__fish_print_apt_packages.fish
++++ b/share/functions/__fish_print_apt_packages.fish
+@@ -9,7 +9,7 @@
+ 
+     set -l search_term (commandline -ct | string replace -ar '[\'"\\\\]' '' | string lower)
+ 
+-    if ! test -f /var/lib/dpkg/status
++    if ! test -f @TERMUX_PREFIX@/var/lib/dpkg/status
+         return 1
+     end
+ 
+@@ -59,6 +59,6 @@
+     print pkg "\t" desc
+     installed=0 # Prevent multiple description translations from being printed
+   }
+-}' </var/lib/dpkg/status
++}' <@TERMUX_PREFIX@/var/lib/dpkg/status
+     end
+ end


### PR DESCRIPTION
Package autocompletions works now by setting appropriate `sources.list` paths. In this case, it will use Termux prefix to find and use its `sources.list`

Compare and test:
### Before
- Install and use the latest fish, run `fish` shell, try typing `apt install cmat<TAB>` and it doesn't autocomplete.
### After
- Testing the patch included for this packages or manually setting the appropriate paths in the fish completions file `$PREFIX/share/fish/completions/apt.fish` through editing would make package autocompletions works.

P.S: Please let me know if this is enough for now, as fish have several builtin completions for variety of apps included in its source code. I had provided the modified completion file in a patchfile format. Also, I will revbump later if it goes well.