### PR TITLE
fix(x11/fluxbox): Fix building with current toolchain

### DIFF
--- a/x11-packages/fluxbox/build.sh
+++ b/x11-packages/fluxbox/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="A lightweight and highly-configurable window manager"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.3.7
-TERMUX_PKG_REVISION=35
+TERMUX_PKG_REVISION=36
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/fluxbox/fluxbox-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=fc8c75fe94c54ed5a5dd3fd4a752109f8949d6df67a48e5b11a261403c382ec0
 TERMUX_PKG_DEPENDS="fontconfig, fribidi, imlib2, libc++, libiconv, libx11, libxext, libxft, libxinerama, libxpm, libxrandr, libxrender, xorg-xmessage"
@@ -17,5 +17,5 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 "
 
 termux_step_pre_configure() {
-	export CXXFLAGS="${CXXFLAGS} -Wno-c++11-narrowing"
+	export CXXFLAGS="${CXXFLAGS} -Wno-c++11-narrowing -std=c++11"
 }


### PR DESCRIPTION
Set `-std=c++11` to fix build errors such as:

> src/FbTk/MemFun.hh:86:28: error: no template named 'binary_function' in namespace 'std'; did you mean '__binary_function'?
> src/FbTk/MenuItem.hh:158:14: error: no template named 'auto_ptr' in namespace 'std'