### PR TITLE
bump(x11/ardour): 8.10

### DIFF
--- a/x11-packages/ardour/build.sh
+++ b/x11-packages/ardour/build.sh
@@ -2,13 +2,13 @@ TERMUX_PKG_HOMEPAGE=https://ardour.org/
 TERMUX_PKG_DESCRIPTION="A professional digital workstation for working with audio and MIDI"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="9.0-pre0"
+TERMUX_PKG_VERSION="8.10"
 TERMUX_PKG_SRCURL=git+https://github.com/Ardour/ardour
 TERMUX_PKG_GIT_BRANCH=$TERMUX_PKG_VERSION
 TERMUX_PKG_DEPENDS="aubio, fftw, fontconfig, gdk-pixbuf, glib, gtk2, gtkmm2, libandroid-execinfo, libarchive, libatkmm-1.6, libc++, libcairo, libcairomm-1.0, libcurl, libglibmm-2.4, liblo, liblrdf, libpangomm-1.4, libsamplerate, libsigc++-2.0, libsndfile, libusb, libwebsockets, libx11, libxml2, lilv, pango, pulseaudio, rubberband, suil, taglib, vamp-plugin-sdk"
 TERMUX_PKG_BUILD_DEPENDS="boost, boost-headers"
 TERMUX_PKG_BUILD_IN_SRC=true
-TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --with-backends=dummy,pulseaudio
 --no-fpu-optimization


### PR DESCRIPTION
The package was auto-updated to `9.0-pre0`, but the package was never built since the build was cancelled: https://github.com/termux/termux-packages/commit/4f3395aed8f4739bbf269451f67c96385fe8ae4d

Switch version to 8.10 (so updating from 8.8 in the apt repository) and disable auto updates for now.