### PR TITLE
fix(main/neovim): turn nvim into a wrapper

### DIFF
--- a/packages/neovim/build.sh
+++ b/packages/neovim/build.sh
@@ -83,6 +83,12 @@ termux_step_post_make_install() {
 
 	# Tree-sitter grammars are packaged separately and installed into TERMUX_PREFIX/lib/tree_sitter.
 	ln -s "${TERMUX_PREFIX}"/lib/tree_sitter "${TERMUX_PREFIX}"/share/nvim/runtime/parser
+
+	# Move the `nvim` binary to $PREFIX/libexec
+	# and replace it with our LD_PRELOAD shim.
+	# See: packages/neovim/nvim-shim.sh for details.
+	mv "${TERMUX_PREFIX}"/bin/nvim "${TERMUX_PREFIX}"/libexec/nvim
+	install -m755 "$TERMUX_PKG_BUILDER_DIR/nvim-shim.sh" "${TERMUX_PREFIX}/bin/nvim"
 }
 
 termux_step_create_debscripts() {

--- a/packages/neovim/build.sh
+++ b/packages/neovim/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="Apache-2.0, VIM License"
 TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION="0.10.2"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://github.com/neovim/neovim/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=546cb2da9fffbb7e913261344bbf4cf1622721f6c5a67aa77609e976e78b8e89
 TERMUX_PKG_AUTO_UPDATE=true
@@ -34,15 +34,15 @@ termux_pkg_auto_update() {
 
 _patch_luv() {
 	# git submodule update --init deps/lua-compat-5.3 failed
-	cp -r $1/build/src/lua-compat-5.3/* $1/build/src/luv/deps/lua-compat-5.3/
-	cp -r $1/build/src/luajit/* $1/build/src/luv/deps/luajit/
-	cp -r $1/build/src/libuv/* $1/build/src/luv/deps/libuv/
+	cp -r "$1/build/src/lua-compat-5.3"/* "$1/build/src/luv/deps/lua-compat-5.3/"
+	cp -r "$1/build/src/luajit"/* "$1/build/src/luv/deps/luajit/"
+	cp -r "$1/build/src/libuv"/* "$1/build/src/luv/deps/libuv/"
 }
 
 termux_step_host_build() {
 	termux_setup_cmake
 
-	TERMUX_ORIGINAL_CMAKE=$(command -v cmake)
+	TERMUX_ORIGINAL_CMAKE="$(command -v cmake)"
 	if [ ! -f "$TERMUX_ORIGINAL_CMAKE.orig" ]; then
 		mv "$TERMUX_ORIGINAL_CMAKE" "$TERMUX_ORIGINAL_CMAKE.orig"
 	fi
@@ -50,26 +50,26 @@ termux_step_host_build() {
 	chmod +x "$TERMUX_ORIGINAL_CMAKE"
 	export TERMUX_ORIGINAL_CMAKE="$TERMUX_ORIGINAL_CMAKE.orig"
 
-	mkdir -p $TERMUX_PKG_HOSTBUILD_DIR/deps
-	cd $TERMUX_PKG_HOSTBUILD_DIR/deps
-	cmake $TERMUX_PKG_SRCDIR/cmake.deps
+	mkdir -p "$TERMUX_PKG_HOSTBUILD_DIR/deps"
+	cd "$TERMUX_PKG_HOSTBUILD_DIR/deps" || termux_error_exit "Error: failed to perform host build for nvim"
+	cmake "$TERMUX_PKG_SRCDIR/cmake.deps"
 
 	make -j 1 \
-		|| (_patch_luv $TERMUX_PKG_HOSTBUILD_DIR/deps && make -j 1)
+		|| (_patch_luv "$TERMUX_PKG_HOSTBUILD_DIR/deps" && make -j 1)
 
-	cd $TERMUX_PKG_SRCDIR
+	cd "$TERMUX_PKG_SRCDIR" || termux_error_exit "Error: failed to perform host build for nvim"
 
 	make CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$TERMUX_PKG_HOSTBUILD_DIR -DUSE_BUNDLED_LUAROCKS=ON" install ||
-		(_patch_luv $TERMUX_PKG_SRCDIR/.deps && make CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$TERMUX_PKG_HOSTBUILD_DIR -DUSE_BUNDLED_LUAROCKS=ON" install)
+		(_patch_luv "$TERMUX_PKG_SRCDIR/.deps" && make CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$TERMUX_PKG_HOSTBUILD_DIR -DUSE_BUNDLED_LUAROCKS=ON" install)
 
 	# Copy away host-built libnlua0.so used by src/nvim/generators/preload.lua.
 	# We patch src/nvim/CMakeLists.txt to use this instead of the cross-compiled one.
-	cp ./build/lib/libnlua0.so $TERMUX_PKG_HOSTBUILD_DIR/
+	cp ./build/lib/libnlua0.so "$TERMUX_PKG_HOSTBUILD_DIR/"
 
 	make distclean
 	rm -Rf build/
 
-	cd $TERMUX_PKG_HOSTBUILD_DIR
+	cd "$TERMUX_PKG_HOSTBUILD_DIR" || termux_error_exit "Error: failed to perform host build for nvim"
 }
 
 termux_step_pre_configure() {
@@ -78,11 +78,11 @@ termux_step_pre_configure() {
 
 termux_step_post_make_install() {
 	local _CONFIG_DIR=$TERMUX_PREFIX/share/nvim
-	mkdir -p $_CONFIG_DIR
-	cp $TERMUX_PKG_BUILDER_DIR/sysinit.vim $_CONFIG_DIR/
+	mkdir -p "$_CONFIG_DIR"
+	cp "$TERMUX_PKG_BUILDER_DIR/sysinit.vim" "$_CONFIG_DIR/"
 
 	# Tree-sitter grammars are packaged separately and installed into TERMUX_PREFIX/lib/tree_sitter.
-	ln -s "${TERMUX_PREFIX}"/lib/tree_sitter "${TERMUX_PREFIX}"/share/nvim/runtime/parser
+	ln -sf "${TERMUX_PREFIX}"/lib/tree_sitter "${TERMUX_PREFIX}"/share/nvim/runtime/parser
 
 	# Move the `nvim` binary to $PREFIX/libexec
 	# and replace it with our LD_PRELOAD shim.

--- a/packages/neovim/nvim-shim.sh
+++ b/packages/neovim/nvim-shim.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+# For further details see:
+# https://github.com/termux/termux-packages/issues/22328
+# https://github.com/termux/termux-packages/wiki/Common-porting-problems#android-dynamic-linker
+# https://github.com/android/ndk/issues/201
+#
+# Shim to properly expose LuaJIT runtime symbols to dynamically linked plugin modules
+LD_PRELOAD="$LD_PRELOAD:libluajit.so" exec "$PREFIX/libexec/nvim" "$@"


### PR DESCRIPTION
See #22328 for further discussion.

My main concern with this PR is that the workaround is likely brittle; Android's `dlopen`, which was already deliberately broken to prevent loading dynamic libraries, might very well be broken further by future Android versions when the Android people realize `LD_PRELOAD` is currently handled correctly.

Also fixes a minor idempotency issue (repeated builds of neovim failed previously, leaving `/data/data/com.termux/usr/bin/sh` as a symlink to `/bin/sh`).