### PR TITLE
chore(main/kakoune-lsp): revbump after maintainer change

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default assignment: frequent contributors from @termux.
-* @Grimler91
+* @Grimler91 @TomJo2000
 
 # Build system.
 /build-all.sh @Grimler91
@@ -181,8 +181,8 @@
 
 # Packages owned by @TomJo2000
 /packages/bash-completion/ @TomJo2000
+/packages/bash/ @TomJo2000
 /packages/borgbackup/ @TomJo2000
-/packages/tree-sitter/ @TomJo2000
 /packages/eza/ @TomJo2000
 /packages/git-delta/ @TomJo2000
 /packages/gopass/ @TomJo2000
@@ -191,8 +191,12 @@
 /packages/lua-lpeg/ @TomJo2000
 /packages/moreutils/ @TomJo2000
 /packages/mpv/ @TomJo2000
+/packages/ncdu/ @TomJo2000
+/packages/ncdu2/ @TomJo2000
 /packages/neovim/ @TomJo2000
 /packages/nerdfix/ @TomJo2000
+/packages/openssh/ @TomJo2000
+/packages/rip2/ @TomJo2000
 /packages/rsgain/ @TomJo2000
 /packages/shellcheck/ @TomJo2000
 /packages/starship/ @TomJo2000
@@ -201,8 +205,8 @@
 /packages/tree-sitter* @TomJo2000
 /packages/typst-lsp/ @TomJo2000
 /packages/typstfmt/ @TomJo2000
-/packages/zrok/ @TomJo2000
 /packages/zls/ @TomJo2000
+/packages/zrok/ @TomJo2000
 /packages/zsh/ @TomJo2000
 /x11-packages/alacritty/ @TomJo2000
 /x11-packages/jwm/ @TomJo2000

--- a/packages/kakoune-lsp/build.sh
+++ b/packages/kakoune-lsp/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Language Server Protocol Client for the Kakoune editor"
 TERMUX_PKG_LICENSE="MIT, Unlicense"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="18.0.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/kakoune-lsp/kakoune-lsp/archive/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=ad33b20437cd7bc89d7992b9449a02c946528e7f91d15d76dba27c7ad2ae7d36
 TERMUX_PKG_CONFLICTS="kak-lsp"


### PR DESCRIPTION
- Follow up to #21959
Package wasn't revbumped so the upload step of the CI failed.

While we're here I also updated and sorted my packages in the CODEOWNERS file and put myself down as a second default for reviews.
I'm happy to nominate @Biswa96 or @twaik for that instead if interested.