### PR TITLE
new packages: JACK Audio Connection Kit and `alsa-lib`

### DIFF
--- a/packages/alsa-lib/0001-path.patch
+++ b/packages/alsa-lib/0001-path.patch
@@ -1,0 +1,27 @@
+diff --git a/src/conf/alsa.conf b/src/conf/alsa.conf
+index e65bf2c..22e0730 100644
+--- a/src/conf/alsa.conf
++++ b/src/conf/alsa.conf
+@@ -8,10 +8,9 @@
+ 	{
+ 		func load
+ 		files [
+-			"/var/lib/alsa/conf.d"
+-			"/usr/etc/alsa/conf.d"
+-			"/etc/alsa/conf.d"
+-			"/etc/asound.conf|||/usr/etc/asound.conf"
++			"@TERMUX_PREFIX@/var/lib/alsa/conf.d"
++			"@TERMUX_PREFIX@/etc/alsa/conf.d"
++			"@TERMUX_PREFIX@/etc/asound.conf"
+ 			"~/.asoundrc"
+ 			{
+ 				@func concat
+@@ -65,7 +64,7 @@ cards.@hooks [
+ 				file {
+ 					@func concat
+ 					strings [
+-						"/var/lib/alsa/card"
++						"@TERMUX_ALSA@/var/lib/alsa/card"
+ 						{ @func private_integer }
+ 						".conf.d"
+ 					]

--- a/packages/alsa-lib/build.sh
+++ b/packages/alsa-lib/build.sh
@@ -1,0 +1,24 @@
+TERMUX_PKG_HOMEPAGE=https://www.alsa-project.org
+TERMUX_PKG_DESCRIPTION="The Advanced Linux Sound Architecture (ALSA) - library"
+TERMUX_PKG_LICENSE="LGPL-2.1"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="1.2.11"
+TERMUX_PKG_SRCURL="https://github.com/alsa-project/alsa-lib/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=12216f0730d6dde3ded6a2a5388bc0009ad07f5c65972bd89aac9a76f8f085a4
+TERMUX_PKG_DEPENDS="libandroid-sysv-semaphore, libandroid-shmem"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--disable-static
+--with-versioned=no
+--with-tmpdir=$TERMUX_PREFIX/tmp
+"
+
+termux_step_pre_configure() {
+	# pcm interface uses sysv semaphore which is broken on Android 14+ (issue #20514)
+	# Nonetheless, it is still enabled because:
+	# 1. probably never called because Android has no /dev/snd/pcm* device
+	# 2. still required for other packages in compile time, e.g. pipewire-alsa
+	# -landroid-shmem is for depending packages in compile time
+	LDFLAGS+=" -landroid-sysv-semaphore -landroid-shmem"
+	autoreconf -fi
+}

--- a/packages/alsa-utils/build.sh
+++ b/packages/alsa-utils/build.sh
@@ -1,0 +1,22 @@
+TERMUX_PKG_HOMEPAGE=https://www.alsa-project.org
+TERMUX_PKG_DESCRIPTION="The Advanced Linux Sound Architecture (ALSA) - utils"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="1.2.11"
+TERMUX_PKG_SRCURL="https://github.com/alsa-project/alsa-utils/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=978961153fa8ca4c783c93767e7054d0dc1fb42ef6f1008040ca71363d0f4d35
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="ncurses"
+TERMUX_PKG_BUILD_DEPENDS="alsa-lib"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--with-udev-rules-dir=$TERMUX_PREFIX/lib/udev/rules.d
+--with-asound-state-dir=$TERMUX_PREFIX/var/lib/alsa
+--disable-bat
+--disable-rst2man
+"
+
+termux_step_pre_configure() {
+	LDFLAGS+=" -llog"
+	export ACLOCAL_PATH="${TERMUX_PREFIX}/share/aclocal"
+	autoreconf -fi
+}

--- a/packages/jack-example-tools/build.sh
+++ b/packages/jack-example-tools/build.sh
@@ -1,0 +1,8 @@
+TERMUX_PKG_HOMEPAGE=https://jackaudio.org/
+TERMUX_PKG_DESCRIPTION="Official JACK example clients and tools"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_LICENSE="GPL-2.0, GPL-3.0"
+TERMUX_PKG_VERSION=4
+TERMUX_PKG_SRCURL=https://github.com/jackaudio/jack-example-tools/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=2b1e0dc3cb3b5bfb0423f0aeb21eb611437cf71ee0ace2ca199f05f02705f174
+TERMUX_PKG_DEPENDS="alsa-lib, jack, libsamplerate, libsndfile"

--- a/packages/jack/build.sh
+++ b/packages/jack/build.sh
@@ -1,0 +1,11 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/termux/termux-packages
+TERMUX_PKG_DESCRIPTION="A metapackage that provides JACK Audio Connection Kit"
+TERMUX_PKG_LICENSE="Public Domain"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=0.0.1
+TERMUX_PKG_AUTO_UPDATE=false
+# TERMUX_PKG_DEPENDS="jack2 | pipewire-jack"
+TERMUX_PKG_DEPENDS="jack2"
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_SKIP_SRC_EXTRACT=true
+TERMUX_PKG_METAPACKAGE=true

--- a/packages/jack2/0001-fix-android-build.patch
+++ b/packages/jack2/0001-fix-android-build.patch
@@ -1,0 +1,403 @@
+diff --git a/common/Jackdmp.cpp b/common/Jackdmp.cpp
+index 04e722b..45a5ba3 100644
+--- a/common/Jackdmp.cpp
++++ b/common/Jackdmp.cpp
+@@ -35,7 +35,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ #include "JackConstants.h"
+ #include "JackPlatformPlug.h"
+ #ifdef __ANDROID__
+-#include "JackControlAPIAndroid.h"
++#include "../android/JackControlAPIAndroid.h"
+ #endif
+ 
+ #if defined(JACK_DBUS) && defined(__linux__)
+diff --git a/common/shm.c b/common/shm.c
+index b1e7fc7..765bb13 100644
+--- a/common/shm.c
++++ b/common/shm.c
+@@ -50,7 +50,7 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <sys/shm.h>
+-#include <sys/sem.h>
++#include <semaphore.h>
+ #include <stdlib.h>
+ #include "promiscuous.h"
+ 
+@@ -143,12 +143,13 @@ static jack_shm_registry_t *jack_shm_registry = NULL;
+  * again on that machine until after a reboot.
+  */
+ 
+-#define JACK_SEMAPHORE_KEY 0x282929
++// #define JACK_SEMAPHORE_NAME "/jack_termux_semaphore"
+ #ifndef USE_POSIX_SHM
+-#define JACK_SHM_REGISTRY_KEY JACK_SEMAPHORE_KEY
++#define JACK_SHM_REGISTRY_KEY 0x282929
+ #endif
+ 
+ static int semid = -1;
++static sem_t semaphore;
+ 
+ #ifdef WIN32
+ 
+@@ -195,55 +196,35 @@ semaphore_error (char *msg)
+ static int
+ semaphore_init ()
+ {
+-	key_t semkey = JACK_SEMAPHORE_KEY;
+-	struct sembuf sbuf;
+-	int create_flags = IPC_CREAT | IPC_EXCL
+-		| S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
+-
+ 	/* Get semaphore ID associated with this key. */
+-	if ((semid = semget(semkey, 0, 0)) == -1) {
+-
+-		/* Semaphore does not exist - Create. */
+-		if ((semid = semget(semkey, 1, create_flags)) != -1) {
+-
+-			/* Initialize the semaphore, allow one owner. */
+-			sbuf.sem_num = 0;
+-			sbuf.sem_op = 1;
+-			sbuf.sem_flg = 0;
+-			if (semop(semid, &sbuf, 1) == -1) {
+-                semaphore_error ("semop");
+-                return -1;
+-			}
+-
+-		} else if (errno == EEXIST) {
+-			if ((semid = semget(semkey, 0, 0)) == -1) {
+-                semaphore_error ("semget");
+-                return -1;
+-			}
+-
+-		} else {
+-            semaphore_error ("semget creation");
+-            return -1;
+-		}
++	// if ((semid = sem_open(JACK_SEMAPHORE_NAME, O_CREAT, 0777, 1)) == SEM_FAILED) {
++	if ((semid = sem_init(&semaphore, 1, 1)) == -1) {
++		semaphore_error("sem_open");
++		return -1;
+ 	}
+ 
+     return 0;
+ }
+ 
+-static inline int
++static int
+ semaphore_add (int value)
+ {
+-	struct sembuf sbuf;
+-
+-	sbuf.sem_num = 0;
+-	sbuf.sem_op = value;
+-	sbuf.sem_flg = SEM_UNDO;
+-
+-	if (semop(semid, &sbuf, 1) == -1) {
+-		semaphore_error ("semop");
+-        return -1;
+-	}
+-
++    if (value == 0) { return 0; }
++    else if (value > 0) {
++        for (int i = 0; i < value; i++) {
++            if (sem_post(&semaphore) == -1) {
++                semaphore_error("sem_post");
++                return -1;
++            }
++        }
++    } else if (value < 0) {
++    	for (int i = 0; i > value; i--) {
++            if (sem_wait(&semaphore) == -1) {
++                semaphore_error("sem_wait");
++                return -1;
++            }
++        }
++    }
+     return 0;
+ }
+ 
+@@ -705,6 +686,67 @@ jack_attach_lib_shm_read (jack_shm_info_t* si)
+ 
+ #ifdef USE_POSIX_SHM
+ 
++
++
++static int shm_unlink(const char *name) {
++    size_t namelen;
++    char *fname;
++
++    /* Construct the filename.  */
++    while (name[0] == '/') ++name;
++
++    if (name[0] == '\0') {
++        /* The name "/" is not supported.  */
++        errno = EINVAL;
++        return -1;
++    }
++
++    namelen = strlen(name);
++    fname = (char *) alloca(sizeof("@TERMUX_PREFIX@/tmp/") - 1 + namelen + 1);
++    memcpy(fname, "@TERMUX_PREFIX@/tmp/", sizeof("@TERMUX_PREFIX@/tmp/") - 1);
++    memcpy(fname + sizeof("@TERMUX_PREFIX@/tmp/") - 1, name, namelen + 1);
++
++    return unlink(fname);
++}
++
++static int shm_open(const char *name, int oflag, mode_t mode) {
++    size_t namelen;
++    char *fname;
++    int fd;
++
++    /* Construct the filename.  */
++    while (name[0] == '/') ++name;
++
++    if (name[0] == '\0') {
++        /* The name "/" is not supported.  */
++        errno = EINVAL;
++        return -1;
++    }
++
++    namelen = strlen(name);
++    fname = (char *) alloca(sizeof("@TERMUX_PREFIX@/tmp/") - 1 + namelen + 1);
++    memcpy(fname, "@TERMUX_PREFIX@/tmp/", sizeof("@TERMUX_PREFIX@/tmp/") - 1);
++    memcpy(fname + sizeof("@TERMUX_PREFIX@/tmp/") - 1, name, namelen + 1);
++
++    fd = open(fname, oflag, mode);
++    if (fd != -1) {
++        /* We got a descriptor.  Now set the FD_CLOEXEC bit.  */
++        int flags = fcntl(fd, F_GETFD, 0);
++        flags |= FD_CLOEXEC;
++        flags = fcntl(fd, F_SETFD, flags);
++
++        if (flags == -1) {
++            /* Something went wrong.  We cannot return the descriptor.  */
++            int save_errno = errno;
++            close(fd);
++            fd = -1;
++            errno = save_errno;
++        }
++    }
++
++    return fd;
++}
++
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  * POSIX interface-dependent functions
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+diff --git a/common/shm.h b/common/shm.h
+index 3e3276d..3f0cf3a 100644
+--- a/common/shm.h
++++ b/common/shm.h
+@@ -70,6 +70,7 @@ extern "C"
+ #endif
+     typedef char shm_name_t[SHM_NAME_MAX];
+     typedef shm_name_t jack_shm_id_t;
++    typedef int jack_shm_fd_t;
+ 
+ #elif WIN32
+ #define NAME_MAX 255
+@@ -89,7 +90,7 @@ extern "C"
+ #define SHM_NAME_MAX NAME_MAX
+ #endif
+     typedef char shm_name_t[SHM_NAME_MAX];
+-    typedef shm_name_t jack_shm_id_t;
++    typedef int	jack_shm_id_t;
+     typedef int jack_shm_fd_t;
+ 
+ #else
+diff --git a/common/wscript b/common/wscript
+index 178d4c1..720b28f 100644
+--- a/common/wscript
++++ b/common/wscript
+@@ -87,7 +87,7 @@ def build(bld):
+             'JackDebugClient.cpp',
+             'timestamps.c',
+             'promiscuous.c',
+-            '../posix/JackPosixThread.cpp',
++            '../android/JackAndroidThread.cpp',
+             '../posix/JackPosixProcessSync.cpp',
+             '../posix/JackPosixMutex.cpp',
+             '../posix/JackSocket.cpp',
+@@ -309,6 +309,7 @@ def build(bld):
+             '../posix/JackSocketNotifyChannel.cpp',
+             '../posix/JackSocketServerNotifyChannel.cpp',
+             '../posix/JackNetUnixSocket.cpp',
++            '../android/JackControlAPIAndroid.cpp',
+             ]
+ 
+     if bld.env['IS_FREEBSD']:
+@@ -397,7 +398,7 @@ def build(bld):
+         if bld.env['IS_LINUX']:
+             netlib.source += [
+                 '../posix/JackNetUnixSocket.cpp',
+-                '../posix/JackPosixThread.cpp',
++                '../android/JackAndroidThread.cpp',
+                 '../posix/JackPosixMutex.cpp',
+                 '../linux/JackLinuxTime.c',
+             ]
+diff --git a/linux/JackLinuxFutex.cpp b/linux/JackLinuxFutex.cpp
+index 29b1390..64b9aeb 100644
+--- a/linux/JackLinuxFutex.cpp
++++ b/linux/JackLinuxFutex.cpp
+@@ -34,6 +34,66 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ #define SYS_futex SYS_futex_time64
+ #endif
+ 
++
++static int shm_unlink(const char *name) {
++    size_t namelen;
++    char *fname;
++
++    /* Construct the filename.  */
++    while (name[0] == '/') ++name;
++
++    if (name[0] == '\0') {
++        /* The name "/" is not supported.  */
++        errno = EINVAL;
++        return -1;
++    }
++
++    namelen = strlen(name);
++    fname = (char *) alloca(sizeof("@TERMUX_PREFIX@/tmp/") - 1 + namelen + 1);
++    memcpy(fname, "@TERMUX_PREFIX@/tmp/", sizeof("@TERMUX_PREFIX@/tmp/") - 1);
++    memcpy(fname + sizeof("@TERMUX_PREFIX@/tmp/") - 1, name, namelen + 1);
++
++    return unlink(fname);
++}
++
++static int shm_open(const char *name, int oflag, mode_t mode) {
++    size_t namelen;
++    char *fname;
++    int fd;
++
++    /* Construct the filename.  */
++    while (name[0] == '/') ++name;
++
++    if (name[0] == '\0') {
++        /* The name "/" is not supported.  */
++        errno = EINVAL;
++        return -1;
++    }
++
++    namelen = strlen(name);
++    fname = (char *) alloca(sizeof("@TERMUX_PREFIX@/tmp/") - 1 + namelen + 1);
++    memcpy(fname, "@TERMUX_PREFIX@/tmp/", sizeof("@TERMUX_PREFIX@/tmp/") - 1);
++    memcpy(fname + sizeof("@TERMUX_PREFIX@/tmp/") - 1, name, namelen + 1);
++
++    fd = open(fname, oflag, mode);
++    if (fd != -1) {
++        /* We got a descriptor.  Now set the FD_CLOEXEC bit.  */
++        int flags = fcntl(fd, F_GETFD, 0);
++        flags |= FD_CLOEXEC;
++        flags = fcntl(fd, F_SETFD, flags);
++
++        if (flags == -1) {
++            /* Something went wrong.  We cannot return the descriptor.  */
++            int save_errno = errno;
++            close(fd);
++            fd = -1;
++            errno = save_errno;
++        }
++    }
++
++    return fd;
++}
++
+ namespace Jack
+ {
+ 
+diff --git a/linux/JackPlatformPlug_os.h b/linux/JackPlatformPlug_os.h
+index 60c9a58..cd0803a 100644
+--- a/linux/JackPlatformPlug_os.h
++++ b/linux/JackPlatformPlug_os.h
+@@ -30,7 +30,7 @@ namespace Jack
+     struct JackResult;
+ 
+     class JackPosixMutex;
+-    class JackPosixThread;
++    class JackAndroidThread;
+     class JackFifo;
+     class JackSocketServerChannel;
+     class JackSocketClientChannel;
+@@ -46,7 +46,7 @@ namespace Jack {typedef JackPosixMutex JackMutex; }
+ 
+ /* __JackPlatformThread__ */
+ #include "JackPosixThread.h"
+-namespace Jack { typedef JackPosixThread JackThread; }
++namespace Jack { typedef JackAndroidThread JackThread; }
+ 
+ /* __JackPlatformSynchro__  client activation */
+ /*
+diff --git a/linux/alsa/JackAlsaDriver.cpp b/linux/alsa/JackAlsaDriver.cpp
+index 0ac2919..2aa310f 100644
+--- a/linux/alsa/JackAlsaDriver.cpp
++++ b/linux/alsa/JackAlsaDriver.cpp
+@@ -40,7 +40,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ #include "JackGraphManager.h"
+ #include "JackLockedEngine.h"
+ #ifdef __ANDROID__
+-#include "JackAndroidThread.h"
++#include "../android/JackAndroidThread.h"
+ #else
+ #include "JackPosixThread.h"
+ #endif
+@@ -362,7 +362,7 @@ int JackAlsaDriver::Open(jack_nframes_t nframes,
+     fPlaybackChannels = ((alsa_driver_t *)fDriver)->playback_nchannels;
+     if (JackServerGlobals::on_device_reservation_loop != NULL) {
+         device_reservation_loop_running = true;
+-        if (JackPosixThread::StartImp(&fReservationLoopThread, 0, 0, on_device_reservation_loop, NULL) != 0) {
++        if (JackAndroidThread::StartImp(&fReservationLoopThread, 0, 0, on_device_reservation_loop, NULL) != 0) {
+             device_reservation_loop_running = false;
+         }
+     }
+@@ -381,7 +381,7 @@ int JackAlsaDriver::Close()
+ 
+     if (device_reservation_loop_running) {
+         device_reservation_loop_running = false;
+-        JackPosixThread::StopImp(fReservationLoopThread);
++        JackAndroidThread::StopImp(fReservationLoopThread);
+     }
+ 
+     if (JackServerGlobals::on_device_release != NULL)
+diff --git a/posix/JackPosixThread.h b/posix/JackPosixThread.h
+index 599bf49..1d0fa32 100644
+--- a/posix/JackPosixThread.h
++++ b/posix/JackPosixThread.h
+@@ -21,6 +21,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ #ifndef __JackPosixThread__
+ #define __JackPosixThread__
+ 
++#ifdef __ANDROID__
++
++#include "../android/JackAndroidThread.h"
++
++#else
++
+ #include "JackThread.h"
+ #include <pthread.h>
+ 
+@@ -85,5 +91,6 @@ SERVER_EXPORT void ThreadExit();
+ 
+ } // end of namespace
+ 
++#endif
+ 
+ #endif
+diff --git a/posix/JackSystemDeps_os.h b/posix/JackSystemDeps_os.h
+index 18ea74c..6d12bad 100644
+--- a/posix/JackSystemDeps_os.h
++++ b/posix/JackSystemDeps_os.h
+@@ -41,4 +41,12 @@
+ 
+ #define JACK_DEBUG (getenv("JACK_CLIENT_DEBUG") && strcmp(getenv("JACK_CLIENT_DEBUG"), "on") == 0)
+ 
++#ifdef __ANDROID__
++
++/**
++ *  bionic c dependent functions, copied from ../android/JackSystemDeps_os.h
++ */
++#define pthread_setcanceltype(x,y)  (0)
++#endif
++
+ #endif

--- a/packages/jack2/0002-fix-path.patch
+++ b/packages/jack2/0002-fix-path.patch
@@ -1,0 +1,54 @@
+diff --git a/common/JackTools.cpp b/common/JackTools.cpp
+index 94e7034..5214a42 100644
+--- a/common/JackTools.cpp
++++ b/common/JackTools.cpp
+@@ -54,7 +54,7 @@ namespace Jack {
+ #endif
+     }
+ 
+-#define DEFAULT_TMP_DIR "/tmp"
++#define DEFAULT_TMP_DIR "@TERMUX_PREFIX@/tmp"
+     char* jack_tmpdir = (char*)DEFAULT_TMP_DIR;
+ 
+     int JackTools::GetPID()
+diff --git a/linux/JackPlatformPlug_os.h b/linux/JackPlatformPlug_os.h
+index cd0803a..e3400a6 100644
+--- a/linux/JackPlatformPlug_os.h
++++ b/linux/JackPlatformPlug_os.h
+@@ -20,8 +20,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ #ifndef __JackPlatformPlug_linux__
+ #define __JackPlatformPlug_linux__
+ 
+-#define jack_server_dir "/dev/shm"
+-#define jack_client_dir "/dev/shm"
++#define jack_server_dir "@TERMUX_PREFIX@/tmp"
++#define jack_client_dir "@TERMUX_PREFIX@/tmp"
+ #define JACK_DEFAULT_DRIVER "alsa"
+ 
+ namespace Jack
+diff --git a/posix/JackPosixSemaphore.cpp b/posix/JackPosixSemaphore.cpp
+index 4901231..ba2d1a9 100644
+--- a/posix/JackPosixSemaphore.cpp
++++ b/posix/JackPosixSemaphore.cpp
+@@ -160,7 +160,7 @@ bool JackPosixSemaphore::Allocate(const char* name, const char* server_name, int
+ #ifdef __linux__
+         if (fPromiscuous) {
+             char sempath[SYNC_MAX_NAME_SIZE+13];
+-            snprintf(sempath, sizeof(sempath), "/dev/shm/sem.%s", fName);
++            snprintf(sempath, sizeof(sempath), "@TERMUX_PREFIX@/tmp/sem.%s", fName);
+             if (jack_promiscuous_perms(-1, sempath, fPromiscuousGid) < 0)
+                 return false;
+         }
+diff --git a/tests/testThread.cpp b/tests/testThread.cpp
+index de012f7..5dfe479 100644
+--- a/tests/testThread.cpp
++++ b/tests/testThread.cpp
+@@ -56,7 +56,7 @@ int main(int argc, char * const argv[])
+ 	printf("Thread test\n");
+ 	std::set_terminate(__gnu_cxx::__verbose_terminate_handler);
+ 
+-	sprintf(fName, "/tmp/fifo");
++	sprintf(fName, "@TERMUX_PREFIX@/tmp/fifo");
+ 
+ 	if (stat(fName, &statbuf)) {
+ 		if (errno == ENOENT) {

--- a/packages/jack2/0003-opensles-driver.patch
+++ b/packages/jack2/0003-opensles-driver.patch
@@ -1,0 +1,42 @@
+diff --git a/android/opensl_io.c b/android/opensl_io.c
+index 38b6ec0..0af9bc5 100644
+--- a/android/opensl_io.c
++++ b/android/opensl_io.c
+@@ -512,7 +512,7 @@ int waitThreadLock(void *lock)
+   }
+   p->s = (unsigned char) 0;
+   pthread_mutex_unlock(&(p->m));
+-  return NULL;
++  return 0;
+ }
+ 
+ void notifyThreadLock(void *lock)
+diff --git a/wscript b/wscript
+index 86eb395..09b0411 100644
+--- a/wscript
++++ b/wscript
+@@ -699,6 +699,11 @@ def build_drivers(bld):
+         'solaris/oss/JackOSSDriver.cpp'
+     ]
+ 
++    opensles_src = [
++        'android/JackOpenSLESDriver.cpp', 
++        'android/opensl_io.c'
++    ]
++
+     portaudio_src = [
+         'windows/portaudio/JackPortAudioDevices.cpp',
+         'windows/portaudio/JackPortAudioDriver.cpp',
+@@ -741,6 +746,12 @@ def build_drivers(bld):
+ 
+     # Create hardware driver objects. Lexically sorted after the conditional,
+     # e.g. BUILD_DRIVER_ALSA.
++    create_driver_obj(
++        bld,
++        target='opensles',
++        source=opensles_src, 
++        lib=['OpenSLES'])
++    
+     if bld.env['BUILD_DRIVER_ALSA']:
+         create_driver_obj(
+             bld,

--- a/packages/jack2/0004-remove-su-features.patch
+++ b/packages/jack2/0004-remove-su-features.patch
@@ -1,0 +1,94 @@
+diff --git a/android/JackAndroidThread.cpp b/android/JackAndroidThread.cpp
+index b30dc78..ac58baf 100644
+--- a/android/JackAndroidThread.cpp
++++ b/android/JackAndroidThread.cpp
+@@ -125,27 +125,6 @@ int JackAndroidThread::StartImp(jack_native_thread_t* thread, int priority, int
+         return -1;
+     }
+ 
+-    if (realtime) {
+-
+-        jack_log("JackAndroidThread::StartImp : create RT thread");
+-
+-        if ((res = pthread_attr_setschedpolicy(&attributes, JACK_SCHED_POLICY))) {
+-            jack_error("Cannot set RR scheduling class for RT thread res = %d", res);
+-            return -1;
+-        }
+-
+-        memset(&rt_param, 0, sizeof(rt_param));
+-        rt_param.sched_priority = priority;
+-
+-        if ((res = pthread_attr_setschedparam(&attributes, &rt_param))) {
+-            jack_error("Cannot set scheduling priority for RT thread res = %d", res);
+-            return -1;
+-        }
+-
+-    } else {
+-        jack_log("JackAndroidThread::StartImp : create non RT thread");
+-    }
+-
+     if ((res = pthread_attr_setstacksize(&attributes, THREAD_STACK))) {
+         jack_error("Cannot set thread stack size res = %d", res);
+         return -1;
+@@ -238,27 +217,6 @@ int JackAndroidThread::AcquireSelfRealTime(int priority)
+ }
+ int JackAndroidThread::AcquireRealTimeImp(jack_native_thread_t thread, int priority)
+ {
+-    struct sched_param rtparam;
+-    int res;
+-    memset(&rtparam, 0, sizeof(rtparam));
+-    rtparam.sched_priority = priority;
+-
+-    jack_log("JackAndroidThread::AcquireRealTimeImp priority = %d", priority);
+-
+-#ifndef JACK_ANDROID_REALTIME_SCHED
+-    if ((res = pthread_setschedparam(thread, JACK_SCHED_POLICY, &rtparam)) != 0) {
+-        jack_error("Cannot use real-time scheduling (RR/%d)"
+-                   "(%d: %s)", rtparam.sched_priority, res,
+-                   strerror(res));
+-        return -1;
+-    }
+-#else
+-    if ((res = android::requestPriority(getpid(), gettid(), priority)) != 0) {
+-        jack_log("Failed to get SCHED_FIFO priority pid %d tid %d; error %d",
+-		    getpid(), gettid(), res);
+-        return -1;
+-    }
+-#endif
+     return 0;
+ }
+ 
+@@ -274,15 +232,6 @@ int JackAndroidThread::DropSelfRealTime()
+ 
+ int JackAndroidThread::DropRealTimeImp(jack_native_thread_t thread)
+ {
+-    struct sched_param rtparam;
+-    int res;
+-    memset(&rtparam, 0, sizeof(rtparam));
+-    rtparam.sched_priority = 0;
+-
+-    if ((res = pthread_setschedparam(thread, SCHED_OTHER, &rtparam)) != 0) {
+-        jack_error("Cannot switch to normal scheduling priority(%s)", strerror(errno));
+-        return -1;
+-    }
+     return 0;
+ }
+ 
+diff --git a/posix/JackShmMem_os.h b/posix/JackShmMem_os.h
+index b572342..5e71b51 100644
+--- a/posix/JackShmMem_os.h
++++ b/posix/JackShmMem_os.h
+@@ -24,9 +24,9 @@
+ #include <sys/types.h>
+ #include <sys/mman.h>
+ 
+-#define CHECK_MLOCK(ptr, size) (mlock((ptr), (size)) == 0)
+-#define CHECK_MUNLOCK(ptr, size) (munlock((ptr), (size)) == 0)
+-#define CHECK_MLOCKALL() (mlockall(MCL_CURRENT | MCL_FUTURE) == 0)
+-#define CHECK_MUNLOCKALL() (munlockall() == 0)
++#define CHECK_MLOCK(ptr, size) (TRUE)
++#define CHECK_MUNLOCK(ptr, size) (TRUE)
++#define CHECK_MLOCKALL() (TRUE)
++#define CHECK_MUNLOCKALL() (TRUE)
+ 
+ #endif

--- a/packages/jack2/build.sh
+++ b/packages/jack2/build.sh
@@ -1,0 +1,23 @@
+TERMUX_PKG_HOMEPAGE=https://jackaudio.org/
+TERMUX_PKG_DESCRIPTION="The JACK low-latency audio server"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_VERSION=1.9.22
+TERMUX_PKG_SRCURL=https://github.com/jackaudio/jack2/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=1e42b9fc4ad7db7befd414d45ab2f8a159c0b30fcd6eee452be662298766a849
+TERMUX_PKG_DEPENDS="alsa-lib, dbus, libandroid-posix-semaphore, libdb, libexpat, libsamplerate, libopus"
+# TERMUX_PKG_CONFLICTS="pipewire-jack"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_configure() {
+	LDFLAGS+=" -landroid-posix-semaphore"
+	python3 ./waf configure --alsa --classic --prefix="$TERMUX_PREFIX" --htmldir=$TERMUX_PREFIX/share/doc/jack2/html --firewire=no
+}
+
+termux_step_make() {
+	python3 ./waf build
+}
+
+termux_step_make_install() {
+	python3 ./waf install
+}

--- a/packages/mpv/build.sh
+++ b/packages/mpv/build.sh
@@ -4,10 +4,11 @@ TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 # Update both mpv and mpv-x to the same version in one PR.
 TERMUX_PKG_VERSION="0.38.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/mpv-player/mpv/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=86d9ef40b6058732f67b46d0bbda24a074fae860b3eaae05bab3145041303066
 TERMUX_PKG_AUTO_UPDATE=false
-TERMUX_PKG_DEPENDS="ffmpeg, libandroid-glob, libandroid-support, libarchive, libass, libcaca, libiconv, liblua52, libsixel, libuchardet, openal-soft, pulseaudio, rubberband, zlib, libplacebo"
+TERMUX_PKG_DEPENDS="alsa-lib, ffmpeg, jack, libandroid-glob, libandroid-support, libarchive, libass, libcaca, libiconv, liblua52, libsixel, libuchardet, openal-soft, pulseaudio, rubberband, zlib, libplacebo"
 TERMUX_PKG_RM_AFTER_INSTALL="share/icons share/applications"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dlibmpv=true

--- a/x11-packages/mpv-x/build.sh
+++ b/x11-packages/mpv-x/build.sh
@@ -5,10 +5,11 @@ TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 # Update both mpv and mpv-x to the same version in one PR.
 TERMUX_PKG_VERSION="0.38.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/mpv-player/mpv/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=86d9ef40b6058732f67b46d0bbda24a074fae860b3eaae05bab3145041303066
 TERMUX_PKG_AUTO_UPDATE=false
-TERMUX_PKG_DEPENDS="ffmpeg, libandroid-glob, libandroid-shmem, libarchive, libass, libbluray, libcaca, libdrm, libdvdnav, libiconv, libjpeg-turbo, liblua52, libsixel, libuchardet, libx11, libxext, libxinerama, libxpresent, libxrandr, libxss, libzimg, littlecms, openal-soft, pipewire, pulseaudio, rubberband, zlib, libplacebo"
+TERMUX_PKG_DEPENDS="alsa-lib, ffmpeg, jack, libandroid-glob, libandroid-shmem, libarchive, libass, libbluray, libcaca, libdrm, libdvdnav, libiconv, libjpeg-turbo, liblua52, libsixel, libuchardet, libx11, libxext, libxinerama, libxpresent, libxrandr, libxss, libzimg, littlecms, openal-soft, pipewire, pulseaudio, rubberband, zlib, libplacebo"
 TERMUX_PKG_CONFLICTS="mpv"
 TERMUX_PKG_REPLACES="mpv"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="


### PR DESCRIPTION
Few packages
* `jack2` is an audio server. On Android, it can use OpenSLES as backend. 
* The metapackage `jack` is for dependency management and will accept the upcoming `pipewire-jack` as an option. By the way, I am not interested in making `jack1` functional and be one of the `jack` option, given that we have `jack2` now and it seems Linux distros usually not packing `jack1` officially (at least for Archlinux it is in AUR). 
* `alsa-lib` as deps of `jack2`. Also, it is tested to work along with `pipewire-alsa` which will be finalized in the pipewire PR. 
* `mpv` and `mpv-x` are updated to support jack and alsa audio output

Tested working with: 
```
jackd -d opensles
```
and then use the updated mpv in this PR
```
mpv --ao=jack ./test.wav
```

By the way, since https://github.com/termux/termux-packages/pull/20353 also use jack (which I put a stub and useless jack1), I will refactor that PR after this is merged. 
