### PR TITLE
fix(main/ca-certificates): update openjdk path

### DIFF
--- a/packages/ca-certificates/build.sh
+++ b/packages/ca-certificates/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Common CA certificates"
 TERMUX_PKG_LICENSE="MPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1:2024.03.11"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://curl.se/ca/cacert-$(sed 's/\./-/g' <<< ${TERMUX_PKG_VERSION:2}).pem
 TERMUX_PKG_SHA256=1794c1d4f7055b7d02c2170337b61b48a2ef6c90d77e95444fd2596f4cac609f
 TERMUX_PKG_AUTO_UPDATE=false
@@ -27,7 +28,7 @@ termux_step_make_install() {
 		$KEYUTIL_JAR \
 		18f1d2c82839d84949b1ad015343c509e81ef678c24db6112acc6c0761314610
 
-	local JAVA_KEYSTORE_DIR=$TERMUX_PREFIX/opt/openjdk-17/lib/security
+	local JAVA_KEYSTORE_DIR=$TERMUX_PREFIX/lib/jvm/java-17-openjdk/lib/security
 	mkdir -p $JAVA_KEYSTORE_DIR
 
 	java -jar $KEYUTIL_JAR \


### PR DESCRIPTION
This was forgotten when openjdk was updated.