### PR TITLE
[docker] fix too long path

### DIFF
--- a/root-packages/containerd/build.sh
+++ b/root-packages/containerd/build.sh
@@ -9,7 +9,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 #
 # Above error is fixed by too_long_path.patch
 TERMUX_PKG_VERSION=1.6.21
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=git+https://github.com/containerd/containerd
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_DEPENDS="runc"

--- a/root-packages/containerd/build.sh
+++ b/root-packages/containerd/build.sh
@@ -6,6 +6,8 @@ TERMUX_PKG_MAINTAINER="@termux"
 # 1.7.7 we get the following error:
 # $ sudo docker run -it ubuntu bash
 # docker: Error response from daemon: failed to create task for container: failed to start shim: start failed: io.containerd.runc.v2: create new shim socket: listen unix /data/data/com.termux/files/usr/var/run/containerd/s/3f71828f1d6c1ead43fded842abc9c3cf5857c74c3e0704cd83ab177e17cfe6c: bind: invalid argument: exit status 1: unknown.
+#
+# Above error is fixed by too_long_path.patch
 TERMUX_PKG_VERSION=1.6.21
 TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=git+https://github.com/containerd/containerd

--- a/root-packages/containerd/too_long_path.patch
+++ b/root-packages/containerd/too_long_path.patch
@@ -1,0 +1,26 @@
+diff --git a/runtime/v1/linux/bundle.go b/runtime/v1/linux/bundle.go
+index b1830d004..b391676a2 100644
+--- a/runtime/v1/linux/bundle.go
++++ b/runtime/v1/linux/bundle.go
+@@ -195,7 +195,7 @@ const socketRoot = "/run/containerd"
+ 
+ func (b *bundle) shimAddress(namespace, socketPath string) string {
+ 	d := sha256.Sum256([]byte(filepath.Join(socketPath, namespace, b.id)))
+-	return fmt.Sprintf("unix://%s/%x", filepath.Join(socketRoot, "s"), d)
++	return fmt.Sprintf("unix://%s/%x", filepath.Join(socketRoot, "s"), d)[:108]
+ }
+ 
+ func (b *bundle) loadAddress() (string, error) {
+diff --git a/runtime/v2/shim/util_unix.go b/runtime/v2/shim/util_unix.go
+index 4e2309a80..159698518 100644
+--- a/runtime/v2/shim/util_unix.go
++++ b/runtime/v2/shim/util_unix.go
+@@ -71,7 +71,7 @@ func SocketAddress(ctx context.Context, socketPath, id string) (string, error) {
+ 		return "", err
+ 	}
+ 	d := sha256.Sum256([]byte(filepath.Join(socketPath, ns, id)))
+-	return fmt.Sprintf("unix://%s/%x", filepath.Join(socketRoot, "s"), d), nil
++	return fmt.Sprintf("unix://%s/%x", filepath.Join(socketRoot, "s"), d)[:108], nil
+ }
+ 
+ // AnonDialer returns a dialer for a socket


### PR DESCRIPTION
docker fails to start containers on android 14 due to too long unix socket path. The limit is 108 characters.