### PR TITLE
FFmpeg 7.1 transition part 3

### DIFF
--- a/packages/python-torchaudio/build.sh
+++ b/packages/python-torchaudio/build.sh
@@ -3,18 +3,82 @@ TERMUX_PKG_DESCRIPTION="Data manipulation and transformation for audio signal pr
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.5.0
-TERMUX_PKG_SRCURL=git+https://github.com/pytorch/audio
-# FFMPEG
-TERMUX_PKG_DEPENDS="libc++, python, python-pip, python-torch"
+TERMUX_PKG_REVISION=1
+# FFmpeg 7 is not yet supported. The subpackage should be removed when FFmpeg 7
+# is supported by an upstream release.
+# https://github.com/pytorch/audio/issues/3857
+_FFMPEG_VERSION=6.1.2
+_FFMPEG_SRCURL="https://www.ffmpeg.org/releases/ffmpeg-$_FFMPEG_VERSION.tar.xz"
+_FFMPEG_RM_AFTER_INSTALL="
+opt/torchaudio/include
+opt/torchaudio/lib/pkgconfig
+opt/torchaudio/share
+"
+TERMUX_PKG_SRCURL=(https://github.com/pytorch/audio/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+                   $_FFMPEG_SRCURL)
+TERMUX_PKG_SHA256=(fca49590d36966879f37cef29dcc83507e97e7cad68035a851734d93066c018e
+                   3b624649725ecdc565c903ca6643d41f33bd49239922e45c9b1442c63dca4e38)
+TERMUX_PKG_DEPENDS="libc++, python, python-pip, python-torch, torchaudio-ffmpeg"
 TERMUX_PKG_PYTHON_COMMON_DEPS="wheel, setuptools"
+TERMUX_PKG_RM_AFTER_INSTALL=$_FFMPEG_RM_AFTER_INSTALL
+
+_ffmpeg_configure_make_install() {
+	export _FFMPEG_PREFIX=${TERMUX_PREFIX}/opt/torchaudio
+	LDFLAGS="-Wl,-rpath=${_FFMPEG_PREFIX}/lib ${LDFLAGS}"
+
+	local _ARCH
+	case ${TERMUX_ARCH} in
+		arm ) _ARCH=armeabi-v7a ;;
+		i686 ) _ARCH=x86 ;;
+		* ) _ARCH=$TERMUX_ARCH ;;
+	esac
+
+	mkdir -p _ffmpeg-${_FFMPEG_VERSION}
+	pushd _ffmpeg-${_FFMPEG_VERSION}
+	$TERMUX_PKG_SRCDIR/ffmpeg-${_FFMPEG_VERSION}/configure \
+		--prefix=${_FFMPEG_PREFIX} \
+		--cc=${CC} \
+		--pkg-config=false \
+		--arch=${_ARCH} \
+		--cross-prefix=llvm- \
+		--enable-cross-compile \
+		--target-os=android \
+		--disable-version3 \
+		--disable-static \
+		--enable-shared \
+		--disable-all \
+		--disable-autodetect \
+		--disable-doc \
+		--enable-avcodec \
+		--enable-avformat \
+		--enable-avdevice \
+		--enable-avfilter \
+		--disable-asm
+	make -j ${TERMUX_PKG_MAKE_PROCESSES}
+	make install
+	popd
+}
+
+_ffmpeg_post_make_install() {
+	local _FFMPEG_DOCDIR=$TERMUX_PREFIX/share/doc/torchaudio-ffmpeg
+	mkdir -p ${_FFMPEG_DOCDIR}
+	ln -sfr ${TERMUX_PREFIX}/share/LICENSES/LGPL-2.1.txt \
+		${_FFMPEG_DOCDIR}/LICENSE
+}
+
+_ffmpeg_post_massage() {
+	rm -rf lib/pkgconfig
+}
 
 termux_step_pre_configure() {
+	_ffmpeg_configure_make_install
 	termux_setup_cmake
 	termux_setup_ninja
 
 	export BUILD_VERSION=$TERMUX_PKG_VERSION
-	# FIXME: The same as torchvision, upstream doesn't support ffmpeg 6.
-	export USE_FFMPEG=0
+	export FFMPEG_ROOT="$_FFMPEG_PREFIX"
+	# use this FFMPEG_ROOT when the system ffmpeg package can work
+	# export FFMPEG_ROOT="$TERMUX_PREFIX"
 	export TORCHAUDIO_CMAKE_PREFIX_PATH="$TERMUX_PYTHON_HOME/site-packages/torch;$TERMUX_PREFIX"
 	export host_alias="$TERMUX_HOST_PLATFORM"
 }
