### PR TITLE
scripts(setup-ubuntu.sh): Remove clang-15

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -99,7 +99,6 @@ PACKAGES+=" gengetopt"
 PACKAGES+=" libdbus-1-dev"
 
 # Needed by package below.
-PACKAGES+=" clang-15"
 PACKAGES+=" libelf-dev"
 
 # Needed by package ghostscript.


### PR DESCRIPTION
After the latest updates below we seem to be able to drop clang-15 (and with that the llvm-15 dependency) from the builder docker image.

- https://github.com/termux/termux-packages/pull/20595
- https://github.com/termux/termux-packages/pull/20585
- https://github.com/termux/termux-packages/pull/20581