### PR TITLE
fix(main/libluajit): Fix mismatch between version and what is built

### DIFF
--- a/packages/libluajit/build.sh
+++ b/packages/libluajit/build.sh
@@ -3,9 +3,9 @@ TERMUX_PKG_DESCRIPTION="Just-In-Time Compiler for Lua"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1:2.1.1716656478"
-_COMMIT="787736990ac3b7d5ceaba2697c7d0f58f77bb782"
-TERMUX_PKG_SRCURL=https://github.com/LuaJIT/LuaJIT/archive/${_COMMIT}.tar.gz
-TERMUX_PKG_SHA256=2e3f74bc279f46cc463abfc67b36e69faaf0366237004771f4cac4bf2a9f5efb
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=git+https://github.com/LuaJIT/LuaJIT.git
+TERMUX_PKG_GIT_BRANCH=v${TERMUX_PKG_VERSION:2:3}
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_METHOD=repology
 TERMUX_PKG_BREAKS="libluajit-dev"
@@ -13,6 +13,16 @@ TERMUX_PKG_REPLACES="libluajit-dev"
 TERMUX_PKG_EXTRA_MAKE_ARGS="amalg PREFIX=$TERMUX_PREFIX"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_LUAJIT_JIT_FOLDER_RELATIVE=share/luajit-${TERMUX_PKG_VERSION:2:3}/jit
+
+termux_step_post_get_source() {
+	# Do the same as e.g. arch linux is doing:
+	# The patch version is the timestamp of the above git commit, obtain via `git show -s --format=%ct`
+	local commit_ts=${TERMUX_PKG_VERSION:6}
+
+	# Find the commit made at the exact timestamp specified in the version:
+	local commit_hash=$(git log --date=unix --before=$commit_ts --after=$commit_ts --pretty=format:"%H")
+	git checkout $commit_hash
+}
 
 termux_step_pre_configure() {
 	# luajit wants same pointer size for host and target build

--- a/packages/libluajit/src-Makefile.patch
+++ b/packages/libluajit/src-Makefile.patch
@@ -1,6 +1,7 @@
---- LuaJIT-old/src/Makefile	2021-03-11 01:19:04.000000000 +0600
-+++ LuaJIT-new/src/Makefile	2021-07-05 09:46:42.681252928 +0600
-@@ -27,7 +27,7 @@
+diff -u -r ../LuaJIT/src/Makefile ./src/Makefile
+--- ../LuaJIT/src/Makefile	2024-06-01 20:36:31.761902429 +0000
++++ ./src/Makefile	2024-06-01 20:38:32.396582115 +0000
+@@ -26,7 +26,7 @@
  DEFAULT_CC = gcc
  #
  # LuaJIT builds as a native 32 or 64 bit binary by default.
@@ -9,7 +10,7 @@
  #
  # Use this if you want to force a 32 bit build on a 64 bit multilib OS.
  #CC= $(DEFAULT_CC) -m32
-@@ -192,7 +192,7 @@
+@@ -191,7 +191,7 @@
  CCOPTIONS= $(CCDEBUG) $(ASOPTIONS)
  LDOPTIONS= $(CCDEBUG) $(LDFLAGS)
  
@@ -18,7 +19,7 @@
  HOST_RM?= rm -f
  # If left blank, minilua is built and used. You can supply an installed
  # copy of (plain) Lua 5.1 or 5.2, plus Lua BitOp. E.g. with: HOST_LUA=lua
-@@ -205,17 +205,17 @@
+@@ -204,17 +204,17 @@
  HOST_ALDFLAGS= $(LDOPTIONS) $(HOST_XLDFLAGS) $(HOST_LDFLAGS)
  HOST_ALIBS= $(HOST_XLIBS) $(LIBS) $(HOST_LIBS)
  
@@ -30,7 +31,7 @@
  TARGET_STCC= $(STATIC_CC)
  TARGET_DYNCC= $(DYNAMIC_CC)
 -TARGET_LD= $(CROSS)$(CC)
--TARGET_AR= $(CROSS)ar rcus 2>/dev/null
+-TARGET_AR= $(CROSS)ar rcus
 -TARGET_STRIP= $(CROSS)strip
 +TARGET_LD= $(CC)
 +TARGET_AR= $(AR) rcus 2>/dev/null
@@ -42,7 +43,7 @@
  TARGET_DYLIBNAME= libluajit-$(ABIVER).$(MAJVER).dylib
  TARGET_DYLIBPATH= $(TARGET_LIBPATH)/$(TARGET_DYLIBNAME)
  TARGET_DLLNAME= lua$(NODOTABIVER).dll
-@@ -589,7 +589,7 @@
+@@ -608,7 +608,7 @@
  endif
  endif
  

--- a/scripts/updates/termux_pkg_auto_update.sh
+++ b/scripts/updates/termux_pkg_auto_update.sh
@@ -4,7 +4,7 @@ termux_pkg_auto_update() {
 		termux_pkg_upgrade_version ${__CACHED_TAG}
 		return $?
 	fi
-	
+
 	local project_host
 	project_host="$(echo "${TERMUX_PKG_SRCURL}" | cut -d"/" -f3)"
 


### PR DESCRIPTION
Background: luajit uses rolling releases - see https://luajit.org/download.html

The recommended approach is to make frequent snapshots, which the termux package is currently taking from the 2.1 branch.

The version scheme follows what arch linux is doing: https://archlinux.org/packages/extra/x86_64/luajit/

That means that the version number "2.1.1716656478" refers to the "2.1" branch, with "1716656478" being the timestamp of the commit built (as displayed by `git show -s --format=%ct`).

The problem is that the termux package was hardcoded to build a specific commit from 2021-03-10: https://github.com/LuaJIT/LuaJIT/commit/787736990ac3b7d5ceaba2697c7d0f58f77bb782

We now instead look up the commit from the timestamp in the version string, so that what is built is correct, and auto updates will start working as expected.