### PR TITLE
fix(main/proot-distro): Depend on file

### DIFF
--- a/packages/proot-distro/build.sh
+++ b/packages/proot-distro/build.sh
@@ -3,9 +3,10 @@ TERMUX_PKG_DESCRIPTION="Termux official utility for managing proot'ed Linux dist
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=4.17.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/termux/proot-distro/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=28eb685aa37658b2ef99545c0d12d96ca481ff72c2fbfc3530ae77d23a1196a1
-TERMUX_PKG_DEPENDS="bash, bzip2, coreutils, curl, findutils, gzip, ncurses-utils, proot (>= 5.1.107-32), sed, tar, termux-tools, util-linux, xz-utils"
+TERMUX_PKG_DEPENDS="bash, bzip2, coreutils, curl, file, findutils, gzip, ncurses-utils, proot (>= 5.1.107-32), sed, tar, termux-tools, util-linux, xz-utils"
 TERMUX_PKG_SUGGESTS="bash-completion, termux-api"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true


### PR DESCRIPTION
After https://github.com/termux/proot-distro/commit/f050095153d5891c1373001070f9eeac3f9a9d7a the `file` utility needs to be installed for proot-distro to work.