### PR TITLE
fix(main/stag): Fix building with current clang

### DIFF
--- a/packages/stag/build.sh
+++ b/packages/stag/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Streaming bar graphs. For stats and stuff."
 TERMUX_PKG_LICENSE="Public Domain"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.0.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/seenaburns/stag/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=391574e6aa12856d5a598a374e3a40a38cbab6ef9d769c0d59af8411b4fbecb6
 TERMUX_PKG_AUTO_UPDATE=true

--- a/packages/stag/stag.c.patch
+++ b/packages/stag/stag.c.patch
@@ -1,5 +1,15 @@
---- stag/stag.c	2016-08-31 15:03:32.627902972 +0200
-+++ stag.c	2016-08-31 15:18:34.487902628 +0200
+diff -u -r ../stag-1.0.0/stag.c ./stag.c
+--- ../stag-1.0.0/stag.c	2014-10-22 05:12:36.000000000 +0000
++++ ./stag.c	2024-05-15 09:59:45.934188475 +0000
+@@ -47,7 +47,7 @@
+ "\n";
+ 
+ // Display usage info
+-void usage(){
++void usage(void){
+   printf(stag_usage_string);
+   exit(0);
+ }
 @@ -87,7 +87,7 @@
    
  


### PR DESCRIPTION
Fix the following build error:
> error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]