### PR TITLE
fix(main/pdf2djvu): Fix build by using --disable-openmp

### DIFF
--- a/packages/pdf2djvu/build.sh
+++ b/packages/pdf2djvu/build.sh
@@ -3,13 +3,14 @@ TERMUX_PKG_DESCRIPTION="PDF to DjVu converter"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.9.19
-TERMUX_PKG_REVISION=5
+TERMUX_PKG_REVISION=6
 TERMUX_PKG_SRCURL=https://github.com/jwilk/pdf2djvu/releases/download/${TERMUX_PKG_VERSION}/pdf2djvu-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=eb45a480131594079f7fe84df30e4a5d0686f7a8049dc7084eebe22acc37aa9a
 TERMUX_PKG_DEPENDS="djvulibre, libc++, libiconv, poppler"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-xmp
+--disable-openmp
 "
 
 termux_step_pre_configure() {


### PR DESCRIPTION
Fix the following build error:

> ERROR: Found files depend on libomp.so
> ERROR: Showing result
> ERROR: ./bin/pdf2djvu: libc++_shared.so, libc.so, libdjvulibre.so, libdl.so, libiconv.so, libm.so, libomp.so, libpoppler.so