### PR TITLE
[Bug's PR]: Creating the extra function, to preserve reverting the custom config of Polybar into the example config of Polybar.

### DIFF
--- a/x11-packages/polybar/build.sh
+++ b/x11-packages/polybar/build.sh
@@ -14,3 +14,28 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DENABLE_I3=ON"
 termux_step_pre_configure() {
 	LDFLAGS+=" -landroid-glob"
 }
+
+termux_step_extra() {
+  local PREFIX_LOCAL="/data/data/com.termux/files/usr/"
+  local HOME_LOCAL="$(find /data/data/com.termux/files -type d -iname 'home*')"
+  local HOME_CACHE="${HOME_LOCAL}/.cache"
+  local POLYBAR_BACKUP_DIR="${HOME_LOCAL}/.backup/polybar"
+
+  if [[ ! -f ${HOME_CACHE}/termux ]]; then
+       $(printf "${SHELL}\n" | sed -E "s|${PREFIX_LOCAL}/bin/||") -c "mkdir --parent --verbose --mode=755 $HOME/.cache/termux"
+  fi
+
+  if [[ ! -f ${POLYBAR_BACKUP_DIR} ]]; then
+       $(printf "${SHELL}\n" | sed -E "s|${PREFIX_LOCAL}/bin/||") -c "mkdir --parent --verbose --mode=755 $HOME/.backup/polybar" | tee -a ${HOME_CACHE}/termux/polyCreate.log
+  fi
+
+  if [[ -f ${PREFIX_LOCAL}/etc/polybar/config.ini ]]; then
+       if [[ -f ${POLYBAR_BACKUP_DIR} ]]; then
+            rm --recursive --force --preserve-root --verbose ${POLYBAR_BACKUP_DIR} | tee -a ${HOME_CACHE}/termux/polybar-config-remove.log
+       fi
+
+       mv --verbose ${PREFIX_LOCAL}/etc/polybar/config.ini ${POLYBAR_BACKUP_DIR} | sed -E "s|renamed|moved and renamed|g"
+       rm --recursive --force --preserve-root --verbose ${PREFIX_LOCAL}/etc/config.ini
+       cp --recursive --force --verbose ${POLYBAR_BACKUP_DIR} ${PREFIX_LOCAL}/etc/polybar/config.ini
+  fi
+}


### PR DESCRIPTION
Closing #22276 and partially #22268 in favor of responding it's code into *"termux/termux-packages"* branch, through the prospect action.

![banner-dark-mode](https://github.com/user-attachments/assets/7adad80a-3ade-4b56-ae83-79e8ccf29f94)