### PR TITLE
rust: restore rust-docs path and support on device build

### DIFF
--- a/packages/rust/build.sh
+++ b/packages/rust/build.sh
@@ -72,6 +72,7 @@ termux_pkg_auto_update() {
 	sed \
 		-e "s/^\tlocal BOOTSTRAP_VERSION=.*/\tlocal BOOTSTRAP_VERSION=${TERMUX_PKG_VERSION}/" \
 		-i "${TERMUX_PKG_BUILDER_DIR}/build.sh"
+
 	termux_pkg_upgrade_version "${latest_version}"
 }
 
@@ -115,6 +116,7 @@ termux_step_pre_configure() {
 	# rust checks libs in PREFIX/lib. It then can't find libc.so and libdl.so because rust program doesn't
 	# know where those are. Putting them temporarly in $PREFIX/lib prevents that failure
 	# https://github.com/termux/termux-packages/issues/11427
+	[[ "${TERMUX_ON_DEVICE_BUILD}" == "true" ]] && return
 	mv $TERMUX_PREFIX/lib/liblzma.a{,.tmp} || :
 	mv $TERMUX_PREFIX/lib/liblzma.so{,.tmp} || :
 	mv $TERMUX_PREFIX/lib/liblzma.so.${_LZMA_VERSION}{,.tmp} || :
@@ -132,17 +134,28 @@ termux_step_configure() {
 
 	# upstream tests build using versions N and N-1
 	local BOOTSTRAP_VERSION=1.78.0
-	if rustup install $BOOTSTRAP_VERSION; then
-	rustup default $BOOTSTRAP_VERSION-x86_64-unknown-linux-gnu
-	export PATH=$HOME/.rustup/toolchains/$BOOTSTRAP_VERSION-x86_64-unknown-linux-gnu/bin:$PATH
-	else
-	echo "WARN: $BOOTSTRAP_VERSION is unavailable, fallback to stable version!"
-	rustup install stable
-	rustup default stable-x86_64-unknown-linux-gnu
-	export PATH=$HOME/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin:$PATH
+	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "false" ]]; then
+		if ! rustup install "${BOOTSTRAP_VERSION}"; then
+			echo "WARN: ${BOOTSTRAP_VERSION} is unavailable, fallback to stable version!"
+			BOOTSTRAP_VERSION=stable
+			rustup install "${BOOTSTRAP_VERSION}"
+		fi
+		rustup default "${BOOTSTRAP_VERSION}-x86_64-unknown-linux-gnu"
+		export PATH="${HOME}/.rustup/toolchains/${BOOTSTRAP_VERSION}-x86_64-unknown-linux-gnu/bin:${PATH}"
 	fi
 	local RUSTC=$(command -v rustc)
 	local CARGO=$(command -v cargo)
+
+	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "true" ]]; then
+		local dir="${TERMUX_STANDALONE_TOOLCHAIN}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+		mkdir -p "${dir}"
+		local target clang
+		for target in aarch64-linux-android armv7a-linux-androideabi i686-linux-android x86_64-linux-android; do
+			for clang in clang clang++; do
+				ln -fsv "${TERMUX_PREFIX}/bin/clang" "${dir}/${target}${TERMUX_PKG_API_LEVEL}-${clang}"
+			done
+		done
+	fi
 
 	sed \
 		-e "s|@TERMUX_PREFIX@|${TERMUX_PREFIX}|g" \
