### PR TITLE
revert(main/redis): freeze version at 7.2.5 pending replacement

### DIFF
--- a/packages/redis/build.sh
+++ b/packages/redis/build.sh
@@ -2,10 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://redis.io/
 TERMUX_PKG_DESCRIPTION="In-memory data structure store used as a database, cache and message broker"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="7.4.0"
-TERMUX_PKG_SRCURL=https://download.redis.io/releases/redis-$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_SHA256=57b47c2c6682636d697dbf5d66d8d495b4e653afc9cd32b7adf9da3e433b8aaf
-TERMUX_PKG_AUTO_UPDATE=true
+# Frozen! Do not update to 7.4.0
+# until the license/replacement discussion is concluded
+TERMUX_PKG_VERSION="1:7.2.5"
+TERMUX_PKG_SRCURL=https://download.redis.io/releases/redis-${TERMUX_PKG_VERSION:2}.tar.gz
+TERMUX_PKG_SHA256=5981179706f8391f03be91d951acafaeda91af7fac56beffb2701963103e423d
 TERMUX_PKG_DEPENDS="libandroid-execinfo, libandroid-glob"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_CONFFILES="etc/redis.conf"


### PR DESCRIPTION
Redis 7.4.0 introduces the new restrictively
RSALv2/SSPLv1 "source available" license model.
Until a final determination is made on it,
freeze Redis at the last BSD licensed version 7.2.5

This reverts commit f91c3b5b4a526fe585cb6407e2f4e18c4964708c.