### PR TITLE
addpkg(x11/qt6-qtwebsockets)

### DIFF
--- a/x11-packages/qt6-qtwebsockets/build.sh
+++ b/x11-packages/qt6-qtwebsockets/build.sh
@@ -1,0 +1,12 @@
+TERMUX_PKG_HOMEPAGE=https://www.qt.io/
+TERMUX_PKG_DESCRIPTION="Qt 6 WebSockets Library"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="6.8.0"
+TERMUX_PKG_SRCURL="https://download.qt.io/official_releases/qt/${TERMUX_PKG_VERSION%.*}/${TERMUX_PKG_VERSION}/submodules/qtwebsockets-everywhere-src-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256=c14be05c46b71c2a89865987ffe0a8d40d8ecb01d48dcdca7fc02ba83a5eaf6f
+TERMUX_PKG_DEPENDS="libc++, qt6-qtbase, qt6-qtdeclarative"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+"


### PR DESCRIPTION
Will be used for transitioning `nextcloud-client` from Qt5 to Qt6.