### PR TITLE
scripts(build-package.sh): make git log more strict in it's output for SOURCE_EPOCH_DATE

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -30,7 +30,7 @@ source "$TERMUX_SCRIPTDIR/scripts/utils/docker/docker.sh"; docker__create_docker
 # Functions for working with packages
 source "$TERMUX_SCRIPTDIR/scripts/utils/package/package.sh"
 
-export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-$(git log -1 --pretty=%ct 2>/dev/null || date "+%s")}
+export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-$(git log -1 --pretty=%ct 2>/dev/null | tail -n 1 | grep -oE '[0-9]+' || date "+%s")}
 
 if [ "$(uname -o)" = "Android" ] || [ -e "/system/bin/app_process" ]; then
 	if [ "$(id -u)" = "0" ]; then

--- a/build-package.sh
+++ b/build-package.sh
@@ -30,7 +30,7 @@ source "$TERMUX_SCRIPTDIR/scripts/utils/docker/docker.sh"; docker__create_docker
 # Functions for working with packages
 source "$TERMUX_SCRIPTDIR/scripts/utils/package/package.sh"
 
-export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-$(git log -1 --pretty=%ct 2>/dev/null | tail -n 1 | grep -oE '[0-9]+' || date "+%s")}
+export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-$(git -c log.showSignature=false log -1 --pretty=%ct 2>/dev/null || date "+%s")}
 
 if [ "$(uname -o)" = "Android" ] || [ -e "/system/bin/app_process" ]; then
 	if [ "$(id -u)" = "0" ]; then


### PR DESCRIPTION
Issue:

Currently, the build-package.sh script fails when trying to build a package like neovim when `git config --system log.showSignature true` is set and the latest commit is signed causing the signature to be included in the output.

Fix:

This fixes the issue by being more strict in it's search for the commit date in the git log output by only retrieving the last line of the log and then searching for a string of numbers corresponding to the expected value for SOURCE_DATE_EPOCH.

This fix has been tested to work against the main branch that is lacking a commit signature in the git log output as well.

This would allow people with commit signing to more easily contribute without needing to disable that security feature to do so.