### PR TITLE
chore(main/libgcrypt): Switch to the clang integrated assembler

### DIFF
--- a/packages/libgcrypt/build.sh
+++ b/packages/libgcrypt/build.sh
@@ -4,10 +4,10 @@ TERMUX_PKG_LICENSE="GPL-2.0, LGPL-2.1, BSD 3-Clause, MIT, Public Domain"
 TERMUX_PKG_LICENSE_FILE="COPYING, COPYING.LIB, LICENSES"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.10.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=8b0870897ac5ac67ded568dcfadf45969cfa8a6beb0fd60af2a9eadc2a3272aa
 TERMUX_PKG_DEPENDS="libgpg-error"
-TERMUX_PKG_BUILD_DEPENDS="binutils-cross"
 TERMUX_PKG_BREAKS="libgcrypt-dev"
 TERMUX_PKG_REPLACES="libgcrypt-dev"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
@@ -34,7 +34,6 @@ termux_step_post_get_source() {
 termux_step_pre_configure() {
 	autoreconf -fi
 
-	termux_setup_no_integrated_as
 	if [ "$TERMUX_ARCH" = arm ]; then
 		# See http://marc.info/?l=gnupg-devel&m=139136972631909&w=3
 		CFLAGS+=" -mno-unaligned-access"


### PR DESCRIPTION
The `-no-integrated-as` build flag was added waaay back (7 years ago) when clang was a lot newer and seems to be no longer necessary, either due to improvements in clang or with code changes to make assembly portable in libgcrypt.