### PR TITLE
fix(main/zsh): Fix zsh-newuser-install being run twice

### DIFF
--- a/packages/zsh/build.sh
+++ b/packages/zsh/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="LICENCE"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION=5.9
-TERMUX_PKG_REVISION=4
+TERMUX_PKG_REVISION=5
 TERMUX_PKG_SRCURL="https://sourceforge.net/projects/zsh/files/zsh/$TERMUX_PKG_VERSION/zsh-$TERMUX_PKG_VERSION".tar.xz
 TERMUX_PKG_SHA256=9b8d1ecedd5b5e81fbf1918e876752a7dd948e05c1a0dba10ab863842d45acd5
 # Remove hard link to bin/zsh as Android does not support hard links:

--- a/packages/zsh/etc-zshrc
+++ b/packages/zsh/etc-zshrc
@@ -3,10 +3,4 @@ command_not_found_handler() {
 	@TERMUX_PREFIX@/libexec/termux/command-not-found $1
 }
 PS1='%# '
-# If there is no .zshrc offer to set one up
-# This is the same fresh install behavior as for example on Arch Linux
-[[ -r "${ZDOTDIR:-$HOME}"/.zshrc ]] || {
-	autoload -U zsh-newuser-install
-	zsh-newuser-install
-}
 # vim: set noet ft=zsh tw=4 sw=4 ff=unix


### PR DESCRIPTION
Zsh already automatically runs `zsh-newuser-install` as part of the `newuser` module. Running it manually in the system `zshrc` caused it to run twice.

Note that `zsh-newuser-install` automatically exits if the terminal's size is less than `72x15`, so it might not run on the default Termux terminal size.