### PR TITLE
Rust rework 1

### DIFF
--- a/packages/rust/build.sh
+++ b/packages/rust/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Systems programming language focused on safety, speed an
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.83.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/rustc-${TERMUX_PKG_VERSION}-src.tar.xz
 TERMUX_PKG_SHA256=7b11d4242dab0921a7d54758ad3fe805153c979c144625fecde11735760f97df
 _LLVM_MAJOR_VERSION=$(. $TERMUX_SCRIPTDIR/packages/libllvm/build.sh; echo $LLVM_MAJOR_VERSION)
@@ -191,6 +192,8 @@ termux_step_configure() {
 	export CC_x86_64_unknown_linux_gnu=gcc
 	export CFLAGS_x86_64_unknown_linux_gnu="-O2"
 	export RUST_BACKTRACE=full
+
+	unset CC CFLAGS CFLAGS_${env_host} CPP CPPFLAGS CXX CXXFLAGS LD LDFLAGS PKG_CONFIG RANLIB
 }
 
 termux_step_make() {
@@ -198,8 +201,6 @@ termux_step_make() {
 }
 
 termux_step_make_install() {
-	unset CC CFLAGS CPP CPPFLAGS CXX CXXFLAGS LD LDFLAGS PKG_CONFIG RANLIB
-
 	# install causes on device build fail to continue
 	# dist uses a lot of spaces on CI
 	local job="install"

--- a/scripts/build/setup/termux_setup_rust.sh
+++ b/scripts/build/setup/termux_setup_rust.sh
@@ -1,10 +1,5 @@
 # shellcheck shell=bash disable=SC1091 disable=SC2086 disable=SC2155
 termux_setup_rust() {
-	export CARGO_TARGET_NAME="${TERMUX_ARCH}-linux-android"
-	if [[ "${TERMUX_ARCH}" == "arm" ]]; then
-		CARGO_TARGET_NAME="armv7-linux-androideabi"
-	fi
-
 	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "true" ]]; then
 		if [[ -z "$(command -v rustc)" ]]; then
 			cat <<- EOL
@@ -28,17 +23,6 @@ termux_setup_rust() {
 		return
 	fi
 
-	local ENV_NAME=CARGO_TARGET_${CARGO_TARGET_NAME^^}_LINKER
-	ENV_NAME=${ENV_NAME//-/_}
-	export $ENV_NAME="${CC:-}"
-	# TARGET_CFLAGS and CFLAGS incorrectly applied globally
-	# for host build and other targets so set them individually
-	export CFLAGS_aarch64_linux_android="${CPPFLAGS:-}"
-	export CFLAGS_armv7_linux_androideabi="${CPPFLAGS:-}"
-	export CFLAGS_i686_linux_android="${CPPFLAGS:-}"
-	export CFLAGS_x86_64_linux_android="${CPPFLAGS:-}"
-	unset CFLAGS
-
 	if [[ -z "${TERMUX_RUST_VERSION-}" ]]; then
 		TERMUX_RUST_VERSION=$(. "${TERMUX_SCRIPTDIR}"/packages/rust/build.sh; echo ${TERMUX_PKG_VERSION})
 	fi
@@ -51,5 +35,7 @@ termux_setup_rust() {
 
 	export PATH="${HOME}/.cargo/bin:${PATH}"
 
-	rustup target add "${CARGO_TARGET_NAME}"
+	if [[ -n "${CARGO_TARGET_NAME-}" ]]; then
+		rustup target add "${CARGO_TARGET_NAME}"
+	fi
 }

--- a/scripts/build/toolchain/termux_setup_toolchain_23c.sh
+++ b/scripts/build/toolchain/termux_setup_toolchain_23c.sh
@@ -93,7 +93,15 @@ termux_setup_toolchain_23c() {
 	export CGO_ENABLED=1
 	export GO_LDFLAGS="-extldflags=-pie"
 	export CGO_CFLAGS="-I$TERMUX_PREFIX/include"
-	export RUSTFLAGS="-C link-arg=-Wl,-rpath=$TERMUX_PREFIX/lib -C link-arg=-Wl,--enable-new-dtags"
+
+	export CARGO_TARGET_NAME="${TERMUX_ARCH}-linux-android"
+	if [[ "${TERMUX_ARCH}" == "arm" ]]; then
+		CARGO_TARGET_NAME="armv7-linux-androideabi"
+	fi
+	local env_host="${CARGO_TARGET_NAME//-/_}"
+	export CARGO_TARGET_${env_host@U}_LINKER="${CC}"
+	export CARGO_TARGET_${env_host@U}_RUSTFLAGS="-L${TERMUX_PREFIX}/lib -C link-arg=-Wl,-rpath=${TERMUX_PREFIX}/lib -C link-arg=-Wl,--enable-new-dtags"
+	export CFLAGS_${env_host}="${CPPFLAGS} ${CFLAGS}"
 
 	export ac_cv_func_getpwent=no
 	export ac_cv_func_endpwent=yes

--- a/scripts/build/toolchain/termux_setup_toolchain_27c.sh
+++ b/scripts/build/toolchain/termux_setup_toolchain_27c.sh
@@ -94,7 +94,15 @@ termux_setup_toolchain_27c() {
 	export GO_LDFLAGS="-extldflags=-pie"
 	export CGO_LDFLAGS="${LDFLAGS/ -Wl,-z,relro,-z,now/}"
 	export CGO_CFLAGS="-I$TERMUX_PREFIX/include"
-	export RUSTFLAGS="-C link-arg=-Wl,-rpath=$TERMUX_PREFIX/lib -C link-arg=-Wl,--enable-new-dtags"
+
+	export CARGO_TARGET_NAME="${TERMUX_ARCH}-linux-android"
+	if [[ "${TERMUX_ARCH}" == "arm" ]]; then
+		CARGO_TARGET_NAME="armv7-linux-androideabi"
+	fi
+	local env_host="${CARGO_TARGET_NAME//-/_}"
+	export CARGO_TARGET_${env_host@U}_LINKER="${CC}"
+	export CARGO_TARGET_${env_host@U}_RUSTFLAGS="-L${TERMUX_PREFIX}/lib -C link-arg=-Wl,-rpath=${TERMUX_PREFIX}/lib -C link-arg=-Wl,--enable-new-dtags"
+	export CFLAGS_${env_host}="${CPPFLAGS} ${CFLAGS}"
 
 	export ac_cv_func_getpwent=no
 	export ac_cv_func_endpwent=yes


### PR DESCRIPTION
The gist of these PRs is to drop `RUSTFLAGS` that is poorly understood causing weird unexplainable build issues. We should use `CARGO_TARGET_*_RUSTFLAGS` instead. Also clean up to match other languages by init variables in setup_toolchain file. Note that `CFLAGS_{target}` is used by `cc` rust crate and not by `cargo` or `rustc`.