### PR TITLE
bump(main/pango): 1.56.0

### DIFF
--- a/packages/pango/build.sh
+++ b/packages/pango/build.sh
@@ -1,10 +1,11 @@
-TERMUX_PKG_HOMEPAGE=https://www.pango.org/
+TERMUX_PKG_HOMEPAGE=https://www.gtk.org/docs/architecture/pango
 TERMUX_PKG_DESCRIPTION="Library for laying out and rendering text"
 TERMUX_PKG_LICENSE="LGPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.54.0"
-TERMUX_PKG_SRCURL=https://ftp.gnome.org/pub/GNOME/sources/pango/${TERMUX_PKG_VERSION%.*}/pango-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=8a9eed75021ee734d7fc0fdf3a65c3bba51dfefe4ae51a9b414a60c70b2d1ed8
+TERMUX_PKG_VERSION="1.56.0"
+TERMUX_PKG_SRCURL=https://download.gnome.org/sources/pango/${TERMUX_PKG_VERSION%.*}/pango-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=1fb98b338ee6f7cf8ef96153b7d242f4568fe60f9b7434524eca630a57bd538b
+TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="fontconfig, freetype, fribidi, glib, harfbuzz, libcairo, libx11, libxft, libxrender"
 TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner"
 TERMUX_PKG_BREAKS="pango-dev"
@@ -12,6 +13,7 @@ TERMUX_PKG_REPLACES="pango-dev"
 TERMUX_PKG_VERSIONED_GIR=false
 TERMUX_PKG_DISABLE_GIR=false
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-Dbuild-testsuite=false
 -Dintrospection=enabled
 "
 

--- a/packages/pango/gir/Pango-1.0.xml
+++ b/packages/pango/gir/Pango-1.0.xml
@@ -186,6 +186,7 @@
     <member name="PANGO_FONT_MASK_SIZE" nick="size" value="32"/>
     <member name="PANGO_FONT_MASK_GRAVITY" nick="gravity" value="64"/>
     <member name="PANGO_FONT_MASK_VARIATIONS" nick="variations" value="128"/>
+    <member name="PANGO_FONT_MASK_FEATURES" nick="features" value="256"/>
   </flags>
   <flags name="PangoShapeFlags" get-type="pango_shape_flags_get_type">
     <member name="PANGO_SHAPE_NONE" nick="none" value="0"/>
@@ -209,6 +210,7 @@
     <member name="PANGO_WRAP_WORD" nick="word" value="0"/>
     <member name="PANGO_WRAP_CHAR" nick="char" value="1"/>
     <member name="PANGO_WRAP_WORD_CHAR" nick="word-char" value="2"/>
+    <member name="PANGO_WRAP_NONE" nick="none" value="3"/>
   </enum>  <enum name="PangoEllipsizeMode" get-type="pango_ellipsize_mode_get_type">
     <member name="PANGO_ELLIPSIZE_NONE" nick="none" value="0"/>
     <member name="PANGO_ELLIPSIZE_START" nick="start" value="1"/>


### PR DESCRIPTION
* Enable auto-update.
* Use new source and home page url.