### PR TITLE
Revise package: pcsx-rearmed

### DIFF
--- a/x11-packages/pcsx-rearmed/build.sh
+++ b/x11-packages/pcsx-rearmed/build.sh
@@ -37,7 +37,7 @@ termux_step_configure() {
 termux_step_make_install() {
 	install -Dm755 pcsx $TERMUX_PREFIX/bin/pcsx
 	mkdir -p $TERMUX_PREFIX/etc/pcsx $TERMUX_PREFIX/lib/pcsx_plugins
-	cp -r frontend/pandora/skin $TERMUX_PREFIX/etc/pcsx/
+	cp -fr frontend/pandora/skin $TERMUX_PREFIX/etc/pcsx/
 	install -m755 plugins/*.so $TERMUX_PREFIX/lib/pcsx_plugins/
 	ln -fs ../../lib/pcsx_plugins $TERMUX_PREFIX/etc/pcsx/plugins
 }

--- a/x11-packages/pcsx-rearmed/build.sh
+++ b/x11-packages/pcsx-rearmed/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Yet another PCSX fork based on the PCSX-Reloaded project
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=23
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=git+https://github.com/notaz/pcsx_rearmed
 TERMUX_PKG_GIT_BRANCH=r${TERMUX_PKG_VERSION}
 TERMUX_PKG_SHA256=887e9b5ee7b8115d35099c730372b4158fd3e215955a06d68e20928b339646af
@@ -24,6 +24,7 @@ termux_pkg_auto_update() {
 
 termux_step_pre_configure() {
 	CFLAGS+=" $CPPFLAGS"
+	CFLAGS="${CFLAGS/-Oz/-Os}"
 	if [ "$TERMUX_ARCH" = "arm" ]; then
 		termux_setup_no_integrated_as
 	fi

--- a/x11-packages/pcsx-rearmed/libpicofe_menu.c.patch
+++ b/x11-packages/pcsx-rearmed/libpicofe_menu.c.patch
@@ -1,6 +1,16 @@
 --- a/frontend/libpicofe/menu.c	2023-01-14 18:47:37.198748509 -0300
-+++ b/frontend/libpicofe/menu.c	2023-01-14 21:01:15.266742774 -0300
-@@ -313,7 +313,7 @@
++++ b/frontend/libpicofe/menu.c	2024-07-24 12:03:41.259401811 -0300
+@@ -258,7 +258,8 @@
+ 
+ void menu_init_base(void)
+ {
+-	int i, c, l, pos;
++	int i, c, l;
++	size_t pos;
+ 	unsigned char *fd, *fds;
+ 	char buff[256];
+ 	FILE *f;
+@@ -313,7 +314,7 @@
  	}
  
  	// load custom font and selector (stored as 1st symbol in font table)

--- a/x11-packages/pcsx-rearmed/libpicofe_plat.c.patch
+++ b/x11-packages/pcsx-rearmed/libpicofe_plat.c.patch
@@ -1,5 +1,5 @@
 --- a/frontend/libpicofe/linux/plat.c	2023-01-14 16:15:27.853589338 -0300
-+++ b/frontend/libpicofe/linux/plat.c	2023-01-16 00:01:24.412662379 -0300
++++ b/frontend/libpicofe/linux/plat.c	2024-07-21 13:30:28.033306193 -0300
 @@ -22,6 +22,7 @@
  #include <sys/stat.h>
  
@@ -8,12 +8,12 @@
  
  /* XXX: maybe unhardcode pagesize? */
  #define HUGETLB_PAGESIZE (2 * 1024 * 1024)
-@@ -49,56 +50,12 @@
+@@ -49,56 +50,13 @@
  	return strlen(dst);
  }
  
 -static int plat_get_exe_dir(char *dst, int len)
-+int plat_get_skin_dir(char *dst)
++size_t plat_get_skin_dir(char *dst)
  {
 -#ifdef PICO_DATA_DIR
 -	memcpy(dst, PICO_DATA_DIR, sizeof PICO_DATA_DIR);
@@ -44,7 +44,8 @@
 -	memcpy(dst + ret, "skin/", sizeof "skin/");
 -	return ret + sizeof("skin/") - 1;
 -}
-+	int len = sizeof(PCSX_DOT_DIR "skin/");
++	static const char path[] = PCSX_DOT_DIR "skin/";
++	static const size_t len = sizeof path / sizeof path[0];
  
 -#ifndef PICO_HOME_DIR
 -#define PICO_HOME_DIR "/.picodrive/"
@@ -64,7 +65,7 @@
 -	}
 -#endif
 -	return plat_get_exe_dir(dst, len);
-+	memcpy(dst, PCSX_DOT_DIR "skin/", len);
++	memcpy(dst, path, len);
 +	return len - 1;
  }
  

--- a/x11-packages/pcsx-rearmed/libpicofe_plat.h.patch
+++ b/x11-packages/pcsx-rearmed/libpicofe_plat.h.patch
@@ -9,7 +9,7 @@
 -
  /* return the dir/ where skin files are found */
 -int  plat_get_skin_dir(char *dst, int len);
-+int  plat_get_skin_dir(char *dst);
++size_t plat_get_skin_dir(char *dst);
  
  /* return the top level dir for image files */
  int  plat_get_data_dir(char *dst, int len);

--- a/x11-packages/pcsx-rearmed/menu.c.patch
+++ b/x11-packages/pcsx-rearmed/menu.c.patch
@@ -36,7 +36,7 @@
  static int menu_do_last_cd_img(int is_get)
  {
 -	static const char *defaults[] = { "/media", "/mnt/sd", "/mnt" };
-+	static const char *default_dir = "@TERMUX_BASE_DIR@";
++	static const char default_dir[] = "@TERMUX_ANDROID_HOME@";
  	char path[256];
 -	struct stat64 st;
  	FILE *f;
@@ -126,12 +126,11 @@
  		if (stat(fname, &st) != 0) {
  			printf("bad memcard file: %s\n", ent->d_name);
  			continue;
-@@ -2532,7 +2505,7 @@
- void menu_init(void)
+@@ -2533,6 +2505,7 @@
  {
  	char buff[MAXPATHLEN];
--	int i;
-+	int i, pos;
+ 	int i;
++	size_t pos;
  
  	cpu_clock_st = cpu_clock = plat_target_cpu_clock_get();
  


### PR DESCRIPTION
00c802bcfb139c92615c4c716cdff97d0639cfc1: `-Oz` crashes the program;
6d1c9128e49cd0f75eed56ccb546ff589e425868: minimal optimizations and parameterizations. 