### PR TITLE
termux_step_get_dependencies_python.sh: adding path to python-crossenv modules

### DIFF
--- a/scripts/build/termux_step_get_dependencies_python.sh
+++ b/scripts/build/termux_step_get_dependencies_python.sh
@@ -30,6 +30,9 @@ termux_step_get_dependencies_python() {
 
 		# adding and setting values ​​to work properly with python modules
 		export PYTHONPATH=$TERMUX_PYTHON_HOME/site-packages
+		if [ "$TERMUX_ON_DEVICE_BUILD" = "false" ]; then
+			export TERMUX_PYTHON_MAINPATH="${PYTHONPATH}:${TERMUX_PYTHON_CROSSENV_PREFIX}/build/lib/python${TERMUX_PYTHON_VERSION}/site-packages"
+		fi
 		export PYTHON_SITE_PKG=$PYTHONPATH
 	fi
 }


### PR DESCRIPTION
so termux python can work with them