### PR TITLE
chore(scripts/lint-packages): Fix minor styling nits lint

### DIFF
--- a/packages/python2/build.sh
+++ b/packages/python2/build.sh
@@ -59,7 +59,7 @@ termux_step_pre_configure() {
 	# Put the host-built python in path:
 	export TERMUX_ORIG_PATH=$PATH
 	export PATH=$TERMUX_PKG_HOSTBUILD_DIR:$PATH
-	
+
 	if [ $TERMUX_ARCH = i686 ] || [ $TERMUX_ARCH = arm ]; then LDFLAGS+=" -lm"; fi
 
 	# Needed when building with clang, as setup.py only probes

--- a/x11-packages/tuxpaint/build.sh
+++ b/x11-packages/tuxpaint/build.sh
@@ -37,7 +37,7 @@ termux_step_pre_configure() {
 	local _PREFIX_FOR_BUILD="$TERMUX_PKG_HOSTBUILD_DIR/prefix"
 	export PATH="$_PREFIX_FOR_BUILD/bin:$PATH"
 	export XDG_DATA_HOME="$TERMUX_PREFIX/share" XDG_DATA_DIRS="$TERMUX_PREFIX" XDG_CURRENT_DESKTOP="X-Generic"
-	
+
 	# Disabling gtk-update-icon-cache
 	ln -s /usr/bin/true "$_PREFIX_FOR_BUILD/bin/update-desktop-database" ||:
 	ln -s /usr/bin/true "$_PREFIX_FOR_BUILD/bin/gtk-update-icon-cache" ||:

--- a/x11-packages/wine-stable/build.sh
+++ b/x11-packages/wine-stable/build.sh
@@ -123,7 +123,7 @@ termux_step_pre_configure() {
 	LDFLAGS="${LDFLAGS/-Wl,-z,relro,-z,now/}"
 
 	LDFLAGS+=" -landroid-spawn"
-	
+
 	if [ "$TERMUX_ARCH" = "x86_64" ]; then
 		mkdir -p "$TERMUX_PKG_TMPDIR/bin"
 		cat <<- EOF > "$TERMUX_PKG_TMPDIR/bin/x86_64-linux-android-clang"


### PR DESCRIPTION
Fix empty lines with only tabs to make `./scripts/lint-packages.sh` pass.

%ci:no-build