### PR TITLE
bump(main/wasi-libc): 22

### DIFF
--- a/packages/wasi-libc/build.sh
+++ b/packages/wasi-libc/build.sh
@@ -3,86 +3,51 @@ TERMUX_PKG_DESCRIPTION="Libc for WebAssembly programs built on top of WASI syste
 TERMUX_PKG_LICENSE="Apache-2.0, BSD 2-Clause, MIT"
 TERMUX_PKG_LICENSE_FILE="LICENSE, src/wasi-libc/LICENSE-MIT, src/wasi-libc/libc-bottom-half/cloudlibc/LICENSE"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=20
-TERMUX_PKG_SRCURL=https://github.com/WebAssembly/wasi-sdk/archive/refs/tags/wasi-sdk-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=28f317520d9b522134f7a014b84833d91ab1329fbd697bad05aa4fcfa2746c83
+TERMUX_PKG_VERSION="22"
+TERMUX_PKG_SRCURL=git+https://github.com/WebAssembly/wasi-sdk
+TERMUX_PKG_GIT_BRANCH=wasi-sdk-${TERMUX_PKG_VERSION}
+TERMUX_PKG_RECOMMENDS="wasm-component-ld"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_NO_STATICSPLIT=true
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_HOSTBUILD=true
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+"
 
-termux_step_post_get_source() {
-	local WASI_LIBC_SRCURL="https://github.com/WebAssembly/wasi-libc/archive/refs/tags/wasi-sdk-${TERMUX_PKG_VERSION}.tar.gz"
-	local WASI_LIBC_SHA256=0a1c09c8c1da62a1ba214254ff4c9db6b60979c00f648a5eae33831d6ee2840e
-	local LLVM_VERSION=$(. "${TERMUX_SCRIPTDIR}/packages/libllvm/build.sh"; echo ${TERMUX_PKG_VERSION})
-	local LLVM_SRCURL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-project-${LLVM_VERSION}.src.tar.xz"
-	local LLVM_SHA256=be5a1e44d64f306bb44fce7d36e3b3993694e8e6122b2348608906283c176db8
-
-	termux_download \
-		"${WASI_LIBC_SRCURL}" \
-		"${TERMUX_PKG_CACHEDIR}/wasi-libc-${TERMUX_PKG_VERSION}.tar.gz" \
-		"${WASI_LIBC_SHA256}"
-	termux_download \
-		"${LLVM_SRCURL}" \
-		"${TERMUX_PKG_CACHEDIR}/$(basename "${LLVM_SRCURL}")" \
-		"${LLVM_SHA256}"
-
-	tar -xf "${TERMUX_PKG_CACHEDIR}/wasi-libc-${TERMUX_PKG_VERSION}.tar.gz" -C src
-	tar -xf "${TERMUX_PKG_CACHEDIR}/llvm-project-${LLVM_VERSION}.src.tar.xz" -C src
-	rm -frv src/{config,llvm-project,wasi-libc}
-	mv -v "src/wasi-libc-wasi-sdk-${TERMUX_PKG_VERSION}" src/wasi-libc
-	mv -v "src/llvm-project-${LLVM_VERSION}.src" src/llvm-project
+termux_pkg_auto_update() {
+	local api_url="https://api.github.com/repos/WebAssembly/wasi-sdk/git/refs/tags"
+	local latest_refs_tags=$(curl -s "${api_url}" | jq .[].ref | grep -oP wasi-sdk-${TERMUX_PKG_UPDATE_VERSION_REGEXP})
+	if [[ -z "${latest_refs_tags}" ]]; then
+		echo "WARN: Unable to get latest refs tags from upstream. Try again later." >&2
+		return
+	fi
+	local latest_version=$(echo "${latest_refs_tags}" | sort -V | tail -n1)
+	termux_pkg_upgrade_version "${latest_version}"
 }
 
-termux_step_pre_configure() {
+termux_step_host_build() {
+	# https://github.com/WebAssembly/wasi-sdk/blob/main/Makefile
 	termux_setup_cmake
 	termux_setup_ninja
+	termux_setup_rust
 
-	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "false" ]]; then
-		# https://github.com/android/ndk/issues/1960
-		# use NDK r26 new wasm target support to build
-		# but need to fix non standard stdatomic.h without pollution
-		rm -fr "${TERMUX_PKG_TMPDIR}/toolchain"
-		mkdir -p "${TERMUX_PKG_TMPDIR}/toolchain"
-		cp -fr "${TERMUX_STANDALONE_TOOLCHAIN}"/{bin,include,lib} \
-			"${TERMUX_PKG_TMPDIR}/toolchain"
-		sed \
-			-e "s|#include <sys/cdefs.h>|//#include <sys/cdefs.h>|" \
-			-i "${TERMUX_PKG_TMPDIR}"/toolchain/lib/clang/*/include/stdatomic.h \
-			-i "${TERMUX_PKG_TMPDIR}"/toolchain/lib/clang/*/include/bits/stdatomic.h
-		export CC="${TERMUX_PKG_TMPDIR}/toolchain/bin/clang"
-		export CXX="${TERMUX_PKG_TMPDIR}/toolchain/bin/clang++"
-		export PATH="${TERMUX_PKG_TMPDIR}/toolchain/bin:${PATH}"
-	fi
-	export AR=$(command -v llvm-ar)
-	export NM=$(command -v llvm-nm)
-	export INSTALL_DIR="${TERMUX_PREFIX}/share/wasi-sysroot"
-	export NINJA_FLAGS="-j ${TERMUX_PKG_MAKE_PROCESSES}"
+	pushd "${TERMUX_PKG_BUILDDIR}"
+	mkdir -p "build/install/${TERMUX_PREFIX#/}"
+	make -j "${TERMUX_PKG_MAKE_PROCESSES}" build NINJA_FLAGS="-j ${TERMUX_PKG_MAKE_PROCESSES}"
+	echo "${PWD}/build/install/${TERMUX_PREFIX#/}/VERSION"
+	cat "${PWD}/build/install/${TERMUX_PREFIX#/}/VERSION"
+	popd
+}
 
