### PR TITLE
bump(x11/libfcft): 3.1.9

### DIFF
--- a/x11-packages/libfcft/build.sh
+++ b/x11-packages/libfcft/build.sh
@@ -2,8 +2,12 @@ TERMUX_PKG_HOMEPAGE=https://codeberg.org/dnkl/fcft
 TERMUX_PKG_DESCRIPTION="A small font loading and glyph rasterization library"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="3.1.7"
-TERMUX_PKG_SRCURL=https://codeberg.org/dnkl/fcft/archive/${TERMUX_PKG_VERSION[0]}.tar.gz
-TERMUX_PKG_SHA256=0e29ea7edca4cf6f0ac6b4f6427a4606c184b3d809071e7d2f56fcc226574d30
-TERMUX_PKG_DEPENDS="fontconfig, freetype, harfbuzz, libpixman, libwayland, libxkbcommon, utf8proc"
-TERMUX_PKG_BUILD_DEPENDS="libtllist"
+TERMUX_PKG_VERSION="3.1.9"
+TERMUX_PKG_SRCURL=https://codeberg.org/dnkl/fcft/archive/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=4b7e3b2ab7e14f532d8a9cb0f2d3b0cdf9d2919b95e6ab8030f7ac87d059c2b6
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="fontconfig, freetype, harfbuzz, libpixman, utf8proc"
+TERMUX_PKG_BUILD_DEPENDS="libtllist, scdoc"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-Ddocs=enabled
+"

--- a/x11-packages/libfcft/doc-meson.build.patch
+++ b/x11-packages/libfcft/doc-meson.build.patch
@@ -1,0 +1,10 @@
+--- a/doc/meson.build
++++ b/doc/meson.build
+@@ -1,6 +1,6 @@
+ sh = find_program('sh', native: true)
+ 
+-scdoc_prog = find_program(scdoc.get_variable('scdoc'), native: true)
++scdoc_prog = find_program('scdoc')
+ 
+ foreach man_src : ['fcft_capabilities.3.scd',
+                    'fcft_clone.3.scd',


### PR DESCRIPTION
* Enable auto update and man pages.
* Remove unused dependencies.