### PR TITLE
chore(main/apt,dpkg): Remove dependency on `libbz2` and `zstd`

### DIFF
--- a/packages/apt/build.sh
+++ b/packages/apt/build.sh
@@ -3,12 +3,12 @@ TERMUX_PKG_DESCRIPTION="Front-end for the dpkg package manager"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.8.1"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 # old tarball are removed in https://deb.debian.org/debian/pool/main/a/apt/apt_${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SRCURL=https://salsa.debian.org/apt-team/apt/-/archive/${TERMUX_PKG_VERSION}/apt-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=87ca18392c10822a133b738118505f7d04e0b31ba1122bf5d32911311cb2dc7e
 # apt-key requires utilities from coreutils, findutils, gpgv, grep, sed.
-TERMUX_PKG_DEPENDS="coreutils, dpkg, findutils, gpgv, grep, libandroid-glob, libbz2, libc++, libiconv, libgcrypt, libgnutls, liblz4, liblzma, sed, termux-keyring, termux-licenses, xxhash, zlib, zstd"
+TERMUX_PKG_DEPENDS="coreutils, dpkg, findutils, gpgv, grep, libandroid-glob, libc++, libiconv, libgcrypt, libgnutls, liblz4, liblzma, sed, termux-keyring, termux-licenses, xxhash, zlib"
 TERMUX_PKG_BUILD_DEPENDS="docbook-xsl,libdb"
 TERMUX_PKG_CONFLICTS="apt-transport-https, libapt-pkg, unstable-repo, game-repo, science-repo"
 TERMUX_PKG_REPLACES="apt-transport-https, libapt-pkg, unstable-repo, game-repo, science-repo"

--- a/packages/dpkg/build.sh
+++ b/packages/dpkg/build.sh
@@ -3,12 +3,12 @@ TERMUX_PKG_DESCRIPTION="Debian package management system"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.22.6"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 # old tarball are removed in https://mirrors.kernel.org/debian/pool/main/d/dpkg/dpkg_${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SRCURL=git+https://salsa.debian.org/dpkg-team/dpkg.git
 TERMUX_PKG_GIT_BRANCH="${TERMUX_PKG_VERSION}"
 TERMUX_PKG_AUTO_UPDATE=false
-TERMUX_PKG_DEPENDS="bzip2, coreutils, diffutils, gzip, less, libbz2, liblzma, libmd, tar, xz-utils, zlib, zstd"
+TERMUX_PKG_DEPENDS="bzip2, coreutils, diffutils, gzip, less, liblzma, libmd, tar, xz-utils, zlib"
 TERMUX_PKG_ANTI_BUILD_DEPENDS="clang"
 TERMUX_PKG_BREAKS="dpkg-dev"
 TERMUX_PKG_REPLACES="dpkg-dev"


### PR DESCRIPTION
As `apt` & `dpkg` are critical packages we should strive to have as few dependencies as possible, to make it less likely that we break our package manager and decrease our worries when changing some packages (see e.g. https://github.com/termux/termux-packages/pull/21453#issuecomment-2350069803).

I don't think anyone is using `bz2` or `zst` compressed package or repository metadata files with Termux, but might be mistaken here (and have not tested this on-device yet), hence the draft status.

See #19980 as a related issue.