### PR TITLE
bump(main/nim): v2.2.0

### DIFF
--- a/packages/nim/build.sh
+++ b/packages/nim/build.sh
@@ -3,9 +3,9 @@ TERMUX_PKG_DESCRIPTION="Nim programming language compiler"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="copying.txt"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=2.0.4
+TERMUX_PKG_VERSION=2.2.0
 TERMUX_PKG_SRCURL=https://nim-lang.org/download/nim-$TERMUX_PKG_VERSION.tar.xz
-TERMUX_PKG_SHA256=71526bd07439dc8e378fa1a6eb407eda1298f1f3d4df4476dca0e3ca3cbe3f09
+TERMUX_PKG_SHA256=ce9842849c9760e487ecdd1cdadf7c0f2844cafae605401c7c72ae257644893c
 TERMUX_PKG_DEPENDS="clang, git, libandroid-glob, openssl"
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -53,6 +53,7 @@ termux_step_make() {
 		pushd $(dirname $cmd)
 		case $cmd in
 			koch) nim_flags="--opt:size" ;;
+			dist/nimble/src/nimble) nim_flags="-d:nimNimbleBootstrap" ;; # See: https://github.com/nim-lang/nimble/issues/1248
 			*) nim_flags= ;;
 		esac
 		nim --cc:clang --clang.exe=$CC --clang.linkerexe=$CC $nim_flags --define:termux -d:release -d:sslVersion=3 --os:android --cpu:$NIM_ARCH  -t:"$CPPFLAGS $CFLAGS" -l:"$LDFLAGS -landroid-glob" -d:tempDir:$TERMUX_PREFIX/tmp c $(basename $cmd).nim


### PR DESCRIPTION
Bump Nim to version [2.2.0](https://nim-lang.org/blog/2024/10/02/nim-220-2010.html)