### PR TITLE
Move the signing keys info for each repo channel to repo json file

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -30,6 +30,9 @@ source "$TERMUX_SCRIPTDIR/scripts/utils/docker/docker.sh"; docker__create_docker
 # Functions for working with packages
 source "$TERMUX_SCRIPTDIR/scripts/utils/package/package.sh"
 
+# Source the repository library.
+source "$TERMUX_SCRIPTDIR/scripts/utils/termux/repository/repository.sh"
+
 export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-$(git -c log.showSignature=false log -1 --pretty=%ct 2>/dev/null || date "+%s")}
 
 if [ "$(uname -o)" = "Android" ] || [ -e "/system/bin/app_process" ]; then
@@ -540,20 +543,8 @@ if [ -n "${TERMUX_PACKAGE_LIBRARY-}" ]; then
 fi
 
 if [ "${TERMUX_INSTALL_DEPS-false}" = "true" ] || [ "${TERMUX_PACKAGE_LIBRARY-bionic}" = "glibc" ]; then
-	# Setup PGP keys for verifying integrity of dependencies.
-	# Keys are obtained from our keyring package.
-	gpg --list-keys 2C7F29AE97891F6419A9E2CDB0076E490B71616B > /dev/null 2>&1 || {
-		gpg --import "$TERMUX_SCRIPTDIR/packages/termux-keyring/grimler.gpg"
-		gpg --no-tty --command-file <(echo -e "trust\n5\ny")  --edit-key 2C7F29AE97891F6419A9E2CDB0076E490B71616B
-	}
-	gpg --list-keys CC72CF8BA7DBFA0182877D045A897D96E57CF20C > /dev/null 2>&1 || {
-		gpg --import "$TERMUX_SCRIPTDIR/packages/termux-keyring/termux-autobuilds.gpg"
-		gpg --no-tty --command-file <(echo -e "trust\n5\ny")  --edit-key CC72CF8BA7DBFA0182877D045A897D96E57CF20C
-	}
-	gpg --list-keys 998DE27318E867EA976BA877389CEED64573DFCA > /dev/null 2>&1 || {
-		gpg --import "$TERMUX_SCRIPTDIR/packages/termux-keyring/termux-pacman.gpg"
-		gpg --no-tty --command-file <(echo -e "trust\n5\ny")  --edit-key 998DE27318E867EA976BA877389CEED64573DFCA
-	}
+	# Setup PGP keys for each repo channel in repo.json file for verifying integrity of dependencies.
+	termux_repository__add_repo_signing_keys_to_keystore "$TERMUX_SCRIPTDIR/repo.json" "$TERMUX_SCRIPTDIR"
 fi
 
 for ((i=0; i<${#PACKAGE_LIST[@]}; i++)); do

--- a/repo.json
+++ b/repo.json
@@ -4,18 +4,30 @@
     "name": "termux-main",
     "distribution": "stable",
     "component": "main",
-    "url": "https://packages-cf.termux.dev/apt/termux-main"
+    "url": "https://packages-cf.termux.dev/apt/termux-main",
+    "signing_keys": [
+      { "key_file": "packages/termux-keyring/termux-autobuilds.gpg" },
+      { "key_file": "packages/termux-keyring/grimler.gpg" }
+    ]
   },
   "root-packages": {
     "name": "termux-root",
     "distribution": "root",
     "component": "stable",
-    "url": "https://packages-cf.termux.dev/apt/termux-root"
+    "url": "https://packages-cf.termux.dev/apt/termux-root",
+    "signing_keys": [
+      { "key_file": "packages/termux-keyring/termux-autobuilds.gpg" },
+      { "key_file": "packages/termux-keyring/grimler.gpg" }
+    ]
   },
   "x11-packages": {
     "name": "termux-x11",
     "distribution": "x11",
     "component": "main",
-    "url": "https://packages-cf.termux.dev/apt/termux-x11"
+    "url": "https://packages-cf.termux.dev/apt/termux-x11",
+    "signing_keys": [
+      { "key_file": "packages/termux-keyring/termux-autobuilds.gpg" },
+      { "key_file": "packages/termux-keyring/grimler.gpg" }
+    ]
   }
 }

--- a/scripts/utils/termux/repository/repository.sh
+++ b/scripts/utils/termux/repository/repository.sh
@@ -1,0 +1,126 @@
+# shellcheck shell=bash
+
+# Title:          repository
+# Description:    A library for Termux repository utils.
+
+
+
+##
+# Add repository signing keys to local keystore.
+# .
+# Each repo channel dict in `repo.json` file should have a
+# `signing_keys` key for an array of dicts, where each dict contains
+# information for each key that may be required by the parent repo
+# channel. At least one signing key info must exist for each repo
+# channel.
+# .
+# The `key_file` key should be set to the path of the key file. If it
+# is a relative path that does not start a slash `/`, then
+# `termux-packages` repo root directory will be prepended to it.
+# .
+#
+# A dict is being used because other keys may be required
+# in future in addition to current `key_file` key, like `key_format`, etc.
+# .
+# ```
+# "<repo_channel_path>": {
+#     "signing_keys": [
+#       {
+#         "key_file": "path/to/key1.gpg"
+#       },
+#       {
+#         "key_file": "path/to/key1.gpg"
+#       }
+#     ]
+# }
+# ```
+# .
+# .
+# **Parameters:**
+# `repo_json_file` - The path to the `repo.json` file.
+# `repo_root_dir` - The path to the `termux-packages` repo root
+#                   directory.
+# .
+# **Returns:**
+# Returns `0` if successful, otherwise returns with a non-zero exit code.
+# .
+# .
+# termux_repository__add_repo_signing_keys_to_keystore `<repo_json_file>`
+#     `<repo_root_dir>`
+##
+termux_repository__add_repo_signing_keys_to_keystore() {
+
+	local repo_json_file="$1"
+	local repo_root_dir="$2"
+
+	local gpg_keys_list
+	local i
+	local key_file
+	local repo_channel_path
+	local repo_channel_paths_list
+	local signing_keys_json
+	local signing_keys_json_array_string
+
+	local -a signing_keys_json_array
+
+	if [[ -z "$repo_json_file" ]]; then
+		echo "The repo_json_file is not set that is passed to 'termux_repository__add_repo_signing_keys_to_keystore'" 1>&2
+		return 1
+	elif [[ ! -f "$repo_json_file" ]]; then
+		echo "The repo_json_file '$repo_json_file' does not exist at path that is passed to 'termux_repository__add_repo_signing_keys_to_keystore'" 1>&2
+		return 1
+	fi
+
+	# Get the paths list for each repo channel and loop on it.
+	repo_channel_paths_list="$(jq --raw-output 'del(.pkg_format) | keys | .[]' "$repo_json_file")" || return $?
+	for repo_channel_path in $repo_channel_paths_list; do
+		# Check if `signing_keys` array exists for repo channel
+		if [[ "$(jq ".[\"$repo_channel_path\"].signing_keys"' | if type=="array" then "found" else "not_found" end' "$repo_json_file")" != '"found"' ]]; then
+			echo "The 'signing_keys' array in '$repo_channel_path' repo channel dict in repo json file '$repo_json_file' does not exist" 1>&2
+			echo "Check 'termux_repository__add_repo_signing_keys_to_keystore()' function for more info." 1>&2
+			return 1
+		fi
+
+		# Get the json for each `dict` in the the `signing_keys` array
+		# of the repo channel, separated by newlines.
+		signing_keys_json_array_string="$(jq --compact-output ".[\"$repo_channel_path\"].signing_keys[]" "$repo_json_file")" || return $?
+		if [[ -z "$signing_keys_json_array_string" ]]; then
+			echo "The 'signing_keys' array in '$repo_channel_path' repo channel dict in repo json file '$repo_json_file' is empty." 1>&2
+			echo "At least one singing key info must exist for a repo channel." 1>&2
+			return 1
+		fi
+
+		# Create an array of jsons and loop on it.
+		readarray -t signing_keys_json_array < <(echo "$signing_keys_json_array_string")
+		i=1
+		for signing_keys_json in "${signing_keys_json_array[@]}"; do
+			key_file=$(echo "$signing_keys_json" | jq --raw-output '.key_file')
+
+			if [[ -z "$key_file" ]] || [[ "$key_file" == "null" ]]; then
+				echo "The 'key_file' key for signing key $i of '$repo_channel_path' repo channel in repo json file '$repo_json_file' does not exist or is not set" 1>&2
+				echo "signing_keys_json: $signing_keys_json" 1>&2
+				return 1
+			fi
+
+			if [[ "$key_file" != "/"* ]]; then
+				key_file="$repo_root_dir/$key_file"
+			fi
+
+			if [[ ! -f "$key_file" ]]; then
+				echo "The key file '$key_file' for signing key $i of '$repo_channel_path' repo channel in repo json file '$repo_json_file' does not exist at path" 1>&2
+				echo "signing_keys_json: $signing_keys_json" 1>&2
+				return 1
+			fi
+
+			gpg_keys_list=$(gpg --show-keys "$key_file" | sed -n 2p | sed -E -e 's/^[ ]+//') || return $?
+			gpg --list-keys "$gpg_keys_list" > /dev/null 2>&1 || {
+				echo "Adding key file '$key_file' for signing key $i of '$repo_channel_path' repo channel in repo json file '$repo_json_file' to gpg keystore"
+				gpg --import "$key_file" || return $?
+				gpg --no-tty --command-file <(echo -e "trust\n5\ny")  --edit-key "$gpg_keys_list" || return $?
+			}
+
+			i=$((i + 1))
+		done
+	done
+
+}


### PR DESCRIPTION
Move the signing keys info for each repo channel to `repo.json` instead of hardcoding it in build scripts

This will allow each repo channel to define its own keys that may be used for verifying signatures of its files. The `termux-packages` fork will just need to add signing keys info in the `repo.json` file itself for any additional channels instead of having to patch build scripts. With the old hardcoded way, the unnecessary pacman key was also being added to local keystore in the current/upstream termux-packages repo, even though no repo channel uses it, so defining the keys in the `repo.json` will solve that issue as well.

The `termux_repository__add_repo_signing_keys_to_keystore()` function now handles the logic for adding the repository signing keys to the local keystore. Check its function docs for more info on the new json format and requirements for `repo.json` file.

---

``````markdown
Add repository signing keys to local keystore.
.
Each repo channel dict in `repo.json` file should have a
`signing_keys` key for an array of dicts, where each dict contains
information for each key that may be required by the parent repo
channel. At least one signing key info must exist for each repo
channel.
.
The `key_file` key should be set to the path of the key file. If it
is a relative path that does not start a slash `/`, then
`termux-packages` repo root directory will be prepended to it.
.
#
A dict is being used because other keys may be required
in future in addition to current `key_file` key, like `key_format`, etc.
.
```
"<repo_channel_path>": {
    "signing_keys": [
      {
        "key_file": "path/to/key1.gpg"
      },
      {
        "key_file": "path/to/key1.gpg"
      }
    ]
}
```
.
.
**Parameters:**
`repo_json_file` - The path to the `repo.json` file.
`repo_root_dir` - The path to the `termux-packages` repo root
                  directory.
.
**Returns:**
Returns `0` if successful, otherwise returns with a non-zero exit code.
.
.
termux_repository__add_repo_signing_keys_to_keystore `<repo_json_file>`
    `<repo_root_dir>`
``````

---

1. @Maxython You will need to make changes to https://github.com/termux-pacman/termux-packages/blob/master/repo.json and add `packages/termux-keyring/termux-pacman.gpg` to each repository channel.
2. @licy183 You can remove the [patch](https://github.com/termux-user-repository/tur/blob/b0f914db048faf6ba8a2245687b100deaa0e75e2/common-files/building-system-patches/0001-import-gpg-key.patch#L8) and make required changes to the https://github.com/termux-user-repository/tur/blob/master/repo.json file itself.