### PR TITLE
Update version to v3.12.4 and modify some reminders.

### DIFF
--- a/packages/python/build.sh
+++ b/packages/python/build.sh
@@ -4,10 +4,11 @@ TERMUX_PKG_DESCRIPTION="Python 3 programming language intended to enable clear p
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="LICENSE"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=3.11.9
+# We get source file archive from Official Python.org's GitHub Account. Uses branch to keep the things latest.
+TERMUX_PKG_VERSION=3.12  # v3.12.4
 TERMUX_PKG_REVISION=2
-TERMUX_PKG_SRCURL=https://www.python.org/ftp/python/${TERMUX_PKG_VERSION}/Python-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=9b1e896523fc510691126c864406d9360a3d1e986acbda59cda57b5abda45b87
+TERMUX_PKG_SRCURL=https://github.com/python/cpython/archive/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=d833211ef08babdeecdba6447f371766f802b56731b34e0188949fb2fdeee968
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_DEPENDS="gdbm, libandroid-posix-semaphore, libandroid-support, libbz2, libcrypt, libexpat, libffi, liblzma, libsqlite, ncurses, ncurses-ui-libs, openssl, readline, zlib"
 TERMUX_PKG_RECOMMENDS="python-ensurepip-wheels, python-pip"
@@ -115,7 +116,7 @@ termux_step_create_debscripts() {
 		echo
 		echo "== Note: pip is now separate from python =="
 		echo "To install, enter the following command:"
-		echo "   pkg install python-pip"
+		echo "   pkg install python-pip. For apt, apt install python --install-recommends -yfm --autoremove --purge."
 		echo
 	fi
 


### PR DESCRIPTION
We updated the `Python` in `Termux` to a version mentioned above title. And add some reminders, calling users if you installing `pip` and `ensurepip` using apt method, consider adding `--install-recommends` your own choice.