### PR TITLE
enhance(x11/{alacritty,kitty}): enable auto updates.

### DIFF
--- a/x11-packages/alacritty/build.sh
+++ b/x11-packages/alacritty/build.sh
@@ -2,13 +2,14 @@ TERMUX_PKG_HOMEPAGE=https://alacritty.org/
 TERMUX_PKG_DESCRIPTION="A fast, cross-platform, OpenGL terminal emulator"
 TERMUX_PKG_LICENSE="Apache-2.0, MIT"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
-# Keep in sync with packages/ncurses/build.sh
 TERMUX_PKG_VERSION=0.13.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/alacritty/alacritty/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=e9a54aabc92bbdc25ab1659c2e5a1e9b76f27d101342c8219cc98a730fd46d90
 TERMUX_PKG_DEPENDS="fontconfig, freetype, libxi, libxcursor, libxrandr"
 TERMUX_PKG_BUILD_DEPENDS="libxcb, libxkbcommon, ncurses"
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
 
 __cargo_fetch_dep_source_for_rust_windowing() {
 	local _name="$1"

--- a/x11-packages/kitty/build.sh
+++ b/x11-packages/kitty/build.sh
@@ -2,10 +2,8 @@ TERMUX_PKG_HOMEPAGE=https://sw.kovidgoyal.net/kitty/
 TERMUX_PKG_DESCRIPTION="Cross-platform, fast, feature-rich, GPU based terminal"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-# When updating the package, also update terminfo for kitty by updating
-# ncurses' kitty sources in main repo
 TERMUX_PKG_VERSION="0.36.4"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/kovidgoyal/kitty/releases/download/v${TERMUX_PKG_VERSION}/kitty-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=10ebf00a8576bca34ae683866c5be307a35f3c517906d6441923fd740db059bd
 # fontconfig is dlopen(3)ed:
@@ -18,7 +16,9 @@ TERMUX_PKG_RM_AFTER_INSTALL="
 share/doc/kitty/html
 share/terminfo/x/xterm-kitty
 "
+TERMUX_PKG_AUTO_UPDATE=true
 
+# shellcheck disable=SC2164
 termux_step_host_build() {
 	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "true" ]]; then return; fi
 
