### PR TITLE
chore(main/re2c): adopt package

### DIFF
--- a/packages/re2c/build.sh
+++ b/packages/re2c/build.sh
@@ -1,8 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://re2c.org/
 TERMUX_PKG_DESCRIPTION="Lexer generator for C, C++ and Go."
 TERMUX_PKG_LICENSE="Public Domain"
-TERMUX_PKG_MAINTAINER="ian4hu <hu2008yinxiang@163.com>"
+TERMUX_PKG_MAINTAINER="Yaksh Bariya <thunder-coding@termux.dev>"
 TERMUX_PKG_VERSION="3.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/skvadrik/re2c/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=087c44de0400fb15caafde09fd72edc7381e688a35ef505ee65e0e3d2fac688b
 TERMUX_PKG_AUTO_UPDATE=true


### PR DESCRIPTION
Earlier maintainer hasn't participated in any of Termux's repositories
since a while now and the package seems to have been maintained by us. I
am currently working on something that requires re2c to build, so it
would make testing the package just another chore for me which I can do
easily