### PR TITLE
fix(ci/packages): Do not try to uninstall packages no longer present

### DIFF
--- a/.github/workflows/package_updates.yml
+++ b/.github/workflows/package_updates.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Free additional disk space
         run: |
           sudo apt purge -yq $(dpkg -l | grep '^ii' | awk '{ print $2 }' | grep -P '(aspnetcore|cabal-|dotnet-|ghc-|libmono|mongodb-|mysql-|php)') \
-            firefox google-chrome-stable google-cloud-cli microsoft-edge-stable mono-devel mono-runtime-common monodoc-manual powershell ruby
+            firefox google-chrome-stable microsoft-edge-stable mono-devel mono-runtime-common monodoc-manual ruby
           sudo apt autoremove -yq
           sudo apt clean
           sudo rm -fr /opt/ghc /opt/hostedtoolcache /usr/lib/node_modules /usr/local/share/boost /usr/share/dotnet /usr/share/swift

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -199,7 +199,7 @@ jobs:
           ./scripts/setup-ubuntu.sh
           sudo apt install ninja-build
           sudo apt purge -yq $(dpkg -l | grep '^ii' | awk '{ print $2 }' | grep -P '(aspnetcore|cabal-|dotnet-|ghc-|libmono|mongodb-|mysql-|php)') \
-            firefox google-chrome-stable google-cloud-cli microsoft-edge-stable mono-devel mono-runtime-common monodoc-manual powershell ruby
+            firefox google-chrome-stable microsoft-edge-stable mono-devel mono-runtime-common monodoc-manual ruby
           sudo apt autoremove -yq
           sudo apt clean
           sudo rm -fr /opt/ghc /opt/hostedtoolcache /usr/lib/node_modules /usr/local/share/boost /usr/share/dotnet /usr/share/swift


### PR DESCRIPTION
Fixes the below errors when trying to build big packages after switching to ubuntu 24.04:

> E: Unable to locate package google-cloud-cli
> E: Unable to locate package powershell