### PR TITLE
fix(main/fossil): Always use bundled sqlite to match required version

### DIFF
--- a/packages/fossil/build.sh
+++ b/packages/fossil/build.sh
@@ -4,10 +4,11 @@ TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_LICENSE_FILE="COPYRIGHT-BSD2.txt"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.25"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.fossil-scm.org/home/tarball/version-$TERMUX_PKG_VERSION/fossil-src-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=611cfa50d08899eb993a5f475f988b4512366cded82688c906cf913e5191b525
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="libsqlite, openssl, zlib"
+TERMUX_PKG_DEPENDS="openssl, zlib"
 
 termux_step_pre_configure() {
 	# Avoid mixup of flags between cross compilation
@@ -17,12 +18,11 @@ termux_step_pre_configure() {
 }
 
 termux_step_configure() {
+	# DO NOT add --disable-internal-sqlite, otherwise fossil panics >_<
 	$TERMUX_PKG_SRCDIR/configure \
 		--prefix=$TERMUX_PREFIX \
 		--host=$TERMUX_HOST_PLATFORM \
 		--json \
-		--disable-internal-sqlite \
-		--with-sqlite=$TERMUX_PREFIX \
 		--with-openssl=$TERMUX_PREFIX \
 		--with-zlib=$TERMUX_PREFIX
 }


### PR DESCRIPTION
This fixes the following runtime error with system sqlite.
Unsuitable SQLite version 3.46.1, must be at least 3.43.0
See also https://fossil-scm.org/forum/forumpost/fc348ef04f

* Fixes #22194 