### PR TITLE
fix(main/enchant): Fix building in 32 bit environment

### DIFF
--- a/packages/enchant/build.sh
+++ b/packages/enchant/build.sh
@@ -3,15 +3,12 @@ TERMUX_PKG_DESCRIPTION="Wraps a number of different spelling libraries and progr
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.6.9"
-TERMUX_PKG_SRCURL=https://github.com/AbiWord/enchant/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=8738710a1f73f3fd19eb1c603e9353c61595e288ca0a43b0805418136df99c4e
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=https://github.com/AbiWord/enchant/releases/download/v${TERMUX_PKG_VERSION}/enchant-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=d9a5a10dc9b38a43b3a0fa22c76ed6ebb7e09eb535aff62954afcdbd40efff6b
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-relocatable" 
 TERMUX_PKG_DEPENDS="aspell, glib, hunspell, libc++"
-
-termux_step_post_get_source() {
-	./bootstrap
-}
 
 termux_step_pre_configure() {
 	LDFLAGS+=" $($CC -print-libgcc-file-name)"


### PR DESCRIPTION

    This changes source tarball from git archive to release asset.
    Git fails to clone entire gnulib source repository in 32 bit
    environment if git archive source tarball is used. It shows the
    following OOM error in ffe7d0d5d35a2900cdc254fb3091440a491321c5
    
    Cloning into 'gnulib'...
    remote: warning: suboptimal pack - out of memory
    remote: error: Out of memory, malloc failed (tried to allocate 6167557 bytes)
    
    In the source tarball from release asset, the gnulib repository
    is already present and bootstrap step can be skipped.
