### PR TITLE
bump(main/ruby): 3.3.2

### DIFF
--- a/packages/ruby/build.sh
+++ b/packages/ruby/build.sh
@@ -5,9 +5,9 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Packages which should be rebuilt after "minor" bump (e.g. 3.1.x to 3.2.0):
 # - asciidoctor
 # - weechat
-TERMUX_PKG_VERSION=3.2.2
+TERMUX_PKG_VERSION=3.3.2
 TERMUX_PKG_SRCURL=https://cache.ruby-lang.org/pub/ruby/$(echo $TERMUX_PKG_VERSION | cut -d . -f 1-2)/ruby-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=4b352d0f7ec384e332e3e44cdbfdcd5ff2d594af3c8296b5636c710975149e23
+TERMUX_PKG_SHA256=b5e8a8ed4a47cdd9a3358b5bdd998c37bd9e971ca63766a37d5ae5933fdb69f1
 # libbffi is used by the fiddle extension module:
 TERMUX_PKG_DEPENDS="libandroid-execinfo, libandroid-support, libffi, libgmp, readline, openssl, libyaml, zlib"
 TERMUX_PKG_RECOMMENDS="clang, make, pkg-config, resolv-conf"
@@ -75,9 +75,6 @@ termux_step_make_install() {
 }
 
 termux_step_post_massage() {
-	if [ ! -f ./lib/ruby/${_RUBY_API_VERSION}/${TERMUX_HOST_PLATFORM}/readline.so ]; then
-		termux_error_exit "The readline extension was not installed."
-	fi
 	local _RUBYGEMS_ARCH=${TERMUX_HOST_PLATFORM/i686-/x86-}
 	if [ ! -d ./lib/ruby/gems/${_RUBY_API_VERSION}/extensions/${_RUBYGEMS_ARCH} ]; then
 		termux_error_exit "Extensions for bundled gems were not installed."

--- a/packages/ruby/fix-paths.patch
+++ b/packages/ruby/fix-paths.patch
@@ -146,27 +146,6 @@ diff -uNr ruby-3.0.0/lib/resolv.rb ruby-3.0.0.mod/lib/resolv.rb
          if File.exist? filename
            config_hash = Config.parse_resolv_conf(filename)
          else
-diff -uNr ruby-3.0.0/mjit.c ruby-3.0.0.mod/mjit.c
---- ruby-3.0.0/mjit.c	2020-12-25 05:33:01.000000000 +0200
-+++ ruby-3.0.0.mod/mjit.c	2021-02-09 17:41:47.157406979 +0200
-@@ -606,7 +606,7 @@
-     RETURN_ENV("TMP");
-     tmpdir = system_default_tmpdir();
-     if (check_tmpdir(tmpdir)) return tmpdir;
--    return ruby_strdup("/tmp");
-+    return ruby_strdup("@TERMUX_PREFIX@/tmp");
- # undef RETURN_ENV
- }
- 
-@@ -1741,7 +1741,7 @@
-     M("--mjit-warnings",           "", "Enable printing JIT warnings"),
-     M("--mjit-debug",              "", "Enable JIT debugging (very slow), or add cflags if specified"),
-     M("--mjit-wait",               "", "Wait until JIT compilation finishes every time (for testing)"),
--    M("--mjit-save-temps",         "", "Save JIT temporary files in $TMP or /tmp (for testing)"),
-+    M("--mjit-save-temps",         "", "Save JIT temporary files in $TMP or @TERMUX_PREFIX@/tmp (for testing)"),
-     M("--mjit-verbose=num",        "", "Print JIT logs of level num or less to stderr (default: 0)"),
-     M("--mjit-max-cache=num",      "", "Max number of methods to be JIT-ed in a cache (default: "
-       STRINGIZE(DEFAULT_MAX_CACHE_SIZE) ")"),
 diff -uNr ruby-3.0.0/process.c ruby-3.0.0.mod/process.c
 --- ruby-3.0.0/process.c	2020-12-25 05:33:01.000000000 +0200
 +++ ruby-3.0.0.mod/process.c	2021-02-09 17:49:30.716668413 +0200
@@ -206,18 +185,6 @@ diff -uNr ruby-3.1.0/ruby.c ruby-3.1.0.mod/ruby.c
          const ptrdiff_t bindir_len = (ptrdiff_t)sizeof(bindir) - 1;
  
          const char *p2 = NULL;
-diff -uNr ruby-3.0.0/spec/bundler/commands/exec_spec.rb ruby-3.0.0.mod/spec/bundler/commands/exec_spec.rb
---- ruby-3.0.0/spec/bundler/commands/exec_spec.rb	2020-12-25 05:33:01.000000000 +0200
-+++ ruby-3.0.0.mod/spec/bundler/commands/exec_spec.rb	2021-02-09 17:50:58.332721054 +0200
-@@ -156,7 +156,7 @@
- 
-     install_gemfile 'gem "rack"'
-     File.open(bundled_app("--verbose"), "w") do |f|
--      f.puts "#!/bin/sh"
-+      f.puts "#!@TERMUX_PREFIX@/bin/sh"
-       f.puts "echo foobar"
-     end
-     File.chmod(0o744, bundled_app("--verbose"))
 diff -uNr ruby-3.0.0/spec/ruby/core/dir/shared/pwd.rb ruby-3.0.0.mod/spec/ruby/core/dir/shared/pwd.rb
 --- ruby-3.0.0/spec/ruby/core/dir/shared/pwd.rb	2020-12-25 05:33:01.000000000 +0200
 +++ ruby-3.0.0.mod/spec/ruby/core/dir/shared/pwd.rb	2021-02-09 17:50:07.720664849 +0200
