### PR TITLE
boost: apply upstream patch for  phoenix symbols

### DIFF
--- a/packages/boost/build.sh
+++ b/packages/boost/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Never forget to always bump revision of reverse dependencies and rebuild them
 # when bumping version.
 TERMUX_PKG_VERSION="1.83.0"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://boostorg.jfrog.io/artifactory/main/release/$TERMUX_PKG_VERSION/source/boost_${TERMUX_PKG_VERSION//./_}.tar.bz2
 TERMUX_PKG_SHA256=6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e
 TERMUX_PKG_AUTO_UPDATE=false

--- a/packages/boost/phoenix-linking-issue.patch
+++ b/packages/boost/phoenix-linking-issue.patch
@@ -1,0 +1,20 @@
+From 665047aac26ad4d96b266d87504b3a88ad21b37e Mon Sep 17 00:00:00 2001
+From: djowel <djowel@gmail.com>
+Date: Mon, 28 Aug 2023 08:33:46 +0800
+Subject: [PATCH] avoid ODR by making this const
+
+diff --git a/boost/phoenix/stl/tuple.hpp b/boost/phoenix/stl/tuple.hpp
+index a83014ac..fb9440d2 100644
+--- a/boost/phoenix/stl/tuple.hpp
++++ b/boost/phoenix/stl/tuple.hpp
+@@ -109,8 +109,8 @@ namespace boost { namespace phoenix {
+     // Make unpacked argument placeholders
+     namespace placeholders {
+         #define BOOST_PP_LOCAL_LIMITS (1, BOOST_PHOENIX_ARG_LIMIT)
+-        #define BOOST_PP_LOCAL_MACRO(N)                                                \
+-            auto uarg##N =                                                             \
++        #define BOOST_PP_LOCAL_MACRO(N)                                                 \
++            const auto uarg##N =                                                        \
+             boost::phoenix::get_<(N)-1>(boost::phoenix::placeholders::arg1);
+         #include BOOST_PP_LOCAL_ITERATE()
+     }


### PR DESCRIPTION
I encountered linking errors with `boost` as I am bringing libreoffice deps to TUR, including a package called `libetonyek` which depends on `boost`. The error prompt is `ld.lld: error: duplicate symbol: boost::phoenix::placeholders::uarg1`. After some investigation, the errors are fixed in `boost` 1.86.0 with this commit https://github.com/boostorg/phoenix/commit/665047aac26ad4d96b266d87504b3a88ad21b37e. These github build actions shows that the patch fixes the problem of building the libreoffice dep `libetonyek`: [without patch](https://github.com/knyipab/termux-packages/actions/runs/10647080259) vs [with patch](https://github.com/knyipab/termux-packages/actions/runs/10647083466). 

Please consider taking this upstream patch. Or bump the package if the dev may wish to. Thank you!