### PR TITLE
CI: move some vars to env and set persist-credentials: false for actions/checkout@v4

### DIFF
--- a/.github/workflows/bootstrap_archives.yml
+++ b/.github/workflows/bootstrap_archives.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Git clone
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Create bootstrap archive
         run: ./scripts/generate-bootstraps.sh --architectures ${{ matrix.arch }}
       - name: Store artifacts
@@ -44,6 +46,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Fetch bootstrap archives
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/command_not_found.yml
+++ b/.github/workflows/command_not_found.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           fetch-depth: 1
           token: ${{ secrets.TERMUXBOT2_TOKEN }}
+          persist-credentials: false
       - name: Revbump main/command-not-found
         env:
           GITHUB_TOKEN: ${{ secrets.TERMUXBOT2_TOKEN }}

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Clone repository
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Build
       run: |
         cd ./scripts
@@ -44,6 +46,7 @@ jobs:
       with:
         username: grimler
         password: ${{ secrets.DOCKER_TOKEN }}
+        persist-credentials: false
     - name: Push
       if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'termux/termux-packages'
       run: |

--- a/.github/workflows/package_updates.yml
+++ b/.github/workflows/package_updates.yml
@@ -153,12 +153,16 @@ jobs:
           CREATE_ISSUE: "true"
           GIT_COMMIT_PACKAGES: "true"
           GIT_PUSH_PACKAGES: "true"
+          MANUAL_INPUT_PACKAGES: ${{ github.event.inputs.packages }}
         run: |
           git config --global user.name "Termux Github Actions"
           git config --global user.email "contact@termux.dev"
 
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            ./scripts/bin/update-packages ${{ github.event.inputs.packages }}
+            # Ensure MANUAL_INPUT_PACKAGES is newline free, and put it
+            # into an array
+            read -a PACKAGES <<< "${MANUAL_INPUT_PACKAGES//$'\n'/ }"
+            ./scripts/bin/update-packages "${PACKAGES[@]}"
           else
             ./scripts/bin/update-packages "@all"
           fi

--- a/.github/workflows/package_updates.yml
+++ b/.github/workflows/package_updates.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       - name: Gather build summary
         run: |
           BASE_COMMIT=$(jq --raw-output .pull_request.base.sha "$GITHUB_EVENT_PATH")
@@ -137,6 +138,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.TERMUXBOT2_TOKEN }}
+          persist-credentials: false
       - name: Free additional disk space
         run: |
           sudo apt purge -yq $(dpkg -l | grep '^ii' | awk '{ print $2 }' | grep -P '(aspnetcore|cabal-|dotnet-|ghc-|libmono|mongodb-|mysql-|php)') \

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -40,6 +40,8 @@ jobs:
         persist-credentials: false
     - name: Gather build summary
       id: build-info
+      env:
+        MANUAL_INPUT_PACKAGES: ${{ github.event.inputs.packages }}
       run: |
         if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
           BASE_COMMIT=$(jq --raw-output .pull_request.base.sha "$GITHUB_EVENT_PATH")
@@ -111,7 +113,10 @@ jobs:
             done<<<${CHANGED_FILES}
           done
         else
-          for pkg in ${{ github.event.inputs.packages }}; do
+          # Ensure MANUAL_INPUT_PACKAGES is newline free, and put it
+          # into an array
+          read -a PACKAGES <<< "${MANUAL_INPUT_PACKAGES//$'\n'/ }"
+          for pkg in "${PACKAGES[@]}"; do
             repo_paths=$(jq --raw-output 'del(.pkg_format) | keys | .[]' repo.json)
             found=false
             for repo_path in $repo_paths; do
@@ -190,6 +195,8 @@ jobs:
         fi
 
     - name: Free additional disk space (if needed)
+      env:
+        DOCKER_BUILD: ${{ steps.build-info.outputs.docker-build }}
       run: |
         declare -a packages
         for repo_path in $(jq --raw-output 'del(.pkg_format) | keys | .[]' repo.json); do
@@ -199,7 +206,7 @@ jobs:
           fi
         done
 
-        if [ ${{ steps.build-info.outputs.docker-build }} == 'false' ]; then
+        if [ "$DOCKER_BUILD" == 'false' ]; then
           ./scripts/setup-ubuntu.sh
           sudo apt install ninja-build
           sudo apt purge -yq $(dpkg -l | grep '^ii' | awk '{ print $2 }' | grep -P '(aspnetcore|cabal-|dotnet-|ghc-|libmono|mongodb-|mysql-|php)') \
@@ -210,6 +217,8 @@ jobs:
         fi
 
     - name: Build packages
+      env:
+        DOCKER_BUILD: ${{ steps.build-info.outputs.docker-build }}
       run: |
         declare -a packages
         for repo_path in $(jq --raw-output 'del(.pkg_format) | keys | .[]' repo.json); do
@@ -219,7 +228,7 @@ jobs:
           fi
         done
 
-        if [ ${{ steps.build-info.outputs.docker-build }} == 'false' ]; then
+        if [ "$DOCKER_BUILD" == 'false' ]; then
           NDK=$ANDROID_NDK ANDROID_HOME=$ANDROID_SDK_ROOT ./build-package.sh -I -a ${{ matrix.target_arch }} $packages
         elif [ -n "$packages" ]; then
           ./scripts/run-docker.sh ./build-package.sh -I -a ${{ matrix.target_arch }} $packages

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -37,6 +37,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 1000
+        persist-credentials: false
     - name: Gather build summary
       id: build-info
       run: |
@@ -274,6 +275,8 @@ jobs:
     steps:
     - name: Clone repository
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Get *.deb files
       uses: actions/download-artifact@v4
       with:
@@ -341,6 +344,8 @@ jobs:
     steps:
     - name: Clone repository
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Get *.deb files
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/vagrant.yml
+++ b/.github/workflows/vagrant.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Clone repository
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Set up Vagrant repo
       run: |
         # https://developer.hashicorp.com/vagrant/downloads#linux


### PR DESCRIPTION
After recent attack through github actions against https://github.com/ultralytics I had a look at our scripts. 

Most of the fixed variables, and `persist-credentials: false` for actions/checkout@v4, was suggested by [zizmor](https://github.com/woodruffw/zizmor), which @Biswa96 showed me.

