### PR TITLE
chore(x11/pyqt5): Add version requirements for runtime and build time dependencies

### DIFF
--- a/x11-packages/pyqt5/build.sh
+++ b/x11-packages/pyqt5/build.sh
@@ -3,13 +3,13 @@ TERMUX_PKG_DESCRIPTION="Comprehensive Python Bindings for Qt v5"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="5.15.10"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://files.pythonhosted.org/packages/source/P/PyQt5/PyQt5-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=d46b7804b1b10a4ff91753f8113e5b5580d2b4462f3226288e2d84497334898a
 TERMUX_PKG_DEPENDS="libc++, python, qt5-qtbase, qt5-qtdeclarative, qt5-qtlocation, qt5-qtmultimedia, qt5-qtsensors, qt5-qtsvg, qt5-qttools, qt5-qtwebchannel, qt5-qtwebkit, qt5-qtwebsockets, qt5-qtx11extras, qt5-qtxmlpatterns, python-pip"
 TERMUX_PKG_BUILD_DEPENDS="qt5-qtbase-cross-tools, qt5-qtdeclarative-cross-tools, qt5-qttools-cross-tools"
-TERMUX_PKG_PYTHON_COMMON_DEPS="wheel, PyQt-builder"
-TERMUX_PKG_PYTHON_TARGET_DEPS="PyQt5-sip"
+TERMUX_PKG_PYTHON_COMMON_DEPS="wheel, 'sip>=6.6.2,<7', 'PyQt-builder>=1.14.1,<2'"
+TERMUX_PKG_PYTHON_TARGET_DEPS="'PyQt5-sip>=12.13,<13'"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_MAKE_ARGS="
 --verbose


### PR DESCRIPTION

    This prevents running pyqt5 with older version of pyqt5-sip and fixes
    the following runtime error.
    
    RuntimeError: the sip module implements API v12.0 to v12.12 but the PyQt5.QtCore module requires API v12.13

Fixes #19755