@@ -230,27 +197,6 @@ diff -uNr ruby-3.0.0/spec/ruby/core/dir/shared/pwd.rb ruby-3.0.0.mod/spec/ruby/c
      end
      platform_is :windows do
        File.stat(pwd).ino.should == File.stat(File.expand_path(`cd`.chomp)).ino
-diff -uNr ruby-3.0.0/spec/ruby/core/process/exec_spec.rb ruby-3.0.0.mod/spec/ruby/core/process/exec_spec.rb
---- ruby-3.0.0/spec/ruby/core/process/exec_spec.rb	2020-12-25 05:33:01.000000000 +0200
-+++ ruby-3.0.0.mod/spec/ruby/core/process/exec_spec.rb	2021-02-09 17:50:27.464678688 +0200
-@@ -154,7 +154,7 @@
-   describe "with a command array" do
-     it "uses the first element as the command name and the second as the argv[0] value" do
-       platform_is_not :windows do
--        ruby_exe('Process.exec(["/bin/sh", "argv_zero"], "-c", "echo $0")', escape: true).should == "argv_zero\n"
-+        ruby_exe('Process.exec(["@TERMUX_PREFIX@/bin/sh", "argv_zero"], "-c", "echo $0")', escape: true).should == "argv_zero\n"
-       end
-       platform_is :windows do
-         ruby_exe('Process.exec(["cmd.exe", "/C"], "/C", "echo", "argv_zero")', escape: true).should == "argv_zero\n"
-@@ -163,7 +163,7 @@
- 
-     it "coerces the argument using to_ary" do
-       platform_is_not :windows do
--        ruby_exe('o = Object.new; def o.to_ary; ["/bin/sh", "argv_zero"]; end; Process.exec(o, "-c", "echo $0")', escape: true).should == "argv_zero\n"
-+        ruby_exe('o = Object.new; def o.to_ary; ["@TERMUX_PREFIX@/bin/sh", "argv_zero"]; end; Process.exec(o, "-c", "echo $0")', escape: true).should == "argv_zero\n"
-       end
-       platform_is :windows do
-         ruby_exe('o = Object.new; def o.to_ary; ["cmd.exe", "/C"]; end; Process.exec(o, "/C", "echo", "argv_zero")', escape: true).should == "argv_zero\n"
 diff -uNr ruby-3.0.0/spec/ruby/core/process/spawn_spec.rb ruby-3.0.0.mod/spec/ruby/core/process/spawn_spec.rb
 --- ruby-3.0.0/spec/ruby/core/process/spawn_spec.rb	2020-12-25 05:33:01.000000000 +0200
 +++ ruby-3.0.0.mod/spec/ruby/core/process/spawn_spec.rb	2021-02-09 17:50:41.692695143 +0200

--- a/packages/ruby/yjit-src-codegen.rs.patch
+++ b/packages/ruby/yjit-src-codegen.rs.patch
@@ -1,0 +1,12 @@
+diff -u -r ../ruby-3.3.2/yjit/src/codegen.rs ./yjit/src/codegen.rs
+--- ../ruby-3.3.2/yjit/src/codegen.rs	2024-05-30 00:23:11.000000000 +0000
++++ ./yjit/src/codegen.rs	2024-06-10 02:06:30.788015891 +0000
+@@ -261,7 +261,7 @@
+ 
+     /// Flush addresses and symbols to /tmp/perf-{pid}.map
+     fn flush_perf_symbols(&self, cb: &CodeBlock) {
+-        let path = format!("/tmp/perf-{}.map", std::process::id());
++        let path = format!("@TERMUX_PREFIX@/tmp/perf-{}.map", std::process::id());
+         let mut f = std::fs::File::options().create(true).append(true).open(path).unwrap();
+         for sym in self.perf_map.borrow().iter() {
+             if let (start, Some(end), name) = sym {

--- a/packages/ruby/yjit-src-yjit.rs.patch
+++ b/packages/ruby/yjit-src-yjit.rs.patch
@@ -1,0 +1,12 @@
+diff -u -r ../ruby-3.3.2/yjit/src/yjit.rs ./yjit/src/yjit.rs
+--- ../ruby-3.3.2/yjit/src/yjit.rs	2024-05-30 00:23:11.000000000 +0000
++++ ./yjit/src/yjit.rs	2024-06-10 02:07:42.975768949 +0000
+@@ -66,7 +66,7 @@
+ 
+     // Make sure --yjit-perf doesn't append symbols to an old file
+     if get_option!(perf_map) {
+-        let perf_map = format!("/tmp/perf-{}.map", std::process::id());
++        let perf_map = format!("@TERMUX_PREFIX@/tmp/perf-{}.map", std::process::id());
+         let _ = std::fs::remove_file(&perf_map);
+         println!("YJIT perf map: {perf_map}");
+     }


### PR DESCRIPTION
See https://bugs.ruby-lang.org/issues/19616 about readline.so removal.

Will rev-bump `asciidoctor` and `weechat` as follow ups.