### PR TITLE
ctags: add host build

### DIFF
--- a/packages/ctags/build.sh
+++ b/packages/ctags/build.sh
@@ -16,8 +16,15 @@ termux_step_post_get_source() {
 	./autogen.sh
 }
 
+termux_step_host_build() {
+	local _PREFIX_FOR_BUILD=${TERMUX_PREFIX}/opt/$TERMUX_PKG_NAME
+	cd $TERMUX_PKG_SRCDIR
+	./configure $TERMUX_PKG_EXTRA_CONFIGURE_ARGS --prefix=$_PREFIX_FOR_BUILD
+	make -j $TERMUX_PKG_MAKE_PROCESSES
+	make install
+	make clean
+}
+
 termux_step_pre_configure() {
 	./autogen.sh
-	cp $TERMUX_PKG_HOSTBUILD_DIR/packcc $TERMUX_PKG_BUILDDIR/
-	touch -d "next hour" $TERMUX_PKG_BUILDDIR/packcc
 }


### PR DESCRIPTION
It had TERMUX_PKG_HOSTBUILD=true but the host recipe was omitted.

Also had to remove packcc games to avoid this:

cp: cannot stat '/home/builder/.termux-build/ctags/host-build/packcc': No such file or directory

This patch allows to build the programs that need ctags during build.