### PR TITLE
revbump(main/libarrow-cpp): abseil-cpp update

### DIFF
--- a/packages/libarrow-cpp/build.sh
+++ b/packages/libarrow-cpp/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # Align the version with `python-pyarrow` package.
 TERMUX_PKG_VERSION="16.0.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/apache/arrow/archive/refs/tags/apache-arrow-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=423eb4c1d6dbbcb7ca429d548e94f8a99cd4603bc023de9c0578d1950ce0f21d
 TERMUX_PKG_AUTO_UPDATE=true


### PR DESCRIPTION
Fixes #20103

```
>>> import pyarrow
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/pyarrow/__init__.py", line 65, in <module>
    import pyarrow.lib as _lib
ImportError: dlopen failed: cannot locate symbol "_ZN6google8protobuf2io19ZeroCopyInputStream8ReadCordEPN4absl12lts_202308024CordEi" referenced by "/data/data/com.termux/files/usr/lib/libarrow.so"...

$ c++filt "_ZN6google8protobuf2io19ZeroCopyInputStream8ReadCordEPN4absl12lts_202308024CordEi"
google::protobuf::io::ZeroCopyInputStream::ReadCord(absl::lts_20230802::Cord*, int)
```
