### PR TITLE
fix(main/swi-prolog): continue even if ABI check fails

### DIFF
--- a/packages/swi-prolog/build.sh
+++ b/packages/swi-prolog/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Most popular and complete prolog implementation"
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="9.3.20"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.swi-prolog.org/download/devel/src/swipl-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=81cae918f75778c285bbecfc2b17c7117b574238e00213043a1fa0022acc36d6
 TERMUX_PKG_DEPENDS="libandroid-execinfo, libarchive, libcrypt, libgmp, libyaml, ncurses, openssl, ossp-uuid, readline, zlib, pcre2"

--- a/packages/swi-prolog/continue-on-abi-check-failure.patch
+++ b/packages/swi-prolog/continue-on-abi-check-failure.patch
@@ -1,0 +1,30 @@
+swi-prolog cannot currently continue in Termux on 32-bit ARM architecture without this patch.
+https://github.com/termux/termux-packages/issues/22737
+--- a/src/pl-init.c
++++ b/src/pl-init.c
+@@ -256,11 +256,21 @@ check_home(const char *dir)
+   Ssnprintf(abi_file_name, sizeof(abi_file_name),
+ 	    "%s/ABI", dir);
+   if ( (fd = Sopen_file(abi_file_name, "r")) )
+-  { char *abi_string = Sfgets(abi_buf, sizeof(abi_buf), fd);
++  { char *build_time_abi_string = Sfgets(abi_buf, sizeof(abi_buf), fd);
+     Sclose(fd);
+-    if ( abi_string )
+-    { remove_trailing_whitespace(abi_string);
+-      return match_abi_version(abi_version(), abi_string);
++    if ( build_time_abi_string )
++    { remove_trailing_whitespace(build_time_abi_string);
++      char *run_time_abi_string = abi_version();
++      if (match_abi_version(run_time_abi_string, build_time_abi_string) == 1)
++      { return true;
++      } else
++      { printf("WARNING: ABI mismatch!\n");
++        printf("build time ABI found in %s: %s\n", abi_file_name, build_time_abi_string);
++        printf("run time ABI returned by abi_version(): %s\n", run_time_abi_string);
++        printf("attempting to continue for workaround purposes...\n");
++        // returning true to force the error into a warning
++        return true;
++      }
+     } else
+     { return BAD_HOME_BAD_ABI;
+     }


### PR DESCRIPTION
By default `swipl` will terminate if `$PREFIX/lib/swipl/ABI` does not contain the exact same string that `swipl --abi-version` prints. The error appears to be spurious, so this bypasses it, while printing a warning about what is happening if the check failed.

Fixes #22737