### PR TITLE
chore(x11/xcb-util-image): link against `libandroid-shmem` explicitly

### DIFF
--- a/x11-packages/xcb-util-image/build.sh
+++ b/x11-packages/xcb-util-image/build.sh
@@ -3,7 +3,12 @@ TERMUX_PKG_DESCRIPTION="Utility libraries for XC Binding - Port of Xlib's XImage
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.4.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://xcb.freedesktop.org/dist/xcb-util-image-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=ccad8ee5dadb1271fd4727ad14d9bd77a64e505608766c4e98267d9aede40d3d
-TERMUX_PKG_DEPENDS="libxcb, xcb-util"
+TERMUX_PKG_DEPENDS="libandroid-shmem, libxcb, xcb-util"
 TERMUX_PKG_BUILD_DEPENDS="xorg-util-macros"
+
+termux_step_pre_configure() {
+	LDFLAGS+=' -landroid-shmem'
+}


### PR DESCRIPTION
part of #21130