-	sed \
-		-e "s|CC=\$(BUILD_PREFIX).*|CC=${CC} \\\\|g" \
-		-e "s|AR=\$(BUILD_PREFIX).*|AR=${AR} \\\\|g" \
-		-e "s|NM=\$(BUILD_PREFIX).*|NM=${NM} \\\\|g" \
-		-e "s|cp -R \$(ROOT_DIR)/build/llvm/|#cp -R \$(ROOT_DIR)/build/llvm/|g" \
-		-i Makefile
-	sed \
-		-e "/^set(CMAKE_C_COMPILER .*/d" \
-		-e "/^set(CMAKE_CXX_COMPILER .*/d" \
-		-e "/^set(CMAKE_ASM_COMPILER .*/d" \
-		-e "/^set(CMAKE_AR .*/d" \
-		-e "/^set(CMAKE_NM .*/d" \
-		-e "/^set(CMAKE_RANLIB .*/d" \
-		-i wasi-sdk.cmake wasi-sdk-pthread.cmake
-
-	mkdir -p build
-	touch build/llvm.BUILT # use our own LLVM
-	touch build/config.BUILT # use our own autoconf config.guess
+termux_step_make() {
+	:
 }
 
 termux_step_make_install() {
-	cp -fr "build/install/${TERMUX_PREFIX}" "$(dirname "${TERMUX_PREFIX}")"
-	install -v -Dm644 -t "${TERMUX_PREFIX}/share/cmake" \
-		wasi-sdk.cmake \
-		wasi-sdk-pthread.cmake
-	install -v -Dm644 -t "${TERMUX_PREFIX}/share/cmake/Platform" \
-		cmake/Platform/WASI.cmake
+	# use our own LLVM, autoconf config.guess, wasm-component-ld
+	local llvm_major_version=$(grep llvm-version "build/install/${TERMUX_PREFIX#/}/VERSION" | cut -d" " -f2 | sed "s|\..*||")
+	mkdir -p "${TERMUX_PREFIX}/lib/clang/${llvm_major_version}"
+	cp -fr "build/install/${TERMUX_PREFIX#/}/lib/clang/${llvm_major_version}/lib" "${TERMUX_PREFIX}/lib/clang/${llvm_major_version}"
+	cp -fr "build/install/${TERMUX_PREFIX#/}/share/cmake" "${TERMUX_PREFIX}/share"
+	cp -fr "build/install/${TERMUX_PREFIX#/}/share/wasi-sysroot" "${TERMUX_PREFIX}/share"
 }

