### PR TITLE
chore(x11/qt5-qtwebengine): Switch from clang-15 to clang-17

### DIFF
--- a/x11-packages/qt5-qtwebengine/build.sh
+++ b/x11-packages/qt5-qtwebengine/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Qt 5 Web Engine Library"
 TERMUX_PKG_LICENSE="LGPL-3.0, LGPL-2.1, BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@licy183"
 TERMUX_PKG_VERSION="5.15.15"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=git+https://github.com/qt/qtwebengine
 TERMUX_PKG_GIT_BRANCH=v$TERMUX_PKG_VERSION-lts
 TERMUX_PKG_DEPENDS="dbus, fontconfig, libc++, libexpat, libjpeg-turbo, libminizip, libnspr, libnss, libpng, libsnappy, libvpx, libwebp, libx11, libxkbfile, qt5-qtbase, qt5-qtdeclarative, zlib"
@@ -14,9 +14,9 @@ TERMUX_PKG_HOSTBUILD=true
 termux_step_host_build() {
 	# Generate ffmpeg headers for i686
 	mkdir -p fake-bin
-	ln -s $(command -v clang-15) fake-bin/clang
-	ln -s $(command -v clang++-15) fake-bin/clang++
-	
+	ln -s $(command -v clang-17) fake-bin/clang
+	ln -s $(command -v clang++-17) fake-bin/clang++
+
 	PATH="$PWD/fake-bin:$PATH" python2 $TERMUX_PKG_SRCDIR/src/3rdparty/chromium/third_party/ffmpeg/chromium/scripts/build_ffmpeg.py --config-only linux noasm-ia32
 }
 


### PR DESCRIPTION
This is one of the few packages depending on host llvm 15 being installed. Soon the transition to llvm 17 is complete, and we can drop llvm 15 from the Docker image for size and maintenance reasons.