### PR TITLE
fix(x11/inkscape): fix openmp-related crash

### DIFF
--- a/x11-packages/inkscape/build.sh
+++ b/x11-packages/inkscape/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Free and open source vector graphics editor"
 TERMUX_PKG_LICENSE="GPL-3.0-or-later"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.4"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://media.inkscape.org/dl/resources/file/inkscape-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=c59a85453b699addebcd51c1dc07684dd96a10c8aec716b19551db50562e13f5
 TERMUX_PKG_DEPENDS="boost, double-conversion, fontconfig, freetype, gdk-pixbuf, graphicsmagick, glib, gsl, gspell, gtk3, gtkmm3, gtksourceview4, harfbuzz, libatkmm-1.6, libc++, libcairo, libcairomm-1.0, libgc, libglibmm-2.4, libiconv, libjpeg-turbo, libpangomm-1.4, libpng, libsigc++-2.0, libsoup, libx11, libxml2, libxslt, littlecms, pango, poppler, potrace, readline, zlib"
@@ -16,8 +17,34 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 "
 
 termux_step_pre_configure() {
+	(	# Doing this in subshell to avoid messing with variables.
+		# We should just download graphicsmagick and build it with -fPIC
+		TERMUX_PKG_SRCDIR="$TERMUX_PKG_TMPDIR/graphicsmagick-src"
+		TERMUX_PKG_BUILDDIR="$TERMUX_PKG_TMPDIR/graphicsmagick-build"
+		TERMUX_PREFIX="$TERMUX_PKG_TMPDIR/graphicsmagick-prefix"
+		mkdir -p "$TERMUX_PKG_SRCDIR" "$TERMUX_PKG_BUILDDIR" "$TERMUX_PREFIX"
+		pwd
+		. $TERMUX_SCRIPTDIR/packages/graphicsmagick/build.sh
+		
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --disable-shared --enable-static"
+		
+		cd "$TERMUX_PKG_SRCDIR"
+		termux_step_get_source
+		cd "$TERMUX_PKG_SRCDIR"
+		termux_step_pre_configure
+		CFLAGS+=" -fPIC"
+		CXXFLAGS+=" -fPIC"
+		cd "$TERMUX_PKG_BUILDDIR"
+		termux_step_configure
+		cd "$TERMUX_PKG_BUILDDIR"
+		termux_step_make
+		cd "$TERMUX_PKG_BUILDDIR"
+		termux_step_make_install
+	)
+	
 	CPPFLAGS+=" -DCMS_NO_REGISTER_KEYWORD -I${TERMUX_PREFIX}/include/libxml2 -include libxml/xmlmemory.h"
-	LDFLAGS+=" -fopenmp -static-openmp -Wl,-rpath=$TERMUX_PREFIX/lib/inkscape"
+	LDFLAGS="-L$TERMUX_PKG_TMPDIR/graphicsmagick-prefix/lib $LDFLAGS -fopenmp -static-openmp -Wl,-rpath=$TERMUX_PREFIX/lib/inkscape"
+	export PKG_CONFIG_PATH="$TERMUX_PREFIX/lib/pkgconfig"
 }
 
 termux_step_install_license() {

--- a/x11-packages/inkscape/link-graphicsmagick-statically.patch
+++ b/x11-packages/inkscape/link-graphicsmagick-statically.patch
@@ -1,0 +1,10 @@
++++ ./CMakeScripts/DefineDependsandFlags.cmake
+@@ -394,7 +394,7 @@
+ endif()
+ if(MAGICK_FOUND)
+     sanitize_ldflags_for_libs(MAGICK_LDFLAGS)
+-    list(APPEND INKSCAPE_LIBS ${MAGICK_LDFLAGS})
++    list(APPEND INKSCAPE_LIBS -Wl,-Bstatic ${MAGICK_LDFLAGS} -Wl,-Bdynamic -ljasper -lheif -lwebp -ljxl_threads -ljxl -lwebpmux)
+     add_definitions(${MAGICK_CFLAGS_OTHER})
+     list(APPEND INKSCAPE_INCS_SYS ${MAGICK_INCLUDE_DIRS})
+ 


### PR DESCRIPTION
I know this PR is not perfect.
Probably much better solution is rebuild `graphicsmagick` with `-fPIC` but I am not sure if it will break reverse dependencies and how exactly.