### PR TITLE
fix(scripts/termux_pkg_upgrade_version): allow NULL in NULL checks.

### DIFF
--- a/scripts/updates/utils/termux_pkg_upgrade_version.sh
+++ b/scripts/updates/utils/termux_pkg_upgrade_version.sh
@@ -18,11 +18,11 @@ termux_pkg_upgrade_version() {
 	fi
 
 	# If needed, filter version numbers using grep regexp.
-	if [[ -n "${TERMUX_PKG_UPDATE_VERSION_REGEXP}" ]]; then
+	if [[ -n "${TERMUX_PKG_UPDATE_VERSION_REGEXP:-}" ]]; then
 		# Extract version numbers.
 		local OLD_LATEST_VERSION="${LATEST_VERSION}"
 		LATEST_VERSION="$(grep -oP "${TERMUX_PKG_UPDATE_VERSION_REGEXP}" <<< "${LATEST_VERSION}" || true)"
-		if [[ -z "${LATEST_VERSION}" ]]; then
+		if [[ -z "${LATEST_VERSION:-}" ]]; then
 			termux_error_exit <<-EndOfError
 				ERROR: failed to filter version numbers using regexp '${TERMUX_PKG_UPDATE_VERSION_REGEXP}'.
 				Ensure that it works correctly with ${OLD_LATEST_VERSION}.
@@ -32,11 +32,11 @@ termux_pkg_upgrade_version() {
 	fi
 
 	# If needed, filter version numbers using sed regexp.
-	if [[ -n "${TERMUX_PKG_UPDATE_VERSION_SED_REGEXP}" ]]; then
+	if [[ -n "${TERMUX_PKG_UPDATE_VERSION_SED_REGEXP:-}" ]]; then
 		# Extract version numbers.
 		local OLD_LATEST_VERSION="${LATEST_VERSION}"
 		LATEST_VERSION="$(sed "${TERMUX_PKG_UPDATE_VERSION_SED_REGEXP}" <<< "${LATEST_VERSION}" || true)"
-		if [[ -z "${LATEST_VERSION}" ]]; then
+		if [[ -z "${LATEST_VERSION:-}" ]]; then
 			termux_error_exit <<-EndOfError
 				ERROR: failed to filter version numbers using regexp '${TERMUX_PKG_UPDATE_VERSION_SED_REGEXP}'.
 				Ensure that it works correctly with ${OLD_LATEST_VERSION}.


### PR DESCRIPTION
If we're testing, with an expectation of a value being NULL.
We clearly don't want `set -u` to end the check if the variable is unset.

That is already the behavior for `$TERMUX_PKG_UPGRADE_VERSION_DRY_RUN`.
This commit just fixes it for the `$TERMUX_PKG_UPDATE_VERSION_REGEXP`, `$TERMUX_PKG_UPDATE_VERSION_SED_REGEXP`, and `$LATEST_VERSION` checks.
https://github.com/termux/termux-packages/blob/d44e30dd91c4d801846800a0ed6cc43f5a880e4d/scripts/updates/utils/termux_pkg_upgrade_version.sh#L60

This closes #20839, where I specifically unset `TERMUX_PKG_UPDATE_VERSION_REGEXP` in `taplo`'s auto update function before calling `termux_pkg_upgrade_version` to avoid re-filtering the version.