### PR TITLE
[lynx] add --enable-default-colors

### DIFF
--- a/packages/lynx/build.sh
+++ b/packages/lynx/build.sh
@@ -7,7 +7,7 @@ TERMUX_PKG_REVISION=8
 TERMUX_PKG_SRCURL=https://invisible-mirror.net/archives/lynx/tarballs/lynx${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=387f193d7792f9cfada14c60b0e5c0bff18f227d9257a39483e14fa1aaf79595
 TERMUX_PKG_DEPENDS="libiconv, ncurses, openssl, libbz2, libidn, zlib"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-screen=ncursesw --enable-widec --enable-scrollbar --enable-nested-tables --enable-htmlized-cfg --with-ssl --with-zlib --with-bzlib --enable-cjk --enable-japanese-utf8 --enable-progressbar --enable-prettysrc --enable-forms-options --enable-8bit-toupper --enable-ascii-ctypes --disable-font-switch --with-mime-libdir=$TERMUX_PREFIX/etc"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-screen=ncursesw --enable-default-colors --enable-widec --enable-scrollbar --enable-nested-tables --enable-htmlized-cfg --with-ssl --with-zlib --with-bzlib --enable-cjk --enable-japanese-utf8 --enable-progressbar --enable-prettysrc --enable-forms-options --enable-8bit-toupper --enable-ascii-ctypes --disable-font-switch --with-mime-libdir=$TERMUX_PREFIX/etc"
 
 ## set default paths for tools that may be used in runtime by 'lynx' binary
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_path_BZIP2=${TERMUX_PREFIX}/bin/bzip2"


### PR DESCRIPTION
this will show a completely black page black on black without --enable-default-colors. otherwise correct black on white 

```
cat .termux/colors.properties
background=#FFFFFF
foreground=#000000
cursor=#5F6368

termux-reload-settings
lynx -nocolor
```

# verify the build

these config settings will not be printed without --enable-default-colors

```
~/.termux-build/lynx/build/lynx -cfg=~/.config/lynx/lynx.cfg -lss= -show_cfg
DEFAULT_COLORS:true
ASSUMED_COLOR:default:default
```

# default with colours 

you have to manually say you want to use default colours if colour is enabled this setting is off by default 

```
lynx.cfg
DEFAULT_COLORS:true
```

and not try this it will break

```
#ASSUMED_COLOR:default:default
```

# upstream patch

I will submit a patch that solve this mess by removing the possibility to disable default colours 


# my colours

my day values replace white with black to correct bugs in apps that draw white on background. the downside is apps that draw black on white will be completely black. the only solution is to patch the apps

```
cat .termux/day.prop
background=#FFFFFF
foreground=#000000
cursor=#5F6368
color7=#222222
color15=#000000
~ cat .termux/night.prop
color1=#FFAAAA
color9=#FFAAAA
background=#000000
foreground=#ffffff
cursor=#5F6368
```


