### PR TITLE
addpkg(root/i2c-tools): tools for interacting with i2c devices

### DIFF
--- a/root-packages/i2c-tools/build.sh
+++ b/root-packages/i2c-tools/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE=https://i2c.wiki.kernel.org/index.php/I2C_Tools
+TERMUX_PKG_DESCRIPTION="Tools for interacting with I2C devices"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
+TERMUX_PKG_VERSION=4.2
+TERMUX_PKG_SRCURL="https://mirrors.edge.kernel.org/pub/software/utils/i2c-tools/i2c-tools-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256=37f2dabc7082d185903ff21d1f584b5dcb4dd2eb2c879bbd8d7c50ae900dacd6
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true


### PR DESCRIPTION
Can be used to learn more about the various hardware chips in your phone (if they communicate over i2c).