### PR TITLE
chore(x11/fcitx5-{configtool,qt}): Switch to Qt6

### DIFF
--- a/x11-packages/fcitx5-configtool/build.sh
+++ b/x11-packages/fcitx5-configtool/build.sh
@@ -3,14 +3,15 @@ TERMUX_PKG_DESCRIPTION="Configuration tool for Fcitx5"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="5.1.7"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/fcitx/fcitx5-configtool/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=c134b082ea9cab0102b9427f39a3714f4a71146ac082e4e6c7c18e4b8dd2aaa7
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
-TERMUX_PKG_DEPENDS="fcitx5, fcitx5-qt, iso-codes, kitemviews, kwidgetsaddons, libc++, libx11, libxkbfile, qt5-qtbase, qt5-qtsvg, qt5-qtx11extras, xkeyboard-config"
+TERMUX_PKG_DEPENDS="fcitx5, fcitx5-qt, iso-codes, kf6-kitemviews, kf6-kwidgetsaddons, libc++, libx11, libxkbfile, qt6-qtbase, qt6-qtsvg, xkeyboard-config"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DENABLE_TEST=OFF
 -DENABLE_CONFIG_QT=ON
 -DENABLE_KCM=OFF
--DUSE_QT6=OFF
+-DUSE_QT6=ON
 "

--- a/x11-packages/fcitx5-qt/build.sh
+++ b/x11-packages/fcitx5-qt/build.sh
@@ -3,14 +3,22 @@ TERMUX_PKG_DESCRIPTION="Fcitx Qt immodule & library"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="5.1.7"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/fcitx/fcitx5-qt/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=586e35e70e656ce387d7c87b58af1294599bd10385f983580235a2efeca666ee
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
-TERMUX_PKG_DEPENDS="fcitx5, libc++, libx11, libxcb, libxkbcommon, qt5-qtbase"
+TERMUX_PKG_DEPENDS="fcitx5, libc++, libx11, libxcb, libxkbcommon, qt6-qtbase"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DENABLE_TEST=OFF
 -DENABLE_QT4=OFF
--DENABLE_QT5=ON
--DENABLE_QT6=OFF
+-DENABLE_QT5=OFF
+-DENABLE_QT6=ON
+-DENABLE_QT6_WAYLAND_WORKAROUND=OFF
 "
+
+termux_step_post_make_install() {
+	local _QT6_PLATFORM_INPUT_CONTEXTS_DIR=$TERMUX_PREFIX/lib/qt6/plugins/platforminputcontexts
+	mkdir -p "$_QT6_PLATFORM_INPUT_CONTEXTS_DIR"
+	mv $TERMUX_PREFIX/opt/qt6/cross/lib/qt6/plugins/platforminputcontexts/libfcitx5platforminputcontextplugin.so $_QT6_PLATFORM_INPUT_CONTEXTS_DIR
+}


### PR DESCRIPTION
The manual copying from `$TERMUX_PREFIX/opt/qt6/cross/lib/qt6/plugins/platforminputcontexts` to `$TERMUX_PREFIX/lib/qt6/plugins/platforminputcontexts` should be fixed in a more central place (perhaps in the `qt6-qtbase` package)? Had to do the same thing in #21816.