### PR TITLE
fix(x11/fcitx5): libdl.a is a stub --- use libdl.so instead

### DIFF
--- a/x11-packages/fcitx5/build.sh
+++ b/x11-packages/fcitx5/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A generic input method framework"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="5.1.12"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/fcitx/fcitx5/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=04fabc12cb8702f06aeb1399f30d41dd9c17a997ccac9a53352ba21a8aef16e7
 TERMUX_PKG_AUTO_UPDATE=true
@@ -13,7 +14,12 @@ TERMUX_PKG_DEPENDS="dbus, enchant, fcitx5-data, fmt, gdk-pixbuf, glib, iso-codes
 TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DDL_INCLUDE_DIR=$TERMUX_PREFIX/include
+-DDL_LIBRARY=0
 -DPTHREAD_INCLUDE_DIR=$TERMUX_PREFIX/include
 -DENABLE_TEST=OFF
 -DENABLE_WAYLAND=OFF
 "
+
+termux_step_pre_configure() {
+	LDFLAGS+=" -ldl"
+}


### PR DESCRIPTION
* Fixes #23039 