@@ -25,4 +89,12 @@ termux_step_configure() {
 
 termux_step_make_install() {
 	pip -v install --no-build-isolation --no-deps --prefix "$TERMUX_PREFIX" "$TERMUX_PKG_SRCDIR"
+}
+
+termux_step_post_make_install() {
+	_ffmpeg_post_make_install
+}
+
+termux_step_post_massage() {
+	_ffmpeg_post_massage
 }

--- a/packages/python-torchaudio/ffmpeg-configure.patch
+++ b/packages/python-torchaudio/ffmpeg-configure.patch
@@ -1,0 +1,51 @@
++++ ./ffmpeg-6.1.2/configure
+@@ -5336,13 +5336,9 @@
+         striptype=""
+         ;;
+     android)
+-        disable symver
+         enable section_data_rel_ro
+         add_cflags -fPIE
+         add_ldexeflags -fPIE -pie
+-        SLIB_INSTALL_NAME='$(SLIBNAME)'
+-        SLIB_INSTALL_LINKS=
+-        SHFLAGS='-shared -Wl,-soname,$(SLIBNAME)'
+         ;;
+     haiku)
+         prefix_default="/boot/common"
++++ ./ffmpeg-6.1.2/libavcodec/allcodecs.c
+@@ -154,7 +154,6 @@
+ extern const FFCodec ff_h264_crystalhd_decoder;
+ extern const FFCodec ff_h264_v4l2m2m_decoder;
+ extern const FFCodec ff_h264_mediacodec_decoder;
+-extern const FFCodec ff_h264_mediacodec_encoder;
+ extern const FFCodec ff_h264_mmal_decoder;
+ extern const FFCodec ff_h264_qsv_decoder;
+ extern const FFCodec ff_h264_rkmpp_decoder;
+@@ -850,6 +849,7 @@
+ extern const FFCodec ff_libopenh264_decoder;
+ extern const FFCodec ff_h264_amf_encoder;
+ extern const FFCodec ff_h264_cuvid_decoder;
++extern const FFCodec ff_h264_mediacodec_encoder;
+ extern const FFCodec ff_h264_mf_encoder;
+ extern const FFCodec ff_h264_nvenc_encoder;
+ extern const FFCodec ff_h264_omx_encoder;
++++ ./ffmpeg-6.1.2/libavutil/file_open.c
+@@ -119,7 +119,7 @@
+ #undef free
+     free(ptr);
+ #else
+-    size_t len = strlen(prefix) + 12; /* room for "/tmp/" and "XXXXXX\0" */
++    size_t len = strlen(prefix) + strlen("@TERMUX_PREFIX@/tmp/") + 7; /* room for "@TERMUX_PREFIX@/tmp/" and "XXXXXX\0" */
+     *filename  = av_malloc(len);
+ #endif
+     /* -----common section-----*/
+@@ -136,7 +136,7 @@
+ #   endif
+     fd = open(*filename, O_RDWR | O_BINARY | O_CREAT | O_EXCL, 0600);
+ #else
+-    snprintf(*filename, len, "/tmp/%sXXXXXX", prefix);
++    snprintf(*filename, len, "@TERMUX_PREFIX@/tmp/%sXXXXXX", prefix);
+     fd = mkstemp(*filename);
+ #if defined(_WIN32) || defined (__ANDROID__)
+     if (fd < 0) {

--- a/packages/python-torchaudio/torchaudio-ffmpeg.subpackage.sh
+++ b/packages/python-torchaudio/torchaudio-ffmpeg.subpackage.sh
@@ -1,0 +1,6 @@
+
+TERMUX_SUBPKG_DESCRIPTION="Minimal FFmpeg libraries for python-torchaudio"
+TERMUX_SUBPKG_INCLUDE="
+opt/torchaudio/lib/
+share/doc/torchaudio-ffmpeg/
+"

--- a/packages/python-torchvision/build.sh
+++ b/packages/python-torchvision/build.sh
@@ -3,9 +3,10 @@ TERMUX_PKG_DESCRIPTION="Datasets, Transforms and Models specific to Computer Vis
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.20.0
-TERMUX_PKG_SRCURL=git+https://github.com/pytorch/vision
-# ffmpeg
-TERMUX_PKG_DEPENDS="libc++, python, python-numpy, python-pillow, python-pip, python-torch, libjpeg-turbo, libpng, zlib"
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=https://github.com/pytorch/vision/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=b59d9896c5c957c6db0018754bbd17d079c5102b82b9be0b438553b40a7b6029
+TERMUX_PKG_DEPENDS="libc++, ffmpeg, python, python-numpy, python-pillow, python-pip, python-torch, libjpeg-turbo, libpng, libwebp, zlib"
 TERMUX_PKG_PYTHON_COMMON_DEPS="wheel, setuptools"
 
 termux_step_pre_configure() {
@@ -14,9 +15,15 @@ termux_step_pre_configure() {
 	CXXFLAGS+=" -DUSE_PYTHON"
 	LDFLAGS+=" -ltorch_cpu -ltorch_python -lc10"
 
-	# FIXME: Disable ffmpeg temporarily because torchvision doesn't support ffmpeg 6.
-	export TORCHVISION_USE_FFMPEG=0
+	# setting this $BUILD_PREFIX variable, which wasn't previously set, causes
+	# libwebp to be detected and libjpeg to be detected,
+	# and assists with detecting ffmpeg
+	export BUILD_PREFIX="$TERMUX_PREFIX"
 	export BUILD_VERSION=$TERMUX_PKG_VERSION
+
+	# this causes ffmpeg to be detected during cross-compilation,
+	# enabling the "video decoder extensions"
+	sed -i "s|shutil.which(\"ffmpeg\")|\"$TERMUX_PREFIX/bin/ffmpeg\"|" setup.py
 }
 
 termux_step_configure() {

--- a/x11-packages/kdenlive/build.sh
+++ b/x11-packages/kdenlive/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION='A non-linear video editor for Linux using the MLT video 
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="24.12.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/kdenlive-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=c61d034dce9c25a9d2f9e7acff990b7ba46f664d1f972acfaba3a84de1c2288a
 TERMUX_PKG_DEPENDS="libc++, ffplay, frei0r-plugins, kf6-karchive, kf6-kbookmarks, kf6-kcodecs, kf6-kcolorscheme, kf6-kcompletion, kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-kdbusaddons, kf6-kfilemetadata, kf6-kguiaddons, kf6-ki18n, kf6-kiconthemes, kf6-kio, kf6-kitemviews, kf6-knewstuff, kf6-knotifications, kf6-knotifyconfig, kf6-ktextwidgets, kf6-kwidgetsaddons, kf6-kxmlgui, kf6-purpose, kf6-qqc2-desktop-style, kf6-solid, mediainfo, mlt, qt6-qtbase, qt6-qtdeclarative, qt6-qtmultimedia, qt6-qtnetworkauth, qt6-qtsvg, shared-mime-info"

--- a/x11-packages/shotcut/build.sh
+++ b/x11-packages/shotcut/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Cross-platform Qt based Video Editor"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="24.11.17"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/mltframework/shotcut/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=cb6a3a819b3ae56325406665273347328ae973250c02a832fce609ee6c0f6b13
 TERMUX_PKG_DEPENDS="ffmpeg, fftw, frei0r-plugins, mlt, libx264, libvpx, lame, ladspa-sdk, movit, qt6-qtbase, qt6-qtcharts, qt6-qtdeclarative, qt6-qtimageformats, qt6-qtmultimedia, qt6-qttranslations, sdl2"


### PR DESCRIPTION
Progress on #22502

#### Recompiled packages

For these, I believe the existing package verifiably calls into FFmpeg 7.1 to play videos with no obvious issues, but revision-bumping to be on the safe side.

- `firefox`
- `kdenlive`
- `shotcut`

#### Packages newly enabling FFmpeg

I have found ways to enable the FFmpeg backends in these that did not previously have FFmpeg support in Termux.

I also changed these packages to use the release downloads instead of git and use checksum verification, which they previously did not. If there is a reason that these specific packages are not supposed to use checksum verification, please let me know.

- `python-torchaudio`: `torchaudio-ffmpeg` subpackage created based on some logic copied from `audacity-ffmpeg`, enabling FFmpeg 6.1.2 support in this package
- `python-torchvision`: minor adjustments to build script appear to enable FFmpeg 7.1 with no build errors

#### Ignored packages

Twaik has directed me to not do anything to these packages right now because the reason for `audacity-ffmpeg` is not currently well-understood, so it might not be safe to remove. Otherwise this package has no obvious issues when compiled, and its FFmpeg decoding and encoding backends tested, using only the `ffmpeg` 7.1 package.

- `audacity`
- `audacity-ffmpeg`