### PR TITLE
bump(main/tmux): 3.4

### DIFF
--- a/packages/tmux/build.sh
+++ b/packages/tmux/build.sh
@@ -1,39 +1,18 @@
 TERMUX_PKG_HOMEPAGE=https://tmux.github.io/
 TERMUX_PKG_DESCRIPTION="Terminal multiplexer"
 TERMUX_PKG_LICENSE="ISC"
-TERMUX_PKG_MAINTAINER="@termux"
-_COMMIT=fbe6fe7f55cfc2a32f9cee4cb50502a53d3ce8bb
-_COMMIT_DATE=20230428
-TERMUX_PKG_VERSION=3.3a-p${_COMMIT_DATE}
-TERMUX_PKG_SRCURL=git+https://github.com/tmux/tmux
-TERMUX_PKG_SHA256=b61189533139bb84bdc0e96546a5420c183d7ba946a559e891d313c1c32d953d
-TERMUX_PKG_GIT_BRANCH=master
+TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
+TERMUX_PKG_VERSION=3.4
+TERMUX_PKG_SRCURL=https://github.com/tmux/tmux/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=ec7ddf021a0a1d3778862feb845fd0c02759dcdb37ba5380ba4e0038164f7187
 TERMUX_PKG_AUTO_UPDATE=false
 # Link against libandroid-support for wcwidth(), see https://github.com/termux/termux-packages/issues/224
 TERMUX_PKG_DEPENDS="ncurses, libevent, libandroid-support, libandroid-glob"
 # Set default TERM to screen-256color, see: https://raw.githubusercontent.com/tmux/tmux/3.3/CHANGES
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-static --with-TERM=screen-256color"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-static --with-TERM=screen-256color --enable-sixel"
 TERMUX_PKG_BUILD_IN_SRC=true
 
 TERMUX_PKG_CONFFILES="etc/tmux.conf etc/profile.d/tmux.sh"
-
-termux_step_post_get_source() {
-	git fetch --unshallow
-	git checkout $_COMMIT
-
-	local pdate="p$(git log -1 --format=%cs | sed 's/-//g')"
-	if [[ "$TERMUX_PKG_VERSION" != *"${pdate}" ]]; then
-		echo -n "ERROR: The version string \"$TERMUX_PKG_VERSION\" is"
-		echo -n " different from what is expected to be; should end"
-		echo " with \"${pdate}\"."
-		return 1
-	fi
-
-	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
-	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
-		termux_error_exit "Checksum mismatch for source files."
-	fi
-}
 
 termux_step_pre_configure() {
 	LDFLAGS+=" -landroid-glob"

--- a/packages/tmux/htonll.patch
+++ b/packages/tmux/htonll.patch
@@ -1,0 +1,82 @@
+From 4f5a944ae3e8f7a230054b6c0b26f423fa738e71 Mon Sep 17 00:00:00 2001
+From: Biswapriyo Nath <nathbappai@gmail.com>
+Date: Thu, 11 Apr 2024 14:14:44 +0000
+Subject: [PATCH] compat: Fix clang compiler error in Android
+
+This includes some missing headers and function declaration and fixes
+the following compiler errors.
+
+../compat/htonll.c:27:9: error: call to undeclared function 'htonl'
+   27 |     b = htonl (v & 0xffffffff);
+      |         ^
+
+../compat/ntohll.c:27:9: error: call to undeclared function 'ntohl'
+   27 |     b = ntohl (v & 0xffffffff);
+      |         ^
+
+../compat/setproctitle.c:39:47: error: call to undeclared function 'getprogname'
+   39 |         used = snprintf(name, sizeof name, "%s: %s", getprogname(), title);
+      |                                                      ^
+
+../compat/imsg.c:82:9: error: call to undeclared function 'getdtablesize'
+   82 |             >= getdtablesize()) {
+      |                ^
+---
+ compat.h              | 5 +++++
+ compat/htonll.c       | 1 +
+ compat/ntohll.c       | 1 +
+ compat/setproctitle.c | 1 +
+ 4 files changed, 8 insertions(+)
+
+diff --git a/compat.h b/compat.h
+index 720cd909ae..f33dcf1ae9 100644
+--- a/compat.h
++++ b/compat.h
+@@ -289,6 +289,11 @@ void		 explicit_bzero(void *, size_t);
+ int		 getdtablecount(void);
+ #endif
+ 
++#ifndef HAVE_GETDTABLESIZE
++/* getdtablesize.c */
++int		 getdtablesize(void);
++#endif
++
+ #ifndef HAVE_CLOSEFROM
+ /* closefrom.c */
+ void		 closefrom(int);
+diff --git a/compat/htonll.c b/compat/htonll.c
+index aef659834b..86f34b4680 100644
+--- a/compat/htonll.c
++++ b/compat/htonll.c
+@@ -14,6 +14,7 @@
+  * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  */
+ 
++#include <arpa/inet.h>
+ #include <sys/types.h>
+ 
+ #include "compat.h"
+diff --git a/compat/ntohll.c b/compat/ntohll.c
+index c2fe1bb79c..b1f77ca734 100644
+--- a/compat/ntohll.c
++++ b/compat/ntohll.c
+@@ -14,6 +14,7 @@
+  * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  */
+ 
++#include <arpa/inet.h>
+ #include <sys/types.h>
+ 
+ #include "compat.h"
+diff --git a/compat/setproctitle.c b/compat/setproctitle.c
+index e72ae274f3..99fad55c21 100644
+--- a/compat/setproctitle.c
++++ b/compat/setproctitle.c
+@@ -17,6 +17,7 @@
+ #include <sys/types.h>
+ 
+ #include <stdarg.h>
++#include <stdlib.h>
+ #include <string.h>
+ 
+ #include "compat.h"


### PR DESCRIPTION
Also enable building with `--enable-sixel` in anticipation of future Sixel support in the main app.

I'd much appreciate testing on this PR before merging.
Instructions below.

<sub>(This is a pre-written, saved reply.)</sub>
To test this PR please download the appropriate DEB package(s)
from the build artifacts of the [associated PR's latest CI run](https://github.com/termux/termux-packages/pull/19736/checks).

After downloading the build artifact, make sure to `unzip` and un-`tar` it.
<details><summary>Detailed instuctions, if needed.</summary>
<p>

```bash
# finding out what architecture you need
# architecture is just below the TERMUX_VERSION
termux-info

# e.g.
# [...]
# TERMUX_MAIN_PACKAGE_FORMAT=debian
# TERMUX_VERSION=0.118.0
# TERMUX__USER_ID=0
# Packages CPU architecture:
# aarch64
# [...]

# =======================

# make sure `unzip` and `tar` are installed using
pkg install unzip tar

# unzip the artifact (if you have a different architecture this might be arm, i686 or x86_64 instead)
unzip debs-aarch64-*.zip

# untar the artifact
tar xf debs-aarch64-*.tar

# You should now have a debs/ directory in your current working directory
# Install the packages from the local source using
pkg install -- ./debs/*.deb

# to clean up, you can remove the debs/ directory, .tar file and .zip file
rm -rfi debs debs-aarch64-*.zip debs-aarch64-*.tar
```

</p>
</details> 