### PR TITLE
scripts: add an option to skip the openmp check

### DIFF
--- a/scripts/build/termux_step_massage.sh
+++ b/scripts/build/termux_step_massage.sh
@@ -312,7 +312,7 @@ termux_step_massage() {
 			echo "INFO: Found ${c} files with OpenMP symbols after exclusion"
 			[[ "${c}" -gt "${numberOfValid}" ]] && termux_error_exit "${c} > ${numberOfValid}"
 		fi
-		if [[ -n "${depend_libomp_so}" ]]; then
+		if [[ -n "${depend_libomp_so}" && "${TERMUX_PKG_NO_OPENMP_CHECK}" != "true" ]]; then
 			echo "ERROR: Found files depend on libomp.so" >&2
 			echo "ERROR: Showing result" >&2
 			local t0=$(get_epoch)

--- a/scripts/build/termux_step_setup_variables.sh
+++ b/scripts/build/termux_step_setup_variables.sh
@@ -178,6 +178,7 @@ termux_step_setup_variables() {
 	TERMUX_PKG_SUGGESTS=""
 	TERMUX_PKG_TMPDIR=$TERMUX_TOPDIR/$TERMUX_PKG_NAME/tmp
 	TERMUX_PKG_UNDEF_SYMBOLS_FILES="" # maintainer acknowledges these files have undefined symbols will not result in broken packages, eg: all, *.elf, ./path/to/file. "error" to always print results as errors
+	TERMUX_PKG_NO_OPENMP_CHECK=false # if true, skip the openmp check
 	TERMUX_PKG_SERVICE_SCRIPT=() # Fill with entries like: ("daemon name" 'script to execute'). Script is echoed with -e so can contain \n for multiple lines
 	TERMUX_PKG_GROUPS="" # https://wiki.archlinux.org/title/Pacman#Installing_package_groups
 	TERMUX_PKG_ON_DEVICE_BUILD_NOT_SUPPORTED=false # if the package does not support compilation on a device, then this package should not be compiled on devices


### PR DESCRIPTION
Some package (like [codon](https://github.com/termux-user-repository/tur/pull/1166)) may ship its own `libomp.so`, so add an option to skip this check

