### PR TITLE
fix(x11/firefox): fix Segmentation fault in the command "firefox -headless"

### DIFF
--- a/x11-packages/firefox/0030-fix-headless-mode.patch
+++ b/x11-packages/firefox/0030-fix-headless-mode.patch
@@ -1,0 +1,31 @@
+Fixes a crash in the command "firefox -headless" when run with no X11 server present
+in all distros when firefox was built with the edge case intersection of:
+with MOZ_HAS_REMOTE, with MOZ_X11, without MOZ_ENABLE_DBUS and without MOZ_WAYLAND
+
+as described here https://github.com/termux/termux-packages/issues/22286
+and here https://bugzilla.mozilla.org/show_bug.cgi?id=1946405
+
+--- a/toolkit/components/remote/nsGTKRemoteServer.cpp
++++ b/toolkit/components/remote/nsGTKRemoteServer.cpp
+@@ -18,9 +18,7 @@
+ 
+ #include "nsGTKToolkit.h"
+ 
+-#ifdef MOZ_WAYLAND
+-#  include "mozilla/WidgetUtilsGtk.h"
+-#endif
++#include "mozilla/WidgetUtilsGtk.h"
+ 
+ nsresult nsGTKRemoteServer::Startup(const char* aAppName,
+                                     const char* aProfileName) {
+@@ -36,6 +34,10 @@ nsresult nsGTKRemoteServer::Startup(const char* aAppName,
+   }
+ #endif
+ 
++  if (!mozilla::widget::GdkIsX11Display()) {
++    return NS_ERROR_FAILURE;
++  }
++
+   XRemoteBaseStartup(aAppName, aProfileName);
+ 
+   mServerWindow = gtk_invisible_new();

--- a/x11-packages/firefox/build.sh
+++ b/x11-packages/firefox/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Mozilla Firefox web browser"
 TERMUX_PKG_LICENSE="MPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="134.0.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://archive.mozilla.org/pub/firefox/releases/${TERMUX_PKG_VERSION}/source/firefox-${TERMUX_PKG_VERSION}.source.tar.xz
 TERMUX_PKG_SHA256=6c6eb7ff13fa689c5cace23a28533361d1ca29158329b6f1c2f2d1c91c53dd27
 # ffmpeg and pulseaudio are dependencies through dlopen(3):


### PR DESCRIPTION
- Fixes #22286

Fixes a crash in the command `firefox -headless` when run with no X11 server present
in all distros when firefox was built with the edge case intersection of:
with `MOZ_HAS_REMOTE`, with `MOZ_X11`, without `MOZ_ENABLE_DBUS` and without `MOZ_WAYLAND`

I have submitted this patch for feedback upstream here: https://bugzilla.mozilla.org/show_bug.cgi?id=1946405

This patch is a dependency of my project, "[How To Run Node.js Puppeteer On Android](https://gist.github.com/robertkirkman/0c2f3426024069546ed9b7bb2f26cb99)", which is a fully functional example of a Javascript program that invokes the system call `firefox -headless` through the Puppeteer library.

I am hoping to possibly upstream the patch part of the necessary code for the headless mode on Termux of the Firefox backend of the Puppeteer Node.js library by submitting this PR.