### PR TITLE
chore(main/libimobiledevice,libusbmuxd): drop depends usbmuxd

### DIFF
--- a/packages/libimobiledevice/build.sh
+++ b/packages/libimobiledevice/build.sh
@@ -6,11 +6,12 @@ _COMMIT=860ffb707af3af94467d2ece4ad258dda957c6cd
 _COMMIT_DATE=20230430
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.3.0-p${_COMMIT_DATE}
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/libimobiledevice/libimobiledevice
 TERMUX_PKG_SHA256=5b88f3b348f06fe9d1b5ffc639f813b5956d757e527d5c7ca724a64c1b0b3b4e
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_AUTO_UPDATE=false
-TERMUX_PKG_DEPENDS="libimobiledevice-glue, libplist, libusbmuxd, openssl, usbmuxd"
+TERMUX_PKG_DEPENDS="libimobiledevice-glue, libplist, libusbmuxd, openssl"
 
 termux_step_post_get_source() {
 	git fetch --unshallow

--- a/packages/libusbmuxd/build.sh
+++ b/packages/libusbmuxd/build.sh
@@ -5,12 +5,12 @@ TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=f47c36f5bd2a653a3bd7fb1cf1d2c50b0e6193fb
 _COMMIT_DATE=20230430
 TERMUX_PKG_VERSION=2.0.2-p${_COMMIT_DATE}
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=git+https://github.com/libimobiledevice/libusbmuxd
 TERMUX_PKG_SHA256=c415b8859ccae494387c14dc9c297910843b16b5ba62aab15d51116137b513c4
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_AUTO_UPDATE=false
-TERMUX_PKG_DEPENDS="libimobiledevice-glue, libplist, libusb, usbmuxd"
+TERMUX_PKG_DEPENDS="libimobiledevice-glue, libplist, libusb"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --without-preflight
 --without-systemd


### PR DESCRIPTION
Fix #21176

@Grimler91 @sylirre
Please clean up https://packages-cf.termux.dev/apt/termux-main/pool/main/u/usbmuxd/
since it was  moved to https://packages-cf.termux.dev/apt/termux-root/pool/stable/u/usbmuxd/