### PR TITLE
libselinux and SELinux support for coreutils

### DIFF
--- a/packages/coreutils/build.sh
+++ b/packages/coreutils/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="Basic file, shell and text manipulation utilities from t
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=9.5
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/coreutils/coreutils-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=cd328edeac92f6a665de9f323c93b712af1858bc2e0d88f3f7100469470a1b8a
-TERMUX_PKG_DEPENDS="libandroid-support, libgmp, libiconv"
+TERMUX_PKG_DEPENDS="libandroid-selinux, libandroid-support, libgmp, libiconv"
 TERMUX_PKG_BREAKS="chroot, busybox (<< 1.30.1-4)"
 TERMUX_PKG_REPLACES="chroot, busybox (<< 1.30.1-4)"
 TERMUX_PKG_ESSENTIAL=true
@@ -32,6 +32,7 @@ termux_step_pre_configure() {
 	fi
 
 	CPPFLAGS+=" -D__USE_FORTIFY_LEVEL=0"
+	LDFLAGS+=" -landroid-selinux"
 
 	# On device build is unsupported as it removes utility 'ln' (and maybe
 	# something else) in the installation process.

--- a/packages/libandroid-selinux/Makefile-android
+++ b/packages/libandroid-selinux/Makefile-android
@@ -1,0 +1,89 @@
+PREFIX ?= /usr
+LIBDIR ?= $(PREFIX)/lib
+INCLUDEDIR ?= $(PREFIX)/include
+
+LIBSEPOL_BASE := ../libsepol
+
+OBJS := src/android/android.o \
+        src/android/android_seapp.o \
+        src/avc.o \
+        src/avc_internal.o \
+        src/avc_sidtab.o \
+        src/booleans.o \
+        src/callbacks.o \
+        src/canonicalize_context.o \
+        src/checkAccess.o \
+        src/check_context.o \
+        src/compute_av.o \
+        src/compute_create.o \
+        src/compute_member.o \
+        src/context.o \
+        src/deny_unknown.o \
+        src/disable.o \
+        src/enabled.o \
+        src/fgetfilecon.o \
+        src/freecon.o \
+        src/fsetfilecon.o \
+        src/get_initial_context.o \
+        src/getenforce.o \
+        src/getfilecon.o \
+        src/getpeercon.o \
+        src/init.o \
+        src/label.o \
+        src/label_backends_android.o \
+        src/label_file.o \
+        src/label_support.o \
+        src/lgetfilecon.o \
+        src/load_policy.o \
+        src/lsetfilecon.o \
+        src/mapping.o \
+        src/matchpathcon.o \
+        src/policyvers.o \
+        src/procattr.o \
+        src/regex.o \
+        src/reject_unknown.o \
+        src/selinux_internal.o \
+        src/sestatus.o \
+        src/setenforce.o \
+        src/setfilecon.o \
+        src/setrans_client.o \
+        src/sha1.o \
+        src/stringrep.o
+
+CFLAGS := -DNO_PERSISTENTLY_STORED_PATTERNS \
+          -DDISABLE_SETRANS \
+          -DDISABLE_BOOL \
+          -D_GNU_SOURCE \
+          -DNO_MEDIA_BACKEND \
+          -DNO_X_BACKEND \
+          -DNO_DB_BACKEND \
+          -DANDROID \
+          -Wall \
+          -Werror \
+          -Wno-error=missing-noreturn \
+          -Wno-error=unused-function \
+          -Wno-error=unused-variable \
+          -DUSE_PCRE2 \
+          '-DAUDITD_LOG_TAG="auditd"' \
+          -DPCRE2_CODE_UNIT_WIDTH=8 \
+          -fPIC \
+          -I include \
+          -I src \
+          -I $(LIBSEPOL_BASE)/include
+
+LIBSELINUX := src/libandroid-selinux.so
+LIBSEPOL := $(LIBSEPOL_BASE)/src/libsepol.a
+
+$(LIBSELINUX): $(OBJS) $(LIBSEPOL)
+	$(CC) -o $@ $^ -shared -lpcre2-8 -llog $(LDFLAGS)
+
+$(LIBSEPOL):
+	$(MAKE) -C $(LIBSEPOL_BASE)/src libsepol.a
+
+install: $(LIBSELINUX)
+	test -d $(PREFIX) || install -d -m 755 $(PREFIX)
+	test -d $(LIBDIR) || install -d -m 755 $(LIBDIR)
+	install -m 755 $(LIBSELINUX) $(LIBDIR)
+	test -d $(INCLUDEDIR) || install -d -m 755 $(INCLUDEDIR)
+	test -d $(INCLUDEDIR)/selinux || install -d -m 755 $(INCLUDEDIR)/selinux
+	install -m 644 $(wildcard include/selinux/*.h) $(INCLUDEDIR)/selinux

--- a/packages/libandroid-selinux/build.sh
+++ b/packages/libandroid-selinux/build.sh
@@ -1,0 +1,29 @@
+TERMUX_PKG_HOMEPAGE=https://selinuxproject.org
+TERMUX_PKG_DESCRIPTION="Android fork of libselinux, an SELinux userland library"
+TERMUX_PKG_LICENSE="Public Domain"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=14.0.0.11
+TERMUX_PKG_SRCURL=https://android.googlesource.com/platform/external/selinux
+TERMUX_PKG_GIT_BRANCH=android-${TERMUX_PKG_VERSION%.*}_r${TERMUX_PKG_VERSION##*.}
+TERMUX_PKG_SHA256=SKIP_CHECKSUM
+TERMUX_PKG_DEPENDS="pcre2"
+TERMUX_PKG_SKIP_SRC_EXTRACT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_post_get_source() {
+	# FIXME: We would like to enable checksums when downloading
+	# tar files, but they change each time as the tar metadata
+	# differs: https://github.com/google/gitiles/issues/84
+	git clone --depth 1 --single-branch --branch $TERMUX_PKG_GIT_BRANCH \
+		$TERMUX_PKG_SRCURL .
+	cp -f "$TERMUX_PKG_BUILDER_DIR/Makefile-android" "$TERMUX_PKG_SRCDIR/libselinux"
+	cp -f "$TERMUX_PKG_BUILDER_DIR/termux_build.h" "$TERMUX_PKG_SRCDIR/libselinux/include"
+}
+
+termux_step_make() {
+	make -C libselinux -f Makefile-android
+}
+
+termux_step_make_install() {
+	make -C libselinux -f Makefile-android install
+}

--- a/packages/libandroid-selinux/termux-build.patch
+++ b/packages/libandroid-selinux/termux-build.patch
@@ -1,0 +1,49 @@
+--- a/libselinux/src/android/android.c
++++ b/libselinux/src/android/android.c
+@@ -1,9 +1,10 @@
++#include <termux_build.h>
+ #include <errno.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <unistd.h>
+ 
+-#include <log/log.h>
++#include <android/log.h>
+ #include <selinux/android.h>
+ #include <selinux/label.h>
+ 
+--- a/libselinux/src/android/android_seapp.c
++++ b/libselinux/src/android/android_seapp.c
+@@ -1,3 +1,5 @@
++#include <termux_build.h>
++
+ #include <ctype.h>
+ #include <limits.h>
+ #include <linux/magic.h>
+@@ -8,7 +10,6 @@
+ #include <string.h>
+ #include <unistd.h>
+ 
+-#include <private/android_filesystem_config.h>
+ #include <selinux/android.h>
+ #include <selinux/context.h>
+ #include <selinux/selinux.h>
+--- a/libselinux/src/label_file.c
++++ b/libselinux/src/label_file.c
+@@ -1,3 +1,5 @@
++#include <termux_build.h>
++
+ /*
+  * File contexts backend for labeling system
+  *
+--- a/libselinux/src/regex.h
++++ b/libselinux/src/regex.h
+@@ -1,6 +1,8 @@
+ #ifndef SRC_REGEX_H_
+ #define SRC_REGEX_H_
+ 
++#include <termux_build.h>
++
+ #include <stdbool.h>
+ #include <stdio.h>
+ 

--- a/packages/libandroid-selinux/termux_build.h
+++ b/packages/libandroid-selinux/termux_build.h
@@ -1,0 +1,18 @@
+#include <stdint.h>
+
+#ifndef LOG_PRI
+#define LOG_PRI(priority, tag, ...) \
+  __android_log_print(priority, tag, __VA_ARGS__)
+#endif
+
+#ifndef LOG_EVENT_STRING
+#define LOG_EVENT_STRING(_tag, _value) \
+  (void)__android_log_buf_write(LOG_ID_EVENTS, ANDROID_LOG_DEFAULT, _tag, _value);
+#endif
+
+#define fgets_unlocked(buf, size, fp) fgets(buf, size, fp)
+
+#define AID_USER_OFFSET 100000 /* offset for uid ranges for each user */
+#define AID_APP_START 10000 /* first app user */
+#define AID_SDK_SANDBOX_PROCESS_START 20000 /* start of uids allocated to sdk sandbox processes */
+#define AID_ISOLATED_START 90000 /* start of uids for fully isolated sandboxed processes */


### PR DESCRIPTION
This PR introduces a new library (libandroid-selinux) for basic SELinux functionality.
Along with that, I've also added SELinux support to coreutils.
`chcon` and `ls -Z` seems to be working.
I still haven't done a thorough testing just yet so it might still have a few catch, but that should not break existing functionalities.
