### PR TITLE
dontmerge: addpkg(main/perf-4.4): Performance analysis tools for Linux

### DIFF
--- a/packages/perf-4.4/build.sh
+++ b/packages/perf-4.4/build.sh
@@ -1,0 +1,157 @@
+TERMUX_PKG_HOMEPAGE=https://perf.wiki.kernel.org/index.php/Main_Page
+TERMUX_PKG_DESCRIPTION="Performance analysis tools for Linux"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@harieamjari"
+# Android Linux kernel version `uname -r`
+TERMUX_PKG_VERSION=4.4
+#TERMUX_PKG_SRCURL=https://github.com/torvalds/linux/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SRCURL=https://android.googlesource.com/kernel/common/+archive/android-trusty-${TERMUX_PKG_VERSION}.tar.gz
+#TERMUX_PKG_SHA256=5b8fc6519a737a5c809171e08225f050bf794f1f369c4c387ed3c8a89b1e995b
+TERMUX_PKG_SHA256=SKIP_CHECKSUM
+TERMUX_PKG_DEPENDS="zlib, liblzma, libelf"
+TERMUX_PKG_BUILD_DEPENDS="bison, flex"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_NO_STATICSPLIT=true
+#TERMUX_PKG_HOSTBUILD=true
+
+#termux_step_get_source() {
+#	mkdir $TERMUX_PKG_SRCDIR
+#	termux_download $TERMUX_PKG_SRCURL \
+#		$TERMUX_PKG_CACHEDIR/kernel-${TERMUX_PKG_VERSION}.tar.gz \
+#		$TERMUX_PKG_SHA256
+#	tar --gzip -xf $TERMUX_PKG_CACHECDIR/kernel-${TERMUX_PKG_VERSION}.tar.gz \
+#		-C $TERMUX_PKG_SRCDIR
+#}
+
+termux_step_post_get_source() {
+	rm -rf $TERMUX_PKG_SRCDIR/*
+	local file="$TERMUX_PKG_CACHEDIR/$(basename $TERMUX_PKG_SRCURL)"
+	tar xf "$file" -C "$TERMUX_PKG_SRCDIR"
+}
+
+termux_step_make() {
+	PERF_LDEMULATION=foo
+	local _PERF_ARCH=
+	if [ $TERMUX_ARCH = "arm" ]; then
+		CC="$TERMUX_ARCH-linux-androideabi-clang"
+		CXX="$TERMUX_ARCH-linux-androideabi-clang++"
+		_PERF_ARCH=arm
+		#FIXME set correct target emulation for arm
+		PERF_LDEMULATION=armelf
+	elif [ $TERMUX_ARCH = "aarch64" ]; then
+		CC="$TERMUX_ARCH-linux-android-clang"
+		CXX="$TERMUX_ARCH-linux-android-clang++"
+		_PERF_ARCH=arm64
+		PERF_LDEMULATION=aarch64linux
+	elif [ $TERMUX_ARCH = "i686" ]; then
+		CC="$TERMUX_ARCH-linux-android-clang"
+		CXX="$TERMUX_ARCH-linux-android-clang++"
+		_PERF_ARCH=x86
+		#FIXME set correct target emulation for i686
+		PERF_LDEMULATION=elf_i386
+	elif [ $TERMUX_ARCH = "x86_64" ]; then
+		CC="$TERMUX_ARCH-linux-android-clang"
+		CXX="$TERMUX_ARCH-linux-android-clang++"
+		_PERF_ARCH=x86
+		#FIXME set correct target emulation for x86_64
+		PERF_LDEMULATION=elf_x86_64
+	else
+		termux_error_exit "invalid architecture ${TERMUX_ARCH}"
+	fi
+
+	pushd $TERMUX_PKG_SRCDIR
+
+#	CFLAGS=" -isysroot=${TERMUX_PREFIX}/../files"
+	local _PERF_EXTRA_CFLAGS=" --verbose"
+	_PERF_EXTRA_CFLAGS+=" -Wno-implicit-function-declaration"
+	_PERF_EXTRA_CFLAGS+=" -Wno-int-conversion"
+	_PERF_EXTRA_CFLAGS+=" -Wno-implicit-int"
+	_PERF_EXTRA_CFLAGS+=" -Wno-format"
+#	_PERF_EXTRA_CFLAGS+=" -I${TERMUX_PREFIX}/include"
+	LDFLAGS+=" -L${TERMUX_PREFIX}/lib"
+
+	sed -i -e 's/ -Wstrict-aliasing=[0-9]*//g' \
+		$TERMUX_PKG_SRCDIR/tools/scripts/Makefile.include
+	sed -i -e 's/ -Werror//g' \
+		$TERMUX_PKG_SRCDIR/tools/{build/feature/Makefile,perf/{Makefile.perf,config/Makefile}}
+
+#	make defconfig \
+#		PREFIX=$TERMUX_PREFIX \
+#		HOSTCC=/usr/bin/gcc \
+#		HOSTCXX=/usr/bin/g++ \
+#		ARCH=$_PERF_ARCH \
+#		EXTRA_CFLAGS="$CFLAGS" \
+#		BIONIC=1 \
+#		LLVM=1
+#
+#	cat <<- EOL > feature_dump.txt
+#	feature-backtrace=0
+#	feature-dwarf=0
+#	feature-dwarf_getlocations=0
+#	feature-fortify-source=0
+#	feature-sync-compare-and-swap=0
+#	feature-glibc=0
+#	feature-gtk2=0
+#	feature-gtk2-infobar=0
+#	feature-libaudit=0
+#	feature-libbfd=0
+#	feature-libelf=1
+#	feature-libelf-getphdrnum=0
+#	feature-libelf-gelf_getnote=0
+#	feature-libelf-getshdrstrndx=0
+#	feature-libelf-mmap=0
+#	feature-libnuma=0
+#	feature-numa_num_possible_cpus=0
+#	feature-libperl=0
+#	feature-libpython=0
+#	feature-libpython-version=0
+#	feature-libslang=0
+#	feature-libcrypto=0
+#	feature-libunwind=0
+#	feature-libunwind-x86=0
+#	feature-libunwind-x86_64=0
+#	feature-libunwind-arm=0
+#	feature-libunwind-aarch64=0
+#	feature-pthread-attr-setaffinity-np=0
+#	feature-stackprotector-all=0
+#	feature-timerfd=0
+#	feature-libdw-dwarf-unwind=0
+#	feature-zlib=1
+#	feature-lzma=1
+#	feature-get_cpuid=0
+#	feature-bpf=0
+#	feature-sdt=0
+#	EOL
+#		FEATURE_DUMP="$TERMUX_PKG_SRCDIR/feature_dump.txt" \
+
+	# Parallel build makes it harder to spot which command
+	# produced which error so we're compiling with JOBS=1
+	#
+#	export CFLAGS
+	export PERF_LDEMULATION
+	export CC
+	export CXX
+	make -C ./tools/perf \
+		prefix="$TERMUX_PREFIX" \
+		CC="$CC" \
+		CXX="$CXX" \
+		HOSTCC="clang" \
+		HOSTCXX="clang++" \
+		HOSTLD=ld \
+		CROSS_COMPILE=" " \
+		ARCH=$_PERF_ARCH  \
+		EXTRA_CFLAGS="$_PERF_EXTRA_CFLAGS" \
+		LDFLAGS="$LDFLAGS" \
+		JOBS=1 \
+		WERROR=0 \
+		BIONIC=1 \
+		LLVM=1 \
+		V=1 \
+		VF=1
+
+	popd
+}
+
+termux_step_make_install() {
+	install -Dm700 $TERMUX_PKG_SRCDIR/tools/perf/perf $TERMUX_PREFIX/bin/perf
+}

