### PR TITLE
fix(main/libgee): Fix build with current toolchain

### DIFF
--- a/packages/libgee/build.sh
+++ b/packages/libgee/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 _MAJOR_VERSION=0.20
 TERMUX_PKG_VERSION=${_MAJOR_VERSION}.6
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://ftp.gnome.org/pub/GNOME/sources/libgee/${_MAJOR_VERSION}/libgee-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=1bf834f5e10d60cc6124d74ed3c1dd38da646787fbf7872220b8b4068e476d4d
 TERMUX_PKG_DEPENDS="glib"
@@ -14,5 +15,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 "
 
 termux_step_pre_configure() {
+	CFLAGS+=" -Wno-incompatible-function-pointer-types"
 	termux_setup_gir
 }


### PR DESCRIPTION
See https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271485:

> Clang 16 has a new error about incompatible function types, which shows
> up when building devel/libgee:
>
> hashmap.c:4089:23: error: incompatible function pointer types assigning to 'gboolean (*)(GeeMapIterator *)' (aka 'int (*)(struct _GeeMapIterator *)') from 'gboolean (GeeHashMapNodeIterator *)' (aka 'int (struct _GeeHashMapNodeIterator *)') [-Wincompatible-function-pointer-types]
>              iface->get_read_only = gee_hash_map_map_iterator_real_get_read_only;
>                                   ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> Since the error occurs in vala-generated code, it does not make sense to
> patch the .c file. Suppress the warning instead.