### PR TITLE
fix(main/just): fix 32bit builds

### DIFF
--- a/packages/just/build.sh
+++ b/packages/just/build.sh
@@ -8,6 +8,12 @@ TERMUX_PKG_SHA256=3d47e27755d39f40e1ca34bc0ef535fa514e7ed547b2af62311dcadd8bd6d5
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
 
+termux_step_post_configure() {
+	# clash with rust host build
+	# causes 32bit builds to fail if set
+	unset CFLAGS
+}
+
 termux_step_post_make_install() {
 	mkdir -p "${TERMUX_PREFIX}/share/man/man1"
 	mkdir -p "${TERMUX_PREFIX}/share/zsh/site-functions"


### PR DESCRIPTION
The 32bit builds failed on commit https://github.com/termux/termux-packages/commit/f6b33bc6ca0d0a567ecb600caf49e6ec543e8089.
- This seems to be the same issue we encountered in https://github.com/termux/termux-packages/commit/966977f4aaacff91cf33d99d7e8acbaf937ca8ed
and #22508

Since [`just_1.38.0`](https://packages.termux.dev/apt/termux-main/pool/main/j/just/) never made it to the repos due to the failed 32 bit builds no package revision is required.