### PR TITLE
fix(scripts/termux_step_install_license): fix logic error

### DIFF
--- a/scripts/build/termux_step_install_license.sh
+++ b/scripts/build/termux_step_install_license.sh
@@ -32,6 +32,7 @@ termux_step_install_license() {
 		done <<< "${TERMUX_PKG_LICENSE_FILE//,/$'\n'}"
 	else # If a license file wasn't specified, find the one we need
 		local TO_LICENSE             # link target for generic licenses
+		local FROM_SOURCES=0         # flag to check if we've included licenses from the source files yet
 		local COMMON_LICENSE_FILES=( # search list for licenses with copyright information
 		'COPYING' 'Copyright.txt'
 		'copyright' 'Copyright' 'COPYRIGHT'
@@ -52,35 +53,43 @@ termux_step_install_license() {
 				'BSD'|'BSD 2-Clause'|'BSD 3-Clause'|'BSD Simplified'\
 				|'curl'|'HPND'|'ISC'|'Libpng'|'MIT'|'Openfont-1.1'\
 				|'PythonPL'|'X11'|'ZLIB')
-				# Find the license file in the source files
-				for FILE in "${COMMON_LICENSE_FILES[@]}"; do
-					[[ -f "$TERMUX_PKG_SRCDIR/$FILE" ]] && {
-						if (( COUNTER )); then
-							cp -f "${TERMUX_PKG_SRCDIR}/$FILE" "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}/copyright.${COUNTER}"
-						else
-							cp -f "${TERMUX_PKG_SRCDIR}/$FILE" "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}/copyright"
+					# We only want to include the license files from the source files once
+					if (( ! FROM_SOURCES )); then
+						local FILE
+						# Find the license file(s) in the source files
+						for FILE in "${COMMON_LICENSE_FILES[@]}"; do
+							[[ -f "$TERMUX_PKG_SRCDIR/$FILE" ]] && {
+								if (( COUNTER )); then
+									cp -f "${TERMUX_PKG_SRCDIR}/$FILE" "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}/copyright.${COUNTER}"
+								else
+									cp -f "${TERMUX_PKG_SRCDIR}/$FILE" "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}/copyright"
+								fi
+								(( ++COUNTER, ++FROM_SOURCES ))
+							}
+						done
+						# If we have not found any licenses after searching, that's an error.
+						if (( ! FROM_SOURCES )); then
+							termux_error_exit "${TERMUX_PKG_NAME}: Could not find a license file for $LICENSE in the package sources"
 						fi
-						# since this is a post-increment, (( 0 )) would be falsey
-						# thus `set -e` would kill the script on the first iteration
-						# using `true` prevents this
-						: $(( COUNTER++ ))
-					}
-				done
+					fi
 				;;
-				# For the rest we can use a link to the generic license file
-				*) [[ -f "$TERMUX_SCRIPTDIR/packages/termux-licenses/LICENSES/${LICENSE}.txt" ]] && {
-						# the link target depends on the libc being used
-						if [[ "$TERMUX_PACKAGE_LIBRARY" == 'bionic' ]]; then
-							TO_LICENSE="../../LICENSES/${LICENSE}.txt"
-						elif [[ "$TERMUX_PACKAGE_LIBRARY" == 'glibc' ]]; then
-							TO_LICENSE="../../../../share/LICENSES/${LICENSE}.txt"
-						fi
-						if (( COUNTER )); then
-							ln -sf "$TO_LICENSE" "$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/copyright.$((COUNTER++))"
-						else
-							ln -sf "$TO_LICENSE" "$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/copyright"
-						fi
+				*) # For the rest we can use a link to the generic license file
+					[[ -f "$TERMUX_SCRIPTDIR/packages/termux-licenses/LICENSES/${LICENSE}.txt" ]] || {
+						# If we get here, no license file could be found
+						termux_error_exit "${TERMUX_PKG_NAME}: Could not find a license file for $LICENSE in packages/termux-licenses"
 					}
+					# the link target depends on the libc being used
+					case "$TERMUX_PACKAGE_LIBRARY" in
+						'bionic') TO_LICENSE="../../LICENSES/${LICENSE}.txt";;
+						'glibc')  TO_LICENSE="../../../../share/LICENSES/${LICENSE}.txt";;
+						*)        termux_error_exit "'$TERMUX_PACKAGE_LIBRARY' is not a supported libc";;
+					esac
+					if (( COUNTER )); then
+						ln -sf "$TO_LICENSE" "$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/copyright.${COUNTER}"
+					else
+						ln -sf "$TO_LICENSE" "$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/copyright"
+					fi
+					(( ++COUNTER ))
 				;;
 			esac
 		done <<< "${TERMUX_PKG_LICENSE//,/$'\n'}"

--- a/x11-packages/gtkwave/build.sh
+++ b/x11-packages/gtkwave/build.sh
@@ -1,12 +1,18 @@
-TERMUX_PKG_HOMEPAGE=https://gtkwave.sourceforge.net/
+TERMUX_PKG_HOMEPAGE=https://gtkwave.github.io/gtkwave/
 TERMUX_PKG_DESCRIPTION="A wave viewer which reads LXT, LXT2, VZT, GHW and VCD/EVCD files"
 TERMUX_PKG_LICENSE="GPL-2.0, MIT"
-TERMUX_PKG_LICENSE_FILE="COPYING, LICENSE.TXT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="3.3.120"
-TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/gtkwave/gtkwave-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=803a1893b473132b2672beac30e90f13333534d0b2a1078979fd965a6dc1de8d
+TERMUX_PKG_VERSION="1:3.3.116"
+TERMUX_PKG_SRCURL=https://github.com/gtkwave/gtkwave/archive/refs/tags/v${TERMUX_PKG_VERSION:2}.tar.gz
+TERMUX_PKG_SHA256=b178398da32f8e1958db74057fec278fe0fcc3400485f20ded3ab2330c58f598
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="gdk-pixbuf, glib, gtk2, libandroid-shmem, libbz2, libc++, liblzma, pango, zlib"
+TERMUX_PKG_DEPENDS="gdk-pixbuf, glib, gtk2, gtk3, libandroid-shmem, libbz2, libc++, liblzma, pango, zlib"
 TERMUX_PKG_RECOMMENDS="desktop-file-utils"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-tcl --disable-mime-update"
+
+termux_step_post_get_source() {
+	rm -rf "$TERMUX_PKG_SRCDIR/gtkwave3"
+	mv "$TERMUX_PKG_SRCDIR/gtkwave3-gtk3" "$TERMUX_PKG_TMPDIR/gtkwave3-gtk3"
+	mv "$TERMUX_PKG_TMPDIR/gtkwave3-gtk3"/* "$TERMUX_PKG_SRCDIR"
+	rm -rf "$TERMUX_PKG_TMPDIR/gtkwave3-gtk3"
+}


### PR DESCRIPTION
Move counter advance to the end of the while loop.
This fixes a logic error where the counter wouldn't advance if the first license was "generic"
and the second one was author specific.
This would cause `cp` to attempt to copy through the dangling symlink to the generic license
in `termux-licenses` which fails and dies.

I also moved the `$TERMUX_PACKAGE_LIBRARY` check into a `case` which should make it easier to follow.