### PR TITLE
fix(main/libhtmlcxx): Fix compiler and linker error

### DIFF
--- a/packages/libhtmlcxx/build.sh
+++ b/packages/libhtmlcxx/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="A simple non-validating css1 and html parser for C++"
 TERMUX_PKG_LICENSE="LGPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.87
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=http://downloads.sourceforge.net/sourceforge/htmlcxx/htmlcxx-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=5d38f938cf4df9a298a5346af27195fffabfef9f460fc2a02233cbcfa8fc75c8
 TERMUX_PKG_DEPENDS="libc++, libiconv"
@@ -11,5 +11,12 @@ TERMUX_PKG_DEPENDS="libc++, libiconv"
 termux_step_pre_configure() {
 	autoreconf -fi
 
-	LDFLAGS+=" $($CC -print-libgcc-file-name)"
+	# error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
+	CXXFLAGS+=" -std=c++11"
+
+	# static library libclang_rt.builtins-x86_64-android.a is not portable
+	local _libgcc_file="$($CC -print-libgcc-file-name)"
+	local _libgcc_path="$(dirname $_libgcc_file)"
+	local _libgcc_name="$(basename $_libgcc_file)"
+	LDFLAGS+=" -L$_libgcc_path -l:$_libgcc_name"
 }


### PR DESCRIPTION

    This fixes the following compiler error.
    
    error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
    
    and the linker warning
    
    *** Warning: Linking the shared library libhtmlcxx.la against the
    *** static library libclang_rt.builtins-x86_64-android.a is not portable!
