### PR TITLE
revbump(main/python-skia-pathops): After python 3.12

### DIFF
--- a/packages/python-skia-pathops/build.sh
+++ b/packages/python-skia-pathops/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Python bindings for the Skia library's Path Ops"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="Nguyen Khanh @nguynkhn"
 TERMUX_PKG_VERSION=0.8.0
+TERMUX_PKG_REVISION=1
 _SUFFIX='post1'
 TERMUX_PKG_SRCURL=https://github.com/fonttools/skia-pathops/archive/refs/tags/v${TERMUX_PKG_VERSION}.${_SUFFIX}.tar.gz
 TERMUX_PKG_SHA256=88bd5872bb96e19108ff7265cae2e1708f5e7f335b39ebfdd023940970e1d54c

--- a/scripts/build/setup/termux_setup_gn.sh
+++ b/scripts/build/setup/termux_setup_gn.sh
@@ -1,6 +1,6 @@
 termux_setup_gn() {
 	termux_setup_ninja
-	local GN_COMMIT=53ef169800760fdc09f0773bf380fe99eaeab339
+	local GN_COMMIT=e30a1fe26e5e72cb7cb9f27d9abe2330e4115ae5
 	local GN_TARFILE=$TERMUX_COMMON_CACHEDIR/gn_$GN_COMMIT.tar.gz
 	local GN_SOURCE=https://gn.googlesource.com/gn/+archive/$GN_COMMIT.tar.gz
 


### PR DESCRIPTION
Also update `gn` version in `termux_setup_gn` (which is currently only used in `python-skia-pathops`) to latest version to fix setting it up under ubuntu 24.04.