### PR TITLE
webkit2gtk-4.1,webkitgtk-6.0: remove workaround for g-ir-scanner

### DIFF
--- a/x11-packages/webkit2gtk-4.1/build.sh
+++ b/x11-packages/webkit2gtk-4.1/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="A full-featured port of the WebKit rendering engine"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.42.4"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://webkitgtk.org/releases/webkitgtk-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=52288b30bda22373442cecb86f9c9a569ad8d4769a1f97b352290ed92a67ed86
 TERMUX_PKG_DEPENDS="atk, enchant, fontconfig, freetype, glib, gst-plugins-bad, gst-plugins-base, gst-plugins-good, gstreamer, gtk3, harfbuzz, harfbuzz-icu, libc++, libcairo, libgcrypt, libhyphen, libicu, libjpeg-turbo, libpng, libsoup3, libtasn1, libwebp, libxml2, libx11, libxcomposite, libxdamage, libxslt, libxt, littlecms, openjpeg, pango, woff2, zlib"
@@ -42,13 +42,8 @@ termux_step_post_get_source() {
 termux_step_pre_configure() {
 	termux_setup_gir
 
-	# FIXME: `GI_VERSION` mismatched from Termux and the building machine. On April 22,
-	# FIXME: 2024, Termux has version 1.80.1 but Ubuntu 22.04 has version 1.72.0.
-	# FIXME: `cmake` will pick up `GI_VERSION` from the config files of Termux, but
-	# FIXME: it is intended to use the version in the building machine.
-	if [ "$TERMUX_ON_DEVICE_BUILD" = false ]; then
-		sed -i 's@if ("${GI_VERSION}" VERSION_GREATER_EQUAL 1.79.2)@if (FALSE)@g' \
-			$TERMUX_PKG_SRCDIR/Source/WebKit/PlatformGTK.cmake
+	if [ "$TERMUX_ON_DEVICE_BUILD" = "true" ]; then
+		export CXXFLAGS+=" -Wno-missing-template-arg-list-after-template-kw"
 	fi
 
 	# Workaround for https://github.com/android/ndk/issues/1973

--- a/x11-packages/webkitgtk-6.0/build.sh
+++ b/x11-packages/webkitgtk-6.0/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A full-featured port of the WebKit rendering engine"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.42.4"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://webkitgtk.org/releases/webkitgtk-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=52288b30bda22373442cecb86f9c9a569ad8d4769a1f97b352290ed92a67ed86
 TERMUX_PKG_DEPENDS="enchant, fontconfig, freetype, glib, gst-plugins-bad, gst-plugins-base, gst-plugins-good, gstreamer, gtk4, harfbuzz, harfbuzz-icu, libc++, libcairo, libgcrypt, libhyphen, libicu, libjpeg-turbo, libpng, libsoup3, libtasn1, libwebp, libxml2, libx11, libxcomposite, libxdamage, libxslt, libxt, littlecms, openjpeg, pango, woff2, zlib"
@@ -35,16 +36,11 @@ termux_step_pre_configure() {
 		-DENABLE_WEBDRIVER=OFF
 	"
 
-	# FIXME: `GI_VERSION` mismatched from Termux and the building machine. On April 22,
-	# FIXME: 2024, Termux has version 1.80.1 but Ubuntu 22.04 has version 1.72.0.
-	# FIXME: `cmake` will pick up `GI_VERSION` from the config files of Termux, but
-	# FIXME: it is intended to use the version in the building machine.
-	if [ "$TERMUX_ON_DEVICE_BUILD" = false ]; then
-		sed -i 's@if ("${GI_VERSION}" VERSION_GREATER_EQUAL 1.79.2)@if (FALSE)@g' \
-			$TERMUX_PKG_SRCDIR/Source/WebKit/PlatformGTK.cmake
-	fi
-
 	termux_setup_gir
+
+	if [ "$TERMUX_ON_DEVICE_BUILD" = "true" ]; then
+		export CXXFLAGS+=" -Wno-missing-template-arg-list-after-template-kw"
+	fi
 
 	# Workaround for https://github.com/android/ndk/issues/1973
 	[ "$TERMUX_ARCH" == "arm" ] && sed -i '/#define MUST_TAIL_CALL \[\[clang::musttail]]/d' Source/WTF/wtf/Compiler.h


### PR DESCRIPTION
Closes #21789 