### PR TITLE
fix(main/fte): fix error: conflicting declaration of strlcpy() during cross-compilation

### DIFF
--- a/packages/fte/build.sh
+++ b/packages/fte/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="A free text editor for developers"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=20110708
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=(https://downloads.sourceforge.net/fte/fte-${TERMUX_PKG_VERSION}-src.zip
                    https://downloads.sourceforge.net/fte/fte-${TERMUX_PKG_VERSION}-common.zip)
 TERMUX_PKG_SHA256=(d6311c542d3f0f2890a54a661c3b67228e27b894b4164e9faf29f014f254499e

--- a/packages/fte/strlcpy.patch.beforehostbuild
+++ b/packages/fte/strlcpy.patch.beforehostbuild
@@ -1,0 +1,26 @@
+Author: Andreas Beckmann <anbe@debian.org>
+Description: fix building with strlcpy() provided by glibc 2.38
+
+--- a/src/sysdep.h
++++ b/src/sysdep.h
+@@ -189,8 +189,13 @@
+ #define ftruncate _ftruncate
+ #endif
+ 
++#if 0
+ #undef HAVE_STRLCPY
+ #undef HAVE_STRLCAT
++#else
++#define HAVE_STRLCPY
++#define HAVE_STRLCAT
++#endif
+ 
+ #ifndef HAVE_BOOL
+ #define bool  int
+--- a/src/s_string.cpp
++++ b/src/s_string.cpp
+@@ -1,3 +1,4 @@
++#include "sysdep.h"
+ #include "s_string.h"
+ 
+ #include <string.h>


### PR DESCRIPTION
Fixes #21960

Patch copied and pasted from https://git.launchpad.net/ubuntu/+source/fte/tree/debian/patches/strlcpy.patch