### PR TITLE
bump(main/gpgme): 1.24.0

### DIFF
--- a/packages/gpgme/build.sh
+++ b/packages/gpgme/build.sh
@@ -3,10 +3,9 @@ TERMUX_PKG_DESCRIPTION="Library designed to make access to GnuPG easier"
 TERMUX_PKG_LICENSE="GPL-2.0, LGPL-2.1, MIT"
 TERMUX_PKG_LICENSE_FILE="COPYING, COPYING.LESSER, LICENSES"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.23.2"
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_VERSION="1.24.0"
 TERMUX_PKG_SRCURL=https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-${TERMUX_PKG_VERSION}.tar.bz2
-TERMUX_PKG_SHA256=9499e8b1f33cccb6815527a1bc16049d35a6198a6c5fae0185f2bd561bce5224
+TERMUX_PKG_SHA256=61e3a6ad89323fecfaff176bc1728fb8c3312f2faa83424d9d5077ba20f5f7da
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="gnupg (>= 2.2.9-1), libassuan, libgpg-error"
 TERMUX_PKG_BREAKS="gpgme-dev"
@@ -19,6 +18,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --without-g13
 --without-gpgconf
 --without-gpgsm
+ac_cv_path_YAT2M=:
 "
 
 termux_step_pre_configure() {

--- a/packages/gpgme/gpgmepp.subpackage.sh
+++ b/packages/gpgme/gpgmepp.subpackage.sh
@@ -2,6 +2,7 @@ TERMUX_SUBPKG_DESCRIPTION="Programmatic C++ library interface to GnuPG"
 TERMUX_SUBPKG_INCLUDE="
 lib/libgpgmepp.so
 lib/cmake/Gpgmepp
+lib/pkgconfig/gpgmepp.pc
 include/gpgme++
 "
 TERMUX_SUBPKG_DEPENDS="libc++"


### PR DESCRIPTION
Workaround the following build error by disabling check for yat2m.
/bin/bash: line 3: /data/data/com.termux/files/usr/bin/yat2m: cannot execute binary file: Exec format error

* Fixes #22143