--- a/packages/perf-4.4/tools.build.Build.include.patch
+++ b/packages/perf-4.4/tools.build.Build.include.patch
@@ -1,0 +1,20 @@
+diff -uNr android-trusty-4.4/tools/build/Build.include android-trusty-4.4.mod/tools/build/Build.include
+--- android-trusty-4.4/tools/build/Build.include	2024-04-12 17:48:47.611999411 +0800
++++ android-trusty-4.4.mod/tools/build/Build.include	2024-04-14 00:28:19.477988232 +0800
+@@ -62,8 +62,8 @@
+            $(fixdep) $(depfile) $@ '$(make-cmd)' > $(dot-target).tmp;           \
+            rm -f $(depfile);                                                    \
+            mv -f $(dot-target).tmp $(dot-target).cmd,                           \
+-           printf '\# cannot find fixdep (%s)\n' $(fixdep) > $(dot-target).cmd; \
+-           printf '\# using basic dep data\n\n' >> $(dot-target).cmd;           \
++           printf '$(pound) cannot find fixdep (%s)\n' $(fixdep) > $(dot-target).cmd; \
++           printf '$(pound) using basic dep data\n\n' >> $(dot-target).cmd;           \
+            cat $(depfile) >> $(dot-target).cmd;                                 \
+            printf '%s\n' 'cmd_$@ := $(make-cmd)' >> $(dot-target).cmd)
+ 
+@@ -89,4 +89,4 @@
+ # - per target C flags
+ # - per object C flags
+ # - BUILD_STR macro to allow '-D"$(variable)"' constructs
+-c_flags = -Wp,-MD,$(depfile),-MT,$@ $(CFLAGS) -D"BUILD_STR(s)=\#s" $(CFLAGS_$(basetarget).o) $(CFLAGS_$(obj))
++c_flags = -Wp,-MD,$(depfile) -Wp,-MT,$@ $(CFLAGS) -D"BUILD_STR(s)=\#s" $(CFLAGS_$(basetarget).o) $(CFLAGS_$(obj))

