### PR TITLE
bump(main/gexiv2): 0.14.3

### DIFF
--- a/packages/gexiv2/build.sh
+++ b/packages/gexiv2/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://wiki.gnome.org/Projects/gexiv2
 TERMUX_PKG_DESCRIPTION="A GObject-based Exiv2 wrapper"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.14.2"
+TERMUX_PKG_VERSION="0.14.3"
 TERMUX_PKG_SRCURL=https://download.gnome.org/sources/gexiv2/${TERMUX_PKG_VERSION%.*}/gexiv2-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=2a0c9cf48fbe8b3435008866ffd40b8eddb0667d2212b42396fdf688e93ce0be
+TERMUX_PKG_SHA256=21e64d2c56e9b333d44fef3f2a4b25653d922c419acd972fa96fab695217e2c8
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="exiv2, glib, libc++"
 TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, valac"
@@ -19,5 +19,14 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 termux_step_pre_configure() {
 	TERMUX_PKG_VERSION=. termux_setup_gir
 
-	CPPFLAGS+=" -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES"
+	local _WRAPPER_BIN="${TERMUX_PKG_BUILDDIR}/_wrapper/bin"
+	mkdir -p "${_WRAPPER_BIN}"
+	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "false" ]]; then
+		sed "s|^export PKG_CONFIG_LIBDIR=|export PKG_CONFIG_LIBDIR=${TERMUX_PREFIX}/opt/glib/cross/lib/x86_64-linux-gnu/pkgconfig:|" \
+			"${TERMUX_STANDALONE_TOOLCHAIN}/bin/pkg-config" \
+			> "${_WRAPPER_BIN}/pkg-config"
+		chmod +x "${_WRAPPER_BIN}/pkg-config"
+		export PKG_CONFIG="${_WRAPPER_BIN}/pkg-config"
+	fi
+	export PATH="${_WRAPPER_BIN}:${PATH}"
 }


### PR DESCRIPTION
* Remove unused -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES compiler flag which was added in 3157a78171fa755e31ed8f776f5b4ad0110c64f8 commit.

* Fix the following build error. OSError: [Errno 8] Exec format error: '/data/data/com.termux/files/usr/bin/glib-mkenums'

Fixes #20729
