### PR TITLE
chore(main/libaom): Use source tarball, enable auto-update

### DIFF
--- a/packages/libaom/build.sh
+++ b/packages/libaom/build.sh
@@ -4,21 +4,13 @@ TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_LICENSE_FILE="LICENSE, PATENTS"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.9.0
-TERMUX_PKG_SRCURL=git+https://aomedia.googlesource.com/aom
-TERMUX_PKG_SHA256=e5be735a080f8e5ca440df979e829e7c369e343b99a86153f6d588ba97bc736b
-TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_SRCURL=https://storage.googleapis.com/aom-releases/libaom-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=a662e22299752547488c8e1412c0b41981efa8dbb1a25c696ded7ba9c472e919
+TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DBUILD_SHARED_LIBS=ON
 -DCMAKE_INSTALL_LIBDIR=lib
 "
-
-termux_step_post_get_source() {
-	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
-	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
-		echo "$s"
-		termux_error_exit "Checksum mismatch for source files."
-	fi
-}
 
 termux_step_pre_configure() {
 	# Do not forget to bump revision of reverse dependencies and rebuild them


### PR DESCRIPTION
Source tarball link can be found in https://groups.google.com/a/aomedia.org/g/av1-discuss

This reverts commit d0221f5207d1b6896d9feda07eea967bd81cc605