--- a/packages/perf-4.4/tools.build.Makefile.build.patch
+++ b/packages/perf-4.4/tools.build.Makefile.build.patch
@@ -1,0 +1,53 @@
+diff -uNr android-trusty-4.4/tools/build/Makefile.build android-trusty-4.4.mod/tools/build/Makefile.build
+--- android-trusty-4.4/tools/build/Makefile.build	2024-04-11 13:24:41.199000000 +0800
++++ android-trusty-4.4.mod/tools/build/Makefile.build	2024-04-14 00:30:00.909988159 +0800
+@@ -32,7 +32,7 @@
+ include $(build-dir)/Build.include
+ 
+ # do not force detected configuration
+--include $(OUTPUT).config-detected
++#-include $(OUTPUT).config-detected
+ 
+ # Init all relevant variables used in build files so
+ # 1) they have correct type
+@@ -54,23 +54,36 @@
+       cmd_mkdir = mkdir -p $(dir $@)
+      rule_mkdir = $(if $(wildcard $(dir $@)),,@$(call echo-cmd,mkdir) $(cmd_mkdir))
+ 
++# remove architecture specific flags (-march=*) when hostbuilding fixdep
++define termux-patch-filter-cflags
++  $(if $(findstring fixdep,$1),$(filter-out -march=armv7-a -march=i686,$2),$2)
++endef
++
+ # Compile command
+ quiet_cmd_cc_o_c = CC       $@
+-      cmd_cc_o_c = $(CC) $(c_flags) -c -o $@ $<
++      cmd_cc_o_c = $(CC) $(call termux-patch-filter-cflags,$@,$(c_flags)) -c -o $@ $<
+ 
+ quiet_cmd_cc_i_c = CPP      $@
+-      cmd_cc_i_c = $(CC) $(c_flags) -E -o $@ $<
++      cmd_cc_i_c = $(CC) $(call termux-patch-filter-cflags,$@,$(c_flags)) -E -o $@ $<
+ 
+ quiet_cmd_cc_s_c = AS       $@
+-      cmd_cc_s_c = $(CC) $(c_flags) -S -o $@ $<
++      cmd_cc_s_c = $(CC) $(call termux-patch-filter-cflags,$@,$(c_flags)) -S -o $@ $<
+ 
+ quiet_cmd_gen = GEN      $@
+ 
++# ld.lld can't guess target emulation when
++# linking with an empty object created from cmd_ld_multi.
++# but we don't need to specify this when building
++# fixdep since it's going to be executed by host.
++define termux-patch-set-emulation
++  $(if $(findstring fixdep,$1),,-m $(PERF_LDEMULATION))
++endef
++
+ # Link agregate command
+ # If there's nothing to link, create empty $@ object.
+ quiet_cmd_ld_multi = LD       $@
+       cmd_ld_multi = $(if $(strip $(obj-y)),\
+-		       $(LD) -r -o $@  $(filter $(obj-y),$^),rm -f $@; $(AR) rcs $@)
++		       $(LD) $(call termux-patch-set-emulation,$@) -r -o $@  $(filter $(obj-y),$^),rm -f $@; $(AR) rcs $@)
+ 
+ # Build rules
+ $(OUTPUT)%.o: %.c FORCE

--- a/packages/perf-4.4/tools.build.Makefile.feature.patch
+++ b/packages/perf-4.4/tools.build.Makefile.feature.patch
@@ -1,0 +1,21 @@
+diff -uNr android-trusty-4.4/tools/build/Makefile.feature android-trusty-4.4.mod/tools/build/Makefile.feature
+--- android-trusty-4.4/tools/build/Makefile.feature	2024-04-11 13:24:41.199000000 +0800
++++ android-trusty-4.4.mod/tools/build/Makefile.feature	2024-04-14 01:25:36.093985774 +0800
+@@ -7,7 +7,7 @@
+ 
+ feature_check = $(eval $(feature_check_code))
+ define feature_check_code
+-  feature-$(1) := $(shell $(MAKE) OUTPUT=$(OUTPUT_FEATURES) CFLAGS="$(EXTRA_CFLAGS) $(FEATURE_CHECK_CFLAGS-$(1))" LDFLAGS="$(LDFLAGS) $(FEATURE_CHECK_LDFLAGS-$(1))" -C $(feature_dir) test-$1.bin >/dev/null 2>/dev/null && echo 1 || echo 0)
++  feature-$(1) := $(shell $(MAKE) CC=$(CC) OUTPUT=$(OUTPUT_FEATURES) CFLAGS="$(CFLAGS) $(FEATURE_CHECK_CFLAGS-$(1))" LDFLAGS="$(LDFLAGS) $(FEATURE_CHECK_LDFLAGS-$(1))" -C $(feature_dir) test-$1.bin >/dev/null 2>/dev/null && echo 1 || echo 0)
+ endef
+ 
+ feature_set = $(eval $(feature_set_code))
+@@ -101,7 +101,7 @@
+   #
+   $(foreach feat,$(FEATURE_TESTS),$(call feature_set,$(feat)))
+ else
+-  $(shell $(MAKE) OUTPUT=$(OUTPUT_FEATURES) CFLAGS="$(EXTRA_CFLAGS)" LDFLAGS=$(LDFLAGS) -i -j -C $(feature_dir) $(addsuffix .bin,$(FEATURE_TESTS)) >/dev/null 2>&1)
++  $(shell $(MAKE) CC=$(CC) OUTPUT=$(OUTPUT_FEATURES) CFLAGS="$(CFLAGS)" LDFLAGS=$(LDFLAGS) -i -j -C $(feature_dir) $(addsuffix .bin,$(FEATURE_TESTS)) >/dev/null 2>&1)
+   $(foreach feat,$(FEATURE_TESTS),$(call feature_check,$(feat)))
+ endif
+ 

