### PR TITLE
enhancement(main/lesspipe): add symlink lesspipe -> lesspipe.sh

### DIFF
--- a/packages/lesspipe/build.sh
+++ b/packages/lesspipe/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="An input filter for the pager less"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.15"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/wofr06/lesspipe/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=dd65d211f0f817b4c361c434fd09ecbcd4a642636f3dc0fc1c575f2fa88506ac
 TERMUX_PKG_AUTO_UPDATE=true
@@ -21,4 +22,5 @@ termux_step_post_make_install() {
 	mkdir -p "$TERMUX_PREFIX"/etc/profile.d
 	echo "export LESSOPEN='|$TERMUX_PREFIX/bin/lesspipe.sh %s'" \
 		> "$TERMUX_PREFIX"/etc/profile.d/lesspipe.sh
+	ln -sf "$TERMUX_PREFIX/bin/lesspipe.sh" "$TERMUX_PREFIX/bin/lesspipe"
 }


### PR DESCRIPTION
Let people use `lesspipe` in Debian way (without `.sh` suffix).
Fixes #21389