### PR TITLE
fix(x11/libqtxdg): Fix missing icons in lxqt

### DIFF
--- a/x11-packages/libqtxdg/build.sh
+++ b/x11-packages/libqtxdg/build.sh
@@ -3,8 +3,13 @@ TERMUX_PKG_DESCRIPTION="Qt implementation of freedesktop.org XDG specifications"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="4.1.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/lxqt/libqtxdg/releases/download/${TERMUX_PKG_VERSION}/libqtxdg-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=0604d397d9561a6a6148930a2b131f2bdee86cec6cca304f7513a8ec7b8e8809
 TERMUX_PKG_DEPENDS="libc++, qt6-qtbase, qt6-qtsvg, glib"
 TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt6-qttools"
 TERMUX_PKG_AUTO_UPDATE=true
+# See plugin path in libqtxdg/src/xdgiconloader/plugin/CMakeLists.txt
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DQTXDGX_ICONENGINEPLUGIN_INSTALL_PATH=${TERMUX_PREFIX}/lib/qt6/plugins/iconengines
+"


### PR DESCRIPTION
This fixes icon engine plugin directory.
Otherwise, it was installed in PREFIX/opt/qt6/cross/ directory.

* Fixes #20779

* After this change 👇

![image](https://github.com/user-attachments/assets/9da7456c-2f66-4763-a875-13fabb6e4f90)
