### PR TITLE
new package: libelf-minimal

### DIFF
--- a/packages/libelf-minimal/build.sh
+++ b/packages/libelf-minimal/build.sh
@@ -1,0 +1,24 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/arachsys/libelf/
+TERMUX_PKG_DESCRIPTION="Freestanding libelf extracted from elfutils"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.192.1"
+TERMUX_PKG_SRCURL="https://github.com/arachsys/libelf/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=a359755a54200e0d9fab4bf169d5af7d2177d12b324874c6c32eaac5cce79295
+TERMUX_PKG_BUILD_DEPENDS="zlib, zstd"
+TERMUX_PKG_DEPENDS="zlib, zstd"
+TERMUX_PKG_CONFLICTS="libelf-dev, libelf"
+TERMUX_PKG_REPLACES="libelf-dev, libelf"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make() {
+	cd $TERMUX_PKG_SRCDIR
+	make -j $TERMUX_PKG_MAKE_PROCESSES PREFIX=$PREFIX PKG_CONFIG=$PKG_CONFIG
+}
+
+termux_step_make_install() {
+	cd $TERMUX_PKG_SRCDIR
+	# don't install static
+	make -j $TERMUX_PKG_MAKE_PROCESSES install-headers \
+		install-shared install-pc PREFIX=$PREFIX
+}

--- a/packages/libelf-minimal/makefile.patch
+++ b/packages/libelf-minimal/makefile.patch
@@ -1,0 +1,19 @@
+diff --git a/Makefile b/Makefile
+index 2e6bbe5..0e00aea 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,9 +1,12 @@
+ INCDIR = $(PREFIX)/include
+ LIBDIR = $(PREFIX)/lib
++PKG_CONFIG = pkg-config
+ 
+-CFLAGS = -O2 -Wall
++CFLAGS = -O2 -Wall $(shell $(PKG_CONFIG) --cflags zlib) \
++  $(shell $(PKG_CONFIG) --cflags libzstd)
+ LDFLAGS =
+-LDLIBS = -lz -lzstd
++LDLIBS = $(shell $(PKG_CONFIG) --libs zlib) \
++  $(shell $(PKG_CONFIG) --libs libzstd)
+ 
+ MAJOR = 1
+ MINOR = 0.192

--- a/packages/libelf-minimal/pkgconf.patch
+++ b/packages/libelf-minimal/pkgconf.patch
@@ -1,0 +1,64 @@
+diff --git a/Makefile b/Makefile
+index 0e00aea..4bb6a39 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,7 @@
++PREFIX ?= /usr/local
+ INCDIR = $(PREFIX)/include
+ LIBDIR = $(PREFIX)/lib
++DATADIR = $(PREFIX)/share
+ PKG_CONFIG = pkg-config
+ 
+ CFLAGS = -O2 -Wall $(shell $(PKG_CONFIG) --cflags zlib) \
+@@ -18,7 +20,7 @@ PICOBJS = $(patsubst %.c,%.os,$(SOURCES))
+ 
+ override CFLAGS += -DHAVE_CONFIG_H -Iinclude -Isrc
+ 
+-all: libelf.a libelf.so
++all: libelf.a libelf.so libelf.pc
+ 
+ clean:
+ 	rm -f src/*.o src/*.os libelf.a libelf.so
+@@ -36,12 +38,24 @@ libelf.so: $(PICOBJS) Makefile
+ %.os:: %.c $(HEADERS) Makefile
+ 	$(CC) $(CFLAGS) -fPIC -c -o $@ $<
+ 
+-install: install-headers install-static install-shared
++libelf.pc: libelf.pc.in Makefile
++	sed \
++		-e 's!@prefix[@]!$(PREFIX)!g' \
++		-e 's!@libdir[@]!$(LIBDIR)!g' \
++		-e 's!@includedir[@]!$(INCDIR)!g' \
++		-e 's!@VERSION[@]!$(MINOR)!g' \
++		$< >$@
++
++install: install-headers install-static install-shared install-pc
+ 
+ install-headers: include/*.h
+ 	mkdir -p $(DESTDIR)$(INCDIR)
+ 	install -m 0644 include/*.h $(DESTDIR)$(INCDIR)
+ 
++install-pc: libelf.pc
++	mkdir -p $(DESTDIR)$(DATADIR)/pkgconfig
++	install -m 0644 $^ $(DESTDIR)$(DATADIR)/pkgconfig
++
+ install-static: libelf.a install-headers
+ 	mkdir -p $(DESTDIR)$(LIBDIR)
+ 	install -m 0644 $< $(DESTDIR)$(LIBDIR)
+diff --git a/libelf.pc.in b/libelf.pc.in
+new file mode 100644
+index 0000000..8212491
+--- /dev/null
++++ b/libelf.pc.in
+@@ -0,0 +1,11 @@
++prefix=@prefix@
++libdir=@libdir@
++includedir=@includedir@
++
++Name: libelf
++Description: elfutils libelf library to read and write ELF files
++Version: @VERSION@
++URL: https://github.com/arachsys/libelf/
++
++Libs: -L${libdir} -lelf
++Cflags: -I${includedir}


### PR DESCRIPTION
This is a minimalistic libelf from here:
https://github.com/arachsys/libelf
It is an actively maintained rip-off from elfutils, called Freestanding libelf.

On Termux it sufficiently reduces build time and the amount of packages, because full elfutils builds debuginfod, which gets in curl, libnghttp3, libsqlite, libsqlite-tcl and many more. libsqlite-tcl brings in the GUI libs! (libxau, libxrender)

libelf-minimal package resolves this mess.