### PR TITLE
fix(main/hexcurse): Fix building with current clang

### DIFF
--- a/packages/hexcurse/build.sh
+++ b/packages/hexcurse/build.sh
@@ -3,12 +3,12 @@ TERMUX_PKG_DESCRIPTION="Console hexeditor"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.60.0
-TERMUX_PKG_REVISION=4
+TERMUX_PKG_REVISION=5
 TERMUX_PKG_SRCURL=https://github.com/LonnyGomes/hexcurse/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=f6919e4a824ee354f003f0c42e4c4cef98a93aa7e3aa449caedd13f9a2db5530
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="ncurses"
 
 termux_step_pre_configure() {
-	export CFLAGS+=" -fcommon"
+	export CFLAGS+=" -fcommon -Wno-error=deprecated-non-prototype"
 }


### PR DESCRIPTION
Fix the following build error:
> [..]/getopt.c:73:1: error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
exchange (argv)
> [..]/getopt.c:98:1: error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
getopt_set_posix_option_order (on_or_off)
> [..]/getopt.c:108:1: error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
_getopt_internal (argc, argv, optstring, longopts, longind, long_only)
> [..]/getopt.c:450:1: error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
hgetopt (argc, argv, optstring)