### PR TITLE
dbus: enable version script

### DIFF
--- a/packages/dbus/build.sh
+++ b/packages/dbus/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Freedesktop.org message bus system"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.15.6
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL="https://dbus.freedesktop.org/releases/dbus/dbus-$TERMUX_PKG_VERSION.tar.xz"
 TERMUX_PKG_SHA256=f97f5845f9c4a5a1fb3df67dfa9e16b5a3fd545d348d6dc850cb7ccc9942bd8c
 TERMUX_PKG_DEPENDS="libexpat, libx11"
@@ -13,6 +13,7 @@ TERMUX_PKG_BUILD_IN_SRC=true
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 ac_cv_func_close_range=no
+--enable-ld-version-script
 --disable-libaudit
 --disable-systemd
 --disable-tests


### PR DESCRIPTION
Since lld 17, `-no-undefined-version` is enabled by default. It causes `ld-version-script` check fails in `dbus` and disables the versioned symbol in `libdbus-1.so`, making some binaries compile failure.

Symbol list in `1.15.6-2`:
```
   123: 000000000002b314    24 FUNC    GLOBAL DEFAULT   12 _dbus_credentials_are_anonymous
   124: 000000000002ba5c   120 FUNC    GLOBAL DEFAULT   12 dbus_move_error
   125: 000000000003af34    36 FUNC    GLOBAL DEFAULT   12 dbus_type_is_valid
   126: 00000000000339c8   160 FUNC    GLOBAL DEFAULT   12 dbus_message_set_interface
```

Symbol list in `1.15.6-1` or `1.15.6-3`:

```
   123: 000000000002b384    24 FUNC    GLOBAL DEFAULT   13 _dbus_credentials_are_anonymous@@LIBDBUS_PRIVATE_1.15.6
   124: 000000000002bacc   120 FUNC    GLOBAL DEFAULT   13 dbus_move_error@@LIBDBUS_1_3
   125: 000000000003afa4    36 FUNC    GLOBAL DEFAULT   13 dbus_type_is_valid@@LIBDBUS_1_3
   126: 0000000000033a38   160 FUNC    GLOBAL DEFAULT   13 dbus_message_set_interface@@LIBDBUS_1_3
```

Related: #18810