### PR TITLE
addpkg(x11/meld): 3.22.2

### DIFF
--- a/x11-packages/meld/build.sh
+++ b/x11-packages/meld/build.sh
@@ -1,0 +1,52 @@
+TERMUX_PKG_HOMEPAGE=https://meldmerge.org/
+TERMUX_PKG_DESCRIPTION="A visual diff and merge tool targeted at developers"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="3.22.2"
+TERMUX_PKG_SRCURL=https://download.gnome.org/sources/meld/${TERMUX_PKG_VERSION%.*}/meld-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=46a0a713fbcd1b153b377a1e0757c8ce255c9822467658eacfbd89b1e92316ef
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="gsettings-desktop-schemas, glib, gtk3, gtksourceview4, libcairo, pango, pycairo, pygobject, python"
+TERMUX_PKG_BUILD_DEPENDS="gettext"
+# build dependency only
+TERMUX_PKG_PYTHON_TARGET_DEPS="itstool"
+TERMUX_MESON_WHEEL_CROSSFILE="$TERMUX_PKG_TMPDIR/wheel-cross-file.txt"
+TERMUX_PKG_SETUP_PYTHON=true
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+# The "byte-compile" build setting will go away in the next release
+# It does not actually turn off byte compiling because Termux has recent Meson
+# (https://gitlab.gnome.org/GNOME/meld/-/commit/361ac82ce94dd46d0eed0e9239c34a8e3d13cd2e)
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-Dbyte-compile=false
+--cross-file $TERMUX_MESON_WHEEL_CROSSFILE
+"
+termux_step_pre_configure() {
+	termux_setup_glib_cross_pkg_config_wrapper
+
+	# This is necessary to prevent the error "...libxml2mod.so: cannot open shared object file..." but is insufficient alone
+	if [ "$TERMUX_ON_DEVICE_BUILD" = "false" ]; then
+		local _bin="$TERMUX_PKG_BUILDDIR/_bin"
+		export ITSTOOL="${_bin}/itstool"
+		rm -rf "${_bin}"
+		mkdir -p "${_bin}"
+		cat > "$ITSTOOL" <<-EOF
+			#!$(command -v sh)
+			unset PYTHONPATH
+			exec $(command -v itstool) "\$@"
+		EOF
+		chmod 0700 "$ITSTOOL"
+	fi
+}
+
+# This is necessary to prevent the error "...libxml2mod.so: cannot open shared object file..." and depends on the block in termux_step_pre_configure()
+termux_step_configure() {
+	termux_setup_meson
+
+	cp -f $TERMUX_MESON_CROSSFILE $TERMUX_MESON_WHEEL_CROSSFILE
+	if [ "$TERMUX_ON_DEVICE_BUILD" = "false" ]; then
+		sed -i 's|^\(\[binaries\]\)$|\1\nitstool = '\'$ITSTOOL\''|g' \
+			$TERMUX_MESON_WHEEL_CROSSFILE
+	fi
+
+	termux_step_configure_meson
+}

--- a/x11-packages/meld/handle-bindtextdomain-oserror.patch
+++ b/x11-packages/meld/handle-bindtextdomain-oserror.patch
@@ -1,0 +1,11 @@
+--- a/bin/meld
++++ b/bin/meld
+@@ -141,7 +141,7 @@ try:
+         locale.bindtextdomain(locale_domain, str(locale_dir))
+         locale.bind_textdomain_codeset(locale_domain, 'UTF-8')
+         locale.textdomain(locale_domain)
+-except AttributeError as e:
++except (AttributeError,OSError) as e:
+     # Python builds linked without libintl (i.e., OSX) don't have
+     # bindtextdomain(), which causes Gtk.Builder translations to fail.
+     print(


### PR DESCRIPTION
A GUI folder diff tool for X11. Packaged in [many distros](https://repology.org/project/meld/versions)

Closes #18900

(that bug was described as "with the general intention of running meld", and this is a newer way and a newer version of meld than that)

![image](https://github.com/user-attachments/assets/286246bb-9f9b-4e2d-ad0b-db942070a621)
