### PR TITLE
fix(main/libvbisam): Fix building with current clang

### DIFF
--- a/packages/libvbisam/build.sh
+++ b/packages/libvbisam/build.sh
@@ -3,11 +3,12 @@ TERMUX_PKG_DESCRIPTION="A replacement for IBM's C-ISAM"
 TERMUX_PKG_LICENSE="GPL-2.0, LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.0
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/project/vbisam/vbisam2/vbisam-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=688b776e0030cce50fd7e44cbe40398ea93431f76510c7100433cc6313eabc4f
 
 termux_step_pre_configure() {
+	CFLAGS+=" -Wno-implicit-int"
 	cp $TERMUX_PKG_BUILDER_DIR/efgcvt_r-template.c $TERMUX_PKG_SRCDIR/libvbisam/
 	cp $TERMUX_PKG_BUILDER_DIR/efgcvt-dbl-macros.h $TERMUX_PKG_SRCDIR/libvbisam/
 	autoreconf -fi


### PR DESCRIPTION
Fix the following build error:
> [..]/ischeck.c:148:12: error: parameter 'ihandle' was not declared, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]