### PR TITLE
scripts: Allow patch files in source url array

### DIFF
--- a/packages/gpac/build.sh
+++ b/packages/gpac/build.sh
@@ -5,29 +5,20 @@ TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.4.0"
 TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://github.com/gpac/gpac/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=99c8c994d5364b963d18eff24af2576b38d38b3460df27d451248982ea16157a
+TERMUX_PKG_SRCURL=(
+	https://github.com/gpac/gpac/archive/refs/tags/v"${TERMUX_PKG_VERSION}".tar.gz
+	https://github.com/gpac/gpac/commit/18863aa2176e423dae2a6d7e39ff6ed6a37b2b78.patch
+)
+TERMUX_PKG_SHA256=(
+	99c8c994d5364b963d18eff24af2576b38d38b3460df27d451248982ea16157a
+	3a4e10a031bc081a402bfd24889f85fcbf99d4fd36a9086aedda546445037bec
+)
 TERMUX_PKG_DEPENDS="ffmpeg, freetype, liba52, libjpeg-turbo, liblzma, libmad, libnghttp2, libogg, libpng, libtheora, libvorbis, openjpeg, openssl, pulseaudio, xvidcore, zlib"
 TERMUX_PKG_EXTRA_MAKE_ARGS="STRIP=:"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-x11"
 
 termux_step_pre_configure() {
-	declare -a _commits=(
-	18863aa2
-	)
-
-	declare -a _checksums=(
-	3a4e10a031bc081a402bfd24889f85fcbf99d4fd36a9086aedda546445037bec
-	)
-
-	for i in "${!_commits[@]}"; do
-		PATCHFILE="${TERMUX_PKG_CACHEDIR}/gpac_patch_${_commits[i]}.patch"
-		termux_download \
-			"https://github.com/gpac/gpac/commit/${_commits[i]}.patch" \
-			"$PATCHFILE" \
-			"${_checksums[i]}"
-		patch -p1 -i "$PATCHFILE"
-	done
+	patch -p1 -i "${TERMUX_PKG_CACHEDIR}"/18863aa2176e423dae2a6d7e39ff6ed6a37b2b78.patch
 
 	CFLAGS+=" -fPIC"
 	for f in $CFLAGS $CPPFLAGS; do

--- a/scripts/build/get_source/termux_unpack_src_archive.sh
+++ b/scripts/build/get_source/termux_unpack_src_archive.sh
@@ -13,6 +13,8 @@ termux_extract_src_archive() {
 			rm -Rf $folder
 			unzip -q "$file"
 			mv $folder "$TERMUX_PKG_SRCDIR"
+		elif [ "${file##*.}" = patch ] || [ "${file##*.}" = diff ]; then
+			continue
 		else
 			test "$i" -gt 0 && STRIP=0
 			mkdir -p "$TERMUX_PKG_SRCDIR"


### PR DESCRIPTION
    Inspired by PKGBUILD and APKBUILD, this commit allows to add patch files
    in source array. Previously, patch files are passed to tar command which
    are excluded now. The patches can be downloaded from upstream source
    repository or from pull requests. Then it will be applied or reverted
    using patch command in termux_step_pre_configure function.