### PR TITLE
addpkg(x11/qbittorrent{,-nox}): 4.6.4

### DIFF
--- a/x11-packages/qbittorrent/build.sh
+++ b/x11-packages/qbittorrent/build.sh
@@ -1,0 +1,27 @@
+TERMUX_PKG_HOMEPAGE=https://www.qbittorrent.org/
+TERMUX_PKG_DESCRIPTION="A Qt based BitTorrent client"
+TERMUX_PKG_LICENSE="GPL-2.0, GPL-3.0"
+TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
+TERMUX_PKG_VERSION="4.6.4"
+TERMUX_PKG_SRCURL=https://github.com/qbittorrent/qBittorrent/archive/refs/tags/release-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=5842eb2cc1745b72b090df562d35a7ec0a6469d898d411544808731578447e1d
+TERMUX_PKG_FORCE_CMAKE=true
+TERMUX_PKG_DEPENDS="libicu, libtorrent-rasterbar, openssl, qt5-qtbase"
+TERMUX_PKG_BUILD_DEPENDS="qt5-qttools, qt5-qtsvg, boost, libc++"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_TAG_TYPE=newest-tag
+TERMUX_PKG_UPDATE_VERSION_REGEXP='\d+\.\d+\.\d+'
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS='
+-DSTACKTRACE=OFF
+-DCMAKE_BUILD_TYPE=Release
+-DBUILD_SHARED_LIBS=off
+'
+
+# based on the secondary `-shared` build in `libncnn`
+termux_step_post_make_install() {
+	echo -e "termux - building qbittorrent-nox for arch ${TERMUX_ARCH}..."
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+='-DGUI=OFF'
+	termux_step_configure
+	termux_step_make
+	termux_step_make_install
+}

--- a/x11-packages/qbittorrent/qbittorrent-nox.subpackage.sh
+++ b/x11-packages/qbittorrent/qbittorrent-nox.subpackage.sh
@@ -1,0 +1,4 @@
+TERMUX_SUBPKG_DEPEND_ON_PARENT=no
+TERMUX_SUBPKG_INCLUDE='bin/qbittorrent-nox share/man/man1/qbittorrent-nox.1.gz'
+TERMUX_SUBPKG_DESCRIPTION='A Qt based BitTorrent client - headless version'
+TERMUX_SUBPKG_DEPENDS='libicu, libtorrent-rasterbar, openssl, qt5-qtbase'


### PR DESCRIPTION
closes:
- #10081

`qbittorrent` (even the headless `-nox` version) depends on `qt5-qtbase`, so it needs to be in the X11 Repo.

I'm forcing Cmake for the build.
Cmake has better [upstream build instructions](https://github.com/qbittorrent/qBittorrent/wiki/Compilation-with-CMake:-common-information).
Builds fine with `make` as well, if that's preferable.

---

If there's an easy way to just build it twice I'd actually like to build it once with GUI and once without,
and split off `qbittorrent-nox` into a subpackage.
But I couldn't figure out a good way to do that.
And the request was for the headless one.