### PR TITLE
fix(main/inetutils): make logger print to logcat instead of syslog

### DIFF
--- a/packages/inetutils/build.sh
+++ b/packages/inetutils/build.sh
@@ -3,12 +3,13 @@ TERMUX_PKG_DESCRIPTION="Collection of common network programs"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.4
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/inetutils/inetutils-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=1789d6b1b1a57dfe2a7ab7b533ee9f5dfd9cbf5b59bb1bb3c2612ed08d0f68b2
 TERMUX_PKG_DEPENDS="readline"
 TERMUX_PKG_BUILD_DEPENDS="libandroid-glob"
 TERMUX_PKG_SUGGESTS="whois"
+TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_RM_AFTER_INSTALL="bin/whois share/man/man1/whois.1"
 # These are old cruft / not suited for android
 # (we --disable-traceroute as it requires root
@@ -29,10 +30,32 @@ ac_cv_lib_crypt_crypt=no
 gl_cv_have_weak=no
 "
 
+termux_step_host_build() {
+	# help2man fails to get mans from our binaries
+	# let's build binaries it can launch for generating mans
+	
+	cp -r "$TERMUX_PKG_SRCDIR"/* .
+	aclocal --force
+	autoreconf -fi
+
+	# For some reason I get undefined reference to `crypt` so I make it noop
+	echo "__attribute__((weak)) void crypt(void) {}" | gcc -x c -c - -o crypt.o
+
+	sed -i 's/PATH_LOG/"logcat"/g' ./src/logger.c
+	LDFLAGS=" $TERMUX_PKG_HOSTBUILD_DIR/crypt.o" \
+	./configure $TERMUX_PKG_EXTRA_CONFIGURE_ARGS
+	make
+}
+
 termux_step_pre_configure() {
+	aclocal --force
+	autoreconf -fi
+
+	# Reuse binaries from host-build to generate mans
+	sed -i 's,@HOSTBUILD@,'"$TERMUX_PKG_HOSTBUILD_DIR"',' "$TERMUX_PKG_SRCDIR/man/Makefile.am"
 	CFLAGS+=" -DNO_INLINE_GETPASS=1"
 	CPPFLAGS+=" -DNO_INLINE_GETPASS=1 -DLOGIN_PROCESS=6 -DDEAD_PROCESS=8 -DLOG_NFACILITIES=24 -fcommon"
-	LDFLAGS+=" -landroid-glob"
+	LDFLAGS+=" -landroid-glob -llog"
 	touch -d "next hour" ./man/whois.1
 }
 

--- a/packages/inetutils/man-Makefile.am.patch
+++ b/packages/inetutils/man-Makefile.am.patch
@@ -1,0 +1,12 @@
+This patch is needed to change path of executable passed to help2man
++++ ./man/Makefile.am
+@@ -206,7 +206,8 @@
+ | sed s,../tftp/tftp,../src/tftp,\
+ | sed s,../tftpd/tftpd,../src/tftpd,\
+ | sed s,../traceroute/traceroute,../src/traceroute,\
+-| sed s,../uucpd/uucpd,../src/uucpd,`
++| sed s,../uucpd/uucpd,../src/uucpd,\
++| sed s,..,@HOSTBUILD@,`
+ 
+ .PHONY: man
+ man:

--- a/packages/inetutils/src-logger.patch
+++ b/packages/inetutils/src-logger.patch
@@ -1,0 +1,45 @@
+Send logs to logcat instead of /dev/log used in regular Linux systems.
++++ ./src/logger.c
+@@ -48,9 +48,14 @@
+ # include "logprio.h"
+ #endif
+ 
++#include <android/log.h>
++#undef PATH_LOG
++#define PATH_LOG "logcat"
++
+ #define MAKE_PRI(fac,pri) (((fac) & LOG_FACMASK) | ((pri) & LOG_PRIMASK))
+ 
+-static char *tag = NULL;
++static int logcat = 0;
++static char *tag = "termux";
+ static int logflags = 0;
+ static int pri = MAKE_PRI (LOG_USER, LOG_NOTICE);  /* Cf. parse_level */
+ /* Only one of `host' and `unixsock' will be non-NULL
+@@ -140,6 +145,11 @@
+   int family;
+   int ret;
+ 
++  if (host != NULL && !strcmp(host, PATH_LOG)) {
++    logcat = 1;
++    return;
++  }
++
+   /* A UNIX socket name can be specified in two ways.
+    * Zero length of `unixsock' is handled automatically.  */
+   if ((host != NULL && strchr (host, '/')) || unixsock != NULL)
+@@ -306,6 +316,14 @@
+   size_t len;
+   ssize_t rc;
+ 
++  if (logcat) {
++    if (logflags & LOG_PID)
++      __android_log_print(ANDROID_LOG_INFO, tag, "<%d>[%d]: %s", pri, pidstr, msg);
++    else
++      __android_log_print(ANDROID_LOG_INFO, tag, "<%d>: %s", pri, msg);
++    return;
++  }
++
+   if (logflags & LOG_PID)
+     rc = asprintf (&pbuf, "<%d>%.15s %s[%s]: %s",
+ 		   pri, ctime (&now) + 4, tag, pidstr, msg);


### PR DESCRIPTION
Also it fixes generating mans.
This project uses `help2man` which invokes `<prog> --help`, and this requires binaries built for host, since host can not launch bionic binaries.
I do not know why and how generating mans worked fine on CI before this commit. My attempt to invoke build with `termux-package-builder` failed.

Closes #1112.

It will be merged in 72 hours if no one minds or earlier if there will be 2+ approves.