### PR TITLE
fix(main/delve): patch debugger.go to contain android

### DIFF
--- a/packages/delve/build.sh
+++ b/packages/delve/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A debugger for the Go programming language"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Krishna kanhaiya @kcubeterm"
 TERMUX_PKG_VERSION="1.22.1"
+TERMUX_PKG_REVISION="1"
 TERMUX_PKG_DEPENDS="golang, git"
 TERMUX_PKG_SRCURL=https://github.com/go-delve/delve/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=fe6f0d97c233d4f0f1ed422c11508cc57c14e9e0915f9a258f1912c46824cbfb
@@ -13,7 +14,7 @@ termux_step_make() {
 	termux_setup_golang
 	cd $TERMUX_PKG_SRCDIR
 
-	mkdir -p "$TERMUX_PKG_BUILDDIR"/src/github.com/go-delve/    
+	mkdir -p "$TERMUX_PKG_BUILDDIR"/src/github.com/go-delve/
 	mkdir -p "$TERMUX_PREFIX"/share/doc/delve
 	cp -a "$TERMUX_PKG_SRCDIR" "$TERMUX_PKG_BUILDDIR"/src/github.com/go-delve/delve/
 	cd "$TERMUX_PKG_BUILDDIR"/src/github.com/go-delve/delve/cmd/dlv/

--- a/packages/delve/debugger.go.patch
+++ b/packages/delve/debugger.go.patch
@@ -1,0 +1,12 @@
+diff -uNr delve/service/debugger/debugger.go delve.mod/service/debugger/debugger.go
+--- delve/service/debugger/debugger.go	2024-04-16 07:54:18.275477304 +0200
++++ delve.mod/service/debugger/debugger.go	2024-04-16 08:01:10.542185042 +0200
+@@ -2408,7 +2407,7 @@
+ 	switch runtime.GOOS {
+ 	case "darwin":
+ 		exe, err = macho.NewFile(f)
+-	case "linux", "freebsd":
++	case "linux", "freebsd", "android":
+ 		exe, err = elf.NewFile(f)
+ 	case "windows":
+ 		exe, err = pe.NewFile(f)


### PR DESCRIPTION
fixes https://github.com/termux/termux-packages/issues/18672


I still need to test it, but running `./build-package.sh delve` compiles a lot of stuff and does not reach delve.
Edit: I got it working with `./build-package.sh -s delve`