### PR TITLE
addpkg(main/python-contourpy): 1.2.1

### DIFF
--- a/packages/matplotlib/build.sh
+++ b/packages/matplotlib/build.sh
@@ -15,11 +15,12 @@ LICENSE/LICENSE_STIX
 LICENSE/LICENSE_YORICK"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.8.4"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/matplotlib/matplotlib/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=7c4f370b7550eec8342c102f9dd80da3bec2895d7f514f5f6378764db4cb0e35
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="freetype, libc++, patchelf, ninja, python, python-numpy, python-pillow, python-pip"
-TERMUX_PKG_PYTHON_TARGET_DEPS="'contourpy>=1.0.1', 'cycler>=0.10', 'fonttools>=4.22.0', 'kiwisolver>=1.0.1', 'packaging>=20.0', 'pyparsing>=2.3.1,<3.1', 'python-dateutil>=2.7'"
+TERMUX_PKG_DEPENDS="freetype, libc++, patchelf, ninja, python, python-contourpy, python-numpy, python-pillow, python-pip"
+TERMUX_PKG_PYTHON_TARGET_DEPS="'cycler>=0.10', 'fonttools>=4.22.0', 'kiwisolver>=1.0.1', 'packaging>=20.0', 'pyparsing>=2.3.1,<3.1', 'python-dateutil>=2.7'"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_PYTHON_COMMON_DEPS="'certifi>=2020.06.20', 'numpy>=1.25', 'pybind11>=2.6', 'setuptools>=42', 'setuptools_scm>=7', wheel"
 

--- a/packages/python-contourpy/build.sh
+++ b/packages/python-contourpy/build.sh
@@ -1,0 +1,40 @@
+TERMUX_PKG_HOMEPAGE=https://contourpy.readthedocs.io/
+TERMUX_PKG_DESCRIPTION="Python library for calculating contours in 2D quadrilateral grids"
+TERMUX_PKG_LICENSE="BSD 3-Clause"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="1.2.1"
+TERMUX_PKG_SRCURL=git+https://github.com/contourpy/contourpy
+TERMUX_PKG_DEPENDS="python, python-numpy"
+TERMUX_PKG_PYTHON_COMMON_DEPS="wheel, meson-python, build"
+_NUMPY_VERSION=$(. $TERMUX_SCRIPTDIR/packages/python-numpy/build.sh; echo $TERMUX_PKG_VERSION)
+TERMUX_PKG_PYTHON_BUILD_DEPS="'pybind11>=2.12.0', 'numpy==$_NUMPY_VERSION'"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_TAG_TYPE="latest-release-tag"
+TERMUX_MESON_WHEEL_CROSSFILE="$TERMUX_PKG_TMPDIR/wheel-cross-file.txt"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--cross-file $TERMUX_MESON_WHEEL_CROSSFILE
+"
+
+termux_step_configure() {
+	termux_setup_meson
+
+	cp -f $TERMUX_MESON_CROSSFILE $TERMUX_MESON_WHEEL_CROSSFILE
+	sed -i 's|^\(\[binaries\]\)$|\1\npython = '\'$(command -v python)\''|g' \
+		$TERMUX_MESON_WHEEL_CROSSFILE
+	sed -i 's|^\(\[properties\]\)$|\1\nnumpy-include-dir = '\'$PYTHON_SITE_PKG/numpy/core/include\''|g' \
+		$TERMUX_MESON_WHEEL_CROSSFILE
+
+	termux_step_configure_meson
+}
+
+termux_step_make() {
+	pushd $TERMUX_PKG_SRCDIR
+	PYTHONPATH= python -m build -w -n -x --config-setting builddir=$TERMUX_PKG_BUILDDIR .
+	popd
+}
+
+termux_step_make_install() {
+	local _pyv="${TERMUX_PYTHON_VERSION/./}"
+	local _whl="contourpy-$TERMUX_PKG_VERSION-cp$_pyv-cp$_pyv-linux_$TERMUX_ARCH.whl"
+	pip install --no-deps --prefix=$TERMUX_PREFIX $TERMUX_PKG_SRCDIR/dist/$_whl
+}


### PR DESCRIPTION
For #19755 with love.

I can not install matplotlib in my old phone because it can not compile python-contourpy with lower memory. If python-contourpy is provided as a package matplotlib can be installed successfully.
