### PR TITLE
bump(x11/vala-panel-appmenu): 24.02

### DIFF
--- a/x11-packages/vala-panel-appmenu/build.sh
+++ b/x11-packages/vala-panel-appmenu/build.sh
@@ -2,10 +2,12 @@ TERMUX_PKG_HOMEPAGE=https://gitlab.com/vala-panel-project/vala-panel-appmenu
 TERMUX_PKG_DESCRIPTION="Global Menu for Vala Panel (metapackage)"
 TERMUX_PKG_LICENSE="LGPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=0.7.6
+TERMUX_PKG_VERSION="24.02"
 TERMUX_PKG_SRCURL=https://gitlab.com/vala-panel-project/vala-panel-appmenu/-/archive/${TERMUX_PKG_VERSION}/vala-panel-appmenu-${TERMUX_PKG_VERSION}.tar.bz2
-TERMUX_PKG_SHA256=c137f8f30ab5925a4a236a8a047b7962ec9be987fe25dd2d092666e0580fdacf
-TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, valac"
+TERMUX_PKG_SHA256=83b1803ea18afa9edfaad008ff378ef4b560d4ef968eadf552915d3569029c52
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="glib"
+TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, glib-cross, valac"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dwm_backend=wnck
 -Dvalapanel=disabled
@@ -18,8 +20,19 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 "
 
 termux_step_pre_configure() {
-	termux_setup_gir
+	TERMUX_PKG_VERSION=. termux_setup_gir
 
 	CPPFLAGS+=" -Dulong=u_long"
 	LDFLAGS+=" -lX11"
+
+	local _WRAPPER_BIN="${TERMUX_PKG_BUILDDIR}/_wrapper/bin"
+	mkdir -p "${_WRAPPER_BIN}"
+	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "false" ]]; then
+		sed "s|^export PKG_CONFIG_LIBDIR=|export PKG_CONFIG_LIBDIR=${TERMUX_PREFIX}/opt/glib/cross/lib/x86_64-linux-gnu/pkgconfig:|" \
+			"${TERMUX_STANDALONE_TOOLCHAIN}/bin/pkg-config" \
+			> "${_WRAPPER_BIN}/pkg-config"
+		chmod +x "${_WRAPPER_BIN}/pkg-config"
+		export PKG_CONFIG="${_WRAPPER_BIN}/pkg-config"
+	fi
+	export PATH="${_WRAPPER_BIN}:${PATH}"
 }

--- a/x11-packages/vala-panel-appmenu/build.sh
+++ b/x11-packages/vala-panel-appmenu/build.sh
@@ -7,7 +7,7 @@ TERMUX_PKG_SRCURL=https://gitlab.com/vala-panel-project/vala-panel-appmenu/-/arc
 TERMUX_PKG_SHA256=83b1803ea18afa9edfaad008ff378ef4b560d4ef968eadf552915d3569029c52
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="glib"
-TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, glib-cross, valac"
+TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, glib-cross, gtk2, gtk3, valac"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dwm_backend=wnck
 -Dvalapanel=disabled
@@ -15,7 +15,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dmate=disabled
 -Dbudgie=disabled
 -Dregistrar=disabled
--Dappmenu-gtk-module=disabled
+-Dappmenu-gtk-module=enabled
 -Djayatana=disabled
 "
 

--- a/x11-packages/vala-panel-appmenu/gir/AppmenuGLibTranslator-24.02.xml
+++ b/x11-packages/vala-panel-appmenu/gir/AppmenuGLibTranslator-24.02.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<dump>
+  <class name="DBusMenuImporter" get-type="dbus_menu_importer_get_type" parents="GObject">
+    <property name="bus-name" type="gchararray" flags="234" default-value="NULL"/>
+    <property name="object-path" type="gchararray" flags="234" default-value="NULL"/>
+    <property name="model" type="GMenuModel" flags="225"/>
+    <property name="action-group" type="GActionGroup" flags="225"/>
+  </class>
+</dump>

--- a/x11-packages/vala-panel-appmenu/xfce4-appmenu-plugin.subpackage.sh
+++ b/x11-packages/vala-panel-appmenu/xfce4-appmenu-plugin.subpackage.sh
@@ -3,5 +3,4 @@ lib/xfce4/panel/plugins/
 share/xfce4/panel/plugins/
 "
 TERMUX_SUBPKG_DESCRIPTION="Global Menu applet for use with xfce4-panel"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=no
 TERMUX_SUBPKG_DEPENDS="glib, gtk3, libwnck, libx11, xfce4-panel, xfconf"


### PR DESCRIPTION
* Enable gobject introspection data.
* xfce4-appmenu-plugin now depends on vala-appmenu-plugin which provides libappmenu-glib-translator.so.

Fixes #17896
