### PR TITLE
fix(main/cvs): fix build without editor

### DIFF
--- a/packages/cvs/build.sh
+++ b/packages/cvs/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Concurrent Versions System"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1:1.12.13"
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL="https://github.com/termux/distfiles/releases/download/2021.01.04/cvs-${TERMUX_PKG_VERSION:2}+real-26.tar.xz"
 TERMUX_PKG_SHA256=0eda91f5e8091b676c90b2a171f24f9293acb552f4e4f77b590ae8d92a547256
 TERMUX_PKG_AUTO_UPDATE=false
@@ -13,6 +13,7 @@ cvs_cv_func_printf_ptr=yes
 ac_cv_header_syslog_h=no
 --disable-server
 --with-external-zlib
+--with-editor=$TERMUX_PREFIX/bin/vi
 "
 TERMUX_PKG_RM_AFTER_INSTALL="bin/cvsbug share/man/man8/cvsbug.8"
 


### PR DESCRIPTION
Fixes "Failed to find a text file editor. CVS cannot be compiled without a default log message editor." during build (within the official termux builder docker image using `scripts/run-docker.sh ./build-package.sh -f cvs`)

Based on code copied from https://gitlab.com/buildroot.org/buildroot/-/commit/1455d5241b288770aeea7f5ba6dcd1ea31966ba1