### PR TITLE
bump(main/libwavpack): 5.8.1

### DIFF
--- a/packages/libwavpack/build.sh
+++ b/packages/libwavpack/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.wavpack.com/
 TERMUX_PKG_DESCRIPTION="A completely open audio compression format providing lossless, high-quality lossy, and a unique hybrid compression mode"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="5.8.0"
+TERMUX_PKG_VERSION="5.8.1"
 TERMUX_PKG_SRCURL=https://github.com/dbry/WavPack/releases/download/${TERMUX_PKG_VERSION}/wavpack-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=a6a7dcd2262a21fa738e831ddd5e65e523b663308031cbd8a925e3b534809f0f
+TERMUX_PKG_SHA256=7322775498602c8850afcfc1ae38f99df4cbcd51386e873d6b0f8047e55c0c26
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libandroid-glob"
 


### PR DESCRIPTION
Fixes the build as 5.8.0 was removed: https://github.com/dbry/WavPack/releases/tag/5.8.1