### PR TITLE
fix(packages/sleuthkit): Fix undefined symbol

### DIFF
--- a/packages/sleuthkit/build.sh
+++ b/packages/sleuthkit/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="licenses/README.md, licenses/GNUv2-COPYING, licenses/GNUv3-COPYING, licenses/IBM-LICENSE, licenses/Apache-LICENSE-2.0.txt, licenses/cpl1.0.txt, licenses/bsd.txt, licenses/mit.txt"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="4.12.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/sleuthkit/sleuthkit/archive/sleuthkit-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=8b04fc40a38188c218a835ff4d4720d3d12b21ae9c88652a41932442f255e971
 TERMUX_PKG_AUTO_UPDATE=true

--- a/packages/sleuthkit/tsk-Makefile.am.patch
+++ b/packages/sleuthkit/tsk-Makefile.am.patch
@@ -1,0 +1,12 @@
+diff -u -r ../sleuthkit-sleuthkit-4.12.1/tsk/Makefile.am ./tsk/Makefile.am
+--- ../sleuthkit-sleuthkit-4.12.1/tsk/Makefile.am	2023-08-29 17:56:43.000000000 +0000
++++ ./tsk/Makefile.am	2024-05-15 23:08:23.584951170 +0000
+@@ -6,7 +6,7 @@
+ libtsk_la_SOURCES =
+ libtsk_la_LIBADD = base/libtskbase.la img/libtskimg.la \
+     vs/libtskvs.la fs/libtskfs.la hashdb/libtskhashdb.la \
+-    auto/libtskauto.la pool/libtskpool.la util/libtskutil.la
++    auto/libtskauto.la pool/libtskpool.la util/libtskutil.la -lm
+ # current:revision:age
+ libtsk_la_LDFLAGS = -version-info 21:1:2 $(LIBTSK_LDFLAGS)
+ 


### PR DESCRIPTION
Fix the following build error:
> ERROR: ./lib/libtsk.so contains undefined symbols:
>   193: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND log