### PR TITLE
ci(packages): continue regardless dbhi/qus fails

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -34,6 +34,7 @@ jobs:
       fail-fast: false
     steps:
     - name: Setup arm and aarch64 CPU emulators
+      continue-on-error: true
       uses: dbhi/qus/action@main
       with:
         targets: arm aarch64


### PR DESCRIPTION
I still think of removing this and replace with an emulator set up. Until then put this as a stopgap for Docker Pull Rate Limit error.