### PR TITLE
chore: override config for protobuf

### DIFF
--- a/packages/libprotobuf/build.sh
+++ b/packages/libprotobuf/build.sh
@@ -9,7 +9,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 #     $TERMUX_SCRIPTDIR/scripts/build/setup/termux_setup_protobuf.sh
 # - ALWAYS bump revision of reverse dependencies and rebuild them.
 TERMUX_PKG_VERSION=2:25.1
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/protocolbuffers/protobuf/archive/v${TERMUX_PKG_VERSION#*:}.tar.gz
 TERMUX_PKG_SHA256=9bd87b8280ef720d3240514f884e56a712f2218f0d693b48050c836028940a42
 TERMUX_PKG_AUTO_UPDATE=false
@@ -28,4 +28,9 @@ TERMUX_PKG_NO_STATICSPLIT=true
 termux_step_post_make_install() {
 	install -Dm600 -t $TERMUX_PREFIX/share/doc/libutf8-range \
 		$TERMUX_PKG_SRCDIR/third_party/utf8_range/LICENSE
+
+	# Copy lib/*.cmake to opt/protobuf-cmake/shared for future use
+	mkdir -p $TERMUX_PREFIX/opt/protobuf-cmake/shared
+	cp $TERMUX_PREFIX/lib/cmake/protobuf/protobuf-targets{,-release}.cmake \
+		$TERMUX_PREFIX/opt/protobuf-cmake/shared/
 }

--- a/packages/protobuf-static/build.sh
+++ b/packages/protobuf-static/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 # Please align the version with `libprotobuf` package.
 TERMUX_PKG_VERSION=25.1
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/protocolbuffers/protobuf/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=9bd87b8280ef720d3240514f884e56a712f2218f0d693b48050c836028940a42
 v_proto_version_shared=$(. $TERMUX_SCRIPTDIR/packages/libprotobuf/build.sh; echo ${TERMUX_PKG_VERSION})
@@ -34,14 +34,13 @@ termux_step_pre_configure() {
 	if [ "${ver_shared}" != "${ver_static}" ]; then
 		termux_error_exit "Version mismatch between libprotobuf and protobuf-static."
 	fi
+}
 
-	# Preserve CMake files for shared libs
-	local f
-	for f in $TERMUX_PREFIX/lib/cmake/protobuf/protobuf-targets{-release,}.cmake; do
-		if [ -e "${f}" ]; then
-			mv "${f}"{,.tmp}
-		fi
-	done
+termux_step_post_make_install() {
+	# Copy lib/*.cmake to opt/protobuf-cmake/static for future use
+	mkdir -p $TERMUX_PREFIX/opt/protobuf-cmake/static
+	cp $TERMUX_PREFIX/lib/cmake/protobuf/protobuf-targets{,-release}.cmake \
+		$TERMUX_PREFIX/opt/protobuf-cmake/static/
 }
 
 termux_step_post_massage() {
@@ -49,18 +48,12 @@ termux_step_post_massage() {
 		! -wholename "./lib/*.a" \
 		! -wholename "./lib/cmake/protobuf/protobuf-targets-release.cmake" \
 		! -wholename "./lib/cmake/protobuf/protobuf-targets.cmake" \
+		! -wholename "./opt/protobuf-cmake/static/protobuf-targets-release.cmake" \
+		! -wholename "./opt/protobuf-cmake/static/protobuf-targets.cmake" \
 		! -wholename "./share/doc/$TERMUX_PKG_NAME/*" \
 		-exec rm -f '{}' \;
 	find . ! -type d \
 		-wholename "./lib/libutf8_*" \
 		-exec rm -f '{}' \;
 	find . -type d -empty -delete
-
-	# Restore CMake files for shared libs
-	local f
-	for f in $TERMUX_PREFIX/lib/cmake/protobuf/protobuf-targets{-release,}.cmake; do
-		if [ -e "${f}".tmp ]; then
-			mv "${f}"{.tmp,}
-		fi
-	done
 }

--- a/scripts/build/termux_step_override_config_scripts.sh
+++ b/scripts/build/termux_step_override_config_scripts.sh
@@ -42,4 +42,12 @@ termux_step_override_config_scripts() {
 			-e "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|g" > $TERMUX_PREFIX/bin/pg_config
 		chmod 755 $TERMUX_PREFIX/bin/pg_config
 	fi
+
+	if [ "$TERMUX_PKG_DEPENDS" != "${TERMUX_PKG_DEPENDS/libprotobuf/}" ]; then
+		rm -f $TERMUX_PREFIX/lib/cmake/protobuf/protobuf-targets{,-release}.cmake
+		cp $TERMUX_PREFIX/opt/protobuf-cmake/shared/protobuf-targets{,-release}.cmake $TERMUX_PREFIX/lib/cmake/protobuf/
+	elif [ "$TERMUX_PKG_BUILD_DEPENDS" != "${TERMUX_PKG_BUILD_DEPENDS/protobuf-static/}" ]; then
+		rm -f $TERMUX_PREFIX/lib/cmake/protobuf/protobuf-targets{,-release}.cmake
+		cp $TERMUX_PREFIX/opt/protobuf-cmake/static/protobuf-targets{,-release}.cmake $TERMUX_PREFIX/lib/cmake/protobuf/
+	fi
 }


### PR DESCRIPTION
For more information for this PR, check https://github.com/termux/termux-packages/pull/19468#issuecomment-2104878325

The test rebuilt `mosh` (depending on the shared library protobuf) and `opencv` (depending on the static library protobuf) in the same PR, and the test has passed. See https://github.com/termux/termux-packages/actions/runs/9052874693.
