### PR TITLE
libxml2: Add missing build options

### DIFF
--- a/packages/libxml2/build.sh
+++ b/packages/libxml2/build.sh
@@ -10,6 +10,9 @@ TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_SETUP_PYTHON=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --with-python
+--with-zlib
+--with-lzma
+--with-http
 "
 TERMUX_PKG_RM_AFTER_INSTALL="share/gtk-doc"
 TERMUX_PKG_DEPENDS="libiconv, liblzma, zlib"


### PR DESCRIPTION
As of libxml2 v2.13.0, some dependencies became optional by default. From the release notes:

https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/NEWS?ref_type=heads#L28

> Support for zlib, liblzma and HTTP is now disabled by default and has to be enabled by passing --with-zlib, --with-lzma or --with-http to configure.

This has caused some downstream applications to break, such as ogr2ogr which need http support, and fail at runtime with a missing symbol error.

This change enables those options again.