### PR TITLE
bump(main/sc-im): 0.8.4

### DIFF
--- a/packages/sc-im/Makefile.patch
+++ b/packages/sc-im/Makefile.patch
@@ -31,20 +31,6 @@
  # Used for date formatting with C-d shortcut using you local d_fmt
  CFLAGS += -DUSELOCALE
  # Comment out to enable mouse support on virtual terminal.
-@@ -134,10 +135,10 @@
-   endif
- 
-   # NOTE: lua support
--  ifneq ($(shell pkg-config --exists lua || echo 'no'),no) # Check for user's default lua
--    CFLAGS += -DXLUA $(shell pkg-config --cflags lua)
-+  ifneq ($(shell pkg-config --exists lua51 || echo 'no'),no) # Check for user's default lua
-+    CFLAGS += -DXLUA $(shell pkg-config --cflags lua51)
-     ifneq ($(shell uname -s),Darwin)
--      LDLIBS += $(shell pkg-config --libs lua) -Wl,--export-dynamic
-+      LDLIBS += $(shell pkg-config --libs lua51) -Wl,--export-dynamic
-     else
-       LDLIBS += $(shell pkg-config --libs lua) -rdynamic
-     endif
 @@ -213,6 +214,9 @@
  statres.h : gram.y sres.sed
  	sed -f sres.sed < $< > $@

--- a/packages/sc-im/build.sh
+++ b/packages/sc-im/build.sh
@@ -2,14 +2,16 @@ TERMUX_PKG_HOMEPAGE=https://github.com/andmarti1424/sc-im
 TERMUX_PKG_DESCRIPTION="An improved version of sc, a spreadsheet calculator"
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=0.8.3
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_VERSION="0.8.4"
 TERMUX_PKG_SRCURL=https://github.com/andmarti1424/sc-im/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=5568f9987b6d26535c0e7a427158848f1bc03d829f74e41cbcf007d8704e9bd3
+TERMUX_PKG_SHA256=ebb1f10006fe49f964a356494f96d86a4f06eb018659e3b9bde63b25c03abdf0
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="libandroid-support, libandroid-wordexp, liblua51, libxls, libxlsxwriter, libxml2, libzip, ncurses"
+TERMUX_PKG_DEPENDS="libandroid-support, libandroid-wordexp, liblua54, libxls, libxlsxwriter, libxml2, libzip, ncurses"
 TERMUX_PKG_SUGGESTS="gnuplot"
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXTRA_MAKE_ARGS="
+LUA_PKGNAME=lua54
+"
 
 termux_step_pre_configure() {
 	CFLAGS+=" $CPPFLAGS -I$TERMUX_PREFIX/include/libandroid-support -DGNUPLOT"

--- a/packages/sc-im/src-interp.c.patch
+++ b/packages/sc-im/src-interp.c.patch
@@ -1,0 +1,22 @@
+--- a/src/interp.c
++++ b/src/interp.c
+@@ -1540,6 +1540,10 @@
+     return;
+ }
+ 
++#ifdef USELOCALE
++#include <locale.h>
++#include <langinfo.h>
++#endif
+ 
+ /**
+  * \brief slet()
+@@ -1609,8 +1613,6 @@
+             // reconvert numeric value based on locale's D_FMT format instead of current format
+             char * f = &v->format[1];
+             #ifdef USELOCALE
+-            #include <locale.h>
+-            #include <langinfo.h>
+             char * loc = NULL;
+             f = NULL;
+             loc = setlocale(LC_TIME, "");


### PR DESCRIPTION
    
    * Use LUA_PKGNAME to select lua version instead of patching makefile.
      That option for make was added in the following upstream commit
      https://github.com/andmarti1424/sc-im/commit/5c2e0a19e26a99e899751f72f9715fd35f3131eb
    
    * Update lua dependency to lua5.4.
    
    * Fix the following compiler error with interp.c and modified langinfo.h.
      langinfo.h:107:1: error: function definition is not allowed here

Fixes #21146
