### PR TITLE
fix(main/flang): Fix unmet dependencies problem

### DIFF
--- a/packages/flang/build.sh
+++ b/packages/flang/build.sh
@@ -5,13 +5,15 @@ TERMUX_PKG_LICENSE_FILE="flang/LICENSE.TXT"
 TERMUX_PKG_MAINTAINER="@termux"
 LLVM_MAJOR_VERSION=18
 TERMUX_PKG_VERSION=${LLVM_MAJOR_VERSION}.1.7
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$TERMUX_PKG_VERSION/llvm-project-$TERMUX_PKG_VERSION.src.tar.xz
 TERMUX_PKG_SHA256=74446ab6943f686391954cbda0d77ae92e8a60c432eff437b8666e121d748ec4
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_HOSTBUILD=true
 # `flang-new` should be rebuilt when libllvm bumps version.
 # See https://github.com/termux/termux-packages/issues/19362
-TERMUX_PKG_DEPENDS="libc++, libllvm (= $TERMUX_PKG_VERSION), clang (= $TERMUX_PKG_VERSION), lld (= $TERMUX_PKG_VERSION), mlir (= $TERMUX_PKG_VERSION)"
+DEP_QUALIFIER=$TERMUX_PKG_VERSION-$TERMUX_PKG_REVISION
+TERMUX_PKG_DEPENDS="libc++, libllvm (= $DEP_QUALIFIER), clang (= $DEP_QUALIFIER), lld (= $DEP_QUALIFIER), mlir (= $DEP_QUALIFIER)"
 TERMUX_PKG_BUILD_DEPENDS="libllvm-static"
 
 # Upstream doesn't support 32-bit arches well. See https://github.com/llvm/llvm-project/issues/57621.


### PR DESCRIPTION
Currently `pkg install flang` gives the below error:

> The following packages have unmet dependencies:
> flang : Depends: libllvm (= 18.1.7) but 18.1.7-1 is to be installed
>         Depends: clang (= 18.1.7) but 18.1.7-1 is to be installed
>         Depends: lld (= 18.1.7) but 18.1.7-1 is to be installed
>         Depends: mlir (= 18.1.7) but 18.1.7-1 is to be installed
> E: Unable to correct problems, you have held broken packages.

This is due to the `(= $TERMUX_PKG_VERSION)` version qualifier on llvm dependencies, introduced in 50737838a5344f1e128f4164b90af07378945cc0 to make sure that llvm matches the flang version.

This is fine for the upstream version (version `18.1.7` of flang should depend on version `18.1.7`).

But when bumping the `TERMUX_PKG_REVISION` on llvm, which was done in 58811a96a6db7f8282bd8e1ad2c99b44d0b1b253, it results in the problem we have now: flang `18.1.7` depends on exactly `18.1.7`, while the repository has `18.1.7-1`.

Ideally we would probably want to ignore the package revision, and allow all revisions of flang 18.1.7 to depend on all revisions of llvm 18.1.7 - effectively a revision wildcard. Is that (or some variant) possible with debian version qualifiers?

This commit just bumps the `TERMUX_PKG_REVISION` of `flang` and uses that to match the current llvm revision in the dependency, so that the flang package is installable again. If we can't come up with a better approach short term we can probably go for this now to make the package installable again.

Reported by @timstrom in https://github.com/termux-play-store/termux-packages/issues/3