### PR TITLE
bump(x11/qt5-qtwebengine): 5.15.17

### DIFF
--- a/x11-packages/qt5-qtwebengine/build.sh
+++ b/x11-packages/qt5-qtwebengine/build.sh
@@ -1,9 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/qt/qtwebengine
 TERMUX_PKG_DESCRIPTION="Qt 5 Web Engine Library"
-TERMUX_PKG_LICENSE="LGPL-3.0, LGPL-2.1, BSD 3-Clause"
+TERMUX_PKG_LICENSE="LGPL-3.0, GPL-2.0, GPL-3.0, BSD 3-Clause"
+TERMUX_PKG_LICENSE_FILE="LICENSE.LGPL3, LICENSE.GPL2, LICENSE.GPL3, LICENSE.Chromium"
 TERMUX_PKG_MAINTAINER="@licy183"
-TERMUX_PKG_VERSION="5.15.15"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION="5.15.17"
 TERMUX_PKG_SRCURL=git+https://github.com/qt/qtwebengine
 TERMUX_PKG_GIT_BRANCH=v$TERMUX_PKG_VERSION-lts
 TERMUX_PKG_DEPENDS="dbus, fontconfig, libc++, libexpat, libjpeg-turbo, libminizip, libnspr, libnss, libpng, libsnappy, libvpx, libwebp, libx11, libxkbfile, qt5-qtbase, qt5-qtdeclarative, zlib"


### PR DESCRIPTION
Fixes two build errors noticed in #21130:
- 5.15.15 not being compatible with current clang
- Licence file not found