### PR TITLE
bump(main/picolisp): 24.3

### DIFF
--- a/packages/picolisp/build.sh
+++ b/packages/picolisp/build.sh
@@ -1,11 +1,11 @@
-TERMUX_PKG_HOMEPAGE=https://picolisp.com/wiki/?home
+TERMUX_PKG_HOMEPAGE="https://picolisp.com/wiki/?home"
 TERMUX_PKG_DESCRIPTION="Lisp interpreter and application server framework"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="23.12"
-TERMUX_PKG_SRCURL=https://deb.debian.org/debian/pool/main/p/picolisp/picolisp_${TERMUX_PKG_VERSION}.orig.tar.gz
-TERMUX_PKG_SHA256=a0633c191c813ae7e6b595713b68979273ddd68c4b6508a2fdb02f0c7bb60aae
+TERMUX_PKG_VERSION="24.3"
+TERMUX_PKG_SRCURL=https://software-lab.de/picoLisp-${TERMUX_PKG_VERSION}.tgz
+TERMUX_PKG_SHA256=141e370c08c7045831772b282f30572f18a2e766b6082875b2464ffd14f37dd7
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libcrypt, libffi, openssl, readline"
 TERMUX_PKG_BUILD_IN_SRC=true


### PR DESCRIPTION
Use upstream link for source tarball. That link was reverted in e45652b2c61e39f9f0cd954aeac41e2671d55573 commit.

Fixes #19667
