### PR TITLE
fix(scripts): Move deadsnakes PPA setup to setup-ubuntu

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -18,7 +18,6 @@ COPY ./build/termux_download.sh /tmp/build/
 RUN apt-get update && \
 	apt-get -yq upgrade && \
 	apt-get install -yq sudo lsb-release software-properties-common && \
-	add-apt-repository -y 'ppa:deadsnakes/ppa' && \
 	userdel ubuntu && \
 	useradd -u 1001 -U -m -s /bin/bash builder && \
 	echo "builder ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/builder && \

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -326,6 +326,9 @@ $SUDO chmod a+r /etc/apt/trusted.gpg.d/apt.llvm.org.asc
 	echo "deb [arch=amd64] http://apt.llvm.org/noble/ llvm-toolchain-noble-17 main"
 } | $SUDO tee /etc/apt/sources.list.d/apt-llvm-org.list > /dev/null
 
+# Add deadsnakes PPA to enable installing python 3.11:
+$SUDO add-apt-repository -y 'ppa:deadsnakes/ppa'
+
 $SUDO apt-get -yq update
 
 $SUDO env DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Fixes the `Free additional disk space` CI step, which calls `setup-ubuntu.sh` without having the setup steps in the `Dockerfile` done.