### PR TITLE
enhance(main/vim{,-python}, x11/vim-gtk): enable auto updates

### DIFF
--- a/packages/vim-python/build.sh
+++ b/packages/vim-python/build.sh
@@ -1,15 +1,15 @@
 TERMUX_PKG_HOMEPAGE=https://www.vim.org
-TERMUX_PKG_DESCRIPTION="Vi IMproved - enhanced vi editor"
+TERMUX_PKG_DESCRIPTION="Vi IMproved - enhanced vi editor - with python support"
 TERMUX_PKG_LICENSE="VIM License"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_DEPENDS="libiconv, ncurses, vim-runtime, python"
 TERMUX_PKG_RECOMMENDS="diffutils"
-# vim should only be updated every 50 releases on multiples of 50.
-# Update all of vim, vim-python and vim-gtk to the same version in one PR.
+TERMUX_PKG_CONFLICTS="vim"
 TERMUX_PKG_VERSION=9.1.0800
 TERMUX_PKG_SRCURL="https://github.com/vim/vim/archive/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=3bc15301f35addac9acde1da64da0976dbeafe1264e904c25a3cdc831e347303
-TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_CONFFILES="share/vim/vimrc"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 vim_cv_getcwd_broken=no
 vim_cv_memmove_handles_overlap=yes
@@ -18,29 +18,13 @@ vim_cv_terminfo=yes
 vim_cv_tgetent=zero
 vim_cv_toupper_broken=no
 vim_cv_tty_group=world
+--with-compiledby='Termux'
 --enable-gui=no
 --enable-multibyte
 --enable-netbeans=no
 --with-features=huge
---without-x
 --with-tlib=ncursesw
-"
-TERMUX_PKG_BUILD_IN_SRC=true
-TERMUX_PKG_RM_AFTER_INSTALL="
-bin/rview
-bin/rvim
-bin/ex
-share/man/man1/evim.1
-share/icons
-share/vim/vim91/spell/en.ascii*
-share/vim/vim91/print
-share/vim/vim91/tools
-"
-TERMUX_PKG_CONFFILES="share/vim/vimrc"
-
-# vim-python:
-TERMUX_PKG_CONFLICTS="vim"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS+="
+--without-x
 vi_cv_path_python3_pfx=$TERMUX_PREFIX
 vi_cv_path_python3_include=${TERMUX_PREFIX}/include/python${TERMUX_PYTHON_VERSION}
 vi_cv_path_python3_platinclude=${TERMUX_PREFIX}/include/python${TERMUX_PYTHON_VERSION}
@@ -49,9 +33,16 @@ vi_cv_var_python3_version=${TERMUX_PYTHON_VERSION}
 --enable-python3interp
 --with-python3-config-dir=$TERMUX_PYTHON_HOME/config-${TERMUX_PYTHON_VERSION}/
 "
-TERMUX_PKG_DESCRIPTION+=" - with python support"
+
 # Remove share/vim/vim91 which is in vim-runtime built as a subpackage of vim:
-TERMUX_PKG_RM_AFTER_INSTALL+=" share/vim/vim91"
+TERMUX_PKG_RM_AFTER_INSTALL="
+share/vim/vim91
+bin/rview
+bin/rvim
+bin/ex
+share/man/man1/evim.1
+share/icons
+"
 
 # Vim releases every commit as a new patch release.
 # To avoid auto update spam, we only update Vim every 50th patch.

--- a/packages/vim-python/build.sh
+++ b/packages/vim-python/build.sh
@@ -52,19 +52,35 @@ vi_cv_var_python3_version=${TERMUX_PYTHON_VERSION}
 TERMUX_PKG_DESCRIPTION+=" - with python support"
 # Remove share/vim/vim91 which is in vim-runtime built as a subpackage of vim:
 TERMUX_PKG_RM_AFTER_INSTALL+=" share/vim/vim91"
