### PR TITLE
scripts(setup-ubuntu.sh): Remove host python2

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -220,7 +220,6 @@ PACKAGES+=" itstool"
 PACKAGES+=" libdbus-glib-1-dev-bin"
 PACKAGES+=" libgdk-pixbuf2.0-dev"
 PACKAGES+=" libwayland-dev"
-PACKAGES+=" python-setuptools"
 PACKAGES+=" python3-html5lib"
 PACKAGES+=" python3-xcbgen"
 PACKAGES+=" sassc"
@@ -332,12 +331,6 @@ $SUDO apt-get -yq update
 
 $SUDO env DEBIAN_FRONTEND=noninteractive \
 	apt-get install -yq --no-install-recommends $PACKAGES
-
-# Pip for python2.
-curl -L --output /tmp/py2-get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py
-$SUDO python2 /tmp/py2-get-pip.py
-rm -f /tmp/py2-get-pip.py
-$SUDO rm -f /usr/local/bin/pip
 
 $SUDO locale-gen --purge en_US.UTF-8
 echo -e 'LANG="en_US.UTF-8"\nLANGUAGE="en_US:en"\n' | $SUDO tee -a /etc/default/locale


### PR DESCRIPTION
Removing host `python2` (which is currently pulled in as a dependency of `python-setuptools`) is a step towards updating to ubuntu 24.04, which does not have a `python2` package out of the box.

While we could always add a third-party `python2` package, it's probably best to start out with checking if we can proceed without one.

Note that this is a separate issue then removing the `python2` termux package (which should eventually be done, but until that it builds fine without a preinstalled host `python2`).

# Remaining packages that uses host python2
- ~~[libduktape](https://github.com/termux/termux-packages/blob/master/packages/libduktape/build.sh) uses host `python2`~~ (fixed in #21407).
- ~~[libglade](https://github.com/termux/termux-packages/blob/master/x11-packages/libglade/build.sh) requires host `python2` to build~~ (removed in #21410).

Please fill in if you know about more packages (possibly) requiring host `python2` to build.