### PR TITLE
ci(packages): get Packages.bz2 for server file check

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -268,7 +268,7 @@ jobs:
     concurrency: ${{ github.workflow }}
     permissions:
       contents: read
-    if: github.event_name != 'pull_request' && github.ref != 'refs/heads/dev' && !startsWith(github.ref, 'refs/heads/dev/')
+    if: github.repository == 'termux/termux-packages'
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -291,6 +291,44 @@ jobs:
         for archive in debs-*/debs-{aarch64,arm,i686,x86_64}-${{ github.sha }}.tar; do
           tar xf "$archive"
         done
+
+        error=0
+        for repo in $(jq --raw-output 'del(.pkg_format) | keys | .[]' repo.json); do
+          name=$(jq --raw-output '.["'${repo}'"].name' repo.json)
+          distribution=$(jq --raw-output '.["'${repo}'"].distribution' repo.json)
+          component=$(jq --raw-output '.["'${repo}'"].component' repo.json)
+          url=$(jq --raw-output '.["'${repo}'"].url' repo.json)
+
+          if [ ! -f debs/built_${name}_packages.txt ]; then
+            continue
+          fi
+          if [ -z "$(cat debs/built_${name}_packages.txt)" ]; then
+            continue
+          fi
+
+          for arch in aarch64 arm i686 x86_64; do
+            if [ ! -f "Packages-${repo}-${arch}" ]; then
+              echo "[*] Downloading ${url}/dists/${distribution}/${component}/binary-${arch}/Packages.bz2"
+              curl -s \
+                --user-agent 'Termux-Packages/1.0\ (https://github.com/termux/termux-packages)' \
+                "${url}/dists/${distribution}/${component}/binary-${arch}/Packages.bz2" \
+                -o "Packages-${repo}-${arch}.bz2"
+              7z x "Packages-${repo}-${arch}.bz2" > /dev/null
+            fi
+            result=$(find debs -maxdepth 1 -type f | cut -d"/" -f2 | xargs -P$(nproc) -i{} grep "^Filename:.*/{}$" -nH "Packages-${repo}-${arch}" || true)
+            if [ -n "$result" ]; then
+              echo "[!] Found local files same name with server files! Please revbump package or tag commit with '%ci:no-build'"
+              echo "$result" | grep -E "${arch}|all" || true
+              error=1
+            fi
+          done
+        done
+        if [ "$error" != 0 ]; then exit 1; fi
+
+        if [ "${{ github.ref }}" != "refs/heads/master" ]; then
+          echo "[!] Not on master branch. Cancelling upload."
+          exit 0
+        fi
 
         for repo in $(jq --raw-output 'del(.pkg_format) | keys | .[]' repo.json); do
           export REPOSITORY_NAME=$(jq --raw-output '.["'$repo'"].name' repo.json)


### PR DESCRIPTION
Close #21906 

Example: https://github.com/termux/termux-packages/actions?query=branch%3Adev%2Fissue-21906

I don't think there is more efficient way than this unless aptly api can query before forcefully upload which I can't make it to work...