### PR TITLE
fix(main/{lit,luvit}): don't embed luvi into {lit,luvit} bin

### DIFF
--- a/packages/lit/build.sh
+++ b/packages/lit/build.sh
@@ -3,11 +3,11 @@ TERMUX_PKG_DESCRIPTION="Toolkit for developing, sharing, and running luvit/lua p
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.8.5
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=git+https://github.com/luvit/lit.git
 TERMUX_PKG_GIT_BRANCH=${TERMUX_PKG_VERSION}
-TERMUX_PKG_BUILD_DEPENDS="luvi"
-TERMUX_PKG_SUGGESTS="luvi, luvit"
+TERMUX_PKG_DEPENDS="luvi"
+TERMUX_PKG_SUGGESTS="luvit"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_NO_STRIP=true
 
@@ -17,9 +17,17 @@ termux_step_configure() {
 }
 
 termux_step_make() {
-	./_lit make . ./lit "${TERMUX_PREFIX}/bin/luvi"
+	touch dummy
+	./_lit make . ./lit dummy
 }
 
 termux_step_make_install() {
-	install -Dm700 lit "${TERMUX_PREFIX}/bin/lit"
+	mkdir -p "${TERMUX_PREFIX}/share/lit"
+	unzip -d "${TERMUX_PREFIX}/share/lit" lit
+
+	cat > "${TERMUX_PREFIX}/bin/lit" <<-EOF
+	#!${TERMUX_PREFIX}/bin/env bash
+	exec luvi ${TERMUX_PREFIX}/share/lit -- \$@
+	EOF
+	chmod 700 "${TERMUX_PREFIX}/bin/lit"
 }

--- a/packages/luvit/build.sh
+++ b/packages/luvit/build.sh
@@ -3,10 +3,11 @@ TERMUX_PKG_DESCRIPTION="Asynchronous I/O for Lua"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.18.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/luvit/luvit/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=b792781d77028edb7e5761e96618c96162bd68747b8fced9a6fc52f123837c2c
-TERMUX_PKG_BUILD_DEPENDS="luvi"
-TERMUX_PKG_SUGGESTS="luvi, lit"
+TERMUX_PKG_DEPENDS="luvi"
+TERMUX_PKG_SUGGESTS="lit"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_NO_STRIP=true
 
@@ -19,9 +20,17 @@ termux_step_configure() {
 }
 
 termux_step_make() {
-	./_lit make . ./luvit "${TERMUX_PREFIX}/bin/luvi"
+	touch dummy
+	./_lit make . ./luvit dummy
 }
 
 termux_step_make_install() {
-	install -Dm700 luvit "${TERMUX_PREFIX}/bin/luvit"
+	mkdir -p "${TERMUX_PREFIX}/share/luvit"
+	unzip -d "${TERMUX_PREFIX}/share/luvit" luvit
+
+	cat > "${TERMUX_PREFIX}/bin/luvit" <<-EOF
+	#!${TERMUX_PREFIX}/bin/env bash
+	exec luvi ${TERMUX_PREFIX}/share/luvit -- \$@
+	EOF
+	chmod 700 "${TERMUX_PREFIX}/bin/luvit"
 }


### PR DESCRIPTION
This PR changes the way how `lit` package and `luvit` package are built and installed.