### PR TITLE
revbump(main/imagemagick): Rebuild after libxml2 2.13.0 update

### DIFF
--- a/packages/imagemagick/build.sh
+++ b/packages/imagemagick/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Suite to create, edit, compose, or convert images in a v
 TERMUX_PKG_LICENSE="ImageMagick"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="7.1.1.33"
+TERMUX_PKG_REVISION="1"
 _VERSION="${TERMUX_PKG_VERSION%.*}-${TERMUX_PKG_VERSION##*.}"
 #TERMUX_PKG_SRCURL=https://github.com/ImageMagick/ImageMagick/archive/refs/tags/${_VERSION}.tar.gz
 TERMUX_PKG_SRCURL=https://imagemagick.org/archive/releases/ImageMagick-${_VERSION}.tar.xz


### PR DESCRIPTION
Getting this error when running any `magick` command.
```
CANNOT LINK EXECUTABLE "magick": cannot locate symbol "xmlNanoHTTPMethod" referenced by "/data/data/com.termux/files/usr/lib/libMagickCore-7.Q16HDRI.so"...
```
This has happened before, a revbump usually fixes that.