### PR TITLE
[WIP] fix(main/abseil-cpp): prevent abseil-cpp from inserting very excessive duplicated flags into pkg-config files

### DIFF
--- a/packages/abseil-cpp/build.sh
+++ b/packages/abseil-cpp/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # Do not forget to rebuild revdeps along with EVERY "major" version bump.
 TERMUX_PKG_VERSION="20240116.2"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/abseil/abseil-cpp/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=733726b8c3a6d39a4120d7e45ea8b41a434cdacde401cba500f14236c49b39dc
 # updating this will break libprotobuf
@@ -14,3 +14,10 @@ TERMUX_PKG_CONFLICTS="libgrpc (<< 1.52.0-1)"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DBUILD_SHARED_LIBS=ON
 "
+
+# prevent abseil-cpp from inserting very excessive duplicated flags into pkg-config files
+# https://github.com/abseil/abseil-cpp/issues/1168
+termux_step_post_make_install() {
+	find "${TERMUX_PREFIX}/lib/pkgconfig" -type f \
+		-name 'absl*' -not -name 'absl_config.pc' -print0 | xargs -0 sed -i '/^Cflags: /d'
+}


### PR DESCRIPTION
This is not the true root cause, but might be part of the problem.
Fixes #21995 
Fixes the error `/usr/bin/cat: Argument list too long` in the build of `libprotobuf-c`
Upstream issue tracked here https://github.com/abseil/abseil-cpp/issues/1168 Code copied and pasted from https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay/+/refs/heads/main/dev-cpp/abseil-cpp/abseil-cpp-20230802.0.ebuild#121

I don't think performing a rebuild of reverse dependencies would be necessary for this change since it changes only plaintext files of the package, but I could be wrong.