### PR TITLE
setup-ubuntu.sh: Remove deadsnakes PPA

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -324,9 +324,6 @@ $SUDO chmod a+r /etc/apt/trusted.gpg.d/apt.llvm.org.asc
 	echo "deb [arch=amd64] http://apt.llvm.org/noble/ llvm-toolchain-noble-17 main"
 } | $SUDO tee /etc/apt/sources.list.d/apt-llvm-org.list > /dev/null
 
-# Add deadsnakes PPA to enable installing python 3.11:
-$SUDO add-apt-repository -y 'ppa:deadsnakes/ppa'
-
 $SUDO apt-get -yq update
 
 $SUDO env DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
As Termux has switched to Python 3.12, there is no need to install deadsnakes PPA