### PR TITLE
chore(main/ansifilter): dont build Qt GUI

### DIFF
--- a/packages/ansifilter/build.sh
+++ b/packages/ansifilter/build.sh
@@ -3,16 +3,18 @@ TERMUX_PKG_DESCRIPTION="Strip or convert ANSI codes into HTML, (La)Tex, RTF, or 
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.21
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://gitlab.com/saalen/ansifilter
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_GIT_BRANCH="$TERMUX_PKG_VERSION"
 TERMUX_PKG_BUILD_IN_SRC=true
-TERMUX_PKG_DEPENDS="libc++, boost, qt6-qtbase"
+TERMUX_PKG_DEPENDS="libc++"
 TERMUX_PKG_EXTRA_MAKE_ARGS="
 DESTDIR=${TERMUX_PREFIX}
 PREFIX=
 "
 
 termux_step_pre_configure() {
+	# dont build Qt GUI
 	rm $TERMUX_PKG_SRCDIR/CMakeLists.txt
 }


### PR DESCRIPTION
It is impossible to install ansifilter before this and wrongly depends on Qt6 when there is no GUI built