### PR TITLE
chore(disabled-packages): Add recently removed packages to disabled

### DIFF
--- a/disabled-packages/libart-lgpl/build.sh
+++ b/disabled-packages/libart-lgpl/build.sh
@@ -1,0 +1,8 @@
+TERMUX_PKG_HOMEPAGE=https://www.levien.com/libart/
+TERMUX_PKG_DESCRIPTION="A library for high-performance 2D graphics"
+TERMUX_PKG_LICENSE="LGPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=2.3.21
+TERMUX_PKG_REVISION=22
+TERMUX_PKG_SRCURL=https://download.gnome.org/sources/libart_lgpl/2.3/libart_lgpl-$TERMUX_PKG_VERSION.tar.bz2
+TERMUX_PKG_SHA256=fdc11e74c10fc9ffe4188537e2b370c0abacca7d89021d4d303afdf7fd7476fa

--- a/disabled-packages/libglade/build.sh
+++ b/disabled-packages/libglade/build.sh
@@ -1,0 +1,23 @@
+TERMUX_PKG_HOMEPAGE=https://www.gnome.org/
+TERMUX_PKG_DESCRIPTION="Allows you to load glade interface files in a program at runtime"
+TERMUX_PKG_LICENSE="LGPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=2.6.4
+TERMUX_PKG_REVISION=24
+TERMUX_PKG_SRCURL=https://download.gnome.org/sources/libglade/2.6/libglade-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_SHA256=64361e7647839d36ed8336d992fd210d3e8139882269bed47dc4674980165dec
+TERMUX_PKG_DEPENDS="atk, fontconfig, freetype, gdk-pixbuf, glib, gtk2, libcairo, libxml2, pango"
+TERMUX_PKG_RM_AFTER_INSTALL="share/gtk-doc"
+
+# For libglade-convert.
+TERMUX_PKG_SUGGESTS="python2"
+
+termux_step_pre_configure() {
+	export LIBS="-lgmodule-2.0"
+}
+
+termux_step_post_make_install() {
+	sed \
+		-i "s|#!/usr/bin/python|#!${TERMUX_PREFIX}/bin/python2|g" \
+		"${TERMUX_PREFIX}/bin/libglade-convert"
+}

