### PR TITLE
scripts(setup-ubuntu.sh): Remove openjdk ppa

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -328,11 +328,6 @@ $SUDO chmod a+r /etc/apt/trusted.gpg.d/apt.llvm.org.asc
 	echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main"
 } | $SUDO tee /etc/apt/sources.list.d/apt-llvm-org.list > /dev/null
 
-# Add ppa repo to be able to get openjdk-17 on ubuntu 22.04
-$SUDO cp $(dirname "$(realpath "$0")")/openjdk-r-ppa.gpg /etc/apt/trusted.gpg.d/
-$SUDO chmod a+r /etc/apt/trusted.gpg.d/openjdk-r-ppa.gpg
-echo "deb https://ppa.launchpadcontent.net/openjdk-r/ppa/ubuntu/ jammy main" | $SUDO tee /etc/apt/sources.list.d/openjdk-r-ubuntu-ppa-jammy.list > /dev/null
-
 $SUDO apt-get -yq update
 
 $SUDO env DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
In both ubuntu 22.04 and 24.04 the `openjdk-17` and `openjdk-21` packages can be installed without adding this ppa, so remove it to simplify things and prepare for updating to ubuntu 24.04.