### PR TITLE
enhance(x11/gtk-layer-shell): Enable gobject introspection data

### DIFF
--- a/x11-packages/gtk-layer-shell/build.sh
+++ b/x11-packages/gtk-layer-shell/build.sh
@@ -3,16 +3,21 @@ TERMUX_PKG_DESCRIPTION="Library to create panels and other desktop components fo
 TERMUX_PKG_LICENSE="LGPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.8.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/wmww/gtk-layer-shell
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="gtk3, libwayland"
-TERMUX_PKG_BUILD_DEPENDS="libwayland-cross-scanner, libwayland-protocols"
+TERMUX_PKG_DEPENDS="glib, gtk3, libwayland"
+TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, libwayland-cross-scanner, libwayland-protocols"
+TERMUX_PKG_DISABLE_GIR=false
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Ddocs=false
--Dintrospection=false
+-Dintrospection=true
 -Dtests=false
+-Dvapi=true
 "
 
 termux_step_pre_configure() {
+	TERMUX_PKG_VERSION=. termux_setup_gir
+
 	export PATH="$TERMUX_PREFIX/opt/libwayland/cross/bin:$PATH"
 }

--- a/x11-packages/gtk-layer-shell/gir/GtkLayerShell-0.1.xml
+++ b/x11-packages/gtk-layer-shell/gir/GtkLayerShell-0.1.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<dump>
+</dump>


### PR DESCRIPTION
<details><summary>Click here to see the list of added files in gtk-layer-shell package</summary>

```diff
--- gtk-layer-shell-old.txt
+++ gtk-layer-shell-new.txt
@@ -8,6 +8,8 @@
 ./data/data/com.termux/files/usr/include/gtk-layer-shell/
 ./data/data/com.termux/files/usr/include/gtk-layer-shell/gtk-layer-shell.h
 ./data/data/com.termux/files/usr/lib/
+./data/data/com.termux/files/usr/lib/girepository-1.0/
+./data/data/com.termux/files/usr/lib/girepository-1.0/GtkLayerShell-0.1.typelib
 ./data/data/com.termux/files/usr/lib/libgtk-layer-shell.so
 ./data/data/com.termux/files/usr/lib/pkgconfig/
 ./data/data/com.termux/files/usr/lib/pkgconfig/gtk-layer-shell-0.pc
@@ -15,3 +17,9 @@
 ./data/data/com.termux/files/usr/share/doc/
 ./data/data/com.termux/files/usr/share/doc/gtk-layer-shell/
 ./data/data/com.termux/files/usr/share/doc/gtk-layer-shell/LICENSE
+./data/data/com.termux/files/usr/share/gir-1.0/
+./data/data/com.termux/files/usr/share/gir-1.0/GtkLayerShell-0.1.gir
+./data/data/com.termux/files/usr/share/vala/
+./data/data/com.termux/files/usr/share/vala/vapi/
+./data/data/com.termux/files/usr/share/vala/vapi/gtk-layer-shell-0.deps
+./data/data/com.termux/files/usr/share/vala/vapi/gtk-layer-shell-0.vapi
```

</details>
