### PR TITLE
fix(main/monolith): Fix linker error for i686 build

### DIFF
--- a/packages/monolith/build.sh
+++ b/packages/monolith/build.sh
@@ -18,4 +18,6 @@ termux_step_pre_configure() {
 	if [[ "${TERMUX_ARCH}" == "i686" ]]; then
 		RUSTFLAGS+=" -C link-arg=$(${CC} -print-libgcc-file-name)"
 	fi
+
+	export OPENSSL_NO_VENDOR=1
 }

--- a/packages/monolith/build.sh
+++ b/packages/monolith/build.sh
@@ -11,4 +11,11 @@ TERMUX_PKG_DEPENDS="openssl"
 
 termux_step_pre_configure() {
 	rm -f Makefile
+
+	# ld: error: undefined symbol: __atomic_is_lock_free
+	# ld: error: undefined symbol: __atomic_fetch_or_8
+	# ld: error: undefined symbol: __atomic_load
+	if [[ "${TERMUX_ARCH}" == "i686" ]]; then
+		RUSTFLAGS+=" -C link-arg=$(${CC} -print-libgcc-file-name)"
+	fi
 }


### PR DESCRIPTION
Build failed in dd30194ca176463e250fbb035b2daa1f75aa0274 commit with i686 arch. CI log https://github.com/termux/termux-packages/actions/runs/10677533883/job/29592861248