### PR TITLE
bump(main/python-msgpack): 1.1.0

### DIFF
--- a/packages/python-msgpack/build.sh
+++ b/packages/python-msgpack/build.sh
@@ -2,10 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://github.com/msgpack/msgpack-python
 TERMUX_PKG_DESCRIPTION="MessagePack serializer implementation for Python"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.0.8"
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=$TERMUX_PKG_HOMEPAGE/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=481996e14606bc215a8aed396c773bd4c3ae8b5afeac6622a3e02a4b33981b02
+TERMUX_PKG_VERSION="1.1.0"
+# _cmsgpack.c is absent in https://github.com/msgpack/msgpack-python/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SRCURL=https://pypi.org/packages/source/m/msgpack/msgpack-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=dd432ccc2c72b914e4cb77afce64aab761c1137cc698be3984eee260bcb2896e
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libc++, python"
 TERMUX_PKG_PYTHON_COMMON_DEPS="build, Cython, 'setuptools==65.7.0', wheel"


### PR DESCRIPTION
Use source tarball from pypi because the GitHub generated tarball does not have _cmsgpack.c file. Also, upstream suggests to use sdist or manually cythoize.
https://github.com/msgpack/msgpack-python/commit/0b1c47b06b55d91c00c9f7153c4a9440ea878886

Fixes #21419