### PR TITLE
chore(main/proot-distro): add `util-linux`(lscpu) dependency

### DIFF
--- a/packages/proot-distro/build.sh
+++ b/packages/proot-distro/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="Termux official utility for managing proot'ed Linux dist
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=4.13.0
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/termux/proot-distro/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=d2f7e9edd99303ef7d1163c3b8d19c9355ed0af0f203f96ea30d49530f7773a9
-TERMUX_PKG_DEPENDS="bash, bzip2, coreutils, curl, findutils, gzip, ncurses-utils, proot (>= 5.1.107-32), sed, tar, termux-tools, xz-utils"
+TERMUX_PKG_DEPENDS="bash, bzip2, coreutils, curl, findutils, gzip, ncurses-utils, proot (>= 5.1.107-32), sed, tar, termux-tools, util-linux, xz-utils"
 TERMUX_PKG_SUGGESTS="bash-completion, termux-api"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true


### PR DESCRIPTION
following termux/proot-distro#413

@sylirre I assume we won't actually need to merge this until proot-distro 4.14, do you still wanna get the `util-linux` (lscpu) dependency sorted out now?