### PR TITLE
bump(main/libx264): 0.164.3191

### DIFF
--- a/packages/libx264/build.sh
+++ b/packages/libx264/build.sh
@@ -2,26 +2,24 @@ TERMUX_PKG_HOMEPAGE=https://www.videolan.org/developers/x264.html
 TERMUX_PKG_DESCRIPTION="Library for encoding video streams into the H.264/MPEG-4 AVC format"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-_COMMIT=b093bbe7d9bc642c8f24067cbdcc73bb43562eab
-TERMUX_PKG_VERSION=1:0.164.3101 # X264_BUILD from x264.h; commit count
+_COMMIT=4613ac3c15fd75cebc4b9f65b7fb95e70a3acce1
+# X264_BUILD from x264.h; commit count using "git rev-list --count HEAD" on x264 git repo
+TERMUX_PKG_VERSION="1:0.164.3191"
 TERMUX_PKG_SRCURL=https://code.videolan.org/videolan/x264/-/archive/$_COMMIT/x264-$_COMMIT.tar.bz2
-TERMUX_PKG_SHA256=8a943822d761c302da647399582354fa8788802570ce3b865edd44b1aa77e9b0
+TERMUX_PKG_SHA256=2a1b197fd1fbc85045794f18c9353648a9ae3cbe194b7b92d523d096f9445464
 TERMUX_PKG_BREAKS="libx264-dev"
 TERMUX_PKG_REPLACES="libx264-dev"
 # Avoid linking against ffmpeg libraries to avoid circular dependency:
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--disable-lavf
 --disable-swscale
---disable-lavf"
+"
 
 termux_step_pre_configure() {
-	#if [ $TERMUX_ARCH = "i686" -o $TERMUX_ARCH = "x86_64" ]; then
 	if [ $TERMUX_ARCH = "i686" ]; then
 		# Avoid text relocations on i686, see:
 		# https://mailman.videolan.org/pipermail/x264-devel/2016-March/011589.html
 		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --disable-asm"
-		# Avoid errors such as "relocation R_386_GOTOFF against preemptible symbol
-		# x264_significant_coeff_flag_offset cannot be used when making a shared object":
-		LDFLAGS+=" -fuse-ld=bfd"
 	elif [ $TERMUX_ARCH = "x86_64" ]; then
 		# Avoid requiring nasm for now:
 		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --disable-asm"
@@ -29,6 +27,5 @@ termux_step_pre_configure() {
 }
 
 termux_step_post_make_install() {
-	mkdir -p ${TERMUX_PREFIX}/share/bash-completion/completions
-	install -m 644 ${TERMUX_PKG_SRCDIR}/tools/bash-autocomplete.sh ${TERMUX_PREFIX}/share/bash-completion/completions/x264
+	install -Dm644 ${TERMUX_PKG_SRCDIR}/tools/bash-autocomplete.sh ${TERMUX_PREFIX}/share/bash-completion/completions/x264
 }


### PR DESCRIPTION
Also revert 2b12322b66f80faeb4c31535049730d24930f9ae that causes build error on NDK r27 for i686:
```console
i686-linux-android-clang conftest.c -m32  -march=i686 -msse3 -mstackrealign -mfpmath=sse -fPIC -fstack-protector-strong -Oz -Wall -I. -I$(SRCPATH)     -m32 -L/data/data/com.termux/files/usr/lib -Wl,-rpath=/data/data/com.termux/files/usr/lib -Wl,--enable-new-dtags -Wl,--as-needed -Wl,-z,relro,-z,now -fuse-ld=bfd -lm -o conftest
/usr/bin/ld.bfd: /home/builder/.termux-build/_cache/android-r27-api-24-v1/bin/../sysroot/usr/lib/i686-linux-android/24/libm.so: unable to initialize decompress status for section .debug_abbrev
/usr/bin/ld.bfd: /home/builder/.termux-build/_cache/android-r27-api-24-v1/bin/../sysroot/usr/lib/i686-linux-android/24/libm.so: unable to initialize decompress status for section .debug_abbrev
/home/builder/.termux-build/_cache/android-r27-api-24-v1/bin/../sysroot/usr/lib/i686-linux-android/24/libm.so: file not recognized: file format not recognized
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```