### PR TITLE
fix(main/libhangul): Fix undefined symbols error with glob and globfree

### DIFF
--- a/packages/libhangul/build.sh
+++ b/packages/libhangul/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=154a5e0f13aebc80a465336642a406d6ddfc06cf
 _COMMIT_DATE=20230415
 TERMUX_PKG_VERSION=0.1.0-p${_COMMIT_DATE}
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/libhangul/libhangul.git
 TERMUX_PKG_SHA256=e1dd5bf2553f2676ac05e99069c6fd0eaa1b24c283b12678b780ea70a19a664d
 TERMUX_PKG_GIT_BRANCH=main
@@ -33,4 +34,6 @@ termux_step_pre_configure() {
 	# prefer autotools
 	rm CMakeLists.txt
 	./autogen.sh
+
+	LDFLAGS+=" -landroid-glob"
 }


### PR DESCRIPTION

    This fixes the following error.
    
    ERROR: ./lib/libhangul.so contains undefined symbols:
        25: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND glob
        26: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND globfree
