### PR TITLE
bump(main/watchexec): 2.1.2

### DIFF
--- a/packages/watchexec/build.sh
+++ b/packages/watchexec/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://github.com/watchexec/watchexec
 TERMUX_PKG_DESCRIPTION="Executes commands in response to file modifications"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1.22.3
+TERMUX_PKG_VERSION=2.1.2
 TERMUX_PKG_SRCURL=https://github.com/watchexec/watchexec/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=698ed1dc178279594542f325b23f321c888c9c12c1960fe11c0ca48ba6edad76
+TERMUX_PKG_SHA256=500b886038ccd553559fe19914e1a502728cfeb8ee9d81f3db448b05e5a890ec
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_BUILD_IN_SRC=true
 
@@ -15,20 +15,16 @@ termux_step_make_install() {
 		--path crates/cli \
 		--force \
 		--locked \
+		--no-track \
 		--target $CARGO_TARGET_NAME \
 		--root $TERMUX_PREFIX \
 		$TERMUX_PKG_EXTRA_CONFIGURE_ARGS
-	# https://github.com/rust-lang/cargo/issues/3316:
-	rm -f $TERMUX_PREFIX/.crates.toml
-	rm -f $TERMUX_PREFIX/.crates2.json
 }
 
 termux_step_post_make_install() {
 	local f
-	for f in doc/watchexec.1.{md,pdf}; do
-		install -Dm600 -t "$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME" \
-			"$TERMUX_PKG_SRCDIR/${f}"
-	done
+	install -Dm600 -t "$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME" \
+		"$TERMUX_PKG_SRCDIR/doc/watchexec.1.md"
 	install -Dm600 -t "$TERMUX_PREFIX/share/man/man1" \
 		"$TERMUX_PKG_SRCDIR"/doc/watchexec.1
 	install -Dm600 -T "completions/bash" \


### PR DESCRIPTION
Fixes a build error noted in #21130, as the new version has an updated time crate dependency and thus compiles under rust 1.80.