### PR TITLE
fix(main/libgts): Fix undefined symbols

### DIFF
--- a/packages/libgts/build.sh
+++ b/packages/libgts/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Provides useful functions to deal with 3D surfaces meshe
 TERMUX_PKG_LICENSE="LGPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.7.6
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/project/gts/gts/${TERMUX_PKG_VERSION}/gts-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=059c3e13e3e3b796d775ec9f96abdce8f2b3b5144df8514eda0cc12e13e8b81e
 TERMUX_PKG_DEPENDS="glib"

--- a/packages/libgts/src-Makefile-in.patch
+++ b/packages/libgts/src-Makefile-in.patch
@@ -1,0 +1,12 @@
+diff -u -r ../gts-0.7.6/src/Makefile.in ./src/Makefile.in
+--- ../gts-0.7.6/src/Makefile.in	2006-03-10 00:31:05.000000000 +0000
++++ ./src/Makefile.in	2024-05-16 11:09:10.292099773 +0000
+@@ -54,7 +54,7 @@
+ am__installdirs = "$(DESTDIR)$(libdir)" "$(DESTDIR)$(bindir)" "$(DESTDIR)$(m4datadir)" "$(DESTDIR)$(includedir)"
+ libLTLIBRARIES_INSTALL = $(INSTALL)
+ LTLIBRARIES = $(lib_LTLIBRARIES)
+-libgts_la_LIBADD =
++libgts_la_LIBADD = -lm
+ am_libgts_la_OBJECTS = object.lo point.lo vertex.lo segment.lo edge.lo \
+ 	triangle.lo face.lo kdtree.lo bbtree.lo misc.lo predicates.lo \
+ 	heap.lo eheap.lo fifo.lo matrix.lo surface.lo stripe.lo \


### PR DESCRIPTION
Fix the following build error:

> ERROR: ./lib/libgts-0.7.so.5.0.1 contains undefined symbols:
>    32: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND atan2
>    64: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND sincos
>    67: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND cos
>    77: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND log
>    78: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND exp