### PR TITLE
bump(phpmyadmin): 5.2.2

### DIFF
--- a/packages/phpmyadmin/build.sh
+++ b/packages/phpmyadmin/build.sh
@@ -1,11 +1,11 @@
 TERMUX_PKG_HOMEPAGE=https://www.phpmyadmin.net
-TERMUX_PKG_DESCRIPTION="A PHP tool for administering MySQL databases"
+TERMUX_PKG_DESCRIPTION="A PHP tool for administering MySQL and MariaDB databases"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=5.2.1
+TERMUX_PKG_VERSION=5.2.2
 TERMUX_PKG_SRCURL=https://files.phpmyadmin.net/phpMyAdmin/$TERMUX_PKG_VERSION/phpMyAdmin-$TERMUX_PKG_VERSION-all-languages.tar.xz
-TERMUX_PKG_SHA256=373f9599dfbd96d6fe75316d5dad189e68c305f297edf42377db9dd6b41b2557
-TERMUX_PKG_DEPENDS="apache2, php"
+TERMUX_PKG_SHA256=f881819a3b11e653b0212afaf0cc105db85c767715cb3f5852670f7fc36c9669
+TERMUX_PKG_DEPENDS="apache2, php, php-apache"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_CONFFILES="etc/phpmyadmin/config.inc.php"
 

--- a/packages/phpmyadmin/phpmyadmin.conf
+++ b/packages/phpmyadmin/phpmyadmin.conf
@@ -3,10 +3,10 @@ Alias /phpmyadmin @TERMUX_PREFIX@/share/phpmyadmin
 <Directory @TERMUX_PREFIX@/share/phpmyadmin>
     Options Indexes FollowSymLinks
     DirectoryIndex index.php
+    Require all granted
 
-    <IfModule mod_php7.c>
-        AddType application/x-httpd-php .php
-
+    <IfModule mod_php.c>
+	php_value error_reporting "E_ALL & ~E_DEPRECATED"
         php_flag magic_quotes_gpc Off
         php_flag track_vars On
         php_flag register_globals Off
@@ -27,6 +27,10 @@ Alias /phpmyadmin @TERMUX_PREFIX@/share/phpmyadmin
 
 # Disallow web access to directories that don't need it
 <Directory @TERMUX_PREFIX@/share/phpmyadmin/libraries>
+    Order Deny,Allow
+    Deny from All
+</Directory>
+<Directory @TERMUX_PREFIX@/share/phpmyadmin/vendor>
     Order Deny,Allow
     Deny from All
 </Directory>


### PR DESCRIPTION
The `php-apache` is incomplete, I had to use https://github.com/termux/termux-packages/issues/7964#issuecomment-2608382401 to make it work.
I decided to ban the vendor folder. And I had to add a line to grant access to the folder or the page is 403

I added a php flag to avoid showing the deprecations:
- https://github.com/termux/termux-packages/issues/22735#issuecomment-2568497301
- https://github.com/phpmyadmin/phpmyadmin/issues/19404#issuecomment-2608396879

The package displays and connects to my database server 🎉 