### PR TITLE
fix(scripts/build): ninja: unknown warning flag 'dupbuild=warn'

### DIFF
--- a/scripts/build/termux_step_make.sh
+++ b/scripts/build/termux_step_make.sh
@@ -7,7 +7,7 @@ termux_step_make() {
 	fi
 
 	if test -f build.ninja; then
-		ninja -w dupbuild=warn -j $TERMUX_MAKE_PROCESSES
+		ninja -j $TERMUX_MAKE_PROCESSES
 	elif ls ./*.cabal &>/dev/null; then
 		cabal build
 	elif ls ./*akefile &>/dev/null || [ ! -z "$TERMUX_PKG_EXTRA_MAKE_ARGS" ]; then

--- a/scripts/build/termux_step_make_install.sh
+++ b/scripts/build/termux_step_make_install.sh
@@ -3,7 +3,7 @@ termux_step_make_install() {
 	[ "$TERMUX_PKG_METAPACKAGE" = "true" ] && return
 
 	if test -f build.ninja; then
-		ninja -w dupbuild=warn -j $TERMUX_MAKE_PROCESSES install
+		ninja -j $TERMUX_MAKE_PROCESSES install
 	elif test -f setup.py || test -f pyproject.toml || test -f setup.cfg; then
 		pip install --no-deps . --prefix $TERMUX_PREFIX
 	elif ls ./*.cabal &>/dev/null; then


### PR DESCRIPTION
ninja has removed the flag `-w dupbuild=warn` since https://github.com/ninja-build/ninja/commit/8f47d5aa33c6c303a71093be2eac02672dfb2966.

```
$ ninja --version
1.12.0
$ ninja -w dupbuild=warn
ninja: error: unknown warning flag 'dupbuild=warn'
```
