### PR TITLE
fix(main/libandroid-complex-math): link with libm

### DIFF
--- a/packages/libandroid-complex-math/build.sh
+++ b/packages/libandroid-complex-math/build.sh
@@ -2,15 +2,14 @@ TERMUX_PKG_HOMEPAGE=https://android.googlesource.com/platform/bionic/+/refs/head
 TERMUX_PKG_DESCRIPTION="A shared library providing libm complex math functions"
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=0.1
-TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_VERSION="0.2"
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
-TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=false
 
 # https://android.googlesource.com/platform/bionic/+/9ee6adb003eb5a9855ff6c47f9c150b415a11299
 # https://android.googlesource.com/platform/bionic/+/refs/tags/android-8.1.0_r81/libm/upstream-netbsd/lib/libm/complex/
-# https://android.googlesource.com/platform/bionic/+/master/libm/libm.map.txt
-# https://android.googlesource.com/platform/bionic/+/master/docs/status.md#libm
+# https://android.googlesource.com/platform/bionic/+/main/libm/libm.map.txt
+# https://android.googlesource.com/platform/bionic/+/main/docs/status.md#libm
 
 # Use the full NetBSD implementation as is from Android O
 # instead of matching the latest Android implementation which is a mix of FreeBSD and NetBSD
@@ -18,6 +17,7 @@ TERMUX_PKG_BUILD_IN_SRC=true
 termux_step_pre_configure() {
 	CPPFLAGS+=" -D__USE_GNU"
 	CFLAGS+=" -fPIC"
+	LDFLAGS+=" -lm"
 }
 
 termux_step_make() {


### PR DESCRIPTION
Fix undefined symbols error
```
ERROR: ./lib/libandroid-complex-math.so contains undefined symbols:
     4: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND csqrtl
     5: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND atan2l
     6: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND logl
     7: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND coshl
     8: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND sincosl
     9: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND sinhl
    11: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND expl
    12: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND cabsf
    13: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND logf
    14: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND atan2f
    15: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND cabsl
    16: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND cabs
    17: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND log
    18: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND atan2
    19: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND cargf
    20: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND powf
    21: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND expf
    22: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND sincosf
    23: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND cargl
    24: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND powl
    25: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND carg
    26: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND pow
    27: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND exp
    28: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND sincos
    29: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND cosl
    30: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND sinl
```