### PR TITLE
chore(main/gopass): fix arm, i686 and x86_64 build

### DIFF
--- a/packages/gopass/build.sh
+++ b/packages/gopass/build.sh
@@ -1,8 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/gopasspw/gopass
 TERMUX_PKG_DESCRIPTION="The slightly more awesome standard unix password manager for teams"
 TERMUX_PKG_LICENSE="MIT"
-TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION="1.15.13"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/gopasspw/gopass/archive/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=8f7ee347f517bf66a7d0760e7a5ed6c948d66737559bd04fa8da594801ed9b4f
 TERMUX_PKG_AUTO_UPDATE=true
@@ -11,6 +12,10 @@ TERMUX_PKG_SUGGESTS="termux-api, openssh"
 
 termux_step_make() {
 	termux_setup_golang
+	# The commit introducing this is 2 years old, no idea why its only causing build failures now
+	# https://github.com/gopasspw/gopass/commit/ffaa9e372999a4c5db82f0a281fc67758d107ac0
+	# needed as of 1.15.13 for all architectures except AArch64
+	sed -i 's|CGO_ENABLED=0|CGO_ENABLED=1|g' "$TERMUX_PKG_SRCDIR/Makefile"
 	export GOPATH=$TERMUX_PKG_BUILDDIR
 
 	mkdir -p ./src


### PR DESCRIPTION
Based on the results of the [last auto update CI run](https://github.com/termux/termux-packages/actions/runs/8582949378),
this package now required CGO to be enabled for all architectures except AArch64.

<details><summary>Details</summary>
<p>

```log
android/arm requires external (cgo) linking, but cgo is not enabled
make: *** [Makefile:72: gopass] Error 1
>> BUILD, version = 1.15.13/, output = gopassmake: Leaving directory '/home/builder/.termux-build/gopass/src'
Error: Process completed with exit code 2.
```

</p>
</details> 

For build consistency I have decided to just turn on CGO for all architectures to avoid future discrepancies between AArch64 and other builds of this package.