### PR TITLE
scripts: NDK r23c clean up

### DIFF
--- a/scripts/build/setup/termux_setup_no_integrated_as.sh
+++ b/scripts/build/setup/termux_setup_no_integrated_as.sh
@@ -28,18 +28,27 @@ termux_setup_no_integrated_as() {
 	for env in CC CXX; do
 		local cmd="$(eval echo \${$env})"
 		local w="$bin/$(basename "$cmd")"
-		if [ ! -e "$w" ]; then
+		if [ -e "$w" ]; then continue; fi
+		if [[ "$(${cmd} -dumpversion | sed "s|\..*||")" -ge 14 ]]; then
 			cat > "$w" <<-EOF
-				#!$(command -v sh)
-				PATH="$binutils_cross_bin:\$PATH"
-				exec "$(command -v "$cmd")" \
-					--start-no-unused-arguments \
-					-fno-integrated-as \
-					--end-no-unused-arguments \
-					"\$@"
+			#!$(command -v sh)
+			PATH="$binutils_cross_bin:\$PATH"
+			exec "$(command -v "$cmd")" \
+				--start-no-unused-arguments \
+				-fno-integrated-as \
+				--end-no-unused-arguments \
+				"\$@"
 			EOF
-			chmod 0700 "$w"
+		else
+			cat > "$w" <<-EOF
+			#!$(command -v sh)
+			PATH="$binutils_cross_bin:\$PATH"
+			exec "$(command -v "$cmd")" \
+				-fno-integrated-as \
+				"\$@"
+			EOF
 		fi
+		chmod u+x "$w"
 	done
 	export PATH="$bin:$PATH"
 }

