### PR TITLE
fix(scripts/Dockerfile): Avoid legacy key-value format

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -7,7 +7,7 @@
 FROM ubuntu:22.04
 
 # Fix locale to avoid warnings:
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 # Needed for setup:
 COPY ./llvm-snapshot.gpg.key ./openjdk-r-ppa.gpg ./properties.sh ./setup-android-sdk.sh ./setup-cgct.sh ./setup-ubuntu.sh /tmp/


### PR DESCRIPTION
Fix the following warning when building the docker image:

>  1 warning found (use docker --debug to expand):
> - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 10)