### PR TITLE
fix(auto-update): check issues before building in CI

### DIFF
--- a/scripts/bin/update-packages
+++ b/scripts/bin/update-packages
@@ -279,6 +279,10 @@ _should_update() {
 	if [[ " ${_ALREADY_SEEN[*]} ${!_FAILED_UPDATES[*]} " =~ " $(basename "${pkg_dir}") " ]]; then
 		return 1 # Skip.
 	fi
+	if [[ "${BUILD_PACKAGES}" == "true" ]] && [[ "${GITHUB_ACTIONS:-}" == "true" ]] && _gh_check_issue_exists "$(basename "${pkg_dir}")"; then
+		echo "INFO: Skipping '$(basename "${pkg_dir}")', an update issue for it hasn't been resolved yet."
+		return 1
+	fi
 
 	return 0
 }


### PR DESCRIPTION
See #20498 and https://github.com/termux/termux-packages/actions/runs/9465206895/job/26074224976

Partial revert of 5f1c3865995c7181a7df17fd47244d4e43445a73 to fix
Breakage (before):
Package Updates always build packages if detected new updates
Fix (after or before the breakge):
Package Updates checks existing issue before build if detected new updates

The last commit already allows PR to check auto update is working or not without closing existing issues.