### PR TITLE
fix(main/qemu): Remove duplicate fdt headers

### DIFF
--- a/packages/qemu-system-x86-64-headless/build.sh
+++ b/packages/qemu-system-x86-64-headless/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="A generic and open source machine emulator and virtualiz
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1:8.2.5
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://download.qemu.org/qemu-${TERMUX_PKG_VERSION:2}.tar.xz
 TERMUX_PKG_SHA256=65693b4a64f28be7501ed0dd3e042478780c516de3f17813d1c32ebb2eb249a9
-TERMUX_PKG_DEPENDS="glib, libbz2, libcurl, libgmp, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libslirp, libspice-server, libssh, libusb, libusbredir, ncurses, pulseaudio, qemu-common, resolv-conf, zlib, zstd"
+TERMUX_PKG_DEPENDS="dtc, glib, libbz2, libcurl, libgmp, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libslirp, libspice-server, libssh, libusb, libusbredir, ncurses, pulseaudio, qemu-common, resolv-conf, zlib, zstd"
 
 # Required by configuration script, but I can't find any binary that uses it.
 TERMUX_PKG_BUILD_DEPENDS="libtasn1"
@@ -106,7 +106,7 @@ termux_step_configure() {
 		--disable-xen-pci-passthrough \
 		--enable-virtfs \
 		--enable-curl \
-		--enable-fdt \
+		--enable-fdt=system \
 		--enable-kvm \
 		--disable-hvf \
 		--disable-whpx \


### PR DESCRIPTION

    This uses system provided dtc package to link with fdt library.
    Otherwise, dtc subproject is used which install duplicate fdt
    header files - fdt.h, libfdt_env.h and libfdt.h.

Fixes #20627

