### PR TITLE
fix(main/libsamplerate): Fix undefined symbols on 32-bit builds

### DIFF
--- a/packages/libsamplerate/CMakeLists.txt.patch32
+++ b/packages/libsamplerate/CMakeLists.txt.patch32
@@ -1,0 +1,15 @@
+libvorbisfile uses some functions that are provided by libm
+in 32-bit builds, while 64-bit builds has them as intrinsics.
+
+diff -u -r ../libsamplerate-0.2.2/CMakeLists.txt ./CMakeLists.txt
+--- ../libsamplerate-0.2.2/CMakeLists.txt	2021-09-05 11:48:12.000000000 +0000
++++ ./CMakeLists.txt	2024-06-02 20:21:49.112629567 +0000
+@@ -67,6 +67,8 @@
+   endif()
+ endif()
+
++link_libraries(m)
++
+ if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+   option(LIBSAMPLERATE_ENABLE_SANITIZERS "Enable ASAN and UBSAN" OFF)
+

--- a/packages/libsamplerate/build.sh
+++ b/packages/libsamplerate/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A library for performing sample rate conversion of audio
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.2.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/libsndfile/libsamplerate/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=16e881487f184250deb4fcb60432d7556ab12cb58caea71ef23960aec6c0405a
 TERMUX_PKG_FORCE_CMAKE=true


### PR DESCRIPTION
Fix the below build error when building for 32-bit arm:

> ERROR: ./lib/libsamplerate.so contains undefined symbols:
     6: 00000000     0 NOTYPE  GLOBAL DEFAULT   UND lrintf
     7: 00000000     0 NOTYPE  GLOBAL DEFAULT   UND lrint
