### PR TITLE
gtk-update-icon-cache: add BREAKS field

### DIFF
--- a/x11-packages/gtk3/build.sh
+++ b/x11-packages/gtk3/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="GObject-based multi-platform GUI toolkit"
 TERMUX_PKG_LICENSE="LGPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.24.41"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://gitlab.gnome.org/GNOME/gtk/-/archive/$TERMUX_PKG_VERSION/gtk-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=0ce1fa6cde05762cfb93a4064d4d211350944a77ebc954542d76e552d2cd0894
 TERMUX_PKG_DEPENDS="adwaita-icon-theme, atk, coreutils, desktop-file-utils, fontconfig, fribidi, gdk-pixbuf, glib, glib-bin, gtk-update-icon-cache, harfbuzz, libcairo, libepoxy, libwayland, libxcomposite, libxcursor, libxdamage, libxfixes, libxi, libxinerama, libxkbcommon, libxrandr, pango, shared-mime-info, ttf-dejavu"

--- a/x11-packages/gtk3/gtk-update-icon-cache.subpackage.sh
+++ b/x11-packages/gtk3/gtk-update-icon-cache.subpackage.sh
@@ -5,6 +5,8 @@ share/man/man1/gtk-update-icon-cache.1.gz
 
 TERMUX_SUBPKG_DEPENDS="gdk-pixbuf, glib"
 TERMUX_SUBPKG_DESCRIPTION="GTK+ icon cache updater"
+TERMUX_SUBPKG_BREAKS="gtk3 (<< 3.24.41)"
+TERMUX_SUBPKG_REPLACES="gtk3 (<< 3.24.41)"
 
 termux_step_create_subpkg_debscripts() {
 	cat <<- EOF > ./triggers


### PR DESCRIPTION
`share/man/man1/gtk-update-icon-cache.1.gz` is moved from gtk3 to gtk-update-icon-cache since version 3.24.41, the latter should have BREAKS field to let the installation process work as intended.