### PR TITLE
fix(main/mediainfo): auto update

### DIFF
--- a/packages/libmediainfo/build.sh
+++ b/packages/libmediainfo/build.sh
@@ -13,7 +13,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-shared --enable-static --with-libcurl"
 termux_pkg_auto_update() {
 	local e=0
 	local api_url="https://mediaarea.net/en/MediaInfo"
-	local api_url_r=$(curl -s "${api_url}/")
+	local api_url_r=$(curl -Ls "${api_url}/")
 	local r1=$(echo "${api_url_r}" | grep -o '"softwareVersion"\s*:\s*"\([^"]\+\)"')
 	local latest_version=$(echo "${r1}" | grep -o '[0-9.]\+')
 

--- a/packages/mediainfo/build.sh
+++ b/packages/mediainfo/build.sh
@@ -12,7 +12,7 @@ TERMUX_PKG_DEPENDS="libandroid-support, libc++, libmediainfo, libzen"
 termux_pkg_auto_update() {
 	local e=0
 	local api_url="https://mediaarea.net/en/MediaInfo"
-	local api_url_r=$(curl -s "${api_url}/")
+	local api_url_r=$(curl -Ls "${api_url}/")
 	local r1=$(echo "${api_url_r}" | grep -o '"softwareVersion"\s*:\s*"\([^"]\+\)"')
 	local latest_version=$(echo "${r1}" | grep -o '[0-9.]\+')
 


### PR DESCRIPTION
Fix https://github.com/termux/termux-packages/actions/runs/8841094968/job/24277612526#step:4:493
```console
INFO: Updating libmediainfo [Current version: 24.04]
WARN: Auto update failure!
api_url_r=<!DOCTYPE html>
<html>
    <head>
        <meta charset="UTF-8" />
        <meta http-equiv="refresh" content="0;url='/en/MediaInfo'" />

        <title>Redirecting to /en/MediaInfo</title>
    </head>
    <body>
        Redirecting to <a href="/en/MediaInfo">/en/MediaInfo</a>.
    </body>
</html>
r1=
latest_version=
termux - took 719ms
```