### PR TITLE
fix(main/yazi): Update rustix to get TCGETS fallback

### DIFF
--- a/packages/yazi/Cargo.lock.patch
+++ b/packages/yazi/Cargo.lock.patch
@@ -1,0 +1,17 @@
+Uodate rustix to get https://github.com/bytecodealliance/rustix/pull/1147
+
+diff -u -r ../yazi-0.3.3/Cargo.lock ./Cargo.lock
+--- ../yazi-0.3.3/Cargo.lock	2024-09-04 15:16:18.000000000 +0000
++++ ./Cargo.lock	2024-09-05 22:10:24.763062579 +0000
+@@ -2105,9 +2105,9 @@
+ 
+ [[package]]
+ name = "rustix"
+-version = "0.38.35"
++version = "0.38.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
++checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
+ dependencies = [
+  "bitflags 2.6.0",
+  "errno",

--- a/packages/yazi/build.sh
+++ b/packages/yazi/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Blazing fast terminal file manager written in Rust, base
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.3.3"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/sxyazi/yazi/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=fe2a458808334fe20eff1ab0145c78d684d8736c9715e4c51bce54038607dc4e
 TERMUX_PKG_AUTO_UPDATE=true


### PR DESCRIPTION
See https://github.com/bytecodealliance/rustix/pull/1147

Fixes #21364