### PR TITLE
fix(main/silicon): Update time crate for rust 1.80 compatibility

### DIFF
--- a/packages/silicon/build.sh
+++ b/packages/silicon/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Silicon is an alternative to Carbon implemented in Rust"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Yaksh Bariya <thunder-coding@termux.dev>"
 TERMUX_PKG_VERSION="0.5.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/Aloxaf/silicon/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=815d41775dd9cd399650addf8056f803f3f57e68438e8b38445ee727a56b4b2d
 TERMUX_PKG_DEPENDS="fontconfig, harfbuzz"

--- a/packages/silicon/bump-time-crate.patch
+++ b/packages/silicon/bump-time-crate.patch
@@ -1,0 +1,46 @@
+diff -u -r ../silicon-0.5.2/Cargo.lock ./Cargo.lock
+--- ../silicon-0.5.2/Cargo.lock	2023-11-22 07:14:56.000000000 +0000
++++ ./Cargo.lock	2024-08-27 12:12:14.579889468 +0000
+@@ -824,6 +824,12 @@
+ ]
+ 
+ [[package]]
++name = "num-conv"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
++
++[[package]]
+ name = "num-integer"
+ version = "0.1.45"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -1474,12 +1480,13 @@
+ 
+ [[package]]
+ name = "time"
+-version = "0.3.30"
++version = "0.3.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
++checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+ dependencies = [
+  "deranged",
+  "itoa",
++ "num-conv",
+  "powerfmt",
+  "serde",
+  "time-core",
+@@ -1494,10 +1501,11 @@
+ 
+ [[package]]
+ name = "time-macros"
+-version = "0.2.15"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+ dependencies = [
++ "num-conv",
+  "time-core",
+ ]
+ 


### PR DESCRIPTION
Fixes build failure noted in #21130.