### PR TITLE
scripts(setup-ubuntu.sh): Apply system libdirs and pkgconfig dirs to new pkgconf build

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -343,12 +343,21 @@ $SUDO ln -sf /data/data/com.termux/files/usr/opt/bionic-host /system
 # Install newer pkg-config then what ubuntu provides, as the stock
 # ubuntu version has performance problems with at least protobuf:
 PKGCONF_VERSION=2.3.0
+HOST_TRIPLET=$(gcc -dumpmachine)
+PKG_CONFIG_DIRS=$(grep DefaultSearchPaths: /usr/share/pkgconfig/personality.d/${HOST_TRIPLET}.personality | cut -d ' ' -f 2)
+SYSTEM_LIBDIRS=$(grep SystemLibraryPaths: /usr/share/pkgconfig/personality.d/${HOST_TRIPLET}.personality | cut -d ' ' -f 2)
 mkdir -p /tmp/pkgconf-build
 cd /tmp/pkgconf-build
 curl -O https://distfiles.ariadne.space/pkgconf/pkgconf-${PKGCONF_VERSION}.tar.xz
 tar xf pkgconf-${PKGCONF_VERSION}.tar.xz
 cd pkgconf-${PKGCONF_VERSION}
-./configure --prefix=/usr && make && $SUDO make install
+echo "SYSTEM_LIBDIRS: $SYSTEM_LIBDIRS"
+echo "PKG_CONFIG_DIRS: $PKG_CONFIG_DIRS"
+./configure --prefix=/usr \
+	--with-system-libdir=${SYSTEM_LIBDIRS} \
+	--with-pkg-config-dir=${PKG_CONFIG_DIRS}
+make
+$SUDO make install
 cd -
 rm -Rf /tmp/pkgconf-build
 # Prevent package from being upgraded and overwriting our manual installation:


### PR DESCRIPTION
Fixes #22060


There are also several other methods that could be used to fix this particular problem, but the way I have written this keeps it mostly similar to how fornwall originally wrote this update, without radically changing the method too much from his general idea.