### PR TITLE
fix(main/libfann): Fix undefined symbols error with math functions

### DIFF
--- a/packages/libfann/build.sh
+++ b/packages/libfann/build.sh
@@ -4,8 +4,13 @@ TERMUX_PKG_GROUPS="science"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.2.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/libfann/fann/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz"
 TERMUX_PKG_SHA256=f31c92c1589996f97d855939b37293478ac03d24b4e1c08ff21e0bd093449c3c
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag" # As of 2022-08-29T00:33:40 no github releases are available.
+
+termux_step_pre_configure() {
+	LDFLAGS+=" -lm"
+}


### PR DESCRIPTION

    This fixes the errors as following.
    
    ERROR: ./lib/libfann.so contains undefined symbols:
        13: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND exp
        14: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND sin
        15: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND cos
        22: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND pow
        31: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND log
