### PR TITLE
[DO NOT MERGE] - Revert "bump(main/libcurl): 8.9.1" (stopgap)

### DIFF
--- a/packages/libcurl/build.sh
+++ b/packages/libcurl/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://curl.se/
 TERMUX_PKG_DESCRIPTION="Easy-to-use client-side URL transfer library"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="8.9.1"
+TERMUX_PKG_VERSION="8.9.0"
 TERMUX_PKG_SRCURL=https://github.com/curl/curl/releases/download/curl-${TERMUX_PKG_VERSION//./_}/curl-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=f292f6cc051d5bbabf725ef85d432dfeacc8711dd717ea97612ae590643801e5
+TERMUX_PKG_SHA256=ff09b2791ca56d25fd5c3f3a4927dce7c8a9dc4182200c487ca889fba1fdd412
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+.\d+.\d+"
 TERMUX_PKG_DEPENDS="libnghttp2, libnghttp3, libssh2, openssl (>= 1:3.2.1-1), zlib"


### PR DESCRIPTION
- This PR is intended as a stopgap measure for users effected by
#21036, though it should be considered a last resort.

# **DO NOT MERGE THIS PR.**

<sup>(This is a pre-written, saved reply.)</sup>
If you want to test this PR please download the appropriate DEB package(s)
from the build artifacts of the [associated PR's latest CI run](https://github.com/termux/termux-packages/actions/runs/10230149755?pr=21037).
![Screenshot_20240619_232413](https://github.com/user-attachments/assets/b763bb98-0fcb-410d-ae72-02b5f28298c5)


After downloading the build artifact, make sure to `unzip` and un-`tar` it.
<details><summary>Detailed instructions, if needed.</summary>
<p>

```bash
# finding out what architecture you need
# architecture is just below the TERMUX_VERSION
termux-info

# e.g.
# [...]
# TERMUX_MAIN_PACKAGE_FORMAT=debian
# TERMUX_VERSION=0.118.0
# TERMUX__USER_ID=0
# Packages CPU architecture:
# aarch64
# [...]

# =======================

# make sure `unzip` and `tar` are installed using
pkg install unzip tar

# unzip the artifact (if you have a different architecture this might be arm, i686 or x86_64 instead)
unzip debs-aarch64-*.zip

# untar the artifact
tar xf debs-aarch64-*.tar

# You should now have a debs/ directory in your current working directory
# Install the packages from the local source using
pkg install -- ./debs/*.deb

# to clean up, you can remove the debs/ directory, .tar file and .zip file
rm -rfi debs debs-aarch64-*.zip debs-aarch64-*.tar
```

</p>
</details> 