### PR TITLE
new packages: shotcut, mlt and their deps

### DIFF
--- a/x11-packages/mlt/0001-rtaudio-soundcard.h.patch
+++ b/x11-packages/mlt/0001-rtaudio-soundcard.h.patch
@@ -1,0 +1,13 @@
+diff --git a/src/modules/rtaudio/RtAudio.cpp b/src/modules/rtaudio/RtAudio.cpp
+index b13f04e..4178219 100644
+--- a/src/modules/rtaudio/RtAudio.cpp
++++ b/src/modules/rtaudio/RtAudio.cpp
+@@ -348,7 +348,7 @@ public:
+ 
+ #if defined(__LINUX_OSS__)
+ 
+-#include <sys/soundcard.h>
++#include <linux/soundcard.h>
+ 
+ class RtApiOss: public RtApi
+ {

--- a/x11-packages/mlt/0002-rtaudio-remove-pthread_testcancel.patch
+++ b/x11-packages/mlt/0002-rtaudio-remove-pthread_testcancel.patch
@@ -1,0 +1,34 @@
+diff --git a/src/modules/rtaudio/RtAudio.cpp b/src/modules/rtaudio/RtAudio.cpp
+index 4178219..bd597ef 100644
+--- a/src/modules/rtaudio/RtAudio.cpp
++++ b/src/modules/rtaudio/RtAudio.cpp
+@@ -9087,7 +9087,9 @@ static void *alsaCallbackHandler( void *ptr )
+ #endif
+ 
+   while ( *isRunning == true ) {
++#ifndef __ANDROID__
+     pthread_testcancel();
++#endif
+     object->callbackEvent();
+   }
+ 
+@@ -9363,7 +9365,9 @@ static void *pulseaudio_callback( void * user )
+ #endif
+   
+   while ( *isRunning ) {
++#ifndef __ANDROID__
+     pthread_testcancel();
++#endif
+     context->callbackEvent();
+   }
+ 
+@@ -10846,7 +10850,9 @@ static void *ossCallbackHandler( void *ptr )
+ #endif
+ 
+   while ( *isRunning == true ) {
++#ifndef __ANDROID__
+     pthread_testcancel();
++#endif
+     object->callbackEvent();
+   }
+ 

--- a/x11-packages/mlt/0003-rtaudio-remove-pthread_attr_setinheritsched.patch
+++ b/x11-packages/mlt/0003-rtaudio-remove-pthread_attr_setinheritsched.patch
@@ -1,0 +1,34 @@
+diff --git a/src/modules/rtaudio/RtAudio.cpp b/src/modules/rtaudio/RtAudio.cpp
+index bd597ef..dc64863 100644
+--- a/src/modules/rtaudio/RtAudio.cpp
++++ b/src/modules/rtaudio/RtAudio.cpp
+@@ -8636,7 +8636,9 @@ bool RtApiAlsa :: probeDeviceOpen( unsigned int deviceId, StreamMode mode, unsig
+       pthread_attr_setschedpolicy(&attr, SCHED_RR);
+       pthread_attr_setscope (&attr, PTHREAD_SCOPE_SYSTEM);
+       // This is definitely required. Otherwise it fails.
++#if !defined __ANDROID__ || __ANDROID_API__ >= 28
+       pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
++#endif
+       pthread_attr_setschedparam(&attr, &param);
+     }
+     else
+@@ -9602,7 +9604,9 @@ bool RtApiPulse::probeDeviceOpen( unsigned int deviceId, StreamMode mode,
+       pthread_attr_setschedpolicy(&attr, SCHED_RR);
+       pthread_attr_setscope (&attr, PTHREAD_SCOPE_SYSTEM);
+       // This is definitely required. Otherwise it fails.
++#if !defined __ANDROID__ || __ANDROID_API__ >= 28
+       pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
++#endif
+       pthread_attr_setschedparam(&attr, &param);
+     }
+     else
+@@ -10454,7 +10458,9 @@ bool RtApiOss :: probeDeviceOpen( unsigned int deviceId, StreamMode mode, unsign
+       pthread_attr_setschedpolicy(&attr, SCHED_RR);
+       pthread_attr_setscope (&attr, PTHREAD_SCOPE_SYSTEM);
+       // This is definitely required. Otherwise it fails.
++#if !defined __ANDROID__ || __ANDROID_API__ >= 28
+       pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
++#endif
+       pthread_attr_setschedparam(&attr, &param);
+     }
+     else

--- a/x11-packages/mlt/0004-fhs-path.patch
+++ b/x11-packages/mlt/0004-fhs-path.patch
@@ -1,0 +1,92 @@
+diff --git a/Doxyfile b/Doxyfile
+index d97915d8..35561561 100644
+--- a/Doxyfile
++++ b/Doxyfile
+@@ -1263,7 +1263,7 @@ EXTERNAL_GROUPS = YES
+ # The PERL_PATH should be the absolute path and name of the perl script 
+ # interpreter (i.e. the result of `which perl').
+ 
+-PERL_PATH = /usr/bin/perl
++PERL_PATH = @TERMUX_PREFIX@/bin/perl
+ 
+ #---------------------------------------------------------------------------
+ # Configuration options related to the dot tool   
+diff --git a/cmake/FindMono.cmake b/cmake/FindMono.cmake
+index 0588a9c3..1378ab2f 100644
+--- a/cmake/FindMono.cmake
++++ b/cmake/FindMono.cmake
+@@ -110,10 +110,10 @@ else( UNIX )
+   set( chsarp_mono_names "mcs" "mcs.exe" "dmcs" "dmcs.exe" "smcs" "smcs.exe" "gmcs" "gmcs.exe" )
+   set(
+     csharp_mono_paths
+-    "/usr/bin/"
+-    "/usr/local/bin/"
+-    "/usr/lib/mono/2.0"
+-    "/opt/novell/mono/bin"
++    "@TERMUX_PREFIX@/bin/"
++    "@TERMUX_PREFIX@/local/bin/"
++    "@TERMUX_PREFIX@/lib/mono/2.0"
++    "@TERMUX_PREFIX@/opt/novell/mono/bin"
+   )
+   find_program(
+     csharp_mono_compiler # variable is added to the cache, we removed it below
+diff --git a/cmake/FindNode.cmake b/cmake/FindNode.cmake
+index 98b9de4f..88b0006b 100644
+--- a/cmake/FindNode.cmake
++++ b/cmake/FindNode.cmake
+@@ -1,8 +1,8 @@
+ # https://github.com/eclipse/upm/blob/master/cmake/modules/FindNode.cmake
+ 
+-# Macro to add directory to NODEJS_INCLUDE_DIRS if it exists and is not /usr/include
++# Macro to add directory to NODEJS_INCLUDE_DIRS if it exists and is not @TERMUX_PREFIX@/include
+ macro(add_include_dir dir)
+-    if (IS_DIRECTORY ${dir} AND NOT ${dir} STREQUAL "/usr/include")
++    if (IS_DIRECTORY ${dir} AND NOT ${dir} STREQUAL "@TERMUX_PREFIX@/include")
+         set(NODEJS_INCLUDE_DIRS ${NODEJS_INCLUDE_DIRS} ${dir})
+     endif()
+ endmacro()
+@@ -16,7 +16,7 @@ find_program (NODEJS_EXECUTABLE NAMES node nodejs
+ include (FindPackageHandleStandardArgs)
+ 
+ # If compat-libuv package exists, it must be at start of include path
+-find_path (UV_ROOT_DIR "uv.h" PATHS /usr/include/compat-libuv010 NO_DEFAULT_PATH)
++find_path (UV_ROOT_DIR "uv.h" PATHS @TERMUX_PREFIX@/include/compat-libuv010 NO_DEFAULT_PATH)
+ if (UV_ROOT_DIR)
+     # set (NODEJS_INCLUDE_DIRS ${UV_ROOT_DIR})
+     add_include_dir(${UV_ROOT_DIR})
+@@ -26,7 +26,7 @@ endif()
+ find_path (NODE_ROOT_DIR
+     NAMES node.h src/node.h
+     PATH_SUFFIXES node node4 node5 node6 node7 node8 nodejs
+-    PATHS /usr/include /usr/local/include)
++    PATHS @TERMUX_PREFIX@/include @TERMUX_PREFIX@/local/include)
+ 
+ if (NODE_ROOT_DIR)
+     add_include_dir(${NODE_ROOT_DIR})
+diff --git a/src/modules/frei0r/factory.c b/src/modules/frei0r/factory.c
+index 10b68ff2..c30635fd 100644
+--- a/src/modules/frei0r/factory.c
++++ b/src/modules/frei0r/factory.c
+@@ -45,8 +45,7 @@
+ #endif
+ #else
+ #define FREI0R_PLUGIN_PATH \
+-    "/usr/lib/frei0r-1:/usr/lib64/frei0r-1:/opt/local/lib/frei0r-1:/usr/local/lib/frei0r-1:$HOME/" \
+-    ".frei0r-1/lib"
++    "@TERMUX_PREFIX@/lib/frei0r-1:$HOME/.frei0r-1/lib"
+ #endif
+ #endif
+ 
+diff --git a/src/modules/jackrack/plugin_mgr.c b/src/modules/jackrack/plugin_mgr.c
+index dd6fd438..c3d46aea 100644
+--- a/src/modules/jackrack/plugin_mgr.c
++++ b/src/modules/jackrack/plugin_mgr.c
+@@ -391,7 +391,7 @@ static void plugin_mgr_get_path_plugins(plugin_mgr_t *plugin_mgr)
+     }
+ #else
+     if (!ladspa_path)
+-        ladspa_path = g_strdup("/usr/local/lib/ladspa:/usr/lib/ladspa:/usr/lib64/ladspa");
++        ladspa_path = g_strdup ("@TERMUX_PREFIX@/lib/ladspa");
+ #endif
+ 
+     for (dir = strtok(ladspa_path, MLT_DIRLIST_DELIMITER); dir;

--- a/x11-packages/mlt/32-bit-symbol.diff
+++ b/x11-packages/mlt/32-bit-symbol.diff
@@ -1,0 +1,10 @@
+--- a/src/mlt++/mlt++.vers
++++ b/src/mlt++/mlt++.vers
+@@ -541,6 +541,7 @@ MLTPP_6.14.0 {
+       "Mlt::Playlist::reorder(int const*)";
+       "Mlt::Transition::connect(Mlt::Service&, int, int)";
+       "Mlt::Producer::set_creation_time(long)";
++      "Mlt::Producer::set_creation_time(long long)";
+       "Mlt::Producer::get_creation_time()";
+   };
+ } MLTPP_6.10.0;

--- a/x11-packages/mlt/build.sh
+++ b/x11-packages/mlt/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE=https://www.mltframework.org/
+TERMUX_PKG_DESCRIPTION="Multimedia Framework. Author, manage, and run multitrack audio/video compositions."
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_LICENSE="LGPL-2.1"
+TERMUX_PKG_VERSION=7.28.0
+TERMUX_PKG_SRCURL=https://github.com/mltframework/mlt/releases/download/v${TERMUX_PKG_VERSION}/mlt-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=bc425bf9602213f5f4855b78cfbbcd43eeb78097c508588bde44415963955aa1
+TERMUX_PKG_DEPENDS="libebur128, swig"
+TERMUX_PKG_BUILD_DEPENDS="ffmpeg, fftw, fontconfig, frei0r-plugins, gdk-pixbuf, glib, jack, movit, ladspa-sdk, libepoxy, libexif, libglvnd, libsamplerate, libvidstab, libvorbis, libx11, libxml2, qt6-qtbase, qt6-qtsvg, pango, python, rubberband, sdl2, sdl-image, sox, zlib"
+TERMUX_PKG_SUGGESTS="$TERMUX_PKG_BUILD_DEPENDS"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_FORCE_CMAKE=true
+
+termux_step_pre_configure() {
+	# Fix linker script error
+	LDFLAGS+=" -Wl,--undefined-version"
+
+	if [ $TERMUX_ARCH_BITS = 32 ]; then
+		patch --silent -p1 -d "$TERMUX_PKG_SRCDIR" < "$TERMUX_PKG_BUILDER_DIR/32-bit-symbol.diff"
+	fi
+}

--- a/x11-packages/shotcut/0001-lib-name.patch
+++ b/x11-packages/shotcut/0001-lib-name.patch
@@ -1,0 +1,13 @@
+diff --git a/src/mainwindow.cpp b/src/mainwindow.cpp
+index 0c602f84..c5bbe91b 100644
+--- a/src/mainwindow.cpp
++++ b/src/mainwindow.cpp
+@@ -148,7 +148,7 @@ MainWindow::MainWindow()
+     } else {
+         libJack.unload();
+     }
+-    QLibrary libSDL("libSDL2-2.0.so.0");
++    QLibrary libSDL("libSDL2-2.0.so");
+     if (!libSDL.load()) {
+         QMessageBox::critical(this, qApp->applicationName(),
+                               tr("Error: This program requires the SDL 2 library.\n\nPlease install it using your package manager. It may be named libsdl2-2.0-0, SDL2, or similar."));

--- a/x11-packages/shotcut/build.sh
+++ b/x11-packages/shotcut/build.sh
@@ -1,0 +1,14 @@
+TERMUX_PKG_HOMEPAGE=https://shotcut.org/
+TERMUX_PKG_DESCRIPTION="Cross-platform Qt based Video Editor"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=24.09.13
+TERMUX_PKG_SRCURL=https://github.com/mltframework/shotcut/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=6a1469c68cfaf4f37e5c9d5692b781f15cc78b893cb9fa3df801ea22507180cd
+TERMUX_PKG_DEPENDS="ffmpeg, fftw, frei0r-plugins, mlt, libx264, libvpx, lame, ladspa-sdk, movit, qt6-qtbase, qt6-qtcharts, qt6-qtdeclarative, qt6-qtimageformats, qt6-qtmultimedia, qt6-qttranslations, sdl2"
+TERMUX_PKG_BUILD_DEPENDS="qt6-qttools"
+TERMUX_PKG_AUTO_UPDATE=true
+
+termux_step_pre_configure(){
+	CXXFLAGS+=' -Wno-c++11-narrowing'
+}


### PR DESCRIPTION
Draft PR. currently the app mostly works ~well but cannot output video results, perhaps there are problems with QProcess, see #20354 .~ [fixed]

Other things to note:
* [fixed] ~32-bit arch does not build (see error log, related to `qint64` type)~
* [fixed] ~GPU mode requires  PR #20352 , related to #20351~
* [optional] rtaudio (mlt optional deps) needs ALSA and jack API, we may need a functioning pipewire, related to #20316 
* [optional: someone may try] `opencv` cannot be included as `mlt`build deps (which is done by Archlinux), prompting some compilation error related to `QPrivate` when building `shotcut`