### PR TITLE
add earlyoom

### DIFF
--- a/packages/earlyoom/build.sh
+++ b/packages/earlyoom/build.sh
@@ -1,0 +1,69 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/rfjakob/earlyoom
+# are line breaks respected?
+TERMUX_PKG_DESCRIPTION='
+out of memory OOM safety net that prevent freezes and closing termux from memory overrun. replacement for  lmk that termux lack  permission to utilise for its programmes  . another alternative is activating the kernel oom_kill.c by increasing the badness from
+
+~/.bashrc
+choom -n 500 -p $$
+
+refer to termux-services for service management . default limit 30 percentage is adapted for 4 gig phone. change it in
+
+$SVDIR/earlyoom/run
+
+print status info from
+
+logcat -d|ack oom
+
+ if a build process is killed by earlyoom  disable parallel building and try again 
+
+~/.gradle/gradle.properties
+org.gradle.parallel=false
+org.gradle.daemon=false
+org.gradle.jvmargs=-Xmx256m
+
+$HOME/.cargo/config.toml
+[build]
+jobs = 1
+
+export MAKEFLAGS=-j1
+'
+# echo "$TERMUX_PKG_DESCRIPTION";exit
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=$(date +"%y%m%d")
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=git+https://github.com/john-peterson/earlyoom 
+TERMUX_PKG_GIT_BRANCH=termux
+TERMUX_PKG_DEPENDS="  "
+TERMUX_PKG_SUGGESTS=" termux-services"
+TERMUX_PKG_BUILD_DEPENDS=" make clang "
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+
+"
+TERMUX_PKG_EXTRA_MAKE_ARGS="V=1"
+if $TERMUX_ON_DEVICE_BUILD; then TERMUX_PKG_MAKE_PROCESSES=1;fi
+TERMUX_PKG_SERVICE_SCRIPT=("earlyoom" 'exec earlyoom -r 0 -m 30,15 -s 30,15 --sort-by-rss --ignore termux -N $PREFIX/bin/earlyoom-wall --syslog')
+
+if !$TERMUX_ON_DEVICE_BUILD; then
+echo " untested off device might fail "
+#read
+fi
+
+termux_step_post_get_source() {
+
+}
+
+
+termux_step_pre_configure() {
+
+}
+
+termux_step_post_configure(){
+	export CFLAGS+=" -w -Wno-error -Wfatal-errors"
+}
+
+termux_step_post_make_install() {
+  install -Dm755 "$TERMUX_PKG_BUILDER_DIR/earlyoom-wall" -t "$TERMUX_PREFIX/bin"
+}

--- a/packages/earlyoom/earlyoom-wall
+++ b/packages/earlyoom/earlyoom-wall
@@ -1,0 +1,2 @@
+#!/bin/sh
+wall $EARLYOOM_NAME was killed by earlyoom


### PR DESCRIPTION
https://github.com/john-peterson/termux-packages/pull/new/earlyoom

# login

if service-daemon doesn't work you can use start-stop-daemon instead 

~~~
~/.bash_login
start-stop-daemon --start --background --pidfile $HOME/earlyoom.pid -m -v --exec $PREFIX/bin/earlyoom -- -r 0 -m 30,15 -s 30,15 --sort-by-rss --ignore termux -N $PREFIX/bin/earlyoom-wall --syslog
~~~

# logout

to stop earlyoom place this in a custom termux-logout

https://github.com/john-peterson/termux-tools/commits/wall

~~~
cp #$PREFIX/bin/termux-logout ~/bin/

~/bin/termux-logout
...
# custom commands
start-stop-daemon --stop --pidfile $HOME/earlyoom.pid --remove-pidfile -v
~~~

# wall

$PREFIX/bin/earlyoom-wall requires wall from termux-tools

https://github.com/john-peterson/termux-tools/commits/wall


# todo adjust memory limits on install

an installer script could adjust the memory limit for the phone according to user reports 

30% is the best limit for 4 gig but could be different on other phones 

anything lower than 30% on a 4 gig phone is a fool's errand. lmk will try to close termux around 25% and if that fails the phone is ready for the trash bin. a gradle build froze my phone and would not boot again without releasing the user partition effectively wiping all my files. i learned my lesson. bail early before the disaster 


# kernel oom_kill can be called to action 

a fifty percent badness increase or adjustment will arouse the usually sleepy kernel oom_kill.c to actively kill termux programs before earlyoom limits are hit

~~~
.bashrc
choom -n 500 -p $$

logcat -d|ack oom-kill
07-31 02:50:16.611     0     0 I oom-kill: constraint=CONSTRAINT_NONE,nodemask=(null),cpuset=/,mems_allowed=0,global_oom,task_memcg=/,task=stress,pid=7079,uid=0
~~~

without this adjustment signal 9 kills are unusual and usually occur to idle bash sessions and i suspect they originate from the phantom manager 

