### PR TITLE
fix(main/oleo): fix building with `./build-all.sh` in docker.

### DIFF
--- a/packages/oleo/build.sh
+++ b/packages/oleo/build.sh
@@ -2,8 +2,8 @@ TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/oleo/
 TERMUX_PKG_DESCRIPTION="The GNU Spreadsheet"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1.99.16
-TERMUX_PKG_REVISION=8
+TERMUX_PKG_VERSION="1.99.16"
+TERMUX_PKG_REVISION=9
 TERMUX_PKG_SRCURL=http://ftp.gnu.org/gnu/oleo/oleo-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=6598df85d06ff2534ec08ed0657508f17dbbc58dd02d419160989de7c487bc86
 TERMUX_PKG_DEPENDS="ncurses"
@@ -15,5 +15,13 @@ Oleo/*
 share/oleo/oleo.html"
 
 termux_step_pre_configure() {
+	# configure script tries to build program which writes `sizeof` expression
+	# result with our toolchain and tries to execute it which is impossible
+	# with cross-compiling inside docker.
+	export ac_cv_sizeof_short=__SIZEOF_SHORT__
+	export ac_cv_sizeof_int=__SIZEOF_INT__
+	export ac_cv_sizeof_long=__SIZEOF_LONG__
+	export ac_cv_header_stdc=yes
+
 	export CFLAGS+=" -fcommon"
 }


### PR DESCRIPTION
Fixes error `#error "Cannot find a 32-bit data type"` from `gettext.h` while invoking `build-all.sh` in docker.

Related to #21130.

It is small fix so I will merge it in 12 hours if nobody minds or after it gets 2+ approves.