--- a/packages/wasm-component-ld/build.sh
+++ b/packages/wasm-component-ld/build.sh
@@ -1,0 +1,22 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/bytecodealliance/wasm-component-ld
+TERMUX_PKG_DESCRIPTION="Command line linker for creating WebAssembly components"
+TERMUX_PKG_LICENSE="Apache-2.0, MIT"
+TERMUX_PKG_LICENSE_FILE="LICENSE-APACHE, LICENSE-Apache-2.0_WITH_LLVM-exception, LICENSE-MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.5.3"
+TERMUX_PKG_SRCURL=https://github.com/bytecodealliance/wasm-component-ld/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=6c7ffea6f1c8399597e17f63df7b479fcd127e8538c58c472d75854023df03cb
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+
+termux_step_pre_configure() {
+	termux_setup_rust
+}
+
+termux_step_make() {
+	cargo build --jobs "${TERMUX_PKG_MAKE_PROCESSES}" --target "${CARGO_TARGET_NAME}" --release
+}
+
+termux_step_make_install() {
+	install -Dm755 -t "${TERMUX_PREFIX}/bin" "target/${CARGO_TARGET_NAME}/release/wasm-component-ld"
+}

--- a/scripts/build/setup/termux_setup_rust.sh
+++ b/scripts/build/setup/termux_setup_rust.sh
@@ -36,13 +36,13 @@ termux_setup_rust() {
 
 	local ENV_NAME=CARGO_TARGET_${CARGO_TARGET_NAME^^}_LINKER
 	ENV_NAME=${ENV_NAME//-/_}
-	export $ENV_NAME="${CC}"
+	export $ENV_NAME="${CC:-}"
 	# TARGET_CFLAGS and CFLAGS incorrectly applied globally
 	# for host build and other targets so set them individually
-	export CFLAGS_aarch64_linux_android="${CPPFLAGS}"
-	export CFLAGS_armv7_linux_androideabi="${CPPFLAGS}"
-	export CFLAGS_i686_linux_android="${CPPFLAGS}"
-	export CFLAGS_x86_64_linux_android="${CPPFLAGS}"
+	export CFLAGS_aarch64_linux_android="${CPPFLAGS:-}"
+	export CFLAGS_armv7_linux_androideabi="${CPPFLAGS:-}"
+	export CFLAGS_i686_linux_android="${CPPFLAGS:-}"
+	export CFLAGS_x86_64_linux_android="${CPPFLAGS:-}"
 	unset CFLAGS
 
 	if [[ -z "${TERMUX_RUST_VERSION-}" ]]; then


### PR DESCRIPTION
Will follow up enabling `rust-std-wasm32-wasip1` and `rust-std-wasm32-wasip2` later
```
~/bin $ cc --target=wasm32-wasi hello.c -o hello.wasm --sysroot=$PREFIX/share/wasi-sysroot; file hello.wasm; wasmtime hello.wasm
hello.wasm: WebAssembly (wasm) binary module version 0x1 (MVP)
Hello world!
~/bin $ cc --target=wasm32-wasip1 hello.c -o hello.wasm --sysroot=$PREFIX/share/wasi-sysroot; file hello.wasm; wasmtime hello.wasm
hello.wasm: WebAssembly (wasm) binary module version 0x1 (MVP)
Hello world!
~/bin $ cc --target=wasm32-wasip2 hello.c -o hello.wasm --sysroot=$PREFIX/share/wasi-sysroot; file hello.wasm; wasmtime hello.wasm
hello.wasm: WebAssembly (wasm) binary module version 0x1000d
Hello world!
~/bin $ cat hello.c
#include <stdio.h>
int main(void) {
        puts("Hello world!");
        return 0;
}
```