### PR TITLE
scripts(setup-ubuntu.sh): Remove python3.9

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -65,7 +65,6 @@ PACKAGES+=" xmlto"
 PACKAGES+=" xmltoman"
 
 # Needed by python modules (e.g. asciinema) and some build systems.
-PACKAGES+=" python3.9"
 PACKAGES+=" python3.10"
 PACKAGES+=" python3.11"
 PACKAGES+=" python3-pip"


### PR DESCRIPTION
A step in cleaning up the ubuntu setup and preparing for updating to ubuntu 24.04.

Note that there is no `python3.9` package actually installed in the builder image even before this change - what was actually happening is this:

> $ sudo env DEBIAN_FRONTEND=noninteractive apt-get install python3.9
> Note, selecting 'python3.9-llfuse' for regex 'python3.9'
> Note, selecting 'python3-llfuse' instead of 'python3.9-llfuse'