+
+# Vim releases every commit as a new patch release.
+# To avoid auto update spam, we only update Vim every 50th patch.
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_VERSION_REGEXP='\d+\.\d+\.\d{2}(5|0)0'
+
+termux_pkg_auto_update() {
+	# This auto_update function is shared by `vim`, `vim-python` and `vim-gtk`
+	# If you make changes to one of them,
+	# remember to apply that change to the other two as well.
+	local release
+	release="$(git ls-remote --tags https://github.com/vim/vim.git \
+	| grep -oP "refs/tags/v\K${TERMUX_PKG_UPDATE_VERSION_REGEXP}$" \
+	| sort -V \
+	| tail -n1)"
+
+	if [[ "${release}" == "${TERMUX_PKG_VERSION}" ]]; then
+		echo "INFO: No update needed. Already at version '${TERMUX_PKG_VERSION}'."
+		return
+	fi
+
+	termux_pkg_upgrade_version "${release}"
+}
+
 termux_step_pre_configure() {
 	# Certain packages are not safe to build on device because their
 	# build.sh script deletes specific files in $TERMUX_PREFIX.
 	if $TERMUX_ON_DEVICE_BUILD; then
 		termux_error_exit "Package '$TERMUX_PKG_NAME' is not safe for on-device builds."
-	fi
-
-	# Version guard
-	local ver_v=$(. $TERMUX_SCRIPTDIR/packages/vim/build.sh; echo ${TERMUX_PKG_VERSION#*:})
-	local ver_p=$(. $TERMUX_SCRIPTDIR/packages/vim-python/build.sh; echo ${TERMUX_PKG_VERSION#*:})
-	local ver_g=$(. $TERMUX_SCRIPTDIR/x11-packages/vim-gtk/build.sh; echo ${TERMUX_PKG_VERSION#*:})
-	if [ "${ver_v}" != "${ver_p}" ] || [ "${ver_p}" != "${ver_g}" ]; then
-		termux_error_exit "Version mismatch between vim, vim-python and vim-gtk."
 	fi
 
 	make distclean

--- a/packages/vim-python/build.sh
+++ b/packages/vim-python/build.sh
@@ -6,6 +6,7 @@ TERMUX_PKG_DEPENDS="libiconv, ncurses, vim-runtime, python"
 TERMUX_PKG_RECOMMENDS="diffutils"
 TERMUX_PKG_CONFLICTS="vim"
 TERMUX_PKG_VERSION=9.1.0800
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/vim/vim/archive/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=3bc15301f35addac9acde1da64da0976dbeafe1264e904c25a3cdc831e347303
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -77,18 +78,20 @@ termux_step_pre_configure() {
 	make distclean
 
 	# Remove eventually existing symlinks from previous builds so that they get re-created
-	for b in rview rvim ex view vimdiff; do rm -f $TERMUX_PREFIX/bin/$b; done
-	rm -f $TERMUX_PREFIX/share/man/man1/view.1
+	for sym in 'rview' 'rvim' 'ex' 'view' 'vimdiff'; do
+		rm -f "${TERMUX_PREFIX}/bin/${sym}"
+	done
+	rm -f "$TERMUX_PREFIX/share/man/man1/view.1"
 }
 
 termux_step_post_make_install() {
-	sed -e "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" $TERMUX_PKG_BUILDER_DIR/vimrc \
-		> $TERMUX_PREFIX/share/vim/vimrc
+	sed -e "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" "$TERMUX_PKG_BUILDER_DIR/vimrc" \
+		> "$TERMUX_PREFIX/share/vim/vimrc"
 
 	# Remove most tutor files:
-	cp $TERMUX_PREFIX/share/vim/vim91/tutor/{tutor,tutor.vim,tutor.utf-8} $TERMUX_PKG_TMPDIR/
-	rm -f $TERMUX_PREFIX/share/vim/vim91/tutor/*
-	cp $TERMUX_PKG_TMPDIR/{tutor,tutor.vim,tutor.utf-8} $TERMUX_PREFIX/share/vim/vim91/tutor/
+	cp "$TERMUX_PREFIX/share/vim/vim91/tutor"/{tutor,tutor.vim,tutor.utf-8} "$TERMUX_PKG_TMPDIR/"
+	rm -f "$TERMUX_PREFIX/share/vim/vim91/tutor"/*
+	cp "$TERMUX_PKG_TMPDIR"/{tutor,tutor.vim,tutor.utf-8} "$TERMUX_PREFIX/share/vim/vim91/tutor/"
 }
 
 termux_step_create_debscripts() {

--- a/packages/vim/build.sh
+++ b/packages/vim/build.sh
@@ -40,19 +40,34 @@ TERMUX_PKG_CONFFILES="share/vim/vimrc"
 
 TERMUX_PKG_CONFLICTS="vim-python"
 
+# Vim releases every commit as a new patch release.
+# To avoid auto update spam, we only update Vim every 50th patch.
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_VERSION_REGEXP='\d+\.\d+\.\d{2}(5|0)0'
+
+termux_pkg_auto_update() {
+	# This auto_update function is shared by `vim`, `vim-python` and `vim-gtk`
+	# If you make changes to one of them,
+	# remember to apply that change to the other two as well.
+	local release
+	release="$(git ls-remote --tags https://github.com/vim/vim.git \
+	| grep -oP "refs/tags/v\K${TERMUX_PKG_UPDATE_VERSION_REGEXP}$" \
+	| sort -V \
+	| tail -n1)"
+
+	if [[ "${release}" == "${TERMUX_PKG_VERSION}" ]]; then
+		echo "INFO: No update needed. Already at version '${TERMUX_PKG_VERSION}'."
+		return
+	fi
+
+	termux_pkg_upgrade_version "${release}"
+}
+
 termux_step_pre_configure() {
 	# Certain packages are not safe to build on device because their
 	# build.sh script deletes specific files in $TERMUX_PREFIX.
 	if $TERMUX_ON_DEVICE_BUILD; then
 		termux_error_exit "Package '$TERMUX_PKG_NAME' is not safe for on-device builds."
-	fi
-
-	# Version guard
-	local ver_v=$(. $TERMUX_SCRIPTDIR/packages/vim/build.sh; echo ${TERMUX_PKG_VERSION#*:})
-	local ver_p=$(. $TERMUX_SCRIPTDIR/packages/vim-python/build.sh; echo ${TERMUX_PKG_VERSION#*:})
-	local ver_g=$(. $TERMUX_SCRIPTDIR/x11-packages/vim-gtk/build.sh; echo ${TERMUX_PKG_VERSION#*:})
-	if [ "${ver_v}" != "${ver_p}" ] || [ "${ver_p}" != "${ver_g}" ]; then
-		termux_error_exit "Version mismatch between vim, vim-python and vim-gtk."
 	fi
 
 	make distclean

--- a/packages/vim/build.sh
+++ b/packages/vim/build.sh
@@ -6,6 +6,7 @@ TERMUX_PKG_DEPENDS="libiconv, ncurses, vim-runtime"
 TERMUX_PKG_RECOMMENDS="diffutils"
 TERMUX_PKG_CONFLICTS="vim-python" # probably also , vim-gtk"
 TERMUX_PKG_VERSION=9.1.0800
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/vim/vim/archive/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=3bc15301f35addac9acde1da64da0976dbeafe1264e904c25a3cdc831e347303
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -71,18 +72,20 @@ termux_step_pre_configure() {
 	make distclean
 
 	# Remove eventually existing symlinks from previous builds so that they get re-created
-	for b in rview rvim ex view vimdiff; do rm -f $TERMUX_PREFIX/bin/$b; done
-	rm -f $TERMUX_PREFIX/share/man/man1/view.1
+	for sym in 'rview' 'rvim' 'ex' 'view' 'vimdiff'; do
+		rm -f "${TERMUX_PREFIX}/bin/${sym}"
+	done
+	rm -f "$TERMUX_PREFIX/share/man/man1/view.1"
 }
 
 termux_step_post_make_install() {
-	sed -e "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" $TERMUX_PKG_BUILDER_DIR/vimrc \
-		> $TERMUX_PREFIX/share/vim/vimrc
+	sed -e "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" "$TERMUX_PKG_BUILDER_DIR/vimrc" \
+		> "$TERMUX_PREFIX/share/vim/vimrc"
 
 	# Remove most tutor files:
-	cp $TERMUX_PREFIX/share/vim/vim91/tutor/{tutor,tutor.vim,tutor.utf-8} $TERMUX_PKG_TMPDIR/
-	rm -f $TERMUX_PREFIX/share/vim/vim91/tutor/*
-	cp $TERMUX_PKG_TMPDIR/{tutor,tutor.vim,tutor.utf-8} $TERMUX_PREFIX/share/vim/vim91/tutor/
+	cp "$TERMUX_PREFIX/share/vim/vim91/tutor"/{tutor,tutor.vim,tutor.utf-8} "$TERMUX_PKG_TMPDIR"/
+	rm -f "$TERMUX_PREFIX/share/vim/vim91/tutor"/*
+	cp "$TERMUX_PKG_TMPDIR"/{tutor,tutor.vim,tutor.utf-8} "$TERMUX_PREFIX/share/vim/vim91/tutor/"
 }
 
 termux_step_create_debscripts() {

--- a/packages/vim/build.sh
+++ b/packages/vim/build.sh
@@ -4,12 +4,12 @@ TERMUX_PKG_LICENSE="VIM License"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_DEPENDS="libiconv, ncurses, vim-runtime"
 TERMUX_PKG_RECOMMENDS="diffutils"
-# vim should only be updated every 50 releases on multiples of 50.
-# Update all of vim, vim-python and vim-gtk to the same version in one PR.
+TERMUX_PKG_CONFLICTS="vim-python" # probably also , vim-gtk"
 TERMUX_PKG_VERSION=9.1.0800
 TERMUX_PKG_SRCURL="https://github.com/vim/vim/archive/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=3bc15301f35addac9acde1da64da0976dbeafe1264e904c25a3cdc831e347303
-TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_CONFFILES="share/vim/vimrc"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 vim_cv_getcwd_broken=no
 vim_cv_memmove_handles_overlap=yes
@@ -18,14 +18,15 @@ vim_cv_terminfo=yes
 vim_cv_tgetent=zero
 vim_cv_toupper_broken=no
 vim_cv_tty_group=world
+--with-compiledby='Termux'
 --enable-gui=no
 --enable-multibyte
 --enable-netbeans=no
 --with-features=huge
---without-x
 --with-tlib=ncursesw
+--without-x
 "
-TERMUX_PKG_BUILD_IN_SRC=true
+
 TERMUX_PKG_RM_AFTER_INSTALL="
 bin/rview
 bin/rvim
@@ -36,9 +37,6 @@ share/vim/vim91/spell/en.ascii*
 share/vim/vim91/print
 share/vim/vim91/tools
 "
-TERMUX_PKG_CONFFILES="share/vim/vimrc"
-
-TERMUX_PKG_CONFLICTS="vim-python"
 
 # Vim releases every commit as a new patch release.
 # To avoid auto update spam, we only update Vim every 50th patch.

--- a/x11-packages/vim-gtk/build.sh
+++ b/x11-packages/vim-gtk/build.sh
@@ -2,25 +2,14 @@ TERMUX_PKG_HOMEPAGE=https://www.vim.org
 TERMUX_PKG_DESCRIPTION="Vi IMproved - enhanced vi editor"
 TERMUX_PKG_LICENSE="VIM License"
 TERMUX_PKG_MAINTAINER="@termux"
-
-# vim should only be updated every 50 releases on multiples of 50.
-# Update all of vim, vim-python and vim-gtk to the same version in one PR.
+TERMUX_PKG_DEPENDS="gdk-pixbuf, glib, gtk3, libcairo, libcanberra, libice, libiconv, liblua52, libsm, libx11, libxt, ncurses, pango, python"
+TERMUX_PKG_RECOMMENDS="diffutils"
+TERMUX_PKG_CONFLICTS="vim, vim-python, vim-runtime"
 TERMUX_PKG_VERSION=9.1.0800
 TERMUX_PKG_SRCURL="https://github.com/vim/vim/archive/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=3bc15301f35addac9acde1da64da0976dbeafe1264e904c25a3cdc831e347303
-TERMUX_PKG_AUTO_UPDATE=false
-TERMUX_PKG_DEPENDS="gdk-pixbuf, glib, gtk3, libcairo, libcanberra, libice, libiconv, liblua52, libsm, libx11, libxt, ncurses, pango, python"
-TERMUX_PKG_CONFLICTS="vim, vim-python, vim-runtime"
 TERMUX_PKG_BUILD_IN_SRC=true
-
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
-ac_cv_small_wchar_t=no
-ac_cv_path_vi_cv_path_plain_lua=lua5.2
-vi_cv_path_python3_pfx=$TERMUX_PREFIX
-vi_cv_path_python3_include=${TERMUX_PREFIX}/include/python${TERMUX_PYTHON_VERSION}
-vi_cv_path_python3_platinclude=${TERMUX_PREFIX}/include/python${TERMUX_PYTHON_VERSION}
-vi_cv_var_python3_abiflags=
-vi_cv_var_python3_version=${TERMUX_PYTHON_VERSION}
 vim_cv_getcwd_broken=no
 vim_cv_memmove_handles_overlap=yes
 vim_cv_stat_ignores_slash=no
@@ -28,16 +17,28 @@ vim_cv_terminfo=yes
 vim_cv_tgetent=zero
 vim_cv_toupper_broken=no
 vim_cv_tty_group=world
---enable-cscope
+--with-compiledby='Termux'
 --enable-gui=gtk3
 --enable-multibyte
---enable-luainterp
---enable-python3interp
+--enable-netbeans=no
 --with-features=huge
 --with-lua-prefix=$TERMUX_PREFIX
 --with-python3-config-dir=$TERMUX_PYTHON_HOME/config-${TERMUX_PYTHON_VERSION}/
 --with-tlib=ncursesw
---with-x"
+--with-x
+ac_cv_small_wchar_t=no
+--enable-cscope
+vi_cv_path_python3_pfx=$TERMUX_PREFIX
+vi_cv_path_python3_include=${TERMUX_PREFIX}/include/python${TERMUX_PYTHON_VERSION}
+vi_cv_path_python3_platinclude=${TERMUX_PREFIX}/include/python${TERMUX_PYTHON_VERSION}
+vi_cv_var_python3_abiflags=
+vi_cv_var_python3_version=${TERMUX_PYTHON_VERSION}
+--enable-python3interp
+--with-python3-config-dir=$TERMUX_PYTHON_HOME/config-${TERMUX_PYTHON_VERSION}/
+ac_cv_path_vi_cv_path_plain_lua=lua5.2
+--enable-luainterp
+--with-lua-prefix=$TERMUX_PREFIX
+"
 
 TERMUX_PKG_RM_AFTER_INSTALL="
 share/vim/vim91/spell/en.ascii*
@@ -73,6 +74,11 @@ termux_pkg_auto_update() {
 termux_step_pre_configure() {
 	LDFLAGS+=" -landroid-shmem"
 
+	# Certain packages are not safe to build on device because their
+	# build.sh script deletes specific files in $TERMUX_PREFIX.
+	if $TERMUX_ON_DEVICE_BUILD; then
+		termux_error_exit "Package '$TERMUX_PKG_NAME' is not safe for on-device builds."
+	fi
 
 	make distclean
 

--- a/x11-packages/vim-gtk/build.sh
+++ b/x11-packages/vim-gtk/build.sh
@@ -6,6 +6,7 @@ TERMUX_PKG_DEPENDS="gdk-pixbuf, glib, gtk3, libcairo, libcanberra, libice, libic
 TERMUX_PKG_RECOMMENDS="diffutils"
 TERMUX_PKG_CONFLICTS="vim, vim-python, vim-runtime"
 TERMUX_PKG_VERSION=9.1.0800
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/vim/vim/archive/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=3bc15301f35addac9acde1da64da0976dbeafe1264e904c25a3cdc831e347303
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -22,8 +23,6 @@ vim_cv_tty_group=world
 --enable-multibyte
 --enable-netbeans=no
 --with-features=huge
---with-lua-prefix=$TERMUX_PREFIX
---with-python3-config-dir=$TERMUX_PYTHON_HOME/config-${TERMUX_PYTHON_VERSION}/
 --with-tlib=ncursesw
 --with-x
 ac_cv_small_wchar_t=no
@@ -83,14 +82,14 @@ termux_step_pre_configure() {
 	make distclean
 
 	# Remove eventually existing symlinks from previous builds so that they get re-created.
-	for link in eview evim ex gview gvim gvimdiff rgview rgvim rview rvim view vimdiff; do
-		rm -f $TERMUX_PREFIX/bin/$link
-		rm -f $TERMUX_PREFIX/share/man/man1/${link}.1*
+	for sym in 'eview' 'evim' 'ex' 'gview' 'gvim' 'gvimdiff' 'rgview' 'rgvim' 'rview' 'rvim' 'view' 'vimdiff'; do
+		rm -f "$TERMUX_PREFIX/bin/${sym}"
+		rm -f "$TERMUX_PREFIX/share/man/man1/${sym}.1"*
 	done
 }
 
 termux_step_post_make_install() {
-	install -Dm600 $TERMUX_PKG_BUILDER_DIR/vimrc $TERMUX_PREFIX/share/vim/vimrc
-	sed -i "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|g" $TERMUX_PREFIX/share/vim/vimrc
-	ln -sfr $TERMUX_PREFIX/bin/vim $TERMUX_PREFIX/bin/vi
+	install -Dm600 "$TERMUX_PKG_BUILDER_DIR/vimrc" "$TERMUX_PREFIX/share/vim/vimrc"
+	sed -i "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|g" "$TERMUX_PREFIX/share/vim/vimrc"
+	ln -sfr "$TERMUX_PREFIX/bin/vim" "$TERMUX_PREFIX/bin/vi"
 }

--- a/x11-packages/vim-gtk/build.sh
+++ b/x11-packages/vim-gtk/build.sh
@@ -47,16 +47,32 @@ share/vim/vim91/tools
 
 TERMUX_PKG_CONFFILES="share/vim/vimrc"
 
+# Vim releases every commit as a new patch release.
+# To avoid auto update spam, we only update Vim every 50th patch.
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_VERSION_REGEXP='\d+\.\d+\.\d{2}(5|0)0'
+
+termux_pkg_auto_update() {
+	# This auto_update function is shared by `vim`, `vim-python` and `vim-gtk`
+	# If you make changes to one of them,
+	# remember to apply that change to the other two as well.
+	local release
+	release="$(git ls-remote --tags https://github.com/vim/vim.git \
+	| grep -oP "refs/tags/v\K${TERMUX_PKG_UPDATE_VERSION_REGEXP}$" \
+	| sort -V \
+	| tail -n1)"
+
+	if [[ "${release}" == "${TERMUX_PKG_VERSION}" ]]; then
+		echo "INFO: No update needed. Already at version '${TERMUX_PKG_VERSION}'."
+		return
+	fi
+
+	termux_pkg_upgrade_version "${release}"
+}
+
 termux_step_pre_configure() {
 	LDFLAGS+=" -landroid-shmem"
 
-	# Version guard
-	local ver_v=$(. $TERMUX_SCRIPTDIR/packages/vim/build.sh; echo ${TERMUX_PKG_VERSION#*:})
-	local ver_p=$(. $TERMUX_SCRIPTDIR/packages/vim-python/build.sh; echo ${TERMUX_PKG_VERSION#*:})
-	local ver_g=$(. $TERMUX_SCRIPTDIR/x11-packages/vim-gtk/build.sh; echo ${TERMUX_PKG_VERSION#*:})
-	if [ "${ver_v}" != "${ver_p}" ] || [ "${ver_p}" != "${ver_g}" ]; then
-		termux_error_exit "Version mismatch between vim, vim-python and vim-gtk."
-	fi
 
 	make distclean
 


### PR DESCRIPTION
This PR does a couple of things:
- First and foremost, enable auto updates on every 50th patch for `vim`, `vim-python` and `vim-gtk`.

As part of some housekeeping I have also standardized the order of control variables between the three build scripts,
and done some general cleanup.

This isn't quite everything I have planned, but it's good enough for review.

I'd like to additionally:
- Split out `xxd` into a separate and independent subpackage so it can be installed as a standalone utility.
- and retire the `vim-python` package in favor of enabling `python` (vim-python), `lua` (VimL), and potentially `perl`, `ruby` and `tcl` (which are also supported) on both `vim` and `vim-gtk`.
  - for `lua` I'd also like to switch over the interpreter 

But that can wait for another time.