### PR TITLE
chore(main/miniupnpc): Disable auto-update

### DIFF
--- a/packages/miniupnpc/build.sh
+++ b/packages/miniupnpc/build.sh
@@ -5,7 +5,10 @@ TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.2.8"
 TERMUX_PKG_SRCURL=http://miniupnp.free.fr/files/miniupnpc-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=05b929679091b9921b6b6c1f25e39e4c8d1f4d46c8feb55a412aa697aee03a93
-TERMUX_PKG_AUTO_UPDATE=true
+# The miniupnp project breaks API and ABI compatibility even in minor releases
+# (see https://github.com/miniupnp/miniupnp/issues/758), so do not auto update
+# - the changelog needs to be checked for ABI and/or API breakage:
+TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_BREAKS="miniupnpc-dev"
 TERMUX_PKG_REPLACES="miniupnpc-dev"
 


### PR DESCRIPTION
The miniupnp project may break API and/or ABI compatibiliity even in minor patch releases, so it's not safe to auto update (see https://github.com/miniupnp/miniupnp/issues/758, and #20490 as an example what it can cause).

%ci:no-build