### PR TITLE
ci(packages): add more buildorder tests

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -283,6 +283,22 @@ jobs:
       uses: actions/checkout@v4
     - name: Randomise buildorder.py test
       run: ./scripts/bin/test-buildorder-random
+    - name: Randomise buildorder.py test (aarch64)
+      env:
+        TERMUX_ARCH: aarch64
+      run: ./scripts/bin/test-buildorder-random
+    - name: Randomise buildorder.py test (arm)
+      env:
+        TERMUX_ARCH: arm
+      run: ./scripts/bin/test-buildorder-random
+    - name: Randomise buildorder.py test (i686)
+      env:
+        TERMUX_ARCH: i686
+      run: ./scripts/bin/test-buildorder-random
+    - name: Randomise buildorder.py test (x86_64)
+      env:
+        TERMUX_ARCH: x86_64
+      run: ./scripts/bin/test-buildorder-random
 
   upload-test:
     permissions:

--- a/scripts/bin/test-buildorder-random
+++ b/scripts/bin/test-buildorder-random
@@ -6,10 +6,17 @@ TERMUX_SCRIPTDIR=$(realpath "$(dirname "$0")/../..") # Root of repository.
 
 cd "${TERMUX_SCRIPTDIR}" || exit 1
 
-no_of_packages=0
-packages=$(find packages -maxdepth 1 -type d | sort)
-[ -n "$packages" ] && no_of_packages=$(echo "${packages}" | wc -l)
-random_package_no=$(shuf -i 1-"${no_of_packages}" -n 1)
-random_package=$(echo "${packages}" | head -n"${random_package_no}" | tail -n1)
+no_of_total_packages=0
+no_of_filter_pacakges=0
+
+total_packages=$(find packages -maxdepth 1 -type d | sort)
+filter_packages=$(find packages -maxdepth 2 -type f -name build.sh | xargs -P$(nproc) -i sh -c "if ! grep -E "^TERMUX_PKG_BLACKLISTED_ARCHES=.*${TERMUX_ARCH}" {} >/dev/null; then dirname {}; fi" | sort)
+
+[ -n "${total_packages}" ] && no_of_total_packages=$(echo "${total_packages}" | wc -l)
+[ -n "${filter_packages}" ] && no_of_filter_packages=$(echo "${filter_packages}" | wc -l)
+echo "INFO: Filtered packages: ${no_of_filter_packages} of ${no_of_total_packages}"
+
+random_package_no=$(shuf -i 1-"${no_of_filter_packages}" -n 1)
+random_package=$(echo "${filter_packages}" | head -n"${random_package_no}" | tail -n1)
 echo "INFO: random_package = ${random_package}"
 ./scripts/buildorder.py "${random_package}"


### PR DESCRIPTION
Add more coverage with lesser CI init cost

Otherwise have to wait until build finished which could take hours

Example test failure: https://github.com/termux/termux-packages/actions/runs/12851323881/job/35831928225?pr=22977