### PR TITLE
chore(main/dpkg): Use upstream git repository instead of tarball from mirror

### DIFF
--- a/packages/dpkg/build.sh
+++ b/packages/dpkg/build.sh
@@ -3,8 +3,10 @@ TERMUX_PKG_DESCRIPTION="Debian package management system"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.22.6"
-TERMUX_PKG_SRCURL=https://mirrors.kernel.org/debian/pool/main/d/dpkg/dpkg_${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=4379123466cf1804f82aaac7fbea7133c58aefa178dfbf7029cdc61a8d220655
+TERMUX_PKG_REVISION=1
+# old tarball are removed in https://mirrors.kernel.org/debian/pool/main/d/dpkg/dpkg_${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SRCURL=git+https://salsa.debian.org/dpkg-team/dpkg.git
+TERMUX_PKG_GIT_BRANCH="${TERMUX_PKG_VERSION}"
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_DEPENDS="bzip2, coreutils, diffutils, gzip, less, libbz2, liblzma, libmd, tar, xz-utils, zlib, zstd"
 TERMUX_PKG_ANTI_BUILD_DEPENDS="clang"
@@ -70,6 +72,11 @@ share/polkit-1
 "
 
 termux_step_pre_configure() {
+	(
+		cd "${TERMUX_PKG_SRCDIR}" && \
+		./autogen && \
+		patch -p1 -i "${TERMUX_PKG_BUILDER_DIR}"/configure.diff
+	)
 	export TAR=tar # To make sure dpkg tries to use "tar" instead of e.g. "gnutar" (which happens when building on OS X)
 	perl -p -i -e "s/TERMUX_ARCH/$TERMUX_ARCH/" $TERMUX_PKG_SRCDIR/configure
 	sed -i 's/$req_vars = \$arch_vars.$varname./if ($varname eq "DEB_HOST_ARCH_CPU" or $varname eq "DEB_HOST_ARCH"){ print("'$TERMUX_ARCH'");exit; }; $req_vars = $arch_vars{$varname}/' scripts/dpkg-architecture.pl

--- a/packages/dpkg/configure.diff
+++ b/packages/dpkg/configure.diff
@@ -1,7 +1,7 @@
 diff -u -r ../dpkg-1.21.7/configure ./configure
 --- ../dpkg-1.21.7/configure	2022-04-30 20:54:49.352689537 -0300
 +++ ./configure	2022-04-30 20:56:52.770022395 -0300
-@@ -29818,7 +29818,7 @@
+@@ -33613,7 +33613,7 @@
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking dpkg cpu type" >&5
  printf %s "checking dpkg cpu type... " >&6; }
  
@@ -10,7 +10,7 @@ diff -u -r ../dpkg-1.21.7/configure ./configure
  
    if test "x$cpu_type" = "x"
  then :
-@@ -29867,7 +29867,7 @@
+@@ -33662,7 +33662,7 @@
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking dpkg architecture name" >&5
  printf %s "checking dpkg architecture name... " >&6; }
  


### PR DESCRIPTION
This fixes building dpkg when old tarball are removed in https://mirrors.kernel.org/debian/pool/main/d/dpkg/