### PR TITLE
chore(main/gdu): fix arm, i686 and x86_64 build

### DIFF
--- a/packages/gdu/Makefile.patch
+++ b/packages/gdu/Makefile.patch
@@ -1,0 +1,11 @@
+--- a/Makefile
++++ b/Makefile
+@@ -7,7 +7,7 @@
+ DATE := $(shell date +'%Y-%m-%d')
+ GOFLAGS ?= -buildmode=pie -trimpath -mod=readonly -modcacherw -pgo=default.pgo
+ GOFLAGS_STATIC ?= -trimpath -mod=readonly -modcacherw -pgo=default.pgo
+-LDFLAGS := -s -w -extldflags '-static' \
++LDFLAGS := -s -w -extldflags '$(LDFLAGS)' \
+ 	-X '$(PACKAGE)/build.Version=$(VERSION)' \
+ 	-X '$(PACKAGE)/build.User=$(shell id -u -n)' \
+ 	-X '$(PACKAGE)/build.Time=$(shell LC_ALL=en_US.UTF-8 date)'

--- a/packages/gdu/build.sh
+++ b/packages/gdu/build.sh
@@ -10,8 +10,9 @@ TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_make() {
 	termux_setup_golang
+	sed -i 's|CGO_ENABLED=0|CGO_ENABLED=1|g' Makefile
 
-	make build
+	make build VERSION=$TERMUX_PKG_VERSION
 	make gdu.1
 }
 


### PR DESCRIPTION
* Now requires CGO for non AArch64 architectures.
* Fix version number.
* Disable static linking which does not work with liblog.

See the build failures in c4fec80f01c9a3fffae7c40dcbf6ebd9736f8b9d commit.