~~~
logcat -d|ack -i phantom
08-11 09:06:06.377  1548  2159 I ActivityManager: Process PhantomProcessRecord {60ca53e 29078:13279:sleep/u0a214} died

logcat -d|ack -i reap
08-02 17:11:44.895     0     0 I init    : Untracked pid 17514 did not have an associated service entry and will not be reaped
~~~

# lmk permission denied 

lmk is inaccessible to termux and even adb uid 2000. it is aware of com.termux but unaware of termux apps and will never kill them directly . it doesn't traverse /proc/pid like earlyoom it maintains a list of programs that it has permission to kill

this stress branch can register with lmk on a development phone with root permission 

https://github.com/john-peterson/stress/commits/cg

~~~
logcat -d|ack lowmem
07-31 15:08:55.527   152   152 I lowmemorykiller: Kill 'stress' (5390), uid 0, oom_score_adj 1000 to free 2517304kB rss, 0kB swap; reason: low watermark is breached and swap is low (143116kB < 267412kB)
~~~


# system freezes

 lmk has failed to act and let my phone freeze instead. it happened four times last year on android 13 and twice this year on 14

in android 13 

- gradle inside aide
- aide reference finder
-eggns

android 14

-firefox twice. the record i have seen is 3,4 gig for Firefox in AppMemoryUsageActivity

this happens rarely and is hard to reproduce . it probably involves a large amount of disk activity with long stalls that prevents lmk to act in time to save an impending disaster precious seconds before it is an irreversible fact

## stress test

the lmk test programs run a single malloc loop that is lame and will never uncover any weakness. i have patched stress to register with lmk to perform a realistic test with a full assault on all systems including disk activity 

https://github.com/john-peterson/stress/commits/cg

### in adb shell

unless you increase the negative badness (reduce the goodness) adb shell test will never work because forks inherit the oom adjustment 

just launching a single malloc loop here will stall the system because shell programs are not submitted to lmk and oom_kill.c will not kill this

~~~
adb shell
cat /proc/self/oom_score_adj
-950

choom -n 0 -p $$
~~~

### in termux shell

unlike the adb shell parent termux parent pid is registered with lmk.
a stress test is less likely to freeze the system but the parent shell will be killed before the fork unless it is registered . like adb shell forks are not registered automatically with lmk  and won't be killed directly by lmk

 termux has no permission for goodness (negative badness) adjusting the lowest adjustment is 0. the badness is adjusted by the system to be

- fg 0
- bg 200


# footnotes don't read this android is bloatware and everyone knows it blame the market place not its loyal servants 

i moved all nagging here instead of removing them. the solution for you is to stop reading here. they are aware of my disappointment  and we are working on a solution that consider all participants. no animals owe me anything and this is just idle talk with little action 

since their engineers are forbidden to visit this site i can speak freely here . when terminal emulators reach one billion in revenue we will get all we ask until then Google engineers are busy drooling at the legs of the market place begging for more candy crush money from normal brained apes

submit a patch to aosp Gerrit and notice that only money matters there . they have absolutely no interest in intellectual pursuit only money . they snooze over my patches but drool over profits 

i need permission to lmk. to disable apps. connect to localhost adb. endless list of sensible patches that has zero priority . core engineering has lower priority than money generating features and play store nonsense . i have effectively 500 to 800 meg ram for javac rustc clang etc on a 4 gig phone but could have 2 gig more by disabling everything so i could build everything I need. ome example is pydantic that countless programmes depend on that need one gig to build that i can't build on my phone 

it is a no brainer that termux should be allowed to register all apps with lmk. it is just a gigantic misunderstanding that termux lack permission to register forks. from their perspective terminal emulators are irrelevant to their empire over brain dead apes on this insignificant planet. their guiding light is increased worship from imbecile apes even if it means the most bloated Linux distribution the world has seen

android is running two hundred background apps and normal phones lack permission to disable them. com.android.systemui has usually leaked one gig and there is no permission to kill it to release one gig ram for work operations . i am not saying i can find the memory leaks but at least let me kill it since everyone knows how gigantic the holes are. it should use 250 meg but usually is seen holding one gig more than that. it leaks one gig in a few days or weeks but stops leaking after that

why don't I use 6 or 8 gig ram and forget about all this? because four gig is more than enough for any sensible workload if all bloat can be removed. which is perfectly reasonable if aosp had different management that was less obsessed with money 

directly after a memory pressure event around five hundred meg more is available for work. but all those programs come back. outlook and messenger that i use once a year are constantly hogging memory with no way to disable them. at least not without adb which i can't use because i have no WiFi

 i have proposed a patch that removes all wifi checks from adb. the response is that adb localhost is unpopular and low priority. most prefer not to type commands directly on the phone . this decision was made by the single adb engineer they employ. the others are busy adding more bloat for brain dead apes and had nothing to say . company management can hardly find the power button.  

 i would like to see more influence from intellectuals to balance against the  empire builders . the system is stable but bloated and desperately need more options to disable all bloat 







