### PR TITLE
fix(x11/synaptic): Fix build with current toolchain

### DIFF
--- a/x11-packages/synaptic/build.sh
+++ b/x11-packages/synaptic/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Synaptic is a graphical package management tool based on
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@Yisus7u7"
 TERMUX_PKG_VERSION=0.91.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/mvo5/synaptic/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=2b943c32c56aca8a133059bae3df01b64b6bb4687b33250d92efb5d6098a606b
 TERMUX_PKG_AUTO_UPDATE=true
@@ -13,6 +14,8 @@ TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_pre_configure(){
 	NOCONFIGURE=1 ./autogen.sh
+	# Fix "error: no template named binary_function" (binary_function was removed in c++17):
+	CXXFLAGS+=" -std=c++14"
 }
 
 


### PR DESCRIPTION
Set `-std=c++14` in `CXXFLAGS` when building `synaptic` to fix the build error:

> error: no template named binary_function

due to `binary_function` being removed in C++17.