### PR TITLE
fix(main/libgmp): fix building with `build-all.sh`

### DIFF
--- a/packages/libgmp/build.sh
+++ b/packages/libgmp/build.sh
@@ -2,7 +2,8 @@ TERMUX_PKG_HOMEPAGE=https://gmplib.org/
 TERMUX_PKG_DESCRIPTION="Library for arbitrary precision arithmetic"
 TERMUX_PKG_LICENSE="LGPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=6.3.0
+TERMUX_PKG_VERSION="6.3.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/gmp/gmp-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898
 TERMUX_PKG_DEPENDS="libc++"
@@ -12,5 +13,5 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-cxx"
 
 termux_step_pre_configure() {
 	# the cxx tests fail because it won't link properly without this
-	CXXFLAGS+=" -L$TERMUX_PREFIX/lib"
+	CXXFLAGS+=" -L$TERMUX_PREFIX/lib -Wl,-rpath=$TERMUX_PREFIX/lib"
 }


### PR DESCRIPTION
Fixes error 
```
checking C++ compiler aarch64-linux-android-clang++  -I/data/data/com.termux/files/usr/include  -fstack-protector-strong -Oz -L/data/data/com.termux/files/usr/lib... no, program does not run
configure: error: C++ compiler not available, see config.log for details
...
configure:10520: checking C++ compiler aarch64-linux-android-clang++  -I/data/data/com.termux/files/usr/include  -fstack-protector-strong -Oz -L/data/data/com.termux/files/usr/lib
Test compile:
configure:10534: aarch64-linux-android-clang++  -I/data/data/com.termux/files/usr/include  -fstack-protector-strong -Oz -L/data/data/com.termux/files/usr/lib conftest.cc >&5
configure:10537: $? = 0
configure:10541: ./a.out || ./b.out || ./a.exe || ./a_out.exe || ./conftest
CANNOT LINK EXECUTABLE "./a.out": library "libc++_shared.so" not found
libc: CANNOT LINK EXECUTABLE "./a.out": library "libc++_shared.so" not found
libc: Fatal signal 6 (SIGABRT), code -6 in tid 952305 (a.out)
libc: failed to spawn debuggerd dispatch thread: Invalid argument
/home/builder/.termux-build/libgmp/src/configure: line 10542: ./b.out: No such file or directory
/home/builder/.termux-build/libgmp/src/configure: line 10542: ./a.exe: No such file or directory
/home/builder/.termux-build/libgmp/src/configure: line 10542: ./a_out.exe: No such file or directory
/home/builder/.termux-build/libgmp/src/configure: line 10542: ./conftest: No such file or directory
configure:10544: $? = 127
failed program was:

int main (void) { return 0; }
configure:10649: result: no, program does not run
configure:10665: error: C++ compiler not available, see config.log for details
```

Related to #21130.