@@ -178,6 +191,7 @@ termux_step_configure() {
 	# for backtrace-sys
 	export CC_x86_64_unknown_linux_gnu=gcc
 	export CFLAGS_x86_64_unknown_linux_gnu="-O2"
+	export RUST_BACKTRACE=full
 }
 
 termux_step_make() {
@@ -187,45 +201,47 @@ termux_step_make() {
 termux_step_make_install() {
 	unset CC CFLAGS CPP CPPFLAGS CXX CXXFLAGS LD LDFLAGS PKG_CONFIG RANLIB
 
-	# remove version suffix: beta, nightly
-	local TERMUX_PKG_VERSION=${TERMUX_PKG_VERSION//~*}
-
 	# needed to workaround build issue that only happens on x86_64
 	# /home/runner/.termux-build/rust/build/build/bootstrap/debug/bootstrap: error while loading shared libraries: /lib/x86_64-linux-gnu/libc.so: invalid ELF header
-	if [[ "$TERMUX_ARCH" == "x86_64" ]]; then
-		mv ${TERMUX_PREFIX}{,.tmp}
-		$TERMUX_PKG_SRCDIR/x.py build --host x86_64-unknown-linux-gnu --stage 1 cargo
+	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "false" ]] && [[ "${TERMUX_ARCH}" == "x86_64" ]]; then
+		mv -v ${TERMUX_PREFIX}{,.tmp}
+		${TERMUX_PKG_SRCDIR}/x.py build -j ${TERMUX_PKG_MAKE_PROCESSES} --host x86_64-unknown-linux-gnu --stage 1 cargo
 		[[ -d "${TERMUX_PREFIX}" ]] && termux_error_exit "Contaminated PREFIX found:\n$(find ${TERMUX_PREFIX} | sort)"
-		mv ${TERMUX_PREFIX}{.tmp,}
+		mv -v ${TERMUX_PREFIX}{.tmp,}
 	fi
 
-	if ! :; then
-	# speed up building rust for testing
-	$TERMUX_PKG_SRCDIR/x.py install --stage 1 --target $CARGO_TARGET_NAME
-	$TERMUX_PKG_SRCDIR/x.py dist rustc-dev --host $CARGO_TARGET_NAME --target $CARGO_TARGET_NAME
-	else
-	# otherwise always build all the supported targets
-	$TERMUX_PKG_SRCDIR/x.py install --stage 1 --target aarch64-linux-android
-	$TERMUX_PKG_SRCDIR/x.py install --stage 1 --target armv7-linux-androideabi
-	$TERMUX_PKG_SRCDIR/x.py install --stage 1 --target i686-linux-android
-	$TERMUX_PKG_SRCDIR/x.py install --stage 1 --target x86_64-linux-android
-	$TERMUX_PKG_SRCDIR/x.py install --stage 1 std --target wasm32-unknown-unknown
-	$TERMUX_PKG_SRCDIR/x.py install --stage 1 std --target wasm32-wasi
-	$TERMUX_PKG_SRCDIR/x.py install --stage 1 std --target wasm32-wasip1
-	$TERMUX_PKG_SRCDIR/x.py install --stage 1 std --target wasm32-wasip2
+	# install causes on device build fail to continue
+	# dist uses a lot of spaces on CI
+	local job="install"
+	[[ "${TERMUX_ON_DEVICE_BUILD}" == "true" ]] && job="dist"
 
-	$TERMUX_PKG_SRCDIR/x.py dist rustc-dev --host $CARGO_TARGET_NAME --target aarch64-linux-android
-	$TERMUX_PKG_SRCDIR/x.py dist rustc-dev --host $CARGO_TARGET_NAME --target armv7-linux-androideabi
-	$TERMUX_PKG_SRCDIR/x.py dist rustc-dev --host $CARGO_TARGET_NAME --target i686-linux-android
-	$TERMUX_PKG_SRCDIR/x.py dist rustc-dev --host $CARGO_TARGET_NAME --target x86_64-linux-android
-	$TERMUX_PKG_SRCDIR/x.py dist rustc-dev --host $CARGO_TARGET_NAME --target wasm32-unknown-unknown
-	$TERMUX_PKG_SRCDIR/x.py dist rustc-dev --host $CARGO_TARGET_NAME --target wasm32-wasi
-	$TERMUX_PKG_SRCDIR/x.py dist rustc-dev --host $CARGO_TARGET_NAME --target wasm32-wasip1
-	$TERMUX_PKG_SRCDIR/x.py dist rustc-dev --host $CARGO_TARGET_NAME --target wasm32-wasip2
+	"${TERMUX_PKG_SRCDIR}/x.py" ${job} -j ${TERMUX_PKG_MAKE_PROCESSES} --stage 1
+
+	# Not putting wasm32-* into config.toml
+	# CI and on device (wasm32*):
+	# error: could not document `std`
+	"${TERMUX_PKG_SRCDIR}/x.py" install -j ${TERMUX_PKG_MAKE_PROCESSES} --target wasm32-unknown-unknown --stage 1 std
+	[[ ! -e "${TERMUX_PREFIX}/share/wasi-sysroot" ]] && termux_error_exit "wasi-sysroot not found"
+	"${TERMUX_PKG_SRCDIR}/x.py" install -j ${TERMUX_PKG_MAKE_PROCESSES} --target wasm32-wasi --stage 1 std
+	"${TERMUX_PKG_SRCDIR}/x.py" install -j ${TERMUX_PKG_MAKE_PROCESSES} --target wasm32-wasip1 --stage 1 std
+	"${TERMUX_PKG_SRCDIR}/x.py" install -j ${TERMUX_PKG_MAKE_PROCESSES} --target wasm32-wasip2 --stage 1 std
+
+	"${TERMUX_PKG_SRCDIR}/x.py" dist -j ${TERMUX_PKG_MAKE_PROCESSES} rustc-dev
+
+	# remove version suffix: beta, nightly
+	local VERSION=${TERMUX_PKG_VERSION//~*}
+
+	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "true" ]]; then
+		echo "WARN: Replacing on device rust! Caveat emptor!"
+		rm -fr ${TERMUX_PREFIX}/lib/rustlib/${CARGO_TARGET_NAME}
+		rm -fv $(find ${TERMUX_PREFIX}/lib -maxdepth 1 -type l -exec ls -l "{}" \; | grep rustlib | sed -e "s|.* ${TERMUX_PREFIX}/lib|${TERMUX_PREFIX}/lib|" -e "s| -> .*||")
 	fi
-
-	tar -xvf build/dist/rustc-dev-$TERMUX_PKG_VERSION-$CARGO_TARGET_NAME.tar.gz
-	./rustc-dev-$TERMUX_PKG_VERSION-$CARGO_TARGET_NAME/install.sh --prefix=$TERMUX_PREFIX
+	ls build/dist/*-${VERSION}*.tar.gz | xargs -P${TERMUX_PKG_MAKE_PROCESSES} -n1 -t -r tar -xf
+	local tgz
+	for tgz in $(ls build/dist/*-${VERSION}*.tar.gz); do
+		echo "INFO: ${tgz}"
+		./$(basename "${tgz}" | sed -e "s|.tar.gz$||")/install.sh --prefix=${TERMUX_PREFIX}
+	done
 
 	cd "$TERMUX_PREFIX/lib"
 	rm -f libc.so libdl.so
@@ -255,8 +271,8 @@ termux_step_make_install() {
 	echo "INFO: ${TERMUX_PKG_BUILDDIR}/rustlib-so.txt"
 	ls *.so | tee "${TERMUX_PKG_BUILDDIR}/rustlib-so.txt"
 
-	echo "INFO: ${TERMUX_PKG_BUILDDIR}/rustc-dev-${TERMUX_PKG_VERSION}-${CARGO_TARGET_NAME}/rustc-dev/manifest.in"
-	cat "${TERMUX_PKG_BUILDDIR}/rustc-dev-${TERMUX_PKG_VERSION}-${CARGO_TARGET_NAME}/rustc-dev/manifest.in" | tee "${TERMUX_PKG_BUILDDIR}/manifest.in"
+	echo "INFO: ${TERMUX_PKG_BUILDDIR}/rustc-dev-${VERSION}-${CARGO_TARGET_NAME}/rustc-dev/manifest.in"
+	cat "${TERMUX_PKG_BUILDDIR}/rustc-dev-${VERSION}-${CARGO_TARGET_NAME}/rustc-dev/manifest.in" | tee "${TERMUX_PKG_BUILDDIR}/manifest.in"
 
 	sed -e 's/^.....//' -i "${TERMUX_PKG_BUILDDIR}/manifest.in"
 	local _included=$(cat "${TERMUX_PKG_BUILDDIR}/manifest.in")

--- a/packages/rust/build.sh
+++ b/packages/rust/build.sh
@@ -2,10 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.rust-lang.org/
 TERMUX_PKG_DESCRIPTION="Systems programming language focused on safety, speed and concurrency"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.79.0"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="1.80.0"
 TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/rustc-${TERMUX_PKG_VERSION}-src.tar.xz
-TERMUX_PKG_SHA256=ab826e84b8d48ec6eda3370065034dea8c006f6a946d78a9ba12bcb50e6d3c7a
+TERMUX_PKG_SHA256=0b9ca1e2e45b8a5f0b58db140af0dc92f8311faeb0ad883c5b71a72c02dc6e80
 _LLVM_MAJOR_VERSION=$(. $TERMUX_SCRIPTDIR/packages/libllvm/build.sh; echo $LLVM_MAJOR_VERSION)
 _LLVM_MAJOR_VERSION_NEXT=$((_LLVM_MAJOR_VERSION + 1))
 _LZMA_VERSION=$(. $TERMUX_SCRIPTDIR/packages/liblzma/build.sh; echo $TERMUX_PKG_VERSION)
@@ -133,7 +132,7 @@ termux_step_configure() {
 	# like 30 to 40 + minutes ... so lets get it right
 
 	# upstream tests build using versions N and N-1
-	local BOOTSTRAP_VERSION=1.78.0
+	local BOOTSTRAP_VERSION=1.79.0
 	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "false" ]]; then
 		if ! rustup install "${BOOTSTRAP_VERSION}"; then
 			echo "WARN: ${BOOTSTRAP_VERSION} is unavailable, fallback to stable version!"

--- a/packages/rust/config.toml
+++ b/packages/rust/config.toml
@@ -11,8 +11,6 @@ target = [
     "armv7-linux-androideabi",
     "i686-linux-android",
     "x86_64-linux-android",
-    "wasm32-unknown-unknown",
-    "wasm32-wasi",
 ]
 rustc = "@RUSTC@"
 cargo = "@CARGO@"

--- a/packages/rust/config.toml
+++ b/packages/rust/config.toml
@@ -32,6 +32,7 @@ android-ndk = "@TERMUX_STANDALONE_TOOLCHAIN@"
 [install]
 prefix = "@TERMUX_PREFIX@"
 sysconfdir = "etc"
+docdir = "share/doc/rust"
 
 [rust]
 optimize = true

--- a/packages/rust/rust-docs.subpackage.sh
+++ b/packages/rust/rust-docs.subpackage.sh
@@ -2,6 +2,5 @@ TERMUX_SUBPKG_DESCRIPTION="Rust documentation"
 TERMUX_SUBPKG_DEPEND_ON_PARENT=false
 TERMUX_SUBPKG_PLATFORM_INDEPENDENT=true
 TERMUX_SUBPKG_INCLUDE="
-share/doc/docs/html
 share/doc/rust/html
 "

--- a/scripts/build/setup/termux_setup_rust.sh
+++ b/scripts/build/setup/termux_setup_rust.sh
@@ -14,12 +14,6 @@ termux_setup_rust() {
 			pkg install rust
 
 			pacman -S rust
-
-			or build it from source with
-
-			./build-package.sh rust
-
-			Note that package 'rust' is known to be problematic for building on device.
 			EOL
 			exit 1
 		fi

--- a/scripts/build/termux_step_massage.sh
+++ b/scripts/build/termux_step_massage.sh
@@ -35,8 +35,8 @@ termux_step_massage() {
 		termux_error_exit "MIME cache found in package. Please disable \`update-mime-database\`."
 	fi
 
-	# Remove old kept libraries (readline):
-	find . -name '*.old' -print0 | xargs -0 -r rm -f
+	# Remove old kept libraries (readline) and directories (rust):
+	find . -name '*.old' -print0 | xargs -0 -r rm -fr
 
 	# Move over sbin to bin:
 	for file in sbin/*; do if test -f "$file"; then mv "$file" bin/; fi; done
@@ -233,8 +233,8 @@ termux_step_massage() {
 				*.a) (( e &= ~1 )) || : ;;
 				*.o) (( e &= ~1 )) || : ;;
 				*.obj) (( e &= ~1 )) || : ;;
-				*.syso) (( e &= ~1 )) || : ;;
 				*.rlib) (( e &= ~1 )) || : ;;
+				*.syso) (( e &= ~1 )) || : ;;
 				*) (( e |= 1 )) || : ;;
 				esac
 				while IFS= read -r excluded_f; do
@@ -284,9 +284,10 @@ termux_step_massage() {
 
 # Local function called by termux_step_massage
 create_grep_pattern() {
-	symbol_type='NOTYPE[[:space:]]+GLOBAL[[:space:]]+DEFAULT[[:space:]]+UND[[:space:]]+'
+	local symbol_type='NOTYPE[[:space:]]+GLOBAL[[:space:]]+DEFAULT[[:space:]]+UND[[:space:]]+'
 	echo -n "$symbol_type$1"'$'
 	shift 1
+	local arg
 	for arg in "$@"; do
 		echo -n "|$symbol_type$arg"'$'
 	done

--- a/scripts/setup-termux.sh
+++ b/scripts/setup-termux.sh
@@ -29,8 +29,10 @@ PACKAGES+=" golang"
 PACKAGES+=" gperf"
 PACKAGES+=" help2man"
 PACKAGES+=" libtool"
+PACKAGES+=" llvm-tools"		# Needed to build rust
 PACKAGES+=" m4"
 PACKAGES+=" make"			# Used for all Makefile-based projects.
+PACKAGES+=" ndk-multilib"		# Needed to build rust
 PACKAGES+=" ninja"			# Used by default to build all CMake projects.
 PACKAGES+=" perl"
 PACKAGES+=" pkg-config"
@@ -52,8 +54,8 @@ source "$TERMUX_PREFIX/bin/termux-setup-package-manager" || true
 
 if [ "$TERMUX_APP_PACKAGE_MANAGER" = "apt" ]; then
 	apt update
-	apt dist-upgrade -y
-	apt install -y $PACKAGES
+	yes | apt dist-upgrade
+	yes | apt install $PACKAGES
 elif [ "$TERMUX_APP_PACKAGE_MANAGER" = "pacman" ]; then
 	pacman -Syu $PACKAGES --needed --noconfirm
 else


### PR DESCRIPTION
Close #20970
* Restore rust-docs path back to `share/doc/rust` from `share/doc/docs` since rust 1.78.0.
* Running `./build-package.sh -I -f rust` on device should not break Termux installation and able to build rust on device. But I doubt there's any benefit to this. There may be unsolved linking issue building on old 32bit arm device but I will not fix it as any "real" 32bit arm device is not able to build with limited RAM and storage.