### PR TITLE
Update NDK 23c patches

### DIFF
--- a/ndk-patches/23c/bits-struct_file.h.patch
+++ b/ndk-patches/23c/bits-struct_file.h.patch
@@ -36,7 +36,7 @@
 +	short   _flags;         /* flags, below; this FILE is free if 0 */
 +	short   _file;          /* fileno, if Unix descriptor, else -1 */
  #endif
--} __attribute__((aligned(sizeof(void*))));
+-} __attribute__((__aligned__(sizeof(void*))));
 +	struct  __sbuf _bf;     /* the buffer (at least 1 byte, if !NULL) */
 +        int     _lbfsize;       /* 0 or -_bf._size, for inline putc */
 +	

--- a/ndk-patches/23c/grp.h.patch
+++ b/ndk-patches/23c/grp.h.patch
@@ -1,13 +1,13 @@
---- ./usr/include/grp.h.orig	2022-11-09 21:58:45.468821763 +0100
-+++ ./usr/include/grp.h	2022-11-09 22:02:55.124538470 +0100
+--- ./usr/include/grp.h.orig
++++ ./usr/include/grp.h
 @@ -50,21 +50,15 @@
- struct group* getgrgid(gid_t __gid);
- struct group* getgrnam(const char* __name);
+ struct group* _Nullable getgrgid(gid_t __gid);
+ struct group* _Nullable getgrnam(const char* _Nonnull __name);
  
 -/* Note: Android has thousands and thousands of ids to iterate through. */
 -
 -#if __ANDROID_API__ >= 26
--struct group* getgrent(void) __INTRODUCED_IN(26);
+-struct group* _Nullable getgrent(void) __INTRODUCED_IN(26);
 -
 -void setgrent(void) __INTRODUCED_IN(26);
 -void endgrent(void) __INTRODUCED_IN(26);
@@ -15,14 +15,14 @@
 -
 -
  #if __ANDROID_API__ >= 24
- int getgrgid_r(gid_t __gid, struct group* __group, char* __buf, size_t __n, struct group** __result) __INTRODUCED_IN(24);
- int getgrnam_r(const char* __name, struct group* __group, char* __buf, size_t __n, struct group** __result) __INTRODUCED_IN(24);
+ int getgrgid_r(gid_t __gid, struct group* __BIONIC_COMPLICATED_NULLNESS __group, char* _Nonnull __buf, size_t __n, struct group* _Nullable * _Nonnull __result) __INTRODUCED_IN(24);
+ int getgrnam_r(const char* _Nonnull __name, struct group* __BIONIC_COMPLICATED_NULLNESS __group, char* _Nonnull __buf, size_t __n, struct group* _Nullable *_Nonnull __result) __INTRODUCED_IN(24);
  #endif /* __ANDROID_API__ >= 24 */
  
-+static struct group* getgrent(void) { return 0; }
++static struct group* _Nullable getgrent(void) { return 0; }
 +static void setgrent(void) {}
 +static void endgrent(void) {}
 +
- int getgrouplist(const char* __user, gid_t __group, gid_t* __groups, int* __group_count);
- int initgroups(const char* __user, gid_t __group);
+ int getgrouplist(const char* _Nonnull __user, gid_t __group, gid_t* __BIONIC_COMPLICATED_NULLNESS __groups, int* _Nonnull __group_count);
+ int initgroups(const char* _Nonnull __user, gid_t __group);
  

--- a/ndk-patches/23c/pwd.h.patch
+++ b/ndk-patches/23c/pwd.h.patch
@@ -1,15 +1,15 @@
---- ./usr/include/pwd.h.orig	2020-01-17 23:55:20.029173926 +0000
-+++ ./usr/include/pwd.h	2020-01-18 00:04:18.758398251 +0000
-@@ -89,13 +89,59 @@
- struct passwd* getpwent(void) __INTRODUCED_IN(26);
+--- ./usr/include/pwd.h.orig
++++ ./usr/include/pwd.h
+@@ -89,13 +89,60 @@
+ struct passwd* _Nullable getpwent(void) __INTRODUCED_IN(26);
  
  void setpwent(void) __INTRODUCED_IN(26);
 -void endpwent(void) __INTRODUCED_IN(26);
  #endif /* __ANDROID_API__ >= 26 */
  
  