--- a/packages/perf-4.4/tools.build.Makefile.patch
+++ b/packages/perf-4.4/tools.build.Makefile.patch
@@ -1,0 +1,32 @@
+diff -uNr android-trusty-4.4/tools/build/Makefile android-trusty-4.4.mod/tools/build/Makefile
+--- android-trusty-4.4/tools/build/Makefile	2024-04-12 13:47:48.665997732 +0800
++++ android-trusty-4.4.mod/tools/build/Makefile	2024-04-12 14:49:40.072997395 +0800
+@@ -14,6 +14,15 @@
+ $(call allow-override,CC,$(CROSS_COMPILE)gcc)
+ $(call allow-override,LD,$(CROSS_COMPILE)ld)
+ 
++define allow-override-host
++  $(if $(or $(findstring environment,$(origin HOST$(1))),\
++            $(findstring command line,$(origin HOST$(1)))),,\
++    $(eval $(1) = $(2)))
++endef
++
++$(call allow-override-host,CC,$(HOSTCC))
++$(call allow-override-host,LD,$(HOSTLD))
++
+ ifeq ($(V),1)
+   Q =
+ else
+@@ -33,10 +42,10 @@
+ 	$(Q)rm -f fixdep
+ 
+ $(OUTPUT)fixdep-in.o: FORCE
+-	$(Q)$(MAKE) $(build)=fixdep
++	$(Q)$(MAKE) CC=$(HOSTCC) $(build)=fixdep
+ 
+ $(OUTPUT)fixdep: $(OUTPUT)fixdep-in.o
+-	$(QUIET_LINK)$(CC) $(LDFLAGS) -o $@ $<
++	$(QUIET_LINK)$(HOSTCC) $(LDFLAGS) -o $@ $<
+ 
+ FORCE:
+ 

--- a/packages/perf-4.4/tools.build.feature.Makefile.patch
+++ b/packages/perf-4.4/tools.build.feature.Makefile.patch
@@ -1,0 +1,12 @@
+diff -uNr android-trusty-4.4/tools/build/feature/Makefile android-trusty-4.4.mod/tools/build/feature/Makefile
+--- android-trusty-4.4/tools/build/feature/Makefile	2024-04-11 13:24:41.199000000 +0800
++++ android-trusty-4.4.mod/tools/build/feature/Makefile	2024-04-14 01:24:30.873985820 +0800
+@@ -44,7 +44,7 @@
+ all: $(FILES)
+ 
+ __BUILD = $(CC) $(CFLAGS) -Wall -Werror -o $(OUTPUT)$@ $(patsubst %.bin,%.c,$@) $(LDFLAGS)
+-  BUILD = $(__BUILD) > $(OUTPUT)$(@:.bin=.make.output) 2>&1
++  BUILD = $(__BUILD)
+ 
+ ###############################
+ 

