### PR TITLE
revbump(main/ghostscript): NDK r27 build fix

### DIFF
--- a/packages/ghostscript/build.sh
+++ b/packages/ghostscript/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Interpreter for the PostScript language and for PDF"
 TERMUX_PKG_LICENSE="AGPL-V3"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="10.03.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs${TERMUX_PKG_VERSION//.}/ghostpdl-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=8ea9dd8768b64576bc4ee2d79611450c9e1edeb686f7824f3bf94b92457b882a
 TERMUX_PKG_AUTO_UPDATE=false
@@ -28,9 +29,6 @@ termux_step_post_get_source() {
 }
 
 termux_step_pre_configure() {
-	# Use `make -j1` otherwise build may fail with error
-	# about missing 'arch.h'.
-	TERMUX_PKG_MAKE_PROCESSES=1
 	CPPFLAGS+=" -I${TERMUX_STANDALONE_TOOLCHAIN}/sysroot/usr/include/c++/v1"
 
 	# Workaround for build break caused by `sha2.h` from `libmd` package:
@@ -39,6 +37,12 @@ termux_step_pre_configure() {
 		mkdir -p "${inc}"
 		ln -sf "$TERMUX_PKG_SRCDIR/base/sha2.h" "${inc}/"
 		CPPFLAGS="-I${inc} ${CPPFLAGS}"
+	fi
+
+	if [[ "${TERMUX_ARCH}" == "aarch64" ]]; then
+		# https://github.com/llvm/llvm-project/issues/74361
+		# NDK r27: clang++: error: unsupported option '-mfpu=' for target 'aarch64-linux-android24'
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --disable-neon"
 	fi
 }
 


### PR DESCRIPTION
Refer:
#21130
https://github.com/llvm/llvm-project/issues/74361