### PR TITLE
chore(main/graphviz): Fix libtool warnings about linking with static library

### DIFF
--- a/packages/graphviz/build.sh
+++ b/packages/graphviz/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Rich set of graph drawing tools"
 TERMUX_PKG_LICENSE="EPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="12.2.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://gitlab.com/graphviz/graphviz/-/archive/$TERMUX_PKG_VERSION/graphviz-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=0063e501fa4642b55f4daf82820b2778bfb7dafa651a862ae5c9810efb8e2311
 TERMUX_PKG_AUTO_UPDATE=true
@@ -39,8 +40,13 @@ termux_step_pre_configure() {
 	./autogen.sh NOCONFIG
 	export HOSTCC="gcc"
 
+	# ERROR: ./lib/graphviz/libgvplugin_neato_layout.so contains undefined symbols: __extendsftf2
+	local _libgcc_file="$($CC -print-libgcc-file-name)"
+	local _libgcc_path="$(dirname $_libgcc_file)"
+	local _libgcc_name="$(basename $_libgcc_file)"
+	LDFLAGS+=" -L$_libgcc_path -l:$_libgcc_name"
+
 	LDFLAGS+=" -lm -landroid-glob"
-	LDFLAGS+=" $($CC -print-libgcc-file-name)"
 	LDFLAGS+=" -Wl,-rpath=$TERMUX_PREFIX/lib/graphviz"
 }
 


### PR DESCRIPTION
This replaces previous workaround in 1b126e9572100f9c2f92903c26c51bf7ef56aac8
commit because it produces the following warning.

Warning: Linking the shared library libcgraph.la against the
static library NDK/lib/clang/18/lib/linux/libclang_rt.builtins-aarch64-android.a is not portable!

The warning is explained here https://stackoverflow.com/a/8352756