### PR TITLE
bump(main/hilbish): 2.3.2/2024.07.30

### DIFF
--- a/packages/hilbish/build.sh
+++ b/packages/hilbish/build.sh
@@ -2,10 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://rosettea.github.io/Hilbish/
 TERMUX_PKG_DESCRIPTION="The Moon-powered shell! A comfy and extensible shell for Lua fans!"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-_COMMIT=40c3cecabb38a68064727368b5882196a59d34d9 # v2.2.2
-TERMUX_PKG_VERSION="2024.04.16"
+_COMMIT=0582fbd30c75e5915108df0183ac05747c69a7d9 # v2.3.2
+TERMUX_PKG_VERSION="2024.07.30"
 TERMUX_PKG_SRCURL=git+https://github.com/Rosettea/Hilbish
-TERMUX_PKG_SHA256=626c9c2dce70c54aeb98ce58566744c411398dd71990a72039bfc1b43a6e0382
+TERMUX_PKG_SHA256=7cbba35c2def313c5b60c1b2d5d16e80c4bcc788c3aad7bc36a56a0d4d22de22
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_BUILD_IN_SRC=true
 
@@ -29,12 +29,13 @@ termux_step_post_get_source() {
 
 termux_step_make() {
 	termux_setup_golang
-	sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d
-
-	sed -i 's/rvalue/$TERMUX_PKG_VERSION/g' Taskfile.yaml
-	GOOS=android ./bin/task
+	export GOPATH=$TERMUX_PKG_SRCDIR
+	GOOS=android CGO_ENABLED=1 go build -ldflags "-checklinkname=0 -s -w -X main.dataDir=${TERMUX_PREFIX}/share/hilbish -X main.gitCommit=$(git ls-remote https://github.com/rosettea/hilbish refs/tags/v$TERMUX_PKG_VERSION) -X main.gitBranch=$TERMUX_PKG_VERSION"
 }
 
 termux_step_make_install() {
-	./bin/task install
+	mkdir -p "$TERMUX_PREFIX/share/hilbish"
+	install -v -d "$TERMUX_PREFIX/bin" && install -m 0755 -v hilbish "$TERMUX_PREFIX/bin/hilbish"
+	cp -r libs docs emmyLuaDocs nature .hilbishrc.lua "$TERMUX_PREFIX/share/hilbish"
+	grep -qxF "$TERMUX_PREFIX/bin/hilbish" "$TERMUX_PREFIX/etc/shells" || echo "$TERMUX_PREFIX/bin/hilbish" >> "$TERMUX_PREFIX/etc/shells"
 }

--- a/packages/hilbish/fix-hardcoded-path.patch
+++ b/packages/hilbish/fix-hardcoded-path.patch
@@ -1,36 +1,4 @@
-diff -uNr Hilbish-2.1.2/Taskfile.yaml Hilbish-2.1.2.mod/Taskfile.yaml
---- Hilbish-2.1.2/Taskfile.yaml	2023-04-11 00:31:32.000000000 +0800
-+++ Hilbish-2.1.2.mod/Taskfile.yaml	2023-08-16 13:36:43.673694676 +0800
-@@ -3,7 +3,7 @@
- version: '3'
- 
- vars:
--  PREFIX: '{{default "/usr/local" .PREFIX}}'
-+  PREFIX: '{{default "@TERMUX_PREFIX@" .PREFIX}}'
-   bindir__: '{{.PREFIX}}/bin'
-   BINDIR: '{{default .bindir__ .BINDIR}}'
-   libdir__: '{{.PREFIX}}/share/hilbish'
-@@ -16,7 +16,7 @@
-     cmds:
-       - CGO_ENABLED=0 go build {{.GOFLAGS}}
-     vars:
--      GOFLAGS: '-ldflags "-s -w -X main.dataDir={{.LIBDIR}} -X main.gitCommit=$(git rev-parse --short HEAD) -X main.gitBranch=$(git rev-parse --abbrev-ref HEAD)"'
-+      GOFLAGS: '-ldflags "-s -w -X main.dataDir={{.LIBDIR}} -X main.gitCommit=$(git ls-remote https://github.com/rosettea/hilbish refs/tags/vrvalue) -X main.gitBranch=rvalue"'
- 
-   build:
-     cmds:
-@@ -27,7 +27,7 @@
-       - install -v -d "{{.DESTDIR}}{{.BINDIR}}/" && install -m 0755 -v hilbish "{{.DESTDIR}}{{.BINDIR}}/hilbish"
-       - mkdir -p "{{.DESTDIR}}{{.LIBDIR}}"
-       - cp -r libs docs emmyLuaDocs nature .hilbishrc.lua {{.DESTDIR}}{{.LIBDIR}}
--      - grep -qxF "{{.DESTDIR}}{{.BINDIR}}/hilbish" /etc/shells || echo "{{.DESTDIR}}{{.BINDIR}}/hilbish" >> /etc/shells
-+      - grep -qxF "{{.DESTDIR}}{{.BINDIR}}/hilbish" @TERMUX_PREFIX@/etc/shells || echo "{{.DESTDIR}}{{.BINDIR}}/hilbish" >> @TERMUX_PREFIX@/etc/shells
- 
-   uninstall:
-     cmds:
-diff -uNr Hilbish-2.1.2/vars_linux.go Hilbish-2.1.2.mod/vars_linux.go
---- Hilbish-2.1.2/vars_linux.go	2023-04-11 00:31:32.000000000 +0800
-+++ Hilbish-2.1.2.mod/vars_linux.go	2023-08-16 13:37:25.913694660 +0800
++++ ./vars_unix.go
 @@ -14,7 +14,7 @@
  	.. hilbish.userDir.config	.. '/hilbish/?/init.lua;'
  	.. hilbish.userDir.config	.. '/hilbish/?/?.lua;'


### PR DESCRIPTION
This update includes temporary fix for `golua` building (due to https://github.com/golang/go/issues/67401) and moves building rules from `Taskfile.yaml` to `build.sh`.

I installed it on device and it seems to work. I only entered hilbish shell with `hilbish` command and tried simple command `ls -la` and it worked fine.

I will merge this in 48 hours if nobody minds or after it gets 2+ approves.
Also it is related #21130 because currently building is impossible without `-checklinkname=0` (Go 1.23).