### PR TITLE
bump(main/grafana): 11.2.0

### DIFF
--- a/packages/grafana/build.sh
+++ b/packages/grafana/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://grafana.com/
 TERMUX_PKG_DESCRIPTION="The open-source platform for monitoring and observability"
 TERMUX_PKG_LICENSE="AGPL-V3"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1:11.1.3"
+TERMUX_PKG_VERSION="1:11.2.0"
 TERMUX_PKG_SRCURL=git+https://github.com/grafana/grafana
 TERMUX_PKG_BUILD_DEPENDS="yarn"
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -13,6 +13,8 @@ TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+\.\d+"
 
 termux_step_pre_configure() {
 	termux_setup_nodejs
+
+	export YARN_ENABLE_HARDENED_MODE=0
 
 	local bin="$TERMUX_PKG_BUILDDIR/_bin"
 	mkdir -p "$bin"

--- a/packages/grafana/go-mod.patch
+++ b/packages/grafana/go-mod.patch
@@ -1,23 +1,11 @@
-diff --git a/go.mod b/go.mod
-index 9aef536350e..e443ee4b148 100644
---- a/go.mod
-+++ b/go.mod
-@@ -519,3 +519,5 @@ exclude github.com/mattn/go-sqlite3 v2.0.3+incompatible
- 
+diff -u -r ../cache/tmp-checkout/go.mod ./go.mod
+--- ../cache/tmp-checkout/go.mod	2024-09-11 19:37:06.886258923 +0000
++++ ./go.mod	2024-09-11 19:38:40.638038867 +0000
+@@ -493,5 +493,7 @@
  // Use our fork xorm. go.work currently overrides this and points to the local ./pkg/util/xorm directory.
  replace xorm.io/xorm => github.com/grafana/grafana/pkg/util/xorm v0.0.1
-+
+ 
 +replace github.com/hashicorp/go-sockaddr v1.0.6 => ./go-sockaddr
-diff --git a/go.sum b/go.sum
-index 2e51b7e84c2..fac0c1149ea 100644
---- a/go.sum
-+++ b/go.sum
-@@ -2271,8 +2271,6 @@ github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5O
- github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
- github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
- github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
--github.com/hashicorp/go-sockaddr v1.0.6 h1:RSG8rKU28VTUTvEKghe5gIhIQpv8evvNpnDEyqO4u9I=
--github.com/hashicorp/go-sockaddr v1.0.6/go.mod h1:uoUUmtwU7n9Dv3O4SNLeFvg0SxQ3lyjsj6+CCykpaxI=
- github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
- github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
- github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
++
+ // lock for mysql tsdb compat
+ replace github.com/go-sql-driver/mysql => github.com/go-sql-driver/mysql v1.7.1


### PR DESCRIPTION
Fixes a build error with the current grafana and golang version:

> github.com/grafana/pyroscope-go/godeltaprof/internal/pprof
> ../../../go/pkg/mod/github.com/grafana/pyroscope-go/godeltaprof@v0.1.6/internal/pprof/delta_mutex.go:30:20: undefined: runtime_cyclesPerSecond
> ../../../go/pkg/mod/github.com/grafana/pyroscope-go/godeltaprof@v0.1.6/internal/pprof/proto.go:320:8: undefined: runtime_expandFinalInlineFrame

Fixes #21183.