### PR TITLE
fix(main/openfoam): Fix undefined symbols and parallel build

### DIFF
--- a/packages/openfoam/build.sh
+++ b/packages/openfoam/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="OpenFOAM is a CFD software written in C++"
 TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_VERSION=2312
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://develop.openfoam.com/Development/openfoam/-/archive/OpenFOAM-v$TERMUX_PKG_VERSION/openfoam-OpenFOAM-v$TERMUX_PKG_VERSION.tar.bz2
 TERMUX_PKG_SHA256=1b50c5c4f5c4e606ba48a82f2f0b07a78a7cb99a0de9e4d7b14ff52e2f9ebbe5
 TERMUX_PKG_DEPENDS="boost, libc++, libgmp, libmpfr, openmpi, readline, zlib"
@@ -77,10 +78,10 @@ termux_step_make() {
 	source "$TERMUX_PKG_SRCDIR"/etc/bashrc || true
 	set -u
 	unset LD_LIBRARY_PATH
-	./Allwmake
+	./Allwmake -j
 	cd wmake/src
 	make clean
-	make
+	make -j $TERMUX_MAKE_PROCESSES
 }
 
 termux_step_make_install() {

--- a/packages/openfoam/src-OpenFOAM-Make-options.patch
+++ b/packages/openfoam/src-OpenFOAM-Make-options.patch
@@ -1,0 +1,9 @@
+diff -u -r ../openfoam-OpenFOAM-v2312/src/OpenFOAM/Make/options ./src/OpenFOAM/Make/options
+--- ../openfoam-OpenFOAM-v2312/src/OpenFOAM/Make/options	2023-12-21 15:23:42.000000000 +0000
++++ ./src/OpenFOAM/Make/options	2024-05-16 12:08:12.936825773 +0000
+@@ -26,3 +26,5 @@
+ else
+     LIB_LIBS += -L$(FOAM_LIBBIN)/dummy -lPstream
+ endif
++
++LIB_LIBS += -L@TERMUX_PREFIX@/lib -landroid-execinfo


### PR DESCRIPTION
Fix the below build error:
> ERROR: ./opt/OpenFOAM-v2312/platforms/linuxARM64ClangDPInt32Opt/lib/libOpenFOAM.so contains undefined symbols:
>   344: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND backtrace
>   345: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND backtrace_symbols
> 56092: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND backtrace
> 56093: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND backtrace_symbols