--- a/scripts/build/termux_step_setup_toolchain.sh
+++ b/scripts/build/termux_step_setup_toolchain.sh
@@ -10,7 +10,7 @@ termux_step_setup_toolchain() {
 			TERMUX_STANDALONE_TOOLCHAIN+="-v4"
 			termux_setup_toolchain_26b
 		elif [ "${TERMUX_NDK_VERSION}" = 23c ]; then
-			TERMUX_STANDALONE_TOOLCHAIN+="-v7"
+			TERMUX_STANDALONE_TOOLCHAIN+="-v8"
 			termux_setup_toolchain_23c
 		else
 			termux_error_exit "We do not have a setup_toolchain function for NDK version $TERMUX_NDK_VERSION"

--- a/scripts/build/toolchain/termux_setup_toolchain_23c.sh
+++ b/scripts/build/toolchain/termux_setup_toolchain_23c.sh
@@ -5,8 +5,8 @@ termux_setup_toolchain_23c() {
 
 	export AS=$TERMUX_HOST_PLATFORM-clang
 	export CC=$TERMUX_HOST_PLATFORM-clang
-	export CXX=$TERMUX_HOST_PLATFORM-clang++
 	export CPP=$TERMUX_HOST_PLATFORM-cpp
+	export CXX=$TERMUX_HOST_PLATFORM-clang++
 	export LD=ld.lld
 	export AR=llvm-ar
 	export OBJCOPY=llvm-objcopy
@@ -15,6 +15,7 @@ termux_setup_toolchain_23c() {
 	export READELF=llvm-readelf
 	export STRIP=llvm-strip
 	export NM=llvm-nm
+	export CXXFILT=llvm-cxxfilt
 
 	export TERMUX_HASKELL_OPTIMISATION="-O"
 	if [ "${TERMUX_DEBUG_BUILD}" = true ]; then
@@ -113,15 +114,6 @@ termux_setup_toolchain_23c() {
 	fi
 
 	if [ -d $TERMUX_STANDALONE_TOOLCHAIN ]; then
-		for HOST_PLAT in aarch64-linux-android armv7a-linux-androideabi i686-linux-android x86_64-linux-android arm-linux-androideabi; do
-			if [ "$TERMUX_PKG_ENABLE_CLANG16_PORTING" = "true" ]; then
-				cp $TERMUX_STANDALONE_TOOLCHAIN/bin/$HOST_PLAT-clang.16-porting \
-					$TERMUX_STANDALONE_TOOLCHAIN/bin/$HOST_PLAT-clang
-			else
-				cp $TERMUX_STANDALONE_TOOLCHAIN/bin/$HOST_PLAT-clang.no-16-porting \
-					$TERMUX_STANDALONE_TOOLCHAIN/bin/$HOST_PLAT-clang
-			fi
-		done
 		return
 	fi
 
@@ -165,22 +157,6 @@ termux_setup_toolchain_23c() {
 	cp $_TERMUX_TOOLCHAIN_TMPDIR/bin/armv7a-linux-androideabi-cpp \
 		$_TERMUX_TOOLCHAIN_TMPDIR/bin/arm-linux-androideabi-cpp
 
-	for HOST_PLAT in aarch64-linux-android armv7a-linux-androideabi i686-linux-android x86_64-linux-android arm-linux-androideabi; do
-		mv $_TERMUX_TOOLCHAIN_TMPDIR/bin/$HOST_PLAT-clang \
-			$_TERMUX_TOOLCHAIN_TMPDIR/bin/$HOST_PLAT-clang.no-16-porting
-		cp $_TERMUX_TOOLCHAIN_TMPDIR/bin/$HOST_PLAT-clang.no-16-porting \
-			$_TERMUX_TOOLCHAIN_TMPDIR/bin/$HOST_PLAT-clang.16-porting
-		sed -i 's/"\$@"/--start-no-unused-arguments -Werror=implicit-function-declaration -Werror=implicit-int -Werror=int-conversion -Werror=incompatible-function-pointer-types --end-no-unused-arguments \0/g' \
-			$_TERMUX_TOOLCHAIN_TMPDIR/bin/$HOST_PLAT-clang.16-porting
-		if [ "$TERMUX_PKG_ENABLE_CLANG16_PORTING" = "true" ]; then
-			cp $_TERMUX_TOOLCHAIN_TMPDIR/bin/$HOST_PLAT-clang.16-porting \
-				$_TERMUX_TOOLCHAIN_TMPDIR/bin/$HOST_PLAT-clang
-		else
-			cp $_TERMUX_TOOLCHAIN_TMPDIR/bin/$HOST_PLAT-clang.no-16-porting \
-				$_TERMUX_TOOLCHAIN_TMPDIR/bin/$HOST_PLAT-clang
-		fi
-	done
-
 	# rust 1.75.0+ expects this directory to be present
 	rm -fr "${_TERMUX_TOOLCHAIN_TMPDIR}"/toolchains
 	mkdir -p "${_TERMUX_TOOLCHAIN_TMPDIR}"/toolchains/llvm/prebuilt
@@ -219,10 +195,12 @@ termux_setup_toolchain_23c() {
 	# Remove <zlib.h> and <zconf.h> as we build our own zlib.
 	# Remove unicode headers provided by libicu.
 	# Remove KHR/khrplatform.h provided by mesa.
+	# Remove EGL, GLES, GLES2, and GLES3 provided by mesa.
 	# Remove NDK vulkan headers.
 	rm usr/include/{sys/{capability,shm,sem},{glob,iconv,spawn,zlib,zconf},KHR/khrplatform}.h
 	rm usr/include/unicode/{char16ptr,platform,ptypes,putil,stringoptions,ubidi,ubrk,uchar,uconfig,ucpmap,udisplaycontext,uenum,uldnames,ulocdata,uloc,umachine,unorm2,urename,uscript,ustring,utext,utf16,utf8,utf,utf_old,utypes,uvernum,uversion}.h
 	rm -Rf usr/include/vulkan
+	rm -Rf usr/include/{EGL,GLES{,2,3}}
 
 	sed -i "s/define __ANDROID_API__ __ANDROID_API_FUTURE__/define __ANDROID_API__ $TERMUX_PKG_API_LEVEL/" \
 		usr/include/android/api-level.h


### PR DESCRIPTION
Mainly to fix issues and follow up of #20312
```
clang-12: error: unsupported option '--start-no-unused-arguments'
clang-12: error: unsupported option '--end-no-unused-arguments'
```