### PR TITLE
fix(main/keychain): Avoid trying to use hard links

### DIFF
--- a/packages/keychain/build.sh
+++ b/packages/keychain/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="keychain ssh-agent front-end"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.8.5
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/funtoo/keychain/archive/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=dcce703e5001211c8ebc0528f45b523f84d2bceeb240600795b4d80cb8475a0b
 TERMUX_PKG_AUTO_UPDATE=true
@@ -12,7 +12,6 @@ TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 
 termux_step_make_install() {
-	sed -iE "s@^PATH=.*@PATH=$TERMUX_PREFIX/bin@" keychain
 	install -Dm700 keychain "${TERMUX_PREFIX}"/bin/keychain
 	install -Dm600 keychain.1 "${TERMUX_PREFIX}"/share/man/man1/keychain.1
 }

--- a/packages/keychain/keychain.patch
+++ b/packages/keychain/keychain.patch
@@ -1,0 +1,31 @@
+diff -u -r ../keychain-2.8.5/keychain ./keychain
+--- ../keychain-2.8.5/keychain	2018-01-24 15:07:59.000000000 +0000
++++ ./keychain	2024-10-09 11:21:21.866473482 +0000
+@@ -15,7 +15,7 @@
+ 
+ version=2.8.5
+ 
+-PATH="${PATH:-/usr/bin:/bin:/sbin:/usr/sbin:/usr/ucb}"
++PATH=@TERMUX_PREFIX@/bin
+ 
+ maintainer="x48rph@gmail.com"
+ unset mesglog
+@@ -360,16 +360,14 @@
+ 		tmpfile="$lockf.$$"
+ 
+ 		echo $$ >"$tmpfile" 2>/dev/null || exit
+-		if ln "$tmpfile" "$lockf" 2>/dev/null; then
+-				rm -f "$tmpfile"
++		if mv --update=none-fail "$tmpfile" "$lockf" 2>/dev/null; then
+ 		havelock=true && return 0
+ 		fi
+ 		if kill -0 $(cat $lockf 2>/dev/null) 2>/dev/null; then
+ 				rm -f "$tmpfile"
+ 			return 1
+ 	fi
+-		if ln "$tmpfile" "$lockf" 2>/dev/null; then
+-				rm -f "$tmpfile"
++		if mv --update=none-fail "$tmpfile" "$lockf" 2>/dev/null; then
+ 		havelock=true && return 0
+ 		fi
+ 		rm -f "$tmpfile" "$lockf" && return 1


### PR DESCRIPTION
Hard links do not work on Android since 6.0.

So modify the file locking mechanism from:

    if ln "$tmpfile" "$lockf"; then rm -f "$tmpfile"; ..

to

     if mv --update=none-fail "$tmpfile" "$lockf"; then ..

Fixes #21736