### PR TITLE
ci(package_updates): allow dry run auto update check

### DIFF
--- a/.github/workflows/package_updates.yml
+++ b/.github/workflows/package_updates.yml
@@ -1,6 +1,14 @@
 name: Package updates
 
 on:
+  push:
+    branches:
+    - '**'
+    - '!master'
+    paths:
+    - 'packages/**'
+    - 'root-packages/**'
+    - 'x11-packages/**'
   pull_request:
     paths:
     - 'packages/**'
@@ -21,7 +29,7 @@ jobs:
   update-packages-dry-run:
     permissions:
       contents: read
-    if: github.event_name == 'pull_request' && github.repository == 'termux/termux-packages'
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
@@ -121,7 +129,7 @@ jobs:
     permissions:
       issues: write
       contents: write
-    if: github.event_name != 'pull_request' && github.repository == 'termux/termux-packages'
+    if: github.event_name != 'pull_request' && github.event_name != 'push' && github.repository == 'termux/termux-packages'
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository

--- a/scripts/bin/update-packages
+++ b/scripts/bin/update-packages
@@ -359,7 +359,7 @@ _gh_create_new_issue() {
 
 	if [[ "${CREATE_ISSUE}" != "true" ]]; then
 		echo "INFO: CREATE_ISSUE set to '${CREATE_ISSUE}'. Not creating new issue."
-		return
+		return 1
 	fi
 	if _gh_check_issue_exists "${pkg_name}"; then
 		echo "INFO: An existing update issue for '${pkg_name}' hasn't been resolved yet."


### PR DESCRIPTION
on branches (except master) and forks

This should allow more people to check for potential auto update issues before submitting