### PR TITLE
bump(main/inxi): 3.3.36-1

### DIFF
--- a/packages/inxi/build.sh
+++ b/packages/inxi/build.sh
@@ -1,10 +1,10 @@
-TERMUX_PKG_HOMEPAGE=https://github.com/smxi/inxi
+TERMUX_PKG_HOMEPAGE=https://smxi.org/site/about.htm#inxi
 TERMUX_PKG_DESCRIPTION="Full featured CLI system information tool"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="3.3.31-2"
-TERMUX_PKG_SRCURL=https://github.com/smxi/inxi/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=ff5d138392ac557e31ede6cf96d73d1b9f972f42f6529d47fec2c51184bff338
+TERMUX_PKG_VERSION="3.3.36-1"
+TERMUX_PKG_SRCURL=https://codeberg.org/smxi/inxi/archive/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=0f1e0ac7d5b702e66aec8fc3c07aaba036c0d47e729c35f26f19cddaa0b234d2
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
 TERMUX_PKG_DEPENDS="perl"
@@ -12,6 +12,6 @@ TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 
 termux_step_make_install() {
-	install -Dm700 -t $TERMUX_PREFIX/bin/ inxi
-	install -Dm600 -t $TERMUX_PREFIX/share/man/man1/ inxi.1
+	install -Dm700 -t "$TERMUX_PREFIX/bin/" inxi
+	install -Dm600 -t "$TERMUX_PREFIX/share/man/man1/" inxi.1
 }


### PR DESCRIPTION
Project has moved from GitHub to Codeberg.
Now housed at: https://codeberg.org/smxi/inxi