--- a/packages/perf-4.4/tools.build.fixdep.c.patch
+++ b/packages/perf-4.4/tools.build.fixdep.c.patch
@@ -1,0 +1,22 @@
+diff -uNr android-trusty-4.4/tools/build/fixdep.c android-trusty-4.4.mod/tools/build/fixdep.c
+--- android-trusty-4.4/tools/build/fixdep.c	2024-04-11 13:24:41.206000000 +0800
++++ android-trusty-4.4.mod/tools/build/fixdep.c	2024-04-12 21:58:38.375997235 +0800
+@@ -49,7 +49,7 @@
+ 	char *end = m + len;
+ 	char *p;
+ 	char s[PATH_MAX];
+-	int is_target;
++	int is_target, has_target = 0;
+ 	int saw_any_target = 0;
+ 	int is_first_dep = 0;
+ 
+@@ -67,7 +67,8 @@
+ 		if (is_target) {
+ 			/* The /next/ file is the first dependency */
+ 			is_first_dep = 1;
+-		} else {
++			has_target = 1;
++		} else if (has_target) {
+ 			/* Save this token/filename */
+ 			memcpy(s, m, p-m);
+ 			s[p - m] = 0;

--- a/packages/perf-4.4/tools.lib.api.Makefile.patch
+++ b/packages/perf-4.4/tools.lib.api.Makefile.patch
@@ -1,0 +1,14 @@
+diff -uNr android-trusty-4.4/tools/lib/api/Makefile android-trusty-4.4.mod/tools/lib/api/Makefile
+--- android-trusty-4.4/tools/lib/api/Makefile	2024-04-11 13:24:41.230000000 +0800
++++ android-trusty-4.4.mod/tools/lib/api/Makefile	2024-04-12 15:28:35.424995725 +0800
+@@ -8,8 +8,8 @@
+ #$(info Determined 'srctree' to be $(srctree))
+ endif
+ 
+-CC = $(CROSS_COMPILE)gcc
+-AR = $(CROSS_COMPILE)ar
++#CC = $(CROSS_COMPILE)gcc
++#AR = $(CROSS_COMPILE)ar
+ 
+ MAKEFLAGS += --no-print-directory
+ 

--- a/packages/perf-4.4/tools.lib.bpf.bpf.c.patch
+++ b/packages/perf-4.4/tools.lib.bpf.bpf.c.patch
@@ -1,0 +1,11 @@
+diff -uNr android-trusty-4.4/tools/lib/bpf/bpf.c android-trusty-4.4.mod/tools/lib/bpf/bpf.c
+--- android-trusty-4.4/tools/lib/bpf/bpf.c	2024-04-11 13:24:41.232000000 +0800
++++ android-trusty-4.4.mod/tools/lib/bpf/bpf.c	2024-04-12 20:01:21.227993722 +0800
+@@ -9,6 +9,7 @@
+ #include <stdlib.h>
+ #include <memory.h>
+ #include <unistd.h>
++#include <strings.h>
+ #include <asm/unistd.h>
+ #include <linux/bpf.h>
+ #include "bpf.h"

--- a/packages/perf-4.4/tools.lib.bpf.libbpf.c.patch
+++ b/packages/perf-4.4/tools.lib.bpf.libbpf.c.patch
@@ -1,0 +1,20 @@
+diff -uNr android-trusty-4.4/tools/lib/bpf/libbpf.c android-trusty-4.4.mod/tools/lib/bpf/libbpf.c
+--- android-trusty-4.4/tools/lib/bpf/libbpf.c	2024-04-11 13:24:41.235000000 +0800
++++ android-trusty-4.4.mod/tools/lib/bpf/libbpf.c	2024-04-12 19:44:12.839994458 +0800
+@@ -11,6 +11,7 @@
+ #include <stdarg.h>
+ #include <inttypes.h>
+ #include <string.h>
++#include <strings.h>
+ #include <unistd.h>
+ #include <fcntl.h>
+ #include <errno.h>
+@@ -641,7 +642,7 @@
+ 				 GELF_R_SYM(rel.r_info),
+ 				 &sym)) {
+ 			pr_warning("relocation: symbol %"PRIx64" not found\n",
+-				   GELF_R_SYM(rel.r_info));
++				   (uint64_t)(GELF_R_SYM(rel.r_info) & 0xffffffff));
+ 			return -LIBBPF_ERRNO__FORMAT;
+ 		}
+ 

--- a/packages/perf-4.4/tools.lib.traceevent.Makefile.patch
+++ b/packages/perf-4.4/tools.lib.traceevent.Makefile.patch
@@ -1,0 +1,12 @@
+diff -uNr android-trusty-4.4/tools/lib/traceevent/Makefile android-trusty-4.4.mod/tools/lib/traceevent/Makefile
+--- android-trusty-4.4/tools/lib/traceevent/Makefile	2024-04-11 13:24:41.251000000 +0800
++++ android-trusty-4.4.mod/tools/lib/traceevent/Makefile	2024-04-12 22:30:38.359995862 +0800
+@@ -251,7 +251,7 @@
+ 
+ define do_generate_dynamic_list_file
+ 	(echo '{';							\
+-	$(NM) -u -D $1 | awk 'NF>1 {print "\t"$$2";"}' | sort -u;	\
++	$(NM) -u -D $1 | awk 'NF>1 {sub("@.*", "", $$2); print "\t"$$2";"}' | sort -u; \
+ 	echo '};';							\
+ 	) > $2
+ endef

