### PR TITLE
revbump(main/python-{contourpy,onnxruntime,scipy},x11/python-torch{audio,vision})

### DIFF
--- a/packages/python-contourpy/build.sh
+++ b/packages/python-contourpy/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Python library for calculating contours in 2D quadrilate
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.3.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/contourpy/contourpy
 TERMUX_PKG_DEPENDS="python, python-numpy"
 TERMUX_PKG_PYTHON_COMMON_DEPS="wheel, meson-python, build"

--- a/packages/python-onnxruntime/build.sh
+++ b/packages/python-onnxruntime/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Cross-platform, high performance ML inferencing and trai
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.19.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/microsoft/onnxruntime
 TERMUX_PKG_DEPENDS="abseil-cpp, libc++, protobuf, libre2, python"
 TERMUX_PKG_BUILD_DEPENDS="python-numpy"

--- a/packages/python-scipy/build.sh
+++ b/packages/python-scipy/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Fundamental algorithms for scientific computing in Pytho
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.14.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/scipy/scipy
 TERMUX_PKG_DEPENDS="libc++, libopenblas, python, python-numpy"
 TERMUX_PKG_BUILD_DEPENDS="python-numpy-static"

--- a/x11-packages/python-torchaudio/build.sh
+++ b/x11-packages/python-torchaudio/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Data manipulation and transformation for audio signal pr
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.4.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/pytorch/audio
 # FFMPEG
 TERMUX_PKG_DEPENDS="libc++, python, python-pip, python-torch"

--- a/x11-packages/python-torchvision/build.sh
+++ b/x11-packages/python-torchvision/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Datasets, Transforms and Models specific to Computer Vis
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.19.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/pytorch/vision
 # ffmpeg
 TERMUX_PKG_DEPENDS="libc++, python, python-numpy, python-pillow, python-pip, python-torch, libjpeg-turbo, libpng, zlib"


### PR DESCRIPTION
Revbump some python packages after python 3.12 (#18078).

Let's await the merge to build and make some general sanity checks before starting revbumping python revdeps.