### PR TITLE
enhance(main/zsh): enable zsh/newuser module.

### DIFF
--- a/packages/zsh/build.sh
+++ b/packages/zsh/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.zsh.org
 TERMUX_PKG_DESCRIPTION="Shell with lots of features"
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="LICENCE"
-TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION=5.9
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL="https://sourceforge.net/projects/zsh/files/zsh/$TERMUX_PKG_VERSION/zsh-$TERMUX_PKG_VERSION".tar.xz
 TERMUX_PKG_SHA256=9b8d1ecedd5b5e81fbf1918e876752a7dd948e05c1a0dba10ab863842d45acd5
 # Remove hard link to bin/zsh as Android does not support hard links:
@@ -68,24 +68,29 @@ termux_step_post_configure() {
 	fi
 
 	# INSTALL file: "For a non-dynamic zsh, the default is to compile the complete, compctl, zle,
-	# computil, complist, sched, # parameter, zleparameter and rlimits modules into the shell,
+	# computil, complist, sched, parameter, zleparameter and rlimits modules into the shell,
 	# and you will need to edit config.modules to make any other modules available."
 	# Since we build zsh non-dynamically (since dynamic loading doesn't work on Android when enabled),
 	# we need to explicitly enable the additional modules we want.
-	# - The files module is needed by `compinstall` (https://github.com/termux/termux-packages/issues/61).
-	# - The regex module seems to be used by several extensions.
-	# - The curses, socket and zprof modules was desired by BrainDamage on IRC (#termux).
-	# - The deltochar and mathfunc modules is used by grml-zshrc (https://github.com/termux/termux-packages/issues/494).
-	# - The system module is needed by zplug (https://github.com/termux/termux-packages/issues/659).
-	# - The zpty module is needed by zsh-async (https://github.com/termux/termux-packages/issues/672).
-	# - The stat module is needed by zui (https://github.com/termux/termux-packages/issues/2829).
-	# - The mapfile module was requested in https://github.com/termux/termux-packages/issues/3116.
-	# - The zselect module is used by multiple plugins (https://github.com/termux/termux-packages/issues/4939)
-	# - The param_private module was requested in https://github.com/termux/termux-packages/issues/7391.
-	# - The cap module was requested in https://github.com/termux/termux-packages/issues/3102.
-	for module in cap curses deltochar files mapfile mathfunc pcre regex \
-		socket stat system zprof zpty zselect param_private
-	do
+	local modules=(
+	'cap'           # - The cap module was requested in https://github.com/termux/termux-packages/issues/3102.
+	'curses'        # - The curses module was requested by BrainDamage on IRC (#termux).
+	'deltochar'     # - The deltochar module is used by grml-zshrc https://github.com/termux/termux-packages/issues/494.
+	'files'         # - The files module is needed by `compinstall` https://github.com/termux/termux-packages/issues/61.
+	'mapfile'       # - The mapfile module was requested in https://github.com/termux/termux-packages/issues/3116.
+	'mathfunc'      # - The mathfunc module is used by grml-zshrc https://github.com/termux/termux-packages/issues/494.
+	'newuser'       # - The newuser module was requested in https://github.com/termux/termux-packages/discussions/20603.
+	'param_private' # - The param_private module was requested in https://github.com/termux/termux-packages/issues/7391.
+	'pcre'          # - The pcre module expands on the regex modules capabilities and is used by several extensions.
+	'regex'         # - The regex module seems to be used by several extensions.
+	'socket'        # - The socket module was requested by BrainDamage on IRC (#termux).
+	'stat'          # - The stat module is needed by zui https://github.com/termux/termux-packages/issues/2829.
+	'system'        # - The system module is needed by zplug https://github.com/termux/termux-packages/issues/659.
+	'zprof'         # - The zprof module was requested by BrainDamage on IRC (#termux).
+	'zpty'          # - The zpty module is needed by zsh-async https://github.com/termux/termux-packages/issues/672.
+	'zselect'       # - The zselect module is used by multiple plugins https://github.com/termux/termux-packages/issues/4939
+	)
+	for module in "${modules[@]}"; do
 		perl -p -i -e "s|${module}.mdd link=no|${module}.mdd link=static|" $TERMUX_PKG_BUILDDIR/config.modules
 	done
 }

--- a/packages/zsh/etc-zshrc
+++ b/packages/zsh/etc-zshrc
@@ -3,3 +3,10 @@ command_not_found_handler() {
 	@TERMUX_PREFIX@/libexec/termux/command-not-found $1
 }
 PS1='%# '
+# If there is no .zshrc offer to set one up
+# This is the same fresh install behavior as for example on Arch Linux
+[[ -r "${ZDOTDIR:-$HOME}"/.zshrc ]] || {
+	autoload -U zsh-newuser-install
+	zsh-newuser-install
+}
+# vim: set noet ft=zsh tw=4 sw=4 ff=unix


### PR DESCRIPTION
I also cleaned up the module listing and history section in build script by turning it into an array,
and set a maintainer.

---

<sup>(This is a pre-written, saved reply.)</sup>
If you want to test this PR please download the appropriate DEB package(s)
from the build artifacts of the [associated PR's latest CI run](https://github.com/termux/termux-packages/pull/20604/checks).
![Screenshot_20240619_232413](https://github.com/termux/termux-packages/assets/43716232/ec9d8de9-50dc-46e6-8e4f-5d9c9b728331)


After downloading the build artifact, make sure to `unzip` and un-`tar` it.
<details><summary>Detailed instructions, if needed.</summary>
<p>

```bash
# finding out what architecture you need
# architecture is just below the TERMUX_VERSION
termux-info

# e.g.
# [...]
# TERMUX_MAIN_PACKAGE_FORMAT=debian
# TERMUX_VERSION=0.118.0
# TERMUX__USER_ID=0
# Packages CPU architecture:
# aarch64
# [...]

# =======================

# make sure `unzip` and `tar` are installed using
pkg install unzip tar

# unzip the artifact (if you have a different architecture this might be arm, i686 or x86_64 instead)
unzip debs-aarch64-*.zip

# untar the artifact
tar xf debs-aarch64-*.tar

# You should now have a debs/ directory in your current working directory
# Install the packages from the local source using
pkg install -- ./debs/*.deb

# to clean up, you can remove the debs/ directory, .tar file and .zip file
rm -rfi debs debs-aarch64-*.zip debs-aarch64-*.tar
```

</p>
</details> 