### PR TITLE
chore(main/grafana): Build with latest golang

### DIFF
--- a/packages/grafana/build.sh
+++ b/packages/grafana/build.sh
@@ -3,8 +3,7 @@ TERMUX_PKG_DESCRIPTION="The open-source platform for monitoring and observabilit
 TERMUX_PKG_LICENSE="AGPL-V3"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1:11.3.0"
-# Until https://github.com/grafana/grafana/pull/92055 is released:
-TERMUX_PKG_GO_USE_OLDER=true
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/grafana/grafana
 TERMUX_PKG_BUILD_DEPENDS="yarn"
 TERMUX_PKG_BUILD_IN_SRC=true


### PR DESCRIPTION
Build grafana with latest golang (1.23) now that the upstream issue https://github.com/grafana/grafana/pull/92055 has been released.

Fixes the last usage of TERMUX_PKG_GO_USE_OLDER=true, meaning that we are better prepared for the next future go 1.24 release.