### PR TITLE
chore(x11/mpv): make X11 default backend

### DIFF
--- a/x11-packages/mpv-x/build.sh
+++ b/x11-packages/mpv-x/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 # Update both mpv and mpv-x to the same version in one PR.
 TERMUX_PKG_VERSION="0.39.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/mpv-player/mpv/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=2ca92437affb62c2b559b4419ea4785c70d023590500e8a52e95ea3ab4554683
 TERMUX_PKG_AUTO_UPDATE=false

--- a/x11-packages/mpv-x/default-to-x11.patch
+++ b/x11-packages/mpv-x/default-to-x11.patch
@@ -1,0 +1,28 @@
+By default mpv chooses wrong video backend
+```
+Error opening/initializing the selected video_out (--vo) device.
+Video: no video
+```
+This patch forces it to choose X11 by default.
++++ ./video/out/vo.c
+@@ -69,8 +69,8 @@
+ 
+ static const struct vo_driver *const video_out_drivers[] =
+ {
+-#if HAVE_ANDROID
+-    &video_out_mediacodec_embed,
++#if HAVE_X11
++    &video_out_x11,
+ #endif
+     &video_out_gpu,
+     &video_out_gpu_next,
+@@ -95,9 +95,6 @@
+ #if HAVE_VAAPI_X11 && HAVE_GPL
+     &video_out_vaapi,
+ #endif
+-#if HAVE_X11
+-    &video_out_x11,
+-#endif
+     &video_out_libmpv,
+     &video_out_null,
+     // should not be auto-selected


### PR DESCRIPTION
By default mpv chooses wrong video backend and shows this:
```
Error opening/initializing the selected video_out (--vo) device.
Video: no video
```
This patch fixes it.

I will merge it in 72 hours if no one minds.
Or anyone else can merge it earlier.