### PR TITLE
fix(main/doctest): Fix building with current clang

### DIFF
--- a/packages/doctest/build.sh
+++ b/packages/doctest/build.sh
@@ -4,7 +4,12 @@ TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.4.11"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/doctest/doctest/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=632ed2c05a7f53fa961381497bf8069093f0d6628c5f26286161fbd32a560186
 TERMUX_PKG_DEPENDS="libc++"
 TERMUX_PKG_AUTO_UPDATE=true
+
+termux_step_pre_configure() {
+	CXXFLAGS+=" -Wno-error=unsafe-buffer-usage -Wno-error=nullable-to-nonnull-conversion"
+}


### PR DESCRIPTION
Suppress compiler warnings as errors until https://github.com/doctest/doctest/issues/766 is fixed.