### PR TITLE
scripts(lint-packages): remove TERMUX_PKG_API_LEVEL upper limit

### DIFF
--- a/scripts/lint-packages.sh
+++ b/scripts/lint-packages.sh
@@ -279,14 +279,14 @@ lint_package() {
 		echo -n "TERMUX_PKG_API_LEVEL: "
 
 			if grep -qP '^[1-9][0-9]$' <<< "$TERMUX_PKG_API_LEVEL"; then
-				if (( TERMUX_PKG_API_LEVEL < 24 || TERMUX_PKG_API_LEVEL > 28 )); then
-					echo "INVALID (allowed: number in range 24 - 28)"
+				if (( TERMUX_PKG_API_LEVEL < 24 )); then
+					echo "INVALID (allowed: number in range >= 24)"
 					pkg_lint_error=true
 				else
 					echo "PASS"
 				fi
 			else
-				echo "INVALID (allowed: number in range 24 - 28)"
+				echo "INVALID (allowed: number in range >= 24)"
 				pkg_lint_error=true
 			fi
 		fi


### PR DESCRIPTION
At some point, we can't be expected to still use API level 24, 25, 26, 27, 28 indefinitely. So remove the upper limit.