### PR TITLE
bump(main/rust): 1.81.0

### DIFF
--- a/packages/rust/build.sh
+++ b/packages/rust/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.rust-lang.org/
 TERMUX_PKG_DESCRIPTION="Systems programming language focused on safety, speed and concurrency"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.80.0"
+TERMUX_PKG_VERSION="1.81.0"
 TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/rustc-${TERMUX_PKG_VERSION}-src.tar.xz
-TERMUX_PKG_SHA256=0b9ca1e2e45b8a5f0b58db140af0dc92f8311faeb0ad883c5b71a72c02dc6e80
+TERMUX_PKG_SHA256=36217ef7e32f40a180e3d79bd666b4dfdaed49dd381023a5fb765fd12d0092ce
 _LLVM_MAJOR_VERSION=$(. $TERMUX_SCRIPTDIR/packages/libllvm/build.sh; echo $LLVM_MAJOR_VERSION)
 _LLVM_MAJOR_VERSION_NEXT=$((_LLVM_MAJOR_VERSION + 1))
 _LZMA_VERSION=$(. $TERMUX_SCRIPTDIR/packages/liblzma/build.sh; echo $TERMUX_PKG_VERSION)
@@ -132,7 +132,7 @@ termux_step_configure() {
 	# like 30 to 40 + minutes ... so lets get it right
 
 	# upstream tests build using versions N and N-1
-	local BOOTSTRAP_VERSION=1.79.0
+	local BOOTSTRAP_VERSION=1.80.0
 	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "false" ]]; then
 		if ! rustup install "${BOOTSTRAP_VERSION}"; then
 			echo "WARN: ${BOOTSTRAP_VERSION} is unavailable, fallback to stable version!"


### PR DESCRIPTION
Should be a lot smoother compared to the 1.80 problems with the time crate breakages (see
https://internals.rust-lang.org/t/type-inference-breakage-in-1-80-has-not-been-handled-well/21374 about that).

Tested building a few rust packages without problems: distant, ripgrep, fd, crowbook, tectonic, fcp, kak-lsp, magic-wormhole-rs, miniserve and typst.