### PR TITLE
enhance(x11/qbittorrent{,-nox}): suggest `python`

### DIFF
--- a/x11-packages/qbittorrent/build.sh
+++ b/x11-packages/qbittorrent/build.sh
@@ -1,20 +1,21 @@
 TERMUX_PKG_HOMEPAGE=https://www.qbittorrent.org/
-TERMUX_PKG_DESCRIPTION="A Qt based BitTorrent client"
+TERMUX_PKG_DESCRIPTION="A Qt6 based BitTorrent client"
 TERMUX_PKG_LICENSE="GPL-2.0, GPL-3.0"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION="5.0.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/qbittorrent/qBittorrent/archive/refs/tags/release-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=9a24a6b95e9afac826295b8203685a515b13e77eb98bb8ed21c814916b999f6e
-TERMUX_PKG_FORCE_CMAKE=true
+TERMUX_PKG_BUILD_DEPENDS="qt6-qtsvg, qt6-qttools, boost"
 TERMUX_PKG_DEPENDS="libc++, libtorrent-rasterbar, openssl, qt6-qtbase, zlib"
-TERMUX_PKG_BUILD_DEPENDS="qt6-qttools, qt6-qtsvg, boost"
+TERMUX_PKG_RECOMMENDS="python"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE=newest-tag
 TERMUX_PKG_UPDATE_VERSION_REGEXP='\d+\.\d+\.\d+'
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS='
--DSTACKTRACE=OFF
+-DBUILD_SHARED_LIBS=OFF
 -DCMAKE_BUILD_TYPE=Release
--DBUILD_SHARED_LIBS=off
+-DSTACKTRACE=OFF
 '
 
 # based on the secondary `-shared` build in `libncnn`

--- a/x11-packages/qbittorrent/qbittorrent-nox.subpackage.sh
+++ b/x11-packages/qbittorrent/qbittorrent-nox.subpackage.sh
@@ -1,4 +1,5 @@
 TERMUX_SUBPKG_DEPEND_ON_PARENT=false
 TERMUX_SUBPKG_INCLUDE='bin/qbittorrent-nox share/man/man1/qbittorrent-nox.1.gz'
-TERMUX_SUBPKG_DESCRIPTION='A Qt based BitTorrent client - headless version'
+TERMUX_SUBPKG_DESCRIPTION='A Qt6 based BitTorrent client - headless version'
 TERMUX_SUBPKG_DEPENDS='libc++, libtorrent-rasterbar, openssl, qt6-qtbase, zlib'
+TERMUX_SUBPKG_RECOMMENDS="python"


### PR DESCRIPTION
Adds `python` as a dependency.
It is used by the search plugin system.

- I updated the description to specify Qt6, since Qt5 has been deprecated by qBittorrent.
- `TERMUX_PKG_FORCE_CMAKE=true` is no longer necessary as support for the `qmake` and `autotools` build systems was also dropped.
  - https://github.com/qbittorrent/qBittorrent/blob/release-5.0.0/Changelog#L83-L85
- I also sorted the `TERMUX_PKG_DEPENDS` and `TERMUX_PKG_EXTRA_CONFIGURE_ARGS`