### PR TITLE
new package: qt6-qt5compat

### DIFF
--- a/x11-packages/qt6-qt5compat/build.sh
+++ b/x11-packages/qt6-qt5compat/build.sh
@@ -1,0 +1,49 @@
+TERMUX_PKG_HOMEPAGE=https://www.qt.io/
+TERMUX_PKG_DESCRIPTION="Qt6 Module that contains unsupported Qt 5 APIs"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="6.7.2"
+TERMUX_PKG_SRCURL="https://download.qt.io/official_releases/qt/${TERMUX_PKG_VERSION%.*}/${TERMUX_PKG_VERSION}/submodules/qt5compat-everywhere-src-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256=8826b5189efc4d9bdb64fdb1aa89d0fdf4e53c60948ed7995621ed046e38c003
+TERMUX_PKG_DEPENDS="libc++, libicu, qt6-qtbase, qt6-qtdeclarative, qt6-shadertools"
+TERMUX_PKG_HOSTBUILD=true
+TERMUX_PKG_NO_STATICSPLIT=true
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_MESSAGE_LOG_LEVEL=STATUS
+-DCMAKE_SYSTEM_NAME=Linux
+"
+
+termux_step_host_build() {
+	termux_setup_cmake
+	termux_setup_ninja
+
+	cmake \
+		-G Ninja \
+		-S ${TERMUX_PKG_SRCDIR} \
+		-DCMAKE_BUILD_TYPE=MinSizeRel \
+		-DCMAKE_INSTALL_PREFIX=${TERMUX_PREFIX}/opt/qt6/cross \
+		-DCMAKE_MESSAGE_LOG_LEVEL=STATUS
+	ninja \
+		-j ${TERMUX_PKG_MAKE_PROCESSES} \
+		install
+}
+
+termux_step_pre_configure() {
+	termux_setup_cmake
+	termux_setup_ninja
+}
+
+termux_step_make_install() {
+	cmake \
+		--install "${TERMUX_PKG_BUILDDIR}" \
+		--prefix "${TERMUX_PREFIX}" \
+		--verbose
+
+	# Drop QMAKE_PRL_BUILD_DIR because reference the build dir
+	find "${TERMUX_PREFIX}/lib" -type f -name "libQt6Core5Compat*.prl" \
+		-exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' "{}" \;
+
+	# Remove *.la files
+	find "${TERMUX_PREFIX}/lib" -iname \*.la -delete
+}

--- a/x11-packages/qt6-qt5compat/qt6-qt5compat-cross-tools.subpackage.sh
+++ b/x11-packages/qt6-qt5compat/qt6-qt5compat-cross-tools.subpackage.sh
@@ -1,0 +1,5 @@
+TERMUX_SUBPKG_DESCRIPTION="Tools for cross build on the host (NOT for Termux)"
+TERMUX_SUBPKG_PLATFORM_INDEPENDENT=true
+TERMUX_SUBPKG_INCLUDE="
+opt/qt6/cross
+"


### PR DESCRIPTION
Grateful for considering to merge this. 

I am trying to build krita with all deps ready, but this `qt6-qt5compat` cannot be built together in one PR, cuz other krita deps (of deps) requires `qt5-qtbase` which messes up the build process of `qt6-qt5compat`. Merging this PR is needed in order to proceed to building krita (though using krita git qt6 version. Cuz termux's qt5 doesn't support opengl and won't build). 

Deps and build deps take ref to  https://archlinux.org/packages/extra/x86_64/qt6-5compat/ and also verified to be sufficient by looking at its cmakelists.txt