### PR TITLE
enhance(main/lesspipe): ship `zsh` completions

### DIFF
--- a/packages/lesspipe/build.sh
+++ b/packages/lesspipe/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="An input filter for the pager less"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION="2.17"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/wofr06/lesspipe/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=8de1525e0c00ccca96d402562c99e527bb6a95a8667dcb899f519350d75c8ba4
 TERMUX_PKG_AUTO_UPDATE=true
@@ -14,7 +15,8 @@ TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_configure() {
 	./configure \
-		--prefix="$TERMUX_PREFIX"
+		--prefix="$TERMUX_PREFIX" \
+		--all-completions
 }
 
 termux_step_post_make_install() {

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -315,6 +315,9 @@ PACKAGES+=" tree-sitter-cli"
 # Needed by wlroots
 PACKAGES+=" glslang-tools"
 
+# Needed by lesspipe for completions
+PACKAGES+=" zsh"
+
 # Do not require sudo if already running as root.
 SUDO="sudo"
 if [ "$(id -u)" = "0" ]; then


### PR DESCRIPTION
`lesspipe` offers Zsh completions, these require `zsh` to be present on the host at build time though.

CC: @Biswa96