### PR TITLE
bump(scripts/setup-nodejs): Update nodejs from 18.16.1 to 20.17.0

### DIFF
--- a/scripts/build/setup/termux_setup_nodejs.sh
+++ b/scripts/build/setup/termux_setup_nodejs.sh
@@ -1,6 +1,6 @@
 termux_setup_nodejs() {
 	# Use LTS version for now
-	local NODEJS_VERSION=18.16.1
+	local NODEJS_VERSION=20.17.0
 	local NODEJS_FOLDER
 
 	if [ "${TERMUX_PACKAGES_OFFLINE-false}" = "true" ]; then
@@ -15,7 +15,7 @@ termux_setup_nodejs() {
 			local NODEJS_TAR_FILE=$TERMUX_PKG_TMPDIR/nodejs-$NODEJS_VERSION.tar.xz
 			termux_download https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-linux-x64.tar.xz \
 				"$NODEJS_TAR_FILE" \
-				ecfe263dbd9c239f37b5adca823b60be1bb57feabbccd25db785e647ebc5ff5e
+				a24db3dcd151a52e75965dba04cf1b3cd579ff30d6e0af9da1aede4d0f17486b
 			tar -xf "$NODEJS_TAR_FILE" -C "$NODEJS_FOLDER" --strip-components=1
 		fi
 		export PATH=$NODEJS_FOLDER/bin:$PATH


### PR DESCRIPTION
Will allow us to fix the `seanime` build error in c66a06a86917e7c5d70b7f00c12c5ee50529d93b:

> You are using Node.js 18.16.1. For Next.js, Node.js version >= v18.17.0 is required.

Will revbump `seanime` as a follow up change.

Note that node.js has two current LTS versions (see https://nodejs.org/en/download/package-manager), `20.17.0` and `18.20.4`. Might as well go for the later one (which matches what we have in our `nodejs-lts` package).