--- a/packages/perf-4.4/tools.lib.traceevent.event-parse.c.patch
+++ b/packages/perf-4.4/tools.lib.traceevent.event-parse.c.patch
@@ -1,0 +1,15 @@
+diff -uNr android-trusty-4.4/tools/lib/traceevent/event-parse.c android-trusty-4.4.mod/tools/lib/traceevent/event-parse.c
+--- android-trusty-4.4/tools/lib/traceevent/event-parse.c	2024-04-11 13:24:41.255000000 +0800
++++ android-trusty-4.4.mod/tools/lib/traceevent/event-parse.c	2024-04-12 18:31:07.427997595 +0800
+@@ -31,8 +31,11 @@
+ #include <errno.h>
+ #include <stdint.h>
+ #include <limits.h>
++#include <inttypes.h>
+ 
+ #include <netinet/ip6.h>
++#include <netinet/in.h>
++#include <sys/socket.h>
+ #include "event-parse.h"
+ #include "event-utils.h"
+ 

--- a/packages/perf-4.4/tools.perf.bench.bench.h.patch
+++ b/packages/perf-4.4/tools.perf.bench.bench.h.patch
@@ -1,0 +1,19 @@
+diff -uNr android-trusty-4.4/tools/perf/bench/bench.h android-trusty-4.4.mod/tools/perf/bench/bench.h
+--- android-trusty-4.4/tools/perf/bench/bench.h	2024-04-11 13:24:41.344000000 +0800
++++ android-trusty-4.4.mod/tools/perf/bench/bench.h	2024-04-12 20:42:40.595991949 +0800
+@@ -1,6 +1,8 @@
+ #ifndef BENCH_H
+ #define BENCH_H
+ 
++#include <sys/time.h>
++
+ /*
+  * The madvise transparent hugepage constants were added in glibc
+  * 2.13. For compatibility with older versions of glibc, define these
+@@ -48,5 +50,6 @@
+ 
+ extern int bench_format;
+ extern unsigned int bench_repeat;
++extern struct timeval termux_bench_start, termux_bench_end, termux_bench_runtime;
+ 
+ #endif

--- a/packages/perf-4.4/tools.perf.bench.futex-hash.c.patch
+++ b/packages/perf-4.4/tools.perf.bench.futex-hash.c.patch
@@ -1,0 +1,50 @@
+diff -uNr android-trusty-4.4/tools/perf/bench/futex-hash.c android-trusty-4.4.mod/tools/perf/bench/futex-hash.c
+--- android-trusty-4.4/tools/perf/bench/futex-hash.c	2024-04-11 13:24:41.344000000 +0800
++++ android-trusty-4.4.mod/tools/perf/bench/futex-hash.c	2024-04-12 20:59:07.259999790 +0800
+@@ -28,7 +28,7 @@
+ static bool fshared = false, done = false, silent = false;
+ static int futex_flag = 0;
+ 
+-struct timeval start, end, runtime;
++struct timeval termux_bench_start, termux_bench_end, termux_bench_runtime;
+ static pthread_mutex_t thread_lock;
+ static unsigned int threads_starting;
+ static struct stats throughput_stats;
+@@ -92,8 +92,8 @@
+ {
+ 	/* inform all threads that we're done for the day */
+ 	done = true;
+-	gettimeofday(&end, NULL);
+-	timersub(&end, &start, &runtime);
++	gettimeofday(&termux_bench_end, NULL);
++	timersub(&termux_bench_end, &termux_bench_start, &termux_bench_runtime);
+ }
+ 
+ static void print_summary(void)
+@@ -103,7 +103,7 @@
+ 
+ 	printf("%sAveraged %ld operations/sec (+- %.2f%%), total secs = %d\n",
+ 	       !silent ? "\n" : "", avg, rel_stddev_stats(stddev, avg),
+-	       (int) runtime.tv_sec);
++	       (int) termux_bench_runtime.tv_sec);
+ }
+ 
+ int bench_futex_hash(int argc, const char **argv,
+@@ -148,7 +148,7 @@
+ 
+ 	threads_starting = nthreads;
+ 	pthread_attr_init(&thread_attr);
+-	gettimeofday(&start, NULL);
++	gettimeofday(&termux_bench_start, NULL);
+ 	for (i = 0; i < nthreads; i++) {
+ 		worker[i].tid = i;
+ 		worker[i].futex = calloc(nfutexes, sizeof(*worker[i].futex));
+@@ -191,7 +191,7 @@
+ 	pthread_mutex_destroy(&thread_lock);
+ 
+ 	for (i = 0; i < nthreads; i++) {
+-		unsigned long t = worker[i].ops/runtime.tv_sec;
++		unsigned long t = worker[i].ops/termux_bench_runtime.tv_sec;
+ 		update_stats(&throughput_stats, t);
+ 		if (!silent) {
+ 			if (nfutexes == 1)

--- a/packages/perf-4.4/tools.perf.bench.futex-lock-pi.c.patch
+++ b/packages/perf-4.4/tools.perf.bench.futex-lock-pi.c.patch
@@ -1,0 +1,49 @@
+diff -uNr android-trusty-4.4/tools/perf/bench/futex-lock-pi.c android-trusty-4.4.mod/tools/perf/bench/futex-lock-pi.c
+--- android-trusty-4.4/tools/perf/bench/futex-lock-pi.c	2024-04-11 13:24:41.345000000 +0800
++++ android-trusty-4.4.mod/tools/perf/bench/futex-lock-pi.c	2024-04-12 20:35:56.227992238 +0800
+@@ -29,7 +29,6 @@
+ static bool done = false, fshared = false;
+ static unsigned int ncpus, nthreads = 0;
+ static int futex_flag = 0;
+-struct timeval start, end, runtime;
+ static pthread_mutex_t thread_lock;
+ static unsigned int threads_starting;
+ static struct stats throughput_stats;
+@@ -56,7 +55,7 @@
+ 
+ 	printf("%sAveraged %ld operations/sec (+- %.2f%%), total secs = %d\n",
+ 	       !silent ? "\n" : "", avg, rel_stddev_stats(stddev, avg),
+-	       (int) runtime.tv_sec);
++	       (int) termux_bench_runtime.tv_sec);
+ }
+ 
+ static void toggle_done(int sig __maybe_unused,
+@@ -65,8 +64,8 @@
+ {
+ 	/* inform all threads that we're done for the day */
+ 	done = true;
+-	gettimeofday(&end, NULL);
+-	timersub(&end, &start, &runtime);
++	gettimeofday(&termux_bench_end, NULL);
++	timersub(&termux_bench_end, &termux_bench_start, &termux_bench_runtime);
+ }
+ 
+ static void *workerfn(void *arg)
+@@ -172,7 +171,7 @@
+ 
+ 	threads_starting = nthreads;
+ 	pthread_attr_init(&thread_attr);
+-	gettimeofday(&start, NULL);
++	gettimeofday(&termux_bench_start, NULL);
+ 
+ 	create_threads(worker, thread_attr);
+ 	pthread_attr_destroy(&thread_attr);
+@@ -198,7 +197,7 @@
+ 	pthread_mutex_destroy(&thread_lock);
+ 
+ 	for (i = 0; i < nthreads; i++) {
+-		unsigned long t = worker[i].ops/runtime.tv_sec;
++		unsigned long t = worker[i].ops/termux_bench_runtime.tv_sec;
+ 
+ 		update_stats(&throughput_stats, t);
+ 		if (!silent)

--- a/packages/perf-4.4/tools.perf.bench.futex.h.patch
+++ b/packages/perf-4.4/tools.perf.bench.futex.h.patch
@@ -1,0 +1,15 @@
+diff -uNr android-trusty-4.4/tools/perf/bench/futex.h android-trusty-4.4.mod/tools/perf/bench/futex.h
+--- android-trusty-4.4/tools/perf/bench/futex.h	2024-04-11 13:24:41.349000000 +0800
++++ android-trusty-4.4.mod/tools/perf/bench/futex.h	2024-04-13 14:44:27.466999281 +0800
+@@ -32,6 +32,11 @@
+  * These argument descriptions are the defaults for all
+  * like-named arguments in the following wrappers except where noted below.
+  */
++
++#if !defined(SYS_futex) && defined(SYS_futex_time64)
++#define SYS_futex SYS_futex_time64
++#endif
++
+ #define futex(uaddr, op, val, timeout, uaddr2, val3, opflags) \
+ 	syscall(SYS_futex, uaddr, op | opflags, val, timeout, uaddr2, val3)
+ 

--- a/packages/perf-4.4/tools.perf.config.Makefile.patch
+++ b/packages/perf-4.4/tools.perf.config.Makefile.patch
@@ -1,0 +1,13 @@
+diff -uNr android-trusty-4.4/tools/perf/config/Makefile android-trusty-4.4.mod/tools/perf/config/Makefile
+--- android-trusty-4.4/tools/perf/config/Makefile	2024-04-14 00:49:51.437987308 +0800
++++ android-trusty-4.4.mod/tools/perf/config/Makefile	2024-04-14 01:23:44.161985854 +0800
+@@ -202,6 +202,9 @@
+ CFLAGS += -I$(srctree)/arch/$(ARCH)/include
+ CFLAGS += -I$(srctree)/include/uapi
+ CFLAGS += -I$(srctree)/include
++# add termux prefix to the last search path.
++# prevents conflicts of "event.h" (libevent) and "event.h" (kernel header)
++CFLAGS += -I$(prefix)/include
+ 
+ # $(obj-perf)      for generated common-cmds.h
+ # $(obj-perf)/util for generated bison/flex headers

--- a/packages/perf-4.4/tools.perf.util.cpumap.c.patch
+++ b/packages/perf-4.4/tools.perf.util.cpumap.c.patch
@@ -1,0 +1,14 @@
+diff -uNr android-trusty-4.4/tools/perf/util/cpumap.c android-trusty-4.4.mod/tools/perf/util/cpumap.c
+--- android-trusty-4.4/tools/perf/util/cpumap.c	2024-04-11 13:24:41.516000000 +0800
++++ android-trusty-4.4.mod/tools/perf/util/cpumap.c	2024-04-12 22:05:18.255996949 +0800
+@@ -7,6 +7,10 @@
+ #include <stdlib.h>
+ #include "asm/bug.h"
+ 
++int max_cpu_num;
++int max_node_num;
++int *cpunode_map;
++
+ static struct cpu_map *cpu_map__default_new(void)
+ {
+ 	struct cpu_map *cpus;

--- a/packages/perf-4.4/tools.perf.util.cpumap.h.patch
+++ b/packages/perf-4.4/tools.perf.util.cpumap.h.patch
@@ -1,0 +1,16 @@
+diff -uNr android-trusty-4.4/tools/perf/util/cpumap.h android-trusty-4.4.mod/tools/perf/util/cpumap.h
+--- android-trusty-4.4/tools/perf/util/cpumap.h	2024-04-11 13:24:41.516000000 +0800
++++ android-trusty-4.4.mod/tools/perf/util/cpumap.h	2024-04-12 22:05:04.719996959 +0800
+@@ -56,9 +56,9 @@
+ 	return map ? map->map[0] == -1 : true;
+ }
+ 
+-int max_cpu_num;
+-int max_node_num;
+-int *cpunode_map;
++extern int max_cpu_num;
++extern int max_node_num;
++extern int *cpunode_map;
+ 
+ int cpu__setup_cpunode_map(void);
+ 

--- a/packages/perf-4.4/tools.perf.util.parse-events.y.patch
+++ b/packages/perf-4.4/tools.perf.util.parse-events.y.patch
@@ -1,0 +1,17 @@
+diff -uNr android-trusty-4.4/tools/perf/util/parse-events.y android-trusty-4.4.mod/tools/perf/util/parse-events.y
+--- android-trusty-4.4/tools/perf/util/parse-events.y	2024-04-11 13:24:41.601000000 +0800
++++ android-trusty-4.4.mod/tools/perf/util/parse-events.y	2024-04-11 16:11:55.490997383 +0800
+@@ -36,6 +36,13 @@
+ 		data->nr_groups++;
+ }
+ 
++/* should fix conflicting types for parse_events_error
++ * due to implicit declaration.
++ */
++void parse_events_error(YYLTYPE *loc, void *data,
++			void *scanner __maybe_unused,
++			char const *msg __maybe_unused);
++
+ %}
+ 
+ %token PE_START_EVENTS PE_START_TERMS


### PR DESCRIPTION
This is a kernel version specific package for performance analysis in Linux. I can't be sure if this would work on all android, kernel version 4.4, once big shot vendors starts messing with the kernel on their own. It would be much better for an individual to request the original kernel source from the vendor and compile perf from those.

My device fails to write to "/proc/sys/kernel/perf_event_paranoid", citing "permission denied" so I guess this package requires root.

To do cleaning.

Resources:

1. [Cross compiling perf](https://lore.kernel.org/all/1728044.WAxNW5e6fy@milian-kdab2/T/)
2. [Clang doesn't support multiple arguments being passed to -Wp, so split
    them.](https://marc.info/?l=git-commits-head&m=148157799109193&w=2)
3. [Perf for Linux ARM](https://learn.arm.com/install-guides/perf/)
4. [Fix escaping # in *.cmd files for future Make](https://patchwork.kernel.org/project/linux-kbuild/patch/2d0bd4a4-98cb-380e-36c4-e46dc5d53991@molgen.mpg.de/)
5. [Perf bench: share some global variables](https://www.mail-archive.com/linux-kernel@vger.kernel.org/msg2257273.html)
6. [fixdep.c patch](https://lore.kernel.org/lkml/CAOFdcFOU5=OZU8qv2funPyV-BkS174k-xUCJ-VMxmzUxgfO0qA@mail.gmail.com/)
7. [libtraceevent: `;` expected, got `@`](https://patchwork.kernel.org/project/linux-trace-devel/patch/20200725010623.GA194964@decadent.org.uk/#23520937)
8. [Building the kernel with LLVM/clang](https://docs.kernel.org/kbuild/llvm.html)
9. [Compiling perf for Android](https://android.googlesource.com/platform/external/linux-tools-perf/+/1aea4ce5992ad450d824b586b485ca62dc19999a/src/tools/perf/Documentation/android.txt)

![Screenshot_20240412-224732_Termux](https://github.com/termux/termux-packages/assets/46589135/4ca3bfb1-e1ed-4efa-9072-553f43ab6160)
![Screenshot_20240412-224737_Termux](https://github.com/termux/termux-packages/assets/46589135/0742bd19-fd2a-4198-80a5-aca607f34b74)
