### PR TITLE
enhance(main/ffmpeg): Use debian patches

### DIFF
--- a/packages/ffmpeg/build.sh
+++ b/packages/ffmpeg/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # Please align version with `ffplay` package.
 TERMUX_PKG_VERSION="7.1"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://www.ffmpeg.org/releases/ffmpeg-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=40973d44970dbc83ef302b0609f2e74982be2d85916dd2ee7472d30678a7abe6
 TERMUX_PKG_DEPENDS="fontconfig, freetype, fribidi, game-music-emu, harfbuzz, libaom, libandroid-glob, libass, libbluray, libbz2, libdav1d, libgnutls, libiconv, liblzma, libmp3lame, libopencore-amr, libopenmpt, libopus, librav1e, libsoxr, libsrt, libssh, libtheora, libv4l, libvidstab, libvmaf, libvo-amrwbenc, libvorbis, libvpx, libwebp, libx264, libx265, libxml2, libzimg, littlecms, ocl-icd, rubberband, svt-av1, xvidcore, zlib"
@@ -14,23 +14,6 @@ TERMUX_PKG_BREAKS="ffmpeg-dev"
 TERMUX_PKG_REPLACES="ffmpeg-dev"
 
 termux_step_pre_configure() {
-	declare -a _commits=(
-	099f88b8641dfc299f3896d17d9addc5b9ae7799
-	)
-
-	declare -a _checksums=(
-	df6250edd358bfba16d18f0e9a99324c7bba002ed96907062d91975c53dafbb8
-	)
-
-	for i in "${!_commits[@]}"; do
-		PATCHFILE="${TERMUX_PKG_CACHEDIR}/ffmpeg_patch_${_commits[i]}.patch"
-		termux_download \
-			"https://github.com/FFmpeg/FFmpeg/commit/${_commits[i]}.patch" \
-			"$PATCHFILE" \
-			"${_checksums[i]}"
-		patch -p1 -i "$PATCHFILE"
-	done
-
 	# Do not forget to bump revision of reverse dependencies and rebuild them
 	# after SOVERSION is changed. (These variables are also used afterwards.)
 	_FFMPEG_SOVER_avutil=59

--- a/packages/ffmpeg/debian-0001-avformat-mov-don-t-return-the-latest-stream-when-an-.patch
+++ b/packages/ffmpeg/debian-0001-avformat-mov-don-t-return-the-latest-stream-when-an-.patch
@@ -1,0 +1,38 @@
+From: James Almer <jamrial@gmail.com>
+Date: Mon, 30 Sep 2024 10:59:02 -0300
+Subject: avformat/mov: don't return the latest stream when an item stream is
+ expected
+
+Otherwise, things like ICC profiles as read from the colr box meant for an item
+with no stream (like a grid) may end up being added to the wrong stream.
+
+Signed-off-by: James Almer <jamrial@gmail.com>
+(cherry picked from commit 04182b55494b44152146e6a6bcd5eb9403f00625)
+---
+ libavformat/mov.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/libavformat/mov.c b/libavformat/mov.c
+index a2333ac..5b0b23f 100644
+--- a/libavformat/mov.c
++++ b/libavformat/mov.c
+@@ -188,6 +188,10 @@ static int mov_read_mac_string(MOVContext *c, AVIOContext *pb, int len,
+     return p - dst;
+ }
+ 
++/**
++ * Get the current stream in the parsing process. This can either be the
++ * latest stream added to the context, or the stream referenced by an item.
++ */
+ static AVStream *get_curr_st(MOVContext *c)
+ {
+     AVStream *st = NULL;
+@@ -206,7 +210,7 @@ static AVStream *get_curr_st(MOVContext *c)
+         st = item->st;
+         break;
+     }
+-    if (!st)
++    if (!st && c->cur_item_id == -1)
+         st = c->fc->streams[c->fc->nb_streams-1];
+ 
+     return st;

--- a/packages/ffmpeg/debian-0002-avformat-internal-Add-ff_get_frame_filename.patch
+++ b/packages/ffmpeg/debian-0002-avformat-internal-Add-ff_get_frame_filename.patch
@@ -1,0 +1,84 @@
+From: Zhao Zhili <zhilizhao@tencent.com>
+Date: Mon, 23 Sep 2024 23:14:19 +0800
+Subject: avformat/internal: Add ff_get_frame_filename
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+It's similar to av_get_frame_filename2 but with int64_t number
+support. Make av_get_frame_filename* a wrapper over
+ff_get_frame_filename.
+
+Co-authored-by: Filip Mašić <shoutplenty@gmail.com>
+Signed-off-by: Zhao Zhili <zhilizhao@tencent.com>
+(cherry picked from commit a2d9663241908d6f558b8e6b24bd42f2aaebc144)
+---
+ libavformat/internal.h | 16 ++++++++++++++++
+ libavformat/utils.c    | 11 ++++++++---
+ 2 files changed, 24 insertions(+), 3 deletions(-)
+
+diff --git a/libavformat/internal.h b/libavformat/internal.h
+index 8e8971b..6c026f0 100644
+--- a/libavformat/internal.h
++++ b/libavformat/internal.h
+@@ -745,6 +745,22 @@ void ff_format_set_url(AVFormatContext *s, char *url);
+  */
+ int ff_match_url_ext(const char *url, const char *extensions);
+ 
++/**
++ * Return in 'buf' the path with '%d' replaced by a number.
++ *
++ * Also handles the '%0nd' format where 'n' is the total number
++ * of digits and '%%'.
++ *
++ * @param buf destination buffer
++ * @param buf_size destination buffer size
++ * @param path path with substitution template
++ * @param number the number to substitute
++ * @param flags AV_FRAME_FILENAME_FLAGS_*
++ * @return 0 if OK, -1 on format error
++ */
++int ff_get_frame_filename(char *buf, int buf_size, const char *path,
++                          int64_t number, int flags);
++
+ struct FFOutputFormat;
+ struct FFInputFormat;
+ void avpriv_register_devices(const struct FFOutputFormat * const o[],
+diff --git a/libavformat/utils.c b/libavformat/utils.c
+index e9ded62..e892e8b 100644
+--- a/libavformat/utils.c
++++ b/libavformat/utils.c
+@@ -280,7 +280,7 @@ uint64_t ff_parse_ntp_time(uint64_t ntp_ts)
+     return (sec * 1000000) + usec;
+ }
+ 
+-int av_get_frame_filename2(char *buf, int buf_size, const char *path, int number, int flags)
++int ff_get_frame_filename(char *buf, int buf_size, const char *path, int64_t number, int flags)
+ {
+     const char *p;
+     char *q, buf1[20], c;
+@@ -313,7 +313,7 @@ int av_get_frame_filename2(char *buf, int buf_size, const char *path, int number
+                 percentd_found = 1;
+                 if (number < 0)
+                     nd += 1;
+-                snprintf(buf1, sizeof(buf1), "%0*d", nd, number);
++                snprintf(buf1, sizeof(buf1), "%0*" PRId64, nd, number);
+                 len = strlen(buf1);
+                 if ((q - buf + len) > buf_size - 1)
+                     goto fail;
+@@ -338,9 +338,14 @@ fail:
+     return -1;
+ }
+ 
++int av_get_frame_filename2(char *buf, int buf_size, const char *path, int number, int flags)
++{
++    return ff_get_frame_filename(buf, buf_size, path, number, flags);
++}
++
+ int av_get_frame_filename(char *buf, int buf_size, const char *path, int number)
+ {
+-    return av_get_frame_filename2(buf, buf_size, path, number, 0);
++    return ff_get_frame_filename(buf, buf_size, path, number, 0);
+ }
+ 
+ void av_url_split(char *proto, int proto_size,

--- a/packages/ffmpeg/debian-0003-avformat-img2enc-Fix-integer-truncation-when-frame_p.patch
+++ b/packages/ffmpeg/debian-0003-avformat-img2enc-Fix-integer-truncation-when-frame_p.patch
@@ -1,0 +1,34 @@
+From: Zhao Zhili <zhilizhao@tencent.com>
+Date: Tue, 24 Sep 2024 00:16:13 +0800
+Subject: avformat/img2enc: Fix integer truncation when frame_pts is enabled
+
+Fix #11194
+
+Signed-off-by: Zhao Zhili <zhilizhao@tencent.com>
+(cherry picked from commit f56a54387b9cea884ca139e9cb993ff6989b8def)
+---
+ libavformat/img2enc.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/libavformat/img2enc.c b/libavformat/img2enc.c
+index 526a11e..41638d9 100644
+--- a/libavformat/img2enc.c
++++ b/libavformat/img2enc.c
+@@ -160,13 +160,13 @@ static int write_packet(AVFormatContext *s, AVPacket *pkt)
+             return AVERROR(EINVAL);
+         }
+     } else if (img->frame_pts) {
+-        if (av_get_frame_filename2(filename, sizeof(filename), s->url, pkt->pts, AV_FRAME_FILENAME_FLAGS_MULTIPLE) < 0) {
++        if (ff_get_frame_filename(filename, sizeof(filename), s->url, pkt->pts, AV_FRAME_FILENAME_FLAGS_MULTIPLE) < 0) {
+             av_log(s, AV_LOG_ERROR, "Cannot write filename by pts of the frames.");
+             return AVERROR(EINVAL);
+         }
+-    } else if (av_get_frame_filename2(filename, sizeof(filename), s->url,
+-                                      img->img_number,
+-                                      AV_FRAME_FILENAME_FLAGS_MULTIPLE) < 0) {
++    } else if (ff_get_frame_filename(filename, sizeof(filename), s->url,
++                                     img->img_number,
++                                     AV_FRAME_FILENAME_FLAGS_MULTIPLE) < 0) {
+         if (img->img_number == img->start_img_number) {
+             av_log(s, AV_LOG_WARNING, "The specified filename '%s' does not contain an image sequence pattern or a pattern is invalid.\n", s->url);
+             av_log(s, AV_LOG_WARNING,

--- a/packages/ffmpeg/debian-0004-avcodec-mediacodecenc-Fix-access-of-uninitialized-va.patch
+++ b/packages/ffmpeg/debian-0004-avcodec-mediacodecenc-Fix-access-of-uninitialized-va.patch
@@ -1,0 +1,26 @@
+From: Zhao Zhili <zhilizhao@tencent.com>
+Date: Fri, 4 Oct 2024 01:30:57 +0800
+Subject: avcodec/mediacodecenc: Fix access of uninitialized value
+
+When crop is skipped, av_strlcatf will access `str` which isn't
+initialized properly.
+
+Signed-off-by: Zhao Zhili <zhilizhao@tencent.com>
+(cherry picked from commit eff9ed7bff45998ea370e3d6f627529ad47e2e74)
+---
+ libavcodec/mediacodecenc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libavcodec/mediacodecenc.c b/libavcodec/mediacodecenc.c
+index 6ca3968..e76ea81 100644
+--- a/libavcodec/mediacodecenc.c
++++ b/libavcodec/mediacodecenc.c
+@@ -134,7 +134,7 @@ static int extract_extradata_support(AVCodecContext *avctx)
+ static int mediacodec_init_bsf(AVCodecContext *avctx)
+ {
+     MediaCodecEncContext *s = avctx->priv_data;
+-    char str[128];
++    char str[128] = {0};
+     int ret;
+     int crop_right = s->width - avctx->width;
+     int crop_bottom = s->height - avctx->height;

--- a/packages/ffmpeg/debian-0005-fftools-do-not-access-out-of-bounds-filtergraph.patch
+++ b/packages/ffmpeg/debian-0005-fftools-do-not-access-out-of-bounds-filtergraph.patch
@@ -1,0 +1,28 @@
+From: Marvin Scholz <epirat07@gmail.com>
+Date: Tue, 1 Oct 2024 02:57:11 +0200
+Subject: fftools: do not access out of bounds filtergraph
+
+The log message was logged for `filtergraphs[j]` which would cause a
+heap buffer overflow in certain circumstances.
+
+Correctly it should be logged for the current filtergraph, so just
+use `fg` here.
+
+(cherry picked from commit 5beeb3a1f97d8f6d4076fe83aaf5e2e5871f945e)
+---
+ fftools/ffmpeg_filter.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/fftools/ffmpeg_filter.c b/fftools/ffmpeg_filter.c
+index 7ec328e..2f2b297 100644
+--- a/fftools/ffmpeg_filter.c
++++ b/fftools/ffmpeg_filter.c
+@@ -1408,7 +1408,7 @@ int fg_finalise_bindings(void)
+         for (int j = 0; j < fg->nb_outputs; j++) {
+             OutputFilter *output = fg->outputs[j];
+             if (!output->bound) {
+-                av_log(filtergraphs[j], AV_LOG_FATAL,
++                av_log(fg, AV_LOG_FATAL,
+                        "Filter %s has an unconnected output\n", output->name);
+                 return AVERROR(EINVAL);
+             }

--- a/packages/ffmpeg/debian-0006-fftools-log-unconnected-filter-output-label.patch
+++ b/packages/ffmpeg/debian-0006-fftools-log-unconnected-filter-output-label.patch
@@ -1,0 +1,24 @@
+From: Marvin Scholz <epirat07@gmail.com>
+Date: Tue, 1 Oct 2024 03:20:04 +0200
+Subject: fftools: log unconnected filter output label
+
+(cherry picked from commit f25c9cc213c7e3eb585d3339eb775b16921c4d98)
+---
+ fftools/ffmpeg_filter.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/fftools/ffmpeg_filter.c b/fftools/ffmpeg_filter.c
+index 2f2b297..4e3a47e 100644
+--- a/fftools/ffmpeg_filter.c
++++ b/fftools/ffmpeg_filter.c
+@@ -1409,7 +1409,9 @@ int fg_finalise_bindings(void)
+             OutputFilter *output = fg->outputs[j];
+             if (!output->bound) {
+                 av_log(fg, AV_LOG_FATAL,
+-                       "Filter %s has an unconnected output\n", output->name);
++                       "Filter '%s' has output %d (%s) unconnected\n",
++                       output->name, j,
++                       output->linklabel ? (const char *)output->linklabel : "unlabeled");
+                 return AVERROR(EINVAL);
+             }
+         }

--- a/packages/ffmpeg/debian-0007-avcodec-libx265-unbreak-build-for-X265_BUILD-213.patch
+++ b/packages/ffmpeg/debian-0007-avcodec-libx265-unbreak-build-for-X265_BUILD-213.patch
@@ -1,0 +1,47 @@
+From: Gyan Doshi <ffmpeg@gyani.pro>
+Date: Sat, 5 Oct 2024 10:08:31 +0530
+Subject: avcodec/libx265: unbreak build for X265_BUILD >= 213
+
+Earlier, x265 made an API change to support alpha and
+other multiple layer pictures. We added guards to accommodate
+that in 1f801dfdb5
+
+They have now reverted that API change in
+https://bitbucket.org/multicoreware/x265_git/commits/78e5b703b1
+
+Updated our wrapper guards to unbreak build again.
+---
+ libavcodec/libx265.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/libavcodec/libx265.c b/libavcodec/libx265.c
+index 513f473..63cc497 100644
+--- a/libavcodec/libx265.c
++++ b/libavcodec/libx265.c
+@@ -661,7 +661,7 @@ static int libx265_encode_frame(AVCodecContext *avctx, AVPacket *pkt,
+ {
+     libx265Context *ctx = avctx->priv_data;
+     x265_picture x265pic;
+-#if X265_BUILD >= 210
++#if (X265_BUILD >= 210) && (X265_BUILD < 213)
+     x265_picture x265pic_layers_out[MAX_SCALABLE_LAYERS];
+     x265_picture* x265pic_lyrptr_out[MAX_SCALABLE_LAYERS];
+ #else
+@@ -805,7 +805,7 @@ static int libx265_encode_frame(AVCodecContext *avctx, AVPacket *pkt,
+ #endif
+     }
+ 
+-#if X265_BUILD >= 210
++#if (X265_BUILD >= 210) && (X265_BUILD < 213)
+     for (i = 0; i < MAX_SCALABLE_LAYERS; i++)
+         x265pic_lyrptr_out[i] = &x265pic_layers_out[i];
+ 
+@@ -844,7 +844,7 @@ static int libx265_encode_frame(AVCodecContext *avctx, AVPacket *pkt,
+             pkt->flags |= AV_PKT_FLAG_KEY;
+     }
+ 
+-#if X265_BUILD >= 210
++#if (X265_BUILD >= 210) && (X265_BUILD < 213)
+     x265pic_out = x265pic_lyrptr_out[0];
+ #else
+     x265pic_out = &x265pic_solo_out;

--- a/packages/ffmpeg/debian-0008-arm-Consistently-use-proper-interworking-function-re.patch
+++ b/packages/ffmpeg/debian-0008-arm-Consistently-use-proper-interworking-function-re.patch
@@ -1,0 +1,101 @@
+From: =?utf-8?q?Martin_Storsj=C3=B6?= <martin@martin.st>
+Date: Fri, 4 Oct 2024 00:30:24 +0300
+Subject: arm: Consistently use proper interworking function returns
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+Use "bx lr", or "pop {lr}", which do proper mode switching
+between thumb and arm modes. A plain "mov pc, lr" does not switch
+from thumb mode to arm mode (while in arm mode, it does switch
+mode for a thumb caller).
+
+This is normally not an issue, as CONFIG_THUMB only is enabled if
+the C compiler defaults to thumb; but stick to patterns that can
+do mode switching if needed, for consistency.
+
+Signed-off-by: Martin Storsjö <martin@martin.st>
+(cherry picked from commit 77e6293735262b20a86b5047b77991a86cf4e9e1)
+---
+ libswresample/arm/resample.S  | 8 ++++----
+ libswscale/arm/hscale.S       | 3 +--
+ libswscale/arm/output.S       | 3 +--
+ libswscale/arm/yuv2rgb_neon.S | 3 +--
+ 4 files changed, 7 insertions(+), 10 deletions(-)
+
+diff --git a/libswresample/arm/resample.S b/libswresample/arm/resample.S
+index 3ce7623..791f4cc 100644
+--- a/libswresample/arm/resample.S
++++ b/libswresample/arm/resample.S
+@@ -30,7 +30,7 @@ function ff_resample_common_apply_filter_x4_float_neon, export=1
+     vpadd.f32           d0, d0, d1                                     @ pair adding of the 4x32-bit accumulated values
+     vpadd.f32           d0, d0, d0                                     @ pair adding of the 4x32-bit accumulator values
+     vst1.32             {d0[0]}, [r0]                                  @ write accumulator
+-    mov pc, lr
++    bx                  lr
+ endfunc
+ 
+ function ff_resample_common_apply_filter_x8_float_neon, export=1
+@@ -46,7 +46,7 @@ function ff_resample_common_apply_filter_x8_float_neon, export=1
+     vpadd.f32           d0, d0, d1                                     @ pair adding of the 4x32-bit accumulated values
+     vpadd.f32           d0, d0, d0                                     @ pair adding of the 4x32-bit accumulator values
+     vst1.32             {d0[0]}, [r0]                                  @ write accumulator
+-    mov pc, lr
++    bx                  lr
+ endfunc
+ 
+ function ff_resample_common_apply_filter_x4_s16_neon, export=1
+@@ -59,7 +59,7 @@ function ff_resample_common_apply_filter_x4_s16_neon, export=1
+     vpadd.s32           d0, d0, d1                                     @ pair adding of the 4x32-bit accumulated values
+     vpadd.s32           d0, d0, d0                                     @ pair adding of the 4x32-bit accumulator values
+     vst1.32             {d0[0]}, [r0]                                  @ write accumulator
+-    mov pc, lr
++    bx                  lr
+ endfunc
+ 
+ function ff_resample_common_apply_filter_x8_s16_neon, export=1
+@@ -73,5 +73,5 @@ function ff_resample_common_apply_filter_x8_s16_neon, export=1
+     vpadd.s32           d0, d0, d1                                     @ pair adding of the 4x32-bit accumulated values
+     vpadd.s32           d0, d0, d0                                     @ pair adding of the 4x32-bit accumulator values
+     vst1.32             {d0[0]}, [r0]                                  @ write accumulator
+-    mov pc, lr
++    bx                  lr
+ endfunc
+diff --git a/libswscale/arm/hscale.S b/libswscale/arm/hscale.S
+index dd4d453..5c3551a 100644
+--- a/libswscale/arm/hscale.S
++++ b/libswscale/arm/hscale.S
+@@ -65,6 +65,5 @@ function ff_hscale_8_to_15_neon, export=1
+     subs                r2, #2                                         @ dstW -= 2
+     bgt                 1b                                             @ loop until end of line
+     vpop                {q4-q7}
+-    pop                 {r4-r12, lr}
+-    mov pc, lr
++    pop                 {r4-r12, pc}
+ endfunc
+diff --git a/libswscale/arm/output.S b/libswscale/arm/output.S
+index 70846de..5f10585 100644
+--- a/libswscale/arm/output.S
++++ b/libswscale/arm/output.S
+@@ -73,6 +73,5 @@ function ff_yuv2planeX_8_neon, export=1
+     subs                r4, r4, #8                                     @ dstW -= 8
+     bgt                 2b                                             @ loop until width is consumed
+     vpop                {q4-q7}
+-    pop                 {r4-r12, lr}
+-    mov                 pc, lr
++    pop                 {r4-r12, pc}
+ endfunc
+diff --git a/libswscale/arm/yuv2rgb_neon.S b/libswscale/arm/yuv2rgb_neon.S
+index 4744654..6777d62 100644
+--- a/libswscale/arm/yuv2rgb_neon.S
++++ b/libswscale/arm/yuv2rgb_neon.S
+@@ -262,8 +262,7 @@ function ff_\ifmt\()_to_\ofmt\()_neon, export=1
+     increment_and_test_\ifmt
+     bgt                 1b
+     vpop                {q4-q7}
+-    pop                 {r4-r12, lr}
+-    mov                 pc, lr
++    pop                 {r4-r12, pc}
+ endfunc
+ .endm
+ 

--- a/packages/ffmpeg/debian-0009-checkasm-lls-Use-relative-tolerances-rather-than-abs.patch
+++ b/packages/ffmpeg/debian-0009-checkasm-lls-Use-relative-tolerances-rather-than-abs.patch
@@ -1,0 +1,62 @@
+From: =?utf-8?q?Martin_Storsj=C3=B6?= <martin@martin.st>
+Date: Fri, 4 Oct 2024 10:22:57 +0300
+Subject: checkasm: lls: Use relative tolerances rather than absolute ones
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+Depending on the magnitude of the output values, the potential
+errors can be larger.
+
+This fixes errors in the lls tests on x86_32 for some seeds,
+observed with GCC 11 (on Ubuntu 22.04, with the distro compiler,
+with -m32).
+
+Signed-off-by: Martin Storsjö <martin@martin.st>
+(cherry picked from commit 6668268e16b6d1a6992840dccb12effece2e7202)
+---
+ tests/checkasm/lls.c | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/tests/checkasm/lls.c b/tests/checkasm/lls.c
+index 1e0b569..4251032 100644
+--- a/tests/checkasm/lls.c
++++ b/tests/checkasm/lls.c
+@@ -46,28 +46,32 @@ static void test_update(LLSModel *lls, const double *var)
+     call_new(lls, var);
+ 
+     for (size_t i = 0; i < lls->indep_count; i++)
+-        for (size_t j = i; j < lls->indep_count; j++)
++        for (size_t j = i; j < lls->indep_count; j++) {
++            double eps = FFMAX(2 * DBL_EPSILON * fabs(refcovar[i][j]),
++                               8 * DBL_EPSILON);
+             if (!double_near_abs_eps(refcovar[i][j], lls->covariance[i][j],
+-                                     8 * DBL_EPSILON)) {
++                                     eps)) {
+                 fprintf(stderr, "%zu, %zu: %- .12f - %- .12f = % .12g\n", i, j,
+                         refcovar[i][j], lls->covariance[i][j],
+                         refcovar[i][j] - lls->covariance[i][j]);
+                 fail();
+             }
++        }
+ 
+     bench_new(lls, var);
+ }
+ 
+-#define EPS 0.2
+ static void test_evaluate(LLSModel *lls, const double *param, int order)
+ {
+-    double refprod, newprod;
++    double refprod, newprod, eps;
+     declare_func_float(double, LLSModel *, const double *, int);
+ 
+     refprod = call_ref(lls, param, order);
+     newprod = call_new(lls, param, order);
+ 
+-    if (!double_near_abs_eps(refprod, newprod, EPS)) {
++    eps = FFMAX(2 * DBL_EPSILON * fabs(refprod), 0.2);
++
++    if (!double_near_abs_eps(refprod, newprod, eps)) {
+         fprintf(stderr, "%- .12f - %- .12f = % .12g\n",
+                 refprod, newprod, refprod - newprod);
+         fail();

--- a/packages/ffmpeg/debian-0010-libavcodec-x86-Remove-an-explicit-include-of-config..patch
+++ b/packages/ffmpeg/debian-0010-libavcodec-x86-Remove-an-explicit-include-of-config..patch
@@ -1,0 +1,28 @@
+From: =?utf-8?q?Martin_Storsj=C3=B6?= <martin@martin.st>
+Date: Tue, 1 Oct 2024 23:59:41 +0300
+Subject: libavcodec: x86: Remove an explicit include of config.asm
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+This file is never included explicitly anywhere else, it's only
+included implicitly by passing -Pconfig.asm on the command line.
+
+Signed-off-by: Martin Storsjö <martin@martin.st>
+(cherry picked from commit 5c4ede6b4ff6fa8818f0ca3f686aa54c1c2092b8)
+---
+ libavcodec/x86/celt_pvq_search.asm | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/libavcodec/x86/celt_pvq_search.asm b/libavcodec/x86/celt_pvq_search.asm
+index e9bff02..3c6974d 100644
+--- a/libavcodec/x86/celt_pvq_search.asm
++++ b/libavcodec/x86/celt_pvq_search.asm
+@@ -20,7 +20,6 @@
+ ;* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ ;******************************************************************************
+ 
+-%include "config.asm"
+ %include "libavutil/x86/x86util.asm"
+ 
+ %ifdef __NASM_VER__

--- a/packages/ffmpeg/debian-0011-avcodec-vaapi_encode-fix-compilation-without-CONFIG_.patch
+++ b/packages/ffmpeg/debian-0011-avcodec-vaapi_encode-fix-compilation-without-CONFIG_.patch
@@ -1,0 +1,30 @@
+From: =?utf-8?q?Ingo_Br=C3=BCckl?= <ib@oddnet.de>
+Date: Wed, 9 Oct 2024 04:43:01 +0200
+Subject: avcodec/vaapi_encode: fix compilation without CONFIG_VAAPI_1
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+This adds VAAPIEncodeContext *ctx that has been removed
+in aa82340b0ccdde4955fba41b8de5e45348ecd11d.
+
+Signed-off-by: Ingo Brückl <ib@oddnet.de>
+(cherry picked from commit 5557c673ea783a48e8b97c2b740b22eeeca6399b)
+---
+ libavcodec/vaapi_encode_h264.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/libavcodec/vaapi_encode_h264.c b/libavcodec/vaapi_encode_h264.c
+index fb87b68..ed20b9c 100644
+--- a/libavcodec/vaapi_encode_h264.c
++++ b/libavcodec/vaapi_encode_h264.c
+@@ -406,6 +406,9 @@ static int vaapi_encode_h264_init_picture_params(AVCodecContext *avctx,
+                                                  FFHWBaseEncodePicture *pic)
+ {
+     FFHWBaseEncodeContext       *base_ctx = avctx->priv_data;
++#if !CONFIG_VAAPI_1
++    VAAPIEncodeContext               *ctx = avctx->priv_data;
++#endif
+     VAAPIEncodeH264Context          *priv = avctx->priv_data;
+     VAAPIEncodePicture         *vaapi_pic = pic->priv;
+     VAAPIEncodeH264Picture          *hpic = pic->codec_priv;

--- a/packages/ffmpeg/debian-0012-avfilter-framesync-fix-forward-EOF-pts.patch
+++ b/packages/ffmpeg/debian-0012-avfilter-framesync-fix-forward-EOF-pts.patch
@@ -1,0 +1,105 @@
+From: Nicolas Gaullier <nicolas.gaullier@cji.paris>
+Date: Fri, 4 Oct 2024 11:02:49 +0200
+Subject: avfilter/framesync: fix forward EOF pts
+
+Note1: when the EOF pts is not accurate enough, the last frame
+can be dropped by vf_fps with default rounding.
+
+Note2: vf_scale use framesync since e82a3997cdd6c0894869b33ba42430ac3,
+so this is a very commonplace scenario.
+
+For example:
+./ffprobe -f lavfi testsrc=d=1,scale,fps -of flat \
+  -count_frames -show_entries stream=nb_read_frames
+
+Before:
+streams.stream.0.nb_read_frames="24"
+
+After:
+streams.stream.0.nb_read_frames="25"
+
+Signed-off-by: Anton Khirnov <anton@khirnov.net>
+(cherry picked from commit de976eaf30df33e86c58c8c9af9905c1d8441934)
+Signed-off-by: Anton Khirnov <anton@khirnov.net>
+---
+ libavfilter/framesync.c | 23 +++++++++++------------
+ 1 file changed, 11 insertions(+), 12 deletions(-)
+
+diff --git a/libavfilter/framesync.c b/libavfilter/framesync.c
+index 8e06e0e..0d5779f 100644
+--- a/libavfilter/framesync.c
++++ b/libavfilter/framesync.c
+@@ -103,14 +103,14 @@ int ff_framesync_init(FFFrameSync *fs, AVFilterContext *parent, unsigned nb_in)
+     return 0;
+ }
+ 
+-static void framesync_eof(FFFrameSync *fs)
++static void framesync_eof(FFFrameSync *fs, int64_t pts)
+ {
+     fs->eof = 1;
+     fs->frame_ready = 0;
+-    ff_outlink_set_status(fs->parent->outputs[0], AVERROR_EOF, AV_NOPTS_VALUE);
++    ff_outlink_set_status(fs->parent->outputs[0], AVERROR_EOF, pts);
+ }
+ 
+-static void framesync_sync_level_update(FFFrameSync *fs)
++static void framesync_sync_level_update(FFFrameSync *fs, int64_t eof_pts)
+ {
+     unsigned i, level = 0;
+ 
+@@ -131,7 +131,7 @@ static void framesync_sync_level_update(FFFrameSync *fs)
+     if (level)
+         fs->sync_level = level;
+     else
+-        framesync_eof(fs);
++        framesync_eof(fs, eof_pts);
+ }
+ 
+ int ff_framesync_configure(FFFrameSync *fs)
+@@ -179,7 +179,7 @@ int ff_framesync_configure(FFFrameSync *fs)
+     for (i = 0; i < fs->nb_in; i++)
+         fs->in[i].pts = fs->in[i].pts_next = AV_NOPTS_VALUE;
+     fs->sync_level = UINT_MAX;
+-    framesync_sync_level_update(fs);
++    framesync_sync_level_update(fs, AV_NOPTS_VALUE);
+ 
+     return 0;
+ }
+@@ -200,7 +200,7 @@ static int framesync_advance(FFFrameSync *fs)
+             if (fs->in[i].have_next && fs->in[i].pts_next < pts)
+                 pts = fs->in[i].pts_next;
+         if (pts == INT64_MAX) {
+-            framesync_eof(fs);
++            framesync_eof(fs, AV_NOPTS_VALUE);
+             break;
+         }
+         for (i = 0; i < fs->nb_in; i++) {
+@@ -222,7 +222,7 @@ static int framesync_advance(FFFrameSync *fs)
+                     fs->frame_ready = 1;
+                 if (fs->in[i].state == STATE_EOF &&
+                     fs->in[i].after == EXT_STOP)
+-                    framesync_eof(fs);
++                    framesync_eof(fs, AV_NOPTS_VALUE);
+             }
+         }
+         if (fs->frame_ready)
+@@ -255,15 +255,14 @@ static void framesync_inject_frame(FFFrameSync *fs, unsigned in, AVFrame *frame)
+     fs->in[in].have_next  = 1;
+ }
+ 
+-static void framesync_inject_status(FFFrameSync *fs, unsigned in, int status, int64_t pts)
++static void framesync_inject_status(FFFrameSync *fs, unsigned in, int status, int64_t eof_pts)
+ {
+     av_assert0(!fs->in[in].have_next);
+-    pts = fs->in[in].state != STATE_RUN || fs->in[in].after == EXT_INFINITY
+-        ? INT64_MAX : framesync_pts_extrapolate(fs, in, fs->in[in].pts);
+     fs->in[in].sync = 0;
+-    framesync_sync_level_update(fs);
++    framesync_sync_level_update(fs, status == AVERROR_EOF ? eof_pts : AV_NOPTS_VALUE);
+     fs->in[in].frame_next = NULL;
+-    fs->in[in].pts_next   = pts;
++    fs->in[in].pts_next   = fs->in[in].state != STATE_RUN || fs->in[in].after == EXT_INFINITY
++                            ? INT64_MAX : framesync_pts_extrapolate(fs, in, fs->in[in].pts);
+     fs->in[in].have_next  = 1;
+ }
+ 

--- a/packages/ffmpeg/debian-0013-lavc-avcodec-fix-global-private-option-precendence.patch
+++ b/packages/ffmpeg/debian-0013-lavc-avcodec-fix-global-private-option-precendence.patch
@@ -1,0 +1,62 @@
+From: Anton Khirnov <anton@khirnov.net>
+Date: Sun, 13 Oct 2024 14:11:39 +0200
+Subject: lavc/avcodec: fix global/private option precendence
+
+Broken after 7753a9d62725d5bd8313e2d249acbe1c8af79ab1. Apply only the
+whitelist early, and the rest with a single call to av_opt_set_dict2()
+with AV_OPT_SEARCH_CHILDREN, which should be equivalent to the original
+behaviour.
+
+Reported-by: Cameron Gutman <aicommander@gmail.com>
+(cherry picked from commit 9ce63e65d65b303813d4ae677228226d7cd232b9)
+Signed-off-by: Anton Khirnov <anton@khirnov.net>
+---
+ libavcodec/avcodec.c | 17 +++++++++++++----
+ 1 file changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/libavcodec/avcodec.c b/libavcodec/avcodec.c
+index d1daf47..1fa8704 100644
+--- a/libavcodec/avcodec.c
++++ b/libavcodec/avcodec.c
+@@ -145,6 +145,7 @@ int attribute_align_arg avcodec_open2(AVCodecContext *avctx, const AVCodec *code
+     int ret = 0;
+     AVCodecInternal *avci;
+     const FFCodec *codec2;
++    const AVDictionaryEntry *e;
+ 
+     if (avcodec_is_open(avctx))
+         return 0;
+@@ -175,8 +176,14 @@ int attribute_align_arg avcodec_open2(AVCodecContext *avctx, const AVCodec *code
+     if (avctx->extradata_size < 0 || avctx->extradata_size >= FF_MAX_EXTRADATA_SIZE)
+         return AVERROR(EINVAL);
+ 
+-    if ((ret = av_opt_set_dict(avctx, options)) < 0)
+-        return ret;
++    // set the whitelist from provided options dict,
++    // so we can check it immediately
++    e = options ? av_dict_get(*options, "codec_whitelist", NULL, 0) : NULL;
++    if (e) {
++        ret = av_opt_set(avctx, e->key, e->value, 0);
++        if (ret < 0)
++            return ret;
++    }
+ 
+     if (avctx->codec_whitelist && av_match_list(codec->name, avctx->codec_whitelist, ',') <= 0) {
+         av_log(avctx, AV_LOG_ERROR, "Codec (%s) not on whitelist \'%s\'\n", codec->name, avctx->codec_whitelist);
+@@ -211,12 +218,14 @@ int attribute_align_arg avcodec_open2(AVCodecContext *avctx, const AVCodec *code
+                 av_opt_set_defaults(avctx->priv_data);
+             }
+         }
+-        if (codec->priv_class && (ret = av_opt_set_dict(avctx->priv_data, options)) < 0)
+-            goto free_and_end;
+     } else {
+         avctx->priv_data = NULL;
+     }
+ 
++    ret = av_opt_set_dict2(avctx, options, AV_OPT_SEARCH_CHILDREN);
++    if (ret < 0)
++        goto free_and_end;
++
+     // only call ff_set_dimensions() for non H.264/VP6F/DXV codecs so as not to overwrite previously setup dimensions
+     if (!(avctx->coded_width && avctx->coded_height && avctx->width && avctx->height &&
+           (avctx->codec_id == AV_CODEC_ID_H264 || avctx->codec_id == AV_CODEC_ID_VP6F || avctx->codec_id == AV_CODEC_ID_DXV))) {

--- a/packages/ffmpeg/debian-0014-fftools-ffmpeg_filter-treat-apad-filter-as-a-source.patch
+++ b/packages/ffmpeg/debian-0014-fftools-ffmpeg_filter-treat-apad-filter-as-a-source.patch
@@ -1,0 +1,85 @@
+From: Anton Khirnov <anton@khirnov.net>
+Date: Sat, 12 Oct 2024 19:08:55 +0200
+Subject: fftools/ffmpeg_filter: treat apad filter as a source
+
+Ideally lavfi should have a dedicated API for detecting this.
+
+Fixes #11168 and #11061
+
+(cherry picked from commit 9e2a231236428c4682c77858c6aabfd74f459b17)
+Signed-off-by: Anton Khirnov <anton@khirnov.net>
+---
+ fftools/ffmpeg_filter.c | 21 ++++++++++++---------
+ 1 file changed, 12 insertions(+), 9 deletions(-)
+
+diff --git a/fftools/ffmpeg_filter.c b/fftools/ffmpeg_filter.c
+index 4e3a47e..38c7676 100644
+--- a/fftools/ffmpeg_filter.c
++++ b/fftools/ffmpeg_filter.c
+@@ -1101,8 +1101,9 @@ int fg_create(FilterGraph **pfg, char *graph_desc, Scheduler *sch)
+ 
+     for (unsigned i = 0; i < graph->nb_filters; i++) {
+         const AVFilter *f = graph->filters[i]->filter;
+-        if (!avfilter_filter_pad_count(f, 0) &&
+-            !(f->flags & AVFILTER_FLAG_DYNAMIC_INPUTS)) {
++        if ((!avfilter_filter_pad_count(f, 0) &&
++             !(f->flags & AVFILTER_FLAG_DYNAMIC_INPUTS)) ||
++            !strcmp(f->name, "apad")) {
+             fgp->have_sources = 1;
+             break;
+         }
+@@ -1497,7 +1498,7 @@ static int insert_filter(AVFilterContext **last_filter, int *pad_idx,
+     return 0;
+ }
+ 
+-static int configure_output_video_filter(FilterGraph *fg, AVFilterGraph *graph,
++static int configure_output_video_filter(FilterGraphPriv *fgp, AVFilterGraph *graph,
+                                          OutputFilter *ofilter, AVFilterInOut *out)
+ {
+     OutputFilterPriv *ofp = ofp_from_ofilter(ofilter);
+@@ -1576,7 +1577,7 @@ static int configure_output_video_filter(FilterGraph *fg, AVFilterGraph *graph,
+     return 0;
+ }
+ 
+-static int configure_output_audio_filter(FilterGraph *fg, AVFilterGraph *graph,
++static int configure_output_audio_filter(FilterGraphPriv *fgp, AVFilterGraph *graph,
+                                          OutputFilter *ofilter, AVFilterInOut *out)
+ {
+     OutputFilterPriv *ofp = ofp_from_ofilter(ofilter);
+@@ -1641,8 +1642,10 @@ static int configure_output_audio_filter(FilterGraph *fg, AVFilterGraph *graph,
+         pad_idx = 0;
+     }
+ 
+-    if (ofilter->apad)
++    if (ofilter->apad) {
+         AUTO_INSERT_FILTER("-apad", "apad", ofilter->apad);
++        fgp->have_sources = 1;
++    }
+ 
+     snprintf(name, sizeof(name), "trim for output %s", ofp->name);
+     ret = insert_trim(ofp->trim_start_us, ofp->trim_duration_us,
+@@ -1658,12 +1661,12 @@ fail:
+     return ret;
+ }
+ 
+-static int configure_output_filter(FilterGraph *fg, AVFilterGraph *graph,
++static int configure_output_filter(FilterGraphPriv *fgp, AVFilterGraph *graph,
+                                    OutputFilter *ofilter, AVFilterInOut *out)
+ {
+     switch (ofilter->type) {
+-    case AVMEDIA_TYPE_VIDEO: return configure_output_video_filter(fg, graph, ofilter, out);
+-    case AVMEDIA_TYPE_AUDIO: return configure_output_audio_filter(fg, graph, ofilter, out);
++    case AVMEDIA_TYPE_VIDEO: return configure_output_video_filter(fgp, graph, ofilter, out);
++    case AVMEDIA_TYPE_AUDIO: return configure_output_audio_filter(fgp, graph, ofilter, out);
+     default: av_assert0(0); return 0;
+     }
+ }
+@@ -1940,7 +1943,7 @@ static int configure_filtergraph(FilterGraph *fg, FilterGraphThread *fgt)
+     avfilter_inout_free(&inputs);
+ 
+     for (cur = outputs, i = 0; cur; cur = cur->next, i++) {
+-        ret = configure_output_filter(fg, fgt->graph, fg->outputs[i], cur);
++        ret = configure_output_filter(fgp, fgt->graph, fg->outputs[i], cur);
+         if (ret < 0) {
+             avfilter_inout_free(&outputs);
+             goto fail;

--- a/packages/ffmpeg/debian-0015-Skip-tests-using-non-existing-mpegts-pmtchange.ts.patch
+++ b/packages/ffmpeg/debian-0015-Skip-tests-using-non-existing-mpegts-pmtchange.ts.patch
@@ -1,0 +1,73 @@
+From: Sebastian Ramacher <sramacher@debian.org>
+Date: Sun, 20 Oct 2024 14:48:06 +0200
+Subject: Skip tests using non-existing mpegts/pmtchange.ts
+
+---
+ tests/fate/ffmpeg.mak   | 4 ----
+ tests/fate/matroska.mak | 5 -----
+ tests/fate/mov.mak      | 7 -------
+ tests/fate/mpegts.mak   | 5 -----
+ 4 files changed, 21 deletions(-)
+
+diff --git a/tests/fate/ffmpeg.mak b/tests/fate/ffmpeg.mak
+index 869376d..3ffaaeb 100644
+--- a/tests/fate/ffmpeg.mak
++++ b/tests/fate/ffmpeg.mak
+@@ -263,7 +263,3 @@ fate-ffmpeg-loopback-decoding: CMD = transcode \
+     "rawvideo -s 352x288 -pix_fmt yuv420p" $(TARGET_PATH)/tests/data/vsynth1.yuv nut \
+     "-map 0:v:0 -c:v mpeg2video -f null - -flags +bitexact -idct simple -threads $$threads -dec 0:0 -filter_complex '[0:v][dec:0]hstack[stack]' -map '[stack]' -c:v ffv1" ""
+ FATE_FFMPEG-$(call ENCDEC2, MPEG2VIDEO, FFV1, NUT, HSTACK_FILTER PIPE_PROTOCOL FRAMECRC_MUXER) += fate-ffmpeg-loopback-decoding
+-
+-# test matching by stream disposition
+-fate-ffmpeg-spec-disposition: CMD = framecrc -i $(TARGET_SAMPLES)/mpegts/pmtchange.ts -map '0:disp:visual_impaired+descriptions:1' -c copy
+-FATE_FFMPEG-$(call FRAMECRC, MPEGTS,,) += fate-ffmpeg-spec-disposition
+diff --git a/tests/fate/matroska.mak b/tests/fate/matroska.mak
+index 563d756..1a705bc 100644
+--- a/tests/fate/matroska.mak
++++ b/tests/fate/matroska.mak
+@@ -180,11 +180,6 @@ FATE_MATROSKA_FFMPEG_FFPROBE-$(call REMUX, MATROSKA, VP8_PARSER)  \
+                                += fate-matroska-vp8-alpha-remux
+ fate-matroska-vp8-alpha-remux: CMD = transcode matroska $(TARGET_SAMPLES)/vp8_alpha/vp8_video_with_alpha.webm matroska "-c copy -disposition +hearing_impaired -cluster_size_limit 100000" "-c copy -t 0.2" "-show_entries stream_disposition:stream_side_data_list"
+ 
+-# The audio stream to be remuxed here has AV_DISPOSITION_VISUAL_IMPAIRED.
+-FATE_MATROSKA_FFMPEG_FFPROBE-$(call REMUX, MATROSKA, MPEGTS_DEMUXER AC3_DECODER) \
+-                               += fate-matroska-mpegts-remux
+-fate-matroska-mpegts-remux: CMD = transcode mpegts $(TARGET_SAMPLES)/mpegts/pmtchange.ts matroska "-map 0:2 -map 0:2 -c copy -disposition:a:1 -visual_impaired+hearing_impaired -default_mode infer" "-map 0 -c copy" "-show_entries stream_disposition:stream=index"
+-
+ # Tests maintaining codec delay while remuxing from Matroska.
+ # For some reason, ffmpeg shifts the timestamps of the input file
+ # to make them zero before reaching the muxer while it does not
+diff --git a/tests/fate/mov.mak b/tests/fate/mov.mak
+index 1200c77..053c87a 100644
+--- a/tests/fate/mov.mak
++++ b/tests/fate/mov.mak
+@@ -182,13 +182,6 @@ FATE_MOV_FFMPEG_FFPROBE_SAMPLES-$(call DEMMUX, MOV, FRAMECRC, HEVC_DECODER HEVC_
+ fate-mov-heic-demux-still-image-iovl-2: CMD = stream_demux mov $(TARGET_SAMPLES)/heif-conformance/C021.heic "" "-c:v copy -map 0:g:0" \
+   "-show_entries stream_group=index,id,nb_streams,type:stream_group_components:stream_group_disposition:stream_group_tags:stream_group_stream=index,id:stream_group_stream_disposition"
+ 
+-# Resulting remux should have:
+-# 1. first audio stream with AV_DISPOSITION_HEARING_IMPAIRED
+-# 2. second audio stream with AV_DISPOSITION_VISUAL_IMPAIRED | DESCRIPTIONS
+-FATE_MOV_FFMPEG_FFPROBE_SAMPLES-$(call REMUX, MP4 MOV, MPEGTS_DEMUXER AC3_DECODER) \
+-                          += fate-mov-mp4-disposition-mpegts-remux
+-fate-mov-mp4-disposition-mpegts-remux: CMD = transcode mpegts $(TARGET_SAMPLES)/mpegts/pmtchange.ts mp4 "-map 0:1 -map 0:2 -c copy -disposition:a:0 +hearing_impaired" "-map 0 -c copy" "-of json -show_entries stream_disposition:stream=index"
+-
+ FATE_MOV_FFMPEG_FFPROBE_SAMPLES-$(call REMUX, MP4 MOV) \
+                           += fate-mov-write-amve
+ fate-mov-write-amve: CMD = transcode mov $(TARGET_SAMPLES)/mov/amve.mov mp4 "-c:v copy" "-c:v copy -t 0.5" "-show_entries stream_side_data_list"
+diff --git a/tests/fate/mpegts.mak b/tests/fate/mpegts.mak
+index eaca8ec..49b2f79 100644
+--- a/tests/fate/mpegts.mak
++++ b/tests/fate/mpegts.mak
+@@ -15,11 +15,6 @@ fate-mpegts-probe-program: SRC = $(TARGET_SAMPLES)/mpegts/loewe.ts
+ fate-mpegts-probe-program: CMD = run $(PROBE_CODEC_NAME_COMMAND) -select_streams p:769:v:0 -i "$(SRC)"
+ 
+ 
+-FATE_MPEGTS_PROBE-$(call DEMDEC, MPEGTS) += fate-mpegts-probe-pmt-merge
+-fate-mpegts-probe-pmt-merge: SRC = $(TARGET_SAMPLES)/mpegts/pmtchange.ts
+-fate-mpegts-probe-pmt-merge: CMD = run $(PROBE_CODEC_NAME_COMMAND) -merge_pmt_versions 1 -i "$(SRC)"
+-
+-
+ FATE_SAMPLES_FFPROBE += $(FATE_MPEGTS_PROBE-yes)
+ 
+ fate-mpegts: $(FATE_MPEGTS_PROBE-yes)

--- a/packages/ffmpeg/sync-debian-patches.sh
+++ b/packages/ffmpeg/sync-debian-patches.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e -u
+
+srcdir=$(realpath "$(dirname "$0")")
+
+rm -Rf debian-*.patch
+
+checkout_dir=$(mktemp -d)
+cd "$checkout_dir"
+git clone --depth=1 https://salsa.debian.org/multimedia-team/ffmpeg.git
+
+for patch in ffmpeg/debian/patches/*.patch; do
+	new_patch=debian-$(basename "$patch")
+	echo "$patch" -> "$new_patch"
+	cp "$patch" "$srcdir/$new_patch"
+done
+
+rm -Rf "$checkout_dir"


### PR DESCRIPTION
ffmpeg is a large and complex code base that has occasional security and functionality issues, while being not that frequently released.

This PR proposes syncing patches from debian, replacing our single handpicked backported commit.

Run `./packages/ffmpeg/sync-debian-patches.sh` to regenerate the patchset from debian.