### PR TITLE
addpkg(x11/swaybg): 1.2.1

### DIFF
--- a/x11-packages/swaybg/0001-use-cross-wayland-scanner.patch
+++ b/x11-packages/swaybg/0001-use-cross-wayland-scanner.patch
@@ -1,0 +1,20 @@
+--- a/meson.build
++++ b/meson.build
+@@ -36,7 +36,7 @@
+ gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('gdk-pixbuf'))
+ 
+ git = find_program('git', required: false, native: true)
+-scdoc = find_program('scdoc', required: get_option('man-pages'), native: true)
++scdoc = find_program('scdoc', required: get_option('man-pages'))
+ 
+ version = '"@0@"'.format(meson.project_version())
+ if git.found()
+@@ -54,7 +54,7 @@
+ 
+ wl_protocol_dir = wayland_protos.get_variable('pkgdatadir')
+ 
+-wayland_scanner_prog = find_program(wayland_scanner.get_variable('wayland_scanner'), native: true)
++wayland_scanner_prog = find_program('wayland-scanner')
+ 
+ wayland_scanner_code = generator(
+ 	wayland_scanner_prog,

--- a/x11-packages/swaybg/0002-impl-shm_open.patch
+++ b/x11-packages/swaybg/0002-impl-shm_open.patch
@@ -1,0 +1,71 @@
+--- a/pool-buffer.c
++++ b/pool-buffer.c
+@@ -12,6 +12,68 @@
+ #include <wayland-client.h>
+ #include "pool-buffer.h"
+ 
++#ifdef __ANDROID__
++#include <alloca.h>
++static int shm_unlink(const char *name) {
++    size_t namelen;
++    char *fname;
++
++    /* Construct the filename.  */
++    while (name[0] == '/') ++name;
++
++    if (name[0] == '\0') {
++        /* The name "/" is not supported.  */
++        errno = EINVAL;
++        return -1;
++    }
++
++    namelen = strlen(name);
++    fname = (char *) alloca(sizeof("@TERMUX_PREFIX@/tmp/") - 1 + namelen + 1);
++    memcpy(fname, "@TERMUX_PREFIX@/tmp/", sizeof("@TERMUX_PREFIX@/tmp/") - 1);
++    memcpy(fname + sizeof("@TERMUX_PREFIX@/tmp/") - 1, name, namelen + 1);
++
++    return unlink(fname);
++}
++
++static int shm_open(const char *name, int oflag, mode_t mode) {
++    size_t namelen;
++    char *fname;
++    int fd;
++
++    /* Construct the filename.  */
++    while (name[0] == '/') ++name;
++
++    if (name[0] == '\0') {
++        /* The name "/" is not supported.  */
++        errno = EINVAL;
++        return -1;
++    }
++
++    namelen = strlen(name);
++    fname = (char *) alloca(sizeof("@TERMUX_PREFIX@/tmp/") - 1 + namelen + 1);
++    memcpy(fname, "@TERMUX_PREFIX@/tmp/", sizeof("@TERMUX_PREFIX@/tmp/") - 1);
++    memcpy(fname + sizeof("@TERMUX_PREFIX@/tmp/") - 1, name, namelen + 1);
++
++    fd = open(fname, oflag, mode);
++    if (fd != -1) {
++        /* We got a descriptor.  Now set the FD_CLOEXEC bit.  */
++        int flags = fcntl(fd, F_GETFD, 0);
++        flags |= FD_CLOEXEC;
++        flags = fcntl(fd, F_SETFD, flags);
++
++        if (flags == -1) {
++            /* Something went wrong.  We cannot return the descriptor.  */
++            int save_errno = errno;
++            close(fd);
++            fd = -1;
++            errno = save_errno;
++        }
++    }
++
++    return fd;
++}
++#endif
++
+ static int anonymous_shm_open(void) {
+ 	int retries = 100;
+ 

--- a/x11-packages/swaybg/build.sh
+++ b/x11-packages/swaybg/build.sh
@@ -1,0 +1,15 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/swaywm/swaybg
+TERMUX_PKG_DESCRIPTION="Wallpaper tool for Wayland compositors"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="1.2.1"
+TERMUX_PKG_SRCURL=https://github.com/swaywm/swaybg/releases/download/v${TERMUX_PKG_VERSION}/swaybg-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=6af1fdf0e57b1cc5345febed786b761fea0e170943a82639f94cfaed7df84f8f
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="gdk-pixbuf, libcairo, libwayland"
+TERMUX_PKG_BUILD_DEPENDS="libwayland-protocols"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-Dgdk-pixbuf=enabled
+-Dman-pages=enabled
+-Dwerror=false
+"


### PR DESCRIPTION
Required for sway. Otherwise, the following warning is shown. [sway/config/output.c:1071] failed to execute 'swaybg' (background configuration probably not applied): No such file or directory