### PR TITLE
fix(main/libsoup): Fix build with current toolchain

### DIFF
--- a/packages/libsoup/0001-Fix-build-with-libxml2-2.12.0-and-clang-17.patch
+++ b/packages/libsoup/0001-Fix-build-with-libxml2-2.12.0-and-clang-17.patch
@@ -1,0 +1,44 @@
+From ced3c5d8cad0177b297666343f1561799dfefb0d Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 22 Nov 2023 18:49:10 -0800
+Subject: [PATCH] Fix build with libxml2-2.12.0 and clang-17
+
+Fixes build errors about missing function prototypes with clang-17
+
+Fixes
+| ../libsoup-2.74.3/libsoup/soup-xmlrpc-old.c:512:8: error: call to undeclared function 'xmlParseMemory'; ISO C99 and later do not support implicit function declarations
+
+Upstream-Status: Submitted [https://gitlab.gnome.org/GNOME/libsoup/-/merge_requests/385]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ libsoup/soup-xmlrpc-old.c | 1 +
+ libsoup/soup-xmlrpc.c     | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/libsoup/soup-xmlrpc-old.c b/libsoup/soup-xmlrpc-old.c
+index c57086b6..527e3b23 100644
+--- a/libsoup/soup-xmlrpc-old.c
++++ b/libsoup/soup-xmlrpc-old.c
+@@ -11,6 +11,7 @@
+ 
+ #include <string.h>
+ 
++#include <libxml/parser.h>
+ #include <libxml/tree.h>
+ 
+ #include "soup-xmlrpc-old.h"
+diff --git a/libsoup/soup-xmlrpc.c b/libsoup/soup-xmlrpc.c
+index 42dcda9c..e991cbf0 100644
+--- a/libsoup/soup-xmlrpc.c
++++ b/libsoup/soup-xmlrpc.c
+@@ -17,6 +17,7 @@
+ 
+ #include <string.h>
+ #include <errno.h>
++#include <libxml/parser.h>
+ #include <libxml/tree.h>
+ #include "soup-xmlrpc.h"
+ #include "soup.h"
+-- 
+2.43.0
+

--- a/packages/libsoup/build.sh
+++ b/packages/libsoup/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 # This specific package is for libsoup-2.4.
 # libsoup-3.0 is packaged as libsoup3.
 TERMUX_PKG_VERSION=2.74.3
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://download.gnome.org/sources/libsoup/${TERMUX_PKG_VERSION%.*}/libsoup-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=e4b77c41cfc4c8c5a035fcdc320c7bc6cfb75ef7c5a034153df1413fa1d92f13
 TERMUX_PKG_AUTO_UPDATE=false
@@ -25,6 +25,17 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 
 termux_step_pre_configure() {
 	termux_setup_gir
+
+	local _WRAPPER_BIN="${TERMUX_PKG_BUILDDIR}/_wrapper/bin"
+	mkdir -p "${_WRAPPER_BIN}"
+	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "false" ]]; then
+		sed "s|^export PKG_CONFIG_LIBDIR=|export PKG_CONFIG_LIBDIR=${TERMUX_PREFIX}/opt/glib/cross/lib/x86_64-linux-gnu/pkgconfig:|" \
+			"${TERMUX_STANDALONE_TOOLCHAIN}/bin/pkg-config" \
+			> "${_WRAPPER_BIN}/pkg-config"
+		chmod +x "${_WRAPPER_BIN}/pkg-config"
+		export PKG_CONFIG="${_WRAPPER_BIN}/pkg-config"
+	fi
+	export PATH="${_WRAPPER_BIN}:${PATH}"
 }
 
 termux_step_post_massage() {


### PR DESCRIPTION
The `_WRAPPER_BIN` section is copied from [libsoup3 build.sh](https://github.com/termux/termux-packages/blob/master/packages/libsoup3/build.sh#L25-L34) - should we do it differently? Without it the build fails with:

> OSError: [Errno 8] Exec format error: '/data/data/com.termux/files/usr/bin/glib-mkenums

The patch is (as seen in the file) taken from https://gitlab.gnome.org/GNOME/libsoup/-/merge_requests/385 - merged upstream but not released yet. It fixes the below build error:

> ../src/libsoup/soup-xmlrpc-old.c:512:8: error: call to undeclared function 'xmlParseMemory'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]                                                                                                                                                                                
        doc = xmlParseMemory (method_call,
              ^
../src/libsoup/soup-xmlrpc-old.c:512:6: error: incompatible integer to pointer conversion assigning to 'xmlDoc *' (aka 'struct _xmlDoc *') from 'int' [-Wint-conversion]
        doc = xmlParseMemory (method_call,
            ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/libsoup/soup-xmlrpc-old.c:629:8: error: call to undeclared function 'xmlParseMemory'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-decla
ration]
        doc = xmlParseMemory (method_response,
              ^
../src/libsoup/soup-xmlrpc-old.c:629:6: error: incompatible integer to pointer conversion assigning to 'xmlDoc *' (aka 'struct _xmlDoc *') from 'int' [-Wint-conversion]
        doc = xmlParseMemory (method_response,
