### PR TITLE
addpkg(main/tree-sitter-markdown): 0.2.3

### DIFF
--- a/packages/neovim/build.sh
+++ b/packages/neovim/build.sh
@@ -4,12 +4,12 @@ TERMUX_PKG_LICENSE="Apache-2.0, VIM License"
 TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION="0.10.0"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/neovim/neovim/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=372ea2584b0ea2a5a765844d95206bda9e4a57eaa1a2412a9a0726bab750f828
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="^\d+\.\d+\.\d+$"
-TERMUX_PKG_DEPENDS="libiconv, libuv, luv, libmsgpack, libvterm (>= 1:0.3-0), libluajit, libunibilium, libtreesitter, libandroid-support, lua51-lpeg, tree-sitter-lua, tree-sitter-query, tree-sitter-vimdoc"
+TERMUX_PKG_DEPENDS="libiconv, libuv, luv, libmsgpack, libvterm (>= 1:0.3-0), libluajit, libunibilium, libtreesitter, libandroid-support, lua51-lpeg, tree-sitter-lua, tree-sitter-markdown, tree-sitter-query, tree-sitter-vimdoc"
 TERMUX_PKG_HOSTBUILD=true
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="

--- a/packages/tree-sitter-markdown/build.sh
+++ b/packages/tree-sitter-markdown/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/tree-sitter-grammars/tree-sitter-markdown
+TERMUX_PKG_DESCRIPTION="Tree-sitter parser for Markdown"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.2.3"
+TERMUX_PKG_SRCURL=https://github.com/tree-sitter-grammars/tree-sitter-markdown/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=4909d6023643f1afc3ab219585d4035b7403f3a17849782ab803c5f73c8a31d5
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXTRA_MAKE_ARGS="
+PARSER_URL="${TERMUX_PKG_HOMEPAGE}"
+"
+
+termux_step_pre_configure() {
+	rm setup.py pyproject.toml
+}
+
+termux_step_post_make_install() {
+	install -d "${TERMUX_PREFIX}"/lib/tree_sitter
+	ln -s "${TERMUX_PREFIX}"/lib/libtree-sitter-vimdoc.so "${TERMUX_PREFIX}"/lib/tree_sitter/vimdoc.so
+}


### PR DESCRIPTION
Add markdown parser.
Used by Neovim for inline "hover" documentation.

The build script is for the most part copied from `tree-sitter-vimdoc`.