### PR TITLE
bump(main/ncdu2): 2.6

### DIFF
--- a/packages/ncdu/build.sh
+++ b/packages/ncdu/build.sh
@@ -1,12 +1,29 @@
 TERMUX_PKG_HOMEPAGE=https://dev.yorhel.nl/ncdu
 TERMUX_PKG_DESCRIPTION="Disk usage analyzer"
 TERMUX_PKG_LICENSE="MIT"
-TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION="1.20"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://dev.yorhel.nl/download/ncdu-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=5fe2bb841abe72374bb242dbb93293c4ae053078432d896a7481b2ff10be9572
 TERMUX_PKG_DEPENDS="libandroid-support, ncurses"
-TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --with-shell=${TERMUX_PREFIX}/bin/sh
 "
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_VERSION_REGEXP='1\.\d+(\.\d+)?'
+
+termux_pkg_auto_update() {
+	local latest_release
+	latest_release="$(git ls-remote --tags https://code.blicky.net/yorhel/ncdu.git \
+	| grep -oP "refs/tags/v\K${TERMUX_PKG_UPDATE_VERSION_REGEXP}$" \
+	| sort -V \
+	| tail -n1)"
+
+	if [[ "${latest_release}" == "${TERMUX_PKG_VERSION}" ]]; then
+		echo "INFO: No update needed. Already at version '${TERMUX_PKG_VERSION}'."
+		return
+	fi
+
+	termux_pkg_upgrade_version "${latest_release}"
+}

--- a/packages/ncdu2/build.sh
+++ b/packages/ncdu2/build.sh
@@ -2,11 +2,28 @@ TERMUX_PKG_HOMEPAGE=https://dev.yorhel.nl/ncdu
 TERMUX_PKG_DESCRIPTION="Disk usage analyzer"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="LICENSES/MIT.txt"
-TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION="2.6"
 TERMUX_PKG_SRCURL=https://dev.yorhel.nl/download/ncdu-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=3f471ebd38b56e60dab80c27e3af1d826666957f02d9e8419b149daaf7ade505
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_VERSION_REGEXP='2\.\d+(\.\d+)?'
+
+termux_pkg_auto_update() {
+	local latest_release
+	latest_release="$(git ls-remote --tags https://code.blicky.net/yorhel/ncdu.git \
+	| grep -oP "refs/tags/v\K${TERMUX_PKG_UPDATE_VERSION_REGEXP}$" \
+	| sort -V \
+	| tail -n1)"
+
+	if [[ "${latest_release}" == "${TERMUX_PKG_VERSION}" ]]; then
+		echo "INFO: No update needed. Already at version '${TERMUX_PKG_VERSION}'."
+		return
+	fi
+
+	termux_pkg_upgrade_version "${latest_release}"
+}
 
 termux_step_post_get_source() {
 	# TODO drop all this once figure out how zig can work with bionic libc

--- a/packages/ncdu2/build.sh
+++ b/packages/ncdu2/build.sh
@@ -3,33 +3,46 @@ TERMUX_PKG_DESCRIPTION="Disk usage analyzer"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="LICENSES/MIT.txt"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="2.4"
+TERMUX_PKG_VERSION="2.6"
 TERMUX_PKG_SRCURL=https://dev.yorhel.nl/download/ncdu-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=4a3d0002309cf6a7cea791938dac9becdece4d529d0d6dc8d91b73b4e6855509
+TERMUX_PKG_SHA256=3f471ebd38b56e60dab80c27e3af1d826666957f02d9e8419b149daaf7ade505
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_post_get_source() {
 	# TODO drop all this once figure out how zig can work with bionic libc
-	local NCURSES_SRCURL=$(. "${TERMUX_SCRIPTDIR}"/packages/ncurses/build.sh; echo ${TERMUX_PKG_SRCURL[0]})
-	local NCURSES_SHA256=$(. "${TERMUX_SCRIPTDIR}"/packages/ncurses/build.sh; echo ${TERMUX_PKG_SHA256[0]})
+	local -a deps=( 'ncurses' 'zstd' )
+	for dep in "${deps[@]}"; do
+		local DEP_SRCURL='' DEP_SHA256=''
+		read -r DEP_SRCURL DEP_SHA256 < <(
+			# This gets shellcheck to shut up about the non-constant source
+			# shellcheck source=/dev/null
+			source "${TERMUX_SCRIPTDIR}/packages/${dep}/build.sh"
 
-	rm -fr ncurses-* ncurses
-	termux_download "${NCURSES_SRCURL}" "${TERMUX_PKG_CACHEDIR}/ncurses.tar.gz" "${NCURSES_SHA256}"
-	tar -xf "${TERMUX_PKG_CACHEDIR}/ncurses.tar.gz"
-	mv -v ncurses-* ncurses
+			# ${var@a} outputs the declaration attributes of a varaible e.g. 'a' for arrays
+			if [[ "${TERMUX_PKG_SRCURL@a}" == 'a' ]]; then
+				echo "${TERMUX_PKG_SRCURL[0]}" "${TERMUX_PKG_SHA256[0]}"
+			else
+				echo "${TERMUX_PKG_SRCURL}" "${TERMUX_PKG_SHA256}"
+			fi
+		)
 
-	echo "INFO: Applying patches from packages/ncurses"
-	for p in "${TERMUX_SCRIPTDIR}"/packages/ncurses/*.patch; do
-	patch -p1 -i "${p}" -d ncurses
+		rm -rf "${dep}"-* "${dep}"
+		termux_download "${DEP_SRCURL}" "${TERMUX_PKG_CACHEDIR}/${dep}.tar.gz" "${DEP_SHA256}"
+		tar -xf "${TERMUX_PKG_CACHEDIR}/${dep}.tar.gz"
+		mv -v "${dep}"-* "${dep}"
+
+		echo "INFO: Applying patches from $dep"
+		local p
+		for p in "${TERMUX_SCRIPTDIR}/packages/$dep/"*.patch; do
+			patch -p1 -i "${p}" -d "${dep}"
+		done
 	done
 
-	local f=$(sed -nE "s|.*SPDX-FileCopyrightText.*: (.*)|\1|p" ChangeLog)
+	local f
+	f=$(sed -nE "s|.*SPDX-FileCopyrightText.*: (.*)|\1|p" ChangeLog)
 	sed \
 		-e "s|<year> <copyright holders>|${f}|" \
 		-i LICENSES/MIT.txt
-	sed \
-		-e "s|--with-default-terminfo-dir=/usr|--with-default-terminfo-dir=${TERMUX_PREFIX}|" \
-		-i Makefile
 }
 
 termux_step_pre_configure() {
@@ -38,12 +51,12 @@ termux_step_pre_configure() {
 }
 
 termux_step_make() {
-	make -j "${TERMUX_PKG_MAKE_PROCESSES}" static-${ZIG_TARGET_NAME}.tar.gz
+	make -j "${TERMUX_PKG_MAKE_PROCESSES}" "static-${ZIG_TARGET_NAME}.tar.gz"
 }
 
 termux_step_make_install() {
 	# allow ncdu2 to co-exist with ncdu
-	tar -xf static-${ZIG_TARGET_NAME}.tar.gz
+	tar -xf "static-${ZIG_TARGET_NAME}.tar.gz"
 	mv -v ncdu ncdu2
 	mv -v ncdu.1 ncdu2.1
 	install -Dm755 -t "${TERMUX_PREFIX}/bin" ncdu2

--- a/packages/ncdu2/fix-hardcoded-paths.patch
+++ b/packages/ncdu2/fix-hardcoded-paths.patch
@@ -1,0 +1,46 @@
+diff --git a/Makefile b/Makefile
+index ad9d7f7..3ce01a3 100644
+--- a/Makefile
++++ b/Makefile
+@@ -71,8 +71,8 @@ static-%.tar.gz:
+ 		--with-pkg-config-libdir="`pwd`/../inst/pkg"\
+ 		--without-cxx --without-cxx-binding --without-ada --without-manpages --without-progs\
+ 		--without-tests --enable-pc-files --without-pkg-config --without-shared --without-debug\
+-		--without-gpm --without-sysmouse --enable-widec --with-default-terminfo-dir=/usr/share/terminfo\
+-		--with-terminfo-dirs=/usr/share/terminfo:/lib/terminfo:/usr/local/share/terminfo\
++		--without-gpm --without-sysmouse --enable-widec --with-default-terminfo-dir=@TERMUX_PREFIX@/share/terminfo\
++		--with-terminfo-dirs=@TERMUX_PREFIX@/share/terminfo:@TERMUX_PREFIX@/lib/terminfo\
+ 		--with-fallbacks="screen linux vt100 xterm xterm-256color" --host=$*\
+ 		CC="${ZIG} cc --target=$*"\
+ 		LD="${ZIG} cc --target=$*"\
+@@ -85,7 +85,7 @@ static-%.tar.gz:
+ 	cd static-$* && ${ZIG} build-exe -target $*\
+ 		-Iinst/include -Iinst/include/ncursesw -Izstd -lc inst/lib/libncursesw.a zstd/libzstd.a\
+ 		--cache-dir zig-cache -static -fstrip -O ReleaseFast ../src/main.zig
+-	strip -R .eh_frame -R .eh_frame_hdr static-$*/main
++	${STRIP} -R .eh_frame -R .eh_frame_hdr static-$*/main
+ 	cd static-$* && mv main ncdu && tar -czf ../static-$*.tar.gz ncdu
+ 	rm -rf static-$*
+ 
+diff --git a/src/main.zig b/src/main.zig
+index bdf98ef..8ebc165 100644
+--- a/src/main.zig
++++ b/src/main.zig
+@@ -492,14 +492,14 @@ pub fn main() void {
+     };
+ 
+     if (loadConf) {
+-        tryReadArgsFile("/etc/ncdu.conf");
++        tryReadArgsFile("@TERMUX_PREFIX@/etc/ncdu2.conf");
+ 
+         if (std.posix.getenvZ("XDG_CONFIG_HOME")) |p| {
+-            const path = std.fs.path.joinZ(allocator, &.{p, "ncdu", "config"}) catch unreachable;
++            const path = std.fs.path.joinZ(allocator, &.{p, "ncdu2", "config"}) catch unreachable;
+             defer allocator.free(path);
+             tryReadArgsFile(path);
+         } else if (std.posix.getenvZ("HOME")) |p| {
+-            const path = std.fs.path.joinZ(allocator, &.{p, ".config", "ncdu", "config"}) catch unreachable;
++            const path = std.fs.path.joinZ(allocator, &.{p, ".config", "ncdu2", "config"}) catch unreachable;
+             defer allocator.free(path);
+             tryReadArgsFile(path);
+         }

--- a/packages/ncdu2/fix-progname.patch
+++ b/packages/ncdu2/fix-progname.patch
@@ -1,0 +1,156 @@
+diff --git a/ncdu.1 b/ncdu.1
+index e26e1e4..c37e6e5 100644
+--- a/ncdu.1
++++ b/ncdu.1
+@@ -1,11 +1,11 @@
+ .\" SPDX-FileCopyrightText: Yorhel <projects@yorhel.nl>
+ .\" SPDX-License-Identifier: MIT
+ .Dd September 27, 2024
+-.Dt NCDU 1
++.Dt NCDU2 1
+ .Os
+ .Sh NAME
+-.Nm ncdu
+-.Nd NCurses Disk Usage
++.Nm ncdu2
++.Nd NCurses Disk Usage 2.x
+ .
+ .Sh SYNOPSIS
+ .Nm
+@@ -51,7 +51,7 @@
+ .
+ .Sh DESCRIPTION
+ .Nm
+-(NCurses Disk Usage) is an interactive curses-based version of the well-known
++(NCurses Disk Usage 2.x) is an interactive curses-based version of the well-known
+ .Xr du 1 ,
+ and provides a fast way to see what directories are using your disk space.
+ .
+@@ -322,7 +322,7 @@ Enable (default) or disable natural sort when sorting by file name.
+ .It Fl \-group\-directories\-first , \-no\-group\-directories\-first
+ Sort (or not) directories before files.
+ .It Fl \-confirm\-quit , \-no\-confirm\-quit
+-Require a confirmation before quitting ncdu.
++Require a confirmation before quitting ncdu2.
+ Can be helpful when you accidentally press 'q' during or after a very long scan.
+ .It Fl \-confirm\-delete , \-no\-confirm\-delete
+ Require a confirmation before deleting a file or directory.
+@@ -347,9 +347,10 @@ The default is
+ .Sh CONFIGURATION
+ .Nm
+ can be configured by placing command-line options in
+-.Pa /etc/ncdu.conf
++.Pa @TERMUX_PREFIX@/etc/ncdu2.conf
+ or
+-.Pa $HOME/.config/ncdu/config .
++.Pa $HOME/.config/ncdu2/config .
++
+ If both files exist, the system configuration will be loaded before the user
+ configuration, allowing users to override options set in the system
+ configuration.
+@@ -447,7 +448,7 @@ For example, to spawn the
+ file manager instead of a shell, run
+ .Nm
+ as follows:
+-.Dl NCDU_SHELL=vifm ncdu
++.Dl NCDU_SHELL=vifm ncdu2
+ The
+ .Ev NCDU_LEVEL
+ environment variable is set or incremented before spawning the shell, allowing
+@@ -486,18 +487,18 @@ Empty directory.
+ .
+ .Sh EXAMPLES
+ To scan and browse the directory you're currently in, all you need is a simple:
+-.Dl ncdu
++.Dl ncdu2
+ If you want to scan a full filesystem, for example your root filesystem, then
+ you'll want to use
+ .Fl x :
+-.Dl ncdu \-x /
++.Dl ncdu2 \-x /
+ .Pp
+ Since scanning a large directory may take a while, you can scan a directory and
+ export the results for later viewing:
+ .Bd -literal -offset indent
+-ncdu \-1xo\- / | gzip >export.gz
++ncdu2 \-1xo\- / | gzip >export.gz
+ # ...some time later:
+-zcat export.gz | ncdu \-f\-
++zcat export.gz | ncdu2 \-f\-
+ .Ed
+ To export from a cron job, make sure to replace
+ .Fl 1
+@@ -506,12 +507,12 @@ with
+ to suppress any unnecessary output.
+ .Pp
+ You can also export a directory and browse it once scanning is done:
+-.Dl ncdu \-o\- | tee export.file | ./ncdu \-f\-
++.Dl ncdu2 \-o\- | tee export.file | ./ncdu2 \-f\-
+ The same is possible with gzip compression, but is a bit kludgey:
+-.Dl ncdu \-o\- | gzip | tee export.gz | gunzip | ./ncdu \-f\-
++.Dl ncdu2 \-o\- | gzip | tee export.gz | gunzip | ./ncdu2 \-f\-
+ .Pp
+ To scan a system remotely, but browse through the files locally:
+-.Dl ssh \-C user@system ncdu \-o\- / | ./ncdu \-f\-
++.Dl ssh \-C user@system ncdu2 \-o\- / | ./ncdu2 \-f\-
+ The
+ .Fl C
+ option to ssh enables compression, which will be very useful over slow links.
+@@ -548,11 +549,11 @@ The unique and shared directory sizes are calculated based on the assumption
+ that the link count of hard links does not change during a filesystem scan or
+ in between refreshes.
+ If this does happen, for example when a hard link is deleted, then these
+-numbers will be very much incorrect and a full refresh by restarting ncdu is
++numbers will be very much incorrect and a full refresh by restarting ncdu2 is
+ needed to get correct numbers again.
+ .Pp
+ All sizes are internally represented as a signed 64bit integer.
+-If you have a directory larger than 8 EiB minus one byte, ncdu will clip its
++If you have a directory larger than 8 EiB minus one byte, ncdu2 will clip its
+ size to 8 EiB minus one byte.
+ When deleting or refreshing items in a directory with a clipped size, the
+ resulting sizes will be incorrect.
+diff --git a/src/main.zig b/src/main.zig
+index bdf98ef..41d68c4 100644
+--- a/src/main.zig
++++ b/src/main.zig
+@@ -38,7 +38,7 @@ test "imports" {
+ }
+ 
+ // "Custom" allocator that wraps the libc allocator and calls ui.oom() on error.
+-// This allocator never returns an error, it either succeeds or causes ncdu to quit.
++// This allocator never returns an error, it either succeeds or causes ncdu2 to quit.
+ // (Which means you'll find a lot of "catch unreachable" sprinkled through the code,
+ // they look scarier than they are)
+ fn wrapAlloc(_: *anyopaque, len: usize, ptr_alignment: u8, return_address: usize) ?[*]u8 {
+@@ -341,14 +341,14 @@ fn tryReadArgsFile(path: [:0]const u8) void {
+ 
+ fn version() noreturn {
+     const stdout = std.io.getStdOut();
+-    stdout.writeAll("ncdu " ++ program_version ++ "\n") catch {};
++    stdout.writeAll("ncdu2 " ++ program_version ++ "\n") catch {};
+     std.process.exit(0);
+ }
+ 
+ fn help() noreturn {
+     const stdout = std.io.getStdOut();
+     stdout.writeAll(
+-    \\ncdu <options> <directory>
++    \\ncdu2 <options> <directory>
+     \\
+     \\Options:
+     \\  -h,--help                  This help message
+@@ -367,11 +367,11 @@ fn help() noreturn {
+     \\  -L, --follow-symlinks      Follow symbolic links (excluding directories)
+     \\  --exclude-caches           Exclude directories containing CACHEDIR.TAG
+     \\  --exclude-kernfs           Exclude Linux pseudo filesystems (procfs,sysfs,cgroup,...)
+-    \\  --confirm-quit             Confirm quitting ncdu
++    \\  --confirm-quit             Confirm quitting ncdu2
+     \\  --color SCHEME             Set color scheme (off/dark/dark-bg)
+     \\  --ignore-config            Don't load config files
+     \\
+-    \\Refer to `man ncdu` for the full list of options.
++    \\Refer to `man ncdu2` for the full list of options.
+     \\
+     ) catch {};
+     std.process.exit(0);


### PR DESCRIPTION
`ncdu` now depends on `zstd` as of version 2.6[^1]
I've taken the opportunity to refactor the `post_get_source` step.

A minor patch to the Makefile is also required to ensure it respected the set `${STRIP}` program.

[^1]: upstream changelog https://g.blicky.net/ncdu.git/tree/ChangeLog?h=v2.6#n6