### PR TITLE
fix(main/cmus): ensure the AAudio buffer is at least 80ms

### DIFF
--- a/packages/cmus/build.sh
+++ b/packages/cmus/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Small, fast and powerful console music player"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.12.0"
-TERMUX_PKG_REVISION="1"
+TERMUX_PKG_REVISION="2"
 TERMUX_PKG_DEPENDS="ffmpeg, libandroid-support, libflac, libiconv, libmad, libmodplug, libvorbis, libwavpack, ncurses, opusfile, pulseaudio"
 TERMUX_PKG_SRCURL=https://github.com/cmus/cmus/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=44b96cd5f84b0d84c33097c48454232d5e6a19cd33b9b6503ba9c13b6686bfc7
@@ -11,6 +11,15 @@ TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_pre_configure() {
+	# cherry-pick patches
+	local sha commits=(
+		8b96ab56184626d01a3a89ce1647b0488cf22391 # ensure the aaudio buffer is at least 80ms
+	)
+	for sha in "${commits[@]}"; do
+		termux_download "https://github.com/cmus/cmus/commit/${sha}.patch" "${TERMUX_PKG_TMPDIR}/${sha}.patch" "SKIP_CHECKSUM" # skip checksum since we're already referencing an exact commit hash
+		git apply "${TERMUX_PKG_TMPDIR}/${sha}.patch"
+	done
+
 	# we need to be able to link against aaudio even on older api levels (it will fall back properly at runtime)
 	if [[ $TERMUX_PKG_API_LEVEL -lt 26 ]]; then
 		local _libdir="$TERMUX_PKG_TMPDIR/libaaudio"


### PR DESCRIPTION
This fixes buffer underruns on the Pixel 9 due to the default buffer capacity and burst size being much lower than other devices (e.g., 2886/962 frames at 48000 Hz on the P9 vs 6734/3367 on the P8).

I am one of the upstream maintainers and the author of the AAudio output plugin.

See cmus/cmus#1386. This PR is a cherry-pick of the first commit (the bugfix), but not the second (a feature to allow overriding the requested buffer capacity).