--- a/disabled-packages/libglade/libglade-2.0.1-nowarning.patch
+++ b/disabled-packages/libglade/libglade-2.0.1-nowarning.patch
@@ -1,0 +1,39 @@
+--- libglade-2.0.1/glade/glade-gtk.c.nowarning	2003-08-29 14:50:10.000000000 -0400
++++ libglade-2.0.1/glade/glade-gtk.c	2003-08-29 14:58:41.000000000 -0400
+@@ -639,9 +639,8 @@
+ 		if (!strcmp (childinfo->properties[j].name, "label")) {
+ 		    label = childinfo->properties[j].value;
+ 		    break;
+-		} else {
+-		    g_warning ("Unknown CList child property: %s", childinfo->properties[j].name);
+ 		}
++		/* Ignore all other properties */
+ 	    }
+ 
+ 	    if (label) {
+@@ -683,6 +682,7 @@
+ 	    char *icon = NULL;
+ 	    gboolean use_stock = FALSE, active = FALSE, new_group = FALSE;
+ 	    gboolean use_underline = FALSE;
++	    gboolean sensitive = TRUE;
+ 	    GtkWidget *iconw = NULL;
+ 	    int j;
+ 
+@@ -708,6 +708,8 @@
+ 		    group_name = value;
+ 		} else if (!strcmp (name, "new_group")) {
+ 		    new_group = BOOL (value);
++		} else if (!strcmp (name, "sensitive")) {
++		    sensitive = BOOL (value);
+ 		} else if (!strcmp (name, "visible")) {
+ 		    /* ignore for now */
+ 		} else if (!strcmp (name, "tooltip")) {
+@@ -785,6 +787,8 @@
+ 		gtk_label_set_use_underline (GTK_LABEL (toolbar_child->label),
+ 					     TRUE);
+ 	    }
++	    
++	    gtk_widget_set_sensitive (child, sensitive);
+ 
+ 	    glade_xml_set_common_params (xml, child, childinfo->child);
+ 	} else {

--- a/disabled-packages/libgnomecanvas/build.sh
+++ b/disabled-packages/libgnomecanvas/build.sh
@@ -1,0 +1,15 @@
+TERMUX_PKG_HOMEPAGE=https://www.gnome.org/
+TERMUX_PKG_DESCRIPTION="The GNOME Canvas library"
+TERMUX_PKG_LICENSE="LGPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=2.30.3
+TERMUX_PKG_REVISION=21
+TERMUX_PKG_SRCURL=https://download.gnome.org/sources/libgnomecanvas/2.30/libgnomecanvas-$TERMUX_PKG_VERSION.tar.bz2
+TERMUX_PKG_SHA256=859b78e08489fce4d5c15c676fec1cd79782f115f516e8ad8bed6abcb8dedd40
+TERMUX_PKG_DEPENDS="atk, glib, gtk2, libart-lgpl, libglade, pango"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-glade"
+TERMUX_PKG_RM_AFTER_INSTALL="lib/locale"
+
+termux_step_post_configure() {
+	sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
+}

--- a/disabled-packages/obconf/build.sh
+++ b/disabled-packages/obconf/build.sh
@@ -1,0 +1,13 @@
+TERMUX_PKG_HOMEPAGE=http://openbox.org/wiki/ObConf:About
+TERMUX_PKG_DESCRIPTION="A configuration tool for the Openbox window manager"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=2.0.4
+TERMUX_PKG_REVISION=30
+TERMUX_PKG_SRCURL=http://openbox.org/dist/obconf/obconf-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=71a3e5f4ee246a27421ba85044f09d449f8de22680944ece9c471cd46a9356b9
+TERMUX_PKG_DEPENDS="gdk-pixbuf, glib, gtk2, libglade, libx11, libxml2, openbox, startup-notification"
+
+termux_step_pre_configure() {
+	export LIBS="-lgmodule-2.0"
+}

--- a/disabled-packages/obconf/obconf-2.0.4-clang16.patch
+++ b/disabled-packages/obconf/obconf-2.0.4-clang16.patch
@@ -1,0 +1,22 @@
+https://github.com/termux/termux-packages/issues/15852
+Borrowed from https://github.com/gentoo/gentoo/blob/6e342407489fd0bf17768951c1391b81cde22465/x11-misc/obconf/files/obconf-2.0.4_p20150213-clang16.patch
+
+https://bugs.gentoo.org/870538
+--- a/src/appearance.c
++++ b/src/appearance.c
+@@ -19,2 +19,3 @@
+ 
++#include <ctype.h>
+ #include "main.h"
+--- a/src/desktops.h
++++ b/src/desktops.h
+@@ -26,2 +26,3 @@
+ void desktops_setup_names(GtkWidget *w);
++void desktops_setup_tab(void);
+ 
+--- a/src/main.c
++++ b/src/main.c
+@@ -26,2 +26,3 @@
+ #include "mouse.h"
++#include "moveresize.h"
+ #include "desktops.h"

--- a/disabled-packages/xournal/build.sh
+++ b/disabled-packages/xournal/build.sh
@@ -1,0 +1,16 @@
+TERMUX_PKG_HOMEPAGE=https://sourceforge.net/projects/xournal/
+TERMUX_PKG_DESCRIPTION="Notetaking and sketching application"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=0.4.8.2016
+TERMUX_PKG_REVISION=38
+TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/xournal/xournal-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=b25898dbd7a149507f37a16769202d69fbebd4a000d766923bbd32c5c7462826
+TERMUX_PKG_DEPENDS="atk, desktop-file-utils, fontconfig, freetype, glib, gtk2, hicolor-icon-theme, libandroid-shmem, libart-lgpl, libcairo, libgnomecanvas, pango, poppler, libx11, shared-mime-info, zlib"
+TERMUX_PKG_RM_AFTER_INSTALL="lib/locale"
+
+termux_step_pre_configure() {
+	CPPFLAGS+=" -D__USE_GNU"
+	CXXFLAGS+=" -std=c++17"
+	export LIBS="-Wl,--no-as-needed -landroid-shmem"
+}

--- a/disabled-packages/xournal/src-ttsubset-ttcr.c.patch
+++ b/disabled-packages/xournal/src-ttsubset-ttcr.c.patch
@@ -1,0 +1,11 @@
+--- a/src/ttsubset/ttcr.c
++++ b/src/ttsubset/ttcr.c
+@@ -50,7 +50,7 @@
+ #endif
+ #include <fcntl.h>
+ #include <stdlib.h>
+-#ifdef sun
++#if defined sun || defined __ANDROID__
+ #include <strings.h> /* bzero() only in strings.h on Solaris */
+ #else
+ #include <string.h>

--- a/disabled-packages/xournal/xo-shapes.c.patch
+++ b/disabled-packages/xournal/xo-shapes.c.patch
@@ -1,0 +1,365 @@
+diff -uNr xournal-0.4.8.2016/src/xo-shapes.c xournal-0.4.8.2016.mod/src/xo-shapes.c
+--- xournal-0.4.8.2016/src/xo-shapes.c	2015-08-11 07:15:33.000000000 +0300
++++ xournal-0.4.8.2016.mod/src/xo-shapes.c	2019-08-14 16:19:09.524716155 +0300
+@@ -5,7 +5,7 @@
+  *  version 2 of the License, or (at your option) any later version.
+  *
+  *  This software is distributed in the hope that it will be useful,
+- *  but WITHOUT ANY WARRANTY; without even the implied warranty of  
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  *  General Public License for more details.
+  *
+@@ -62,53 +62,53 @@
+   s->syy += dm*pt[1]*pt[1];
+   s->sxy += dm*pt[0]*pt[1];
+ }
+-   
++
+ void calc_inertia(double *pt, int start, int end, struct Inertia *s)
+ {
+   int i;
+-  
++
+   s->mass = s->sx = s->sy = s->sxx = s->sxy = s->syy = 0.;
+   for (i=start, pt+=2*start; i<end; i++, pt+=2) incr_inertia(pt, s, 1);
+ }
+ 
+ /* compute normalized quantities */
+ 
+-inline double center_x(struct Inertia s) 
+-{ 
++double center_x(struct Inertia s)
++{
+   return s.sx/s.mass;
+ }
+ 
+-inline double center_y(struct Inertia s) 
+-{ 
++double center_y(struct Inertia s)
++{
+   return s.sy/s.mass;
+ }
+ 
+-inline double I_xx(struct Inertia s)
++double I_xx(struct Inertia s)
+ {
+   if (s.mass <= 0.) return 0.;
+   return (s.sxx - s.sx*s.sx/s.mass)/s.mass;
+ }
+ 
+-inline double I_xy(struct Inertia s)
++double I_xy(struct Inertia s)
+ {
+   if (s.mass <= 0.) return 0.;
+   return (s.sxy - s.sx*s.sy/s.mass)/s.mass;
+ }
+ 
+-inline double I_yy(struct Inertia s)
++double I_yy(struct Inertia s)
+ {
+   if (s.mass <= 0.) return 0.;
+   return (s.syy - s.sy*s.sy/s.mass)/s.mass;
+ }
+ 
+-inline double I_rad(struct Inertia s)
++double I_rad(struct Inertia s)
+ {
+   double ixx = I_xx(s), iyy = I_yy(s);
+   if (ixx+iyy <= 0.) return 0.;
+   return sqrt(ixx+iyy);
+ }
+ 
+-inline double I_det(struct Inertia s)
++double I_det(struct Inertia s)
+ {
+   double ixx = I_xx(s), iyy = I_yy(s), ixy = I_xy(s);
+   if (s.mass <= 0.) return 0.;
+@@ -123,27 +123,27 @@
+   struct Inertia s, s1, s2;
+   int k, i1, i2, n1, n2;
+   double det1, det2;
+-  
++
+   if (end == start) return 0; // no way
+   if (nsides <= 0) return 0;
+   if (end-start<5) nsides = 1; // too small for a polygon
+-  
++
+   // look for a linear piece that's big enough
+   for (k=0; k<nsides; k++) {
+-    i1 = start + (k*(end-start))/nsides; 
++    i1 = start + (k*(end-start))/nsides;
+     i2 = start + ((k+1)*(end-start))/nsides;
+     calc_inertia(pt, i1, i2, &s);
+     if (I_det(s) < LINE_MAX_DET) break;
+   }
+   if (k==nsides) return 0; // failed!
+-  
++
+   // grow the linear piece we found
+   while (1) {
+     if (i1>start) {
+       s1 = s;
+       incr_inertia(pt+2*(i1-1), &s1, 1);
+       det1 = I_det(s1);
+-    } 
++    }
+     else det1 = 1.;
+     if (i2<end) {
+       s2 = s;
+@@ -155,7 +155,7 @@
+     else if (det2<det1 && det2<LINE_MAX_DET) { i2++; s=s2; }
+     else break;
+   }
+-  
++
+   if (i1>start) {
+     n1 = find_polygonal(pt, start, i1, (i2==end)?(nsides-1):(nsides-2), breaks, ss);
+     if (n1 == 0) return 0; // it doesn't work
+@@ -171,7 +171,7 @@
+     if (n2 == 0) return 0;
+   }
+   else n2 = 0;
+-  
++
+   return n1+n2+1;
+ }
+ 
+@@ -183,7 +183,7 @@
+   double cost, newcost;
+   struct Inertia s1, s2;
+   gboolean improved;
+-  
++
+   for (i=1; i<nsides; i++) {
+     // optimize break between sides i and i+1
+     cost = I_det(ss[i-1])*I_det(ss[i-1])+I_det(ss[i])*I_det(ss[i]);
+@@ -196,7 +196,7 @@
+       newcost = I_det(s1)*I_det(s1)+I_det(s2)*I_det(s2);
+       if (newcost >= cost) break;
+       improved = TRUE;
+-      cost = newcost; 
++      cost = newcost;
+       breaks[i]--;
+       ss[i-1] = s1;
+       ss[i] = s2;
+@@ -209,7 +209,7 @@
+       incr_inertia(pt+2*breaks[i], &s2, -1);
+       newcost = I_det(s1)*I_det(s1)+I_det(s2)*I_det(s2);
+       if (newcost >= cost) break;
+-      cost = newcost; 
++      cost = newcost;
+       breaks[i]++;
+       ss[i-1] = s1;
+       ss[i] = s2;
+@@ -223,14 +223,14 @@
+ {
+   double a, b, c, lmin, lmax, l;
+   int i;
+-  
++
+   r->xcenter = center_x(*s);
+   r->ycenter = center_y(*s);
+   a = I_xx(*s); b = I_xy(*s); c = I_yy(*s);
+   /* max angle for inertia quadratic form solves: tan(2t) = 2b/(a-c) */
+-  r->angle = atan2(2*b, a-c)/2; 
++  r->angle = atan2(2*b, a-c)/2;
+   r->radius = sqrt(3*(a+c));
+-  
++
+   lmin = lmax = 0.;
+   for (i=start, pt+=2*start; i<=end; i++, pt+=2) {
+     l = (pt[0]-r->xcenter)*cos(r->angle)+(pt[1]-r->ycenter)*sin(r->angle);
+@@ -249,7 +249,7 @@
+ {
+   double sum, x0, y0, r0, dm, deltar;
+   int i;
+-  
++
+   if (s->mass == 0.) return 0;
+   sum = 0.;
+   x0 = center_x(*s); y0 = center_y(*s); r0 = I_rad(*s);
+@@ -268,7 +268,7 @@
+   int npts, i;
+   struct Item *item;
+   struct UndoErasureData *erasure;
+-  
++
+   npts = (int)(2*r);
+   if (npts<12) npts = 12; // min. number of points
+   realloc_cur_path(npts+1);
+@@ -282,7 +282,7 @@
+ void calc_edge_isect(struct RecoSegment *r1, struct RecoSegment *r2, double *pt)
+ {
+   double t;
+-  t = (r2->xcenter - r1->xcenter) * sin(r2->angle) - 
++  t = (r2->xcenter - r1->xcenter) * sin(r2->angle) -
+       (r2->ycenter - r1->ycenter) * cos(r2->angle);
+   t /= sin(r2->angle-r1->angle);
+   pt[0] = r1->xcenter + t*cos(r1->angle);
+@@ -301,7 +301,7 @@
+   undo->layer = ui.cur_layer;
+   undo->erasurelist = NULL;
+   shift = 0;
+-  
++
+   for (i=0; i<num_old_items; i++) {
+     if (rs[i].item == old_item) continue; // already done
+     old_item = rs[i].item;
+@@ -335,7 +335,7 @@
+   item->widths = NULL;
+   update_item_bbox(item);
+   ui.cur_path.num_points = 0;
+-  
++
+   erasure->nrepl++;
+   erasure->replacement_items = g_list_append(erasure->replacement_items, item);
+   ui.cur_layer->items = g_list_append(ui.cur_layer->items, item);
+@@ -352,7 +352,7 @@
+   struct RecoSegment *rs, *r1, *r2;
+   int i;
+   double dist, avg_angle;
+-  
++
+   // first, we need whole strokes to combine to 4 segments...
+   if (recognizer_queue_length<4) return FALSE;
+   rs = recognizer_queue + recognizer_queue_length - 4;
+@@ -377,7 +377,7 @@
+                  (r1->reversed?r1->y1:r1->y2) - (r2->reversed?r2->y2:r2->y1));
+     if (dist > RECTANGLE_LINEAR_TOLERANCE*(r1->radius+r2->radius)) return FALSE;
+   }
+-  
++
+   // make a rectangle of the correct size and slope
+   avg_angle = avg_angle/4;
+   if (fabs(avg_angle)<SLANT_TOLERANCE) avg_angle = 0.;
+@@ -388,7 +388,7 @@
+   for (i=0; i<=3; i++) calc_edge_isect(rs+i, rs+(i+1)%4, ui.cur_path.coords+2*i+2);
+   ui.cur_path.coords[0] = ui.cur_path.coords[8];
+   ui.cur_path.coords[1] = ui.cur_path.coords[9];
+-  
++
+   remove_recognized_strokes(rs, 4);
+   insert_recognized_curpath();
+   return TRUE;
+@@ -401,7 +401,7 @@
+   double alpha[3], dist, pt[2], tmp, delta;
+   double x1, y1, x2, y2, angle;
+   gboolean rev[3];
+-  
++
+   // first, we need whole strokes to combine to nsides segments...
+   if (recognizer_queue_length<3) return FALSE;
+   rs = recognizer_queue + recognizer_queue_length - 3;
+@@ -414,15 +414,15 @@
+               hypot(rs[i].xcenter-rs->x2, rs[i].ycenter-rs->y2));
+   }
+   if (rev[1]!=rev[2]) return FALSE;
+-  if (rev[1]) { 
+-    x1 = rs->x2; y1 = rs->y2; x2 = rs->x1; y2 = rs->y1; 
++  if (rev[1]) {
++    x1 = rs->x2; y1 = rs->y2; x2 = rs->x1; y2 = rs->y1;
+     angle = rs->angle + M_PI;
+   }
+-  else { 
++  else {
+     x1 = rs->x1; y1 = rs->y1; x2 = rs->x2; y2 = rs->y2;
+     angle = rs->angle;
+   }
+-    
++
+   // check arrow head not too big, and angles roughly ok
+   for (i=1; i<=2; i++) {
+     rs[i].reversed = FALSE;
+@@ -434,7 +434,7 @@
+ #endif
+     if (fabs(alpha[i])<ARROW_ANGLE_MIN || fabs(alpha[i])>ARROW_ANGLE_MAX) return FALSE;
+   }
+-  
++
+   // check arrow head segments are roughly symmetric
+   if (alpha[1]*alpha[2]>0 || fabs(alpha[1]+alpha[2]) > ARROW_ASYMMETRY_MAX_ANGLE) return FALSE;
+   if (rs[1].radius/rs[2].radius > 1+ARROW_ASYMMETRY_MAX_LINEAR) return FALSE;
+@@ -479,7 +479,7 @@
+   delta = fabs(alpha[1]-alpha[2])/2;
+   dist = (hypot(rs[1].x1-rs[1].x2, rs[1].y1-rs[1].y2) +
+           hypot(rs[2].x1-rs[2].x2, rs[2].y1-rs[2].y2))/2;
+-  
++
+   realloc_cur_path(2);
+   ui.cur_path.num_points = 2;
+   ui.cur_path.coords[0] = x1; ui.cur_path.coords[1] = y1;
+@@ -491,7 +491,7 @@
+   ui.cur_path.num_points = 3;
+   ui.cur_path.coords[0] = x2 - dist*cos(angle+delta);
+   ui.cur_path.coords[1] = y2 - dist*sin(angle+delta);
+-  ui.cur_path.coords[2] = x2; 
++  ui.cur_path.coords[2] = x2;
+   ui.cur_path.coords[3] = y2;
+   ui.cur_path.coords[4] = x2 - dist*cos(angle-delta);
+   ui.cur_path.coords[5] = y2 - dist*sin(angle-delta);
+@@ -505,7 +505,7 @@
+   struct RecoSegment *rs, *r1, *r2;
+   int i;
+   double dist, pt[2];
+-  
++
+   // first, we need whole strokes to combine to nsides segments...
+   if (recognizer_queue_length<nsides) return FALSE;
+   rs = recognizer_queue + recognizer_queue_length - nsides;
+@@ -526,15 +526,15 @@
+     if (dist > POLYGON_LINEAR_TOLERANCE*(r1->radius+r2->radius)) return FALSE;
+     if (fabs(pt[0])>2*ui.cur_page->width || fabs(pt[1])>2*ui.cur_page->height) return FALSE;
+   }
+-  
++
+   // make a polygon of the correct size and slope
+   realloc_cur_path(nsides+1);
+   ui.cur_path.num_points = nsides+1;
+-  for (i=0; i<nsides; i++) 
++  for (i=0; i<nsides; i++)
+     calc_edge_isect(rs+i, rs+(i+1)%nsides, ui.cur_path.coords+2*i+2);
+   ui.cur_path.coords[0] = ui.cur_path.coords[2*nsides];
+   ui.cur_path.coords[1] = ui.cur_path.coords[2*nsides+1];
+-  
++
+   remove_recognized_strokes(rs, nsides);
+   insert_recognized_curpath();
+   return TRUE;
+@@ -549,7 +549,7 @@
+   int n, i;
+   int brk[5];
+   double score;
+-  
++
+   if (!undo || undo->type!=ITEM_STROKE) return;
+   if (undo->next != last_item_checker) reset_recognizer(); // reset queue
+   if (last_item_checker!=NULL && ui.cur_layer != last_item_checker->layer) reset_recognizer();
+@@ -558,7 +558,7 @@
+   calc_inertia(it->path->coords, 0, it->path->num_points-1, &s);
+ #ifdef RECOGNIZER_DEBUG
+   printf("DEBUG: Mass=%.0f, Center=(%.1f,%.1f), I=(%.0f,%.0f, %.0f), "
+-     "Rad=%.2f, Det=%.4f \n", 
++     "Rad=%.2f, Det=%.4f \n",
+      s.mass, center_x(s), center_y(s), I_xx(s), I_yy(s), I_xy(s), I_rad(s), I_det(s));
+ #endif
+ 
+@@ -578,7 +578,7 @@
+       i=1;
+       while (i<recognizer_queue_length && recognizer_queue[i].startpt!=0) i++;
+       recognizer_queue_length-=i;
+-      g_memmove(recognizer_queue, recognizer_queue+i, 
++      g_memmove(recognizer_queue, recognizer_queue+i,
+               recognizer_queue_length * sizeof(struct RecoSegment));
+     }
+ #ifdef RECOGNIZER_DEBUG
+@@ -591,7 +591,7 @@
+       rs[i].startpt = brk[i];
+       rs[i].endpt = brk[i+1];
+       get_segment_geometry(it->path->coords, brk[i], brk[i+1], ss+i, rs+i);
+-    }  
++    }
+     if (try_rectangle()) { reset_recognizer(); return; }
+     if (try_arrow()) { reset_recognizer(); return; }
+     if (try_closed_polygon(3)) { reset_recognizer(); return; }

--- a/disabled-packages/xournal/xournal-0.4.8-c99-fix.patch
+++ b/disabled-packages/xournal/xournal-0.4.8-c99-fix.patch
@@ -1,0 +1,65 @@
+https://github.com/termux/termux-packages/issues/15852
+Borrowed from https://github.com/gentoo/gentoo/blob/0e2d85999128ffd8df2b17b1ba1379b81ad69ea0/app-text/xournal/files/xournal-0.4.8-c99-fix.patch
+
+Bug: https://bugs.gentoo.org/875158
+
+Patch: https://src.fedoraproject.org/rpms/xournal/raw/dacd5bf30ec95debca62946868d9450f68ea54de/f/xournal-c99-1.patch
+Patch: https://src.fedoraproject.org/rpms/xournal/raw/dacd5bf30ec95debca62946868d9450f68ea54de/f/xournal-c99-2.patch
+Author: Denis Auroux <auroux@users.sourceforge.net>
+Date:   Sun Jan 24 15:48:16 2021 -0500
+
+    Fix implicit function declarations by including config.h in ttsubset/*.c
+
+--- a/src/ttsubset/list.c
++++ b/src/ttsubset/list.c
+@@ -44,6 +44,10 @@
+  *
+  */
+ 
++#ifdef HAVE_CONFIG_H
++#  include <config.h>
++#endif
++
+ #include <stdlib.h>
+ #include <assert.h>
+ #ifdef MALLOC_TRACE
+--- a/src/ttsubset/sft.c
++++ b/src/ttsubset/sft.c
+@@ -43,6 +43,10 @@
+  * @version 1.0
+  */
+ 
++#ifdef HAVE_CONFIG_H
++#  include <config.h>
++#endif
++
+ #include <assert.h>
+ #include <stdlib.h>
+ #include <string.h>
+--- a/src/ttsubset/ttcr.c
++++ b/src/ttsubset/ttcr.c
+@@ -44,6 +44,10 @@
+  *
+  */
+ 
++#ifdef HAVE_CONFIG_H
++#  include <config.h>
++#endif
++
+ #include <sys/types.h>
+ #ifdef HAVE_UNISTD_H
+ #include <unistd.h>
+
+Add missing include directives for make_dashed, set_cursor_busy.
+
+--- a/src/xo-image.c
++++ b/src/xo-image.c
+@@ -25,6 +25,8 @@
+ #include "xo-support.h"
+ #include "xo-image.h"
+ #include "xo-misc.h"
++#include "xo-selection.h"
++#include "xo-paint.h"
+ 
+ // create pixbuf from buffer, or return NULL on failure
+ GdkPixbuf *pixbuf_from_buffer(const gchar *buf, gsize buflen)


### PR DESCRIPTION
Add back recently removed packages (#21409 and #21410) to `disabled-packages/`:

- libart-lgpg
- libglade
- libgnomecanvas
- obconf
- xournal