### PR TITLE
addpkg(x11/luanti{-common,-server}): moved from TUR 

### DIFF
--- a/x11-packages/luanti/0001-enable-egl-without-sdl2.patch
+++ b/x11-packages/luanti/0001-enable-egl-without-sdl2.patch
@@ -1,0 +1,457 @@
+This is https://github.com/minetest/minetest/commit/4838eb2 cherry-picked to enable EGL
+support while using OpenGL ES without SDL2 enabled (using only Irrlicht).
+--- a/irr/src/CIrrDeviceLinux.cpp
++++ b/irr/src/CIrrDeviceLinux.cpp
+@@ -38,7 +38,7 @@
+ #include "CEGLManager.h"
+ #endif
+ 
+-#if defined(_IRR_COMPILE_WITH_OPENGL_)
++#if defined(_IRR_COMPILE_WITH_GLX_MANAGER_)
+ #include "CGLXManager.h"
+ #endif
+ 
+@@ -69,24 +69,6 @@
+ 
+ #endif // _IRR_COMPILE_WITH_JOYSTICK_EVENTS_
+ 
+-namespace irr
+-{
+-namespace video
+-{
+-#ifdef _IRR_COMPILE_WITH_OPENGL_
+-IVideoDriver *createOpenGLDriver(const irr::SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager);
+-#endif
+-
+-#ifdef _IRR_COMPILE_WITH_OGLES2_
+-IVideoDriver *createOGLES2Driver(const irr::SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager);
+-#endif
+-
+-#ifdef _IRR_COMPILE_WITH_WEBGL1_
+-IVideoDriver *createWebGL1Driver(const irr::SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager);
+-#endif
+-}
+-} // end namespace irr
+-
+ namespace
+ {
+ Atom X_ATOM_CLIPBOARD;
+@@ -397,10 +379,11 @@ bool CIrrDeviceLinux::createWindow()
+ 	if (WMCheck != None)
+ 		HasNetWM = true;
+ 
+-#if defined(_IRR_COMPILE_WITH_OPENGL_)
++#if defined(_IRR_COMPILE_WITH_GLX_MANAGER_)
+ 	// don't use the XVisual with OpenGL, because it ignores all requested
+ 	// properties of the CreationParams
+-	if (CreationParams.DriverType == video::EDT_OPENGL) {
++	if (CreationParams.DriverType == video::EDT_OPENGL
++			|| CreationParams.DriverType == video::EDT_OPENGL3) {
+ 		video::SExposedVideoData data;
+ 		data.OpenGLLinux.X11Display = XDisplay;
+ 		ContextManager = new video::CGLXManager(CreationParams, data, Screennr);
+@@ -539,51 +522,54 @@ void CIrrDeviceLinux::createDriver()
+ 	switch (CreationParams.DriverType) {
+ #ifdef _IRR_COMPILE_WITH_X11_
+ 	case video::EDT_OPENGL:
+-#ifdef _IRR_COMPILE_WITH_OPENGL_
+ 	{
++#ifdef _IRR_COMPILE_WITH_OPENGL_
+ 		video::SExposedVideoData data;
+ 		data.OpenGLLinux.X11Window = XWindow;
+ 		data.OpenGLLinux.X11Display = XDisplay;
+ 
+ 		ContextManager->initialize(CreationParams, data);
+-
++#endif
+ 		VideoDriver = video::createOpenGLDriver(CreationParams, FileSystem, ContextManager);
+ 	}
+-#else
+-		os::Printer::log("No OpenGL support compiled in.", ELL_ERROR);
++	break;
++	case video::EDT_OPENGL3:
++	{
++#ifdef ENABLE_OPENGL3
++		video::SExposedVideoData data;
++		data.OpenGLLinux.X11Window = XWindow;
++		data.OpenGLLinux.X11Display = XDisplay;
++
++		ContextManager->initialize(CreationParams, data);
+ #endif
++		VideoDriver = video::createOpenGL3Driver(CreationParams, FileSystem, ContextManager);
++	}
+ 	break;
+ 	case video::EDT_OGLES2:
+-#ifdef _IRR_COMPILE_WITH_OGLES2_
+ 	{
++#ifdef _IRR_COMPILE_WITH_OGLES2_
+ 		video::SExposedVideoData data;
+ 		data.OpenGLLinux.X11Window = XWindow;
+ 		data.OpenGLLinux.X11Display = XDisplay;
+ 
+ 		ContextManager = new video::CEGLManager();
+ 		ContextManager->initialize(CreationParams, data);
+-
++#endif
+ 		VideoDriver = video::createOGLES2Driver(CreationParams, FileSystem, ContextManager);
+ 	}
+-#else
+-		os::Printer::log("No OpenGL-ES2 support compiled in.", ELL_ERROR);
+-#endif
+ 	break;
+ 	case video::EDT_WEBGL1:
+-#ifdef _IRR_COMPILE_WITH_WEBGL1_
+ 	{
++#ifdef _IRR_COMPILE_WITH_WEBGL1_
+ 		video::SExposedVideoData data;
+ 		data.OpenGLLinux.X11Window = XWindow;
+ 		data.OpenGLLinux.X11Display = XDisplay;
+ 
+ 		ContextManager = new video::CEGLManager();
+ 		ContextManager->initialize(CreationParams, data);
+-
++#endif
+ 		VideoDriver = video::createWebGL1Driver(CreationParams, FileSystem, ContextManager);
+ 	}
+-#else
+-		os::Printer::log("No WebGL1 support compiled in.", ELL_ERROR);
+-#endif
+ 	break;
+ 	case video::EDT_NULL:
+ 		VideoDriver = video::createNullDriver(FileSystem, CreationParams.WindowSize);
+@@ -591,7 +577,7 @@ void CIrrDeviceLinux::createDriver()
+ 	default:
+ 		os::Printer::log("Unable to create video driver of unknown type.", ELL_ERROR);
+ 		break;
+-#else
++#else // no X11
+ 	case video::EDT_NULL:
+ 		VideoDriver = video::createNullDriver(FileSystem, CreationParams.WindowSize);
+ 		break;
+--- a/irr/src/CIrrDeviceOSX.mm
++++ b/irr/src/CIrrDeviceOSX.mm
+@@ -433,14 +433,6 @@ long GetDictionaryLong(CFDictionaryRef theDict, const void *key)
+ 	return value;
+ }
+ 
+-namespace irr
+-{
+-namespace video
+-{
+-IVideoDriver *createOpenGLDriver(const SIrrlichtCreationParameters &param, io::IFileSystem *io, IContextManager *contextManager);
+-}
+-} // end namespace irr
+-
+ static bool firstLaunch = true;
+ 
+ @implementation CIrrDelegateOSX {
+@@ -721,6 +713,7 @@ - (BOOL)isQuit
+ #endif
+ 	break;
+ 
++	case video::EDT_OPENGL3:
+ 	case video::EDT_OGLES2:
+ 		os::Printer::log("This driver is not available on OSX.", ELL_ERROR);
+ 		break;
+--- a/irr/src/CIrrDeviceSDL.cpp
++++ b/irr/src/CIrrDeviceSDL.cpp
+@@ -29,53 +29,6 @@
+ 
+ static int SDLDeviceInstances = 0;
+ 
+-namespace irr
+-{
+-namespace video
+-{
+-#ifdef _IRR_COMPILE_WITH_OPENGL_
+-IVideoDriver *createOpenGLDriver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager);
+-#else
+-static IVideoDriver *createOpenGLDriver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager)
+-{
+-	os::Printer::log("No OpenGL support compiled in.", ELL_ERROR);
+-	return nullptr;
+-}
+-#endif
+-
+-#ifdef ENABLE_OPENGL3
+-IVideoDriver *createOpenGL3Driver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager);
+-#else
+-static IVideoDriver *createOpenGL3Driver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager)
+-{
+-	os::Printer::log("No OpenGL 3 support compiled in.", ELL_ERROR);
+-	return nullptr;
+-}
+-#endif
+-
+-#ifdef _IRR_COMPILE_WITH_OGLES2_
+-IVideoDriver *createOGLES2Driver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager);
+-#else
+-static IVideoDriver *createOGLES2Driver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager)
+-{
+-	os::Printer::log("No OpenGL ES 2 support compiled in.", ELL_ERROR);
+-	return nullptr;
+-}
+-#endif
+-
+-#ifdef _IRR_COMPILE_WITH_WEBGL1_
+-IVideoDriver *createWebGL1Driver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager);
+-#else
+-static IVideoDriver *createWebGL1Driver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager)
+-{
+-	os::Printer::log("No WebGL 1 support compiled in.", ELL_ERROR);
+-	return nullptr;
+-}
+-#endif
+-} // end namespace video
+-
+-} // end namespace irr
+-
+ namespace irr
+ {
+ #ifdef _IRR_EMSCRIPTEN_PLATFORM_
+--- a/irr/src/CIrrDeviceStub.cpp
++++ b/irr/src/CIrrDeviceStub.cpp
+@@ -17,6 +17,42 @@
+ 
+ namespace irr
+ {
++namespace video
++{
++#ifndef _IRR_COMPILE_WITH_OPENGL_
++IVideoDriver *createOpenGLDriver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager)
++{
++	os::Printer::log("No OpenGL support compiled in.", ELL_ERROR);
++	return nullptr;
++}
++#endif
++
++#ifndef ENABLE_OPENGL3
++IVideoDriver *createOpenGL3Driver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager)
++{
++	os::Printer::log("No OpenGL 3 support compiled in.", ELL_ERROR);
++	return nullptr;
++}
++#endif
++
++#ifndef _IRR_COMPILE_WITH_OGLES2_
++IVideoDriver *createOGLES2Driver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager)
++{
++	os::Printer::log("No OpenGL ES 2 support compiled in.", ELL_ERROR);
++	return nullptr;
++}
++#endif
++
++#ifndef _IRR_COMPILE_WITH_WEBGL1_
++IVideoDriver *createWebGL1Driver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager)
++{
++	os::Printer::log("No WebGL 1 support compiled in.", ELL_ERROR);
++	return nullptr;
++}
++#endif
++}
++
++
+ //! constructor
+ CIrrDeviceStub::CIrrDeviceStub(const SIrrlichtCreationParameters &params) :
+ 		IrrlichtDevice(), VideoDriver(0), GUIEnvironment(0), SceneManager(0),
+--- a/irr/src/CIrrDeviceStub.h
++++ b/irr/src/CIrrDeviceStub.h
+@@ -33,7 +33,15 @@ IFileSystem *createFileSystem();
+ 
+ namespace video
+ {
+-IVideoDriver *createNullDriver(io::IFileSystem *io, const core::dimension2d<u32> &screenSize);
++	IVideoDriver *createNullDriver(io::IFileSystem *io, const core::dimension2d<u32> &screenSize);
++
++	IVideoDriver *createOpenGLDriver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager);
++
++	IVideoDriver *createOpenGL3Driver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager);
++
++	IVideoDriver *createOGLES2Driver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager);
++
++	IVideoDriver *createWebGL1Driver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager);
+ }
+ 
+ //! Stub for an Irrlicht Device implementation
+--- a/irr/src/CIrrDeviceWin32.cpp
++++ b/irr/src/CIrrDeviceWin32.cpp
+@@ -34,24 +34,10 @@
+ #include "CEGLManager.h"
+ #endif
+ 
+-#if defined(_IRR_COMPILE_WITH_OPENGL_)
++#if defined(_IRR_COMPILE_WITH_WGL_MANAGER_)
+ #include "CWGLManager.h"
+ #endif
+ 
+-namespace irr
+-{
+-namespace video
+-{
+-#ifdef _IRR_COMPILE_WITH_OPENGL_
+-IVideoDriver *createOpenGLDriver(const irr::SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager);
+-#endif
+-
+-#ifdef _IRR_COMPILE_WITH_OGLES2_
+-IVideoDriver *createOGLES2Driver(const irr::SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager);
+-#endif
+-}
+-} // end namespace irr
+-
+ namespace irr
+ {
+ struct SJoystickWin32Control
+@@ -880,14 +866,23 @@ void CIrrDeviceWin32::createDriver()
+ 
+ 		ContextManager = new video::CWGLManager();
+ 		ContextManager->initialize(CreationParams, video::SExposedVideoData(HWnd));
+-
++#endif
+ 		VideoDriver = video::createOpenGLDriver(CreationParams, FileSystem, ContextManager);
+ 
+ 		if (!VideoDriver)
+ 			os::Printer::log("Could not create OpenGL driver.", ELL_ERROR);
+-#else
+-		os::Printer::log("OpenGL driver was not compiled in.", ELL_ERROR);
++		break;
++	case video::EDT_OPENGL3:
++#ifdef ENABLE_OPENGL3
++		switchToFullScreen();
++
++		ContextManager = new video::CWGLManager();
++		ContextManager->initialize(CreationParams, video::SExposedVideoData(HWnd));
+ #endif
++		VideoDriver = video::createOpenGL3Driver(CreationParams, FileSystem, ContextManager);
++
++		if (!VideoDriver)
++			os::Printer::log("Could not create OpenGL 3 driver.", ELL_ERROR);
+ 		break;
+ 	case video::EDT_OGLES2:
+ #ifdef _IRR_COMPILE_WITH_OGLES2_
+@@ -895,14 +890,11 @@ void CIrrDeviceWin32::createDriver()
+ 
+ 		ContextManager = new video::CEGLManager();
+ 		ContextManager->initialize(CreationParams, video::SExposedVideoData(HWnd));
+-
++#endif
+ 		VideoDriver = video::createOGLES2Driver(CreationParams, FileSystem, ContextManager);
+ 
+ 		if (!VideoDriver)
+ 			os::Printer::log("Could not create OpenGL-ES2 driver.", ELL_ERROR);
+-#else
+-		os::Printer::log("OpenGL-ES2 driver was not compiled in.", ELL_ERROR);
+-#endif
+ 		break;
+ 	case video::EDT_WEBGL1:
+ 		os::Printer::log("WebGL1 driver not supported on Win32 device.", ELL_ERROR);
+--- a/irr/src/CMakeLists.txt
++++ b/irr/src/CMakeLists.txt
+@@ -123,10 +123,10 @@ if(USE_SDL2)
+ 	if(NOT ANDROID)
+ 		set(DEFAULT_OPENGL3 TRUE)
+ 	endif()
+-	option(ENABLE_OPENGL3 "Enable OpenGL 3+" ${DEFAULT_OPENGL3})
+ else()
+-	set(ENABLE_OPENGL3 FALSE)
++	set(DEFAULT_OPENGL3 FALSE)
+ endif()
++option(ENABLE_OPENGL3 "Enable OpenGL 3+" ${DEFAULT_OPENGL3})
+ 
+ if(ANDROID OR EMSCRIPTEN)
+ 	set(ENABLE_OPENGL FALSE)
+@@ -152,9 +152,11 @@ else()
+ 	endif()
+ endif()
+ 
+-if(ENABLE_OPENGL)
+-	add_definitions(-D_IRR_COMPILE_WITH_OPENGL_)
+-	set(OPENGL_DIRECT_LINK TRUE) # driver relies on this
++if(ENABLE_OPENGL OR (ENABLE_OPENGL3 AND NOT USE_SDL2))
++	if(ENABLE_OPENGL)
++		add_definitions(-D_IRR_COMPILE_WITH_OPENGL_)
++		set(OPENGL_DIRECT_LINK TRUE) # driver relies on this
++	endif()
+ 	if(DEVICE STREQUAL "WINDOWS")
+ 		add_definitions(-D_IRR_COMPILE_WITH_WGL_MANAGER_)
+ 	elseif(DEVICE STREQUAL "X11")
+@@ -165,7 +167,11 @@ if(ENABLE_OPENGL)
+ endif()
+ 
+ if(ENABLE_OPENGL3)
+-	if (NOT USE_SDL2)
++	if(DEVICE STREQUAL "WINDOWS")
++		# supported
++	elseif(DEVICE STREQUAL "X11")
++		# supported
++	elseif (NOT USE_SDL2)
+ 		message(FATAL_ERROR "OpenGL 3 driver requires SDL2")
+ 	endif()
+ endif()
+--- a/irr/src/COpenGLDriver.cpp
++++ b/irr/src/COpenGLDriver.cpp
+@@ -3239,19 +3239,9 @@ COpenGLCacheHandler *COpenGLDriver::getCacheHandler() const
+ 	return CacheHandler;
+ }
+ 
+-} // end namespace
+-} // end namespace
+-
+-#endif // _IRR_COMPILE_WITH_OPENGL_
+-
+-namespace irr
+-{
+-namespace video
+-{
+ 
+ IVideoDriver *createOpenGLDriver(const SIrrlichtCreationParameters &params, io::IFileSystem *io, IContextManager *contextManager)
+ {
+-#ifdef _IRR_COMPILE_WITH_OPENGL_
+ 	COpenGLDriver *ogl = new COpenGLDriver(params, io, contextManager);
+ 
+ 	if (!ogl->initDriver()) {
+@@ -3260,10 +3250,8 @@ IVideoDriver *createOpenGLDriver(const SIrrlichtCreationParameters &params, io::
+ 	}
+ 
+ 	return ogl;
+-#else
+-	return 0;
+-#endif
+ }
+ 
+-} // end namespace
+-} // end namespace
++} // end namespace video
++} // end namespace irr
++#endif // opengl
+--- a/irr/src/OpenGL/Driver.cpp
++++ b/irr/src/OpenGL/Driver.cpp
+@@ -226,8 +226,8 @@ void COpenGL3DriverBase::initVersion()
+ 	printVersion();
+ 
+ 	// print renderer information
+-	VendorName = GL.GetString(GL_VENDOR);
+-	os::Printer::log("Vendor", VendorName.c_str(), ELL_INFORMATION);
++	VendorName = GL.GetString(GL_RENDERER);
++	os::Printer::log("Renderer", VendorName.c_str(), ELL_INFORMATION);
+ 
+ 	Version = getVersionFromOpenGL();
+ }
+--- a/irr/src/OpenGL3/Driver.cpp
++++ b/irr/src/OpenGL3/Driver.cpp
+@@ -34,8 +34,14 @@ OpenGLVersion COpenGL3Driver::getVersionFromOpenGL() const
+ 
+ void COpenGL3Driver::initFeatures()
+ {
+-	assert(Version.Spec == OpenGLSpec::Compat);
+-	assert(isVersionAtLeast(3, 2));
++	if (Version.Spec != OpenGLSpec::Compat) {
++		os::Printer::log("OpenGL 3 driver requires Compatibility Mode", ELL_ERROR);
++		throw std::exception();
++	}
++	if (!isVersionAtLeast(3, 2)) {
++		os::Printer::log("OpenGL 3 driver requires OpenGL >= 3.2 ", ELL_ERROR);
++		throw std::exception();
++	}
+ 	initExtensions();
+ 
+ 	TextureFormats[ECF_A1R5G5B5] = {GL_RGB5_A1, GL_BGRA, GL_UNSIGNED_SHORT_1_5_5_5_REV}; // WARNING: may not be renderable

--- a/x11-packages/luanti/0002-fix-elf-directory-for-cross-compiling.patch
+++ b/x11-packages/luanti/0002-fix-elf-directory-for-cross-compiling.patch
@@ -1,0 +1,28 @@
+Normally, Luanti does not set the EXECUTABLE_OUTPUT_PATH variable when cross-compiling is detected,
+because Luanti does not officially cross-compile for any platforms that require EXECUTABLE_OUTPUT_PATH.
+
+Later on elsewhere in the CMakeLists.txt, there is this logic: "if not ANDROID... then if UNIX...
+then create a symlink in the EXECUTABLE_OUTPUT_PATH".
+
+https://github.com/minetest/minetest/blob/6a1d22b2c516abbb9ce9670dedff47451317706f/src/CMakeLists.txt#L1045-L1054
+
+A different patch, 0003-bionic-libc-x11-wsi-opengl-es-2.patch, replaces the ANDROID variable there 
+to force this codepath, but the reason this patch is not combined into that patch is because this patch
+is technically only required for cross-compiling,
+while building the package in non-cross-compiling mode does not actually require this
+change in order to work, so it seemed appropriate to organize them in separate patches.
+
+This prevents the error "CMake Error: failed to create symbolic link '/minetest': Permission denied",
+which is the error that happens if EXECUTABLE_OUTPUT_PATH does not exist when that linked point
+in the CMakeLists.txt is reached, and normally happens only when cross-compiling Luanti.
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -569,7 +569,7 @@ endif()
+ 
+ # When cross-compiling assume the user doesn't want to run the executable anyway,
+ # otherwise place it in <source dir>/bin/ since Luanti can only run from there.
+-if(NOT CMAKE_CROSSCOMPILING)
++if(NOT DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK)
+ 	set(EXECUTABLE_OUTPUT_PATH "${CMAKE_SOURCE_DIR}/bin")
+ endif()
+ 

--- a/x11-packages/luanti/0003-bionic-libc-x11-wsi-opengl-es-2.patch
+++ b/x11-packages/luanti/0003-bionic-libc-x11-wsi-opengl-es-2.patch
@@ -1,0 +1,672 @@
+This patch explicitly disables everything in Luanti that was
+written for the .apk file builds of Luanti on F-Droid and
+Google Play that is believed to be unusable or unnecessary inside Termux, including:
+
+- JNI (Java-Native Interface) method calls to, and entrypoints from, the "AndroidX" "Android Runtime" "app_process" execution environment
+- ANativeWindow backend of Irrlicht/SDL windowing libraries, required by the SurfaceFlinger display server
+- bug fixes believed to be only necessary while using above APIs
+- there might be other things not listed
+
+but without disabling anything that was written for the .apk file
+builds of Luanti that seems, or is, useful or necessary inside Termux,
+including:
+
+- OpenGL ES support
+- OpenSL ES support
+- Touchscreen Buttons
+- Reduced default graphics settings
+- Preexisting Bionic-libc porting code like threading using calls to pthread_kill() in place of pthread_cancel()
+- there might be other things not listed
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -90,7 +90,7 @@ set(ENABLE_UPDATE_CHECKER (NOT ${DEVELOPMENT_BUILD}) CACHE BOOL
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+ 
+ # Load default options for Android
+-if(ANDROID)
++if(DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK)
+ 	cmake_minimum_required(VERSION 3.20)
+ 	include(AndroidLibs)
+ endif()
+--- a/irr/src/CIrrDeviceSDL.cpp
++++ b/irr/src/CIrrDeviceSDL.cpp
+@@ -305,7 +305,7 @@ CIrrDeviceSDL::CIrrDeviceSDL(const SIrrlichtCreationParameters &param) :
+ #endif
+ 
+ 	if (++SDLDeviceInstances == 1) {
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 		// Blocking on pause causes problems with multiplayer.
+ 		// See https://github.com/minetest/minetest/issues/10842.
+ 		SDL_SetHint(SDL_HINT_ANDROID_BLOCK_ON_PAUSE, "0");
+@@ -794,7 +794,7 @@ bool CIrrDeviceSDL::run()
+ #endif
+ 
+ 			auto button = SDL_event.button.button;
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 			// Android likes to send the right mouse button as the back button.
+ 			// According to some web searches I did, this is probably
+ 			// vendor/device-specific.
+--- a/irr/src/CIrrDeviceSDL.h
++++ b/irr/src/CIrrDeviceSDL.h
+@@ -161,7 +161,7 @@ class CIrrDeviceSDL : public CIrrDeviceStub
+ 		//! Sets the new position of the cursor.
+ 		void setPosition(s32 x, s32 y) override
+ 		{
+-#ifndef __ANDROID__
++#ifndef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 			// On Android, this somehow results in a camera jump when enabling
+ 			// relative mouse mode and it isn't supported anyway.
+ 			SDL_WarpMouseInWindow(Device->Window,
+--- a/irr/src/CMakeLists.txt
++++ b/irr/src/CMakeLists.txt
+@@ -61,7 +61,7 @@ if(WIN32)
+ elseif(APPLE)
+ 	add_definitions(-D_IRR_OSX_PLATFORM_)
+ 	set(DEVICE "OSX")
+-elseif(ANDROID)
++elseif(DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK)
+ 	add_definitions(-D_IRR_ANDROID_PLATFORM_)
+ 	if(NOT USE_SDL2)
+ 		message(FATAL_ERROR "The Android build requires SDL2")
+@@ -216,7 +216,7 @@ if(ENABLE_OPENGL)
+ 	find_package(OpenGL REQUIRED)
+ endif()
+ if(USE_SDL2)
+-	if(NOT ANDROID)
++	if(NOT DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK)
+ 		find_package(SDL2 REQUIRED)
+ 	else()
+ 		# provided by AndroidLibs.cmake
+@@ -263,7 +263,7 @@ endif()
+ 
+ # Platform-specific libs
+ 
+-if(ANDROID)
++if(DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK)
+ 	enable_language(C)
+ elseif(APPLE)
+ 	find_library(COCOA_LIB Cocoa REQUIRED)
+@@ -498,7 +498,6 @@ target_link_libraries(IrrlichtMt PRIVATE
+ 	${EGL_LIBRARY}
+ 
+ 	# incl. transitive SDL2 dependencies for static linking
+-	"$<$<PLATFORM_ID:Android>:-landroid -llog -lGLESv2 -lGLESv1_CM -lOpenSLES>"
+ 	${COCOA_LIB}
+ 	${IOKIT_LIB}
+ 	"$<$<PLATFORM_ID:Windows>:gdi32>"
+@@ -513,6 +512,6 @@ endif()
+ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+ 	target_compile_definitions(IrrlichtMt INTERFACE _DEBUG) # same
+ endif()
+-if(APPLE OR ANDROID OR EMSCRIPTEN)
++if(APPLE OR DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK OR EMSCRIPTEN)
+ 	target_compile_definitions(IrrlichtMt PUBLIC IRR_MOBILE_PATHS)
+ endif()
+--- a/lib/catch2/catch_amalgamated.hpp
++++ b/lib/catch2/catch_amalgamated.hpp
+@@ -9046,7 +9046,7 @@ namespace Catch {
+ #define CATCH_CONFIG_ANDROID_LOGWRITE_HPP_INCLUDED
+ 
+ 
+-#if defined(__ANDROID__)
++#if defined(DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK)
+ #    define CATCH_INTERNAL_CONFIG_ANDROID_LOGWRITE
+ #endif
+ 
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -329,7 +329,7 @@ else()
+ 		set(PLATFORM_LIBS ${PLATFORM_LIBS} network)
+ 	endif()
+ 
+-	if (ANDROID)
++	if (DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK)
+ 		set(PLATFORM_LIBS ${PLATFORM_LIBS} android log)
+ 	endif()
+ endif()
+@@ -467,7 +467,7 @@ set(common_SRCS
+ 	${server_network_SRCS}
+ )
+ 
+-if(ANDROID)
++if(DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK)
+ 	set(common_SRCS ${common_SRCS} porting_android.cpp)
+ endif()
+ 
+@@ -558,7 +558,6 @@ include_directories(SYSTEM
+ 	${LUA_BIT_INCLUDE_DIR}
+ 	# on Android, Luanti depends on SDL2 directly
+ 	# on other platforms, only IrrlichtMt depends on SDL2
+-	"$<$<PLATFORM_ID:Android>:${SDL2_INCLUDE_DIRS}>"
+ )
+ 
+ if(USE_GETTEXT)
+@@ -608,7 +607,7 @@ endif()
+ 
+ if(BUILD_CLIENT)
+ 	# client target
+-	if(ANDROID)
++	if(DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK)
+ 		add_library(${PROJECT_NAME} SHARED)
+ 	else()
+ 		add_executable(${PROJECT_NAME})
+@@ -1042,7 +1041,7 @@ macro(CreateLegacyAlias _cmake_target _old_path _new_name)
+ 	install(PROGRAMS "${_old_path}" DESTINATION ${BINDIR})
+ endmacro()
+ 
+-if(BUILD_CLIENT AND NOT ANDROID)
++if(BUILD_CLIENT AND NOT DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK)
+ 	install(TARGETS ${PROJECT_NAME}
+ 		RUNTIME DESTINATION ${BINDIR}
+ 		LIBRARY DESTINATION ${BINDIR}
+@@ -1080,7 +1079,7 @@ if(BUILD_SERVER)
+ 	endif()
+ endif()
+ 
+-if (ANDROID)
++if (DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK)
+ 	# Android does this manually in app/build.gradle -> prepareAssets
+ 	# for now!
+ elseif (USE_GETTEXT)
+--- a/src/client/game.cpp
++++ b/src/client/game.cpp
+@@ -151,7 +151,7 @@ struct LocalFormspecHandler : public TextDest
+ 
+ 			if (fields.find("btn_exit_os") != fields.end()) {
+ 				g_gamecallback->exitToOS();
+-#ifndef __ANDROID__
++#ifndef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 				RenderingEngine::get_raw_device()->closeDevice();
+ #endif
+ 				return;
+@@ -800,7 +800,7 @@ class Game {
+ 		return input->wasKeyReleased(k);
+ 	}
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	void handleAndroidChatInput();
+ #endif
+ 
+@@ -944,7 +944,7 @@ class Game {
+ 	inline bool isTouchCrosshairDisabled() {
+ 		return !m_touch_use_crosshair && camera->getCameraMode() == CAMERA_MODE_FIRST;
+ 	}
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	bool m_android_chat_open;
+ #endif
+ 
+@@ -2032,7 +2032,7 @@ void Game::processUserInput(f32 dtime)
+ 	// Input handler step() (used by the random input generator)
+ 	input->step(dtime);
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	auto formspec = m_game_ui->getFormspecGUI();
+ 	if (formspec)
+ 		formspec->getAndroidUIInput();
+@@ -2063,7 +2063,7 @@ void Game::processKeyInput()
+ 	} else if (wasKeyDown(KeyType::INVENTORY)) {
+ 		openInventory();
+ 	} else if (input->cancelPressed()) {
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 		m_android_chat_open = false;
+ #endif
+ 		if (!gui_chat_console->isOpenInhibited()) {
+@@ -2278,7 +2278,7 @@ void Game::openConsole(float scale, const wchar_t *line)
+ {
+ 	assert(scale > 0.0f && scale <= 1.0f);
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	if (!porting::hasPhysicalKeyboardAndroid()) {
+ 		porting::showTextInputDialog("", "", 2);
+ 		m_android_chat_open = true;
+@@ -2291,12 +2291,12 @@ void Game::openConsole(float scale, const wchar_t *line)
+ 		gui_chat_console->setCloseOnEnter(true);
+ 		gui_chat_console->replaceAndAddToHistory(line);
+ 	}
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	} // else
+ #endif
+ }
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ void Game::handleAndroidChatInput()
+ {
+ 	// It has to be a text input
+@@ -4504,7 +4504,7 @@ void Game::showPauseMenu()
+ 		os << "field[4.95,0;5,1.5;;" << strgettext("Game paused") << ";]";
+ 	}
+ 
+-#ifndef __ANDROID__
++#ifndef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ #if USE_SOUND
+ 	if (g_settings->getBool("enable_sound")) {
+ 		os << "button_exit[4," << (ypos++) << ";3,0.5;btn_sound;"
+--- a/src/client/hud.cpp
++++ b/src/client/hud.cpp
+@@ -393,7 +393,7 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
+ 				if (e->size.X > 0)
+ 					font_size *= e->size.X;
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 				// The text size on Android is not proportional with the actual scaling
+ 				// FIXME: why do we have such a weird unportable hack??
+ 				if (font_size > 3 && e->offset.X < -20)
+--- a/src/client/renderingengine.cpp
++++ b/src/client/renderingengine.cpp
+@@ -163,7 +163,7 @@ RenderingEngine::RenderingEngine(MyEventReceiver *receiver)
+ 
+ 	// Resolution selection
+ 	bool fullscreen = g_settings->getBool("fullscreen");
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	u16 screen_w = 0, screen_h = 0;
+ 	bool window_maximized = false;
+ #else
+@@ -328,7 +328,7 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
+ 				tsrc->getTexture("progress_bar_bg.png");
+ 
+ 		if (progress_img && progress_img_bg) {
+-#ifndef __ANDROID__
++#ifndef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 			const core::dimension2d<u32> &img_size =
+ 					progress_img_bg->getSize();
+ 			float density = g_settings->getFloat("gui_scaling", 0.5f, 20.0f) *
+@@ -419,14 +419,14 @@ const VideoDriverInfo &RenderingEngine::getVideoDriverInfo(irr::video::E_DRIVER_
+ float RenderingEngine::getDisplayDensity()
+ {
+ 	float user_factor = g_settings->getFloat("display_density_factor", 0.5f, 5.0f);
+-#ifndef __ANDROID__
++#ifndef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	float dpi = get_raw_device()->getDisplayDensity();
+ 	if (dpi == 0.0f)
+ 		dpi = 96.0f;
+ 	return std::max(dpi / 96.0f * user_factor, 0.5f);
+-#else // __ANDROID__
++#else // DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	return porting::getDisplayDensity() * user_factor;
+-#endif // __ANDROID__
++#endif // DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ }
+ 
+ void RenderingEngine::autosaveScreensizeAndCo(
+--- a/src/defaultsettings.cpp
++++ b/src/defaultsettings.cpp
+@@ -401,7 +401,7 @@ void set_default_settings()
+ 	settings->setDefault("contentdb_enable_updates_indicator", "true");
+ 	settings->setDefault("contentdb_max_concurrent_downloads", "3");
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	settings->setDefault("contentdb_flag_blacklist", "nonfree, android_default");
+ #else
+ 	settings->setDefault("contentdb_flag_blacklist", "nonfree, desktop_default");
+@@ -553,9 +553,6 @@ void set_default_settings()
+ 	settings->setDefault("touch_punch_gesture", "short_tap");
+ 	settings->setDefault("clickable_chat_weblinks", "true");
+ 	// Altered settings for Android
+-#ifdef __ANDROID__
+-	settings->setDefault("screen_w", "0");
+-	settings->setDefault("screen_h", "0");
+ 	settings->setDefault("performance_tradeoffs", "true");
+ 	settings->setDefault("max_simultaneous_block_sends_per_client", "10");
+ 	settings->setDefault("emergequeue_limit_diskonly", "16");
+@@ -570,6 +567,9 @@ void set_default_settings()
+ 	settings->setDefault("enable_post_processing", "false");
+ 	settings->setDefault("debanding", "false");
+ 	settings->setDefault("curl_verify_cert", "false");
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
++	settings->setDefault("screen_w", "0");
++	settings->setDefault("screen_h", "0");
+ 
+ 	// Apply settings according to screen size
+ 	float x_inches = (float) porting::getDisplaySize().X /
+--- a/src/filesys.cpp
++++ b/src/filesys.cpp
+@@ -436,7 +436,7 @@ std::string TempPath()
+ 		configuration hardcodes mkstemp("/tmp/lua_XXXXXX").
+ 	*/
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	return porting::path_cache;
+ #else
+ 	return DIR_DELIM "tmp";
+--- a/src/gui/guiEngine.cpp
++++ b/src/gui/guiEngine.cpp
+@@ -375,7 +375,7 @@ void GUIEngine::run()
+ 		sound_volume_control(m_sound_manager.get(), device->isWindowActive());
+ 		m_sound_manager->step(dtime);
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 		m_menu->getAndroidUIInput();
+ #endif
+ 	}
+--- a/src/gui/guiFormSpecMenu.cpp
++++ b/src/gui/guiFormSpecMenu.cpp
+@@ -3326,7 +3326,7 @@ void GUIFormSpecMenu::legacySortElements(std::list<IGUIElement *>::iterator from
+ 	reorderChildren(from, to, elements);
+ }
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ void GUIFormSpecMenu::getAndroidUIInput()
+ {
+ 	porting::AndroidDialogState dialogState = getAndroidUIInputState();
+--- a/src/gui/guiFormSpecMenu.h
++++ b/src/gui/guiFormSpecMenu.h
+@@ -277,7 +277,7 @@ class GUIFormSpecMenu : public GUIModalMenu
+ 	// This will only return a meaningful value if called after drawMenu().
+ 	core::rect<s32> getAbsoluteRect();
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	void getAndroidUIInput();
+ #endif
+ 
+--- a/src/gui/guiOpenURL.cpp
++++ b/src/gui/guiOpenURL.cpp
+@@ -153,7 +153,7 @@ void GUIOpenURLMenu::drawMenu()
+ 	driver->draw2DRectangle(bgcolor, AbsoluteRect, &AbsoluteClippingRect);
+ 
+ 	gui::IGUIElement::draw();
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	getAndroidUIInput();
+ #endif
+ }
+--- a/src/gui/guiPasswordChange.cpp
++++ b/src/gui/guiPasswordChange.cpp
+@@ -154,7 +154,7 @@ void GUIPasswordChange::drawMenu()
+ 	driver->draw2DRectangle(bgcolor, AbsoluteRect, &AbsoluteClippingRect);
+ 
+ 	gui::IGUIElement::draw();
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	getAndroidUIInput();
+ #endif
+ }
+@@ -250,7 +250,7 @@ std::string GUIPasswordChange::getNameByID(s32 id)
+ 	return "";
+ }
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ void GUIPasswordChange::getAndroidUIInput()
+ {
+ 	porting::AndroidDialogState dialogState = getAndroidUIInputState();
+--- a/src/gui/guiPasswordChange.h
++++ b/src/gui/guiPasswordChange.h
+@@ -44,7 +44,7 @@ class GUIPasswordChange : public GUIModalMenu
+ 	bool processInput();
+ 
+ 	bool OnEvent(const SEvent &event);
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	void getAndroidUIInput();
+ #endif
+ 
+--- a/src/gui/modalMenu.cpp
++++ b/src/gui/modalMenu.cpp
+@@ -38,7 +38,7 @@ GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment* env, gui::IGUIElement* parent,
+ 	s32 id, IMenuManager *menumgr, bool remap_click_outside) :
+ 		IGUIElement(gui::EGUIET_ELEMENT, env, parent, id,
+ 				core::rect<s32>(0, 0, 100, 100)),
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 		m_jni_field_name(""),
+ #endif
+ 		m_menumgr(menumgr),
+@@ -242,7 +242,7 @@ void GUIModalMenu::leave()
+ 
+ bool GUIModalMenu::preprocessEvent(const SEvent &event)
+ {
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	// display software keyboard when clicking edit boxes
+ 	if (event.EventType == EET_MOUSE_INPUT_EVENT &&
+ 			event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN &&
+@@ -369,7 +369,7 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
+ 	return false;
+ }
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ porting::AndroidDialogState GUIModalMenu::getAndroidUIInputState()
+ {
+ 	// No dialog is shown
+--- a/src/gui/modalMenu.h
++++ b/src/gui/modalMenu.h
+@@ -7,7 +7,7 @@
+ #include "irrlichttypes_extrabloated.h"
+ #include "irr_ptr.h"
+ #include "util/string.h"
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	#include <porting_android.h>
+ #endif
+ 
+@@ -49,7 +49,7 @@ class GUIModalMenu : public gui::IGUIElement
+ 	virtual bool preprocessEvent(const SEvent &event);
+ 	virtual bool OnEvent(const SEvent &event) { return false; };
+ 	virtual bool pausesGame() { return false; } // Used for pause menu
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	virtual void getAndroidUIInput() {};
+ 	porting::AndroidDialogState getAndroidUIInputState();
+ #endif
+@@ -66,7 +66,7 @@ class GUIModalMenu : public gui::IGUIElement
+ 
+ 	v2u32 m_screensize_old;
+ 	float m_gui_scale;
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	std::string m_jni_field_name;
+ #endif
+ 
+--- a/src/log.cpp
++++ b/src/log.cpp
+@@ -14,7 +14,7 @@
+ #include "util/numeric.h"
+ #include "filesys.h"
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ #include <android/log.h>
+ #endif
+ 
+@@ -59,7 +59,7 @@ class LevelTarget : public LogTarget {
+ 
+ Logger g_logger;
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ AndroidLogOutput stdout_output;
+ AndroidLogOutput stderr_output;
+ #else
+@@ -88,7 +88,7 @@ thread_local LogStream derr_con(verbose_target);
+ thread_local LogStream dout_con(trace_target);
+ 
+ // Android
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 
+ constexpr static unsigned int g_level_to_android[] = {
+ 	ANDROID_LOG_INFO,     // LL_NONE
+--- a/src/log_internal.h
++++ b/src/log_internal.h
+@@ -186,14 +186,14 @@ class CaptureLogOutput : public ILogOutput {
+ };
+ 
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ class AndroidLogOutput : public ICombinedLogOutput {
+ public:
+ 	void logRaw(LogLevel lev, std::string_view line);
+ };
+ #endif
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ extern AndroidLogOutput stdout_output;
+ extern AndroidLogOutput stderr_output;
+ #else
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -543,7 +543,7 @@ static bool create_userdata_path()
+ {
+ 	bool success;
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	if (!fs::PathExists(porting::path_user)) {
+ 		success = fs::CreateDir(porting::path_user);
+ 	} else {
+@@ -596,7 +596,7 @@ namespace {
+ 
+ static bool use_debugger(int argc, char *argv[])
+ {
+-#if defined(__ANDROID__)
++#if defined(DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK)
+ 	return false;
+ #else
+ #ifdef _WIN32
+--- a/src/porting.cpp
++++ b/src/porting.cpp
+@@ -25,7 +25,7 @@
+ #if !defined(_WIN32)
+ 	#include <unistd.h>
+ 	#include <sys/utsname.h>
+-	#if !defined(__ANDROID__)
++	#if !defined(DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK)
+ 		#include <spawn.h>
+ 	#endif
+ #endif
+@@ -33,7 +33,7 @@
+ 	#define _PSTAT64
+ 	#include <sys/pstat.h>
+ #endif
+-#if defined(__ANDROID__)
++#if defined(DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK)
+ 	#include "porting_android.h"
+ 	#include <android/api-level.h>
+ #endif
+@@ -241,7 +241,7 @@ static std::string detectSystemInfo()
+ 	delete[] filePath;
+ 
+ 	return oss.str();
+-#elif defined(__ANDROID__)
++#elif defined(DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK)
+ 	std::ostringstream oss;
+ 	struct utsname osinfo;
+ 	uname(&osinfo);
+@@ -461,7 +461,7 @@ bool setSystemPaths()
+ 
+ //// Android
+ 
+-#elif defined(__ANDROID__)
++#elif defined(DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK)
+ 
+ extern bool setSystemPaths(); // defined in porting_android.cpp
+ 
+@@ -661,7 +661,7 @@ void initializePaths()
+ 	if (!setSystemPaths())
+ 		errorstream << "Failed to get one or more system-wide path" << std::endl;
+ 
+-#  ifdef __ANDROID__
++#  ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	sanity_check(!path_cache.empty());
+ #  elif defined(_WIN32)
+ 	path_cache = path_user + DIR_DELIM + "cache";
+@@ -761,7 +761,7 @@ bool secure_rand_fill_buf(void *buf, size_t len)
+ 
+ #endif
+ 
+-#ifndef __ANDROID__
++#ifndef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 
+ void osSpecificInit()
+ {
+@@ -860,7 +860,7 @@ int mt_snprintf(char *buf, const size_t buf_size, const char *fmt, ...)
+ 	return c;
+ }
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ // defined in porting_android.cpp
+ extern void openURIAndroid(const char *url);
+ #endif
+@@ -874,7 +874,7 @@ static bool open_uri(const std::string &uri)
+ 
+ #if defined(_WIN32)
+ 	return (intptr_t)ShellExecuteA(NULL, NULL, uri.c_str(), NULL, NULL, SW_SHOWNORMAL) > 32;
+-#elif defined(__ANDROID__)
++#elif defined(DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK)
+ 	openURIAndroid(uri.c_str());
+ 	return true;
+ #elif defined(__APPLE__)
+--- a/src/porting.h
++++ b/src/porting.h
+@@ -326,6 +326,6 @@ bool open_directory(const std::string &path);
+ 
+ } // namespace porting
+ 
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ #include "porting_android.h"
+ #endif
+--- a/src/porting_android.cpp
++++ b/src/porting_android.cpp
+@@ -2,7 +2,7 @@
+ // SPDX-License-Identifier: LGPL-2.1-or-later
+ // Copyright (C) 2014 celeron55, Perttu Ahola <celeron55@gmail.com>
+ 
+-#ifndef __ANDROID__
++#ifndef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ #error This file may only be compiled for android!
+ #endif
+ 
+--- a/src/porting_android.h
++++ b/src/porting_android.h
+@@ -4,7 +4,7 @@
+ 
+ #pragma once
+ 
+-#ifndef __ANDROID__
++#ifndef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ #error This header has to be included on Android port only!
+ #endif
+ 
+--- a/src/script/lua_api/l_mainmenu.cpp
++++ b/src/script/lua_api/l_mainmenu.cpp
+@@ -1076,7 +1076,7 @@ int ModApiMainMenu::l_open_dir(lua_State *L)
+ /******************************************************************************/
+ int ModApiMainMenu::l_share_file(lua_State *L)
+ {
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	std::string path = luaL_checkstring(L, 1);
+ 	porting::shareFileAndroid(path);
+ 	lua_pushboolean(L, true);
+--- a/src/server.cpp
++++ b/src/server.cpp
+@@ -3100,7 +3100,7 @@ std::wstring Server::handleChat(const std::string &name,
+ 			Workaround for fixing chat on Android. Lua doesn't handle
+ 			the Cyrillic alphabet and some characters on older Android devices
+ 		*/
+-#ifdef __ANDROID__
++#ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 		line += L"<" + utf8_to_wide(name) + L"> " + wmessage;
+ #else
+ 		line += utf8_to_wide(m_script->formatChatMessage(name, message));

--- a/x11-packages/luanti/0004-prepend-termux-prefix-to-tmp-path.patch
+++ b/x11-packages/luanti/0004-prepend-termux-prefix-to-tmp-path.patch
@@ -1,0 +1,30 @@
+Fixes "An error occurred: Failed to download 'Minetest Game'"
+when trying to download any gamemode through the builtin browser,
+as described here: https://github.com/termux-user-repository/tur/issues/1325
+
+Lua portion adapted from https://github.com/termux/termux-packages/blob/master/packages/liblua52/lua-5.2.4_src_loslib.c.patch
+--- a/lib/lua/src/luaconf.h
++++ b/lib/lua/src/luaconf.h
+@@ -653,9 +653,9 @@ union luai_Cast { double l_d; long l_l; };
+ 
+ #if defined(LUA_USE_MKSTEMP)
+ #include <unistd.h>
+-#define LUA_TMPNAMBUFSIZE	32
++#define LUA_TMPNAMBUFSIZE	512
+ #define lua_tmpnam(b,e)	{ \
+-	strcpy(b, "/tmp/lua_XXXXXX"); \
++	strcpy(b, "@TERMUX_PREFIX@/tmp/lua_XXXXXX"); \
+ 	e = mkstemp(b); \
+ 	if (e != -1) close(e); \
+ 	e = (e == -1); }
+--- a/src/filesys.cpp
++++ b/src/filesys.cpp
+@@ -439,7 +439,7 @@ std::string TempPath()
+ #ifdef DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK
+ 	return porting::path_cache;
+ #else
+-	return DIR_DELIM "tmp";
++	return "@TERMUX_PREFIX@" DIR_DELIM "tmp";
+ #endif
+ }
+ 

--- a/x11-packages/luanti/0005-toggle-on-the-recent-upstream-migration-away-from-sdl2.patch
+++ b/x11-packages/luanti/0005-toggle-on-the-recent-upstream-migration-away-from-sdl2.patch
@@ -1,0 +1,15 @@
+This is https://github.com/minetest/minetest/pull/15284
+(Luanti's current choice to use Irrlicht only without SDL2, until a future release)
+In Termux this is necessary to enable EGL support for improved driver compatibility
+and performance, but if Luanti migrates to SDL2 in the future, at that time, it might
+be possible to enable EGL support in SDL2 for Luanti on Termux also.
+--- a/irr/src/CMakeLists.txt
++++ b/irr/src/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ # When enabling SDL2 by default on macOS, don't forget to change
+ # "NSHighResolutionCapable" to true in "Info.plist".
+-if(ANDROID)
++if(THIS_IS_OPTIONAL)
+ 	set(DEFAULT_SDL2 ON)
+ endif()
+ 

--- a/x11-packages/luanti/0006-fix-incompatible-type-ekey-code.patch
+++ b/x11-packages/luanti/0006-fix-incompatible-type-ekey-code.patch
@@ -1,0 +1,13 @@
+This prevents an error during compiling with recent C++ compilers while SDL2 is disabled,
+which was: CIrrDeviceLinux.cpp:682:13: error: assigning to 'EKEY_CODE' from incompatible type 'int'
+--- a/irr/src/CIrrDeviceLinux.cpp
++++ b/irr/src/CIrrDeviceLinux.cpp
+@@ -693,7 +693,7 @@ EKEY_CODE CIrrDeviceLinux::getKeyCode(XEvent &event)
+ 		keyCode = (EKEY_CODE)KeyMap[idx].Win32Key;
+ 	}
+ 	if (keyCode == 0) {
+-		keyCode = KEY_UNKNOWN;
++		keyCode = (EKEY_CODE)KEY_UNKNOWN;
+ 		if (!mp.X11Key) {
+ 			os::Printer::log("No such X11Key, event keycode", core::stringc(event.xkey.keycode).c_str(), ELL_INFORMATION);
+ 		} else if (idx == -1) {

--- a/x11-packages/luanti/0007-replace-xdg-open.patch
+++ b/x11-packages/luanti/0007-replace-xdg-open.patch
@@ -1,0 +1,19 @@
+xdg-open, from the package main/termux-tools, does not work on folders.
+xdg-utils-xdg-open, the name of the X11 version of xdg-open from desktopp PC,
+is from x11/xdg-utils and does work on folders.
+This is a folder (~/.minetest) so it's necessary to use the implementation that works on
+folders. It's also inside the /data/data/com.termux/files folder.
+--- a/src/porting.cpp
++++ b/src/porting.cpp
+@@ -882,8 +882,8 @@ static bool open_uri(const std::string &uri)
+ 	return posix_spawnp(NULL, "open", NULL, NULL, (char**)argv,
+ 		(*_NSGetEnviron())) == 0;
+ #else
+-	const char *argv[] = {"xdg-open", uri.c_str(), NULL};
+-	return posix_spawnp(NULL, "xdg-open", NULL, NULL, (char**)argv, environ) == 0;
++	const char *argv[] = {"xdg-utils-xdg-open", uri.c_str(), NULL};
++	return posix_spawnp(NULL, "xdg-utils-xdg-open", NULL, NULL, (char**)argv, environ) == 0;
+ #endif
+ }
+
+

--- a/x11-packages/luanti/build.sh
+++ b/x11-packages/luanti/build.sh
@@ -1,0 +1,20 @@
+TERMUX_PKG_HOMEPAGE=https://www.luanti.org
+TERMUX_PKG_DESCRIPTION="An open source voxel game engine."
+TERMUX_PKG_LICENSE="LGPL-2.1"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=1:5.10.0
+TERMUX_PKG_REVISION=4
+TERMUX_PKG_SRCURL=https://github.com/minetest/minetest/archive/refs/tags/${TERMUX_PKG_VERSION:2}.zip
+TERMUX_PKG_SHA256=e74e994c0f1b188d60969477f553ad83b8ce20ee1e0e2dcd068120189cb0f56c
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="freetype, jsoncpp, libandroid-spawn, libc++, libcurl, libgmp, libjpeg-turbo, libiconv, libluajit, libpng, libsqlite, libvorbis, libx11, libxi, luanti-common, openal-soft, opengl, xdg-utils, zlib, zstd"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DBUILD_SERVER=TRUE
+-DBUILD_BENCHMARKS=TRUE
+-DENABLE_UPDATE_CHECKER=0
+-DENABLE_CURSES=0
+"
+
+termux_step_pre_configure() {
+	export LDFLAGS+=" -landroid-spawn"
+}

--- a/x11-packages/luanti/luanti-common.subpackage.sh
+++ b/x11-packages/luanti/luanti-common.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_INCLUDE="share/luanti/ share/man/ share/doc/"
+TERMUX_SUBPKG_DESCRIPTION="Common files, including docs, shared between luanti and luanti-server"
+TERMUX_SUBPKG_PLATFORM_INDEPENDENT=true
+TERMUX_SUBPKG_DEPEND_ON_PARENT=false
+TERMUX_SUBPKG_BREAKS="luanti (<< 1:5.10.0-4)"
+TERMUX_SUBPKG_REPLACES="luanti (<< 1:5.10.0-4)"

--- a/x11-packages/luanti/luanti-server.subpackage.sh
+++ b/x11-packages/luanti/luanti-server.subpackage.sh
@@ -1,0 +1,6 @@
+TERMUX_SUBPKG_INCLUDE="bin/luantiserver bin/minetestserver"
+TERMUX_SUBPKG_DESCRIPTION="Headless server for the Luanti voxel game engine."
+TERMUX_SUBPKG_DEPENDS="jsoncpp, libandroid-spawn, libc++, libcurl, libgmp, libiconv, libluajit, libsqlite, luanti-common, zlib, zstd"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=false
+TERMUX_SUBPKG_BREAKS="luanti (<< 1:5.10.0-4)"
+TERMUX_SUBPKG_REPLACES="luanti (<< 1:5.10.0-4)"


### PR DESCRIPTION
Copied and pasted from https://github.com/termux-user-repository/tur/tree/master/tur/luanti

Previous documentation here:
- https://github.com/termux-user-repository/tur/issues/1295
- https://github.com/termux-user-repository/tur/pull/1296
- https://github.com/termux-user-repository/tur/pull/1331
- https://github.com/termux-user-repository/tur/pull/1327

Summary of key points:

- for better performance than normal `virglrenderer-android`, test using [termux-wsi-layer](https://github.com/termux/termux-packages/pull/22353) or [new virglrenderer](https://github.com/termux/termux-packages/pull/22385)

- to use touchscreen input, set "Touchscreen input mode: Direct touch" in Termux:X11 settings

![image](https://github.com/user-attachments/assets/92753c6c-d094-4a23-9c08-9fc04e2c8514)

- to use keyboard input, set "Prefer scancodes" in Termux:X11 settings

![image](https://github.com/user-attachments/assets/2a2a1ec7-c46e-4d89-b87c-78add4c9b6fd)

- to use mouse input, set "Capture external pointer devices" in Termux:X11 settings and then click once with the mouse

![image](https://github.com/user-attachments/assets/435822c3-c996-42d9-ae31-fa591ee74c64)


<details>
<summary>New recommended Termux:X11 settings for Luanti</summary>

```
$ termux-x11-preference list
"hideCutout"="false"
"displayStretch"="false"
"notificationButton1Action"="exit"
"forceOrientation"="reverse landscape"
"adjustResolution"="false"
"tapToMove"="false"
"enableAccessibilityServiceAutomatically"="false"
"backButtonAction"="toggle soft keyboard"
"xrMode"="false"
"adjustHeightForEK"="false"
"notificationTapAction"="open preferences"
"showAdditionalKbd"="false"
"stylusButtonContactModifierMode"="false"
"additionalKbdVisible"="true"
"opacityEKBar"="100"
"displayResolutionCustom"="1280x1024"
"stylusIsMouse"="false"
"clipboardEnable"="true"
"extra_keys_config"="[['ESC','/',{key: '-', popup: '|'},'HOME','UP','END','PGUP','PREFERENCES'], ['TAB','CTRL','ALT','LEFT','DOWN','RIGHT','PGDN','KEYBOARD']]"
"pauseKeyInterceptingWithEsc"="false"
"preferScancodes"="true"
"storeSecondaryDisplayPreferencesSeparately"="false"
"showIMEWhileExternalConnected"="true"
"useTermuxEKBarBehaviour"="false"
"showMouseHelper"="false"
"transformCapturedPointer"="No"
"displayResolutionExact"="1280x1024"
"keepScreenOn"="true"
"pointerCapture"="true"
"swipeDownAction"="toggle additional key bar"
"touchMode"="Direct touch"
"dexMetaKeyCapture"="false"
"scaleTouchpad"="true"
"hardwareKbdScancodesWorkaround"="true"
"notificationButton0Action"="open preferences"
"volumeUpAction"="no action"
"fullscreen"="true"
"enableGboardCJK"="false"
"Reseed"="false"
"PIP"="false"
"capturedPointerSpeedFactor"="100"
"displayResolutionMode"="native"
"swipeUpAction"="no action"
"filterOutWinkey"="false"
"displayScale"="100"
"volumeDownAction"="no action"
"showStylusClickOverride"="false"
```

</details>

- 6 patches are written entirely or mostly by me, but `0001-enable-egl-without-sdl2.patch` is not, it is this commit cherrypicked. https://github.com/minetest/minetest/commit/4838eb2f7de8477ef5be7e064d072954ff78e36c

> [!NOTE]
> In the future, Luanti might "transition back to SDL2" I think that a blocker for that in this build of luanti might be that building it with SDL2 prevented accessing EGL mode, at least for me. I have been building versions of SDL2 that might work with EGL when I test them, so that might come next eventually.