### PR TITLE
scripts: Set timestamp and owner for all files in apt package

### DIFF
--- a/scripts/build/termux_create_debian_subpackages.sh
+++ b/scripts/build/termux_create_debian_subpackages.sh
@@ -84,7 +84,10 @@ termux_create_debian_subpackages() {
 		fi
 		local SUB_PKG_INSTALLSIZE
 		SUB_PKG_INSTALLSIZE=$(du -sk . | cut -f 1)
-		tar -cJf "$SUB_PKG_PACKAGE_DIR/data.tar.xz" .
+		tar --sort=name \
+			--mtime="@${SOURCE_DATE_EPOCH}" \
+			--owner=0 --group=0 --numeric-owner \
+			-cJf "$SUB_PKG_PACKAGE_DIR/data.tar.xz" .
 
 		mkdir -p DEBIAN
 		cd DEBIAN
@@ -134,7 +137,10 @@ termux_create_debian_subpackages() {
 		termux_step_create_subpkg_debscripts
 
 		# Create control.tar.xz
-		tar -cJf "$SUB_PKG_PACKAGE_DIR/control.tar.xz" -H gnu .
+		tar --sort=name \
+			--mtime="@${SOURCE_DATE_EPOCH}" \
+			--owner=0 --group=0 --numeric-owner \
+			-cJf "$SUB_PKG_PACKAGE_DIR/control.tar.xz" -H gnu .
 
 		# Create the actual .deb file:
 		TERMUX_SUBPKG_DEBFILE=$TERMUX_OUTPUT_DIR/${SUB_PKG_NAME}${DEBUG}_${TERMUX_PKG_FULLVERSION}_${SUB_PKG_ARCH}.deb

--- a/scripts/build/termux_step_create_debian_package.sh
+++ b/scripts/build/termux_step_create_debian_package.sh
@@ -3,7 +3,10 @@ termux_step_create_debian_package() {
 		# Metapackage doesn't have data inside.
 		rm -rf data
 	fi
-        tar -cJf "$TERMUX_PKG_PACKAGEDIR/data.tar.xz" -H gnu .
+	tar --sort=name \
+		--mtime="@${SOURCE_DATE_EPOCH}" \
+		--owner=0 --group=0 --numeric-owner \
+		-cJf "$TERMUX_PKG_PACKAGEDIR/data.tar.xz" -H gnu .
 
 	# Get install size. This will be written as the "Installed-Size" deb field so is measured in 1024-byte blocks:
 	local TERMUX_PKG_INSTALLSIZE
@@ -50,7 +53,10 @@ termux_step_create_debian_package() {
 	termux_step_create_debscripts
 
 	# Create control.tar.xz
-	tar -cJf "$TERMUX_PKG_PACKAGEDIR/control.tar.xz" -H gnu .
+	tar --sort=name \
+		--mtime="@${SOURCE_DATE_EPOCH}" \
+		--owner=0 --group=0 --numeric-owner \
+		-cJf "$TERMUX_PKG_PACKAGEDIR/control.tar.xz" -H gnu .
 
 	test ! -f "$TERMUX_COMMON_CACHEDIR/debian-binary" && echo "2.0" > "$TERMUX_COMMON_CACHEDIR/debian-binary"
 	TERMUX_PKG_DEBFILE=$TERMUX_OUTPUT_DIR/${TERMUX_PKG_NAME}${DEBUG}_${TERMUX_PKG_FULLVERSION}_${TERMUX_ARCH}.deb

--- a/scripts/build/termux_step_massage.sh
+++ b/scripts/build/termux_step_massage.sh
@@ -104,7 +104,7 @@ termux_step_massage() {
 		find ./${ADDING_PREFIX}share/man -mindepth 1 -maxdepth 1 -type d ! -name man\* | xargs -r rm -rf
 
 		# Compress man pages with gzip:
-		find ./${ADDING_PREFIX}share/man -type f ! -iname \*.gz -print0 | xargs -r -0 gzip
+		find ./${ADDING_PREFIX}share/man -type f ! -iname \*.gz -print0 | xargs -r -0 gzip -9 -n
 
 		# Update man page symlinks, e.g. unzstd.1 -> zstd.1:
 		while IFS= read -r -d '' file; do


### PR DESCRIPTION

    This makes apt packages somewhat reproducible. The tar options were copied from
    https://salsa.debian.org/dpkg-team/dpkg/-/blob/1.22.6/scripts/Dpkg/Source/Archive.pm?ref_type=tags#L70-L73
    
    The changes are similar as 287ce955619578b2fa06766b06165fd8548acef7 commit.
