### PR TITLE
fix(main/lighttpd): link with libandroid-spawn

### DIFF
--- a/packages/lighttpd/build.sh
+++ b/packages/lighttpd/build.sh
@@ -3,9 +3,10 @@ TERMUX_PKG_DESCRIPTION="Fast webserver with minimal memory footprint"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.4.76"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=8cbf4296e373cfd0cedfe9d978760b5b05c58fdc4048b4e2bcaf0a61ac8f5011
-TERMUX_PKG_DEPENDS="libandroid-glob, libbz2, libcrypt, openssl, pcre2, zlib"
+TERMUX_PKG_DEPENDS="libandroid-glob, libandroid-spawn, libbz2, libcrypt, openssl, pcre2, zlib"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dwith_bzip=enabled
@@ -25,7 +26,7 @@ termux_step_post_get_source() {
 }
 
 termux_step_pre_configure() {
-	LDFLAGS="$LDFLAGS -landroid-glob"
+	LDFLAGS+=" -landroid-glob -landroid-spawn"
 }
 
 termux_step_post_make_install() {


### PR DESCRIPTION
Progress on https://github.com/termux/termux-packages/issues/21130

Fixes this error during build:

```
ld.lld: error: undefined symbol: posix_spawn_file_actions_init
>>> referenced by fdevent.c:495 (../src/src/fdevent.c:495)
>>>               src/test_mod.p/fdevent.c.o:(fdevent_fork_execve)
```

I tested this by using the docker container to cross-compile this package, then copying the .deb file to my aarch64 Android 10 device. I was able to successfully test the resulting program as a functioning web server at runtime after installing the .deb file by typing these commands (note: identical commands are also required for testing the previous build of the `lighttpd` package from the time of NDK revision 26 that's currently in the repositories, so I believe that my update most likely has equivalent functionality without any regression):

```bash
mkdir -p $PREFIX/var/log/lighttpd
mkdir -p $PREFIX/var/www/htdocs
echo 'hello lighttpd' > $PREFIX/var/www/htdocs/index.html
lighttpd -f $PREFIX/etc/lighttpd/lighttpd.conf
```

My Android 10 device's WiFi LAN local IP address is 192.168.120.74, so then I used a separate computer's web browser to go to this address: http://192.168.120.74:8080/index.html, where I am able to see the text I wrote into the `index.html` file, "hello lighttpd"

![image](https://github.com/user-attachments/assets/90d0d744-975b-4965-ad59-e89489c48edf)