### PR TITLE
bump({main,x11}/mpv{,-x}): 0.38.0

### DIFF
--- a/packages/mpv/build.sh
+++ b/packages/mpv/build.sh
@@ -1,11 +1,11 @@
 TERMUX_PKG_HOMEPAGE=https://mpv.io/
 TERMUX_PKG_DESCRIPTION="Command-line media player"
 TERMUX_PKG_LICENSE="GPL-2.0"
-TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 # Update both mpv and mpv-x to the same version in one PR.
-TERMUX_PKG_VERSION="0.37.0"
+TERMUX_PKG_VERSION="0.38.0"
 TERMUX_PKG_SRCURL=https://github.com/mpv-player/mpv/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=1d2d4adbaf048a2fa6ee134575032c4b2dad9a7efafd5b3e69b88db935afaddf
+TERMUX_PKG_SHA256=86d9ef40b6058732f67b46d0bbda24a074fae860b3eaae05bab3145041303066
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_DEPENDS="ffmpeg, libandroid-glob, libandroid-support, libarchive, libass, libcaca, libiconv, liblua52, libsixel, libuchardet, openal-soft, pulseaudio, rubberband, zlib, libplacebo"
 TERMUX_PKG_RM_AFTER_INSTALL="share/icons share/applications"

--- a/x11-packages/mpv-x/build.sh
+++ b/x11-packages/mpv-x/build.sh
@@ -2,11 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://mpv.io/
 TERMUX_PKG_DESCRIPTION="Command-line media player"
 # License: GPL-2.0-or-later
 TERMUX_PKG_LICENSE="GPL-2.0"
-TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 # Update both mpv and mpv-x to the same version in one PR.
-TERMUX_PKG_VERSION="0.37.0"
+TERMUX_PKG_VERSION="0.38.0"
 TERMUX_PKG_SRCURL=https://github.com/mpv-player/mpv/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=1d2d4adbaf048a2fa6ee134575032c4b2dad9a7efafd5b3e69b88db935afaddf
+TERMUX_PKG_SHA256=86d9ef40b6058732f67b46d0bbda24a074fae860b3eaae05bab3145041303066
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_DEPENDS="ffmpeg, libandroid-glob, libandroid-shmem, libarchive, libass, libbluray, libcaca, libdrm, libdvdnav, libiconv, libjpeg-turbo, liblua52, libsixel, libuchardet, libx11, libxext, libxinerama, libxpresent, libxrandr, libxss, libzimg, littlecms, openal-soft, pipewire, pulseaudio, rubberband, zlib, libplacebo"
 TERMUX_PKG_CONFLICTS="mpv"
@@ -22,7 +22,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dvdpau=disabled
 -Dvaapi=disabled
 -Dvulkan=disabled
--Dwayland=disabled
 -Dxv=disabled
 -Dandroid-media-ndk=disabled
 "


### PR DESCRIPTION
Also enable Wayland support for mpv-x and set maintainer