### PR TITLE
fix(main/libspdlog): Backport fmt 11.1 compatibility patch

### DIFF
--- a/packages/libspdlog/276ee5f5c0eb13626bd367b006ace5eae9526d8a.patch
+++ b/packages/libspdlog/276ee5f5c0eb13626bd367b006ace5eae9526d8a.patch
@@ -1,0 +1,32 @@
+From 276ee5f5c0eb13626bd367b006ace5eae9526d8a Mon Sep 17 00:00:00 2001
+From: Rui Chen <rui@chenrui.dev>
+Date: Thu, 26 Dec 2024 02:13:57 -0500
+Subject: [PATCH] fix: update to_string_view function for fmt 11.1 (#3301)
+
+Signed-off-by: Rui Chen <rui@chenrui.dev>
+---
+ include/spdlog/common.h | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/include/spdlog/common.h b/include/spdlog/common.h
+index aca483c20..2d73f8300 100644
+--- a/include/spdlog/common.h
++++ b/include/spdlog/common.h
+@@ -365,10 +365,17 @@ SPDLOG_CONSTEXPR_FUNC spdlog::wstring_view_t to_string_view(spdlog::wstring_view
+ #endif
+ 
+ #ifndef SPDLOG_USE_STD_FORMAT
++#if FMT_VERSION >= 110100
++template <typename T, typename... Args>
++inline fmt::basic_string_view<T> to_string_view(fmt::basic_format_arg<T> fmt) {
++    return fmt;
++}
++#else
+ template <typename T, typename... Args>
+ inline fmt::basic_string_view<T> to_string_view(fmt::basic_format_string<T, Args...> fmt) {
+     return fmt;
+ }
++#endif
+ #elif __cpp_lib_format >= 202207L
+ template <typename T, typename... Args>
+ SPDLOG_CONSTEXPR_FUNC std::basic_string_view<T> to_string_view(

--- a/packages/libspdlog/build.sh
+++ b/packages/libspdlog/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Very fast, header-only/compiled, C++ logging library"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.15.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/gabime/spdlog/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=9962648c9b4f1a7bbc76fd8d9172555bad1871fdb14ff4f842ef87949682caa5
 TERMUX_PKG_AUTO_UPDATE=true


### PR DESCRIPTION
Fixes building cherrytree (and probably other libspdlog using packages).