### PR TITLE
chore(main/apt): Use source tarball from upstream git archive

### DIFF
--- a/packages/apt/build.sh
+++ b/packages/apt/build.sh
@@ -3,8 +3,10 @@ TERMUX_PKG_DESCRIPTION="Front-end for the dpkg package manager"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.7.12"
-TERMUX_PKG_SRCURL=https://deb.debian.org/debian/pool/main/a/apt/apt_${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=e46d166b5fc887c2d9bca7add7e0ccda547b962b762e1272a08c0426baa99caf
+TERMUX_PKG_REVISION=1
+# old tarball are removed in https://deb.debian.org/debian/pool/main/a/apt/apt_${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SRCURL=https://salsa.debian.org/apt-team/apt/-/archive/${TERMUX_PKG_VERSION}/apt-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_SHA256=8fd7a30e565fd218587a456da633156275d633003d41613bf93e4411259fe45f
 # apt-key requires utilities from coreutils, findutils, gpgv, grep, sed.
 TERMUX_PKG_DEPENDS="coreutils, dpkg, findutils, gpgv, grep, libandroid-glob, libbz2, libc++, libcurl, libgnutls, liblz4, liblzma, sed, termux-keyring, termux-licenses, xxhash, zlib, zstd"
 TERMUX_PKG_BUILD_DEPENDS="docbook-xsl"


### PR DESCRIPTION
    
    This fixes building apt when old tarball are removed in https://deb.debian.org/debian/pool/main/a/apt/
    
    The same source link is used in other Linux distributions. For example,
    
    * Alpine Linux https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/apt/APKBUILD
    * Fedora Linux https://src.fedoraproject.org/rpms/apt/blob/rawhide/f/apt.spec

Fixes #20288
