### PR TITLE
abseil-cpp: revbump

### DIFF
--- a/packages/abseil-cpp/build.sh
+++ b/packages/abseil-cpp/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # Do not forget to rebuild revdeps along with EVERY "major" version bump.
 TERMUX_PKG_VERSION="20240116.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/abseil/abseil-cpp/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=733726b8c3a6d39a4120d7e45ea8b41a434cdacde401cba500f14236c49b39dc
 # updating this will break libprotobuf


### PR DESCRIPTION
clang changed their mangling rules since clang-18, and some symbols in absl_log have different symbol names between clang-17/ndk-26 and clang-18/ndk-27
