### PR TITLE
scripts(setup-ubuntu.sh): Remove host python3.11

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -65,11 +65,9 @@ PACKAGES+=" xmlto"
 PACKAGES+=" xmltoman"
 
 # Needed by python modules (e.g. asciinema) and some build systems.
-PACKAGES+=" python3.11"
 PACKAGES+=" python3-pip"
 PACKAGES+=" python3-setuptools"
 PACKAGES+=" python-wheel-common"
-PACKAGES+=" python3.11-venv"
 PACKAGES+=" python3.12-venv"
 
 # Needed by package bc.


### PR DESCRIPTION
After switching to python 3.12 we no longer need host python 3.11.