### PR TITLE
fix(main/libnfc): fix building with `./build-all.sh`

### DIFF
--- a/packages/libnfc/build.sh
+++ b/packages/libnfc/build.sh
@@ -2,11 +2,13 @@ TERMUX_PKG_HOMEPAGE=https://github.com/nfc-tools/libnfc
 TERMUX_PKG_DESCRIPTION="Free/Libre Near Field Communication (NFC) library"
 TERMUX_PKG_LICENSE="LGPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1.8.0
+TERMUX_PKG_VERSION="1.8.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/nfc-tools/libnfc/releases/download/libnfc-${TERMUX_PKG_VERSION}/libnfc-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=6d9ad31c86408711f0a60f05b1933101c7497683c2e0d8917d1611a3feba3dd5
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+\.\d+"
+TERMUX_PKG_BUILD_DEPENDS="readline"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --with-drivers=acr122s,arygon,pn532_uart,pn532_spi,pn532_i2c
 "


### PR DESCRIPTION
Fixes the following error which appears during running `./build-all.sh`.
```
/home/builder/.termux-build/libnfc/src/examples/pn53x-tamashell.c:48:12: fatal error: 'readline/readline.h' file not found
   48 | #  include <readline/readline.h>
      |            ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Since `libnfc.so` has only `libc.so` in `NEEDED` section I put `readline` to build dependency section.

Related to #21130.

I will merge it in 36 hours if nobody minds or after it gets 2+ approves.