### PR TITLE
enhance(main/pueue)

### DIFF
--- a/packages/pueue/build.sh
+++ b/packages/pueue/build.sh
@@ -29,12 +29,12 @@ termux_step_make_install() {
 
 termux_step_post_make_install() {
 	# Make a placeholder for shell-completions (to be filled with postinst)
-	mkdir -p "${TERMUX_PREFIX}"/share/bash-completions/completions
+	mkdir -p "${TERMUX_PREFIX}"/share/bash-completion/completions
 	mkdir -p "${TERMUX_PREFIX}"/share/elvish/lib
 	mkdir -p "${TERMUX_PREFIX}"/share/fish/vendor_completions.d
 	mkdir -p "${TERMUX_PREFIX}"/share/nushell/vendor/autoload
 	mkdir -p "${TERMUX_PREFIX}"/share/zsh/site-functions
-	touch "${TERMUX_PREFIX}"/share/bash-completions/completions/pueue
+	touch "${TERMUX_PREFIX}"/share/bash-completion/completions/pueue
 	touch "${TERMUX_PREFIX}"/share/elvish/lib/pueue.elv
 	touch "${TERMUX_PREFIX}"/share/fish/vendor_completions.d/pueue.fish
 	touch "${TERMUX_PREFIX}"/share/nushell/vendor/autoload/pueue.nu
@@ -45,7 +45,7 @@ termux_step_create_debscripts() {
 	cat <<-EOF >./postinst
 		#!${TERMUX_PREFIX}/bin/sh
 
-		pueue completions bash > ${TERMUX_PREFIX}/share/bash-completions/completions/pueue
+		pueue completions bash > ${TERMUX_PREFIX}/share/bash-completion/completions/pueue
 		pueue completions elvish > ${TERMUX_PREFIX}/share/elvish/lib/pueue.elv
 		pueue completions fish > ${TERMUX_PREFIX}/share/fish/vendor_completions.d/pueue.fish
 		pueue completions nushell > ${TERMUX_PREFIX}/share/nushell/vendor/autoload/pueue.nu

--- a/packages/pueue/build.sh
+++ b/packages/pueue/build.sh
@@ -51,4 +51,7 @@ termux_step_create_debscripts() {
 		pueue completions nushell > ${TERMUX_PREFIX}/share/nushell/vendor/autoload/pueue.nu
 		pueue completions zsh > ${TERMUX_PREFIX}/share/zsh/site-functions/_pueue
 	EOF
+	if [ "$TERMUX_PACKAGE_FORMAT" = "pacman" ]; then
+		echo "post_install" > postupg
+	fi
 }


### PR DESCRIPTION
This fixes some issues with the `pueue` package I submitted in [addpkg(main/pueue): a command-line task management tool by stevenxxiu · Pull Request #20959 · termux/termux-packages](https://github.com/termux/termux-packages/pull/20959):

- Fix typo in *Bash* completions dir. I copied that from the `starship` package <https://github.com/termux/termux-packages/blob/df4b49c63779c74411395a396566b7ebc41fed36/packages/starship/build.sh#L38>. You might want to fix this up. I thought it's nicer to not fix that in the same PR, as it's a separate package.
- Run `post_install` after reinstalling or upgrading with *Pacman*, so the completions are generated. I tested that this works.
