### PR TITLE
bump(main/htslib): 1.21

### DIFF
--- a/packages/htslib/build.sh
+++ b/packages/htslib/build.sh
@@ -2,10 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://github.com/samtools/htslib
 TERMUX_PKG_DESCRIPTION="C library for high-throughput sequencing data formats"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.20"
+TERMUX_PKG_VERSION="1.21"
 TERMUX_PKG_SRCURL=https://github.com/samtools/htslib/releases/download/${TERMUX_PKG_VERSION}/htslib-${TERMUX_PKG_VERSION}.tar.bz2
-TERMUX_PKG_SHA256=e52d95b14da68e0cfd7d27faf56fef2f88c2eaf32a2be51c72e146e3aa928544
+TERMUX_PKG_SHA256=84b510e735f4963641f26fd88c8abdee81ff4cb62168310ae716636aac0f1823
 TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_DEPENDS="libbz2, liblzma, zlib, libdeflate, libcurl"
 
 # error: assigning to 'uint8x8_t' (vector of 8 'uint8_t' values) from incompatible type 'int'


### PR DESCRIPTION
Build package in source directory to mitigate the following compiler error.
htslib/src/test/test_khash.c:43:10: fatal error: 'htslib/khash.h' file not found

Fixes #21455
