### PR TITLE
chore(main/eltclsh): conform to #20867 changes

### DIFF
--- a/packages/eltclsh/build.sh
+++ b/packages/eltclsh/build.sh
@@ -6,7 +6,7 @@ TERMUX_PKG_MAINTAINER="@flosnvjx"
 TERMUX_PKG_VERSION="1.19"
 TERMUX_PKG_SRCURL=https://www.openrobots.org/distfiles/eltclsh/eltclsh-"$TERMUX_PKG_VERSION".tar.gz
 TERMUX_PKG_SHA256=d4e4f7b79d89a5ed37dc7535d00ac3894fcf3ba33245e672d7a0753ede39d351
-TERMUX_PKG_DEPENDS="tcl, libedit"
+TERMUX_PKG_DEPENDS="tcl, libandroid-support, libedit"
 TERMUX_PKG_BUILD_DEPENDS="tk"
 TERMUX_PKG_SUGGESTS="tk"
 TERMUX_PKG_AUTO_UPDATE=true
@@ -14,6 +14,6 @@ TERMUX_PKG_UPDATE_METHOD=repology
 TERMUX_PKG_NO_STATICSPLIT=true
 
 termux_step_post_make_install() {
-	mkdir -p $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME
-	sed -ne '/Copyright/,/ADVISED OF THE POSSIBILITY OF SUCH DAMAGE./s%^# %%p' $TERMUX_PKG_SRCDIR/tcl/init.tcl > $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/LICENSE
+	mkdir -p "$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME"
+	sed -ne '/Copyright/,/ADVISED OF THE POSSIBILITY OF SUCH DAMAGE./s%^# %%p' "$TERMUX_PKG_SRCDIR/tcl/init.tcl" > "$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/copyright"
 }


### PR DESCRIPTION
I'm still getting the following symbol error.
```styl
ERROR: ./lib/libeltclsh.so contains undefined symbols:
    28: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND mblen
```
Should be a simple missing `-l<libname>`, just don't know what library contains `mblen`.