### PR TITLE
bump(main/mesa): 24.1.1

### DIFF
--- a/packages/mesa/0000-disable-android-detection.patch
+++ b/packages/mesa/0000-disable-android-detection.patch
@@ -1,0 +1,20 @@
++++ ./src/util/detect_os.h
+@@ -24,7 +24,7 @@
+  * Android defines __linux__, so DETECT_OS_LINUX and DETECT_OS_UNIX will
+  * also be defined.
+  */
+-#if defined(__ANDROID__)
++#if 0
+ #define DETECT_OS_ANDROID 1
+ #endif
+ 
++++ ./include/vulkan/vk_android_native_buffer.h	
+@@ -18,7 +18,7 @@
+ #define __VK_ANDROID_NATIVE_BUFFER_H__
+ 
+ /* MESA: A hack to avoid #ifdefs in driver code. */
+-#ifdef __ANDROID__
++#if 0
+ #include <cutils/native_handle.h>
+ #include <vulkan/vulkan.h>
+ 

--- a/packages/mesa/0002-fix-for-getprogname.patch
+++ b/packages/mesa/0002-fix-for-getprogname.patch
@@ -4,7 +4,7 @@
  {
     return strdup(program_invocation_short_name);
  }
--#elif defined(__FreeBSD__) || defined(__DragonFly__) || defined(__APPLE__) || defined(ANDROID) || defined(__NetBSD__)
+-#elif defined(__FreeBSD__) || defined(__DragonFly__) || defined(__APPLE__) || DETECT_OS_ANDROID || defined(__NetBSD__)
 +#elif defined(__FreeBSD__) || defined(__DragonFly__) || defined(__APPLE__) || defined(__ANDROID__) || defined(__NetBSD__)
  #if defined(__NetBSD__)
  #    include <sys/param.h>
@@ -13,7 +13,7 @@
  #endif
  
  #if defined(GET_PROGRAM_NAME_NOT_AVAILABLE)
--#if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__UCLIBC__) || defined(ANDROID)
+-#if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__UCLIBC__) || DETECT_OS_ANDROID
 +#if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__UCLIBC__) || defined(__ANDROID__)
  /* This is a hack. It's said to work on OpenBSD, NetBSD and GNU.
   * Rogelio M.Serrano Jr. reported it's also working with UCLIBC. It's

--- a/packages/mesa/0004-do-not-check-xlocale.patch
+++ b/packages/mesa/0004-do-not-check-xlocale.patch
@@ -1,11 +1,13 @@
 --- a/meson.build
 +++ b/meson.build
-@@ -1377,7 +1377,7 @@
+@@ -1383,8 +1383,8 @@
    endif
  endif
  
 -foreach h : ['xlocale.h', 'linux/futex.h', 'endian.h', 'dlfcn.h', 'sys/shm.h',
+-             'cet.h', 'pthread_np.h', 'renderdoc_app.h', 'sys/inotify.h', 'linux/udmabuf.h']
 +foreach h : ['linux/futex.h', 'endian.h', 'dlfcn.h', 'sys/shm.h',
-              'cet.h', 'pthread_np.h', 'renderdoc_app.h', 'sys/inotify.h']
++             'cet.h', 'pthread_np.h', 'renderdoc_app.h', 'sys/inotify.h']
    if cc.check_header(h)
      pre_args += '-DHAVE_@0@'.format(h.to_upper().underscorify())
+   endif

--- a/packages/mesa/build.sh
+++ b/packages/mesa/build.sh
@@ -3,12 +3,11 @@ TERMUX_PKG_DESCRIPTION="An open-source implementation of the OpenGL specificatio
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="docs/license.rst"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="24.0.8"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="24.1.1"
 _LLVM_MAJOR_VERSION=$(. $TERMUX_SCRIPTDIR/packages/libllvm/build.sh; echo $LLVM_MAJOR_VERSION)
 _LLVM_MAJOR_VERSION_NEXT=$((_LLVM_MAJOR_VERSION + 1))
 TERMUX_PKG_SRCURL=https://archive.mesa3d.org/mesa-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=d1ed86a266d5b7b8c136ae587ef5618ed1a9837a43440f3713622bf0123bf5c1
+TERMUX_PKG_SHA256=0038826c6f7e88d90b4ce6f719192fa58ca7dedf4edcaa1174cf7bd920ef89ea
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libandroid-shmem, libc++, libdrm, libglvnd, libllvm (<< ${_LLVM_MAJOR_VERSION_NEXT}), libwayland, libx11, libxext, libxfixes, libxshmfence, libxxf86vm, ncurses, vulkan-loader, zlib, zstd"
 TERMUX_PKG_SUGGESTS="mesa-dev"
@@ -33,7 +32,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dplatforms=x11,wayland
 -Dgallium-drivers=swrast,virgl,zink
 -Dosmesa=true
--Dglvnd=true
+-Dglvnd=enabled
 -Dxmlconfig=disabled
 "
 


### PR DESCRIPTION
Closes #20432.

I tested it with glmark2 (llvmpipe) and with vkcube (lavapipe + `-disable-dri3`) and they worked fine. 

I will merge it in 72 hours if no one minds or when it gets 2+ approves.