### PR TITLE
bump(main/apt): 2.7.14

### DIFF
--- a/packages/apt/0000-cmake-fix.patch
+++ b/packages/apt/0000-cmake-fix.patch
@@ -58,11 +58,11 @@ diff -uNr apt-2.1.13/methods/CMakeLists.txt apt-2.1.13.mod/methods/CMakeLists.tx
  add_executable(rred rred.cc)
  add_executable(rsh rsh.cc)
  
-@@ -21,12 +20,11 @@
+@@ -23,12 +22,11 @@
  
  # Additional libraries to link against for networked stuff
- target_link_libraries(http ${GNUTLS_LIBRARIES} $<$<BOOL:${SYSTEMD_FOUND}>:${SYSTEMD_LIBRARIES}>)
--target_link_libraries(ftp ${GNUTLS_LIBRARIES})
+ target_link_libraries(http $<$<BOOL:${GNUTLS_FOUND}>:${GNUTLS_LIBRARIES}> $<$<BOOL:${SYSTEMD_FOUND}>:${SYSTEMD_LIBRARIES}>)
+-target_link_libraries(ftp $<$<BOOL:${GNUTLS_FOUND}>:${GNUTLS_LIBRARIES}>)
  
  target_link_libraries(rred apt-private)
  

--- a/packages/apt/build.sh
+++ b/packages/apt/build.sh
@@ -2,13 +2,12 @@ TERMUX_PKG_HOMEPAGE=https://packages.debian.org/apt
 TERMUX_PKG_DESCRIPTION="Front-end for the dpkg package manager"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="2.7.12"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION="2.7.14"
 # old tarball are removed in https://deb.debian.org/debian/pool/main/a/apt/apt_${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SRCURL=https://salsa.debian.org/apt-team/apt/-/archive/${TERMUX_PKG_VERSION}/apt-${TERMUX_PKG_VERSION}.tar.bz2
-TERMUX_PKG_SHA256=8fd7a30e565fd218587a456da633156275d633003d41613bf93e4411259fe45f
+TERMUX_PKG_SHA256=083f4af84f1e61f74710b0baa324e8e5a7bbab2dabadbb84d120cff92e262a7c
 # apt-key requires utilities from coreutils, findutils, gpgv, grep, sed.
-TERMUX_PKG_DEPENDS="coreutils, dpkg, findutils, gpgv, grep, libandroid-glob, libbz2, libc++, libgnutls, liblz4, liblzma, sed, termux-keyring, termux-licenses, xxhash, zlib, zstd"
+TERMUX_PKG_DEPENDS="coreutils, dpkg, findutils, gpgv, grep, libandroid-glob, libbz2, libc++, libiconv, libgcrypt, libgnutls, liblz4, liblzma, sed, termux-keyring, termux-licenses, xxhash, zlib, zstd"
 TERMUX_PKG_BUILD_DEPENDS="docbook-xsl"
 TERMUX_PKG_CONFLICTS="apt-transport-https, libapt-pkg, unstable-repo, game-repo, science-repo"
 TERMUX_PKG_REPLACES="apt-transport-https, libapt-pkg, unstable-repo, game-repo, science-repo"


### PR DESCRIPTION
Add libiconv and libgcypt depdencies explicitly.
https://salsa.debian.org/apt-team/apt/-/blob/2.7.14/CMakeLists.txt?ref_type=tags#L44 https://salsa.debian.org/apt-team/apt/-/blob/2.7.14/CMakeLists.txt?ref_type=tags#L143