### PR TITLE
firefox: avoid using the highest byte of pointer

### DIFF
--- a/x11-packages/firefox/0029-fix-tagged-pointer.patch
+++ b/x11-packages/firefox/0029-fix-tagged-pointer.patch
@@ -1,0 +1,65 @@
+https://github.com/termux/termux-packages/issues/22907
+
+--- a/layout/generic/IntrinsicISizesCache.h
++++ b/layout/generic/IntrinsicISizesCache.h
+@@ -131,25 +131,14 @@
+   };
+ 
+   // If the high bit of mOutOfLine is 1, then it points to an OutOfLineCache.
++  bool mIsOutOfLine = false;
+   union {
+     InlineCache mInline;
+-    struct {
+-#ifndef HAVE_64BIT_BUILD
+-      uintptr_t mPadding = 0;
+-#endif
+-      uintptr_t mOutOfLine = 0;
+-    };
++    uintptr_t mOutOfLine = 0;
+   };
+ 
+-  static constexpr uintptr_t kHighBit = uintptr_t(1)
+-                                        << (sizeof(void*) * CHAR_BIT - 1);
+-
+   bool IsOutOfLine() const {
+-#ifdef HAVE_64BIT_BUILD
+-    return mOutOfLine & kHighBit;
+-#else
+-    return mPadding & kHighBit;
+-#endif
++    return mIsOutOfLine;
+   }
+   bool IsInline() const { return !IsOutOfLine(); }
+   OutOfLineCache* EnsureOutOfLine() {
+@@ -159,13 +148,8 @@
+     auto inlineCache = mInline;
+     auto* ool = new OutOfLineCache();
+     ool->mCacheWithoutPercentageBasis = inlineCache;
+-#ifdef HAVE_64BIT_BUILD
+-    MOZ_ASSERT((reinterpret_cast<uintptr_t>(ool) & kHighBit) == 0);
+-    mOutOfLine = reinterpret_cast<uintptr_t>(ool) | kHighBit;
+-#else
+     mOutOfLine = reinterpret_cast<uintptr_t>(ool);
+-    mPadding = kHighBit;
+-#endif
++    mIsOutOfLine = true;
+     MOZ_ASSERT(IsOutOfLine());
+     return ool;
+   }
+@@ -174,16 +158,10 @@
+     if (!IsOutOfLine()) {
+       return nullptr;
+     }
+-#ifdef HAVE_64BIT_BUILD
+-    return reinterpret_cast<OutOfLineCache*>(mOutOfLine & ~kHighBit);
+-#else
+     return reinterpret_cast<OutOfLineCache*>(mOutOfLine);
+-#endif
+   }
+ };
+ 
+-static_assert(sizeof(IntrinsicISizesCache) == 8, "Unexpected cache size");
+-
+ }  // namespace mozilla
+ 
+ #endif

--- a/x11-packages/firefox/build.sh
+++ b/x11-packages/firefox/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Mozilla Firefox web browser"
 TERMUX_PKG_LICENSE="MPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="134.0.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://archive.mozilla.org/pub/firefox/releases/${TERMUX_PKG_VERSION}/source/firefox-${TERMUX_PKG_VERSION}.source.tar.xz
 TERMUX_PKG_SHA256=e3a1853ce70f0fc0007a40a5000d8c9ca7ddd42a4de7d1eb52b0b22fcc2265e5
 # ffmpeg and pulseaudio are dependencies through dlopen(3):


### PR DESCRIPTION
Closes #22907 