- int getpwnam_r(const char* __name, struct passwd* __pwd, char* __buf, size_t __n, struct passwd** __result);
- int getpwuid_r(uid_t __uid, struct passwd* __pwd, char* __buf, size_t __n, struct passwd** __result);
+ int getpwnam_r(const char* _Nonnull __name, struct passwd* _Nonnull __pwd, char* _Nonnull __buf, size_t __n, struct passwd* _Nullable * _Nonnull __result);
+ int getpwuid_r(uid_t __uid, struct passwd* _Nonnull __pwd, char* _Nonnull __buf, size_t __n, struct passwd* _Nullable * _Nonnull __result);
  
 +int access(const char* __path, int __mode);
 +
@@ -56,6 +56,7 @@
 +#define getpwuid android_polyfill_getpwuid
 +#define getpwuid_r android_polyfill_getpwuid_r
 +static void endpwent(void) { /* Do nothing. */ }
++
 +
 +
  __END_DECLS

--- a/ndk-patches/23c/semaphore.h.patch
+++ b/ndk-patches/23c/semaphore.h.patch
@@ -1,18 +1,18 @@
 --- ./usr/include/semaphore.h.orig
 +++ ./usr/include/semaphore.h
 @@ -71,9 +71,14 @@
- int sem_trywait(sem_t* __sem);
- int sem_wait(sem_t* __sem);
+ int sem_trywait(sem_t* _Nonnull __sem);
+ int sem_wait(sem_t* _Nonnull __sem);
  
 -/* These aren't actually implemented. */
 +#undef sem_open
 +#define sem_open libandroid_sem_open
- sem_t* sem_open(const char* __name, int _flags, ...);
+ sem_t* _Nullable sem_open(const char* _Nonnull __name, int _flags, ...);
 +#undef sem_close
 +#define sem_close libandroid_sem_close
- int sem_close(sem_t* __sem);
+ int sem_close(sem_t* _Nonnull __sem);
 +#undef sem_unlink
 +#define sem_unlink libandroid_sem_unlink
- int sem_unlink(const char* __name);
+ int sem_unlink(const char* _Nonnull __name);
  
  __END_DECLS

--- a/ndk-patches/23c/stdio.h.patch
+++ b/ndk-patches/23c/stdio.h.patch
@@ -1,10 +1,12 @@
 --- ./usr/include/stdio.h.orig	2021-08-16 11:48:44.308954400 +0200
 +++ ./usr/include/stdio.h	2021-08-16 11:50:00.438924014 +0200
-@@ -44,6 +44,9 @@
+@@ -44,6 +44,11 @@
  #include <stdarg.h>
  #include <stddef.h>
  
++#if !defined(__swift__)
 +#include <string.h>            /* For strcpy(3) used by ctermid() */
++#endif
 +#include <asm/fcntl.h>         /* For O_RDWR and other O_* constants */
 +
  #include <bits/seek_constants.h>
@@ -12,38 +14,40 @@
  #if __ANDROID_API__ < 24
 @@ -165,7 +166,7 @@
      __printflike(2, 0) __warnattr_strict("vsprintf is often misused; please use vsnprintf");
- char* tmpnam(char* __s)
+ char* _Nullable tmpnam(char* _Nullable __s)
      __warnattr("tmpnam is unsafe, use mkstemp or tmpfile instead");
 -#define P_tmpdir "/tmp/" /* deprecated */
 +#define P_tmpdir "@TERMUX_PREFIX@/tmp/" /* deprecated */
- char* tempnam(const char* __dir, const char* __prefix)
+ char* _Nullable tempnam(const char* _Nullable __dir, const char* _Nullable __prefix)
      __warnattr("tempnam is unsafe, use mkstemp or tmpfile instead");
  
 @@ -289,8 +290,6 @@
