### PR TITLE
fix(main/dbus): Fix launching systemwide message bus with dbus-daemon

### DIFF
--- a/packages/dbus/build.sh
+++ b/packages/dbus/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Freedesktop.org message bus system"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.15.6
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL="https://dbus.freedesktop.org/releases/dbus/dbus-$TERMUX_PKG_VERSION.tar.xz"
 TERMUX_PKG_SHA256=f97f5845f9c4a5a1fb3df67dfa9e16b5a3fd545d348d6dc850cb7ccc9942bd8c
 TERMUX_PKG_DEPENDS="libexpat, libx11"
@@ -24,6 +24,11 @@ ac_cv_func_close_range=no
 
 termux_step_pre_configure() {
 	export LIBS="-llog"
+}
+
+termux_step_post_make_install() {
+	mkdir -p $TERMUX_PREFIX/var/run/dbus
+	echo "dbus needs this folder to put pid and system_bus_socket" >> $TERMUX_PREFIX/var/run/dbus/README.dbus
 }
 
 termux_step_create_debscripts() {


### PR DESCRIPTION

    This fixes the following error with `dbus-daemon --system' command by
    creating a PREFIX/var/run/dbus directory with a dummy file.
    
    dbus-daemon[16282]: Failed to start message bus: Failed to bind socket
    "/data/data/com.termux/files/usr/var/run/dbus/system_bus_socket": No such file or directory
    
    The workaround is similar as openssh. If that directory is not present
    dbus-daemon can not create pid and system_bus_socket files.
