### PR TITLE
chore(main/aapt): Update from android-33 to android-35

### DIFF
--- a/packages/aapt/build.sh
+++ b/packages/aapt/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 _TAG_VERSION=13.0.0
 _TAG_REVISION=6
 TERMUX_PKG_VERSION=${_TAG_VERSION}.${_TAG_REVISION}
-TERMUX_PKG_REVISION=14
+TERMUX_PKG_REVISION=15
 TERMUX_PKG_SRCURL=(https://android.googlesource.com/platform/frameworks/base
                    https://android.googlesource.com/platform/system/core
                    https://android.googlesource.com/platform/system/libbase
@@ -235,7 +235,7 @@ termux_step_make_install() {
 	rm -rf android-jar
 	mkdir android-jar
 	cd android-jar
-	cp $ANDROID_HOME/platforms/android-33/android.jar .
+	cp $ANDROID_HOME/platforms/android-35/android.jar .
 	unzip -q android.jar
 	mkdir -p $TERMUX_PREFIX/share/aapt
 	jar cfM $TERMUX_PREFIX/share/aapt/android.jar AndroidManifest.xml resources.arsc


### PR DESCRIPTION
Follow up to #21561 - allows the `aapt` package to build both in Docker and when built directly on the `ubuntu-24.04` CI image, due to being touched in the same PR as a big package.