### PR TITLE
scripts(toolchain): Update from android-33 to android-35

### DIFF
--- a/scripts/setup-android-sdk.sh
+++ b/scripts/setup-android-sdk.sh
@@ -72,6 +72,6 @@ yes | $SDK_MANAGER --sdk_root="$ANDROID_HOME" --licenses
 yes | $SDK_MANAGER --sdk_root="$ANDROID_HOME" \
 		"platform-tools" \
 		"build-tools;${TERMUX_ANDROID_BUILD_TOOLS_VERSION}" \
-		"platforms;android-33" \
+		"platforms;android-35" \
 		"platforms;android-28" \
 		"platforms;android-24"


### PR DESCRIPTION
In the `ubuntu-24.04` runner image android-35 is preinstalled, not android-33. Syncing with that image makes building packages work when they are built outside of docker due to being built in the same PR as a package listed in `scripts/big-pkgs.list`.

This will be followed by a bump to reference android-35 in `aapt`.