### PR TITLE
fix(root/nexttrace): version info

### DIFF
--- a/root-packages/nexttrace/build.sh
+++ b/root-packages/nexttrace/build.sh
@@ -5,6 +5,9 @@ TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.3.2"
 TERMUX_PKG_SRCURL=https://github.com/nxtrace/Ntrace-V1/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=da543516932672e80fd08e80a9d52e69c4ad1cb4f483b7efbd235ae0f8a1aaaa
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_BREAKS="nexttrace-enhanced"
+TERMUX_PKG_REPLACES="nexttrace-enhanced"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 
@@ -16,7 +19,12 @@ termux_step_pre_configure() {
 }
 
 termux_step_make() {
-	go build -o nexttrace
+	local _BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	local _COMMIT_SHA1=$(git ls-remote https://github.com/nxtrace/Ntrace-V1 refs/tags/v$TERMUX_PKG_VERSION | head -c 9)
+	go build -trimpath -o nexttrace \
+	-ldflags "-X 'github.com/nxtrace/NTrace-core/config.Version=${TERMUX_PKG_VERSION}' \
+	-X 'github.com/nxtrace/NTrace-core/config.BuildDate=${_BUILD_DATE}' \
+	-X 'github.com/nxtrace/NTrace-core/config.CommitID=${_COMMIT_SHA1}' -w -s"	
 }
 
 termux_step_make_install() {


### PR DESCRIPTION
`nexttrace-enhanced` was renamed to `nexttrace`, and the `enhanced` version has been removed from the original repository.