### PR TITLE
fix(x11/kf6-kwindowsystem): Fix qml and plugins directory

### DIFF
--- a/x11-packages/kf6-kwindowsystem/build.sh
+++ b/x11-packages/kf6-kwindowsystem/build.sh
@@ -10,7 +10,7 @@ LICENSES/LicenseRef-KDE-Accepted-LGPL.txt
 LICENSES/MIT.txt"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="6.3.0"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL="https://download.kde.org/stable/frameworks/${TERMUX_PKG_VERSION%.*}/kwindowsystem-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=40e33c592934bc27484b922e3dab3c9fdbe078063fa5bcaf29d50d2cd8e8aab9
 TERMUX_PKG_AUTO_UPDATE=true
@@ -18,4 +18,6 @@ TERMUX_PKG_DEPENDS="libc++, libwayland, libx11, libxcb, libxfixes, qt6-qtbase, q
 TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, libwayland-protocols, plasma-wayland-protocols, qt6-qttools"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
 "


### PR DESCRIPTION

    This fixes the following warning while running lxqt.
    kf.windowsystem: Could not find any platform plugin.
    
    The cmake options move plugin files from lib/plugins to lib/qt6/plugins
    and qml files from lib/qml to lib/qt6/qml. The new paths are set by
    TERMUX_PKG_EXTRA_CONFIGURE_ARGS in qt6-qtbase.
