### PR TITLE
bump(main/hunspell-en-us): 20240129

### DIFF
--- a/packages/hunspell-en-us/build.sh
+++ b/packages/hunspell-en-us/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://hunspell.github.io
 TERMUX_PKG_DESCRIPTION="American english dictionary for hunspell"
 TERMUX_PKG_LICENSE="LGPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=20210101
+TERMUX_PKG_VERSION=20240129
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
@@ -15,7 +15,7 @@ termux_step_make_install() {
 	# In which case we need to bump version and checksum used.
 	termux_download https://cgit.freedesktop.org/libreoffice/dictionaries/plain/en/en_US.aff \
 			$TERMUX_PREFIX/share/hunspell/en_US.aff \
-			c7a8c4d08c29d237880844b1623099f59092602f189be38ce3912e457ff38bc1
+			e746c882dd6f303c2c46e7452804b9201115a6942cfeb15f18f8edf774d2e24e
 	termux_download https://cgit.freedesktop.org/libreoffice/dictionaries/plain/en/en_US.dic \
 			$TERMUX_PREFIX/share/hunspell/en_US.dic \
 			f0b1a234bd178bdd01875b2a392a9647f888b8fe879f79c52aae62c2759b3647


### PR DESCRIPTION
Fixes a build error due to checksum mismatch after an upstream dictionary update.