### PR TITLE
DONOTMERGE: csharp example

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -84,6 +84,10 @@ source "$TERMUX_SCRIPTDIR/scripts/build/setup/termux_setup_cargo_c.sh"
 # shellcheck source=scripts/build/setup/termux_setup_crystal.sh
 source "$TERMUX_SCRIPTDIR/scripts/build/setup/termux_setup_crystal.sh"
 
+# Utility function for setting up DotNet toolchain.
+# shellcheck source=scripts/build/setup/termux_setup_dotnet.sh
+source "$TERMUX_SCRIPTDIR/scripts/build/setup/termux_setup_dotnet.sh"
+
 # Utility function for setting up Flang toolchain.
 # shellcheck source=scripts/build/setup/termux_setup_flang.sh
 source "$TERMUX_SCRIPTDIR/scripts/build/setup/termux_setup_flang.sh"

--- a/packages/csharp-example/build.sh
+++ b/packages/csharp-example/build.sh
@@ -1,0 +1,41 @@
+TERMUX_PKG_HOMEPAGE=https://example.com
+TERMUX_PKG_DESCRIPTION="CSharp Example"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=0.1
+TERMUX_PKG_SKIP_SRC_EXTRACT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+	termux_setup_dotnet
+}
+
+termux_step_make() {
+	dotnet new console -o hellocs #--aot
+	pushd hellocs
+	ls -l
+	echo "$PWD/Program.cs"
+	cat Program.cs
+	echo "$PWD/hellocs.csproj"
+	cat hellocs.csproj
+	sed "/.*<\/Project>.*/d" -i hellocs.csproj
+	cat <<-EOL >> hellocs.csproj
+	<ItemGroup Condition="\$(RuntimeIdentifier.StartsWith('linux-bionic'))">
+	<LinkerArg Include="-Wl,--undefined-version" />
+	</ItemGroup>
+	</Project>
+	EOL
+	dotnet publish hellocs.csproj -r ${DOTNET_TARGET_NAME} --self-contained -p:DisableUnsupportedError=true
+	#-p:PublishAotUsingRuntimePack=true
+	popd
+}
+
+termux_step_make_install() {
+	pushd hellocs/bin/Release/net8.0/${DOTNET_TARGET_NAME}
+	ls -l
+	find publish -name "*.a" -exec chmod a-x "{}" \;
+	find publish -name "*.dll" -exec chmod a-x "{}" \;
+	find publish -name "*.so" -exec chmod a-x "{}" \;
+	cp -r publish ${TERMUX_PREFIX}/lib/${TERMUX_PKG_NAME}
+	ln -sv ../lib/${TERMUX_PKG_NAME}/hellocs ${TERMUX_PREFIX}/bin/hellocs
+}

--- a/scripts/build/setup/termux_setup_dotnet.sh
+++ b/scripts/build/setup/termux_setup_dotnet.sh
@@ -1,0 +1,51 @@
+# shellcheck shell=bash disable=SC1091 disable=SC2086 disable=SC2155
+termux_setup_dotnet() {
+	export DOTNET_TARGET_NAME="linux-bionic"
+	case "${TERMUX_ARCH}" in
+	aarch64) DOTNET_TARGET_NAME+="-arm64" ;;
+	arm) DOTNET_TARGET_NAME+="-arm" ;;
+	i686) DOTNET_TARGET_NAME+="-x86" ;;
+	x86_64) DOTNET_TARGET_NAME+="-x64" ;;
+	esac
+
+	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "true" ]]; then
+		if [[ -z "$(command -v dotnet)" ]]; then
+			cat <<- EOL
+			Package 'dotnet' is not installed.
+			You can install it with
+
+			pkg install dotnet
+
+			pacman -S dotnet
+
+			or build it from source with
+
+			./build-package.sh dotnet
+
+			Note that package 'dotnet' is known to be problematic for building on device.
+			EOL
+			exit 1
+		fi
+		local DOTNET_VERSION=$(dotnet --version)
+		if [[ -n "${TERMUX_DOTNET_VERSION-}" && "${TERMUX_DOTNET_VERSION-}" != "${DOTNET_VERSION}" ]]; then
+			cat <<- EOL >&2
+			WARN: On device build with old dotnet version is not possible!
+			TERMUX_DOTNET_VERSION = ${TERMUX_DOTNET_VERSION}
+			DOTNET_VERSION        = ${DOTNET_VERSION}
+			EOL
+		fi
+		return
+	fi
+
+	if [[ -z "${TERMUX_DOTNET_VERSION-}" ]]; then
+		TERMUX_DOTNET_VERSION=$(. "${TERMUX_SCRIPTDIR}"/packages/dotnet8.0/build.sh; echo ${TERMUX_PKG_VERSION})
+	fi
+
+	curl https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh -sSfo "${TERMUX_PKG_TMPDIR}"/dotnet-install.sh
+	bash "${TERMUX_PKG_TMPDIR}"/dotnet-install.sh --version latest
+
+	export PATH="${HOME}/.dotnet:${PATH}"
+	if [[ -z "$(command -v dotnet)" ]]; then
+		termux_error_exit "termux_setup_dotnet: No dotnet executable found!"
+	fi
+}


### PR DESCRIPTION
This is just a preview of supposedly porting a Csharp package to Termux. It shows some of the issues of using vanilla dotnet toolchain directly from Microsoft for our use case.
It needs to have its own runtime packaged (maybe need to change hardcoded paths or until packaged actual dotnet). It is also likely we need to recompile dotnet toolchain ourselves and maybe add missing support for arm and i686.

Part of #516 