### PR TITLE
scripts(termux_step_install_license): Look for LICEN{C,S}E-MIT

### DIFF
--- a/scripts/build/termux_step_install_license.sh
+++ b/scripts/build/termux_step_install_license.sh
@@ -56,8 +56,12 @@ termux_step_install_license() {
 					# We only want to include the license files from the source files once
 					if (( ! FROM_SOURCES )); then
 						local FILE
+						local EXTRA_LICENSE_FILES=()
+						if [ "$LICENSE" = 'MIT' ]; then
+							EXTRA_LICENSE_FILES+=('LICENCE-MIT' 'LICENSE-MIT')
+						fi
 						# Find the license file(s) in the source files
-						for FILE in "${COMMON_LICENSE_FILES[@]}"; do
+						for FILE in "${COMMON_LICENSE_FILES[@]}" "${EXTRA_LICENSE_FILES[@]}"; do
 							[[ -f "$TERMUX_PKG_SRCDIR/$FILE" ]] && {
 								if (( COUNTER )); then
 									cp -f "${TERMUX_PKG_SRCDIR}/$FILE" "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}/copyright.${COUNTER}"


### PR DESCRIPTION
Look for `LICEN{C,S}E-MIT` files for packages using the MIT license.

Fixes the build failures for at least `fselect`, `nerdfix` and `tokei` as observed in #21130.