### PR TITLE
fix(main/taskwarrior): Fix 32-bit arm build by setting CMAKE_ANDROID_ARM_MODE

### DIFF
--- a/packages/taskwarrior/build.sh
+++ b/packages/taskwarrior/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Utility for managing your TODO list"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.0.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v${TERMUX_PKG_VERSION}/task-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=633b76637b0c74e4845ffa28249f01a16ed2c84000ece58d4358e72bf88d5f10
 TERMUX_PKG_AUTO_UPDATE=true
@@ -33,8 +34,9 @@ termux_step_pre_configure() {
 	LDFLAGS+=" -landroid-glob"
 
 	if [ "$TERMUX_ARCH" = "arm" ]; then
-		rustup target add thumbv7neon-linux-androideabi
-	fi	
+		# See https://cmake.org/cmake/help/latest/variable/CMAKE_ANDROID_ARM_MODE.html
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DCMAKE_ANDROID_ARM_MODE=ON"
+	fi
 }
 
 termux_step_post_make_install() {


### PR DESCRIPTION
By setting `CMAKE_ANDROID_ARM_MODE` we get the normal `armv7-linux-androideabi` target which we set:
https://github.com/termux/termux-packages/blob/master/scripts/build/setup/termux_setup_rust.sh#L5

See
https://github.com/corrosion-rs/corrosion/blob/master/cmake/FindRust.cmake#L705-L711:

```cmake
  elseif (ANDROID)
      if (CMAKE_ANDROID_ARCH_ABI STREQUAL armeabi-v7a)
          if (CMAKE_ANDROID_ARM_MODE)
              set(_Rust_ANDROID_TARGET armv7-linux-androideabi)
          else ()
              set(_Rust_ANDROID_TARGET thumbv7neon-linux-androideabi)
          endif()
```

This avoids having to install another rust target, and actually fixes the current 32-bit arm build which before this change fails with:

```txt
  cargo:warning=crypto/curve25519/asm/x25519-asm-arm.S:36:1: error: invalid instruction, any one of the following would fix this:
  cargo:warning=strd r4,[sp,#0]
  cargo:warning=^
  cargo:warning=crypto/curve25519/asm/x25519-asm-arm.S:36:14: note: too few operands for instruction
  cargo:warning=strd r4,[sp,#0]
  cargo:warning=             ^
  cargo:warning=crypto/curve25519/asm/x25519-asm-arm.S:36:1: note: instruction requires: armv5te
  cargo:warning=strd r4,[sp,#0]
  cargo:warning=^
  cargo:warning=crypto/curve25519/asm/x25519-asm-arm.S:36:1: note: instruction requires: thumb2
  cargo:warning=strd r4,[sp,#0]
```

This seems to be due to cmake targeting 16-bit Thumb processors if `CMAKE_ANDROID_ARM_MODE` is not set -
https://cmake.org/cmake/help/latest/variable/CMAKE_ANDROID_ARM_MODE.html:

> When Cross Compiling for Android and CMAKE_ANDROID_ARCH_ABI is set to one of the
> armeabi architectures, set CMAKE_ANDROID_ARM_MODE to ON to target 32-bit ARM processors
> (-marm). Otherwise, the default is to target the 16-bit Thumb processors (-mthumb).

I don't know what has changed since the original taskwarrior 3.0.2 bump built successfully:
https://github.com/termux/termux-packages/commit/0658b35d86ce6719d757ecdf6f7d090f2fdac2f1?