### PR TITLE
fix(main/plutolang): Fix buffer overflow in os.tmpname

### DIFF
--- a/packages/plutolang/build.sh
+++ b/packages/plutolang/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A superset of Lua 5.4, with unique features, optimizatio
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Komo @cattokomo"
 TERMUX_PKG_VERSION="0.9.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/PlutoLang/Pluto/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=1401cc2e25c9e8e23c9d30bd4ed83be48d48967a01f0cea3961ecaef4f97be8e
 TERMUX_PKG_AUTO_UPDATE=true

--- a/packages/plutolang/src-loslib.cpp.patch
+++ b/packages/plutolang/src-loslib.cpp.patch
@@ -2,8 +2,12 @@ diff --git a/src/loslib.cpp b/src/loslib.cpp
 index e496940..3e4cb3d 100644
 --- a/src/loslib.cpp
 +++ b/src/loslib.cpp
-@@ -112,7 +112,7 @@
- #define LUA_TMPNAMBUFSIZE	32
+@@ -111,10 +111,10 @@
+ 
+ #include <unistd.h>
+ 
+-#define LUA_TMPNAMBUFSIZE	32
++#define LUA_TMPNAMBUFSIZE	256
  
  #if !defined(LUA_TMPNAMTEMPLATE)
 -#define LUA_TMPNAMTEMPLATE	"/tmp/lua_XXXXXX"


### PR DESCRIPTION
```
$ pluto
Pluto 0.9.0 Copyright (C) 2022-2024 PlutoLang.org, Ryan Starrett, Sainan.
Based on Lua 5.4.6 Copyright (C) 1994-2023 Lua.org, PUC-Rio.
> os.tmpname()
stack corruption detected (-fstack-protector)
Aborted
```

