### PR TITLE
CODEOWNERS: Remove myself as default code owner and kak-lsp maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default assignment: frequent contributors from @termux.
-* @finagolfin @Grimler91
+* @Grimler91
 
 # Build system.
 /build-all.sh @Grimler91
@@ -21,7 +21,6 @@
 /x11-packages/*/gir/ @xtkoba
 
 # Packages owned by @finagolfin
-/packages/kak-lsp/ @finagolfin
 /packages/libdispatch/ @finagolfin
 /packages/libllvm/ @finagolfin
 /packages/llbuild/ @finagolfin

--- a/packages/kakoune-lsp/build.sh
+++ b/packages/kakoune-lsp/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/kakoune-lsp/kakoune-lsp
 TERMUX_PKG_DESCRIPTION="Language Server Protocol Client for the Kakoune editor"
 TERMUX_PKG_LICENSE="MIT, Unlicense"
-TERMUX_PKG_MAINTAINER="@finagolfin"
+TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="18.0.2"
 TERMUX_PKG_SRCURL=https://github.com/kakoune-lsp/kakoune-lsp/archive/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=ad33b20437cd7bc89d7992b9449a02c946528e7f91d15d76dba27c7ad2ae7d36


### PR DESCRIPTION
I'm winding down my personal use of Android and Termux, plus I was never that active for most packages. I will continue maintaining the listed compiler packages though.