### PR TITLE
bump(scripts/setup-meson): Update meson from 1.4.0 to 1.5.1

### DIFF
--- a/scripts/build/setup/termux_setup_meson.sh
+++ b/scripts/build/setup/termux_setup_meson.sh
@@ -1,6 +1,6 @@
 termux_setup_meson() {
 	termux_setup_ninja
-	local MESON_VERSION=1.4.0
+	local MESON_VERSION=1.5.1
 	local MESON_FOLDER
 
 	if [ "${TERMUX_PACKAGES_OFFLINE-false}" = "true" ]; then
@@ -16,7 +16,7 @@ termux_setup_meson() {
 		termux_download \
 			"https://github.com/mesonbuild/meson/releases/download/$MESON_VERSION/meson-$MESON_VERSION.tar.gz" \
 			"$MESON_TAR_FILE" \
-			8fd6630c25c27f1489a8a0392b311a60481a3c161aa699b330e25935b750138d
+			567e533adf255de73a2de35049b99923caf872a455af9ce03e01077e0d384bed
 		tar xf "$MESON_TAR_FILE" -C "$TERMUX_PKG_TMPDIR"
 		shopt -s nullglob
 		local f


### PR DESCRIPTION
Tested with a few packages: glib, gstreamer, libwayland, python-numpy and kitty.

Reference: [Meson 1.5 reles notes](https://mesonbuild.com/Release-notes-for-1-5-0.html)