@@ -32,58 +32,64 @@ termux_step_host_build() {
 	termux_setup_meson
 	unset AR CC CFLAGS CPPFLAGS CXX CXXFLAGS LD LDFLAGS PKG_CONFIG STRIP
 
-	local xcb_proto_ver=$(. ${TERMUX_SCRIPTDIR}/packages/xcb-proto/build.sh; echo ${TERMUX_PKG_VERSION})
-	local xcb_proto_srcurl=$(. ${TERMUX_SCRIPTDIR}/packages/xcb-proto/build.sh; echo ${TERMUX_PKG_SRCURL})
-	local xcb_proto_sha256=$(. ${TERMUX_SCRIPTDIR}/packages/xcb-proto/build.sh; echo ${TERMUX_PKG_SHA256})
-	local libxcb_ver=$(. ${TERMUX_SCRIPTDIR}/packages/libxcb/build.sh; echo ${TERMUX_PKG_VERSION})
-	local libxcb_srcurl=$(. ${TERMUX_SCRIPTDIR}/packages/libxcb/build.sh; echo ${TERMUX_PKG_SRCURL})
-	local libxcb_sha256=$(. ${TERMUX_SCRIPTDIR}/packages/libxcb/build.sh; echo ${TERMUX_PKG_SHA256})
-	local libxkbcommon_ver=$(. ${TERMUX_SCRIPTDIR}/x11-packages/libxkbcommon/build.sh; echo ${TERMUX_PKG_VERSION})
-	local libxkbcommon_srcurl=$(. ${TERMUX_SCRIPTDIR}/x11-packages/libxkbcommon/build.sh; echo ${TERMUX_PKG_SRCURL})
-	local libxkbcommon_sha256=$(. ${TERMUX_SCRIPTDIR}/x11-packages/libxkbcommon/build.sh; echo ${TERMUX_PKG_SHA256})
-	local libx11_ver=$(. ${TERMUX_SCRIPTDIR}/packages/libx11/build.sh; echo ${TERMUX_PKG_VERSION})
-	local libx11_srcurl=$(. ${TERMUX_SCRIPTDIR}/packages/libx11/build.sh; echo ${TERMUX_PKG_SRCURL})
-	local libx11_sha256=$(. ${TERMUX_SCRIPTDIR}/packages/libx11/build.sh; echo ${TERMUX_PKG_SHA256})
+	local -A ver=(
+		[libx11]="$(. "${TERMUX_SCRIPTDIR}/packages/libx11/build.sh"; echo "${TERMUX_PKG_VERSION}")"
+		[libxcb]="$(. "${TERMUX_SCRIPTDIR}/packages/libxcb/build.sh"; echo "${TERMUX_PKG_VERSION}")"
+		[xcb_proto]="$(. "${TERMUX_SCRIPTDIR}/packages/xcb-proto/build.sh"; echo "${TERMUX_PKG_VERSION}")"
+		[libxkbcommon]="$(. "${TERMUX_SCRIPTDIR}/x11-packages/libxkbcommon/build.sh"; echo "${TERMUX_PKG_VERSION}")"
+	)
+	local -A srcurl=(
+		[libx11]="$(. "${TERMUX_SCRIPTDIR}/packages/libx11/build.sh"; echo "${TERMUX_PKG_SRCURL}")"
+		[libxcb]="$(. "${TERMUX_SCRIPTDIR}/packages/libxcb/build.sh"; echo "${TERMUX_PKG_SRCURL}")"
+		[xcb_proto]="$(. "${TERMUX_SCRIPTDIR}/packages/xcb-proto/build.sh"; echo "${TERMUX_PKG_SRCURL}")"
+		[libxkbcommon]="$(. "${TERMUX_SCRIPTDIR}/x11-packages/libxkbcommon/build.sh"; echo "${TERMUX_PKG_SRCURL}")"
+	)
+	local -A sha256=(
+		[libx11]="$(. "${TERMUX_SCRIPTDIR}/packages/libx11/build.sh"; echo "${TERMUX_PKG_SHA256}")"
+		[libxcb]="$(. "${TERMUX_SCRIPTDIR}/packages/libxcb/build.sh"; echo "${TERMUX_PKG_SHA256}")"
+		[xcb_proto]="$(. "${TERMUX_SCRIPTDIR}/packages/xcb-proto/build.sh"; echo "${TERMUX_PKG_SHA256}")"
+		[libxkbcommon]="$(. "${TERMUX_SCRIPTDIR}/x11-packages/libxkbcommon/build.sh"; echo "${TERMUX_PKG_SHA256}")"
+	)
 
-	termux_download "${xcb_proto_srcurl}" "${TERMUX_PKG_CACHEDIR}/$(basename ${xcb_proto_srcurl})" "${xcb_proto_sha256}"
-	termux_download "${libxcb_srcurl}" "${TERMUX_PKG_CACHEDIR}/$(basename ${libxcb_srcurl})" "${libxcb_sha256}"
-	termux_download "${libxkbcommon_srcurl}" "${TERMUX_PKG_CACHEDIR}/$(basename ${libxkbcommon_srcurl})" "${libxkbcommon_sha256}"
-	termux_download "${libx11_srcurl}" "${TERMUX_PKG_CACHEDIR}/$(basename ${libx11_srcurl})" "${libx11_sha256}"
+	termux_download "${srcurl[libx11]}" "${TERMUX_PKG_CACHEDIR}/$(basename "${srcurl[libx11]}")" "${sha256[libx11]}"
+	termux_download "${srcurl[libxcb]}" "${TERMUX_PKG_CACHEDIR}/$(basename "${srcurl[libxcb]}")" "${sha256[libxcb]}"
+	termux_download "${srcurl[xcb_proto]}" "${TERMUX_PKG_CACHEDIR}/$(basename "${srcurl[xcb_proto]}")" "${sha256[xcb_proto]}"
+	termux_download "${srcurl[libxkbcommon]}" "${TERMUX_PKG_CACHEDIR}/$(basename "${srcurl[libxkbcommon]}")" "${sha256[libxkbcommon]}"
 
-	tar -xf "${TERMUX_PKG_CACHEDIR}/$(basename "${xcb_proto_srcurl}")"
-	tar -xf "${TERMUX_PKG_CACHEDIR}/$(basename "${libxcb_srcurl}")"
-	tar -xf "${TERMUX_PKG_CACHEDIR}/$(basename "${libxkbcommon_srcurl}")"
-	tar -xf "${TERMUX_PKG_CACHEDIR}/$(basename "${libx11_srcurl}")"
+	tar -xf "${TERMUX_PKG_CACHEDIR}/$(basename "${srcurl[libx11]}")"
+	tar -xf "${TERMUX_PKG_CACHEDIR}/$(basename "${srcurl[libxcb]}")"
+	tar -xf "${TERMUX_PKG_CACHEDIR}/$(basename "${srcurl[xcb_proto]}")"
+	tar -xf "${TERMUX_PKG_CACHEDIR}/$(basename "${srcurl[libxkbcommon]}")"
 
 	export PKG_CONFIG_PATH="${TERMUX_PKG_HOSTBUILD_DIR}/lib/pkgconfig"
 	PKG_CONFIG_PATH+=":${TERMUX_PKG_HOSTBUILD_DIR}/share/pkgconfig"
 	PKG_CONFIG_PATH+=":${TERMUX_PKG_HOSTBUILD_DIR}/lib/x86_64-linux-gnu/pkgconfig"
 
-	pushd "xcb-proto-${xcb_proto_ver}"
+	pushd "xcb-proto-${ver[xcb_proto]}" || termux_error_exit "Failed to hostbuild 'xcb_proto'"
 	./configure --prefix "${TERMUX_PKG_HOSTBUILD_DIR}"
 	make -j "${TERMUX_PKG_MAKE_PROCESSES}" install
 	popd
-	pushd "libxcb-${libxcb_ver}"
+	pushd "libxcb-${ver[libxcb]}" || termux_error_exit "Failed to hostbuild 'libxcb'"
 	./configure --prefix "${TERMUX_PKG_HOSTBUILD_DIR}"
 	make -j "${TERMUX_PKG_MAKE_PROCESSES}" install
 	popd
-	pushd "libxkbcommon-xkbcommon-${libxkbcommon_ver}"
+	pushd "libxkbcommon-xkbcommon-${ver[libxkbcommon]}" || termux_error_exit "Failed to hostbuild 'libxkbcommon'"
 	${TERMUX_MESON} \
-		${TERMUX_PKG_HOSTBUILD_DIR}/build-xkbcommon . \
+		"${TERMUX_PKG_HOSTBUILD_DIR}/build-xkbcommon" . \
 		--prefix "${TERMUX_PKG_HOSTBUILD_DIR}" \
 		-Denable-bash-completion=false \
 		-Denable-wayland=false \
 		-Denable-docs=false
 	ninja \
-		-C ${TERMUX_PKG_HOSTBUILD_DIR}/build-xkbcommon \
+		-C "${TERMUX_PKG_HOSTBUILD_DIR}/build-xkbcommon" \
 		-j "${TERMUX_PKG_MAKE_PROCESSES}" install
 	popd
-	pushd "libX11-${libx11_ver}"
+	pushd "libX11-${ver[libx11]}" || termux_error_exit "Failed to hostbuild 'libx11'"
 	./configure --prefix "${TERMUX_PKG_HOSTBUILD_DIR}"
 	make -j "${TERMUX_PKG_MAKE_PROCESSES}" install
 	popd
 
-	pushd "${TERMUX_PKG_SRCDIR}"
+	pushd "${TERMUX_PKG_SRCDIR}" || termux_error_exit "Failed to run './dev.sh build'"
 	echo "./dev.sh build" && ./dev.sh build
 	python3 setup.py clean --clean-for-cross-compile --verbose
 	popd
@@ -91,14 +97,17 @@ termux_step_host_build() {
 
 termux_step_pre_configure() {
 	mkdir -p "$TERMUX_PKG_SRCDIR"/fonts
-	termux_download https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/NerdFontsSymbolsOnly/SymbolsNerdFontMono-Regular.ttf "$TERMUX_PKG_SRCDIR"/fonts/SymbolsNerdFontMono-Regular.ttf SKIP_CHECKSUM
+	termux_download \
+		"https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/NerdFontsSymbolsOnly/SymbolsNerdFontMono-Regular.ttf" \
+		"$TERMUX_PKG_SRCDIR/fonts/SymbolsNerdFontMono-Regular.ttf" \
+		SKIP_CHECKSUM
 
 	termux_setup_golang
 	CFLAGS+=" $CPPFLAGS"
 
 	sed 's|@TERMUX_PREFIX@|'"${TERMUX_PREFIX}"'|g' \
-		${TERMUX_PKG_BUILDER_DIR}/posix-shm.c.in > kitty/posix-shm.c
-	cp ${TERMUX_PKG_BUILDER_DIR}/reallocarray.c glfw/
+		"${TERMUX_PKG_BUILDER_DIR}/posix-shm.c.in" > kitty/posix-shm.c
+	cp "${TERMUX_PKG_BUILDER_DIR}/reallocarray.c" glfw/
 }
 
 termux_step_make() {
@@ -115,9 +124,9 @@ termux_step_make() {
 		--verbose
 
 	# Needs a new host build each time it's built:
-	rm -Rf $TERMUX_PKG_HOSTBUILD_DIR
+	rm -Rf "$TERMUX_PKG_HOSTBUILD_DIR"
 }
 
 termux_step_make_install() {
-	cp -rT linux-package $TERMUX_PREFIX
+	cp -rT linux-package "$TERMUX_PREFIX"
 }


### PR DESCRIPTION
> [!IMPORTANT]
> **DO NOT MERGE THIS BEFORE #21949**

- This PR is going to follow up #21949
Since the `alacritty`, `foot` and `kitty` terminfo files shipped with `ncurses`
will no longer be pulled from hardcoded versions of their respective project.
Thus enabling safe auto-updating for them.