### PR TITLE
chore,scripts(build/termux_step_handle_host_build): fix glob matching

### DIFF
--- a/scripts/build/termux_step_handle_host_build.sh
+++ b/scripts/build/termux_step_handle_host_build.sh
@@ -3,10 +3,11 @@ termux_step_handle_host_build() {
 	[ "$TERMUX_PKG_HOSTBUILD" = "false" ] && return
 
 	cd "$TERMUX_PKG_SRCDIR"
-	for patch in $TERMUX_PKG_BUILDER_DIR/*.patch.beforehostbuild; do
-		echo "Applying patch: $(basename $patch)"
-		test -f "$patch" && sed "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" "$patch" | patch --silent -p1
-	done
+	find $TERMUX_PKG_BUILDER_DIR -mindepth 1 -maxdepth 1 -name \*.patch.beforehostbuild | sort \
+		| while read -r patch; do
+			echo "Applying patch: $(basename $patch)"
+			test -f "$patch" && sed "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" "$patch" | patch --silent -p1
+		done
 
 	if [ ! -f "$TERMUX_HOSTBUILD_MARKER" ]; then
 		rm -Rf "$TERMUX_PKG_HOSTBUILD_DIR"


### PR DESCRIPTION
Fix glob matching patches on `termux_step_handle_host_build` where if no files found, it will return `*.patch.beforehostbuild`.