### PR TITLE
fix(main/distcc): Fix building with current clang

### DIFF
--- a/packages/distcc/build.sh
+++ b/packages/distcc/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Distributed C/C++ compiler"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.4
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://github.com/distcc/distcc/releases/download/v$TERMUX_PKG_VERSION/distcc-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=2b99edda9dad9dbf283933a02eace6de7423fe5650daa4a728c950e5cd37bd7d
 TERMUX_PKG_DEPENDS="libpopt"
@@ -17,5 +17,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 
 termux_step_pre_configure() {
 	./autogen.sh
+	CFLAGS+=" -Wno-error=strict-prototypes"
 	export LIBS="-llog"
 }


### PR DESCRIPTION
Fixes the below error:
> error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
> void dcc_read_localslots_configuration()