### PR TITLE
fix(main/libebur128): Link to libm

### DIFF
--- a/packages/libebur128/build.sh
+++ b/packages/libebur128/build.sh
@@ -3,5 +3,6 @@ TERMUX_PKG_DESCRIPTION="Implements the EBU R 128 standard for loudness normalisa
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.2.6
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/jiixyj/libebur128/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=baa7fc293a3d4651e244d8022ad03ab797ca3c2ad8442c43199afe8059faa613

--- a/packages/libebur128/ebur128-CMakeLists.txt.patch
+++ b/packages/libebur128/ebur128-CMakeLists.txt.patch
@@ -1,0 +1,21 @@
+diff -u -r ../libebur128-1.2.6/ebur128/CMakeLists.txt ./ebur128/CMakeLists.txt
+--- ../libebur128-1.2.6/ebur128/CMakeLists.txt	2021-02-14 14:31:05.000000000 +0000
++++ ./ebur128/CMakeLists.txt	2024-05-14 09:21:03.212349904 +0000
+@@ -47,9 +47,14 @@
+ endif()
+ 
+ # Link with Math library if available
+-find_library(MATH_LIBRARY m)
+-if(MATH_LIBRARY)
+-  target_link_libraries(ebur128 ${MATH_LIBRARY})
++if(ANDROID)
++  # find_library(MATH_LIBRARY m) does not work on Android
++  target_link_libraries(ebur128 m)
++else()
++  find_library(MATH_LIBRARY m)
++  if(MATH_LIBRARY)
++    target_link_libraries(ebur128 ${MATH_LIBRARY})
++  endif()
+ endif()
+ 
+ if(ENABLE_FUZZER)


### PR DESCRIPTION
Fix the following build error:

>ERROR: ./lib/libebur128.so contains undefined symbols:
>     8: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND pow
>     9: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND tan
>    12: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND log
>    15: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND sin
>    16: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND cos