### PR TITLE
ci(packages): add randomise buildorder.py test

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -274,6 +274,16 @@ jobs:
         name: debs-${{ matrix.target_arch }}-${{ github.sha }}
         path: ./artifacts
 
+  test-buildorder-random:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v4
+    - name: Randomise buildorder.py test
+      run: ./scripts/bin/test-buildorder-random
+
   upload-test:
     permissions:
       contents: read
@@ -329,16 +339,16 @@ jobs:
             fi
             result=$(find debs -maxdepth 1 -type f | cut -d"/" -f2 | xargs -P$(nproc) -i{} grep "^Filename:.*/{}$" -nH "Packages-${repo}-${arch}" || true)
             if [ -n "$result" ]; then
-              if [ "$error" = 0 ]; then
-                echo "[!] Found local files same name with server files!"
-                echo "[!] Please revbump package, rebase or tag commit with '%ci:no-build'"
-              fi
               echo "$result" | grep -E "${arch}|all" || true
               error=1
             fi
           done
         done
-        if [ "$error" != 0 ]; then exit 1; fi
+        if [ "$error" != 0 ]; then
+          echo "[!] Found local files same name with server files!"
+          echo "[!] Please revbump package, rebase or tag commit with '%ci:no-build'"
+          exit 1
+        fi
 
   upload:
     concurrency: ${{ github.workflow }}

--- a/scripts/bin/test-buildorder-random
+++ b/scripts/bin/test-buildorder-random
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Randomise buildorder.py test on packages directory
+
+export TERMUX_SCRIPTDIR
+TERMUX_SCRIPTDIR=$(realpath "$(dirname "$0")/../..") # Root of repository.
+
+cd "${TERMUX_SCRIPTDIR}" || exit 1
+
+no_of_packages=0
+packages=$(find packages -maxdepth 1 -type d | sort)
+[ -n "$packages" ] && no_of_packages=$(echo "${packages}" | wc -l)
+random_package_no=$(shuf -i 1-"${no_of_packages}" -n 1)
+random_package=$(echo "${packages}" | head -n"${random_package_no}" | tail -n1)
+echo "INFO: random_package = ${random_package}"
+./scripts/buildorder.py "${random_package}"

--- a/x11-packages/vkmark/build.sh
+++ b/x11-packages/vkmark/build.sh
@@ -1,14 +1,15 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/vkmark/vkmark
-TERMUX_PKG_DESCRIPTION="vulkan benchmark"
+TERMUX_PKG_DESCRIPTION="Vulkan benchmark"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2017.08
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/vkmark/vkmark/archive/ab6e6f34077722d5ae33f6bd40b18ef9c0e99a15.tar.gz
 TERMUX_PKG_SHA256=d08143e8828d5b9ed005cb6dcef4d88a49df0ac4c9e1356ace739b449c165f54
 TERMUX_PKG_AUTO_UPDATE=false
-TERMUX_PKG_DEPENDS="assimp, glm, libxcb, vulkan-headers, vulkan-loader-generic, xcb-util-wm"
+TERMUX_PKG_DEPENDS="assimp, libc++, libxcb, vulkan-loader-generic, xcb-util-wm"
+TERMUX_PKG_BUILD_DEPENDS="glm, vulkan-headers"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-Dxcb=true -Dkms=false"
-TERMUX_PKG_BLACKLISTED_ARCHES="i686, arm"
 
 termux_step_pre_configure() {
 	LDFLAGS+=" -llog"


### PR DESCRIPTION
vkmark depends on xcb-util-wm which is only available on x11 repo.
This means vkmark is not installable without x11 repo.
It also likely broke certain package build for some time.
Move vkmark to x11 repo.
Add unit test to guard against this.
Test fail demo in https://github.com/termux/termux-packages/actions/runs/12809167538/job/35713414417