### PR TITLE
electrum: sync python dependencies, disable auto updates and add electrum daemon service script 

### DIFF
--- a/packages/electrum/build.sh
+++ b/packages/electrum/build.sh
@@ -3,12 +3,16 @@ TERMUX_PKG_DESCRIPTION="Electrum is a lightweight Bitcoin wallet"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="4.5.8"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://download.electrum.org/$TERMUX_PKG_VERSION/Electrum-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=dd8595a138132dee87cee76ce760a1d622fc2fd65d3b6ac7df7e53b7fb6ea7e8
-TERMUX_PKG_AUTO_UPDATE=true
+# The python dependency list should be compared to
+# contrib/requirements/requirements.txt in upstream project on every
+# update (or at least every major update).  Disable auto updates for
+# now.
+TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_DEPENDS="python, libsecp256k1, python-pip, python-cryptography"
-TERMUX_PKG_PYTHON_TARGET_DEPS="'qrcode', 'protobuf<4,>=3.20', 'qdarkstyle>=2.7', 'aiorpcx<0.23,>=0.22.0', 'aiohttp<4.0.0,>=3.3.0', 'aiohttp_socks>=0.3', 'certifi', 'bitstring', 'attrs>=19.2.0', 'dnspython>=2.0', 'jsonpatch'"
+TERMUX_PKG_PYTHON_TARGET_DEPS="'qrcode', 'protobuf<4,>=3.20', 'qdarkstyle>=2.7', 'aiorpcx<0.24,>=0.22.0', 'aiohttp<4.0.0,>=3.3.0', 'aiohttp_socks>=0.8.4', 'certifi', 'attrs>=20.1.0', 'jsonpatch', 'dnspython>=2.0'"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 # asciinema previously contained some files that python packages have in common

--- a/packages/electrum/build.sh
+++ b/packages/electrum/build.sh
@@ -14,6 +14,7 @@ TERMUX_PKG_PLATFORM_INDEPENDENT=true
 # asciinema previously contained some files that python packages have in common
 TERMUX_PKG_CONFLICTS="asciinema (<< 1.4.0-1)"
 TERMUX_PKG_PYTHON_COMMON_DEPS="wheel"
+TERMUX_PKG_SERVICE_SCRIPT=("electrum" 'exec electrum daemon 2>&1')
 
 termux_step_create_debscripts() {
 	cat <<- EOF > ./postinst


### PR DESCRIPTION
Dependencies synced with https://github.com/spesmilo/electrum/blob/4.5.8/contrib/requirements/requirements.txt.
Electrum was broken after an auto-update due to missing dependencies until @DarkJoker360 fixed it in https://github.com/termux/termux-packages/pull/22979. Let's disable auto updates so that we do not get the same issues again.

Also add an `electrum daemon` termux-services script. To use, install `termux-services` and then run `sv up electrum`, or `sv-enable electrum`. 