### PR TITLE
bump(main/macchina): 6.3.1

### DIFF
--- a/packages/macchina/build.sh
+++ b/packages/macchina/build.sh
@@ -2,16 +2,17 @@ TERMUX_PKG_HOMEPAGE=https://github.com/Macchina-CLI/macchina
 TERMUX_PKG_DESCRIPTION="A system information fetcher, with an emphasis on performance and minimalism."
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="6.2.1"
-TERMUX_PKG_SRCURL=https://github.com/Macchina-CLI/macchina/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=87a38bde067fadd96615899d6a8b9efdb238a4bd3859008be47b3e4c2a02c607
+TERMUX_PKG_VERSION="6.3.1"
+TERMUX_PKG_SRCURL=git+https://github.com/Macchina-CLI/macchina
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_BLACKLISTED_ARCHES="arm, i686"
 
-termux_step_make_install() {
+termux_step_make() {
 	termux_setup_rust
-	
 	cargo build --jobs ${TERMUX_PKG_MAKE_PROCESSES} --target ${CARGO_TARGET_NAME} --release
+}
+
+termux_step_make_install() {
 	install -Dm755 -t ${TERMUX_PREFIX}/bin target/${CARGO_TARGET_NAME}/release/macchina
 }


### PR DESCRIPTION
Use git repository in source URL to get ansi-to-tui and color-to-tui git submodules which were added in the following upstream commit. https://github.com/Macchina-CLI/macchina/commit/b9ea77335ed6b45734abb3371df258f521745bc1

Fixes #22021
