### PR TITLE
fix(main/wasmedge): Fix version number output

### DIFF
--- a/packages/wasmedge/build.sh
+++ b/packages/wasmedge/build.sh
@@ -4,9 +4,10 @@ TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_LICENSE_FILE="LICENSE, LICENSE.spdx"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.14.0"
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://github.com/WasmEdge/WasmEdge/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=27ef0ffa399fbaf44fb43733ea4ae4a4c1d9836a175269924ffd7e3d258d3567
+TERMUX_PKG_REVISION=2
+# Use source tarball from release assets to get VERSION file for proper version number
+TERMUX_PKG_SRCURL=https://github.com/WasmEdge/WasmEdge/releases/download/${TERMUX_PKG_VERSION}/WasmEdge-${TERMUX_PKG_VERSION}-src.tar.gz
+TERMUX_PKG_SHA256=3fc518c172329d128ab41671b86e3de0544bcaacdec9c9b47bfc4ce8b421dfd5
 TERMUX_PKG_DEPENDS="libc++, libspdlog"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="


### PR DESCRIPTION

    * before: wasmedge version 0.0.0-unreleased
    * after: wasmedge version 0.14.0
    
    This uses source tarball from release assets to get VERSION file for proper version number.
