### PR TITLE
enhance(root/runc): static build runc to avoid runtime linker deadlock

### DIFF
--- a/root-packages/runc/build.sh
+++ b/root-packages/runc/build.sh
@@ -3,12 +3,18 @@ TERMUX_PKG_DESCRIPTION="A tool for spawning and running containers according to 
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.1.15"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/opencontainers/runc/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=8446718a107f3e437bc33a4c9b89b94cb24ae58ed0a49d08cd83ac7d39980860
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="libseccomp"
+TERMUX_PKG_BUILD_DEPENDS="libseccomp-static"
 
 termux_step_make() {
+	${CC} -c -o stubs.o "$TERMUX_PKG_BUILDER_DIR/stubs.c"
+	${AR} rcs liblog.a stubs.o
+
+	export CGO_LDFLAGS="-L$TERMUX_PKG_BUILDDIR"
+
 	termux_setup_golang
 
 	export GOPATH="${PWD}/go"
@@ -16,7 +22,7 @@ termux_step_make() {
 	mkdir -p "${GOPATH}/src/github.com/opencontainers"
 	ln -sf "${TERMUX_PKG_SRCDIR}" "${GOPATH}/src/github.com/opencontainers/runc"
 
-	cd "${GOPATH}/src/github.com/opencontainers/runc" && make
+	cd "${GOPATH}/src/github.com/opencontainers/runc" && make static
 }
 
 termux_step_make_install() {

--- a/root-packages/runc/fix_static_build.patch
+++ b/root-packages/runc/fix_static_build.patch
@@ -1,0 +1,54 @@
+diff --git a/Makefile b/Makefile
+index 452ee94c..6ffd06d7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -19,28 +19,12 @@ LDFLAGS_COMMON := -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION)
+ GOARCH := $(shell $(GO) env GOARCH)
+ 
+ GO_BUILDMODE :=
+-# Enable dynamic PIE executables on supported platforms.
+-ifneq (,$(filter $(GOARCH),386 amd64 arm arm64 ppc64le riscv64 s390x))
+-	ifeq (,$(findstring -race,$(EXTRA_FLAGS)))
+-		GO_BUILDMODE := "-buildmode=pie"
+-	endif
+-endif
+ GO_BUILD := $(GO) build -trimpath $(GO_BUILDMODE) \
+ 	$(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \
+ 	-ldflags "$(LDFLAGS_COMMON) $(EXTRA_LDFLAGS)"
+ 
+ GO_BUILDMODE_STATIC :=
+ LDFLAGS_STATIC := -extldflags -static
+-# Enable static PIE executables on supported platforms.
+-# This (among the other things) requires libc support (rcrt1.o), which seems
+-# to be available only for arm64 and amd64 (Debian Bullseye).
+-ifneq (,$(filter $(GOARCH),arm64 amd64))
+-	ifeq (,$(findstring -race,$(EXTRA_FLAGS)))
+-		GO_BUILDMODE_STATIC := -buildmode=pie
+-		LDFLAGS_STATIC := -linkmode external -extldflags --static-pie
+-	endif
+-endif
+-# Enable static PIE binaries on supported platforms.
+ GO_BUILD_STATIC := $(GO) build -trimpath $(GO_BUILDMODE_STATIC) \
+ 	$(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo" \
+ 	-ldflags "$(LDFLAGS_COMMON) $(LDFLAGS_STATIC) $(EXTRA_LDFLAGS)"
+diff --git a/libcontainer/nsenter/cloned_binary.c b/libcontainer/nsenter/cloned_binary.c
+index d1b2d4c5..c10347c3 100644
+--- a/libcontainer/nsenter/cloned_binary.c
++++ b/libcontainer/nsenter/cloned_binary.c
+@@ -91,6 +91,8 @@
+ #  define MFD_ALLOW_SEALING 0x0002U
+ #endif
+ 
++int memfd_create(const char *name, unsigned int flags);
++#ifndef __ANDROID__
+ int memfd_create(const char *name, unsigned int flags)
+ {
+ #ifdef SYS_memfd_create
+@@ -100,6 +102,7 @@ int memfd_create(const char *name, unsigned int flags)
+ 	return -1;
+ #endif
+ }
++#endif
+ 
+ /* This comes directly from <linux/fcntl.h>. */
+ #ifndef F_LINUX_SPECIFIC_BASE

--- a/root-packages/runc/stubs.c
+++ b/root-packages/runc/stubs.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/system_properties.h>
+
+int __android_log_vprint(int prio, const char* tag, const char* fmt, va_list ap) {
+    char buf[1024];
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    fprintf(stdout, "%s: %s\n", tag, buf);
+    return 0;
+}
+
+void* dlopen(const char* filename, int flag) {
+    return (void*)1;
+}
+
+void* dlsym(void* handle, const char* symbol) {
+	// https://github.com/golang/go/issues/59942
+	if (strcmp(symbol, "android_get_device_api_level") != 0) {
+		fprintf(stderr, "Error: Unexpected symbol requested: %s\n", symbol);
+		exit(1);
+	}
+	char buff[PROP_VALUE_MAX];
+	int n = __system_property_get("ro.build.version.sdk", buff);
+	if (n <= 0) {
+		fprintf(stderr, "Error: Failed to get device API level\n");
+		exit(1);
+	}
+	int api_level = atoi(buff);
+	if (api_level < 29) {
+		return NULL;
+	}
+	return (void*)1;
+}
+
+int dlclose(void* handle) {
+    return 0;
+}


### PR DESCRIPTION
After creating new namespace runc deadlocks in dlopen on android 14. Switching to static build so there is no problem with dl anymore. It include workaround for https://github.com/golang/go/issues/59942