### PR TITLE
bump(main/libpixman): 0.43.4

### DIFF
--- a/packages/libpixman/build.sh
+++ b/packages/libpixman/build.sh
@@ -2,13 +2,13 @@ TERMUX_PKG_HOMEPAGE=http://www.pixman.org/
 TERMUX_PKG_DESCRIPTION="Low-level library for pixel manipulation"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=0.42.2
+TERMUX_PKG_VERSION="0.43.4"
 TERMUX_PKG_SRCURL=https://cairographics.org/releases/pixman-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=ea1480efada2fd948bc75366f7c349e1c96d3297d09a3fe62626e38e234a625e
+TERMUX_PKG_SHA256=a0624db90180c7ddb79fc7a9151093dc37c646d8c38d3f232f767cf64b85a226
 TERMUX_PKG_BUILD_DEPENDS="binutils-cross"
 TERMUX_PKG_BREAKS="libpixman-dev"
 TERMUX_PKG_REPLACES="libpixman-dev"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-libpng"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-Dlibpng=disabled"
 
 termux_step_pre_configure() {
 	if [ "$TERMUX_ARCH" = arm ] || [ "$TERMUX_ARCH" = aarch64 ]; then


### PR DESCRIPTION
Requires some testing with two or more reverse dependencies.
```
  xwayland
  xorg-server-xvfb
  xorg-server-xephyr
  xorg-server
  wlroots
  wayvnc
  tigervnc-viewer
  tigervnc
  thunderbird
  qemu-system-x86-64
  qemu-system-riscv64
  qemu-system-riscv32
  qemu-system-ppc64
  qemu-system-ppc
  qemu-system-m68k
  qemu-system-i386
  qemu-system-arm
  qemu-system-aarch64
  picom
  libneatvnc
  libfcft
  gtk2-engines-murrine
  foot
  firefox
  texlive-bin
  qemu-utils
  qemu-user-x86-64
  qemu-user-riscv64
  qemu-user-riscv32
  qemu-user-ppc64
  qemu-user-ppc
  qemu-user-m68k
  qemu-user-i386
  qemu-user-arm
  qemu-user-aarch64
  qemu-system-x86-64-headless
  qemu-system-riscv64-headless
  qemu-system-riscv32-headless
  qemu-system-ppc64-headless
  qemu-system-ppc-headless
  qemu-system-m68k-headless
  qemu-system-i386-headless
  qemu-system-arm-headless
  qemu-system-aarch64-headless
  qemu-common
  libspice-server
  libcairo
  libfcft
```