### PR TITLE
ctags: package clean-up

### DIFF
--- a/packages/ctags/build.sh
+++ b/packages/ctags/build.sh
@@ -3,21 +3,14 @@ TERMUX_PKG_DESCRIPTION="Universal ctags: Source code index builder"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2:6.1.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/universal-ctags/ctags/archive/refs/tags/v${TERMUX_PKG_VERSION:2}.tar.gz
 TERMUX_PKG_SHA256=1eb6d46d4c4cace62d230e7700033b8db9ad3d654f2d4564e87f517d4b652a53
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libiconv, libjansson, libxml2, libyaml"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-tmpdir=$TERMUX_PREFIX/tmp --disable-static"
 TERMUX_PKG_BUILD_IN_SRC=true
-TERMUX_PKG_HOSTBUILD=true
 
 termux_step_post_get_source() {
-	export regcomp_works=yes
 	./autogen.sh
-}
-
-termux_step_pre_configure() {
-	./autogen.sh
-	cp $TERMUX_PKG_HOSTBUILD_DIR/packcc $TERMUX_PKG_BUILDDIR/
-	touch -d "next hour" $TERMUX_PKG_BUILDDIR/packcc
 }


### PR DESCRIPTION
This patch cleans up ctags package in several ways:
- Added TERMUX_PKG_REVISION (per @twaik suggestion) instead of playing the version tricks. This has an extra benefit of removing colon from deb file name, with which I had problems in my CI.
- Removed regcomp_works=yes hack that is no longer needed since this: https://github.com/universal-ctags/ctags/pull/3054/commits/daa1a0f9169324eb3176eda8c59414c9e0770a49#diff-49473dca262eeab3b4a43002adb08b4db31020d190caaad1594b47f1d5daa810L607-L617
- Removed TERMUX_PKG_HOSTBUILD and the related packcc games. They are no longer needed per https://github.com/termux/termux-packages/pull/22639#issuecomment-2558116781 (@truboxl) and are making problems in my CI.
- Removed double autogen.sh invocation

The result is faster-building (no hostbuild, no double autogen) and easier to extend package.