### PR TITLE
fix(main/nushell): Build with default features

### DIFF
--- a/packages/nushell/build.sh
+++ b/packages/nushell/build.sh
@@ -3,14 +3,12 @@ TERMUX_PKG_DESCRIPTION="A new type of shell operating on structured data"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.98.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/nushell/nushell/archive/$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=c77fd63c4a5f2d35f7dcbb3e9bd76dfaa23acc6bc21fb1de4e7a4a94dc458839
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="openssl"
 TERMUX_PKG_BUILD_IN_SRC=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
---no-default-features
-"
 
 termux_step_pre_configure() {
 	termux_setup_rust


### PR DESCRIPTION
Clipboard integration historically hasn't worked on Termux anyway, so cargo's features were chosen to explicitly opt into a feature that included all default features except clipboard support.

9f0a6bee57dd96fd608ffefb166686111d4682d8 upgraded to 0.98.0, which removed support for clipboard integration, and thus the need for that feature flag went away. Unfortunately, it removed the `default-no-clipboard` feature, but not the `no-default-features` flag, so the resulting binary is missing a lot of stuff, like plug-in support, sqlite, and others.

This fixes that by removing the `--no-default-features` flag.
