### PR TITLE
chore(main/rsgain): Use libc++ instead of the fmt library

### DIFF
--- a/packages/rsgain/build.sh
+++ b/packages/rsgain/build.sh
@@ -3,7 +3,9 @@ TERMUX_PKG_DESCRIPTION="A simple audio normalizazion utility"
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION="3.5.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/complexlogic/rsgain/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=c76ba0dfaafcaa3ceb71a3e5a1de128200d92f7895d8c2ad45360adefe5a103b
-TERMUX_PKG_DEPENDS='taglib, fmt, libinih, libebur128, ffmpeg'
+TERMUX_PKG_DEPENDS='taglib, libc++, libinih, libebur128, ffmpeg'
 TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DUSE_STD_FORMAT=ON"


### PR DESCRIPTION
See
https://github.com/complexlogic/rsgain/blob/master/docs/BUILDING.md?plain=1#L21-L26C10:

> The features that rsgain uses from the fmt library have been integrated into the C++20 and C++23 standards, specifically the `<format>` and `<print>` headers. The standard library implementations are planned to completely replace rsgain's fmt dependency in the future. To support the transition, rsgain can use either the fmt library or standard library, depending on platform:
> - MSVC has full support in the standard library since version 19.37. The fmt library has been dropped from the Windows version in favor of the standard library implementation
> - GCC (libstdc++) has full support in the standard library since version 14. Pass `-DUSE_STD_FORMAT=ON` to `cmake` to use the standard library instead of the fmt library
> - Clang (libc++) has full support in the standard library since version 18. Enable it using the configuration switch described above for GCC