- FILE* freopen64(const char* __path, const char* __mode, FILE* __fp) __INTRODUCED_IN(24);
+ FILE* _Nullable freopen64(const char* _Nullable __path, const char* _Nonnull __mode, FILE* _Nonnull __fp) __INTRODUCED_IN(24);
  #endif /* __ANDROID_API__ >= 24 */
  
--FILE* tmpfile(void);
+-FILE* _Nullable tmpfile(void);
 -
  #if __ANDROID_API__ >= 24
- FILE* tmpfile64(void) __INTRODUCED_IN(24);
+ FILE* _Nullable tmpfile64(void) __INTRODUCED_IN(24);
  #endif /* __ANDROID_API__ >= 24 */
-@@ -304,10 +303,15 @@
+@@ -304,10 +303,17 @@
  
  #define L_ctermid 1024 /* size for ctermid() */
  
 -#if __ANDROID_API__ >= 26
--char* ctermid(char* __buf) __INTRODUCED_IN(26);
+-char* _Nonnull ctermid(char* _Nullable __buf) __INTRODUCED_IN(26);
 -#endif /* __ANDROID_API__ >= 26 */
 +/* Needed by gnulibs freading(). */
 +#define __sferror(p)    (((p)->_flags & __SERR) != 0)
  
 +/* Used by perl, fish, and others. */
-+static __inline__ char* ctermid(char* s) {
++#if !defined(__swift__)
++static __inline__ char* _Nonnull ctermid(char* _Nullable s) {
 +	if (s == 0) return (char*) "/dev/tty";
 +	strcpy(s, "/dev/tty");
 +	return s;
 +}
++#endif
  
  FILE* fdopen(int __fd, const char* __mode);
  int fileno(FILE* __fp);
@@ -56,7 +60,7 @@
 +extern int unlink(const char*);
 +void free(void* p);
 +uint32_t arc4random(void);
-+static __inline__ FILE* tmpfile() {
++static __inline__ FILE* _Nullable tmpfile() {
 +	int p = getpid();
 +	char* path;
 +	int i;

--- a/ndk-patches/23c/stdlib.h.patch
+++ b/ndk-patches/23c/stdlib.h.patch
@@ -1,20 +1,22 @@
 --- ./usr/include/stdlib.h.orig	2021-08-16 11:50:47.432239182 +0200
 +++ ./usr/include/stdlib.h	2021-08-16 11:51:31.102222894 +0200
-@@ -33,6 +33,7 @@
+@@ -33,6 +33,9 @@
  #include <bits/wait.h>
  #include <malloc.h>
  #include <stddef.h>
++#if !defined(__swift__)
 +#include <stdint.h>
++#endif
  #include <sys/cdefs.h>
  #include <xlocale.h>
  
-@@ -224,8 +225,7 @@
- size_t wcstombs(char* __dst, const wchar_t* __src, size_t __n);
+@@ -207,8 +207,7 @@
  
- #if __ANDROID_API__ >= 21
--size_t __ctype_get_mb_cur_max(void) __INTRODUCED_IN(21);
+ size_t wcstombs(char* _Nullable __dst, const wchar_t* _Nullable __src, size_t __n);
+ 
+-size_t __ctype_get_mb_cur_max(void);
 -#define MB_CUR_MAX __ctype_get_mb_cur_max()
 +#define MB_CUR_MAX 4
- #else
- /*
-  * Pre-L we didn't have any locale support and so we were always the POSIX
+ 
+ #if defined(__BIONIC_INCLUDE_FORTIFY_HEADERS)
+ #include <bits/fortify/stdlib.h>


### PR DESCRIPTION
While testing different approaches to compile RNote, someone suggested that I attempt compiling it with an older NDK so I updated the patches needed for the NDK to work as the old patches don't apply anymore.
The patches needed were copied over from ndk 27's patches