### PR TITLE
bump(x11/audacity-ffmpeg): 7.1, revbump audacity for ffmpeg-audacity 7.1

### DIFF
--- a/x11-packages/audacity/build.sh
+++ b/x11-packages/audacity/build.sh
@@ -3,12 +3,13 @@ TERMUX_PKG_DESCRIPTION="An easy-to-use, multi-track audio editor and recorder"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.7.1"
-_FFMPEG_VERSION=6.1.1
+TERMUX_PKG_REVISION=1
+_FFMPEG_VERSION=7.1
 TERMUX_PKG_SRCURL=(https://github.com/audacity/audacity/archive/Audacity-${TERMUX_PKG_VERSION}.tar.gz
                    https://www.ffmpeg.org/releases/ffmpeg-${_FFMPEG_VERSION}.tar.xz)
 TERMUX_PKG_SHA256=(
 	02457fe0ae1dab3a9a50ce54836cdd78a2d3ab51650d42696cab417210f03906
-	8684f4b00f94b85461884c3719382f1261f0d9eb3d59640a1f4ac0873616f968
+	40973d44970dbc83ef302b0609f2e74982be2d85916dd2ee7472d30678a7abe6
 )
 TERMUX_PKG_DEPENDS="gdk-pixbuf, glib, gtk3, libc++, libexpat, libflac, libid3tag, libogg, libopus, libsndfile, libsoundtouch, libsoxr, libuuid, libvorbis, libwavpack, mpg123, opusfile, portaudio, portmidi, wxwidgets"
 TERMUX_PKG_BUILD_DEPENDS="libjpeg-turbo, libjpeg-turbo-static, libmp3lame, libpng, rapidjson, zlib"
@@ -85,7 +86,7 @@ obtain_deb_url() {
 termux_step_host_build() {
 	termux_setup_cmake
 	termux_setup_ninja
-	
+
 	( # Running build in a subshell to avoid variable mess
 		# We must build the `image-compiler` for building.
 		# See https://github.com/audacity/audacity/blob/Audacity-3.6.4/BUILDING.md#selecting-target-architecture-on-macos

--- a/x11-packages/audacity/ffmpeg-configure.patch
+++ b/x11-packages/audacity/ffmpeg-configure.patch
@@ -1,4 +1,4 @@
-+++ ./ffmpeg-6.1.1/configure
++++ ./ffmpeg-7.1/configure
 @@ -5336,13 +5336,9 @@
          striptype=""
          ;;
@@ -13,7 +13,7 @@
          ;;
      haiku)
          prefix_default="/boot/common"
-+++ ./ffmpeg-6.1.1/libavcodec/allcodecs.c
++++ ./ffmpeg-7.1/libavcodec/allcodecs.c
 @@ -154,7 +154,6 @@
  extern const FFCodec ff_h264_crystalhd_decoder;
  extern const FFCodec ff_h264_v4l2m2m_decoder;
@@ -30,22 +30,22 @@
  extern const FFCodec ff_h264_mf_encoder;
  extern const FFCodec ff_h264_nvenc_encoder;
  extern const FFCodec ff_h264_omx_encoder;
-+++ ./ffmpeg-6.1.1/libavutil/file_open.c
-@@ -119,7 +119,7 @@
- #undef free
-     free(ptr);
- #else
++++ ./ffmpeg-7.1/libavutil/file_open.c
+@@ -113,7 +113,7 @@
+     FileLogContext file_log_ctx = { &file_log_ctx_class, log_offset, log_ctx };
+     int fd = -1;
+ #if HAVE_MKSTEMP
 -    size_t len = strlen(prefix) + 12; /* room for "/tmp/" and "XXXXXX\0" */
 +    size_t len = strlen(prefix) + strlen("@TERMUX_PREFIX@/tmp/") + 7; /* room for "@TERMUX_PREFIX@/tmp/" and "XXXXXX\0" */
      *filename  = av_malloc(len);
- #endif
-     /* -----common section-----*/
-@@ -136,7 +136,7 @@
+ #elif HAVE_TEMPNAM
+     void *ptr= tempnam(NULL, prefix);
+@@ -139,7 +139,7 @@
  #   endif
      fd = open(*filename, O_RDWR | O_BINARY | O_CREAT | O_EXCL, 0600);
  #else
 -    snprintf(*filename, len, "/tmp/%sXXXXXX", prefix);
 +    snprintf(*filename, len, "@TERMUX_PREFIX@/tmp/%sXXXXXX", prefix);
      fd = mkstemp(*filename);
- #if defined(_WIN32) || defined (__ANDROID__)
+ #if defined(_WIN32) || defined (__ANDROID__) || defined(__DJGPP__)
      if (fd < 0) {


### PR DESCRIPTION
following the directions given here: https://github.com/termux/termux-packages/issues/22502#issuecomment-2552191867

(paraphrased) "if audacity works with ffmpeg 7 we should recompile it and upgrade the ffmpeg subpackage"

<details>
<summary>Alternative implementation of this change (deleting subpackage) that I tested first</summary>

```diff
--- a/x11-packages/audacity/audacity-ffmpeg.subpackage.sh
+++ /dev/null
@@ -1,5 +0,0 @@
-TERMUX_SUBPKG_DESCRIPTION="Minimal FFmpeg libraries for Audacity"
-TERMUX_SUBPKG_INCLUDE="
-opt/audacity/lib/
-share/doc/audacity-ffmpeg/
-"
--- a/x11-packages/audacity/build.sh
+++ b/x11-packages/audacity/build.sh
@@ -3,18 +3,11 @@ TERMUX_PKG_DESCRIPTION="An easy-to-use, multi-track audio editor and recorder"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.7.1"
-_FFMPEG_VERSION=6.1.1
-TERMUX_PKG_SRCURL=(https://github.com/audacity/audacity/archive/Audacity-${TERMUX_PKG_VERSION}.tar.gz
-                   https://www.ffmpeg.org/releases/ffmpeg-${_FFMPEG_VERSION}.tar.xz)
-TERMUX_PKG_SHA256=(
-	02457fe0ae1dab3a9a50ce54836cdd78a2d3ab51650d42696cab417210f03906
-	8684f4b00f94b85461884c3719382f1261f0d9eb3d59640a1f4ac0873616f968
-)
-TERMUX_PKG_DEPENDS="gdk-pixbuf, glib, gtk3, libc++, libexpat, libflac, libid3tag, libogg, libopus, libsndfile, libsoundtouch, libsoxr, libuuid, libvorbis, libwavpack, mpg123, opusfile, portaudio, portmidi, wxwidgets"
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=https://github.com/audacity/audacity/archive/Audacity-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=02457fe0ae1dab3a9a50ce54836cdd78a2d3ab51650d42696cab417210f03906
+TERMUX_PKG_DEPENDS="ffmpeg, gdk-pixbuf, glib, gtk3, libc++, libexpat, libflac, libid3tag, libogg, libopus, libsndfile, libsoundtouch, libsoxr, libuuid, libvorbis, libwavpack, mpg123, opusfile, portaudio, portmidi, wxwidgets"
 TERMUX_PKG_BUILD_DEPENDS="libjpeg-turbo, libjpeg-turbo-static, libmp3lame, libpng, rapidjson, zlib"
-# Support for FFmpeg 5.0 is not backported:
-# https://github.com/audacity/audacity/issues/2445
-TERMUX_PKG_SUGGESTS="audacity-ffmpeg"
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+.\d+.\d+"
 TERMUX_PKG_AUTO_UPDATE=true
@@ -44,11 +37,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Daudacity_use_twolame=off
 -DUSE_MIDI=OFF
 "
-TERMUX_PKG_RM_AFTER_INSTALL="
-opt/audacity/include
-opt/audacity/lib/pkgconfig
-opt/audacity/share
-"
 
 # Function to obtain the .deb URL
 obtain_deb_url() {
@@ -119,49 +107,6 @@ termux_step_host_build() {
 }
 
 termux_step_pre_configure() {
-	local _FFMPEG_PREFIX=${TERMUX_PREFIX}/opt/${TERMUX_PKG_NAME}
-	LDFLAGS="-Wl,-rpath=${_FFMPEG_PREFIX}/lib ${LDFLAGS}"
-
-	local _ARCH
-	case ${TERMUX_ARCH} in
-		arm ) _ARCH=armeabi-v7a ;;
-		i686 ) _ARCH=x86 ;;
-		* ) _ARCH=$TERMUX_ARCH ;;
-	esac
-
-	mkdir -p _ffmpeg-${_FFMPEG_VERSION}
-	pushd _ffmpeg-${_FFMPEG_VERSION}
-	$TERMUX_PKG_SRCDIR/ffmpeg-${_FFMPEG_VERSION}/configure \
-		--prefix=${_FFMPEG_PREFIX} \
-		--cc=${CC} \
-		--pkg-config=false \
-		--arch=${_ARCH} \
-		--cross-prefix=llvm- \
-		--enable-cross-compile \
-		--target-os=android \
-		--disable-version3 \
-		--disable-static \
-		--enable-shared \
-		--disable-all \
-		--disable-autodetect \
-		--disable-doc \
-		--enable-avcodec \
-		--enable-avformat \
-		--disable-asm
-	make -j ${TERMUX_PKG_MAKE_PROCESSES}
-	make install
-	popd
-
-	local lib
-	for lib in libavcodec libavformat libavutil; do
-		local pc=${TERMUX_PREFIX}/lib/pkgconfig/${lib}.pc
-		if [ -e ${pc} ]; then
-			mv ${pc}{,.tmp}
-		fi
-	done
-	export PKG_CONFIG_PATH=${_FFMPEG_PREFIX}/lib/pkgconfig
-	CPPFLAGS="-I${_FFMPEG_PREFIX}/include ${CPPFLAGS}"
-
 	CPPFLAGS+=" -Dushort=u_short -Dulong=u_long"
 	CXXFLAGS+=" -std=c++17"
 	# Adding `image-compiler` we built in host_build step
@@ -171,26 +116,6 @@ termux_step_pre_configure() {
 	export LD_LIBRARY_PATH="$TERMUX_PKG_HOSTBUILD_DIR/prefix/usr/lib/x86_64-linux-gnu"
 }
 
-termux_step_post_make_install() {
-	unset PKG_CONFIG_PATH
-	local lib
-	for lib in libavcodec libavformat libavutil; do
-		local pc=${TERMUX_PREFIX}/lib/pkgconfig/${lib}.pc
-		if [ -e ${pc}.tmp ] && [ ! -e ${pc} ]; then
-			mv ${pc}{.tmp,}
-		fi
-	done
-
-	local _FFMPEG_DOCDIR=$TERMUX_PREFIX/share/doc/audacity-ffmpeg
-	mkdir -p ${_FFMPEG_DOCDIR}
-	ln -sfr ${TERMUX_PREFIX}/share/LICENSES/LGPL-2.1.txt \
-		${_FFMPEG_DOCDIR}/LICENSE
-}
-
-termux_step_post_massage() {
-	rm -rf lib/pkgconfig
-}
-
 termux_step_create_debscripts() {
 	cat <<-EOF > ./postinst
 		#!$TERMUX_PREFIX/bin/sh
--- a/x11-packages/audacity/ffmpeg-configure.patch
+++ /dev/null
@@ -1,51 +0,0 @@
-+++ ./ffmpeg-6.1.1/configure
-@@ -5336,13 +5336,9 @@
-         striptype=""
-         ;;
-     android)
--        disable symver
-         enable section_data_rel_ro
-         add_cflags -fPIE
-         add_ldexeflags -fPIE -pie
--        SLIB_INSTALL_NAME='$(SLIBNAME)'
--        SLIB_INSTALL_LINKS=
--        SHFLAGS='-shared -Wl,-soname,$(SLIBNAME)'
-         ;;
-     haiku)
-         prefix_default="/boot/common"
-+++ ./ffmpeg-6.1.1/libavcodec/allcodecs.c
-@@ -154,7 +154,6 @@
- extern const FFCodec ff_h264_crystalhd_decoder;
- extern const FFCodec ff_h264_v4l2m2m_decoder;
- extern const FFCodec ff_h264_mediacodec_decoder;
--extern const FFCodec ff_h264_mediacodec_encoder;
- extern const FFCodec ff_h264_mmal_decoder;
- extern const FFCodec ff_h264_qsv_decoder;
- extern const FFCodec ff_h264_rkmpp_decoder;
-@@ -850,6 +849,7 @@
- extern const FFCodec ff_libopenh264_decoder;
- extern const FFCodec ff_h264_amf_encoder;
- extern const FFCodec ff_h264_cuvid_decoder;
-+extern const FFCodec ff_h264_mediacodec_encoder;
- extern const FFCodec ff_h264_mf_encoder;
- extern const FFCodec ff_h264_nvenc_encoder;
- extern const FFCodec ff_h264_omx_encoder;
-+++ ./ffmpeg-6.1.1/libavutil/file_open.c
-@@ -119,7 +119,7 @@
- #undef free
-     free(ptr);
- #else
--    size_t len = strlen(prefix) + 12; /* room for "/tmp/" and "XXXXXX\0" */
-+    size_t len = strlen(prefix) + strlen("@TERMUX_PREFIX@/tmp/") + 7; /* room for "@TERMUX_PREFIX@/tmp/" and "XXXXXX\0" */
-     *filename  = av_malloc(len);
- #endif
-     /* -----common section-----*/
-@@ -136,7 +136,7 @@
- #   endif
-     fd = open(*filename, O_RDWR | O_BINARY | O_CREAT | O_EXCL, 0600);
- #else
--    snprintf(*filename, len, "/tmp/%sXXXXXX", prefix);
-+    snprintf(*filename, len, "@TERMUX_PREFIX@/tmp/%sXXXXXX", prefix);
-     fd = mkstemp(*filename);
- #if defined(_WIN32) || defined (__ANDROID__)
-     if (fd < 0) {
```

</details>

and described [here](https://github.com/termux/termux-packages/pull/22551#issuecomment-2543502072), before modifying it to be the way shown in this PR on the advice of twaik.