### PR TITLE
new package: carbonyl-host-tools

### DIFF
--- a/scripts/big-pkgs.list
+++ b/scripts/big-pkgs.list
@@ -1,5 +1,6 @@
 angle-android
 bionic-host
+carbonyl-host-tools
 clvk
 dart
 dotnet8.0

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -294,6 +294,10 @@ PACKAGES+=" libwebp7 libwebp7:i386 libwebp-dev"
 PACKAGES+=" libwebpdemux2 libwebpdemux2:i386"
 PACKAGES+=" libwebpmux3 libwebpmux3:i386"
 
+# Required by chromium-based packages
+PACKAGES+=" libfontconfig1"
+PACKAGES+=" libfontconfig1:i386"
+
 # Required by wine-stable
 PACKAGES+=" libfreetype-dev:i386"
 

--- a/x11-packages/carbonyl-host-tools/0001-override-build-target.patch
+++ b/x11-packages/carbonyl-host-tools/0001-override-build-target.patch
@@ -1,0 +1,11 @@
+--- a/src/browser/BUILD.gn
++++ b/src/browser/BUILD.gn
+@@ -40,7 +40,7 @@
+   if (is_mac) {
+     target += "apple-darwin"
+   } else if (is_linux) {
+-    target += "unknown-linux-gnu"
++    target += "linux-android"
+   }
+ 
+   libs = ["carbonyl"]

--- a/x11-packages/carbonyl-host-tools/0002-fix-cxx-include.patch
+++ b/x11-packages/carbonyl-host-tools/0002-fix-cxx-include.patch
@@ -1,0 +1,9 @@
+--- a/chromium/src/carbonyl/src/browser/renderer.cc
++++ b/chromium/src/carbonyl/src/browser/renderer.cc
+@@ -1,5 +1,6 @@
+ #include "carbonyl/src/browser/renderer.h"
+ 
++#include <vector>
+ #include <memory>
+ #include <iostream>
+ #include <stdio.h>

--- a/x11-packages/carbonyl-host-tools/0003-properly-include-base-callback.patch
+++ b/x11-packages/carbonyl-host-tools/0003-properly-include-base-callback.patch
@@ -1,0 +1,11 @@
+--- a/src/browser/host_display_client.h
++++ b/src/browser/host_display_client.h
+@@ -3,7 +3,7 @@
+ 
+ #include <memory>
+ 
+-#include "base/callback.h"
++#include "base/functional/callback.h"
+ #include "base/memory/shared_memory_mapping.h"
+ #include "carbonyl/src/browser/export.h"
+ #include "components/viz/host/host_display_client.h"

--- a/x11-packages/carbonyl-host-tools/0004-add-support-for-putty.patch
+++ b/x11-packages/carbonyl-host-tools/0004-add-support-for-putty.patch
@@ -1,0 +1,23 @@
+From 62d5b2d96bd8890d82ee5150fc4d0db76e68106d Mon Sep 17 00:00:00 2001
+From: Boyi C <fanthos@live.com>
+Date: Tue, 28 Mar 2023 12:23:33 +0800
+Subject: [PATCH] Update tty.rs to support putty
+
+Add mode 1002 to tts, to make mouse works in Putty.
+---
+ src/input/tty.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/input/tty.rs b/src/input/tty.rs
+index 5cf491b..38dd3f6 100644
+--- a/src/input/tty.rs
++++ b/src/input/tty.rs
+@@ -65,7 +65,7 @@ enum TTY {
+     File(File),
+ }
+ 
+-const SEQUENCES: [(u32, bool); 4] = [(1049, true), (1003, true), (1006, true), (25, false)];
++const SEQUENCES: [(u32, bool); 5] = [(1049, true), (1002, true), (1003, true), (1006, true), (25, false)];
+ 
+ impl TTY {
+     fn stdin() -> TTY {

--- a/x11-packages/carbonyl-host-tools/0005-passing-args-from-c-main.patch
+++ b/x11-packages/carbonyl-host-tools/0005-passing-args-from-c-main.patch
@@ -1,0 +1,156 @@
+
+--- a/src/browser/bridge.rs
++++ b/src/browser/bridge.rs
+@@ -44,6 +44,11 @@
+     rect: CRect,
+     color: CColor,
+ }
++#[repr(C)]
++#[derive(Copy, Clone)]
++pub struct InitArg {
++    arg: *const c_char,
++}
+ 
+ #[repr(C)]
+ pub struct RendererBridge {
+@@ -103,8 +108,8 @@
+     post_task: extern "C" fn(extern "C" fn(*mut c_void), *mut c_void),
+ }
+ 
+-fn main() -> io::Result<Option<i32>> {
+-    let cmd = match CommandLineProgram::parse_or_run() {
++fn main(args: Vec<String>) -> io::Result<Option<i32>> {
++    let cmd = match CommandLineProgram::parse_or_run(args) {
+         None => return Ok(Some(0)),
+         Some(cmd) => cmd,
+     };
+@@ -142,8 +147,22 @@
+ }
+ 
+ #[no_mangle]
+-pub extern "C" fn carbonyl_bridge_main() {
+-    if let Some(code) = main().unwrap() {
++pub extern "C" fn carbonyl_bridge_main(
++    args: *const InitArg,
++    argc: size_t,
++) {
++    // Parse Vec<String> from params
++    let args = unsafe { std::slice::from_raw_parts(args, argc) };
++    let args = args.iter()
++        .skip(1)
++        .map(|arg| {
++            let str = unsafe { CStr::from_ptr(arg.arg) };
++
++            str.to_str().unwrap().to_owned()
++        })
++        .collect::<Vec<String>>();
++
++    if let Some(code) = main(args).unwrap() {
+         std::process::exit(code)
+     }
+ }
+--- a/src/cli/cli.rs
++++ b/src/cli/cli.rs
+@@ -1,4 +1,5 @@
+ use std::{env, ffi::OsStr};
++use std::sync::OnceLock;
+ 
+ use super::CommandLineProgram;
+ 
+@@ -35,7 +36,17 @@
+     }
+ }
+ 
++static INIT: OnceLock<Vec<String>> = OnceLock::new();
++
+ impl CommandLine {
++    pub fn set_args(args: Vec<String>) {
++        INIT.get_or_init(|| { args });
++    }
++
++    pub fn get_args() -> Vec<String> {
++        INIT.get_or_init(|| Vec::new()).to_vec()
++    }
++
+     pub fn parse() -> CommandLine {
+         let mut fps = 60.0;
+         let mut zoom = 1.0;
+@@ -43,7 +54,7 @@
+         let mut bitmap = false;
+         let mut shell_mode = false;
+         let mut program = CommandLineProgram::Main;
+-        let args = env::args().skip(1).collect::<Vec<String>>();
++        let args = Self::get_args();
+ 
+         for arg in &args {
+             let split: Vec<&str> = arg.split("=").collect();
+--- a/src/cli/program.rs
++++ b/src/cli/program.rs
+@@ -8,7 +8,8 @@
+ }
+ 
+ impl CommandLineProgram {
+-    pub fn parse_or_run() -> Option<CommandLine> {
++    pub fn parse_or_run(args: Vec<String>) -> Option<CommandLine> {
++        CommandLine::set_args(args);
+         let cmd = CommandLine::parse();
+ 
+         match cmd.program {
+--- a/src/browser/renderer.h
++++ b/src/browser/renderer.h
+@@ -47,7 +47,7 @@
+ 
+ class CARBONYL_RENDERER_EXPORT Renderer {
+ public:
+-    static void Main();
++    static void Main(int argc, const char** argv);
+     static Renderer* GetCurrent();
+ 
+     gfx::Size GetSize();
+--- a/src/browser/renderer.cc
++++ b/src/browser/renderer.cc
+@@ -34,8 +34,14 @@
+     carbonyl_renderer_rect rect;
+     carbonyl_renderer_color color;
+ };
++struct carbonyl_init_arg {
++    const char *arg;
++};
+ 
+-void carbonyl_bridge_main();
++void carbonyl_bridge_main(
++    const struct carbonyl_init_arg* args,
++    size_t argc
++);
+ bool carbonyl_bridge_bitmap_mode();
+ float carbonyl_bridge_get_dpi();
+ 
+@@ -71,8 +77,15 @@
+ 
+ Renderer::Renderer(struct carbonyl_renderer* ptr): ptr_(ptr) {}
+ 
+-void Renderer::Main() {
+-    carbonyl_bridge_main();
++void Renderer::Main(int argc, const char** argv) {
++    if (argc < 0) {
++        argc = 0;
++    }
++    struct carbonyl_init_arg args[argc];
++    for (int i = 0; i < argc; ++i) {
++        args[i].arg = argv[i];
++    }
++    carbonyl_bridge_main(args, (size_t) argc);
+ 
+     Bridge::Configure(
+         carbonyl_bridge_get_dpi(),
+--- a/chromium/src/headless/app/headless_shell_main.cc
++++ b/chromium/src/headless/app/headless_shell_main.cc
+@@ -17,7 +17,7 @@
+ #include "carbonyl/src/browser/renderer.h"
+ 
+ int main(int argc, const char** argv) {
+-  carbonyl::Renderer::Main();
++  carbonyl::Renderer::Main(argc, argv);
+ 
+   content::ContentMainParams params(nullptr);
+ #if BUILDFLAG(IS_WIN)

--- a/x11-packages/carbonyl-host-tools/9001-Add-Carbonyl-service.diff
+++ b/x11-packages/carbonyl-host-tools/9001-Add-Carbonyl-service.diff
@@ -1,0 +1,20 @@
+--- a/chromium/patches/chromium/0002-Add-Carbonyl-service.patch
++++ b/chromium/patches/chromium/0002-Add-Carbonyl-service.patch
+@@ -590,7 +590,7 @@
+ +      base64.c_str(),
+ +      PrimaryFont()->
+ +        PlatformData().
+-+        CreateSkFont(false, &font_description_)
+++        CreateSkFont(&font_description_)
+ +    );
+ +
+ +    if (node_id != cc::kInvalidNodeId) {
+@@ -622,7 +622,7 @@
+ +      base64.c_str(),
+ +      PrimaryFont()->
+ +        PlatformData().
+-+        CreateSkFont(false, &font_description_)
+++        CreateSkFont(&font_description_)
+ +    );
+ +
+ +    if (node_id != cc::kInvalidNodeId) {

--- a/x11-packages/carbonyl-host-tools/9002-Setup-browser-default-settings.diff
+++ b/x11-packages/carbonyl-host-tools/9002-Setup-browser-default-settings.diff
@@ -1,0 +1,34 @@
+--- a/chromium/patches/chromium/0004-Setup-browser-default-settings.patch
++++ b/chromium/patches/chromium/0004-Setup-browser-default-settings.patch
+@@ -10,9 +10,9 @@
+ 
+ diff --git a/headless/public/headless_browser.cc b/headless/public/headless_browser.cc
+ index b6c70ecb0fc23..c836a082d2e68 100644
+---- a/headless/public/headless_browser.cc
+-+++ b/headless/public/headless_browser.cc
+-@@ -22,14 +22,14 @@ namespace headless {
++--- a/headless/lib/browser/headless_browser_impl.cc
+++++ b/headless/lib/browser/headless_browser_impl.cc
++@@ -25,7 +25,7 @@
+  
+  namespace {
+  // Product name for building the default user agent string.
+@@ -21,14 +21,15 @@
+  constexpr gfx::Size kDefaultWindowSize(800, 600);
+  
+  constexpr gfx::FontRenderParams::Hinting kDefaultFontRenderHinting =
+-     gfx::FontRenderParams::Hinting::HINTING_FULL;
++@@ -122,7 +122,7 @@
+  
+- std::string GetProductNameAndVersion() {
++ /// static
++ std::string HeadlessBrowser::GetProductNameAndVersion() {
+ -  return std::string(kHeadlessProductName) + "/" + PRODUCT_VERSION;
+ +  return std::string(kHeadlessProductName) + "/" + PRODUCT_VERSION + " (Carbonyl)";
+  }
+- }  // namespace
+  
++ HeadlessBrowserImpl::HeadlessBrowserImpl(
+ diff --git a/headless/public/headless_browser.h b/headless/public/headless_browser.h
+ index 48efaa7d57ca2..afc0236147519 100644
+ --- a/headless/public/headless_browser.h

--- a/x11-packages/carbonyl-host-tools/9003-Bridge-browser-into-Carbonyl-library.diff
+++ b/x11-packages/carbonyl-host-tools/9003-Bridge-browser-into-Carbonyl-library.diff
@@ -1,0 +1,88 @@
+--- a/chromium/patches/chromium/0009-Bridge-browser-into-Carbonyl-library.patch
++++ b/chromium/patches/chromium/0009-Bridge-browser-into-Carbonyl-library.patch
+@@ -18,14 +18,14 @@
+ +++ b/headless/app/headless_shell.cc
+ @@ -4,6 +4,8 @@
+  
+- #include "headless/app/headless_shell.h"
++ #include "headless/public/headless_shell.h"
+  
+ +#include "carbonyl/src/browser/bridge.h"
+ +
+  #include <memory>
+  
+  #include "base/base_switches.h"
+-@@ -90,6 +92,8 @@ void HeadlessShell::OnBrowserStart(HeadlessBrowser* browser) {
++@@ -103,6 +105,8 @@
+    HeadlessBrowserContext::Builder context_builder =
+        browser_->CreateBrowserContextBuilder();
+  
+@@ -34,15 +34,13 @@
+    // Retrieve the locale set by InitApplicationLocale() in
+    // headless_content_main_delegate.cc in a way that is free of side-effects.
+    context_builder.SetAcceptLanguage(base::i18n::GetConfiguredLocale());
+-@@ -113,39 +117,14 @@ void HeadlessShell::OnBrowserStart(HeadlessBrowser* browser) {
+- 
+-   GURL target_url = ConvertArgumentToURL(args.front());
++@@ -133,35 +137,12 @@
++   HeadlessWebContents::Builder builder(
++       browser_context->CreateWebContentsBuilder());
+  
+ -  // If driven by a debugger just open the target page and
+ -  // leave expecting the debugger will do what they need.
+--  if (IsRemoteDebuggingEnabled()) {
+--    HeadlessWebContents::Builder builder(
+--        browser_context_->CreateWebContentsBuilder());
++-  if (devtools_enabled) {
+ -    HeadlessWebContents* web_contents =
+ -        builder.SetInitialURL(target_url).Build();
+ -    if (!web_contents) {
+@@ -56,8 +54,6 @@
+ -  // execute the commands against the target page.
+ -#if defined(HEADLESS_ENABLE_COMMANDS)
+ -  GURL handler_url = HeadlessCommandHandler::GetHandlerUrl();
+-   HeadlessWebContents::Builder builder(
+-       browser_context_->CreateWebContentsBuilder());
+    HeadlessWebContents* web_contents =
+ -      builder.SetInitialURL(handler_url).Build();
+ +      builder.SetInitialURL(target_url).Build();
+@@ -71,7 +67,7 @@
+ -  HeadlessCommandHandler::ProcessCommands(
+ -      HeadlessWebContentsImpl::From(web_contents)->web_contents(),
+ -      std::move(target_url),
+--      base::BindOnce(&HeadlessShell::ShutdownSoon, weak_factory_.GetWeakPtr()));
++-      base::BindOnce(&HeadlessShell::ShutdownSoon, base::Unretained(this)));
+ -#endif
+  }
+  
+@@ -90,9 +86,9 @@
+  int main(int argc, const char** argv) {
+ +  carbonyl_shell_main();
+ +
++   content::ContentMainParams params(nullptr);
+  #if BUILDFLAG(IS_WIN)
+    sandbox::SandboxInterfaceInfo sandbox_info = {nullptr};
+-   content::InitializeSandboxInfo(&sandbox_info);
+ diff --git a/headless/lib/browser/headless_browser_impl.cc b/headless/lib/browser/headless_browser_impl.cc
+ index 1a1223108be6d..fd45d215479ab 100644
+ --- a/headless/lib/browser/headless_browser_impl.cc
+@@ -550,7 +546,7 @@
+  
+  #include "base/memory/weak_ptr.h"
+  #include "base/task/single_thread_task_runner.h"
+-@@ -121,9 +122,24 @@ class HEADLESS_EXPORT HeadlessBrowserImpl : public HeadlessBrowser,
++@@ -121,7 +122,22 @@
+    policy::PolicyService* GetPolicyService();
+  #endif
+  
+@@ -566,9 +562,7 @@
+ +  void OnMouseDownInput(unsigned int x, unsigned int y);
+ +  void OnMouseMoveInput(unsigned int x, unsigned int y);
+ +
+-   bool did_shutdown() const { return did_shutdown_; }
+- 
+-  protected:
++  private:
+ + // TODO: use base::TaskRunner
+ +  std::thread input_thread_;
+ +

--- a/x11-packages/carbonyl-host-tools/9004-Rename-carbonyl-Renderer-to-carbonyl-Bridge.diff
+++ b/x11-packages/carbonyl-host-tools/9004-Rename-carbonyl-Renderer-to-carbonyl-Bridge.diff
@@ -1,0 +1,20 @@
+--- a/chromium/patches/chromium/0011-Rename-carbonyl-Renderer-to-carbonyl-Bridge.patch
++++ b/chromium/patches/chromium/0011-Rename-carbonyl-Renderer-to-carbonyl-Bridge.patch
+@@ -17,14 +17,14 @@
+ --- a/headless/app/headless_shell.cc
+ +++ b/headless/app/headless_shell.cc
+ @@ -12,6 +12,7 @@
+- #include "base/bind.h"
+  #include "base/command_line.h"
+  #include "base/files/file_util.h"
++ #include "base/functional/bind.h"
+ +#include "base/functional/callback.h"
+  #include "base/i18n/rtl.h"
++ #include "base/logging.h"
+  #include "base/task/thread_pool.h"
+- #include "build/branding_buildflags.h"
+-@@ -92,7 +93,9 @@ void HeadlessShell::OnBrowserStart(HeadlessBrowser* browser) {
++@@ -105,7 +106,9 @@
+    HeadlessBrowserContext::Builder context_builder =
+        browser_->CreateBrowserContextBuilder();
+  

--- a/x11-packages/carbonyl-host-tools/9005-Refactor-rendering-bridge.diff
+++ b/x11-packages/carbonyl-host-tools/9005-Refactor-rendering-bridge.diff
@@ -1,0 +1,121 @@
+--- a/chromium/patches/chromium/0013-Refactor-rendering-bridge.patch
++++ b/chromium/patches/chromium/0013-Refactor-rendering-bridge.patch
+@@ -528,35 +528,34 @@
+ index 1df3ffe72c93d..5aa0bdc25e409 100644
+ --- a/headless/lib/browser/headless_browser_impl.cc
+ +++ b/headless/lib/browser/headless_browser_impl.cc
+-@@ -15,6 +15,7 @@
++@@ -13,6 +13,7 @@
++ #include "base/functional/callback.h"
+  #include "base/memory/ptr_util.h"
+- #include "base/run_loop.h"
+- #include "base/threading/thread_task_runner_handle.h"
++ #include "base/task/single_thread_task_runner.h"
+ +#include "components/zoom/zoom_controller.h"
+- #include "content/public/app/content_main.h"
+  #include "content/public/browser/browser_task_traits.h"
+  #include "content/public/browser/browser_thread.h"
+-@@ -24,9 +25,11 @@
++ #include "content/public/browser/devtools_agent_host.h"
++@@ -20,6 +21,7 @@
+  #include "headless/lib/browser/headless_browser_context_impl.h"
+  #include "headless/lib/browser/headless_browser_main_parts.h"
+  #include "headless/lib/browser/headless_devtools_agent_host_client.h"
+ +#include "headless/lib/browser/headless_screen.h"
+  #include "headless/lib/browser/headless_web_contents_impl.h"
+- #include "net/http/http_util.h"
+- #include "services/network/public/cpp/network_switches.h"
+-+#include "ui/compositor/compositor.h"
+- #include "ui/events/devices/device_data_manager.h"
++ #include "headless/public/version.h"
+  
+- #include "content/public/browser/render_frame_host.h"
+-@@ -34,6 +37,7 @@
++@@ -28,8 +30,10 @@
+  #include "content/public/browser/render_widget_host.h"
+  #include "content/public/browser/web_contents.h"
+  #include "carbonyl/src/browser/bridge.h"
+ +#include "carbonyl/src/browser/renderer.h"
+  #include "third_party/blink/public/common/input/web_mouse_event.h"
+  #include "third_party/blink/public/common/input/web_mouse_wheel_event.h"
+++#include "ui/compositor/compositor.h"
+  #include "ui/events/keycodes/keyboard_codes.h"
+-@@ -119,7 +123,7 @@ void HeadlessBrowserImpl::set_browser_main_parts(
++ 
++ namespace carbonyl {
++@@ -213,7 +217,7 @@
+  }
+  
+  void HeadlessBrowserImpl::Resize() {
+@@ -565,7 +564,7 @@
+    auto rect = gfx::Rect(0, 0, size.width(), size.height());
+  
+    for (auto* ctx: GetAllBrowserContexts()) {
+-@@ -133,8 +137,6 @@ void HeadlessBrowserImpl::Resize() {
++@@ -227,8 +231,6 @@
+        PlatformSetWebContentsBounds(impl, rect);
+      }
+    }
+@@ -574,7 +573,7 @@
+  }
+  
+  void HeadlessBrowserImpl::OnShutdownInput() {
+-@@ -436,7 +438,7 @@ void HeadlessBrowserImpl::RunOnStartCallback() {
++@@ -530,7 +532,7 @@
+    input_thread_ = std::thread([=]() {
+      carbonyl::browser = this;
+  
+@@ -583,7 +582,7 @@
+        .shutdown = []() {
+          if (carbonyl::browser) {
+            carbonyl::browser->OnShutdownInput();
+-@@ -500,7 +502,7 @@ void HeadlessBrowserImpl::RunOnStartCallback() {
++@@ -594,7 +596,7 @@
+        }
+      };
+  
+@@ -609,30 +608,25 @@
+ index e2cb88fbcf708..397b2585f3d0f 100644
+ --- a/headless/lib/browser/headless_browser_impl_mac.mm
+ +++ b/headless/lib/browser/headless_browser_impl_mac.mm
+-@@ -6,6 +6,8 @@
+- 
++@@ -7,6 +7,8 @@
+  #import "base/mac/scoped_objc_class_swizzler.h"
++ #include "base/memory/weak_ptr.h"
+  #include "base/no_destructor.h"
+ +#include "carbonyl/src/browser/bridge.h"
+ +#include "content/browser/renderer_host/render_widget_host_view_mac.h"
++ #include "content/public/browser/browser_task_traits.h"
++ #include "content/public/browser/browser_thread.h"
+  #include "content/public/browser/render_widget_host_view.h"
+- #include "content/public/browser/web_contents.h"
+- #include "headless/lib/browser/headless_web_contents_impl.h"
+-@@ -95,8 +97,13 @@ void HeadlessBrowserImpl::PlatformSetWebContentsBounds(
+- 
+-   content::RenderWidgetHostView* host_view =
+-       web_contents->web_contents()->GetRenderWidgetHostView();
+--  if (host_view)
+-+  if (host_view) {
+-     host_view->SetWindowFrameInScreen(bounds);
+-+
+-+    static_cast<content::RenderWidgetHostViewMac*>(host_view)->SetCurrentDeviceScaleFactor(
+-+      carbonyl::Bridge::GetDPI()
+-+    );
+-+  }
+- }
+- 
+- ui::Compositor* HeadlessBrowserImpl::PlatformGetCompositor(
++@@ -109,6 +111,9 @@
++                   content_web_contents->GetRenderWidgetHostView();
++               if (host_view) {
++                 host_view->SetWindowFrameInScreen(bounds);
+++                static_cast<content::RenderWidgetHostViewMac*>(host_view)->SetCurrentDeviceScaleFactor(
+++                  carbonyl::Bridge::GetDPI()
+++                );
++               }
++             }
++           },
+ diff --git a/headless/lib/browser/headless_browser_main_parts_mac.mm b/headless/lib/browser/headless_browser_main_parts_mac.mm
+ index 718e37ef8bd3e..8ca30b9d88d5b 100644
+ --- a/headless/lib/browser/headless_browser_main_parts_mac.mm

--- a/x11-packages/carbonyl-host-tools/9006-Move-Skia-text-rendering-control-to-bridge.diff
+++ b/x11-packages/carbonyl-host-tools/9006-Move-Skia-text-rendering-control-to-bridge.diff
@@ -1,0 +1,52 @@
+--- a/chromium/patches/chromium/0014-Move-Skia-text-rendering-control-to-bridge.patch
++++ b/chromium/patches/chromium/0014-Move-Skia-text-rendering-control-to-bridge.patch
+@@ -12,7 +12,7 @@
+ index 379cf6c58b2b0..891efd6a9d796 100644
+ --- a/content/renderer/render_frame_impl.cc
+ +++ b/content/renderer/render_frame_impl.cc
+-@@ -285,7 +285,6 @@
++@@ -285,11 +285,10 @@
+  #include "third_party/skia/include/svg/SkSVGCanvas.h"
+  #include "third_party/skia/include/utils/SkBase64.h"
+  #include "third_party/skia/src/text/GlyphRun.h"
+@@ -20,7 +20,22 @@
+  #include "third_party/skia/src/core/SkClipStackDevice.h"
+  #include "third_party/skia/src/core/SkDevice.h"
+  #include "third_party/skia/src/core/SkFontPriv.h"
+-@@ -2244,10 +2243,6 @@ void RenderFrameImpl::Initialize(blink::WebFrame* parent) {
++-#include "third_party/skia/src/utils/SkUTF.h"
+++#include "third_party/skia/include/core/SkTypes.h"
++ 
++ using base::Time;
++ using blink::ContextMenuData;
++@@ -335,6 +334,9 @@
++ using blink::mojom::SelectionMenuBehavior;
++ using network::mojom::ReferrerPolicy;
++ 
+++template <size_t size, typename T>
+++using SkAutoSTArray = skia_private::AutoSTArray<size, T>;
+++
++ namespace content {
++ 
++ namespace {
++@@ -2250,10 +2252,6 @@
+    );
+  
+    host->ObserveTerminalRender(render_callback_);
+@@ -35,12 +35,12 @@
+ index b330273c16db3..297ffacf073fa 100644
+ --- a/skia/BUILD.gn
+ +++ b/skia/BUILD.gn
+-@@ -203,7 +203,7 @@ source_set("skcms") {
++@@ -205,7 +205,7 @@
+  }
+  
+  component("skia") {
+ -  deps = []
+ +  deps = [ "//carbonyl/src/browser:bridge" ]
+-   sources = [
+-     # Chrome sources.
+-     "config/SkUserConfig.h",
++   public = [
++     "ext/benchmarking_canvas.h",
++     "ext/cicp.h",

--- a/x11-packages/carbonyl-host-tools/build.sh
+++ b/x11-packages/carbonyl-host-tools/build.sh
@@ -1,0 +1,308 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/fathyb/carbonyl
+TERMUX_PKG_DESCRIPTION="Chromium based browser built to run in a terminal (Host tools, NOT FOR TERMUX)"
+TERMUX_PKG_LICENSE="BSD 3-Clause"
+TERMUX_PKG_LICENSE_FILE="license.md"
+TERMUX_PKG_MAINTAINER="@licy183"
+_CHROMIUM_VERSION=111.0.5563.146
+TERMUX_PKG_VERSION=0.0.3
+TERMUX_PKG_SRCURL=(https://github.com/fathyb/carbonyl/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz
+					https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$_CHROMIUM_VERSION.tar.xz)
+TERMUX_PKG_SHA256=(bf421b9498a084a7cf2238a574d37d31b498d3e271fdb3dcf466e7ed6c80013d
+					1e701fa31b55fa0633c307af8537b4dbf67e02d8cad1080c57d845ed8c48b5fe)
+TERMUX_PKG_DEPENDS="atk, cups, dbus, fontconfig, gtk3, krb5, libc++, libdrm, libevdev, libxkbcommon, libminizip, libnss, libwayland, libx11, mesa, openssl, pango, pulseaudio, zlib"
+TERMUX_PKG_BUILD_DEPENDS="libnotify, libffi-static"
+TERMUX_PKG_ON_DEVICE_BUILD_NOT_SUPPORTED=true
+# Chromium doesn't support i686 on Linux.
+# Carbonyl donesn't support arm.
+TERMUX_PKG_BLACKLISTED_ARCHES="arm, i686"
+
+SYSTEM_LIBRARIES="    libdrm  fontconfig"
+# TERMUX_PKG_DEPENDS="libdrm, fontconfig"
+
+termux_step_post_get_source() {
+	# Move chromium source
+	mv chromium-$_CHROMIUM_VERSION chromium/src
+
+	# Apply diffs
+	for f in $(find "$TERMUX_PKG_BUILDER_DIR/" -maxdepth 1 -type f -name *.diff | sort); do
+		echo "Applying patch: $(basename $f)"
+		patch -p1 < "$f"
+	done
+
+	# Apply patches related to chromium
+	pushd chromium/src
+		for f in $(find "$TERMUX_PKG_BUILDER_DIR/patches" -maxdepth 1 -type f -name *.patch | sort); do
+			echo "Applying patch: $(basename $f)"
+			patch -p1 < "$f"
+		done
+	popd
+
+	# Apply patches related to carbonyl
+	pushd chromium/src
+	for f in $(find "$TERMUX_PKG_SRCDIR/chromium/patches/chromium/" -maxdepth 1 -type f -name *.patch | sort); do
+		echo "Applying patch: $(basename $f)"
+		patch --silent -p1 < "$f"
+	done
+	popd
+
+	pushd chromium/src/third_party/skia
+	for f in $(find "$TERMUX_PKG_SRCDIR/chromium/patches/skia/" -maxdepth 1 -type f -name *.diff | sort); do
+		echo "Applying patch: $(basename $f)"
+		patch --silent -p1 < "$f"
+	done
+	popd
+
+	pushd chromium/src/third_party/webrtc
+	for f in $(find "$TERMUX_PKG_SRCDIR/chromium/patches/webrtc/" -maxdepth 1 -type f -name *.diff | sort); do
+		echo "Applying patch: $(basename $f)"
+		patch --silent -p1 < "$f"
+	done
+	popd
+}
+
+termux_step_configure() {
+	cd $TERMUX_PKG_SRCDIR/chromium/src
+	termux_setup_ninja
+	termux_setup_gn
+	termux_setup_nodejs
+
+	# Remove termux's dummy pkg-config
+	local _target_pkg_config=$(command -v pkg-config)
+	local _host_pkg_config="$(cat $_target_pkg_config | grep exec | awk '{print $2}')"
+	rm -rf $TERMUX_PKG_TMPDIR/host-pkg-config-bin
+	mkdir -p $TERMUX_PKG_TMPDIR/host-pkg-config-bin
+	ln -s $_host_pkg_config $TERMUX_PKG_TMPDIR/host-pkg-config-bin/pkg-config
+	export PATH="$TERMUX_PKG_TMPDIR/host-pkg-config-bin:$PATH"
+
+	# Install amd64 rootfs if necessary
+	build/linux/sysroot_scripts/install-sysroot.py --arch=amd64
+	local _amd64_sysroot_path="$(pwd)/build/linux/$(ls build/linux | grep 'amd64-sysroot')"
+
+	# Link to system tools required by the build
+	mkdir -p third_party/node/linux/node-linux-x64/bin
+	ln -sf $(command -v node) third_party/node/linux/node-linux-x64/bin/
+	ln -sf $(command -v java) third_party/jdk/current/bin/
+
+	# Dummy librt.so
+	# Why not dummy a librt.a? Some of the binaries reference symbols only exists in Android
+	# for some reason, such as the `chrome_crashpad_handler`, which needs to link with
+	# libprotobuf_lite.a, but it is hard to remove the usage of `android/log.h` in protobuf.
+	echo "INPUT(-llog -liconv -landroid-shmem)" > "$TERMUX_PREFIX/lib/librt.so"
+
+	# Dummy libpthread.a and libresolv.a
+	echo '!<arch>' > "$TERMUX_PREFIX/lib/libpthread.a"
+	echo '!<arch>' > "$TERMUX_PREFIX/lib/libresolv.a"
+
+	# Symlink libffi.a to libffi_pic.a
+	ln -sfr $TERMUX_PREFIX/lib/libffi.a $TERMUX_PREFIX/lib/libffi_pic.a
+
+	# Merge sysroots
+	rm -rf $TERMUX_PKG_TMPDIR/sysroot
+	mkdir -p $TERMUX_PKG_TMPDIR/sysroot
+	pushd $TERMUX_PKG_TMPDIR/sysroot
+	mkdir -p usr/include usr/lib usr/bin
+	cp -R $TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/include/* usr/include
+	cp -R $TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/include/$TERMUX_HOST_PLATFORM/* usr/include
+	cp -R $TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib/$TERMUX_HOST_PLATFORM/$TERMUX_PKG_API_LEVEL/* usr/lib/
+	cp "$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib/$TERMUX_HOST_PLATFORM/libc++_shared.so" usr/lib/
+	cp "$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib/$TERMUX_HOST_PLATFORM/libc++_static.a" usr/lib/
+	cp "$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib/$TERMUX_HOST_PLATFORM/libc++abi.a" usr/lib/
+	cp -Rf $TERMUX_PREFIX/include/* usr/include
+	cp -Rf $TERMUX_PREFIX/lib/* usr/lib
+	ln -sf /data ./data
+	# This is needed to build cups
+	cp -Rf $TERMUX_PREFIX/bin/cups-config usr/bin/
+	chmod +x usr/bin/cups-config
+	popd
+
+	# Construct args
+	local _clang_base_path="/usr/lib/llvm-18"
+	local _host_cc="$_clang_base_path/bin/clang"
+	local _host_cxx="$_clang_base_path/bin/clang++"
+	local _host_toolchain="$TERMUX_PKG_CACHEDIR/custom-toolchain:host"
+	local _target_cpu _target_sysroot="$TERMUX_PKG_TMPDIR/sysroot"
+	local _v8_toolchain_name _v8_current_cpu _v8_sysroot_path
+	if [ "$TERMUX_ARCH" = "aarch64" ]; then
+		_target_cpu="arm64"
+		_v8_current_cpu="arm64"
+		_v8_sysroot_path="$_amd64_sysroot_path"
+		_v8_toolchain_name="host"
+	elif [ "$TERMUX_ARCH" = "arm" ]; then
+		# Install i386 rootfs if necessary
+		build/linux/sysroot_scripts/install-sysroot.py --arch=i386
+		_target_cpu="arm"
+		_v8_current_cpu="x86"
+		_v8_sysroot_path="$_i386_sysroot_path"
+		_v8_toolchain_name="clang_x86_v8_arm"
+	elif [ "$TERMUX_ARCH" = "x86_64" ]; then
+		_target_cpu="x64"
+		_v8_current_cpu="x64"
+		_v8_sysroot_path="$_amd64_sysroot_path"
+		_v8_toolchain_name="host"
+	fi
+
+	local _common_args_file=$TERMUX_PKG_TMPDIR/common-args-file
+	rm -f $_common_args_file
+	touch $_common_args_file
+
+	echo "
+import(\"//carbonyl/src/browser/args.gn\")
+# Do not build with symbols
+is_debug = false
+is_component_build = false
+symbol_level = 0
+# Use our custom toolchain
+use_sysroot = false
+target_cpu = \"$_target_cpu\"
+target_rpath = \"$TERMUX_PREFIX/lib\"
+target_sysroot = \"$_target_sysroot\"
+clang_base_path = \"$_clang_base_path\"
+custom_toolchain = \"//build/toolchain/linux/unbundle:default\"
+host_toolchain = \"$TERMUX_PKG_CACHEDIR/custom-toolchain:host\"
+v8_snapshot_toolchain = \"$TERMUX_PKG_CACHEDIR/custom-toolchain:$_v8_toolchain_name\"
+clang_use_chrome_plugins = false
+dcheck_always_on = false
+chrome_pgo_phase = 0
+treat_warnings_as_errors = false
+# Use system libraries as little as possible
+use_bundled_fontconfig = false
+use_system_freetype = true
+use_system_libdrm = true
+use_custom_libcxx = false
+use_allocator_shim = false
+use_partition_alloc_as_malloc = false
+enable_backup_ref_ptr_support = false
+enable_mte_checked_ptr_support = false
+use_nss_certs = true
+use_udev = false
+use_gnome_keyring = false
+use_alsa = false
+use_libpci = false
+use_pulseaudio = false
+use_ozone = true
+use_qt = false
+ozone_auto_platforms = false
+ozone_platform = \"headless\"
+ozone_platform_x11 = false
+ozone_platform_wayland = false
+ozone_platform_headless = true
+angle_enable_vulkan = true
+angle_enable_swiftshader = true
+rtc_use_pipewire = false
+use_vaapi_x11 = false
+# See comments on Chromium package
+enable_nacl = false
+use_thin_lto=false
+# Enable jumbo build (unified build)
+use_jumbo_build = true
+" >> $_common_args_file
+
+	if [ "$TERMUX_ARCH" = "arm" ]; then
+		echo "arm_arch = \"armv7-a\"" >> $_common_args_file
+		echo "arm_float_abi = \"softfp\"" >> $_common_args_file
+	fi
+
+	# Use custom toolchain
+	rm -rf $TERMUX_PKG_CACHEDIR/custom-toolchain
+	mkdir -p $TERMUX_PKG_CACHEDIR/custom-toolchain
+	cp -f $TERMUX_PKG_BUILDER_DIR/toolchain-template/host-toolchain.gn.in $TERMUX_PKG_CACHEDIR/custom-toolchain/BUILD.gn
+	sed -i "s|@HOST_CC@|$_host_cc|g
+			s|@HOST_CXX@|$_host_cxx|g
+			s|@HOST_LD@|$_host_cxx|g
+			s|@HOST_AR@|$(command -v llvm-ar)|g
+			s|@HOST_NM@|$(command -v llvm-nm)|g
+			s|@HOST_IS_CLANG@|true|g
+			s|@HOST_USE_GOLD@|false|g
+			s|@HOST_SYSROOT@|$_amd64_sysroot_path|g
+			s|@V8_CURRENT_CPU@|$_target_cpu|g
+			" $TERMUX_PKG_CACHEDIR/custom-toolchain/BUILD.gn
+	if [ "$_v8_toolchain_name" != "host" ]; then
+		cat $TERMUX_PKG_BUILDER_DIR/toolchain-template/v8-toolchain.gn.in >> $TERMUX_PKG_CACHEDIR/custom-toolchain/BUILD.gn
+		sed -i "s|@V8_CC@|$_host_cc|g
+				s|@V8_CXX@|$_host_cxx|g
+				s|@V8_LD@|$_host_cxx|g
+				s|@V8_AR@|$(command -v llvm-ar)|g
+				s|@V8_NM@|$(command -v llvm-nm)|g
+				s|@V8_TOOLCHAIN_NAME@|$_v8_toolchain_name|g
+				s|@V8_CURRENT_CPU@|$_v8_current_cpu|g
+				s|@V8_V8_CURRENT_CPU@|$_target_cpu|g
+				s|@V8_IS_CLANG@|true|g
+				s|@V8_USE_GOLD@|false|g
+				s|@V8_SYSROOT@|$_v8_sysroot_path|g
+				" $TERMUX_PKG_CACHEDIR/custom-toolchain/BUILD.gn
+	fi
+
+	cd $TERMUX_PKG_SRCDIR/chromium/src
+	mkdir -p $TERMUX_PKG_BUILDDIR/out/Release
+	cat $_common_args_file > $TERMUX_PKG_BUILDDIR/out/Release/args.gn
+	gn gen $TERMUX_PKG_BUILDDIR/out/Release --export-compile-commands
+
+	export cr_v8_toolchain="$_v8_toolchain_name"
+}
+
+termux_step_make() {
+	cd $TERMUX_PKG_BUILDDIR
+	# Build v8 snapshot and tools
+	time ninja -C out/Release \
+					v8_context_snapshot \
+					run_mksnapshot_default \
+					run_torque \
+					generate_bytecode_builtins_list \
+					v8:run_gen-regexp-special-case
+
+	# Build host tools
+	time ninja -C out/Release \
+					generate_top_domain_list_variables_file \
+					generate_chrome_colors_info \
+					character_data \
+					gen_root_store_inc \
+					generate_transport_security_state \
+					generate_top_domains_trie
+
+	# Build swiftshader
+	time ninja -C out/Release \
+						third_party/swiftshader/src/Vulkan:icd_file \
+						third_party/swiftshader/src/Vulkan:swiftshader_libvulkan
+}
+
+termux_step_make_install() {
+	cd $TERMUX_PKG_BUILDDIR
+	mkdir -p $TERMUX_PREFIX/opt/$TERMUX_PKG_NAME
+
+	local v8_tools=(
+		mksnapshot                       # run_mksnapshot_default
+		torque                           # torque
+		bytecode_builtins_list_generator # generate_bytecode_builtins_list
+		gen-regexp-special-case          # v8:run_gen-regexp-special-case
+	)
+	mkdir -p "$TERMUX_PREFIX/opt/$TERMUX_PKG_NAME/$cr_v8_toolchain/"
+	cp "${v8_tools[@]/#/out/Release/$cr_v8_toolchain/}" "$TERMUX_PREFIX/opt/$TERMUX_PKG_NAME/$cr_v8_toolchain/"
+
+	local host_tools=(
+		make_top_domain_list_variables     # generate_top_domain_list_variables_file
+		generate_colors_info               # generate_chrome_colors_info
+		character_data_generator           # character_data
+		root_store_tool                    # gen_root_store_inc
+		transport_security_state_generator # generate_transport_security_state
+		top_domain_generator               # generate_top_domains_trie
+		icudtl.dat                         # icu data
+	)
+	mkdir -p "$TERMUX_PREFIX/opt/$TERMUX_PKG_NAME/host/"
+	cp "${host_tools[@]/#/out/Release/host/}" "$TERMUX_PREFIX/opt/$TERMUX_PKG_NAME/host/"
+
+	local normal_files=(
+		# v8 snapshot data
+		snapshot_blob.bin
+		v8_context_snapshot.bin
+
+		# swiftshader
+		libvk_swiftshader.so
+		vk_swiftshader_icd.json
+	)
+	cp "${normal_files[@]/#/out/Release/}" "$TERMUX_PREFIX/opt/$TERMUX_PKG_NAME/"
+}
+
+termux_step_post_make_install() {
+	# Remove the dummy files
+	rm $TERMUX_PREFIX/lib/lib{{pthread,resolv,ffi_pic}.a,rt.so}
+}

--- a/x11-packages/carbonyl-host-tools/build.sh
+++ b/x11-packages/carbonyl-host-tools/build.sh
@@ -15,6 +15,8 @@ TERMUX_PKG_ON_DEVICE_BUILD_NOT_SUPPORTED=true
 # Chromium doesn't support i686 on Linux.
 # Carbonyl donesn't support arm.
 TERMUX_PKG_BLACKLISTED_ARCHES="arm, i686"
+# Host tools, no need to run elf-cleaner
+TERMUX_PKG_NO_ELF_CLEANER=true
 
 SYSTEM_LIBRARIES="    libdrm  fontconfig"
 # TERMUX_PKG_DEPENDS="libdrm, fontconfig"

--- a/x11-packages/carbonyl-host-tools/patches/0000-patches-desc
+++ b/x11-packages/carbonyl-host-tools/patches/0000-patches-desc
@@ -1,0 +1,13 @@
+Patches 0001-0999 are reserved for the building system of chromium.
+
+Patches 1001-2999 are reserved to make chromium work properly on Termux.
+
+1001-1499 are reserved for chromium (base, content, etc.).
+1501-1599 are reserved for angle, blink, swiftshader and v8.
+2001-2999 are reserved for other 3rd-party libraries and mixed patches.
+
+Patches 6001-6999 are reserved for some patches that cherry-picks or reverts a commit.
+
+Patches 7001-7999 are reserved for some patches related to compiler features or bugs.
+
+Patches 8001-8999 are reserved for some patches that adds missing includes or namespaces.

--- a/x11-packages/carbonyl-host-tools/patches/0001-compiler-use-android-target.patch
+++ b/x11-packages/carbonyl-host-tools/patches/0001-compiler-use-android-target.patch
@@ -1,0 +1,24 @@
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -960,8 +960,8 @@
+     } else if (current_cpu == "arm") {
+       if (is_clang && !is_android && !is_nacl &&
+           !(is_chromeos_lacros && is_chromeos_device)) {
+-        cflags += [ "--target=arm-linux-gnueabihf" ]
+-        ldflags += [ "--target=arm-linux-gnueabihf" ]
++        cflags += [ "--target=armv7a-linux-android24" ]
++        ldflags += [ "--target=armv7a-linux-android24" ]
+       }
+       if (!is_nacl) {
+         cflags += [
+@@ -975,8 +975,8 @@
+     } else if (current_cpu == "arm64") {
+       if (is_clang && !is_android && !is_nacl && !is_fuchsia &&
+           !(is_chromeos_lacros && is_chromeos_device)) {
+-        cflags += [ "--target=aarch64-linux-gnu" ]
+-        ldflags += [ "--target=aarch64-linux-gnu" ]
++        cflags += [ "--target=aarch64-linux-android24" ]
++        ldflags += [ "--target=aarch64-linux-android24" ]
+       }
+     } else if (current_cpu == "mipsel" && !is_nacl) {
+       ldflags += [ "-Wl,--hash-style=sysv" ]

--- a/x11-packages/carbonyl-host-tools/patches/0002-compiler-warnings.patch
+++ b/x11-packages/carbonyl-host-tools/patches/0002-compiler-warnings.patch
@@ -1,0 +1,45 @@
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -1608,6 +1608,12 @@
+       "-Wno-unused-parameter",  # Unused function parameters.
+     ]
+ 
++    cflags_cc += [
++      # Disables for C++ only
++      "-Wno-invalid-offsetof",  # offsetof on non-standard-layout type
++                                # (crbug.com/40285259)
++    ]
++
+     if (!is_nacl || is_nacl_saigo) {
+       cflags += [
+         # An ABI compat warning we don't care about, https://crbug.com/1102157
+@@ -1618,6 +1624,11 @@
+     }
+   }
+ 
++  cflags += [
++    "-Wno-unknown-warning-option",
++    "-Wno-unknown-pragmas",
++  ]
++
+   if (is_clang) {
+     cflags += [
+       "-Wloop-analysis",
+@@ -1636,6 +1647,17 @@
+       }
+ 
+       cflags += [
++        # TODO(crbug.com/40284799): Fix and re-enable.
++        "-Wno-thread-safety-reference-return",
++      ]
++
++      cflags_cc += [
++          # Will be fix later, disable it for now
++          "-Wno-deprecated-this-capture",
++          "-Wno-vla-cxx-extension",
++      ]
++
++      cflags += [
+         "-Wenum-compare-conditional",
+ 
+         # Ignore warnings about MSVC optimization pragmas.

--- a/x11-packages/carbonyl-host-tools/patches/0004-compiler-remove-unsupported-flags.patch
+++ b/x11-packages/carbonyl-host-tools/patches/0004-compiler-remove-unsupported-flags.patch
@@ -1,0 +1,19 @@
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -1569,16 +1569,6 @@
+         # TODO(thakis): Only for no_chromium_code? http://crbug.com/912662
+         "-Wno-ignored-pragma-optimize",
+       ]
+-
+-      if (!is_nacl) {
+-        cflags += [
+-          # TODO(crbug.com/1343975) Evaluate and possibly enable.
+-          "-Wno-deprecated-builtins",
+-
+-          # TODO(crbug.com/1352183) Evaluate and possibly enable.
+-          "-Wno-bitfield-constant-conversion",
+-        ]
+-      }
+     }
+   }
+ }

--- a/x11-packages/carbonyl-host-tools/patches/0005-compiler-remove-gsimple-template-names.patch
+++ b/x11-packages/carbonyl-host-tools/patches/0005-compiler-remove-gsimple-template-names.patch
@@ -1,0 +1,15 @@
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -808,9 +808,9 @@
+   #   lldb doesn't have the needed changes yet.
+   # * Fuchsia isn't supported as zxdb doesn't support simple template names yet.
+   # TODO(crbug.com/1379070): Remove if the upstream default ever changes.
+-  if (is_clang && !is_nacl && !is_win && !is_apple && !is_fuchsia) {
+-    cflags_cc += [ "-gsimple-template-names" ]
+-  }
++  # if (is_clang && !is_nacl && !is_win && !is_apple && !is_fuchsia) {
++  #   cflags_cc += [ "-gsimple-template-names" ]
++  # }
+ 
+   # MLGO specific flags. These flags enable an ML-based inliner trained on
+   # Chrome on Android (arm32) with ThinLTO enabled, optimizing for size.

--- a/x11-packages/carbonyl-host-tools/patches/0100-reland-jumbo-build.patch
+++ b/x11-packages/carbonyl-host-tools/patches/0100-reland-jumbo-build.patch
@@ -1,0 +1,5129 @@
+From 639ec7a8b59cd19a5db9793ac09ba79a09d2da31 Mon Sep 17 00:00:00 2001
+From: Chongyun Lee <licy183@termux.dev>
+Date: Wed, 29 Jan 2025 22:21:25 +0800
+Subject: [PATCH] Reland jumbo build
+
+Based on https://github.com/qt/qtwebengine-chromium/commit/8b55b5c01d1ca28e9b68dcb7ed22fbe820f2b83a
+
+---
+ ash/keyboard/ui/BUILD.gn                      |   3 +-
+ base/BUILD.gn                                 |   3 +-
+ build/config/jumbo.gni                        | 296 ++++++++++++++++++
+ build/config/merge_for_jumbo.py               | 145 +++++++++
+ cc/cc.gni                                     |   5 +-
+ components/autofill/content/browser/BUILD.gn  |   3 +-
+ components/autofill/content/renderer/BUILD.gn |   6 +-
+ components/autofill/core/browser/BUILD.gn     |   5 +-
+ components/autofill/core/common/BUILD.gn      |   4 +-
+ components/cdm/browser/BUILD.gn               |   5 +-
+ components/cdm/common/BUILD.gn                |   3 +-
+ components/cdm/renderer/BUILD.gn              |   3 +-
+ .../content_settings/core/browser/BUILD.gn    |   5 +-
+ .../content_settings/core/common/BUILD.gn     |   5 +-
+ .../content_settings/core/test/BUILD.gn       |   4 +-
+ components/domain_reliability/BUILD.gn        |   6 +-
+ .../feature_engagement/internal/BUILD.gn      |   6 +-
+ .../feature_engagement/internal/test/BUILD.gn |   4 +-
+ components/feature_engagement/public/BUILD.gn |   6 +-
+ components/lookalikes/core/BUILD.gn           |   7 +-
+ .../providers/cast/certificate/BUILD.gn       |  11 +-
+ components/metrics/BUILD.gn                   |   7 +-
+ components/omnibox/browser/BUILD.gn           |   5 +-
+ .../password_manager/content/browser/BUILD.gn |   4 +-
+ .../password_manager/core/browser/BUILD.gn    |   7 +-
+ .../core/browser/leak_detection/BUILD.gn      |   7 +-
+ .../password_manager/core/common/BUILD.gn     |   3 +-
+ components/payments/content/BUILD.gn          |  11 +-
+ components/payments/content/icon/BUILD.gn     |   4 +-
+ components/payments/core/BUILD.gn             |  11 +-
+ components/policy/content/BUILD.gn            |   5 +-
+ components/policy/core/browser/BUILD.gn       |   5 +-
+ components/policy/core/common/BUILD.gn        |   9 +-
+ .../safe_browsing/content/browser/BUILD.gn    |   5 +-
+ .../safe_browsing/core/browser/BUILD.gn       |   3 +-
+ components/security_state/content/BUILD.gn    |   4 +-
+ components/security_state/core/BUILD.gn       |   6 +-
+ components/sync/BUILD.gn                      |   1 +
+ components/sync/base/BUILD.gn                 |   3 +-
+ components/sync/driver/BUILD.gn               |   3 +-
+ components/sync/protocol/BUILD.gn             |   3 +-
+ components/sync_device_info/BUILD.gn          |   3 +-
+ components/sync_user_events/BUILD.gn          |   4 +-
+ components/url_formatter/BUILD.gn             |   7 +-
+ components/viz/common/BUILD.gn                |   2 +
+ components/viz/service/BUILD.gn               |   4 +
+ components/viz/viz.gni                        |   7 +-
+ components/webauthn/content/browser/BUILD.gn  |   4 +-
+ components/wifi/BUILD.gn                      |   6 +-
+ content/browser/BUILD.gn                      |   3 +-
+ content/gpu/BUILD.gn                          |   5 +-
+ content/public/browser/BUILD.gn               |   3 +-
+ content/public/child/BUILD.gn                 |   3 +-
+ content/public/common/BUILD.gn                |   3 +-
+ content/public/renderer/BUILD.gn              |   5 +-
+ content/renderer/BUILD.gn                     |   5 +-
+ content/test/BUILD.gn                         |   5 +-
+ content/utility/BUILD.gn                      |   3 +-
+ docs/clang_tidy.md                            |   8 +
+ docs/clang_tool_refactoring.md                |   2 +
+ docs/linux/build_instructions.md              |   9 +
+ docs/mac_build_instructions.md                |   9 +
+ docs/windows_build_instructions.md            |   2 +-
+ extensions/BUILD.gn                           |   3 +-
+ extensions/browser/BUILD.gn                   |   5 +-
+ extensions/common/BUILD.gn                    |   3 +-
+ extensions/renderer/BUILD.gn                  |   5 +-
+ gpu/BUILD.gn                                  |   3 +-
+ gpu/command_buffer/client/BUILD.gn            |   9 +-
+ gpu/command_buffer/common/BUILD.gn            |   5 +-
+ gpu/command_buffer/service/BUILD.gn           |   7 +-
+ gpu/config/BUILD.gn                           |   3 +-
+ gpu/ipc/service/BUILD.gn                      |   3 +-
+ media/base/BUILD.gn                           |   3 +-
+ media/base/android/BUILD.gn                   |   3 +-
+ media/base/ipc/BUILD.gn                       |   4 +-
+ media/base/mac/BUILD.gn                       |   4 +-
+ media/base/win/BUILD.gn                       |   4 +-
+ media/capture/BUILD.gn                        |   7 +-
+ media/cast/BUILD.gn                           |  11 +-
+ media/filters/BUILD.gn                        |   3 +-
+ media/media_options.gni                       |   6 +-
+ media/mojo/clients/BUILD.gn                   |   4 +-
+ media/mojo/common/BUILD.gn                    |   4 +-
+ media/mojo/services/BUILD.gn                  |   3 +-
+ mojo/public/tools/bindings/mojom.gni          |   5 +-
+ ppapi/cpp/BUILD.gn                            |   5 +-
+ ppapi/host/BUILD.gn                           |   3 +-
+ ppapi/proxy/BUILD.gn                          |  11 +-
+ ppapi/shared_impl/BUILD.gn                    |   9 +-
+ .../cert_net_url_loader/BUILD.gn              |   3 +-
+ services/network/BUILD.gn                     |   5 +-
+ services/network/public/cpp/BUILD.gn          |   9 +-
+ storage/browser/BUILD.gn                      |   5 +-
+ third_party/blink/common/BUILD.gn             |   5 +-
+ .../blink/renderer/bindings/core/v8/BUILD.gn  |   4 +-
+ .../renderer/bindings/modules/v8/BUILD.gn     |   2 +-
+ .../blink/renderer/controller/BUILD.gn        |   7 +-
+ third_party/blink/renderer/core/BUILD.gn      |  10 +-
+ third_party/blink/renderer/core/core.gni      |   5 +-
+ .../blink/renderer/core/inspector/BUILD.gn    |   3 +-
+ third_party/blink/renderer/modules/BUILD.gn   |   6 +-
+ .../blink/renderer/modules/gamepad/BUILD.gn   |   2 +-
+ .../blink/renderer/modules/hid/BUILD.gn       |   2 +-
+ .../blink/renderer/modules/media/BUILD.gn     |   1 +
+ .../renderer/modules/mediastream/BUILD.gn     |   3 +-
+ .../blink/renderer/modules/modules.gni        |   3 +-
+ .../renderer/modules/peerconnection/BUILD.gn  |   2 +-
+ .../blink/renderer/modules/storage/BUILD.gn   |   2 +-
+ .../blink/renderer/modules/webrtc/BUILD.gn    |   1 +
+ .../renderer/modules/webtransport/BUILD.gn    |   2 +-
+ third_party/blink/renderer/platform/BUILD.gn  |  11 +-
+ .../blink/renderer/platform/blob/BUILD.gn     |   7 +-
+ .../blink/renderer/platform/heap/BUILD.gn     |   5 +-
+ .../platform/instrumentation/BUILD.gn         |   3 +-
+ .../blink/renderer/platform/loader/BUILD.gn   |   5 +-
+ .../blink/renderer/platform/network/BUILD.gn  |   5 +-
+ .../blink/renderer/platform/platform.gni      |   4 +-
+ .../renderer/platform/scheduler/BUILD.gn      |   7 +-
+ .../blink/renderer/platform/wtf/BUILD.gn      |   5 +-
+ third_party/inspector_protocol/BUILD.gn       |   4 +-
+ ui/accessibility/BUILD.gn                     |   5 +-
+ ui/accessibility/platform/BUILD.gn            |   1 +
+ ui/aura/BUILD.gn                              |   5 +-
+ ui/base/BUILD.gn                              |   7 +-
+ ui/base/clipboard/BUILD.gn                    |   9 +-
+ ui/base/ime/BUILD.gn                          |   5 +-
+ ui/base/ime/ash/BUILD.gn                      |   3 +-
+ ui/base/ime/fuchsia/BUILD.gn                  |   4 +-
+ ui/base/ime/init/BUILD.gn                     |   3 +-
+ ui/base/ime/linux/BUILD.gn                    |   3 +-
+ ui/base/ime/mac/BUILD.gn                      |   4 +-
+ ui/base/ime/win/BUILD.gn                      |   4 +-
+ ui/base/prediction/BUILD.gn                   |   4 +-
+ ui/base/x/BUILD.gn                            |   3 +-
+ ui/color/BUILD.gn                             |   7 +-
+ ui/compositor/BUILD.gn                        |   5 +-
+ ui/display/BUILD.gn                           |   5 +-
+ ui/display/fake/BUILD.gn                      |   3 +-
+ ui/display/manager/BUILD.gn                   |   3 +-
+ ui/display/types/BUILD.gn                     |   4 +-
+ ui/display/util/BUILD.gn                      |   3 +-
+ ui/events/BUILD.gn                            |  13 +-
+ ui/events/blink/BUILD.gn                      |   5 +-
+ ui/events/devices/BUILD.gn                    |   4 +-
+ ui/events/devices/x11/BUILD.gn                |   3 +-
+ ui/events/ipc/BUILD.gn                        |   4 +-
+ ui/events/keycodes/BUILD.gn                   |   5 +-
+ ui/events/platform/BUILD.gn                   |   3 +-
+ ui/events/platform/x11/BUILD.gn               |   3 +-
+ ui/gfx/BUILD.gn                               |  15 +-
+ ui/gfx/animation/BUILD.gn                     |   3 +-
+ ui/gfx/codec/BUILD.gn                         |   3 +-
+ ui/gfx/geometry/BUILD.gn                      |   4 +-
+ ui/gfx/ipc/BUILD.gn                           |   4 +-
+ ui/gfx/ipc/buffer_types/BUILD.gn              |   4 +-
+ ui/gfx/ipc/color/BUILD.gn                     |   4 +-
+ ui/gfx/ipc/geometry/BUILD.gn                  |   4 +-
+ ui/gfx/ipc/skia/BUILD.gn                      |   4 +-
+ ui/gfx/range/BUILD.gn                         |   4 +-
+ ui/gfx/x/BUILD.gn                             |   3 +-
+ ui/gl/BUILD.gn                                |   7 +-
+ ui/gl/init/BUILD.gn                           |   3 +-
+ ui/gtk/BUILD.gn                               |   4 +-
+ ui/latency/BUILD.gn                           |   5 +-
+ ui/message_center/BUILD.gn                    |   3 +-
+ ui/message_center/public/cpp/BUILD.gn         |   3 +-
+ ui/native_theme/BUILD.gn                      |   9 +-
+ ui/ozone/BUILD.gn                             |  11 +-
+ ui/platform_window/stub/BUILD.gn              |   4 +-
+ ui/platform_window/win/BUILD.gn               |   4 +-
+ ui/resources/BUILD.gn                         |   1 +
+ ui/shell_dialogs/BUILD.gn                     |   3 +-
+ ui/snapshot/BUILD.gn                          |   5 +-
+ ui/surface/BUILD.gn                           |   3 +-
+ ui/touch_selection/BUILD.gn                   |   3 +-
+ ui/views/BUILD.gn                             |   7 +-
+ ui/views/controls/webview/BUILD.gn            |   3 +-
+ ui/views/examples/BUILD.gn                    |   5 +-
+ ui/views_content_client/BUILD.gn              |   3 +-
+ ui/web_dialogs/BUILD.gn                       |   6 +-
+ ui/wm/BUILD.gn                                |   5 +-
+ ui/wm/public/BUILD.gn                         |   3 +-
+ 183 files changed, 993 insertions(+), 305 deletions(-)
+ create mode 100644 build/config/jumbo.gni
+ create mode 100755 build/config/merge_for_jumbo.py
+
+diff --git a/ash/keyboard/ui/BUILD.gn b/ash/keyboard/ui/BUILD.gn
+index 113c6c81f..e99f151b1 100644
+--- a/ash/keyboard/ui/BUILD.gn
++++ b/ash/keyboard/ui/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//mojo/public/tools/bindings/mojom.gni")
+ import("//testing/test.gni")
+ import("//third_party/google_input_tools/closure.gni")
+@@ -11,7 +12,7 @@ import("//tools/grit/grit_rule.gni")
+ 
+ assert(is_chromeos_ash)
+ 
+-component("ui") {
++jumbo_component("ui") {
+   sources = [
+     "container_behavior.cc",
+     "container_behavior.h",
+diff --git a/base/BUILD.gn b/base/BUILD.gn
+index 1f0e5cc5f..e0139a879 100644
+--- a/base/BUILD.gn
++++ b/base/BUILD.gn
+@@ -29,6 +29,7 @@ import("//build/config/compiler/compiler.gni")
+ import("//build/config/cronet/config.gni")
+ import("//build/config/dcheck_always_on.gni")
+ import("//build/config/ios/config.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/logging.gni")
+ import("//build/config/nacl/config.gni")
+ import("//build/config/profiling/profiling.gni")
+@@ -187,7 +188,7 @@ buildflag_header("message_pump_buildflags") {
+ # base compilation units to be linked in where they wouldn't have otherwise.
+ # This does not include test code (test support and anything in the test
+ # directory) which should use source_set as is recommended for GN targets).
+-component("base") {
++jumbo_component("base") {
+   sources = [
+     "allocator/allocator_check.cc",
+     "allocator/allocator_check.h",
+diff --git a/build/config/jumbo.gni b/build/config/jumbo.gni
+new file mode 100644
+index 000000000..dd8972423
+--- /dev/null
++++ b/build/config/jumbo.gni
+@@ -0,0 +1,296 @@
++# Copyright 2017 The Chromium Authors. All rights reserved.
++# Use of this source code is governed by a BSD-style license that can be
++# found in the LICENSE file.
++
++import("//build/config/nacl/config.gni")  # To see if jumbo should be turned off
++import("//build/toolchain/goma.gni")
++
++declare_args() {
++  # If true, use a jumbo build (files compiled together) to speed up
++  # compilation.
++  use_jumbo_build = false
++
++  # A list of build targets to exclude from jumbo builds, for optimal
++  # round trip time when frequently changing a set of cpp files. The
++  # targets can be just the short name (in which case it matches any
++  # target with that name), a directory prefixed with the root
++  # specifier //, or a full build target label.
++  #
++  # Example:
++  # These would all exclude the "browser" target in a file
++  # content/browser/BUILD.gn, and potentially more.
++  #
++  # jumbo_build_excluded = [ "browser" ]
++  # jumbo_build_excluded = [ "//content/browser" ]
++  # jumbo_build_excluded = [ "//content/browser:browser" ]
++  jumbo_build_excluded = []
++
++  # How many files to group on average. Smaller numbers give more
++  # parallellism, higher numbers give less total CPU usage. Higher
++  # numbers also give longer single-file recompilation times.
++  #
++  # Recommendations:
++  # Higher numbers than 100 does not reduce wall clock compile times
++  # even for 4 cores or less so no reason to go higher than 100.
++  # Going from 50 to 100 with a 4 core CPU saves about 3% CPU time and
++  # 3% wall clock time in a tree with blink, v8 and content
++  # jumbofied. At the same time it increases the compile time for the
++  # largest jumbo chunks by 10-20% and reduces the chance to use all
++  # available CPU cores. So set the default to 50 to balance between
++  # high and low-core build performance. -1 means do the default which
++  # varies depending on whether goma is enabled.
++  jumbo_file_merge_limit = -1
++}
++
++# Normal builds benefit from lots of jumbification
++jumbo_file_merge_default = 50
++
++# Goma builds benefit from more parallelism
++jumbo_file_merge_goma = 8
++
++# Use one of the targets jumbo_source_set, jumbo_static_library, or
++# jumbo_component to generate a target which merges sources if possible to
++# compile much faster.
++#
++# Special values.
++#
++#   target_type
++#      The kind of target to build. For example the string
++#      "static_library".
++#
++#   always_build_jumbo
++#      If set and set to true, then use jumbo compile even when it is
++#      globally disabled. Otherwise it has no effect.
++#
++#   never_build_jumbo
++#      If set and set to true, then do not jumbo compile even if it is
++#      globally enabled. Otherwise it has no effect.
++#
++#   jumbo_excluded_sources
++#      If set to a list of files, those files will not be merged with
++#      the rest. This can be necessary if merging the files causes
++#      compilation issues and fixing the issues is impractical.
++template("internal_jumbo_target") {
++  use_jumbo_build_for_target = use_jumbo_build
++  if (defined(invoker.always_build_jumbo) && invoker.always_build_jumbo) {
++    use_jumbo_build_for_target = true
++  }
++  if (defined(invoker.never_build_jumbo) && invoker.never_build_jumbo) {
++    use_jumbo_build_for_target = false
++  }
++  if (is_nacl_irt || is_nacl_nonsfi) {
++    # The code is barely compatible with the nacl toolchain anymore and we
++    # don't want to stress it further with jumbo compilation units.
++    use_jumbo_build_for_target = false
++  }
++
++  foreach(excluded_target, jumbo_build_excluded) {
++    if (excluded_target == target_name ||
++        excluded_target == get_label_info(":" + target_name, "dir") ||
++        excluded_target ==
++        get_label_info(":" + target_name, "label_no_toolchain")) {
++      use_jumbo_build_for_target = false
++    }
++  }
++
++  excluded_sources = []
++  if (defined(invoker.jumbo_excluded_sources)) {
++    excluded_sources = invoker.jumbo_excluded_sources
++  }
++
++  if (defined(invoker.sources)) {
++    invoker_sources = invoker.sources
++  } else {
++    invoker_sources = []
++  }
++
++  gen_target_dir = invoker.target_gen_dir
++
++  not_needed([ "gen_target_dir" ])  # Prevent "unused variable".
++
++  if (use_jumbo_build_for_target) {
++    jumbo_files = []
++
++    # Split the sources list into chunks that are not excessively large
++    current_file_index = 0
++    next_chunk_start = 0
++    next_chunk_number = 1
++    merge_limit = jumbo_file_merge_limit
++    if (merge_limit == -1) {
++      if (use_goma) {
++        merge_limit = jumbo_file_merge_goma
++      } else {
++        merge_limit = jumbo_file_merge_default
++      }
++    }
++    has_c_file = false
++    has_objective_c_file = false
++    sources_in_jumbo_files = []
++    assert(merge_limit > 0)
++    foreach(source_file, invoker_sources) {
++      source_ext = get_path_info(source_file, "extension")
++      is_source_file = true
++      if (source_ext == "c") {
++        has_c_file = true
++      } else if (source_ext == "mm") {
++        has_objective_c_file = true
++      } else if (source_ext == "cc" || source_ext == "cpp") {
++        if (current_file_index == next_chunk_start) {
++          jumbo_files += [ "$gen_target_dir/" + target_name + "_jumbo_" +
++                           next_chunk_number + ".cc" ]
++          next_chunk_number += 1
++          next_chunk_start += merge_limit
++        }
++        current_file_index += 1
++      } else {
++        is_source_file = false
++      }
++      if (is_source_file) {
++        sources_in_jumbo_files += [ source_file ]
++      }
++    }
++
++    if (jumbo_files == [] || current_file_index == 1) {
++      # Empty sources list or a sources list with only header files or
++      # at most one non-header file.
++      use_jumbo_build_for_target = false
++      not_needed([
++                   "sources_in_jumbo_files",
++                   "current_file_index",
++                   "next_chunk_start",
++                   "next_chunk_number",
++                 ])
++    }
++
++    if (has_c_file) {
++      jumbo_files += [ "$gen_target_dir/" + target_name + "_jumbo_c.c" ]
++    }
++    if (has_objective_c_file) {
++      jumbo_files += [ "$gen_target_dir/" + target_name + "_jumbo_mm.mm" ]
++    }
++  }
++
++  if (use_jumbo_build_for_target) {
++    merge_action_name = target_name + "__jumbo_merge"
++    sources_in_jumbo_files -= excluded_sources
++
++    # Create an action that calls a script that merges all the source files.
++    action(merge_action_name) {
++      script = "//build/config/merge_for_jumbo.py"
++      response_file_contents =
++          rebase_path(sources_in_jumbo_files, root_build_dir)
++      outputs = jumbo_files
++      args = [ "--outputs" ] + rebase_path(outputs, root_build_dir) +
++             [ "--file-list={{response_file_name}}" ]
++
++      # For the "gn analyze" step to work, gn needs to know about the
++      # original source files. They can't be in |sources| because then
++      # they will be compiled, so they have to be somewhere else where
++      # gn analyze looks. One alternative is the |data| list but that
++      # will affect test packaging with known bad effects on
++      # distributed testing. Putting them in this action's input list
++      # is the least bad place.
++      inputs = []
++      foreach(f, invoker_sources - excluded_sources) {
++        # Avoid generated files and non non-source files.
++        in_source_tree = string_replace(rebase_path(f),
++                                        rebase_path(root_out_dir),
++                                        "dummy") == rebase_path(f)
++        is_source_file = get_path_info(f, "extension") == "cc" ||
++                         get_path_info(f, "extension") == "cpp" ||
++                         get_path_info(f, "extension") == "c" ||
++                         get_path_info(f, "extension") == "mm"
++        if (in_source_tree && is_source_file) {
++          inputs += [ f ]
++        }
++      }
++    }
++  } else {
++    # If the list subtraction triggers a gn error,
++    # jumbo_excluded_sources lists a file that is not in sources.
++    sources_after_exclusion = invoker_sources - excluded_sources
++    not_needed([ "sources_after_exclusion" ])
++  }
++
++  target_type = invoker.target_type
++
++  # Perform the actual operation, either on the original sources or
++  # the sources post-jumbo merging.
++  target(target_type, target_name) {
++    deps = []
++    if (defined(invoker.deps)) {
++      deps += invoker.deps
++    }
++
++    # Take everything else not handled above from the invoker.
++    variables_to_not_forward = [ "deps" ]
++    if (use_jumbo_build_for_target) {
++      deps += [ ":" + merge_action_name ]
++      variables_to_not_forward += [ "sources" ]
++      assert(jumbo_files != [])
++      sources = invoker_sources - sources_in_jumbo_files + jumbo_files
++
++      # Change include_dirs to make sure that the jumbo file can find its
++      # #included files.
++      variables_to_not_forward += [ "include_dirs" ]
++      include_dirs = []
++      if (defined(invoker.include_dirs)) {
++        include_dirs = invoker.include_dirs
++      }
++      include_dirs += [ root_build_dir ]
++    }
++    forward_variables_from(invoker, "*", variables_to_not_forward)
++  }
++}
++
++# See documentation above by "internal_jumbo_target".
++template("jumbo_source_set") {
++  internal_jumbo_target(target_name) {
++    target_type = "source_set"
++    forward_variables_from(invoker, "*")
++  }
++}
++
++set_defaults("jumbo_source_set") {
++  # This sets the default list of configs when the jumbo_source_set target
++  # is defined. The default_compiler_configs comes from BUILDCONFIG.gn and
++  # is the list normally applied to static libraries and source sets.
++  configs = default_compiler_configs
++}
++
++# See documentation above by "internal_jumbo_target".
++template("jumbo_static_library") {
++  internal_jumbo_target(target_name) {
++    target_type = "static_library"
++    forward_variables_from(invoker, "*")
++  }
++}
++
++set_defaults("jumbo_static_library") {
++  # This sets the default list of configs when the jumbo_static_library target
++  # is defined. The default_compiler_configs comes from BUILDCONFIG.gn and
++  # is the list normally applied to static libraries and source sets.
++  configs = default_compiler_configs
++}
++
++# See documentation above by "internal_jumbo_target".
++template("jumbo_component") {
++  internal_jumbo_target(target_name) {
++    target_type = "component"
++    forward_variables_from(invoker, "*")
++  }
++}
++
++set_defaults("jumbo_component") {
++  # This sets the default list of configs when the jumbo_component
++  # target is defined. This code is a clone of set_defaults for the
++  # ordinary "component" template.
++  if (is_component_build) {
++    configs = default_shared_library_configs
++    if (is_android) {
++      configs -= [ "//build/config/android:hide_all_but_jni_onload" ]
++    }
++  } else {
++    configs = default_compiler_configs
++  }
++}
+diff --git a/build/config/merge_for_jumbo.py b/build/config/merge_for_jumbo.py
+new file mode 100755
+index 000000000..6d037a80e
+--- /dev/null
++++ b/build/config/merge_for_jumbo.py
+@@ -0,0 +1,145 @@
++#!/usr/bin/env python
++#
++# Copyright 2016 The Chromium Authors. All rights reserved.
++# Use of this source code is governed by a BSD-style license that can be
++# found in the LICENSE file.
++
++"""This script creates a "jumbo" file which merges all incoming files
++for compiling.
++
++"""
++
++from __future__ import print_function
++from __future__ import unicode_literals
++
++import argparse
++import hashlib
++import io
++import os
++
++def cut_ranges(boundaries):
++  # Given an increasing sequence of boundary indices, generate a sequence of
++  # non-overlapping ranges. The total range is inclusive of the first index
++  # and exclusive of the last index from the given sequence.
++  for start, stop in zip(boundaries, boundaries[1:]):
++    yield range(start, stop)
++
++
++def generate_chunk_stops(inputs, output_count, smart_merge=True):
++  # Note: In the comments below, unique numeric labels are assigned to files.
++  #       Consider them as the sorted rank of the hash of each file path.
++  # Simple jumbo chunking generates uniformly sized chunks with the ceiling of:
++  # (output_index + 1) * input_count / output_count
++  input_count = len(inputs)
++  stops = [((i + 1) * input_count + output_count - 1) // output_count
++           for i in range(output_count)]
++  # This is disruptive at times because file insertions and removals can
++  # invalidate many chunks as all files are offset by one.
++  # For example, say we have 12 files in 4 uniformly sized chunks:
++  # 9, 4, 0; 7,  1, 11;  5, 10, 2; 6, 3, 8
++  # If we delete the first file we get:
++  # 4, 0, 7; 1, 11,  5; 10,  2, 6; 3, 8
++  # All of the chunks have new sets of inputs.
++
++  # With path-aware chunking, we start with the uniformly sized chunks:
++  # 9, 4, 0; 7,  1, 11;  5, 10, 2; 6, 3, 8
++  # First we find the smallest rank in each of the chunks. Their indices are
++  # stored in the |centers| list and in this example the ranks would be:
++  # 0, 1, 2, 3
++  # Then we find the largest rank between the centers. Their indices are stored
++  # in the |stops| list and in this example the ranks would be:
++  # 7, 11, 6
++  # These files mark the boundaries between chunks and these boundary files are
++  # often maintained even as files are added or deleted.
++  # In this example, 7, 11, and 6 are the first files in each chunk:
++  # 9, 4, 0; 7,  1; 11,  5, 10, 2; 6, 3, 8
++  # If we delete the first file and repeat the process we get:
++  # 4, 0; 7, 1; 11,  5, 10,  2; 6, 3, 8
++  # Only the first chunk has a new set of inputs.
++  if smart_merge:
++    # Starting with the simple chunks, every file is assigned a rank.
++    # This requires a hash function that is stable across runs.
++    hasher = lambda n: hashlib.md5(inputs[n].encode()).hexdigest()
++    # In each chunk there is a key file with lowest rank; mark them.
++    # Note that they will not easily change.
++    centers = [min(indices, key=hasher) for indices in cut_ranges([0] + stops)]
++    # Between each pair of key files there is a file with highest rank.
++    # Mark these to be used as border files. They also will not easily change.
++    # Forget the inital chunks and create new chunks by splitting the list at
++    # every border file.
++    stops = [max(indices, key=hasher) for indices in cut_ranges(centers)]
++    stops.append(input_count)
++  return stops
++
++
++def write_jumbo_files(inputs, outputs, written_input_set, written_output_set):
++  chunk_stops = generate_chunk_stops(inputs, len(outputs))
++
++  written_inputs = 0
++  for output_index, output_file in enumerate(outputs):
++    written_output_set.add(output_file)
++    if os.path.isfile(output_file):
++      with open(output_file, "r") as current:
++        current_jumbo_file = current.read()
++    else:
++      current_jumbo_file = None
++
++    out = io.StringIO()
++    out.write("/* This is a Jumbo file. Don't edit. */\n\n")
++    out.write("/* Generated with merge_for_jumbo.py. */\n\n")
++    input_limit = chunk_stops[output_index]
++    while written_inputs < input_limit:
++      filename = inputs[written_inputs]
++      written_inputs += 1
++      out.write("#include \"%s\"\n" % filename)
++      written_input_set.add(filename)
++    new_jumbo_file = out.getvalue()
++    out.close()
++
++    if new_jumbo_file != current_jumbo_file:
++      with open(output_file, "w") as out:
++        out.write(new_jumbo_file)
++
++
++def main():
++  parser = argparse.ArgumentParser()
++  parser.add_argument("--outputs", nargs="+", required=True,
++                      help='List of output files to split input into')
++  parser.add_argument("--file-list", required=True)
++  parser.add_argument("--verbose", action="store_true")
++  args = parser.parse_args()
++
++  lines = []
++  # If written with gn |write_file| each file is on its own line.
++  with open(args.file_list) as file_list_file:
++    lines = [line.strip() for line in file_list_file if line.strip()]
++  # If written with gn |response_file_contents| the files are space separated.
++  all_inputs = []
++  for line in lines:
++    all_inputs.extend(line.split())
++
++  written_output_set = set()  # Just for double checking
++  written_input_set = set()  # Just for double checking
++  for language_ext in (".cc", ".c", ".mm",):
++    if language_ext == ".cc":
++      ext_pattern = (".cc", ".cpp")
++    else:
++      ext_pattern = tuple([language_ext])
++
++    outputs = [x for x in args.outputs if x.endswith(ext_pattern)]
++    inputs = [x for x in all_inputs if x.endswith(ext_pattern)]
++
++    if not outputs:
++      assert not inputs
++      continue
++
++    write_jumbo_files(inputs, outputs, written_input_set, written_output_set)
++
++  assert set(args.outputs) == written_output_set, "Did not fill all outputs"
++  assert set(all_inputs) == written_input_set, "Did not use all inputs"
++  if args.verbose:
++    print("Generated %s (%d files) based on %s" % (
++      str(args.outputs), len(written_input_set), args.file_list))
++
++if __name__ == "__main__":
++  main()
+diff --git a/cc/cc.gni b/cc/cc.gni
+index 090420c90..6b0e76bf2 100644
+--- a/cc/cc.gni
++++ b/cc/cc.gni
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//testing/test.gni")
+ 
+ cc_remove_configs = []
+@@ -16,7 +17,7 @@ if (!is_debug) {
+ }
+ 
+ template("cc_component") {
+-  component(target_name) {
++  jumbo_component(target_name) {
+     forward_variables_from(invoker, "*", [ "configs" ])
+     if (defined(invoker.configs)) {
+       configs += invoker.configs
+@@ -27,7 +28,7 @@ template("cc_component") {
+ }
+ 
+ template("cc_test_static_library") {
+-  static_library(target_name) {
++  jumbo_static_library(target_name) {
+     forward_variables_from(invoker, "*", [ "configs" ])
+     if (defined(invoker.configs)) {
+       configs += invoker.configs
+diff --git a/components/autofill/content/browser/BUILD.gn b/components/autofill/content/browser/BUILD.gn
+index 41281a8a3..0956447f2 100644
+--- a/components/autofill/content/browser/BUILD.gn
++++ b/components/autofill/content/browser/BUILD.gn
+@@ -2,9 +2,10 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//third_party/protobuf/proto_library.gni")
+ 
+-static_library("browser") {
++jumbo_static_library("browser") {
+   sources = [
+     "autofill_log_router_factory.cc",
+     "autofill_log_router_factory.h",
+diff --git a/components/autofill/content/renderer/BUILD.gn b/components/autofill/content/renderer/BUILD.gn
+index 74d600740..c501e95a0 100644
+--- a/components/autofill/content/renderer/BUILD.gn
++++ b/components/autofill/content/renderer/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-static_library("renderer") {
++import("//build/config/jumbo.gni")
++
++jumbo_static_library("renderer") {
+   sources = [
+     "autofill_agent.cc",
+     "autofill_agent.h",
+@@ -54,7 +56,7 @@ static_library("renderer") {
+   ]
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "autofill_agent_test_api.h",
+diff --git a/components/autofill/core/browser/BUILD.gn b/components/autofill/core/browser/BUILD.gn
+index dd87df9e1..56ed0accc 100644
+--- a/components/autofill/core/browser/BUILD.gn
++++ b/components/autofill/core/browser/BUILD.gn
+@@ -4,6 +4,7 @@
+ 
+ import("//build/buildflag_header.gni")
+ import("//build/config/chrome_build.gni")
++import("//build/config/jumbo.gni")
+ import("//chrome/version.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+ import("//tools/grit/grit_rule.gni")
+@@ -56,7 +57,7 @@ action("regex_patterns_inl_h") {
+          rebase_path(outputs, root_build_dir)
+ }
+ 
+-static_library("browser") {
++jumbo_static_library("browser") {
+   sources = [
+     "address_normalization_manager.cc",
+     "address_normalization_manager.h",
+@@ -638,7 +639,7 @@ if (is_android) {
+   }
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "autofill_form_test_utils.cc",
+diff --git a/components/autofill/core/common/BUILD.gn b/components/autofill/core/common/BUILD.gn
+index 525e406b1..a3ae400a5 100644
+--- a/components/autofill/core/common/BUILD.gn
++++ b/components/autofill/core/common/BUILD.gn
+@@ -1,10 +1,10 @@
+ # Copyright 2014 The Chromium Authors
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+-
++import("//build/config/jumbo.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+ 
+-static_library("common") {
++jumbo_static_library("common") {
+   sources = [
+     "aliases.h",
+     "autocomplete_parsing_util.cc",
+diff --git a/components/cdm/browser/BUILD.gn b/components/cdm/browser/BUILD.gn
+index 100695c76..440335a3e 100644
+--- a/components/cdm/browser/BUILD.gn
++++ b/components/cdm/browser/BUILD.gn
+@@ -2,10 +2,11 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//media/media_options.gni")
+ 
+ if (enable_media_drm_storage) {
+-  source_set("browser") {
++  jumbo_source_set("browser") {
+     sources = [
+       "media_drm_storage_impl.cc",
+       "media_drm_storage_impl.h",
+@@ -36,7 +37,7 @@ if (enable_media_drm_storage) {
+     }
+   }
+ 
+-  source_set("unit_tests") {
++  jumbo_source_set("unit_tests") {
+     testonly = true
+     sources = [ "media_drm_storage_impl_unittest.cc" ]
+     deps = [
+diff --git a/components/cdm/common/BUILD.gn b/components/cdm/common/BUILD.gn
+index 92910a901..ddcd5da6e 100644
+--- a/components/cdm/common/BUILD.gn
++++ b/components/cdm/common/BUILD.gn
+@@ -1,10 +1,11 @@
+ # Copyright 2014 The Chromium Authors
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
++import("//build/config/jumbo.gni")
+ 
+ import("//third_party/widevine/cdm/widevine.gni")
+ 
+-static_library("common") {
++jumbo_static_library("common") {
+   sources = [
+     "cdm_message_generator.cc",
+     "cdm_message_generator.h",
+diff --git a/components/cdm/renderer/BUILD.gn b/components/cdm/renderer/BUILD.gn
+index 3369afc6e..c22ad2fd4 100644
+--- a/components/cdm/renderer/BUILD.gn
++++ b/components/cdm/renderer/BUILD.gn
+@@ -2,9 +2,10 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//third_party/widevine/cdm/widevine.gni")
+ 
+-static_library("renderer") {
++jumbo_static_library("renderer") {
+   sources = [
+     "external_clear_key_key_system_info.cc",
+     "external_clear_key_key_system_info.h",
+diff --git a/components/content_settings/core/browser/BUILD.gn b/components/content_settings/core/browser/BUILD.gn
+index e6b576fca..c999aa971 100644
+--- a/components/content_settings/core/browser/BUILD.gn
++++ b/components/content_settings/core/browser/BUILD.gn
+@@ -3,9 +3,10 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//ppapi/buildflags/buildflags.gni")
+ 
+-static_library("browser") {
++jumbo_static_library("browser") {
+   sources = [
+     "content_settings_default_provider.cc",
+     "content_settings_default_provider.h",
+@@ -79,7 +80,7 @@ static_library("browser") {
+   configs += [ "//build/config/compiler:wexit_time_destructors" ]
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+   sources = [
+     "content_settings_pref_unittest.cc",
+diff --git a/components/content_settings/core/common/BUILD.gn b/components/content_settings/core/common/BUILD.gn
+index 54060e445..de23fe321 100644
+--- a/components/content_settings/core/common/BUILD.gn
++++ b/components/content_settings/core/common/BUILD.gn
+@@ -2,10 +2,11 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//mojo/public/tools/bindings/mojom.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+ 
+-static_library("common") {
++jumbo_static_library("common") {
+   sources = [
+     "content_settings.cc",
+     "content_settings.h",
+@@ -48,7 +49,7 @@ static_library("common") {
+   }
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+   sources = [
+     "content_settings_pattern_parser_unittest.cc",
+diff --git a/components/content_settings/core/test/BUILD.gn b/components/content_settings/core/test/BUILD.gn
+index 56bef89ec..adfa5131d 100644
+--- a/components/content_settings/core/test/BUILD.gn
++++ b/components/content_settings/core/test/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-static_library("test_support") {
++import("//build/config/jumbo.gni")
++
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "content_settings_mock_provider.cc",
+diff --git a/components/domain_reliability/BUILD.gn b/components/domain_reliability/BUILD.gn
+index 1e61419d6..8d53a1c71 100644
+--- a/components/domain_reliability/BUILD.gn
++++ b/components/domain_reliability/BUILD.gn
+@@ -2,6 +2,8 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
++
+ action("bake_in_configs") {
+   visibility = [ ":*" ]
+   script = "bake_in_configs.py"
+@@ -43,7 +45,7 @@ action("bake_in_configs") {
+   ]
+ }
+ 
+-component("domain_reliability") {
++jumbo_component("domain_reliability") {
+   sources = [
+     "baked_in_configs.h",
+     "beacon.cc",
+@@ -86,7 +88,7 @@ component("domain_reliability") {
+   ]
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+   sources = [
+     "config_unittest.cc",
+diff --git a/components/feature_engagement/internal/BUILD.gn b/components/feature_engagement/internal/BUILD.gn
+index edf92e022..3c183cc41 100644
+--- a/components/feature_engagement/internal/BUILD.gn
++++ b/components/feature_engagement/internal/BUILD.gn
+@@ -2,12 +2,14 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
++
+ if (is_android) {
+   import("//build/config/android/config.gni")
+   import("//build/config/android/rules.gni")
+ }
+ 
+-static_library("internal") {
++jumbo_static_library("internal") {
+   visibility = [
+     ":*",
+     "//components/feature_engagement",
+@@ -84,7 +86,7 @@ static_library("internal") {
+   }
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+ 
+   visibility = [ "//components/feature_engagement:unit_tests" ]
+diff --git a/components/feature_engagement/internal/test/BUILD.gn b/components/feature_engagement/internal/test/BUILD.gn
+index 56bb9c947..aefded72e 100644
+--- a/components/feature_engagement/internal/test/BUILD.gn
++++ b/components/feature_engagement/internal/test/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-source_set("test_support") {
++import("//build/config/jumbo.gni")
++
++jumbo_source_set("test_support") {
+   testonly = true
+ 
+   visibility = [ "//components/feature_engagement/internal:unit_tests" ]
+diff --git a/components/feature_engagement/public/BUILD.gn b/components/feature_engagement/public/BUILD.gn
+index 01a489fec..cb1223d3a 100644
+--- a/components/feature_engagement/public/BUILD.gn
++++ b/components/feature_engagement/public/BUILD.gn
+@@ -2,12 +2,14 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
++
+ if (is_android) {
+   import("//build/config/android/config.gni")
+   import("//build/config/android/rules.gni")
+ }
+ 
+-source_set("public") {
++jumbo_source_set("public") {
+   sources = [
+     "configuration.cc",
+     "configuration.h",
+@@ -46,7 +48,7 @@ source_set("public") {
+   }
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+ 
+   visibility = [ "//components/feature_engagement:unit_tests" ]
+diff --git a/components/lookalikes/core/BUILD.gn b/components/lookalikes/core/BUILD.gn
+index 6b3f610f2..a06e3e539 100644
+--- a/components/lookalikes/core/BUILD.gn
++++ b/components/lookalikes/core/BUILD.gn
+@@ -2,9 +2,10 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//third_party/protobuf/proto_library.gni")
+ 
+-static_library("core") {
++jumbo_static_library("core") {
+   sources = [
+     "lookalike_url_ui_util.cc",
+     "lookalike_url_ui_util.h",
+@@ -32,7 +33,7 @@ static_library("core") {
+   ]
+ }
+ 
+-static_library("safety_tips") {
++jumbo_static_library("safety_tips") {
+   sources = [
+     "safety_tip_test_utils.cc",
+     "safety_tip_test_utils.h",
+@@ -48,7 +49,7 @@ static_library("safety_tips") {
+   ]
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+   sources = [
+     "lookalike_url_util_unittest.cc",
+diff --git a/components/media_router/common/providers/cast/certificate/BUILD.gn b/components/media_router/common/providers/cast/certificate/BUILD.gn
+index c5e579cb4..98e1d2faf 100644
+--- a/components/media_router/common/providers/cast/certificate/BUILD.gn
++++ b/components/media_router/common/providers/cast/certificate/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//third_party/openscreen/src/build/config/cast.gni")
+ 
+ config("developer_certificate_config") {
+@@ -11,7 +12,7 @@ config("developer_certificate_config") {
+   }
+ }
+ 
+-source_set("certificate_reader") {
++jumbo_source_set("certificate_reader") {
+   sources = [
+     "cast_cert_reader.cc",
+     "cast_cert_reader.h",
+@@ -29,7 +30,7 @@ source_set("certificate_roots") {
+   ]
+ }
+ 
+-static_library("certificate") {
++jumbo_static_library("certificate") {
+   sources = [
+     "cast_cert_validator.cc",
+     "cast_cert_validator.h",
+@@ -57,7 +58,7 @@ static_library("certificate") {
+   }
+ }
+ 
+-source_set("openscreen_certificate_verifier") {
++jumbo_source_set("openscreen_certificate_verifier") {
+   sources = [
+     "net_parsed_certificate.cc",
+     "net_parsed_certificate.h",
+@@ -72,7 +73,7 @@ source_set("openscreen_certificate_verifier") {
+   ]
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "cast_cert_test_helpers.cc",
+@@ -88,7 +89,7 @@ static_library("test_support") {
+   ]
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+   sources = [
+     "cast_cert_validator_unittest.cc",
+diff --git a/components/metrics/BUILD.gn b/components/metrics/BUILD.gn
+index 05bf0885e..5c3b006ec 100644
+--- a/components/metrics/BUILD.gn
++++ b/components/metrics/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//testing/test.gni")
+ 
+ if (is_android) {
+@@ -58,7 +59,7 @@ if (is_android) {
+   }
+ }
+ 
+-static_library("metrics") {
++jumbo_static_library("metrics") {
+   sources = [
+     "android_metrics_provider.cc",
+     "android_metrics_provider.h",
+@@ -319,7 +320,7 @@ source_set("library_support") {
+   ]
+ }
+ 
+-static_library("net") {
++jumbo_static_library("net") {
+   sources = [
+     "net/cellular_logic_helper.cc",
+     "net/cellular_logic_helper.h",
+@@ -442,7 +443,7 @@ source_set("call_stack_profile_collector") {
+   ]
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "test/test_enabled_state_provider.cc",
+diff --git a/components/omnibox/browser/BUILD.gn b/components/omnibox/browser/BUILD.gn
+index 00aad3bc6..1c9461202 100644
+--- a/components/omnibox/browser/BUILD.gn
++++ b/components/omnibox/browser/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/buildflag_header.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//components/optimization_guide/features.gni")
+ import("//components/vector_icons/vector_icons.gni")
+@@ -90,7 +91,7 @@ static_library("vector_icons") {
+   ]
+ }
+ 
+-static_library("browser") {
++jumbo_static_library("browser") {
+   sources = [
+     "actions/omnibox_action.cc",
+     "actions/omnibox_action.h",
+@@ -554,7 +555,7 @@ if (is_android) {
+   }
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "fake_autocomplete_provider.h",
+diff --git a/components/password_manager/content/browser/BUILD.gn b/components/password_manager/content/browser/BUILD.gn
+index fbbfc6b59..ad1d43dc5 100644
+--- a/components/password_manager/content/browser/BUILD.gn
++++ b/components/password_manager/content/browser/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-static_library("browser") {
++import("//build/config/jumbo.gni")
++
++jumbo_static_library("browser") {
+   sources = [
+     "bad_message.cc",
+     "bad_message.h",
+diff --git a/components/password_manager/core/browser/BUILD.gn b/components/password_manager/core/browser/BUILD.gn
+index c48d5b19c..9055d146f 100644
+--- a/components/password_manager/core/browser/BUILD.gn
++++ b/components/password_manager/core/browser/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+ import("//third_party/libprotobuf-mutator/fuzzable_proto_library.gni")
+ 
+@@ -17,7 +18,7 @@ config("password_reuse_detection_config") {
+   }
+ }
+ 
+-static_library("browser") {
++jumbo_static_library("browser") {
+   sources = [
+     "affiliation/affiliated_match_helper.cc",
+     "affiliation/affiliated_match_helper.h",
+@@ -462,7 +463,7 @@ fuzzable_proto_library("affiliation_proto") {
+   sources = [ "affiliation/affiliation_api.proto" ]
+ }
+ 
+-static_library("password_hash_data") {
++jumbo_static_library("password_hash_data") {
+   sources = [
+     "password_hash_data.cc",
+     "password_hash_data.h",
+@@ -488,7 +489,7 @@ static_library("hash_password_manager") {
+   ]
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "affiliation/fake_affiliation_api.cc",
+diff --git a/components/password_manager/core/browser/leak_detection/BUILD.gn b/components/password_manager/core/browser/leak_detection/BUILD.gn
+index 11171fb39..1fe2f56b0 100644
+--- a/components/password_manager/core/browser/leak_detection/BUILD.gn
++++ b/components/password_manager/core/browser/leak_detection/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//third_party/libprotobuf-mutator/fuzzable_proto_library.gni")
+ 
+ fuzzable_proto_library("proto") {
+@@ -20,7 +21,7 @@ source_set("leak_detection_interface_headers") {
+   ]
+ }
+ 
+-source_set("leak_detection") {
++jumbo_source_set("leak_detection") {
+   sources = [
+     "bulk_leak_check.h",
+     "bulk_leak_check_impl.cc",
+@@ -59,7 +60,7 @@ source_set("leak_detection") {
+   ]
+ }
+ 
+-source_set("test_support") {
++jumbo_source_set("test_support") {
+   testonly = true
+   sources = [
+     "mock_leak_detection_check_factory.cc",
+@@ -77,7 +78,7 @@ source_set("test_support") {
+   ]
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+   sources = [
+     "bulk_leak_check_impl_unittest.cc",
+diff --git a/components/password_manager/core/common/BUILD.gn b/components/password_manager/core/common/BUILD.gn
+index e560bfa59..9913a38f1 100644
+--- a/components/password_manager/core/common/BUILD.gn
++++ b/components/password_manager/core/common/BUILD.gn
+@@ -5,8 +5,9 @@
+ if (is_android) {
+   import("//build/config/android/rules.gni")
+ }
++import("//build/config/jumbo.gni")
+ 
+-static_library("common") {
++jumbo_static_library("common") {
+   sources = [
+     "credential_manager_types.cc",
+     "credential_manager_types.h",
+diff --git a/components/payments/content/BUILD.gn b/components/payments/content/BUILD.gn
+index 6e4c00c32..d61b22010 100644
+--- a/components/payments/content/BUILD.gn
++++ b/components/payments/content/BUILD.gn
+@@ -3,8 +3,9 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ 
+-static_library("content") {
++jumbo_static_library("content") {
+   sources = [
+     "android_app_communication.cc",
+     "android_app_communication.h",
+@@ -127,7 +128,7 @@ static_library("content") {
+ }
+ 
+ # Files used by content and utility.
+-static_library("content_common") {
++jumbo_static_library("content_common") {
+   sources = [
+     "web_app_manifest.cc",
+     "web_app_manifest.h",
+@@ -139,7 +140,7 @@ static_library("content_common") {
+   ]
+ }
+ 
+-static_library("utils") {
++jumbo_static_library("utils") {
+   sources = [
+     "developer_console_logger.cc",
+     "developer_console_logger.h",
+@@ -186,7 +187,7 @@ static_library("utils") {
+   ]
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "mock_payment_manifest_web_data_service.cc",
+@@ -203,7 +204,7 @@ static_library("test_support") {
+   ]
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+   sources = [
+     "android_app_communication_test_support.h",
+diff --git a/components/payments/content/icon/BUILD.gn b/components/payments/content/icon/BUILD.gn
+index 517b3dd3d..a9b2aba72 100644
+--- a/components/payments/content/icon/BUILD.gn
++++ b/components/payments/content/icon/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-static_library("icon") {
++import("//build/config/jumbo.gni")
++
++jumbo_static_library("icon") {
+   sources = [
+     "icon_size.cc",
+     "icon_size.h",
+diff --git a/components/payments/core/BUILD.gn b/components/payments/core/BUILD.gn
+index a1eba8c24..6b0985ef5 100644
+--- a/components/payments/core/BUILD.gn
++++ b/components/payments/core/BUILD.gn
+@@ -3,8 +3,9 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ 
+-static_library("core") {
++jumbo_static_library("core") {
+   sources = [
+     "android_app_description.cc",
+     "android_app_description.h",
+@@ -105,7 +106,7 @@ static_library("core") {
+   ]
+ }
+ 
+-static_library("error_strings") {
++jumbo_static_library("error_strings") {
+   sources = [
+     "error_strings.cc",
+     "error_strings.h",
+@@ -121,14 +122,14 @@ static_library("error_strings") {
+   }
+ }
+ 
+-static_library("method_strings") {
++jumbo_static_library("method_strings") {
+   sources = [
+     "method_strings.cc",
+     "method_strings.h",
+   ]
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "const_csp_checker.cc",
+@@ -156,7 +157,7 @@ static_library("test_support") {
+   ]
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+   sources = [
+     "android_app_description_tools_unittest.cc",
+diff --git a/components/policy/content/BUILD.gn b/components/policy/content/BUILD.gn
+index 59fba6739..cd76604b2 100644
+--- a/components/policy/content/BUILD.gn
++++ b/components/policy/content/BUILD.gn
+@@ -3,10 +3,11 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ 
+ assert(!is_ios, "Policy Throttle should not be referenced on iOS")
+ 
+-source_set("safe_sites_navigation_throttle") {
++jumbo_source_set("safe_sites_navigation_throttle") {
+   sources = [
+     "safe_search_service.cc",
+     "safe_search_service.h",
+@@ -26,7 +27,7 @@ source_set("safe_sites_navigation_throttle") {
+   ]
+ }
+ 
+-source_set("content") {
++jumbo_source_set("content") {
+   sources = [
+     "policy_blocklist_navigation_throttle.cc",
+     "policy_blocklist_navigation_throttle.h",
+diff --git a/components/policy/core/browser/BUILD.gn b/components/policy/core/browser/BUILD.gn
+index 5386fa78b..a5908ec67 100644
+--- a/components/policy/core/browser/BUILD.gn
++++ b/components/policy/core/browser/BUILD.gn
+@@ -4,6 +4,7 @@
+ 
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ 
+ group("browser") {
+   if (is_component_build) {
+@@ -13,7 +14,7 @@ group("browser") {
+   }
+ }
+ 
+-source_set("internal") {
++jumbo_source_set("internal") {
+   visibility = [ "//components/policy/*" ]
+   sources = [
+     "browser_policy_connector.cc",
+@@ -106,7 +107,7 @@ source_set("internal") {
+   ]
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "configuration_policy_pref_store_test.cc",
+diff --git a/components/policy/core/common/BUILD.gn b/components/policy/core/common/BUILD.gn
+index 7adc855d1..5db665ef6 100644
+--- a/components/policy/core/common/BUILD.gn
++++ b/components/policy/core/common/BUILD.gn
+@@ -4,6 +4,7 @@
+ 
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+ 
+ group("policy_namespace") {
+@@ -18,7 +19,7 @@ group("common") {
+   }
+ }
+ 
+-source_set("policy_namespace_internal") {
++jumbo_source_set("policy_namespace_internal") {
+   visibility = [ "//components/policy/*" ]
+ 
+   configs += [ "//components/policy:component_implementation" ]
+@@ -30,7 +31,7 @@ source_set("policy_namespace_internal") {
+   ]
+ }
+ 
+-source_set("util") {
++jumbo_source_set("util") {
+   sources = [
+     "cloud/cloud_policy_util.cc",
+     "cloud/cloud_policy_util.h",
+@@ -60,7 +61,7 @@ source_set("util") {
+   }
+ }
+ 
+-source_set("internal") {
++jumbo_source_set("internal") {
+   visibility = [ "//components/policy/*" ]
+ 
+   configs += [ "//components/policy:component_implementation" ]
+@@ -379,7 +380,7 @@ source_set("internal") {
+   }
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "cloud/mock_cloud_external_data_manager.cc",
+diff --git a/components/safe_browsing/content/browser/BUILD.gn b/components/safe_browsing/content/browser/BUILD.gn
+index 7c9ed1b84..8959b7f04 100644
+--- a/components/safe_browsing/content/browser/BUILD.gn
++++ b/components/safe_browsing/content/browser/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//components/safe_browsing/buildflags.gni")
+ 
+ # NOTE: This target is separated from :browser as
+@@ -61,7 +62,7 @@ if (safe_browsing_mode > 0) {
+   }
+ }
+ 
+-source_set("browser") {
++jumbo_source_set("browser") {
+   sources = [
+     "base_blocking_page.cc",
+     "base_blocking_page.h",
+@@ -190,7 +191,7 @@ source_set("unit_tests") {
+   ]
+ }
+ 
+-source_set("client_side_detection") {
++jumbo_source_set("client_side_detection") {
+   sources = [
+     "client_side_detection_host.cc",
+     "client_side_detection_host.h",
+diff --git a/components/safe_browsing/core/browser/BUILD.gn b/components/safe_browsing/core/browser/BUILD.gn
+index f8174fe6e..7fa572899 100644
+--- a/components/safe_browsing/core/browser/BUILD.gn
++++ b/components/safe_browsing/core/browser/BUILD.gn
+@@ -3,8 +3,9 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ 
+-source_set("browser") {
++jumbo_source_set("browser") {
+   sources = [
+     "hash_database_mechanism.cc",
+     "hash_database_mechanism.h",
+diff --git a/components/security_state/content/BUILD.gn b/components/security_state/content/BUILD.gn
+index 0331f31f7..e79f5a83d 100644
+--- a/components/security_state/content/BUILD.gn
++++ b/components/security_state/content/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-static_library("content") {
++import("//build/config/jumbo.gni")
++
++jumbo_static_library("content") {
+   sources = [
+     "content_utils.cc",
+     "content_utils.h",
+diff --git a/components/security_state/core/BUILD.gn b/components/security_state/core/BUILD.gn
+index 497dcf512..1f69e4ad0 100644
+--- a/components/security_state/core/BUILD.gn
++++ b/components/security_state/core/BUILD.gn
+@@ -2,12 +2,14 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
++
+ if (is_android) {
+   import("//build/config/android/config.gni")
+   import("//build/config/android/rules.gni")
+ }
+ 
+-static_library("core") {
++jumbo_static_library("core") {
+   sources = [
+     "security_state.cc",
+     "security_state.h",
+@@ -33,7 +35,7 @@ if (is_android) {
+   }
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+   sources = [ "security_state_unittest.cc" ]
+ 
+diff --git a/components/sync/BUILD.gn b/components/sync/BUILD.gn
+index 858d78f65..18ac65924 100644
+--- a/components/sync/BUILD.gn
++++ b/components/sync/BUILD.gn
+@@ -4,6 +4,7 @@
+ 
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//testing/test.gni")
+ 
+ group("sync") {
+diff --git a/components/sync/base/BUILD.gn b/components/sync/base/BUILD.gn
+index 363a0753d..a6aaee0b4 100644
+--- a/components/sync/base/BUILD.gn
++++ b/components/sync/base/BUILD.gn
+@@ -4,13 +4,14 @@
+ 
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ 
+ declare_args() {
+   # Controls the product part of the user agent calculated in sync_util.cc.
+   sync_user_agent_product = "Chrome"
+ }
+ 
+-static_library("base") {
++jumbo_static_library("base") {
+   sources = [
+     "bind_to_task_runner.h",
+     "client_tag_hash.cc",
+diff --git a/components/sync/driver/BUILD.gn b/components/sync/driver/BUILD.gn
+index 2016439ad..e366920f9 100644
+--- a/components/sync/driver/BUILD.gn
++++ b/components/sync/driver/BUILD.gn
+@@ -4,8 +4,9 @@
+ 
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ 
+-static_library("driver") {
++jumbo_static_library("driver") {
+   sources = [
+     "active_devices_provider.h",
+     "backend_migrator.cc",
+diff --git a/components/sync/protocol/BUILD.gn b/components/sync/protocol/BUILD.gn
+index b2bcd8fbb..308e324ad 100644
+--- a/components/sync/protocol/BUILD.gn
++++ b/components/sync/protocol/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//third_party/protobuf/proto_library.gni")
+ import("protocol_sources.gni")
+ 
+@@ -15,7 +16,7 @@ proto_library("protocol") {
+ # it being listed in public_deps of upper directories (even though it doesn't
+ # fit the definition of public_deps). Consider using a group() to expose this
+ # together with the "protocol" target and simplify things.
+-static_library("util") {
++jumbo_static_library("util") {
+   sources = [
+     "entity_data.cc",
+     "entity_data.h",
+diff --git a/components/sync_device_info/BUILD.gn b/components/sync_device_info/BUILD.gn
+index a5dd5cb4f..b9ee683ef 100644
+--- a/components/sync_device_info/BUILD.gn
++++ b/components/sync_device_info/BUILD.gn
+@@ -4,12 +4,13 @@
+ 
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ if (is_android) {
+   import("//build/config/android/config.gni")
+   import("//build/config/android/rules.gni")
+ }
+ 
+-static_library("sync_device_info") {
++jumbo_static_library("sync_device_info") {
+   sources = [
+     "device_count_metrics_provider.cc",
+     "device_count_metrics_provider.h",
+diff --git a/components/sync_user_events/BUILD.gn b/components/sync_user_events/BUILD.gn
+index 3470bc2b6..02c216bd9 100644
+--- a/components/sync_user_events/BUILD.gn
++++ b/components/sync_user_events/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-static_library("sync_user_events") {
++import("//build/config/jumbo.gni")
++
++jumbo_static_library("sync_user_events") {
+   sources = [
+     "global_id_mapper.h",
+     "no_op_user_event_service.cc",
+diff --git a/components/url_formatter/BUILD.gn b/components/url_formatter/BUILD.gn
+index 1ea38702d..225fb724b 100644
+--- a/components/url_formatter/BUILD.gn
++++ b/components/url_formatter/BUILD.gn
+@@ -2,13 +2,14 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+ 
+ if (is_android) {
+   import("//build/config/android/rules.gni")
+ }
+ 
+-static_library("skeleton_generator") {
++jumbo_static_library("skeleton_generator") {
+   sources = [
+     "spoof_checks/skeleton_generator.cc",
+     "spoof_checks/skeleton_generator.h",
+@@ -19,7 +20,7 @@ static_library("skeleton_generator") {
+   ]
+ }
+ 
+-static_library("url_formatter") {
++jumbo_static_library("url_formatter") {
+   sources = [
+     "elide_url.cc",
+     "elide_url.h",
+@@ -64,7 +65,7 @@ if (is_android) {
+   }
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+   sources = [
+     "elide_url_unittest.cc",
+diff --git a/components/viz/common/BUILD.gn b/components/viz/common/BUILD.gn
+index 61c722392..d8075e84c 100644
+--- a/components/viz/common/BUILD.gn
++++ b/components/viz/common/BUILD.gn
+@@ -375,6 +375,8 @@ viz_component("common") {
+ }
+ 
+ viz_source_set("unit_tests") {
++  # Not ready for jumbo compilation. Too much repeated test code.
++  never_build_jumbo = true
+   testonly = true
+   sources = [
+     "display/overlay_strategy_unittest.cc",
+diff --git a/components/viz/service/BUILD.gn b/components/viz/service/BUILD.gn
+index 77fc13c92..bebc21404 100644
+--- a/components/viz/service/BUILD.gn
++++ b/components/viz/service/BUILD.gn
+@@ -450,6 +450,8 @@ viz_component("service") {
+ }
+ 
+ viz_source_set("unit_tests") {
++  # Not ready for jumbo compilation. Too much repeated test code.
++  never_build_jumbo = true
+   testonly = true
+   sources = [
+     "debugger/viz_debugger_unittests/viz_debugger_internal.cc",
+@@ -596,6 +598,8 @@ viz_source_set("unit_tests") {
+ }
+ 
+ viz_source_set("perf_tests") {
++  # Not ready for jumbo compilation. Too much repeated test code.
++  never_build_jumbo = true
+   testonly = true
+   sources = [
+     "display/bsp_tree_perftest.cc",
+diff --git a/components/viz/viz.gni b/components/viz/viz.gni
+index c4b5a16a4..d8786c5b1 100644
+--- a/components/viz/viz.gni
++++ b/components/viz/viz.gni
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//gpu/vulkan/features.gni")
+ import("//skia/features.gni")
+ import("//testing/test.gni")
+@@ -31,7 +32,7 @@ if (!is_debug) {
+ }
+ 
+ template("viz_source_set") {
+-  source_set(target_name) {
++  jumbo_source_set(target_name) {
+     forward_variables_from(invoker, "*", [ "configs" ])
+     if (defined(invoker.configs)) {
+       configs += invoker.configs
+@@ -42,7 +43,7 @@ template("viz_source_set") {
+ }
+ 
+ template("viz_component") {
+-  component(target_name) {
++  jumbo_component(target_name) {
+     forward_variables_from(invoker, "*", [ "configs" ])
+     if (defined(invoker.configs)) {
+       configs += invoker.configs
+@@ -53,7 +54,7 @@ template("viz_component") {
+ }
+ 
+ template("viz_static_library") {
+-  static_library(target_name) {
++  jumbo_static_library(target_name) {
+     forward_variables_from(invoker, "*", [ "configs" ])
+     if (defined(invoker.configs)) {
+       configs += invoker.configs
+diff --git a/components/webauthn/content/browser/BUILD.gn b/components/webauthn/content/browser/BUILD.gn
+index 5d17d9f9a..f3e00ee81 100644
+--- a/components/webauthn/content/browser/BUILD.gn
++++ b/components/webauthn/content/browser/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-static_library("browser") {
++import("//build/config/jumbo.gni")
++
++jumbo_static_library("browser") {
+   if (is_component_build) {
+     check_includes = false
+   }
+diff --git a/components/wifi/BUILD.gn b/components/wifi/BUILD.gn
+index c05f146af..61361ec6f 100644
+--- a/components/wifi/BUILD.gn
++++ b/components/wifi/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-component("wifi") {
++import("//build/config/jumbo.gni")
++
++jumbo_component("wifi") {
+   sources = [
+     "network_properties.cc",
+     "network_properties.h",
+@@ -42,7 +44,7 @@ component("wifi") {
+   }
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   sources = [
+     "fake_wifi_service.cc",
+     "fake_wifi_service.h",
+diff --git a/content/browser/BUILD.gn b/content/browser/BUILD.gn
+index 62a5aa48f..24283757c 100644
+--- a/content/browser/BUILD.gn
++++ b/content/browser/BUILD.gn
+@@ -8,6 +8,7 @@ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/compiler/pgo/pgo.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/linux/pangocairo/pangocairo.gni")
+ import("//build/config/ozone.gni")
+ import("//build/config/ui.gni")
+@@ -36,7 +37,7 @@ buildflag_header("buildflags") {
+   flags = [ "USE_SOCKET_BROKER=$use_socket_broker" ]
+ }
+ 
+-source_set("browser") {
++jumbo_source_set("browser") {
+   # Only the public target should depend on this. All other targets (even
+   # internal content ones) should depend on the public one.
+   visibility = [
+diff --git a/content/gpu/BUILD.gn b/content/gpu/BUILD.gn
+index 9f5f303b2..361151ada 100644
+--- a/content/gpu/BUILD.gn
++++ b/content/gpu/BUILD.gn
+@@ -4,6 +4,7 @@
+ 
+ import("//build/config/chromecast_build.gni")
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//gpu/vulkan/features.gni")
+ import("//media/media_options.gni")
+@@ -20,9 +21,9 @@ group("gpu") {
+ }
+ 
+ if (is_component_build) {
+-  link_target_type = "source_set"
++  link_target_type = "jumbo_source_set"
+ } else {
+-  link_target_type = "static_library"
++  link_target_type = "jumbo_static_library"
+ }
+ 
+ target(link_target_type, "gpu_sources") {
+diff --git a/content/public/browser/BUILD.gn b/content/public/browser/BUILD.gn
+index 34e280653..458179958 100644
+--- a/content/public/browser/BUILD.gn
++++ b/content/public/browser/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//device/vr/buildflags/buildflags.gni")
+ import("//ppapi/buildflags/buildflags.gni")
+@@ -22,7 +23,7 @@ group("browser") {
+   }
+ }
+ 
+-source_set("browser_sources") {
++jumbo_source_set("browser_sources") {
+   # External code should depend on via ":browser" above.
+   visibility = [ "//content/*" ]
+   sources = [
+diff --git a/content/public/child/BUILD.gn b/content/public/child/BUILD.gn
+index 73fce2d99..2f298f5cd 100644
+--- a/content/public/child/BUILD.gn
++++ b/content/public/child/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//ppapi/buildflags/buildflags.gni")
+ 
+ # See //content/BUILD.gn for how this works.
+@@ -19,7 +20,7 @@ group("child") {
+   }
+ }
+ 
+-source_set("child_sources") {
++jumbo_source_set("child_sources") {
+   # External code should depend in via ":child" above.
+   visibility = [ "//content/*" ]
+ 
+diff --git a/content/public/common/BUILD.gn b/content/public/common/BUILD.gn
+index 6d88bcb5c..2bbc9c55f 100644
+--- a/content/public/common/BUILD.gn
++++ b/content/public/common/BUILD.gn
+@@ -6,6 +6,7 @@ import("//build/buildflag_header.gni")
+ import("//build/config/chromecast_build.gni")
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//content/public/common/zygote/features.gni")
+ import("//media/media_options.gni")
+@@ -147,7 +148,7 @@ component("main_function_params") {
+   configs += [ "//content:content_implementation" ]
+ }
+ 
+-source_set("common_sources") {
++jumbo_source_set("common_sources") {
+   # External code should depend on via ":common" above.
+   visibility = [ "//content/*" ]
+ 
+diff --git a/content/public/renderer/BUILD.gn b/content/public/renderer/BUILD.gn
+index 68a045575..99605eb86 100644
+--- a/content/public/renderer/BUILD.gn
++++ b/content/public/renderer/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//media/media_options.gni")
+ import("//ppapi/buildflags/buildflags.gni")
+ 
+@@ -16,9 +17,9 @@ group("renderer") {
+ }
+ 
+ if (is_component_build) {
+-  link_target_type = "source_set"
++  link_target_type = "jumbo_source_set"
+ } else {
+-  link_target_type = "static_library"
++  link_target_type = "jumbo_static_library"
+ }
+ target(link_target_type, "renderer_sources") {
+   # External code should depend on via ":renderer" above.
+diff --git a/content/renderer/BUILD.gn b/content/renderer/BUILD.gn
+index a1f691c0d..0ea6bc0ef 100644
+--- a/content/renderer/BUILD.gn
++++ b/content/renderer/BUILD.gn
+@@ -5,6 +5,7 @@
+ import("//build/config/chromecast_build.gni")
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//content/common/features.gni")
+ import("//media/media_options.gni")
+@@ -14,9 +15,9 @@ import("//third_party/webrtc/webrtc.gni")
+ import("//tools/ipc_fuzzer/ipc_fuzzer.gni")
+ 
+ if (is_component_build) {
+-  link_target_type = "source_set"
++  link_target_type = "jumbo_source_set"
+ } else {
+-  link_target_type = "static_library"
++  link_target_type = "jumbo_static_library"
+ }
+ 
+ target(link_target_type, "renderer") {
+diff --git a/content/test/BUILD.gn b/content/test/BUILD.gn
+index 00ac83055..1796ef8fb 100644
+--- a/content/test/BUILD.gn
++++ b/content/test/BUILD.gn
+@@ -7,6 +7,7 @@ import("//build/config/chromecast_build.gni")
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/compiler/compiler.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//build/nocompile.gni")
+ import("//components/viz/common/debugger/viz_debugger.gni")
+@@ -32,7 +33,7 @@ if (is_android) {
+ 
+ # Use a static library here because many test binaries depend on this but don't
+ # require many files from it. This makes linking more efficient.
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+ 
+   # See comment at the top of //content/BUILD.gn for why this is disabled in
+@@ -910,7 +911,7 @@ group("telemetry_gpu_integration_test_data") {
+ 
+ # browsertest_support can be used by targets that run content_shell based
+ # browser tests.
+-static_library("browsertest_support") {
++jumbo_static_library("browsertest_support") {
+   testonly = true
+ 
+   # See comment at the top of //content/BUILD.gn for why this is disabled in
+diff --git a/content/utility/BUILD.gn b/content/utility/BUILD.gn
+index c23c3610a..a92269a11 100644
+--- a/content/utility/BUILD.gn
++++ b/content/utility/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//chromeos/ash/components/assistant/assistant.gni")
+ import("//components/services/screen_ai/buildflags/features.gni")
+ import("//device/vr/buildflags/buildflags.gni")
+@@ -11,7 +12,7 @@ import("//media/media_options.gni")
+ import("//printing/buildflags/buildflags.gni")
+ import("//services/accessibility/buildflags.gni")
+ 
+-source_set("utility") {
++jumbo_source_set("utility") {
+   # Only the public target should depend on this. All other targets (even
+   # internal content ones other than test) should depend on the public one.
+   visibility = [
+diff --git a/docs/clang_tidy.md b/docs/clang_tidy.md
+index d6a95c6df..c29802964 100644
+--- a/docs/clang_tidy.md
++++ b/docs/clang_tidy.md
+@@ -265,6 +265,14 @@ Copy-Paste Friendly (though you'll still need to stub in the variables):
+     'chrome/browser/.*'
+ ```
+ 
++\*It's not clear which, if any, `gn` flags outside of `use_jumbo_build` may
++cause issues for `clang-tidy`. I've had no problems building a component release
++build, both with and without goma. if you run into issues, let us know!
++||||||| fa98118a45f
++\*It's not clear which, if any, `gn` flags may cause issues for
++`clang-tidy`. I've had no problems building a component release build,
++both with and without goma. if you run into issues, let us know!
++
+ Note that the source file regex must match how the build specified the file.
+ This means that on Windows, you must use (escaped) backslashes even from a bash
+ shell.
+diff --git a/docs/clang_tool_refactoring.md b/docs/clang_tool_refactoring.md
+index 418a31bcc..ff0a35e12 100644
+--- a/docs/clang_tool_refactoring.md
++++ b/docs/clang_tool_refactoring.md
+@@ -15,6 +15,8 @@ with a traditional find-and-replace regexp:
+ 
+ ## Caveats
+ 
++* Clang tools do not work with jumbo builds.
++
+ * Invocations of a clang tool runs on on only one build config at a time. For
+ example, running the tool across a `target_os="win"` build won't update code
+ that is guarded by `OS_POSIX`. Performing a global refactoring will often
+diff --git a/docs/linux/build_instructions.md b/docs/linux/build_instructions.md
+index c1943042f..a357fcace 100644
+--- a/docs/linux/build_instructions.md
++++ b/docs/linux/build_instructions.md
+@@ -161,6 +161,15 @@ please follow [Goma for Chromium contributors](https://chromium.googlesource.com
+ If you are a Google employee, see
+ [go/building-chrome](https://goto.google.com/building-chrome) instead.
+ 
++#### Jumbo/Unity builds
++
++Jumbo builds merge many translation units ("source files") and compile them
++together. Since a large portion of Chromium's code is in shared header files,
++this dramatically reduces the total amount of work needed. Check out the
++[Jumbo / Unity builds](jumbo.md) for more information.
++
++Enable jumbo builds by setting the GN arg `use_jumbo_build=true`.
++
+ #### Disable NaCl
+ 
+ By default, the build includes support for
+diff --git a/docs/mac_build_instructions.md b/docs/mac_build_instructions.md
+index 57571c3cb..f76f1e517 100644
+--- a/docs/mac_build_instructions.md
++++ b/docs/mac_build_instructions.md
+@@ -154,6 +154,15 @@ in your args.gn to disable debug symbols altogether.  This makes both full
+ rebuilds and linking faster (at the cost of not getting symbolized backtraces
+ in gdb).
+ 
++#### Jumbo/Unity builds
++
++Jumbo builds merge many translation units ("source files") and compile them
++together. Since a large portion of Chromium's code is in shared header files,
++this dramatically reduces the total amount of work needed. Check out the
++[Jumbo / Unity builds](jumbo.md) for more information.
++
++Enable jumbo builds by setting the GN arg `use_jumbo_build=true`.
++
+ #### CCache
+ 
+ You might also want to [install ccache](ccache_mac.md) to speed up the build.
+diff --git a/docs/windows_build_instructions.md b/docs/windows_build_instructions.md
+index eb878ed16..bdc7e4d34 100644
+--- a/docs/windows_build_instructions.md
++++ b/docs/windows_build_instructions.md
+@@ -219,7 +219,7 @@ There are some gn flags that can improve build speeds. You can specify these
+ in the editor that appears when you create your output directory
+ (`gn args out/Default`) or on the gn gen command line
+ (`gn gen out/Default --args="is_component_build = true is_debug = true"`).
+-Some helpful settings to consider using include:
++* `use_jumbo_build = true` - [Jumbo/unity](jumbo.md) builds.
+ * `is_component_build = true` - this uses more, smaller DLLs, and may avoid
+ having to relink chrome.dll after every change.
+ * `enable_nacl = false` - this disables Native Client which is usually not
+diff --git a/extensions/BUILD.gn b/extensions/BUILD.gn
+index eb5b6dc41..b6f980bd2 100644
+--- a/extensions/BUILD.gn
++++ b/extensions/BUILD.gn
+@@ -3,6 +3,7 @@
+ 
+ import("//build/config/chromecast_build.gni")
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//extensions/buildflags/buildflags.gni")
+ import("//testing/test.gni")
+ import("//tools/grit/grit_rule.gni")
+@@ -74,7 +75,7 @@ grit("extensions_renderer_resources") {
+   ]
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "browser/api/declarative/test_rules_registry.cc",
+diff --git a/extensions/browser/BUILD.gn b/extensions/browser/BUILD.gn
+index 6e38824c9..128b78af9 100644
+--- a/extensions/browser/BUILD.gn
++++ b/extensions/browser/BUILD.gn
+@@ -4,6 +4,7 @@
+ 
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//extensions/buildflags/buildflags.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+ 
+@@ -68,7 +69,7 @@ source_set("core_keyed_service_factories") {
+ # nodes" and could be easily toggled on-and-off through dependencies for
+ # different platforms).
+ # See also https://crbug.com/883570.
+-source_set("browser_sources") {
++jumbo_source_set("browser_sources") {
+   visibility = [ "./*" ]
+ 
+   sources = [
+@@ -768,7 +769,7 @@ source_set("browser_tests") {
+ }
+ 
+ # The set of sources that are needed for both browser and unit tests.
+-source_set("test_support") {
++jumbo_source_set("test_support") {
+   testonly = true
+   sources = [
+     "api/declarative_net_request/test_utils.cc",
+diff --git a/extensions/common/BUILD.gn b/extensions/common/BUILD.gn
+index 31ad56f8e..97c23c3ae 100644
+--- a/extensions/common/BUILD.gn
++++ b/extensions/common/BUILD.gn
+@@ -4,6 +4,7 @@
+ 
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//components/nacl/features.gni")
+ import("//extensions/buildflags/buildflags.gni")
+ import("//mojo/public/tools/bindings/mojom.gni")
+@@ -197,7 +198,7 @@ mojom("mojom") {
+ # This must be a static library because extensions common depends on
+ # GetTrustedICAPublicKey in extensions/browser which isn't always linked
+ # in. TODO(brettw): This reverse dependency should be fixed.
+-static_library("common") {
++jumbo_static_library("common") {
+   sources = [
+     "activation_sequence.h",
+     "alias.h",
+diff --git a/extensions/renderer/BUILD.gn b/extensions/renderer/BUILD.gn
+index f473618f4..6cd5aec4f 100644
+--- a/extensions/renderer/BUILD.gn
++++ b/extensions/renderer/BUILD.gn
+@@ -3,11 +3,12 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//extensions/buildflags/buildflags.gni")
+ 
+ assert(enable_extensions)
+ 
+-source_set("renderer") {
++jumbo_source_set("renderer") {
+   sources = [
+     "activity_log_converter_strategy.cc",
+     "activity_log_converter_strategy.h",
+@@ -278,7 +279,7 @@ source_set("renderer") {
+   deps += [ "//components/crash/core/common:crash_key" ]
+ }
+ 
+-static_library("unit_test_support") {
++jumbo_static_library("unit_test_support") {
+   # Sources that are shared between chrome-based renderer unit tests and
+   # top-level extensions renderer unit tests.
+   testonly = true
+diff --git a/gpu/BUILD.gn b/gpu/BUILD.gn
+index dc5668200..6a50784a7 100644
+--- a/gpu/BUILD.gn
++++ b/gpu/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//gpu/vulkan/features.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+@@ -163,7 +164,7 @@ if (!use_static_angle) {
+   }
+ }  # if (!use_static_angle)
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "command_buffer/client/client_test_helper.cc",
+diff --git a/gpu/command_buffer/client/BUILD.gn b/gpu/command_buffer/client/BUILD.gn
+index e12714a4b..136df7d5c 100644
+--- a/gpu/command_buffer/client/BUILD.gn
++++ b/gpu/command_buffer/client/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//components/nacl/toolchain.gni")
+ import("//ui/gl/features.gni")
+ 
+@@ -49,7 +50,7 @@ group("webgpu") {
+   }
+ }
+ 
+-source_set("client_sources") {
++jumbo_source_set("client_sources") {
+   # External code should depend on this via //gpu/client above rather than
+   # depending on this directly or the component build will break.
+   visibility = [ "//gpu/*" ]
+@@ -223,7 +224,7 @@ source_set("webgpu_interface") {
+ }
+ 
+ # Library emulates GLES2 using command_buffers.
+-component("gles2_implementation") {
++jumbo_component("gles2_implementation") {
+   sources = gles2_implementation_source_files
+ 
+   defines = [ "GLES2_IMPL_IMPLEMENTATION" ]
+@@ -325,7 +326,7 @@ source_set("webgpu_sources") {
+ }
+ 
+ # Library emulates GLES2 using command_buffers.
+-component("gles2_implementation_no_check") {
++jumbo_component("gles2_implementation_no_check") {
+   sources = gles2_implementation_source_files
+ 
+   defines = [
+@@ -372,7 +373,7 @@ component("gles2_c_lib") {
+ 
+ # Same as gles2_c_lib except with no parameter checking. Required for
+ # OpenGL ES 2.0 conformance tests.
+-component("gles2_c_lib_nocheck") {
++jumbo_component("gles2_c_lib_nocheck") {
+   sources = gles2_c_lib_source_files
+ 
+   defines = [
+diff --git a/gpu/command_buffer/common/BUILD.gn b/gpu/command_buffer/common/BUILD.gn
+index 0bba94461..497dcf156 100644
+--- a/gpu/command_buffer/common/BUILD.gn
++++ b/gpu/command_buffer/common/BUILD.gn
+@@ -7,6 +7,7 @@
+ # non-component build. This needs to match the GYP build which was likely an
+ # attempt to make larger components to help with loading.
+ 
++import("//build/config/jumbo.gni")
+ import("//ui/gl/features.gni")
+ 
+ group("common") {
+@@ -47,7 +48,7 @@ group("webgpu") {
+ 
+ # Minimal set of definitions which don't have GPU dependencies outside of this
+ # directory.
+-source_set("common_base_sources") {
++jumbo_source_set("common_base_sources") {
+   visibility = [ "//gpu/*" ]
+   sources = [
+     "command_buffer_id.h",
+@@ -66,7 +67,7 @@ source_set("common_base_sources") {
+   configs += [ "//gpu:gpu_implementation" ]
+ }
+ 
+-source_set("common_sources") {
++jumbo_source_set("common_sources") {
+   visibility = [ "//gpu/*" ]
+ 
+   sources = [
+diff --git a/gpu/command_buffer/service/BUILD.gn b/gpu/command_buffer/service/BUILD.gn
+index 375215e6b..2e0a3176b 100644
+--- a/gpu/command_buffer/service/BUILD.gn
++++ b/gpu/command_buffer/service/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//gpu/vulkan/features.gni")
+ import("//skia/features.gni")
+@@ -26,9 +27,9 @@ group("gles2") {
+ }
+ 
+ if (is_component_build) {
+-  link_target_type = "source_set"
++  link_target_type = "jumbo_source_set"
+ } else {
+-  link_target_type = "static_library"
++  link_target_type = "jumbo_static_library"
+ }
+ target(link_target_type, "service_sources") {
+   # External code should depend on this via //gpu/command_buffer/service above
+@@ -593,7 +594,7 @@ proto_library("disk_cache_proto") {
+ }
+ 
+ if (is_android) {
+-  static_library("android_texture_owner_test_support") {
++  jumbo_static_library("android_texture_owner_test_support") {
+     testonly = true
+     sources = [
+       "mock_abstract_texture.cc",
+diff --git a/gpu/config/BUILD.gn b/gpu/config/BUILD.gn
+index d8ee27329..4f552bc9f 100644
+--- a/gpu/config/BUILD.gn
++++ b/gpu/config/BUILD.gn
+@@ -5,6 +5,7 @@
+ import("//build/config/chrome_build.gni")
+ import("//build/config/chromecast_build.gni")
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//gpu/vulkan/features.gni")
+ import("//skia/features.gni")
+@@ -113,7 +114,7 @@ if (enable_vulkan) {
+   }
+ }
+ 
+-source_set("config_sources") {
++jumbo_source_set("config_sources") {
+   # External code should depend on this via //gpu/config above rather than
+   # depending on this directly or the component build will break.
+   visibility = [ "//gpu/*" ]
+diff --git a/gpu/ipc/service/BUILD.gn b/gpu/ipc/service/BUILD.gn
+index e5bc3c86e..7b407ff11 100644
+--- a/gpu/ipc/service/BUILD.gn
++++ b/gpu/ipc/service/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//gpu/vulkan/features.gni")
+ import("//testing/test.gni")
+@@ -13,7 +14,7 @@ declare_args() {
+   subpixel_font_rendering_disabled = false
+ }
+ 
+-component("service") {
++jumbo_component("service") {
+   output_name = "gpu_ipc_service"
+   sources = [
+     "command_buffer_stub.cc",
+diff --git a/media/base/BUILD.gn b/media/base/BUILD.gn
+index 85aeba882..a4702a9d6 100644
+--- a/media/base/BUILD.gn
++++ b/media/base/BUILD.gn
+@@ -5,6 +5,7 @@
+ import("//build/config/android/config.gni")
+ import("//build/config/arm.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/linux/pkg_config.gni")
+ import("//build/config/ozone.gni")
+ import("//build/config/ui.gni")
+@@ -15,7 +16,7 @@ if (is_android) {
+   import("//build/config/android/rules.gni")
+ }
+ 
+-source_set("base") {
++jumbo_source_set("base") {
+   # Do not expand the visibility here without double-checking with OWNERS, this
+   # is a roll-up target which is part of the //media component. Most other DEPs
+   # should be using //media and not directly DEP this roll-up target.
+diff --git a/media/base/android/BUILD.gn b/media/base/android/BUILD.gn
+index b4b17de4b..8bba35a9c 100644
+--- a/media/base/android/BUILD.gn
++++ b/media/base/android/BUILD.gn
+@@ -4,6 +4,7 @@
+ 
+ import("//build/config/android/config.gni")
+ import("//build/config/arm.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//media/media_options.gni")
+ 
+@@ -13,7 +14,7 @@ if (is_android) {
+   # This is bundled into //media, so all dependencies should be on //media.
+   # APK targets that depend on this indirectly, should also
+   # depend on :media_java to get the corresponding Java classes.
+-  source_set("android") {
++  jumbo_source_set("android") {
+     visibility = [
+       "//media",
+       "//media/filters",
+diff --git a/media/base/ipc/BUILD.gn b/media/base/ipc/BUILD.gn
+index 621787352..98da4b475 100644
+--- a/media/base/ipc/BUILD.gn
++++ b/media/base/ipc/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-source_set("ipc") {
++import("//build/config/jumbo.gni")
++
++jumbo_source_set("ipc") {
+   sources = [
+     "media_param_traits.cc",
+     "media_param_traits.h",
+diff --git a/media/base/mac/BUILD.gn b/media/base/mac/BUILD.gn
+index 0c770ef02..5b860c92b 100644
+--- a/media/base/mac/BUILD.gn
++++ b/media/base/mac/BUILD.gn
+@@ -2,9 +2,11 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
++
+ assert(is_apple)
+ 
+-source_set("mac") {
++jumbo_source_set("mac") {
+   # Note: This source_set is depended on only by //media. In the component
+   # build, if other component targets also depend on it, multiple copies of
+   # the ObjC classes declared in the files below will cause warnings at
+diff --git a/media/base/win/BUILD.gn b/media/base/win/BUILD.gn
+index 297076823..dca1840aa 100644
+--- a/media/base/win/BUILD.gn
++++ b/media/base/win/BUILD.gn
+@@ -2,6 +2,8 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
++
+ assert(is_win)
+ 
+ config("delay_load_mf") {
+@@ -13,7 +15,7 @@ config("delay_load_mf") {
+   ]
+ }
+ 
+-component("media_foundation_util") {
++jumbo_component("media_foundation_util") {
+   defines = [ "IS_MF_UTIL_IMPL" ]
+   sources = [
+     "dxgi_device_manager.cc",
+diff --git a/media/capture/BUILD.gn b/media/capture/BUILD.gn
+index 3e6bfcbff..62127fe94 100644
+--- a/media/capture/BUILD.gn
++++ b/media/capture/BUILD.gn
+@@ -4,6 +4,7 @@
+ 
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//media/media_options.gni")
+ import("//testing/test.gni")
+@@ -29,7 +30,7 @@ component("capture_switches") {
+ }
+ 
+ # Things needed by //media/capture/mojom/video_capture_types.mojom.
+-component("capture_base") {
++jumbo_component("capture_base") {
+   defines = [ "CAPTURE_IMPLEMENTATION" ]
+   sources = [
+     "capture_export.h",
+@@ -52,7 +53,7 @@ component("capture_base") {
+ }
+ 
+ # Target which allows breakout of Android BUILD.gn files.
+-source_set("capture_device_specific") {
++jumbo_source_set("capture_device_specific") {
+   visibility = [
+     ":capture_lib",
+     "//media/capture/content/android",
+@@ -111,7 +112,7 @@ source_set("capture_device_specific") {
+   }
+ }
+ 
+-component("capture_lib") {
++jumbo_component("capture_lib") {
+   defines = [ "CAPTURE_IMPLEMENTATION" ]
+   sources = [
+     "video/create_video_capture_device_factory.cc",
+diff --git a/media/cast/BUILD.gn b/media/cast/BUILD.gn
+index 088b9dd60..832d4e571 100644
+--- a/media/cast/BUILD.gn
++++ b/media/cast/BUILD.gn
+@@ -5,6 +5,7 @@
+ import("//build/config/android/config.gni")
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+ import("//testing/test.gni")
+@@ -16,7 +17,7 @@ proto_library("logging_proto") {
+ }
+ 
+ # Common code shared by all cast components.
+-source_set("common") {
++jumbo_source_set("common") {
+   sources = [
+     "cast_callbacks.h",
+     "cast_config.cc",
+@@ -77,7 +78,7 @@ source_set("common") {
+   ]
+ }
+ 
+-source_set("net") {
++jumbo_source_set("net") {
+   sources = [
+     "net/cast_transport.h",
+     "net/cast_transport_config.cc",
+@@ -129,7 +130,7 @@ source_set("net") {
+   public_deps = [ ":common" ]
+ }
+ 
+-source_set("encoding") {
++jumbo_source_set("encoding") {
+   sources = [
+     "encoding/audio_encoder.cc",
+     "encoding/audio_encoder.h",
+@@ -193,7 +194,7 @@ source_set("encoding") {
+ 
+ # TODO(https://crbug.com/1327074): should be split into multiple source sets
+ # once the new Open Screen frame sender implementation is added.
+-source_set("sender") {
++jumbo_source_set("sender") {
+   sources = [
+     "cast_sender.h",
+     "cast_sender_impl.cc",
+@@ -231,7 +232,7 @@ source_set("sender") {
+   }
+ }
+ 
+-source_set("test_receiver") {
++jumbo_source_set("test_receiver") {
+   testonly = true
+   sources = [
+     "test/receiver/audio_decoder.cc",
+diff --git a/media/filters/BUILD.gn b/media/filters/BUILD.gn
+index 93c112499..c03caa985 100644
+--- a/media/filters/BUILD.gn
++++ b/media/filters/BUILD.gn
+@@ -2,10 +2,11 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//media/gpu/args.gni")
+ import("//media/media_options.gni")
+ 
+-source_set("filters") {
++jumbo_source_set("filters") {
+   # Do not expand the visibility here without double-checking with OWNERS, this
+   # is a roll-up target which is part of the //media component. Most other DEPs
+   # should be using //media and not directly DEP this roll-up target.
+diff --git a/media/media_options.gni b/media/media_options.gni
+index cda336a92..fa878c039 100644
+--- a/media/media_options.gni
++++ b/media/media_options.gni
+@@ -7,6 +7,7 @@ import("//build/config/chromecast_build.gni")
+ import("//build/config/chromeos/args.gni")
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//media/gpu/args.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+@@ -84,7 +85,7 @@ declare_args() {
+   # Enable logging override, e.g. enable DVLOGs through level 2 at build time.
+   # On Cast devices, these are logged as INFO.
+   # When enabled on Fuchsia, these are logged as VLOGs.
+-  enable_logging_override = is_cast_media_device
++  enable_logging_override = !use_jumbo_build && is_cast_media_device
+ 
+   enable_dav1d_decoder = !is_ios
+ 
+@@ -164,6 +165,9 @@ assert(
+     !enable_platform_dolby_vision || enable_platform_hevc,
+     "enable_platform_hevc required for enable_platform_dolby_vision")
+ 
++# Logging override must not be enabled in jumbo builds.
++assert(!use_jumbo_build || !enable_logging_override)
++
+ # Use another declare_args() to pick up possible overrides of |use_cras|.
+ declare_args() {
+   # Enables runtime selection of PulseAudio library.
+diff --git a/media/mojo/clients/BUILD.gn b/media/mojo/clients/BUILD.gn
+index 0c7eab9d1..3e7198e67 100644
+--- a/media/mojo/clients/BUILD.gn
++++ b/media/mojo/clients/BUILD.gn
+@@ -2,8 +2,10 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
++
+ # Implementations of media C++ interfaces using corresponding mojo services.
+-source_set("clients") {
++jumbo_source_set("clients") {
+   visibility = [
+     "//chromecast/*",
+ 
+diff --git a/media/mojo/common/BUILD.gn b/media/mojo/common/BUILD.gn
+index ae5303dc1..30141f142 100644
+--- a/media/mojo/common/BUILD.gn
++++ b/media/mojo/common/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-source_set("common") {
++import("//build/config/jumbo.gni")
++
++jumbo_source_set("common") {
+   sources = [
+     "audio_data_s16_converter.cc",
+     "audio_data_s16_converter.h",
+diff --git a/media/mojo/services/BUILD.gn b/media/mojo/services/BUILD.gn
+index b79cb992f..3a2a76481 100644
+--- a/media/mojo/services/BUILD.gn
++++ b/media/mojo/services/BUILD.gn
+@@ -4,6 +4,7 @@
+ 
+ import("//build/config/chromecast_build.gni")
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//media/gpu/args.gni")
+ import("//media/media_options.gni")
+ import("//mojo/public/tools/fuzzers/mojolpm.gni")
+@@ -12,7 +13,7 @@ import("//testing/test.gni")
+ enable_playback_events_recorder =
+     enable_cast_receiver && (is_fuchsia || is_android)
+ 
+-component("services") {
++jumbo_component("services") {
+   output_name = "media_mojo_services"
+   sources = [
+     "deferred_destroy_unique_receiver_set.h",
+diff --git a/mojo/public/tools/bindings/mojom.gni b/mojo/public/tools/bindings/mojom.gni
+index 496934eeb..6b29f9c12 100644
+--- a/mojo/public/tools/bindings/mojom.gni
++++ b/mojo/public/tools/bindings/mojom.gni
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//third_party/closure_compiler/closure_args.gni")
+ import("//third_party/closure_compiler/compile_js.gni")
+ import("//third_party/protobuf/proto_library.gni")
+@@ -946,7 +947,7 @@ template("mojom") {
+   }
+ 
+   shared_cpp_sources_target_name = "${target_name}_shared_cpp_sources"
+-  source_set(shared_cpp_sources_target_name) {
++  jumbo_source_set(shared_cpp_sources_target_name) {
+     if (defined(invoker.testonly)) {
+       testonly = invoker.testonly
+     }
+@@ -1566,7 +1567,7 @@ template("mojom") {
+       sources_target_name = output_target_name
+     }
+ 
+-    target(sources_target_type, sources_target_name) {
++    target("jumbo_" + sources_target_type, sources_target_name) {
+       if (defined(output_name_override)) {
+         output_name = output_name_override
+       }
+diff --git a/ppapi/cpp/BUILD.gn b/ppapi/cpp/BUILD.gn
+index c916c3a5c..0e03f92de 100644
+--- a/ppapi/cpp/BUILD.gn
++++ b/ppapi/cpp/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//ppapi/buildflags/buildflags.gni")
+ 
+ if (is_nacl) {
+@@ -13,7 +14,7 @@ assert(enable_ppapi)
+ if (is_nacl && is_nacl_glibc) {
+   cpp_target_type = "shared_library"
+ } else {
+-  cpp_target_type = "static_library"
++  cpp_target_type = "jumbo_static_library"
+ }
+ 
+ # Link to this target to get the PPAPI C++ wrapper objects and plugin startup
+@@ -54,7 +55,7 @@ target(cpp_target_type, "cpp") {
+ # Link to this target to get only the PPAPI C++ wrapper objects but not the
+ # plugin startup code. Some plugins need special startup code that they supply
+ # themselves.
+-source_set("objects") {
++jumbo_source_set("objects") {
+   sources = [
+     "array_output.cc",
+     "array_output.h",
+diff --git a/ppapi/host/BUILD.gn b/ppapi/host/BUILD.gn
+index 46c0f0159..acf4d9f46 100644
+--- a/ppapi/host/BUILD.gn
++++ b/ppapi/host/BUILD.gn
+@@ -2,11 +2,12 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//ppapi/buildflags/buildflags.gni")
+ 
+ assert(enable_ppapi)
+ 
+-component("host") {
++jumbo_component("host") {
+   output_name = "ppapi_host"
+ 
+   sources = [
+diff --git a/ppapi/proxy/BUILD.gn b/ppapi/proxy/BUILD.gn
+index 21cacd867..882449ba0 100644
+--- a/ppapi/proxy/BUILD.gn
++++ b/ppapi/proxy/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/nacl/config.gni")
+ import("//components/nacl/toolchain.gni")
+ import("//ppapi/buildflags/buildflags.gni")
+@@ -12,9 +13,15 @@ config("proxy_implementation") {
+   defines = [ "PPAPI_PROXY_IMPLEMENTATION" ]
+ }
+ 
+-component("proxy") {
++jumbo_component("proxy") {
+   output_name = "ppapi_proxy"
+ 
++  if (is_nacl) {
++    # The nacl toolchain has template related bugs that are triggered
++    # in jumbo builds. https://crbug.com/912152
++    never_build_jumbo = true
++  }
++
+   sources = [
+     # Take some standalone files from the C++ wrapper allowing us to more
+     # easily make async callbacks in the proxy. We can't depend on the
+@@ -327,7 +334,7 @@ source_set("ipc_sources") {
+   }
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+ 
+   sources = [
+diff --git a/ppapi/shared_impl/BUILD.gn b/ppapi/shared_impl/BUILD.gn
+index 3b5c21ab0..a202bb7a0 100644
+--- a/ppapi/shared_impl/BUILD.gn
++++ b/ppapi/shared_impl/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/nacl/config.gni")
+ import("//components/nacl/toolchain.gni")
+ import("//ppapi/buildflags/buildflags.gni")
+@@ -42,12 +43,18 @@ source_set("headers") {
+ }
+ 
+ # This contains the things that //ppapi/thunk needs.
+-source_set("common") {
++jumbo_source_set("common") {
+   visibility = [
+     ":*",
+     "//ppapi/thunk:*",
+   ]
+ 
++  if (is_nacl) {
++    # The nacl toolchain has template related bugs that are triggered
++    # in jumbo builds. https://crbug.com/912152
++    never_build_jumbo = true
++  }
++
+   sources = [
+     "array_var.cc",
+     "array_var.h",
+diff --git a/services/cert_verifier/cert_net_url_loader/BUILD.gn b/services/cert_verifier/cert_net_url_loader/BUILD.gn
+index ffc6bdc4a..28ab85355 100644
+--- a/services/cert_verifier/cert_net_url_loader/BUILD.gn
++++ b/services/cert_verifier/cert_net_url_loader/BUILD.gn
+@@ -2,10 +2,11 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//crypto/features.gni")
+ import("//testing/test.gni")
+ 
+-component("cert_net_url_loader") {
++jumbo_component("cert_net_url_loader") {
+   sources = [
+     "cert_net_fetcher_url_loader.cc",
+     "cert_net_fetcher_url_loader.h",
+diff --git a/services/network/BUILD.gn b/services/network/BUILD.gn
+index 5c4cfc609..20c632ec8 100644
+--- a/services/network/BUILD.gn
++++ b/services/network/BUILD.gn
+@@ -3,12 +3,13 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//mojo/public/tools/bindings/mojom.gni")
+ import("//net/features.gni")
+ import("//services/network/public/cpp/features.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+ 
+-component("network_service") {
++jumbo_component("network_service") {
+   sources = [
+     "brokered_client_socket_factory.cc",
+     "brokered_client_socket_factory.h",
+@@ -505,7 +506,7 @@ source_set("tests") {
+   }
+ }
+ 
+-source_set("test_support") {
++jumbo_source_set("test_support") {
+   testonly = true
+ 
+   sources = [
+diff --git a/services/network/public/cpp/BUILD.gn b/services/network/public/cpp/BUILD.gn
+index d23e85462..8d757bb4e 100644
+--- a/services/network/public/cpp/BUILD.gn
++++ b/services/network/public/cpp/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/buildflag_header.gni")
++import("//build/config/jumbo.gni")
+ import("//mojo/public/tools/bindings/mojom.gni")
+ import("//services/network/public/cpp/features.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+@@ -17,7 +18,7 @@ buildflag_header("buildflags") {
+   ]
+ }
+ 
+-component("crash_keys") {
++jumbo_component("crash_keys") {
+   sources = [
+     "crash_keys.cc",
+     "crash_keys.h",
+@@ -26,7 +27,7 @@ component("crash_keys") {
+   defines = [ "IS_NETWORK_CPP_CRASH_KEYS_IMPL" ]
+ }
+ 
+-component("cpp") {
++jumbo_component("cpp") {
+   output_name = "network_cpp"
+ 
+   sources = [
+@@ -310,7 +311,7 @@ component("schemeful_site_mojom_support") {
+ 
+ # This component is separate from cpp_base as it is a dependency of
+ # //services/network/public/mojom:cookies_mojom.
+-component("first_party_sets_mojom_support") {
++jumbo_component("first_party_sets_mojom_support") {
+   sources = [
+     "first_party_sets_mojom_traits.cc",
+     "first_party_sets_mojom_traits.h",
+@@ -324,7 +325,7 @@ component("first_party_sets_mojom_support") {
+   defines = [ "IS_FIRST_PARTY_SETS_MOJOM_TRAITS_IMPL" ]
+ }
+ 
+-component("cpp_base") {
++jumbo_component("cpp_base") {
+   output_name = "network_cpp_base"
+ 
+   sources = [
+diff --git a/storage/browser/BUILD.gn b/storage/browser/BUILD.gn
+index 5addf5624..e30e9df29 100644
+--- a/storage/browser/BUILD.gn
++++ b/storage/browser/BUILD.gn
+@@ -1,10 +1,11 @@
+ # Copyright 2014 The Chromium Authors
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
++import("//build/config/jumbo.gni")
+ import("//mojo/public/tools/bindings/mojom.gni")
+ import("//testing/test.gni")
+ 
+-component("browser") {
++jumbo_component("browser") {
+   output_name = "storage_browser"
+   sources = [
+     "blob/blob_builder_from_stream.cc",
+@@ -366,7 +367,7 @@ source_set("unittests") {
+   ]
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+ 
+   sources = [
+diff --git a/third_party/blink/common/BUILD.gn b/third_party/blink/common/BUILD.gn
+index 108b79fbc..f1921c283 100644
+--- a/third_party/blink/common/BUILD.gn
++++ b/third_party/blink/common/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+ import("//testing/test.gni")
+ import("//third_party/blink/renderer/build/scripts/scripts.gni")
+@@ -117,7 +118,7 @@ config("blink_common_implementation") {
+   defines = [ "BLINK_COMMON_IMPLEMENTATION=1" ]
+ }
+ 
+-source_set("common") {
++jumbo_source_set("common") {
+   # No target should directly depend on this target since this is just the
+   # source set rather than the actual component that can be linked to.
+   # Dependencies instead should be to //third_party/blink/public/common:common.
+@@ -365,7 +366,7 @@ test("blink_common_unittests") {
+   data_deps = [ ":common_unittests_data" ]
+ }
+ 
+-source_set("common_unittests_sources") {
++jumbo_source_set("common_unittests_sources") {
+   testonly = true
+ 
+   sources = [
+diff --git a/third_party/blink/renderer/bindings/core/v8/BUILD.gn b/third_party/blink/renderer/bindings/core/v8/BUILD.gn
+index 8ea091846..e5249c3f4 100644
+--- a/third_party/blink/renderer/bindings/core/v8/BUILD.gn
++++ b/third_party/blink/renderer/bindings/core/v8/BUILD.gn
+@@ -29,7 +29,7 @@ blink_core_sources("v8") {
+   ]
+ }
+ 
+-source_set("testing") {
++jumbo_source_set("testing") {
+   testonly = true
+ 
+   visibility = []
+@@ -61,8 +61,6 @@ group("generated") {
+     "//third_party/blink/renderer/core/*",
+   ]
+ 
+-  public_deps =
+-      [ "//third_party/blink/renderer/bindings:generate_bindings_all" ]
+ }
+ 
+ fuzzer_test("v8_serialized_script_value_fuzzer") {
+diff --git a/third_party/blink/renderer/bindings/modules/v8/BUILD.gn b/third_party/blink/renderer/bindings/modules/v8/BUILD.gn
+index 5f1951cde..472bdb77a 100644
+--- a/third_party/blink/renderer/bindings/modules/v8/BUILD.gn
++++ b/third_party/blink/renderer/bindings/modules/v8/BUILD.gn
+@@ -29,7 +29,7 @@ blink_modules_sources("v8") {
+   ]
+ }
+ 
+-source_set("testing") {
++jumbo_source_set("testing") {
+   testonly = true
+ 
+   visibility = []
+diff --git a/third_party/blink/renderer/controller/BUILD.gn b/third_party/blink/renderer/controller/BUILD.gn
+index 2cf3784f8..5d8e526ef 100644
+--- a/third_party/blink/renderer/controller/BUILD.gn
++++ b/third_party/blink/renderer/controller/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//testing/test.gni")
+ import("//third_party/blink/renderer/bindings/bindings.gni")
+@@ -14,7 +15,7 @@ visibility = [
+   "//third_party/blink/*",
+ ]
+ 
+-component("controller") {
++jumbo_component("controller") {
+   output_name = "blink_controller"
+ 
+   deps = [
+@@ -174,7 +175,7 @@ test("blink_perf_tests") {
+   deps = [ ":blink_perf_tests_sources" ]
+ }
+ 
+-source_set("blink_perf_tests_sources") {
++jumbo_source_set("blink_perf_tests_sources") {
+   visibility = []  # Allow re-assignment of list.
+   visibility = [ "*" ]
+   testonly = true
+@@ -219,7 +220,7 @@ source_set("blink_bindings_test_sources") {
+   ]
+ }
+ 
+-source_set("blink_unittests_sources") {
++jumbo_source_set("blink_unittests_sources") {
+   visibility = []  # Allow re-assignment of list.
+   visibility = [ "*" ]
+   testonly = true
+diff --git a/third_party/blink/renderer/core/BUILD.gn b/third_party/blink/renderer/core/BUILD.gn
+index fabf49654..e1234cafb 100644
+--- a/third_party/blink/renderer/core/BUILD.gn
++++ b/third_party/blink/renderer/core/BUILD.gn
+@@ -422,7 +422,7 @@ blink_core_sources("core_hot") {
+   }
+ }
+ 
+-source_set("testing") {
++jumbo_source_set("testing") {
+   testonly = true
+ 
+   configs += [
+@@ -1224,7 +1224,7 @@ if (is_component_build) {
+   core_generated_target_type = "static_library"
+ }
+ 
+-target(core_generated_target_type, "core_generated") {
++target("jumbo_" + core_generated_target_type, "core_generated") {
+   # Add all sources generated by the targets above.
+   sources = []
+   foreach(current, targets_generating_sources) {
+@@ -1317,7 +1317,7 @@ fuzzer_test("text_resource_decoder_fuzzer") {
+   ]
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+ 
+   # If you create a new subdirectory 'foo' that contains unit tests, list them in
+@@ -1480,7 +1480,7 @@ group("js_files_for_form_controls_web_tests") {
+   data_deps = [ ":form_controls_pickers_js" ]
+ }
+ 
+-source_set("perf_tests") {
++jumbo_source_set("perf_tests") {
+   testonly = true
+   sources = [
+     "css/style_perftest.cc",
+@@ -1505,7 +1505,7 @@ source_set("perf_tests") {
+   ]
+ }
+ 
+-source_set("unit_test_support") {
++jumbo_source_set("unit_test_support") {
+   testonly = true
+   sources = [
+     "frame/frame_test_helpers.cc",
+diff --git a/third_party/blink/renderer/core/core.gni b/third_party/blink/renderer/core/core.gni
+index 443e3ffba..046fb8e8a 100644
+--- a/third_party/blink/renderer/core/core.gni
++++ b/third_party/blink/renderer/core/core.gni
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chrome_build.gni")
++import("//build/config/jumbo.gni")
+ import("//third_party/blink/renderer/config.gni")
+ 
+ blink_core_output_dir = "$root_gen_dir/third_party/blink/renderer/core"
+@@ -54,9 +55,9 @@ core_config_add += blink_symbols_config
+ #      Normal meaning if defined. If undefined, defaults to everything in core.
+ template("blink_core_sources") {
+   if (is_component_build) {
+-    target_type = "source_set"
++    target_type = "jumbo_source_set"
+   } else {
+-    target_type = "static_library"
++    target_type = "jumbo_static_library"
+   }
+   target(target_type, target_name) {
+     # The visibility will get overridden by forward_variables_from below if the
+diff --git a/third_party/blink/renderer/core/inspector/BUILD.gn b/third_party/blink/renderer/core/inspector/BUILD.gn
+index 33e53526f..2946ef406 100644
+--- a/third_party/blink/renderer/core/inspector/BUILD.gn
++++ b/third_party/blink/renderer/core/inspector/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//third_party/blink/renderer/bindings/bindings.gni")
+ import("//third_party/blink/renderer/core/core.gni")
+ import("//third_party/inspector_protocol/inspector_protocol.gni")
+@@ -90,7 +91,7 @@ inspector_protocol_generate("protocol_sources") {
+ }
+ 
+ # Compiles the sources generated above.
+-source_set("generated") {
++jumbo_source_set("generated") {
+   sources = get_target_outputs(":protocol_sources")
+ 
+   configs -= core_config_remove
+diff --git a/third_party/blink/renderer/modules/BUILD.gn b/third_party/blink/renderer/modules/BUILD.gn
+index df8cc60b5..e4abf3d79 100644
+--- a/third_party/blink/renderer/modules/BUILD.gn
++++ b/third_party/blink/renderer/modules/BUILD.gn
+@@ -20,7 +20,7 @@ config("modules_implementation") {
+   defines = [ "BLINK_MODULES_IMPLEMENTATION=1" ]
+ }
+ 
+-component("modules") {
++jumbo_component("modules") {
+   output_name = "blink_modules"
+ 
+   visibility = []  # Allow re-assignment of list.
+@@ -204,7 +204,7 @@ component("modules") {
+   configs += blink_symbols_config
+ }
+ 
+-source_set("modules_testing") {
++jumbo_source_set("modules_testing") {
+   testonly = true
+ 
+   sources = [
+@@ -408,7 +408,7 @@ blink_modules_sources("modules_generated") {
+   }
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+ 
+   sources = [
+diff --git a/third_party/blink/renderer/modules/gamepad/BUILD.gn b/third_party/blink/renderer/modules/gamepad/BUILD.gn
+index fdc2eb785..921155f7a 100644
+--- a/third_party/blink/renderer/modules/gamepad/BUILD.gn
++++ b/third_party/blink/renderer/modules/gamepad/BUILD.gn
+@@ -37,7 +37,7 @@ blink_modules_sources("gamepad") {
+   ]
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+   sources = [ "gamepad_comparisons_test.cc" ]
+ 
+diff --git a/third_party/blink/renderer/modules/hid/BUILD.gn b/third_party/blink/renderer/modules/hid/BUILD.gn
+index df06706c3..2bec1cbfe 100644
+--- a/third_party/blink/renderer/modules/hid/BUILD.gn
++++ b/third_party/blink/renderer/modules/hid/BUILD.gn
+@@ -17,7 +17,7 @@ blink_modules_sources("hid") {
+   ]
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+   sources = [ "hid_device_test.cc" ]
+ 
+diff --git a/third_party/blink/renderer/modules/media/BUILD.gn b/third_party/blink/renderer/modules/media/BUILD.gn
+index 4f54fc2c3..52f80b8e7 100644
+--- a/third_party/blink/renderer/modules/media/BUILD.gn
++++ b/third_party/blink/renderer/modules/media/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//third_party/blink/renderer/modules/modules.gni")
+ 
+ blink_modules_sources("media") {
+diff --git a/third_party/blink/renderer/modules/mediastream/BUILD.gn b/third_party/blink/renderer/modules/mediastream/BUILD.gn
+index 398597446..8ce74e0a7 100644
+--- a/third_party/blink/renderer/modules/mediastream/BUILD.gn
++++ b/third_party/blink/renderer/modules/mediastream/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//third_party/blink/renderer/modules/modules.gni")
+ 
+ blink_modules_sources("mediastream") {
+@@ -129,7 +130,7 @@ blink_modules_sources("mediastream") {
+   public_deps = [ "//media/capture:capture_lib" ]
+ }
+ 
+-source_set("test_support") {
++jumbo_source_set("test_support") {
+   testonly = true
+ 
+   sources = [
+diff --git a/third_party/blink/renderer/modules/modules.gni b/third_party/blink/renderer/modules/modules.gni
+index 5b252edfd..6f9aae8dd 100644
+--- a/third_party/blink/renderer/modules/modules.gni
++++ b/third_party/blink/renderer/modules/modules.gni
+@@ -7,6 +7,7 @@
+ # This file is shared with all modules' BUILD files which shouldn't need access
+ # to the huge and slow lists of sources. If sharing is necessary, make a
+ # separate .gni.
++import("//build/config/jumbo.gni")
+ import("//third_party/blink/renderer/config.gni")
+ blink_modules_output_dir = "$root_gen_dir/third_party/blink/renderer/modules"
+ 
+@@ -25,7 +26,7 @@ template("blink_modules_sources") {
+     target_type = "static_library"
+   }
+ 
+-  target(target_type, target_name) {
++  target("jumbo_" + target_type, target_name) {
+     # The visibility will get overridden by forward_variables_from below if the
+     # invoker defined it.
+     visibility = [ "//third_party/blink/renderer/modules/*" ]
+diff --git a/third_party/blink/renderer/modules/peerconnection/BUILD.gn b/third_party/blink/renderer/modules/peerconnection/BUILD.gn
+index 31a6b976c..a3434145e 100644
+--- a/third_party/blink/renderer/modules/peerconnection/BUILD.gn
++++ b/third_party/blink/renderer/modules/peerconnection/BUILD.gn
+@@ -175,7 +175,7 @@ blink_modules_sources("peerconnection") {
+       [ "//third_party/blink/renderer/modules/mediastream" ]
+ }
+ 
+-source_set("test_support") {
++jumbo_source_set("test_support") {
+   testonly = true
+ 
+   sources = [
+diff --git a/third_party/blink/renderer/modules/storage/BUILD.gn b/third_party/blink/renderer/modules/storage/BUILD.gn
+index def668aa1..056722af5 100644
+--- a/third_party/blink/renderer/modules/storage/BUILD.gn
++++ b/third_party/blink/renderer/modules/storage/BUILD.gn
+@@ -27,7 +27,7 @@ blink_modules_sources("storage") {
+   ]
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+   sources = [
+     "cached_storage_area_test.cc",
+diff --git a/third_party/blink/renderer/modules/webrtc/BUILD.gn b/third_party/blink/renderer/modules/webrtc/BUILD.gn
+index f06918f31..e87c5354b 100644
+--- a/third_party/blink/renderer/modules/webrtc/BUILD.gn
++++ b/third_party/blink/renderer/modules/webrtc/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//third_party/blink/renderer/modules/modules.gni")
+ 
+ blink_modules_sources("webrtc") {
+diff --git a/third_party/blink/renderer/modules/webtransport/BUILD.gn b/third_party/blink/renderer/modules/webtransport/BUILD.gn
+index e5865de82..70e678bee 100644
+--- a/third_party/blink/renderer/modules/webtransport/BUILD.gn
++++ b/third_party/blink/renderer/modules/webtransport/BUILD.gn
+@@ -25,7 +25,7 @@ blink_modules_sources("webtransport") {
+   ]
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+   sources = [
+     "bidirectional_stream_test.cc",
+diff --git a/third_party/blink/renderer/platform/BUILD.gn b/third_party/blink/renderer/platform/BUILD.gn
+index f4559b5ee..415d024f2 100644
+--- a/third_party/blink/renderer/platform/BUILD.gn
++++ b/third_party/blink/renderer/platform/BUILD.gn
+@@ -7,6 +7,7 @@ import("//build/buildflag_header.gni")
+ import("//build/compiled_action.gni")
+ import("//build/config/compiler/compiler.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//build/nocompile.gni")
+ import("//media/media_options.gni")
+@@ -278,7 +279,7 @@ source_set("allow_discouraged_type") {
+   visibility = [ "//third_party/blink/renderer/platform/*" ]
+ }
+ 
+-component("platform") {
++jumbo_component("platform") {
+   visibility = []  # Allow re-assignment of list.
+   visibility = [
+     "//third_party/blink/*",
+@@ -1847,7 +1848,7 @@ component("platform") {
+   configs += blink_symbols_config
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   visibility += [
+     "//third_party/blink/*",
+     "//tools/privacy_budget/font_indexer:*",
+@@ -2002,7 +2003,7 @@ test("blink_platform_unittests") {
+   }
+ }
+ 
+-source_set("blink_platform_unittests_sources") {
++jumbo_source_set("blink_platform_unittests_sources") {
+   visibility = []  # Allow re-assignment of list.
+   visibility = [ "*" ]
+   testonly = true
+@@ -2455,7 +2456,7 @@ test("blink_fuzzer_unittests") {
+ 
+ # This source set is used for fuzzers that need an environment similar to unit
+ # tests.
+-source_set("blink_fuzzer_test_support") {
++jumbo_source_set("blink_fuzzer_test_support") {
+   testonly = true
+   visibility = []  # Allow re-assignment of list.
+   visibility = [ "*" ]
+@@ -2637,7 +2638,7 @@ blink_text_codec_fuzzer("WINDOWS_1252") {
+ # NOTE: These are legacy unit tests and tests that require a Platform
+ # object. Do not add more unless the test requires a Platform object.
+ # These tests are a part of the blink_unittests binary.
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+   visibility = []
+   visibility = [ "//third_party/blink/renderer/*" ]
+diff --git a/third_party/blink/renderer/platform/blob/BUILD.gn b/third_party/blink/renderer/platform/blob/BUILD.gn
+index 280ba683b..471c4bf9f 100644
+--- a/third_party/blink/renderer/platform/blob/BUILD.gn
++++ b/third_party/blink/renderer/platform/blob/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//third_party/blink/renderer/platform/platform.gni")
+ 
+ # Intentionally depends on generator targets so to depend only on generated
+@@ -10,7 +11,7 @@ import("//third_party/blink/renderer/platform/platform.gni")
+ # There is no tool to detect missing indirect generated header dependency today
+ # and this is easy to be broken when mojom files are updated to depend on
+ # another.
+-source_set("generator") {
++jumbo_source_set("generator") {
+   public_deps = [
+     "//third_party/blink/public/mojom:mojom_platform_blink_headers",
+     "//url/mojom:url_mojom_gurl_blink_headers",
+@@ -39,7 +40,7 @@ blink_platform_sources("blob") {
+   ]
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   visibility = [ "//third_party/blink/renderer/platform:*" ]
+   testonly = true
+ 
+@@ -60,7 +61,7 @@ source_set("unit_tests") {
+   ]
+ }
+ 
+-source_set("test_support") {
++jumbo_source_set("test_support") {
+   # This target defines test files for platform:test_support that
+   # blink_platform_unittests and blink_unittests can use.
+   visibility = [ "//third_party/blink/renderer/platform:test_support" ]
+diff --git a/third_party/blink/renderer/platform/heap/BUILD.gn b/third_party/blink/renderer/platform/heap/BUILD.gn
+index ae0183e9d..dec9d08d2 100644
+--- a/third_party/blink/renderer/platform/heap/BUILD.gn
++++ b/third_party/blink/renderer/platform/heap/BUILD.gn
+@@ -4,6 +4,7 @@
+ 
+ import("//build/buildflag_header.gni")
+ import("//build/config/compiler/compiler.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/sanitizers/sanitizers.gni")
+ import("//testing/test.gni")
+ import("//third_party/blink/public/public_features.gni")
+@@ -86,7 +87,7 @@ blink_platform_sources("heap") {
+   ]
+ }
+ 
+-source_set("test_support") {
++jumbo_source_set("test_support") {
+   testonly = true
+ 
+   sources = [
+@@ -136,7 +137,7 @@ test("blink_heap_unittests") {
+   }
+ }
+ 
+-source_set("blink_heap_unittests_sources") {
++jumbo_source_set("blink_heap_unittests_sources") {
+   testonly = true
+ 
+   sources = [
+diff --git a/third_party/blink/renderer/platform/instrumentation/BUILD.gn b/third_party/blink/renderer/platform/instrumentation/BUILD.gn
+index 9a9b63602..ef64a8332 100644
+--- a/third_party/blink/renderer/platform/instrumentation/BUILD.gn
++++ b/third_party/blink/renderer/platform/instrumentation/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//third_party/blink/renderer/platform/platform.gni")
+ 
+ blink_platform_sources("instrumentation") {
+@@ -43,7 +44,7 @@ blink_platform_sources("instrumentation") {
+   allow_circular_includes_from = public_deps
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+ 
+   sources = [
+diff --git a/third_party/blink/renderer/platform/loader/BUILD.gn b/third_party/blink/renderer/platform/loader/BUILD.gn
+index 1e0d9ed68..bfeb9be0f 100644
+--- a/third_party/blink/renderer/platform/loader/BUILD.gn
++++ b/third_party/blink/renderer/platform/loader/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//third_party/blink/renderer/build/scripts/scripts.gni")
+ import("//third_party/blink/renderer/platform/platform.gni")
+ import("//third_party/blink/renderer/platform/platform_generated.gni")
+@@ -194,7 +195,7 @@ blink_platform_sources("loader") {
+       [ "//third_party/blink/renderer/platform/network:network" ]
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   # This target defines test files for blink_platform_unittests and only the
+   # blink_platform_unittests target should depend on it.
+   visibility = [ "//third_party/blink/renderer/platform:*" ]
+@@ -251,7 +252,7 @@ source_set("unit_tests") {
+   ]
+ }
+ 
+-source_set("test_support") {
++jumbo_source_set("test_support") {
+   # This target defines test files for platform:test_support that
+   # blink_platform_unittests and blink_unittests can use.
+   visibility = [ "//third_party/blink/renderer/platform:test_support" ]
+diff --git a/third_party/blink/renderer/platform/network/BUILD.gn b/third_party/blink/renderer/platform/network/BUILD.gn
+index 9ea9032d8..cdaa4017c 100644
+--- a/third_party/blink/renderer/platform/network/BUILD.gn
++++ b/third_party/blink/renderer/platform/network/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//third_party/blink/renderer/build/scripts/scripts.gni")
+ import("//third_party/blink/renderer/platform/platform.gni")
+ import("//third_party/blink/renderer/platform/platform_generated.gni")
+@@ -73,7 +74,7 @@ blink_platform_sources("network") {
+   ]
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   visibility = [ "//third_party/blink/renderer/platform:*" ]
+   testonly = true
+ 
+@@ -101,7 +102,7 @@ source_set("unit_tests") {
+   public_deps = [ "//third_party/blink/renderer/platform:platform" ]
+ }
+ 
+-source_set("test_support") {
++jumbo_source_set("test_support") {
+   visibility = [ "//third_party/blink/renderer/platform:test_support" ]
+   testonly = true
+ 
+diff --git a/third_party/blink/renderer/platform/platform.gni b/third_party/blink/renderer/platform/platform.gni
+index aa98a0432..972945ff5 100644
+--- a/third_party/blink/renderer/platform/platform.gni
++++ b/third_party/blink/renderer/platform/platform.gni
+@@ -2,6 +2,8 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
++
+ platform_config_add = [
+   "//build/config/compiler:wexit_time_destructors",
+   "//third_party/blink/renderer:config",
+@@ -14,7 +16,7 @@ platform_config_add = [
+ platform_config_remove = []
+ 
+ template("blink_platform_sources") {
+-  source_set(target_name) {
++  jumbo_source_set(target_name) {
+     # Only platform can directly depend on this.
+     # Any target outside platform should instead depend on platform.
+     visibility = [ "//third_party/blink/renderer/platform/*" ]
+diff --git a/third_party/blink/renderer/platform/scheduler/BUILD.gn b/third_party/blink/renderer/platform/scheduler/BUILD.gn
+index 24b34e4e6..01dffab03 100644
+--- a/third_party/blink/renderer/platform/scheduler/BUILD.gn
++++ b/third_party/blink/renderer/platform/scheduler/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+ import("//third_party/blink/renderer/platform/platform.gni")
+ import("//third_party/protobuf/proto_library.gni")
+@@ -199,7 +200,7 @@ blink_platform_sources("scheduler") {
+   ]
+ }
+ 
+-source_set("test_support") {
++jumbo_source_set("test_support") {
+   testonly = true
+ 
+   sources = [
+@@ -230,7 +231,7 @@ source_set("test_support") {
+   configs += [ "//third_party/blink/renderer/platform:blink_platform_config" ]
+ }
+ 
+-source_set("unit_tests") {
++jumbo_source_set("unit_tests") {
+   testonly = true
+ 
+   sources = [
+@@ -282,7 +283,7 @@ source_set("unit_tests") {
+   configs += [ "//third_party/blink/renderer/platform:blink_platform_config" ]
+ }
+ 
+-source_set("scheduler_fuzzer_tests") {
++jumbo_source_set("scheduler_fuzzer_tests") {
+   testonly = true
+ 
+   sources = []
+diff --git a/third_party/blink/renderer/platform/wtf/BUILD.gn b/third_party/blink/renderer/platform/wtf/BUILD.gn
+index 99b403ace..33da51102 100644
+--- a/third_party/blink/renderer/platform/wtf/BUILD.gn
++++ b/third_party/blink/renderer/platform/wtf/BUILD.gn
+@@ -6,6 +6,7 @@ assert(!is_ios)
+ 
+ import("//build/buildflag_header.gni")
+ import("//build/config/compiler/compiler.gni")
++import("//build/config/jumbo.gni")
+ import("//testing/test.gni")
+ import("//third_party/blink/public/public_features.gni")
+ import("//third_party/blink/renderer/config.gni")
+@@ -35,7 +36,7 @@ config("wtf_config") {
+   }
+ }
+ 
+-component("wtf") {
++jumbo_component("wtf") {
+   output_name = "blink_platform_wtf"
+ 
+   sources = [
+@@ -284,7 +285,7 @@ test("wtf_unittests") {
+   deps = [ ":wtf_unittests_sources" ]
+ }
+ 
+-source_set("wtf_unittests_sources") {
++jumbo_source_set("wtf_unittests_sources") {
+   visibility = []  # Allow re-assignment of list.
+   visibility = [ "*" ]
+   testonly = true
+diff --git a/third_party/inspector_protocol/BUILD.gn b/third_party/inspector_protocol/BUILD.gn
+index 646e0cf92..6131bb250 100644
+--- a/third_party/inspector_protocol/BUILD.gn
++++ b/third_party/inspector_protocol/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-component("crdtp") {
++import("//build/config/jumbo.gni")
++
++jumbo_component("crdtp") {
+   sources = [
+     "crdtp/cbor.cc",
+     "crdtp/cbor.h",
+diff --git a/ui/accessibility/BUILD.gn b/ui/accessibility/BUILD.gn
+index 71d3b5922..6babc4c33 100644
+--- a/ui/accessibility/BUILD.gn
++++ b/ui/accessibility/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/linux/pkg_config.gni")
+ import("//build/config/ui.gni")
+ import("//extensions/buildflags/buildflags.gni")
+@@ -36,7 +37,7 @@ mojom_component("ax_enums_mojo") {
+ # included by Blink. The rule of thumb (for now) is that it's
+ # anything platform-neutral (no platform/ directory) that
+ # relates to a single accessibility node (no trees, etc.).
+-component("ax_base") {
++jumbo_component("ax_base") {
+   defines = [ "AX_BASE_IMPLEMENTATION" ]
+ 
+   sources = [
+@@ -124,7 +125,7 @@ group("accessibility") {
+   ]
+ }
+ 
+-component("accessibility_internal") {
++jumbo_component("accessibility_internal") {
+   defines = [ "AX_IMPLEMENTATION" ]
+ 
+   sources = [
+diff --git a/ui/accessibility/platform/BUILD.gn b/ui/accessibility/platform/BUILD.gn
+index 3bec9f0f7..32b684df0 100644
+--- a/ui/accessibility/platform/BUILD.gn
++++ b/ui/accessibility/platform/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/linux/pkg_config.gni")
+ import("//build/config/ui.gni")
+ import("//extensions/buildflags/buildflags.gni")
+diff --git a/ui/aura/BUILD.gn b/ui/aura/BUILD.gn
+index 1beb9003b..a3ce2932f 100644
+--- a/ui/aura/BUILD.gn
++++ b/ui/aura/BUILD.gn
+@@ -2,10 +2,11 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//testing/test.gni")
+ 
+-component("aura") {
++jumbo_component("aura") {
+   public = [
+     "client/aura_constants.h",
+     "client/capture_client.h",
+@@ -178,7 +179,7 @@ component("aura") {
+   }
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "test/aura_test_base.cc",
+diff --git a/ui/base/BUILD.gn b/ui/base/BUILD.gn
+index acd063852..b2e7e5a28 100644
+--- a/ui/base/BUILD.gn
++++ b/ui/base/BUILD.gn
+@@ -6,6 +6,7 @@ import("//build/buildflag_header.gni")
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/compiler/compiler.gni")
+ import("//build/config/dcheck_always_on.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/linux/gtk/gtk.gni")
+ import("//build/config/linux/pangocairo/pangocairo.gni")
+ import("//build/config/locales.gni")
+@@ -105,7 +106,7 @@ source_set("types") {
+   deps = [ "//build:chromeos_buildflags" ]
+ }
+ 
+-component("base") {
++jumbo_component("base") {
+   output_name = "ui_base"
+ 
+   sources = [
+@@ -691,7 +692,7 @@ component("features") {
+ }
+ 
+ if (is_win || is_mac || is_linux || is_chromeos) {
+-  static_library("pixel_diff_test_support") {
++  jumbo_static_library("pixel_diff_test_support") {
+     testonly = true
+     sources = [
+       "test/skia_gold_matching_algorithm.cc",
+@@ -734,7 +735,7 @@ if (!is_ios) {
+   }
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "interaction/element_test_util.cc",
+diff --git a/ui/base/clipboard/BUILD.gn b/ui/base/clipboard/BUILD.gn
+index e6348b486..56d58ceb5 100644
+--- a/ui/base/clipboard/BUILD.gn
++++ b/ui/base/clipboard/BUILD.gn
+@@ -4,10 +4,11 @@
+ 
+ import("///build/config/ozone.gni")
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+ 
+-component("clipboard_types") {
++jumbo_component("clipboard_types") {
+   output_name = "ui_base_clipboard_types"
+   sources = [
+     "clipboard_buffer.h",
+@@ -70,7 +71,7 @@ component("file_info") {
+ 
+ # This is a source set because it needs to be included only on the Mac for the
+ # final executable, but needs to be included on any platform for the fuzzer.
+-source_set("url_file_parser") {
++jumbo_source_set("url_file_parser") {
+   sources = [
+     "url_file_parser.cc",
+     "url_file_parser.h",
+@@ -79,7 +80,7 @@ source_set("url_file_parser") {
+   deps = [ "//base" ]
+ }
+ 
+-component("clipboard") {
++jumbo_component("clipboard") {
+   output_name = "ui_base_clipboard"
+ 
+   sources = [
+@@ -176,7 +177,7 @@ component("clipboard") {
+   }
+ }
+ 
+-source_set("clipboard_test_support") {
++jumbo_source_set("clipboard_test_support") {
+   testonly = true
+ 
+   if (!is_ios) {
+diff --git a/ui/base/ime/BUILD.gn b/ui/base/ime/BUILD.gn
+index 649e7175d..abc6e71db 100644
+--- a/ui/base/ime/BUILD.gn
++++ b/ui/base/ime/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ 
+ source_set("text_input_types") {
+@@ -14,7 +15,7 @@ source_set("text_input_types") {
+   ]
+ }
+ 
+-component("ime_types") {
++jumbo_component("ime_types") {
+   output_name = "ui_base_ime_types"
+   sources = [
+     "candidate_window.cc",
+@@ -54,7 +55,7 @@ component("ime_types") {
+   }
+ }
+ 
+-component("ime") {
++jumbo_component("ime") {
+   output_name = "ui_base_ime"
+   sources = [
+     "constants.cc",
+diff --git a/ui/base/ime/ash/BUILD.gn b/ui/base/ime/ash/BUILD.gn
+index 58b747a73..af220adb0 100644
+--- a/ui/base/ime/ash/BUILD.gn
++++ b/ui/base/ime/ash/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/chromeos/ui_mode.gni")
+ 
+ assert(is_chromeos_ash)
+@@ -22,7 +23,7 @@ source_set("typing_session_manager") {
+   ]
+ }
+ 
+-component("ash") {
++jumbo_component("ash") {
+   output_name = "ui_base_ime_ash"
+ 
+   sources = [
+diff --git a/ui/base/ime/fuchsia/BUILD.gn b/ui/base/ime/fuchsia/BUILD.gn
+index 4ceaf0be6..df2a01a78 100644
+--- a/ui/base/ime/fuchsia/BUILD.gn
++++ b/ui/base/ime/fuchsia/BUILD.gn
+@@ -2,9 +2,11 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
++
+ assert(is_fuchsia)
+ 
+-component("fuchsia") {
++jumbo_component("fuchsia") {
+   output_name = "ui_base_ime_fuchsia"
+ 
+   sources = [
+diff --git a/ui/base/ime/init/BUILD.gn b/ui/base/ime/init/BUILD.gn
+index 1ff77334f..9a56d96eb 100644
+--- a/ui/base/ime/init/BUILD.gn
++++ b/ui/base/ime/init/BUILD.gn
+@@ -3,9 +3,10 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ 
+-component("init") {
++jumbo_component("init") {
+   output_name = "ui_base_ime_init"
+ 
+   sources = [
+diff --git a/ui/base/ime/linux/BUILD.gn b/ui/base/ime/linux/BUILD.gn
+index ec20ec866..e9f1a18f9 100644
+--- a/ui/base/ime/linux/BUILD.gn
++++ b/ui/base/ime/linux/BUILD.gn
+@@ -2,12 +2,13 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/linux/pangocairo/pangocairo.gni")
+ 
+ assert(is_linux || is_chromeos_lacros)
+ 
+-component("linux") {
++jumbo_component("linux") {
+   output_name = "ui_base_ime_linux"
+   sources = [
+     "fake_input_method_context.cc",
+diff --git a/ui/base/ime/mac/BUILD.gn b/ui/base/ime/mac/BUILD.gn
+index fc5cb85b0..8e50ead62 100644
+--- a/ui/base/ime/mac/BUILD.gn
++++ b/ui/base/ime/mac/BUILD.gn
+@@ -2,9 +2,11 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
++
+ assert(is_mac)
+ 
+-component("mac") {
++jumbo_component("mac") {
+   output_name = "ui_base_ime_mac"
+ 
+   sources = [
+diff --git a/ui/base/ime/win/BUILD.gn b/ui/base/ime/win/BUILD.gn
+index 1a2a40db4..67ff94a8c 100644
+--- a/ui/base/ime/win/BUILD.gn
++++ b/ui/base/ime/win/BUILD.gn
+@@ -2,9 +2,11 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
++
+ assert(is_win)
+ 
+-component("win") {
++jumbo_component("win") {
+   output_name = "ui_base_ime_win"
+   sources = [
+     "imm32_manager.cc",
+diff --git a/ui/base/prediction/BUILD.gn b/ui/base/prediction/BUILD.gn
+index 2e653b3df..dae307013 100644
+--- a/ui/base/prediction/BUILD.gn
++++ b/ui/base/prediction/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-component("prediction") {
++import("//build/config/jumbo.gni")
++
++jumbo_component("prediction") {
+   sources = [
+     "empty_filter.cc",
+     "empty_filter.h",
+diff --git a/ui/base/x/BUILD.gn b/ui/base/x/BUILD.gn
+index 67a3aae27..70b57c65c 100644
+--- a/ui/base/x/BUILD.gn
++++ b/ui/base/x/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/linux/gtk/gtk.gni")
+ import("//build/config/ozone.gni")
+ import("//build/config/ui.gni")
+@@ -9,7 +10,7 @@ import("//testing/libfuzzer/fuzzer_test.gni")
+ 
+ assert(ozone_platform_x11)
+ 
+-component("x") {
++jumbo_component("x") {
+   output_name = "ui_base_x"
+ 
+   sources = [
+diff --git a/ui/color/BUILD.gn b/ui/color/BUILD.gn
+index 3a9623e34..1179f2721 100644
+--- a/ui/color/BUILD.gn
++++ b/ui/color/BUILD.gn
+@@ -4,11 +4,12 @@
+ 
+ import("//build/buildflag_header.gni")
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//mojo/public/tools/bindings/mojom.gni")
+ import("//testing/test.gni")
+ import("//ui/base/ui_features.gni")
+ 
+-source_set("color_headers") {
++jumbo_source_set("color_headers") {
+   sources = [
+     "color_id.h",
+     "color_id_macros.inc",
+@@ -29,7 +30,7 @@ source_set("color_headers") {
+   ]
+ }
+ 
+-component("color") {
++jumbo_component("color") {
+   sources = [
+     "color_metrics.cc",
+     "color_mixer.cc",
+@@ -122,7 +123,7 @@ if (is_win) {
+   }
+ }
+ 
+-component("mixers") {
++jumbo_component("mixers") {
+   sources = [
+     "color_mixers.cc",
+     "color_mixers.h",
+diff --git a/ui/compositor/BUILD.gn b/ui/compositor/BUILD.gn
+index c0fbef6ec..2bba3fb1e 100644
+--- a/ui/compositor/BUILD.gn
++++ b/ui/compositor/BUILD.gn
+@@ -2,10 +2,11 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//testing/test.gni")
+ 
+-component("compositor") {
++jumbo_component("compositor") {
+   sources = [
+     "animation_throughput_reporter.cc",
+     "animation_throughput_reporter.h",
+@@ -121,7 +122,7 @@ component("compositor") {
+   }
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "test/animation_throughput_reporter_test_base.cc",
+diff --git a/ui/display/BUILD.gn b/ui/display/BUILD.gn
+index aadf9f2a5..6a65be75f 100644
+--- a/ui/display/BUILD.gn
++++ b/ui/display/BUILD.gn
+@@ -3,10 +3,11 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//testing/test.gni")
+ 
+-component("display") {
++jumbo_component("display") {
+   sources = [
+     "display.cc",
+     "display.h",
+@@ -150,7 +151,7 @@ if (is_chromeos_ash) {
+   }
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "test/display_matchers.cc",
+diff --git a/ui/display/fake/BUILD.gn b/ui/display/fake/BUILD.gn
+index 64d377764..0a8843468 100644
+--- a/ui/display/fake/BUILD.gn
++++ b/ui/display/fake/BUILD.gn
+@@ -2,11 +2,12 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ 
+ # This target contains dummy or fake classes that can be used as
+ # placeholders when lacking something better, or for testing.
+-component("fake") {
++jumbo_component("fake") {
+   sources = [
+     "fake_display_delegate.cc",
+     "fake_display_delegate.h",
+diff --git a/ui/display/manager/BUILD.gn b/ui/display/manager/BUILD.gn
+index 257d9a20b..9281589b7 100644
+--- a/ui/display/manager/BUILD.gn
++++ b/ui/display/manager/BUILD.gn
+@@ -3,11 +3,12 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ 
+ assert(is_chromeos_ash || is_castos || is_cast_android)
+ 
+-component("manager") {
++jumbo_component("manager") {
+   sources = [
+     "display_manager_export.h",
+     "display_manager_util.cc",
+diff --git a/ui/display/types/BUILD.gn b/ui/display/types/BUILD.gn
+index d148b0949..b1cb48ffc 100644
+--- a/ui/display/types/BUILD.gn
++++ b/ui/display/types/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-component("types") {
++import("//build/config/jumbo.gni")
++
++jumbo_component("types") {
+   output_name = "display_types"
+   sources = [
+     "display_configuration_params.cc",
+diff --git a/ui/display/util/BUILD.gn b/ui/display/util/BUILD.gn
+index 33731b1cc..64df64c32 100644
+--- a/ui/display/util/BUILD.gn
++++ b/ui/display/util/BUILD.gn
+@@ -3,10 +3,11 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+ 
+-component("util") {
++jumbo_component("util") {
+   output_name = "display_util"
+   sources = [
+     "display_util.cc",
+diff --git a/ui/events/BUILD.gn b/ui/events/BUILD.gn
+index 3862f66a2..5de7dd52e 100644
+--- a/ui/events/BUILD.gn
++++ b/ui/events/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ozone.gni")
+ import("//build/config/ui.gni")
+ import("//testing/test.gni")
+@@ -16,7 +17,7 @@ if (is_ios) {
+   import("//ios/build/config.gni")
+ }
+ 
+-static_library("dom_keycode_converter") {
++jumbo_static_library("dom_keycode_converter") {
+   public = [
+     "keycodes/dom/dom_code.h",
+     "keycodes/dom/dom_codes_array.h",
+@@ -94,7 +95,7 @@ source_set("platform_event") {
+   public_deps = [ "//base" ]
+ }
+ 
+-component("events_base") {
++jumbo_component("events_base") {
+   sources = [
+     "base_event_utils.cc",
+     "base_event_utils.h",
+@@ -192,7 +193,7 @@ component("events_base") {
+   }
+ }
+ 
+-component("events") {
++jumbo_component("events") {
+   public = [
+     "cocoa/cocoa_event_utils.h",
+     "event.h",
+@@ -380,7 +381,7 @@ component("events") {
+   }
+ }
+ 
+-component("keyboard_hook") {
++jumbo_component("keyboard_hook") {
+   public = [ "keyboard_hook.h" ]
+ 
+   defines = [ "IS_KEYBOARD_HOOK_IMPL" ]
+@@ -434,7 +435,7 @@ component("keyboard_hook") {
+   }
+ }
+ 
+-component("gesture_detection") {
++jumbo_component("gesture_detection") {
+   sources = [
+     "gesture_detection/bitset_32.h",
+     "gesture_detection/filtered_gesture_provider.cc",
+@@ -500,7 +501,7 @@ component("gesture_detection") {
+   }
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   sources = [
+     "test/event_generator.cc",
+     "test/event_generator.h",
+diff --git a/ui/events/blink/BUILD.gn b/ui/events/blink/BUILD.gn
+index d707bb6e0..8b4d97f46 100644
+--- a/ui/events/blink/BUILD.gn
++++ b/ui/events/blink/BUILD.gn
+@@ -2,9 +2,10 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ 
+-component("blink_features") {
++jumbo_component("blink_features") {
+   defines = [ "IS_BLINK_FEATURES_IMPL" ]
+ 
+   sources = [
+@@ -15,7 +16,7 @@ component("blink_features") {
+   deps = [ "//base" ]
+ }
+ 
+-source_set("blink") {
++jumbo_source_set("blink") {
+   sources = [
+     "blink_event_util.cc",
+     "blink_event_util.h",
+diff --git a/ui/events/devices/BUILD.gn b/ui/events/devices/BUILD.gn
+index 9cd3bd80b..ccd9bf547 100644
+--- a/ui/events/devices/BUILD.gn
++++ b/ui/events/devices/BUILD.gn
+@@ -2,12 +2,14 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
++
+ if (is_android) {
+   import("//build/config/android/config.gni")
+   import("//build/config/android/rules.gni")
+ }
+ 
+-component("devices") {
++jumbo_component("devices") {
+   sources = [
+     "device_data_manager.cc",
+     "device_data_manager.h",
+diff --git a/ui/events/devices/x11/BUILD.gn b/ui/events/devices/x11/BUILD.gn
+index ab1766bf2..02674d175 100644
+--- a/ui/events/devices/x11/BUILD.gn
++++ b/ui/events/devices/x11/BUILD.gn
+@@ -2,12 +2,13 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ozone.gni")
+ import("//build/config/ui.gni")
+ 
+ assert(ozone_platform_x11)
+ 
+-component("x11") {
++jumbo_component("x11") {
+   output_name = "events_devices_x11"
+ 
+   sources = [
+diff --git a/ui/events/ipc/BUILD.gn b/ui/events/ipc/BUILD.gn
+index 5e2744b86..ff529c38e 100644
+--- a/ui/events/ipc/BUILD.gn
++++ b/ui/events/ipc/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-component("ipc") {
++import("//build/config/jumbo.gni")
++
++jumbo_component("ipc") {
+   output_name = "ui_events_ipc"
+ 
+   sources = [
+diff --git a/ui/events/keycodes/BUILD.gn b/ui/events/keycodes/BUILD.gn
+index 9cdd599f0..576002096 100644
+--- a/ui/events/keycodes/BUILD.gn
++++ b/ui/events/keycodes/BUILD.gn
+@@ -2,11 +2,12 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ozone.gni")
+ import("//build/config/ui.gni")
+ import("//ui/base/ui_features.gni")
+ 
+-source_set("xkb") {
++jumbo_source_set("xkb") {
+   sources = [
+     "keyboard_code_conversion_xkb.cc",
+     "keyboard_code_conversion_xkb.h",
+@@ -27,7 +28,7 @@ source_set("xkb") {
+ }
+ 
+ if (ozone_platform_x11) {
+-  component("x11") {
++  jumbo_component("x11") {
+     output_name = "keycodes_x11"
+ 
+     sources = [
+diff --git a/ui/events/platform/BUILD.gn b/ui/events/platform/BUILD.gn
+index 1b54f4b46..1b6b162b0 100644
+--- a/ui/events/platform/BUILD.gn
++++ b/ui/events/platform/BUILD.gn
+@@ -2,9 +2,10 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ 
+-component("platform") {
++jumbo_component("platform") {
+   sources = [
+     # Allow this target to include events_export.h without depending on the
+     # events target (which would be circular).
+diff --git a/ui/events/platform/x11/BUILD.gn b/ui/events/platform/x11/BUILD.gn
+index 630c207d5..c3338effb 100644
+--- a/ui/events/platform/x11/BUILD.gn
++++ b/ui/events/platform/x11/BUILD.gn
+@@ -3,12 +3,13 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ozone.gni")
+ import("//build/config/ui.gni")
+ 
+ assert(ozone_platform_x11)
+ 
+-component("x11") {
++jumbo_component("x11") {
+   output_name = "x11_events_platform"
+ 
+   sources = [
+diff --git a/ui/gfx/BUILD.gn b/ui/gfx/BUILD.gn
+index d2692c742..fb96d4fb8 100644
+--- a/ui/gfx/BUILD.gn
++++ b/ui/gfx/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ozone.gni")
+ import("//build/config/ui.gni")
+ import("//device/vr/buildflags/buildflags.gni")
+@@ -22,7 +23,7 @@ source_set("gfx_export") {
+ }
+ 
+ # Used for color generation at build time without importing all the gfx.
+-component("color_utils") {
++jumbo_component("color_utils") {
+   sources = [
+     "color_palette.h",
+     "color_utils.cc",
+@@ -37,7 +38,7 @@ component("color_utils") {
+   ]
+ }
+ 
+-component("gfx_skia") {
++jumbo_component("gfx_skia") {
+   sources = [
+     "gfx_skia_export.h",
+     "skia_util.cc",
+@@ -51,7 +52,7 @@ component("gfx_skia") {
+   defines = [ "GFX_SKIA_IMPLEMENTATION" ]
+ }
+ 
+-component("gfx") {
++jumbo_component("gfx") {
+   sources = [
+     "break_list.h",
+     "color_analysis.cc",
+@@ -414,7 +415,7 @@ component("gfx") {
+   }
+ }
+ 
+-component("color_space") {
++jumbo_component("color_space") {
+   sources = [
+     "color_conversion_sk_filter_cache.cc",
+     "color_conversion_sk_filter_cache.h",
+@@ -532,7 +533,7 @@ group("memory_buffer") {
+ }
+ 
+ # Cannot be a static_library in component builds due to exported functions
+-source_set("memory_buffer_sources") {
++jumbo_source_set("memory_buffer_sources") {
+   visibility = [ ":*" ]  # Depend on through ":memory_buffer".
+ 
+   # TODO(brettw) refactor this so these sources are in a coherent directory
+@@ -620,7 +621,7 @@ source_set("memory_buffer_sources") {
+ }
+ 
+ # TODO(ccameron): This can be moved into a separate source_set.
+-component("gfx_switches") {
++jumbo_component("gfx_switches") {
+   sources = [
+     "switches.cc",
+     "switches.h",
+@@ -632,7 +633,7 @@ component("gfx_switches") {
+   deps = [ "//base" ]
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "animation/animation_test_api.cc",
+diff --git a/ui/gfx/animation/BUILD.gn b/ui/gfx/animation/BUILD.gn
+index 9dabaaca3..151a60994 100644
+--- a/ui/gfx/animation/BUILD.gn
++++ b/ui/gfx/animation/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ 
+ if (is_android) {
+@@ -10,7 +11,7 @@ if (is_android) {
+   import("//build/config/android/rules.gni")
+ }
+ 
+-component("animation") {
++jumbo_component("animation") {
+   sources = [
+     "animation.cc",
+     "animation.h",
+diff --git a/ui/gfx/codec/BUILD.gn b/ui/gfx/codec/BUILD.gn
+index c8a021173..efb03ea06 100644
+--- a/ui/gfx/codec/BUILD.gn
++++ b/ui/gfx/codec/BUILD.gn
+@@ -2,9 +2,10 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ 
+-component("codec") {
++jumbo_component("codec") {
+   sources = [
+     "codec_export.h",
+     "jpeg_codec.cc",
+diff --git a/ui/gfx/geometry/BUILD.gn b/ui/gfx/geometry/BUILD.gn
+index 9a17685c9..e2d00bbb6 100644
+--- a/ui/gfx/geometry/BUILD.gn
++++ b/ui/gfx/geometry/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-component("geometry") {
++import("//build/config/jumbo.gni")
++
++jumbo_component("geometry") {
+   sources = [
+     "../gfx_export.h",
+     "angle_conversions.h",
+diff --git a/ui/gfx/ipc/BUILD.gn b/ui/gfx/ipc/BUILD.gn
+index 83f5cd0b1..44f4ad493 100644
+--- a/ui/gfx/ipc/BUILD.gn
++++ b/ui/gfx/ipc/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-component("ipc") {
++import("//build/config/jumbo.gni")
++
++jumbo_component("ipc") {
+   output_name = "gfx_ipc"
+ 
+   sources = [
+diff --git a/ui/gfx/ipc/buffer_types/BUILD.gn b/ui/gfx/ipc/buffer_types/BUILD.gn
+index 550b4f0ed..957f9d9e6 100644
+--- a/ui/gfx/ipc/buffer_types/BUILD.gn
++++ b/ui/gfx/ipc/buffer_types/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-component("buffer_types") {
++import("//build/config/jumbo.gni")
++
++jumbo_component("buffer_types") {
+   output_name = "gfx_ipc_buffer_types"
+ 
+   sources = [
+diff --git a/ui/gfx/ipc/color/BUILD.gn b/ui/gfx/ipc/color/BUILD.gn
+index 38a069456..9bbf35412 100644
+--- a/ui/gfx/ipc/color/BUILD.gn
++++ b/ui/gfx/ipc/color/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-component("color") {
++import("//build/config/jumbo.gni")
++
++jumbo_component("color") {
+   output_name = "gfx_ipc_color"
+ 
+   sources = [
+diff --git a/ui/gfx/ipc/geometry/BUILD.gn b/ui/gfx/ipc/geometry/BUILD.gn
+index 4d0a15040..bd24a217e 100644
+--- a/ui/gfx/ipc/geometry/BUILD.gn
++++ b/ui/gfx/ipc/geometry/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-component("geometry") {
++import("//build/config/jumbo.gni")
++
++jumbo_component("geometry") {
+   output_name = "gfx_ipc_geometry"
+ 
+   sources = [
+diff --git a/ui/gfx/ipc/skia/BUILD.gn b/ui/gfx/ipc/skia/BUILD.gn
+index b96b1c754..d6178dcba 100644
+--- a/ui/gfx/ipc/skia/BUILD.gn
++++ b/ui/gfx/ipc/skia/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-component("skia") {
++import("//build/config/jumbo.gni")
++
++jumbo_component("skia") {
+   output_name = "gfx_ipc_skia"
+ 
+   sources = [
+diff --git a/ui/gfx/range/BUILD.gn b/ui/gfx/range/BUILD.gn
+index aa17a9745..e1c9b52f1 100644
+--- a/ui/gfx/range/BUILD.gn
++++ b/ui/gfx/range/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-component("range") {
++import("//build/config/jumbo.gni")
++
++jumbo_component("range") {
+   sources = [
+     "gfx_range_export.h",
+     "range.cc",
+diff --git a/ui/gfx/x/BUILD.gn b/ui/gfx/x/BUILD.gn
+index 623635136..f49995f8a 100644
+--- a/ui/gfx/x/BUILD.gn
++++ b/ui/gfx/x/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ozone.gni")
+ import("//build/config/ui.gni")
+ import("//tools/generate_library_loader/generate_library_loader.gni")
+@@ -191,7 +192,7 @@ source_set("xproto") {
+   libs = [ "xcb" ]
+ }
+ 
+-component("x") {
++jumbo_component("x") {
+   output_name = "gfx_x11"
+ 
+   sources = [
+diff --git a/ui/gl/BUILD.gn b/ui/gl/BUILD.gn
+index 1e71ae443..a7fa6c74c 100644
+--- a/ui/gl/BUILD.gn
++++ b/ui/gl/BUILD.gn
+@@ -6,6 +6,7 @@ import("//build/buildflag_header.gni")
+ import("//build/config/chrome_build.gni")
+ import("//build/config/chromecast_build.gni")
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/linux/pkg_config.gni")
+ import("//build/config/ozone.gni")
+ import("//build/config/ui.gni")
+@@ -45,7 +46,7 @@ config("gl_config") {
+   }
+ }
+ 
+-component("gl") {
++jumbo_component("gl") {
+   output_name = "gl_wrapper"  # Avoid colliding with OS X"s libGL.dylib.
+ 
+   sources = [
+@@ -454,7 +455,7 @@ if (is_mac) {
+   }
+ }
+ 
+-static_library("gl_unittest_utils") {
++jumbo_static_library("gl_unittest_utils") {
+   testonly = true
+   sources = [
+     "egl_bindings_autogen_mock.cc",
+@@ -480,7 +481,7 @@ static_library("gl_unittest_utils") {
+   ]
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "test/gl_image_test_support.cc",
+diff --git a/ui/gl/init/BUILD.gn b/ui/gl/init/BUILD.gn
+index f6b4cf961..78a7d81dd 100644
+--- a/ui/gl/init/BUILD.gn
++++ b/ui/gl/init/BUILD.gn
+@@ -2,10 +2,11 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//ui/gl/features.gni")
+ 
+-component("init") {
++jumbo_component("init") {
+   output_name = "gl_init"
+ 
+   public = [
+diff --git a/ui/gtk/BUILD.gn b/ui/gtk/BUILD.gn
+index 4fc6b6d61..21849421f 100644
+--- a/ui/gtk/BUILD.gn
++++ b/ui/gtk/BUILD.gn
+@@ -4,6 +4,7 @@
+ 
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/linux/gtk/gtk.gni")
+ import("//build/config/linux/pkg_config.gni")
+ import("//build/config/ozone.gni")
+@@ -68,10 +69,9 @@ generate_stubs("gtk_stubs") {
+   logging_include = "ui/gtk/log_noop.h"
+ }
+ 
+-component("gtk") {
++jumbo_component("gtk") {
+   visibility = [ "//ui/linux:linux_ui_factory" ]
+   public = [ "gtk_ui_factory.h" ]
+-
+   sources = [
+     "gtk_color_mixers.cc",
+     "gtk_color_mixers.h",
+diff --git a/ui/latency/BUILD.gn b/ui/latency/BUILD.gn
+index 6e8ca7dba..3019b821d 100644
+--- a/ui/latency/BUILD.gn
++++ b/ui/latency/BUILD.gn
+@@ -2,9 +2,10 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//testing/test.gni")
+ 
+-source_set("latency") {
++jumbo_source_set("latency") {
+   sources = [
+     "latency_info.cc",
+     "latency_info.h",
+@@ -21,7 +22,7 @@ source_set("latency") {
+   public_deps = [ "//services/metrics/public/cpp:metrics_cpp" ]
+ }
+ 
+-source_set("test_support") {
++jumbo_source_set("test_support") {
+   testonly = true
+   sources = [ "latency_info_test_support.cc" ]
+ 
+diff --git a/ui/message_center/BUILD.gn b/ui/message_center/BUILD.gn
+index 1bd8354cd..d24f08b3e 100644
+--- a/ui/message_center/BUILD.gn
++++ b/ui/message_center/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//components/vector_icons/vector_icons.gni")
+ import("//testing/test.gni")
+@@ -23,7 +24,7 @@ aggregate_vector_icons("message_center_vector_icons") {
+ }
+ 
+ # TODO(msw|mukai|dewittj): Move ash-specific files: crbug.com/585175
+-component("message_center") {
++jumbo_component("message_center") {
+   deps = [
+     "//base",
+     "//build:chromeos_buildflags",
+diff --git a/ui/message_center/public/cpp/BUILD.gn b/ui/message_center/public/cpp/BUILD.gn
+index 1e9e3ec8d..33925d047 100644
+--- a/ui/message_center/public/cpp/BUILD.gn
++++ b/ui/message_center/public/cpp/BUILD.gn
+@@ -2,10 +2,11 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ 
+ # C++ headers and sources that can be used outside message_center.
+-component("cpp") {
++jumbo_component("cpp") {
+   output_name = "ui_message_center_cpp"
+ 
+   sources = [
+diff --git a/ui/native_theme/BUILD.gn b/ui/native_theme/BUILD.gn
+index 6b022564c..b714e00e0 100644
+--- a/ui/native_theme/BUILD.gn
++++ b/ui/native_theme/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//testing/test.gni")
+ 
+@@ -22,7 +23,7 @@ component("features") {
+   ]
+ }
+ 
+-component("native_theme") {
++jumbo_component("native_theme") {
+   sources = [
+     "caption_style.cc",
+     "caption_style.h",
+@@ -103,7 +104,7 @@ component("native_theme") {
+ }
+ 
+ if (is_win) {
+-  component("native_theme_browser") {
++  jumbo_component("native_theme_browser") {
+     defines = [ "NATIVE_THEME_IMPLEMENTATION" ]
+ 
+     # These files cannot work in the renderer on Windows.
+@@ -125,11 +126,11 @@ if (is_win) {
+     libs = [ "uxtheme.lib" ]
+   }
+ } else {
+-  source_set("native_theme_browser") {
++  jumbo_source_set("native_theme_browser") {
+   }
+ }
+ 
+-source_set("test_support") {
++jumbo_source_set("test_support") {
+   testonly = true
+ 
+   deps = [
+diff --git a/ui/ozone/BUILD.gn b/ui/ozone/BUILD.gn
+index bc1d2cf52..10951066a 100644
+--- a/ui/ozone/BUILD.gn
++++ b/ui/ozone/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/buildflag_header.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ozone.gni")
+ import("//build/config/python.gni")
+ import("//build/config/ui.gni")
+@@ -83,7 +84,7 @@ constructor_list_cc_file = "$target_gen_dir/constructor_list.cc"
+ 
+ test_constructor_list_cc_file = "$target_gen_dir/test_constructor_list.cc"
+ 
+-component("ozone_base") {
++jumbo_component("ozone_base") {
+   sources = [
+     "public/gl_ozone.h",
+     "public/gpu_platform_support_host.cc",
+@@ -246,7 +247,7 @@ source_set("ozone_switches") {
+   ]
+ }
+ 
+-component("ozone") {
++jumbo_component("ozone") {
+   visibility = []
+   visibility = [ "*" ]
+   public_deps = [
+@@ -255,7 +256,7 @@ component("ozone") {
+   ]
+ }
+ 
+-source_set("test_support_internal") {
++jumbo_source_set("test_support_internal") {
+   testonly = true
+ 
+   sources = [
+@@ -278,7 +279,7 @@ source_set("test_support_internal") {
+   public_deps = [ "//base/test:test_support" ]
+ }
+ 
+-static_library("ui_test_support") {
++jumbo_static_library("ui_test_support") {
+   visibility = []
+   visibility = [ "//ui/views:test_support" ]
+ 
+@@ -314,7 +315,7 @@ source_set("ozone_interactive_ui_tests") {
+   deps = ozone_platform_interactive_ui_tests_sources
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   visibility = []
+   visibility = [
+     ":*",
+diff --git a/ui/platform_window/stub/BUILD.gn b/ui/platform_window/stub/BUILD.gn
+index 5f4194932..1d64d126b 100644
+--- a/ui/platform_window/stub/BUILD.gn
++++ b/ui/platform_window/stub/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-component("stub") {
++import("//build/config/jumbo.gni")
++
++jumbo_component("stub") {
+   output_name = "stub_window"
+ 
+   deps = [
+diff --git a/ui/platform_window/win/BUILD.gn b/ui/platform_window/win/BUILD.gn
+index e172d7b2b..f57d6db0d 100644
+--- a/ui/platform_window/win/BUILD.gn
++++ b/ui/platform_window/win/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-component("win") {
++import("//build/config/jumbo.gni")
++
++jumbo_component("win") {
+   output_name = "win_window"
+ 
+   deps = [
+diff --git a/ui/resources/BUILD.gn b/ui/resources/BUILD.gn
+index 67a0edca7..c86b02b1c 100644
+--- a/ui/resources/BUILD.gn
++++ b/ui/resources/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//tools/grit/grit_rule.gni")
+ import("//tools/grit/repack.gni")
+ import("//ui/webui/webui_features.gni")
+diff --git a/ui/shell_dialogs/BUILD.gn b/ui/shell_dialogs/BUILD.gn
+index 7d1dbaca0..3697bf169 100644
+--- a/ui/shell_dialogs/BUILD.gn
++++ b/ui/shell_dialogs/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/features.gni")
+ import("//build/config/ui.gni")
+ import("//testing/test.gni")
+@@ -14,7 +15,7 @@ if (is_mac) {
+   import("//build/config/mac/rules.gni")
+ }
+ 
+-component("shell_dialogs") {
++jumbo_component("shell_dialogs") {
+   sources = [
+     "base_shell_dialog.cc",
+     "base_shell_dialog.h",
+diff --git a/ui/snapshot/BUILD.gn b/ui/snapshot/BUILD.gn
+index 34e4040c3..c7c1cfabc 100644
+--- a/ui/snapshot/BUILD.gn
++++ b/ui/snapshot/BUILD.gn
+@@ -2,10 +2,11 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//testing/test.gni")
+ 
+-component("snapshot") {
++jumbo_component("snapshot") {
+   sources = [
+     "screenshot_grabber.cc",
+     "screenshot_grabber.h",
+@@ -79,7 +80,7 @@ component("snapshot") {
+   }
+ }
+ 
+-source_set("snapshot_export") {
++jumbo_source_set("snapshot_export") {
+   sources = [ "snapshot_export.h" ]
+   visibility = [ ":*" ]
+ }
+diff --git a/ui/surface/BUILD.gn b/ui/surface/BUILD.gn
+index 531dbf120..1d2751db6 100644
+--- a/ui/surface/BUILD.gn
++++ b/ui/surface/BUILD.gn
+@@ -2,9 +2,10 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ 
+-component("surface") {
++jumbo_component("surface") {
+   sources = [
+     "surface_export.h",
+     "transport_dib.cc",
+diff --git a/ui/touch_selection/BUILD.gn b/ui/touch_selection/BUILD.gn
+index 219b8ee61..852fd7cb9 100644
+--- a/ui/touch_selection/BUILD.gn
++++ b/ui/touch_selection/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//testing/test.gni")
+ 
+@@ -9,7 +10,7 @@ if (is_android) {
+   import("//build/config/android/rules.gni")
+ }
+ 
+-component("touch_selection") {
++jumbo_component("touch_selection") {
+   output_name = "ui_touch_selection"
+ 
+   sources = [
+diff --git a/ui/views/BUILD.gn b/ui/views/BUILD.gn
+index accb86903..d871768c9 100644
+--- a/ui/views/BUILD.gn
++++ b/ui/views/BUILD.gn
+@@ -5,6 +5,7 @@
+ import("//build/buildflag_header.gni")
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ozone.gni")
+ import("//build/config/ui.gni")
+ import("//components/vector_icons/vector_icons.gni")
+@@ -57,7 +58,7 @@ buildflag_header("buildflags") {
+   flags = [ "ENABLE_DESKTOP_AURA=$enable_desktop_aura" ]
+ }
+ 
+-component("views") {
++jumbo_component("views") {
+   all_dependent_configs = [ ":flags" ]
+ 
+   public = [
+@@ -923,7 +924,7 @@ component("views") {
+ }
+ 
+ if (is_win || is_mac || is_linux || is_chromeos) {
+-  static_library("view_pixel_diff_test_support") {
++  jumbo_static_library("view_pixel_diff_test_support") {
+     testonly = true
+     sources = [
+       "test/view_skia_gold_pixel_diff.cc",
+@@ -942,7 +943,7 @@ if (is_win || is_mac || is_linux || is_chromeos) {
+   }
+ }
+ 
+-source_set("test_support") {
++jumbo_source_set("test_support") {
+   testonly = true
+   sources = [
+     "animation/test/flood_fill_ink_drop_ripple_test_api.cc",
+diff --git a/ui/views/controls/webview/BUILD.gn b/ui/views/controls/webview/BUILD.gn
+index f37a5a881..a0c34efce 100644
+--- a/ui/views/controls/webview/BUILD.gn
++++ b/ui/views/controls/webview/BUILD.gn
+@@ -2,9 +2,10 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ozone.gni")
+ 
+-component("webview") {
++jumbo_component("webview") {
+   sources = [
+     "unhandled_keyboard_event_handler.cc",
+     "unhandled_keyboard_event_handler.h",
+diff --git a/ui/views/examples/BUILD.gn b/ui/views/examples/BUILD.gn
+index 05338165a..6ebe3fc5c 100644
+--- a/ui/views/examples/BUILD.gn
++++ b/ui/views/examples/BUILD.gn
+@@ -3,11 +3,12 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//testing/test.gni")
+ import("//tools/grit/grit_rule.gni")
+ 
+-component("views_examples_lib") {
++jumbo_component("views_examples_lib") {
+   testonly = true
+ 
+   sources = [
+@@ -221,7 +222,7 @@ executable("views_examples") {
+   ]
+ }
+ 
+-component("views_examples_with_content_lib") {
++jumbo_component("views_examples_with_content_lib") {
+   testonly = true
+   sources = [
+     "examples_window_with_content.cc",
+diff --git a/ui/views_content_client/BUILD.gn b/ui/views_content_client/BUILD.gn
+index e01d44b0c..11684632b 100644
+--- a/ui/views_content_client/BUILD.gn
++++ b/ui/views_content_client/BUILD.gn
+@@ -3,9 +3,10 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ 
+-component("views_content_client") {
++jumbo_component("views_content_client") {
+   testonly = true
+   sources = [
+     "views_content_browser_client.cc",
+diff --git a/ui/web_dialogs/BUILD.gn b/ui/web_dialogs/BUILD.gn
+index fd379adfc..1655faa7c 100644
+--- a/ui/web_dialogs/BUILD.gn
++++ b/ui/web_dialogs/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-component("web_dialogs") {
++import("//build/config/jumbo.gni")
++
++jumbo_component("web_dialogs") {
+   sources = [
+     "web_dialog_delegate.cc",
+     "web_dialog_delegate.h",
+@@ -31,7 +33,7 @@ component("web_dialogs") {
+   }
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   sources = [
+     "test/test_web_contents_handler.cc",
+     "test/test_web_contents_handler.h",
+diff --git a/ui/wm/BUILD.gn b/ui/wm/BUILD.gn
+index 2450d399f..5f8a4e73d 100644
+--- a/ui/wm/BUILD.gn
++++ b/ui/wm/BUILD.gn
+@@ -3,12 +3,13 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/chromeos/ui_mode.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//testing/test.gni")
+ 
+ assert(use_aura)
+ 
+-component("wm") {
++jumbo_component("wm") {
+   output_name = "ui_wm"
+   sources = [
+     "core/accelerator_delegate.h",
+@@ -102,7 +103,7 @@ component("wm") {
+   }
+ }
+ 
+-static_library("test_support") {
++jumbo_static_library("test_support") {
+   testonly = true
+   sources = [
+     "test/testing_cursor_client_observer.cc",
+diff --git a/ui/wm/public/BUILD.gn b/ui/wm/public/BUILD.gn
+index e27ef11fd..15b7e911c 100644
+--- a/ui/wm/public/BUILD.gn
++++ b/ui/wm/public/BUILD.gn
+@@ -2,11 +2,12 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ 
+ assert(use_aura)
+ 
+-component("public") {
++jumbo_component("public") {
+   output_name = "wm_public"
+ 
+   public = [
+-- 
+2.43.0
+

--- a/x11-packages/carbonyl-host-tools/patches/0101-fixes-for-jumbo-build.patch
+++ b/x11-packages/carbonyl-host-tools/patches/0101-fixes-for-jumbo-build.patch
@@ -1,0 +1,7330 @@
+From 8b6d4e7552132d1c536d39ae7111ef1692fafe5a Mon Sep 17 00:00:00 2001
+From: Chongyun Lee <licy183@termux.dev>
+Date: Wed, 29 Jan 2025 22:54:37 +0800
+Subject: [PATCH] Fixes for jumbo build
+
+Based on https://github.com/qt/qtwebengine-chromium/commit/93e068edee318bb23af7a5a85b12d629123491fc
+
+---
+ base/BUILD.gn                                 |  11 ++
+ base/task/sequence_manager/task_order.cc      |  10 +-
+ base/task/single_thread_task_runner.cc        |  18 +--
+ build/config/jumbo.gni                        |   2 +-
+ cc/metrics/compositor_frame_reporter.cc       |  16 +-
+ .../compositor_frame_reporting_controller.cc  |  14 +-
+ cc/metrics/frame_sequence_tracker.cc          |   6 +-
+ cc/metrics/jank_injector.cc                   |   4 +-
+ cc/metrics/jank_metrics.cc                    |   8 +-
+ components/guest_view/browser/BUILD.gn        |   4 +-
+ components/guest_view/renderer/BUILD.gn       |   4 +-
+ components/metrics/metrics_log.cc             |   4 +-
+ components/metrics/metrics_state_manager.cc   |   4 +-
+ components/performance_manager/BUILD.gn       |   4 +-
+ .../decorators/page_live_state_decorator.cc   |   4 +-
+ .../decorators/page_load_tracker_decorator.cc |   4 +-
+ .../frame_audible_voter.cc                    |   8 +-
+ .../frame_visibility_voter.cc                 |  16 +-
+ .../inherit_client_priority_voter.cc          |  36 ++---
+ .../graph/frame_node_impl_describer.cc        |   4 +-
+ .../graph/page_node_impl_describer.cc         |   4 +-
+ .../graph/process_node_impl_describer.cc      |   4 +-
+ .../graph/worker_node_impl_describer.cc       |   4 +-
+ .../performance_manager_registry_impl.cc      |  14 +-
+ .../site_data/site_data_cache_factory.cc      |  12 +-
+ .../core/common/policy_proto_decoders.cc      |   4 +-
+ components/printing/browser/BUILD.gn          |   4 +-
+ components/storage_monitor/BUILD.gn           |   3 +-
+ components/viz/common/BUILD.gn                |   1 +
+ components/viz/service/BUILD.gn               |  14 ++
+ .../display/display_resource_provider.h       |   2 +-
+ .../skia_output_device_webview.cc             |   8 +-
+ .../transferable_resource_tracker.cc          |   2 +-
+ content/browser/BUILD.gn                      | 152 +++++++++++-------
+ .../attribution_internals_handler_impl.cc     |  10 +-
+ .../attribution_storage_sql.cc                |   4 +-
+ .../cookie_change_subscription.cc             |   7 +-
+ content/browser/devtools/BUILD.gn             |   2 +-
+ .../browser/devtools/protocol/page_handler.cc |   4 +-
+ .../web_contents_devtools_agent_host.cc       |  18 +--
+ .../first_party_set_parser.cc                 |   2 +-
+ .../first_party_sets_handler_impl.cc          |   6 +-
+ content/browser/gpu/compositor_util.cc        |  16 +-
+ content/browser/gpu/gpu_process_host.cc       |   2 +-
+ .../interest_group_manager_impl.cc            |   4 +-
+ .../interest_group_permissions_checker.cc     |   4 +-
+ .../media/media_internals_cdm_helper.cc       |   4 +-
+ .../cross_origin_embedder_policy_reporter.cc  |   6 +-
+ .../prerender/prerender_host_registry.cc      |   2 +-
+ .../push_messaging/push_messaging_router.cc   |   4 +-
+ .../agent_scheduling_group_host.cc            |  32 ++--
+ .../renderer_host/code_cache_host_impl.h      |   6 +-
+ .../media/media_stream_manager.cc             |  88 +++++-----
+ .../media/media_stream_power_logger.cc        |  10 +-
+ .../pepper_internal_file_ref_backend.cc       |   4 +-
+ .../renderer_host/render_frame_proxy_host.cc  |  12 +-
+ .../embedded_worker_instance.cc               |   4 +-
+ .../service_worker_context_wrapper.cc         |   6 +-
+ ...rvice_worker_controllee_request_handler.cc |  16 +-
+ content/child/BUILD.gn                        |   5 +-
+ content/common/BUILD.gn                       |   8 +-
+ .../pepper/pepper_plugin_instance_impl.h      |   5 +
+ .../web_service_worker_provider_impl.cc       |   8 +-
+ dbus/message.cc                               |   4 +-
+ device/fido/cable/cable_discovery_data.h      |   2 +-
+ .../fido/public_key_credential_descriptor.h   |   4 +-
+ device/fido/public_key_credential_params.h    |   4 +-
+ device/fido/public_key_credential_rp_entity.h |   4 +-
+ .../fido/public_key_credential_user_entity.h  |   4 +-
+ .../webrequest_condition.cc                   |  16 +-
+ .../webrequest_condition_attribute.cc         |  82 +++++-----
+ .../api/hid/hid_connection_resource.cc        |   4 +-
+ .../browser/api/hid/hid_device_manager.cc     |   6 +-
+ .../browser/api/usb/usb_device_manager.cc     |   4 +-
+ .../browser/api/usb/usb_device_resource.cc    |   4 +-
+ .../api/web_request/upload_data_presenter.cc  |   6 +-
+ .../api/web_request/web_request_api.cc        | 134 +++++++--------
+ .../api/web_request/web_request_info.cc       |   8 +-
+ ...web_request_proxying_url_loader_factory.cc |  18 +--
+ .../web_request_proxying_url_loader_factory.h |   2 +-
+ extensions/browser/app_window/app_window.cc   |   4 +-
+ .../browser/extension_message_filter.cc       |  20 +--
+ ...extension_service_worker_message_filter.cc |  20 +--
+ extensions/common/BUILD.gn                    |   5 +
+ .../manifest_handlers/shared_module_info.cc   |  10 +-
+ gpu/command_buffer/service/BUILD.gn           |   7 +-
+ gpu/config/BUILD.gn                           |   3 +-
+ .../h265_to_annex_b_bitstream_converter.cc    |  30 ++--
+ .../mac/audio_toolbox_audio_encoder.cc        |   8 +-
+ media/filters/media_file_checker.cc           |   4 +-
+ .../services/gpu_mojo_media_client_cros.cc    |   5 +-
+ .../services/gpu_mojo_media_client_mac.cc     |   3 +-
+ .../services/gpu_mojo_media_client_stubs.cc   |   4 +-
+ .../services/gpu_mojo_media_client_win.cc     |   3 +-
+ mojo/public/tools/bindings/mojom.gni          |   5 +-
+ services/network/public/cpp/BUILD.gn          |   5 +
+ .../web_bundle_url_loader_factory.cc          |   4 +-
+ storage/browser/BUILD.gn                      |   4 +
+ storage/browser/blob/blob_url_registry.cc     |   8 +-
+ storage/browser/quota/quota_settings.cc       |   9 +-
+ .../common/frame/user_activation_state.cc     |   4 +-
+ .../common/user_agent/user_agent_metadata.cc  |   6 +-
+ .../scripts/bind_gen/callback_interface.py    |   1 +
+ .../bindings/scripts/bind_gen/interface.py    |  33 +++-
+ third_party/blink/renderer/core/BUILD.gn      |  13 +-
+ .../blink/renderer/core/animation/BUILD.gn    |   3 +
+ .../css_shadow_list_interpolation_type.cc     |   2 +-
+ .../css/box_shadow_paint_image_generator.cc   |  10 +-
+ .../css/clip_path_paint_image_generator.cc    |  10 +-
+ .../core/frame/local_frame_mojo_handler.cc    |   4 +-
+ .../renderer/core/frame/sticky_ad_detector.cc |   8 +-
+ .../core/html/forms/html_input_element.cc     |   6 +-
+ .../core/html/forms/html_text_area_element.cc |   6 +-
+ .../core/html/parser/html_tree_builder.cc     |   4 +-
+ .../renderer/core/html/track/cue_timeline.cc  |   2 +-
+ .../renderer/core/html/track/text_track.cc    |   4 +-
+ .../core/imagebitmap/image_bitmap_source.cc   |   4 +-
+ .../core/layout/flexible_box_algorithm.cc     |   8 +-
+ .../core/layout/flexible_box_algorithm.h      |   4 +-
+ .../ng/flex/ng_flex_layout_algorithm.cc       |  50 +++---
+ .../core/layout/ng/grid/ng_grid_item.cc       |   4 +-
+ .../core/layout/ng/grid/ng_grid_item.h        |   6 +-
+ .../ng/grid/ng_grid_layout_algorithm.cc       |  18 +--
+ .../ng_math_scripts_layout_algorithm.cc       |   4 +-
+ .../core/layout/ng/ng_baseline_utils.h        |  10 +-
+ .../blink/renderer/core/page/drag_image.cc    |   3 +
+ .../core/paint/ng/ng_highlight_painter.cc     |  14 +-
+ .../core/paint/pre_paint_tree_walk.cc         |   4 +-
+ .../speculation_rules/speculation_rule_set.cc |  44 ++---
+ .../core/timing/performance_timing.cc         |   6 +-
+ .../inspector_type_builder_helper.cc          |   6 +-
+ .../modules/bluetooth/bluetooth_device.cc     |   6 +-
+ ...edia_stream_video_track_underlying_sink.cc |   6 +-
+ .../blink/renderer/modules/canvas/BUILD.gn    |   4 +
+ .../credentials_container.cc                  |  30 ++--
+ .../federated_credential.cc                   |   4 +-
+ .../identity_credential.cc                    |   4 +-
+ .../credentialmanagement/otp_credential.cc    |   6 +-
+ .../blink/renderer/modules/hid/hid_device.cc  |   6 +-
+ .../modules/mediarecorder/h264_encoder.cc     |  12 +-
+ .../modules/mediarecorder/vpx_encoder.cc      |  58 ++++---
+ .../renderer/modules/mediastream/BUILD.gn     |   7 +
+ .../modules/payments/payment_instruments.cc   |  14 +-
+ .../renderer/modules/peerconnection/BUILD.gn  |   6 +
+ .../peerconnection/rtc_peer_connection.cc     |   6 +-
+ .../renderer/modules/permissions/BUILD.gn     |   1 +
+ .../modules/webaudio/analyser_handler.cc      |   8 +-
+ .../webaudio/audio_buffer_source_handler.cc   |   4 +-
+ .../modules/webaudio/audio_worklet_handler.cc |   4 +-
+ .../modules/webaudio/biquad_filter_node.cc    |   4 +-
+ .../webaudio/constant_source_handler.cc       |   4 +-
+ .../modules/webaudio/convolver_handler.cc     |   4 +-
+ .../webaudio/dynamics_compressor_handler.cc   |   6 +-
+ .../modules/webaudio/iir_filter_handler.cc    |   4 +-
+ .../media_element_audio_source_handler.cc     |   4 +-
+ .../modules/webaudio/oscillator_handler.cc    |   4 +-
+ .../webaudio/realtime_audio_worklet_thread.cc |  16 +-
+ .../semi_realtime_audio_worklet_thread.cc     |  16 +-
+ .../modules/webaudio/stereo_panner_handler.cc |  16 +-
+ .../modules/webaudio/wave_shaper_handler.cc   |   4 +-
+ .../blink/renderer/modules/webcodecs/BUILD.gn |   5 +
+ .../modules/webcodecs/decoder_template.cc     |  18 +--
+ .../modules/webcodecs/encoder_base.cc         |  20 +--
+ .../webcodecs/gpu_factories_retriever.cc      |   6 +-
+ .../blink/renderer/modules/webgpu/BUILD.gn    |   2 +
+ third_party/blink/renderer/platform/BUILD.gn  |   9 ++
+ .../cpu/x86/audio_delay_dsp_kernel_sse2.cc    |   2 +
+ .../renderer/platform/audio/hrtf_panner.cc    |  16 +-
+ .../platform/fonts/shaping/harfbuzz_shaper.cc |  22 +--
+ .../compositing/paint_artifact_compositor.cc  |   2 +-
+ .../image-decoders/jpeg/jpeg_image_decoder.cc |   4 +
+ .../platform/loader/web_url_request_util.cc   |   1 +
+ .../stats_collecting_decoder.cc               |  12 +-
+ .../widget/compositing/layer_tree_view.cc     |   4 +-
+ .../input/elastic_overscroll_controller.cc    |   2 +-
+ .../widget/input/widget_base_input_handler.cc |   4 +-
+ ui/base/BUILD.gn                              |   4 +
+ ui/base/ime/win/BUILD.gn                      |   1 +
+ ui/base/x/BUILD.gn                            |   3 +-
+ ui/color/BUILD.gn                             |   7 +-
+ ui/gfx/geometry/transform_operations.cc       |   6 +-
+ ui/gl/BUILD.gn                                |   4 +
+ ui/gl/direct_composition_surface_win.cc       |   6 +-
+ ui/native_theme/BUILD.gn                      |   9 +-
+ 184 files changed, 1035 insertions(+), 878 deletions(-)
+
+diff --git a/base/BUILD.gn b/base/BUILD.gn
+index e0139a879..8eb16b4fc 100644
+--- a/base/BUILD.gn
++++ b/base/BUILD.gn
+@@ -1404,6 +1404,11 @@ jumbo_component("base") {
+     ]
+   }
+ 
++  jumbo_excluded_sources = [
++      "logging.cc",
++      "strings/string_piece.cc",
++  ]
++
+   if (is_linux || is_chromeos) {
+     sources += [
+       "debug/proc_maps_linux.cc",
+@@ -1421,6 +1426,7 @@ jumbo_component("base") {
+       "threading/thread_type_delegate.cc",
+       "threading/thread_type_delegate.h",
+     ]
++    jumbo_excluded_sources += [ "process/memory_linux.cc" ]
+   }
+ 
+   if (is_linux || is_chromeos || is_android || is_fuchsia) {
+@@ -2097,6 +2103,11 @@ jumbo_component("base") {
+       "file_descriptor_store.h",
+     ]
+ 
++    # winternl.h and NTSecAPI.h have different definitions of UNICODE_STRING.
++    # There's only one client of NTSecAPI.h in base but several of winternl.h,
++    # so exclude the NTSecAPI.h one.
++    jumbo_excluded_sources += [ "rand_util_win.cc" ]
++
+     deps += [ "//base/win:base_win_buildflags" ]
+ 
+     data_deps += [ "//build/win:runtime_libs" ]
+diff --git a/base/task/sequence_manager/task_order.cc b/base/task/sequence_manager/task_order.cc
+index b2bdae4e9..1e9635b28 100644
+--- a/base/task/sequence_manager/task_order.cc
++++ b/base/task/sequence_manager/task_order.cc
+@@ -17,7 +17,7 @@ namespace {
+ // Returns true iff `task_order1` Comparator{} `task_order2`. Used to
+ // implement other comparison operators.
+ template <typename Comparator>
+-static bool Compare(const base::sequence_manager::TaskOrder& task_order1,
++static bool CompareTO(const base::sequence_manager::TaskOrder& task_order1,
+                     const base::sequence_manager::TaskOrder& task_order2) {
+   Comparator cmp{};
+ 
+@@ -60,19 +60,19 @@ TaskOrder& TaskOrder::operator=(const TaskOrder& other) = default;
+ TaskOrder::~TaskOrder() = default;
+ 
+ bool TaskOrder::operator>(const TaskOrder& other) const {
+-  return Compare<std::greater<>>(*this, other);
++  return CompareTO<std::greater<>>(*this, other);
+ }
+ 
+ bool TaskOrder::operator<(const TaskOrder& other) const {
+-  return Compare<std::less<>>(*this, other);
++  return CompareTO<std::less<>>(*this, other);
+ }
+ 
+ bool TaskOrder::operator<=(const TaskOrder& other) const {
+-  return Compare<std::less_equal<>>(*this, other);
++  return CompareTO<std::less_equal<>>(*this, other);
+ }
+ 
+ bool TaskOrder::operator>=(const TaskOrder& other) const {
+-  return Compare<std::greater_equal<>>(*this, other);
++  return CompareTO<std::greater_equal<>>(*this, other);
+ }
+ 
+ bool TaskOrder::operator==(const TaskOrder& other) const {
+diff --git a/base/task/single_thread_task_runner.cc b/base/task/single_thread_task_runner.cc
+index ebf286712..ca1f9279e 100644
+--- a/base/task/single_thread_task_runner.cc
++++ b/base/task/single_thread_task_runner.cc
+@@ -21,7 +21,7 @@ namespace base {
+ namespace {
+ 
+ ThreadLocalPointer<SingleThreadTaskRunner::CurrentDefaultHandle>&
+-CurrentDefaultHandleTls() {
++CurrentDefaultHandleTls2() {
+   static NoDestructor<
+       ThreadLocalPointer<SingleThreadTaskRunner::CurrentDefaultHandle>>
+       instance;
+@@ -34,7 +34,7 @@ CurrentDefaultHandleTls() {
+ const scoped_refptr<SingleThreadTaskRunner>&
+ SingleThreadTaskRunner::GetCurrentDefault() {
+   const SingleThreadTaskRunner::CurrentDefaultHandle* current_default =
+-      CurrentDefaultHandleTls().Get();
++      CurrentDefaultHandleTls2().Get();
+   CHECK(current_default)
+       << "Error: This caller requires a single-threaded context (i.e. the "
+          "current task needs to run from a SingleThreadTaskRunner). If you're "
+@@ -50,7 +50,7 @@ SingleThreadTaskRunner::GetCurrentDefault() {
+ 
+ // static
+ bool SingleThreadTaskRunner::HasCurrentDefault() {
+-  return !!CurrentDefaultHandleTls().Get();
++  return !!CurrentDefaultHandleTls2().Get();
+ }
+ 
+ SingleThreadTaskRunner::CurrentDefaultHandle::CurrentDefaultHandle(
+@@ -58,14 +58,14 @@ SingleThreadTaskRunner::CurrentDefaultHandle::CurrentDefaultHandle(
+     : task_runner_(std::move(task_runner)),
+       sequenced_task_runner_current_default_(task_runner_) {
+   DCHECK(task_runner_->BelongsToCurrentThread());
+-  DCHECK(!CurrentDefaultHandleTls().Get());
+-  CurrentDefaultHandleTls().Set(this);
++  DCHECK(!CurrentDefaultHandleTls2().Get());
++  CurrentDefaultHandleTls2().Set(this);
+ }
+ 
+ SingleThreadTaskRunner::CurrentDefaultHandle::~CurrentDefaultHandle() {
+   DCHECK(task_runner_->BelongsToCurrentThread());
+-  DCHECK_EQ(CurrentDefaultHandleTls().Get(), this);
+-  CurrentDefaultHandleTls().Set(nullptr);
++  DCHECK_EQ(CurrentDefaultHandleTls2().Get(), this);
++  CurrentDefaultHandleTls2().Set(nullptr);
+ }
+ 
+ SingleThreadTaskRunner::CurrentHandleOverride::CurrentHandleOverride(
+@@ -89,7 +89,7 @@ SingleThreadTaskRunner::CurrentHandleOverride::CurrentHandleOverride(
+   expected_task_runner_before_restore_ = overriding_task_runner.get();
+ #endif
+   SingleThreadTaskRunner::CurrentDefaultHandle* current_default =
+-      CurrentDefaultHandleTls().Get();
++      CurrentDefaultHandleTls2().Get();
+   SequencedTaskRunner::SetCurrentDefaultHandleTaskRunner(
+       current_default->sequenced_task_runner_current_default_,
+       overriding_task_runner);
+@@ -108,7 +108,7 @@ SingleThreadTaskRunner::CurrentHandleOverride::CurrentHandleOverride(
+ SingleThreadTaskRunner::CurrentHandleOverride::~CurrentHandleOverride() {
+   if (task_runner_to_restore_) {
+     SingleThreadTaskRunner::CurrentDefaultHandle* current_default =
+-        CurrentDefaultHandleTls().Get();
++        CurrentDefaultHandleTls2().Get();
+ 
+ #if DCHECK_IS_ON()
+     DCHECK_EQ(expected_task_runner_before_restore_,
+diff --git a/build/config/jumbo.gni b/build/config/jumbo.gni
+index dd8972423..025314908 100644
+--- a/build/config/jumbo.gni
++++ b/build/config/jumbo.gni
+@@ -78,7 +78,7 @@ template("internal_jumbo_target") {
+   if (defined(invoker.never_build_jumbo) && invoker.never_build_jumbo) {
+     use_jumbo_build_for_target = false
+   }
+-  if (is_nacl_irt || is_nacl_nonsfi) {
++  if (is_nacl_irt) {
+     # The code is barely compatible with the nacl toolchain anymore and we
+     # don't want to stress it further with jumbo compilation units.
+     use_jumbo_build_for_target = false
+diff --git a/cc/metrics/compositor_frame_reporter.cc b/cc/metrics/compositor_frame_reporter.cc
+index 2187f7f62..1fcb907be 100644
+--- a/cc/metrics/compositor_frame_reporter.cc
++++ b/cc/metrics/compositor_frame_reporter.cc
+@@ -172,7 +172,7 @@ void ReportEventLatencyMetric(
+   }
+ }
+ 
+-constexpr char kTraceCategory[] =
++constexpr char kTraceCategory2[] =
+     "cc,benchmark," TRACE_DISABLED_BY_DEFAULT("devtools.timeline.frame");
+ 
+ base::TimeTicks ComputeSafeDeadlineForFrame(const viz::BeginFrameArgs& args) {
+@@ -1145,7 +1145,7 @@ void CompositorFrameReporter::ReportCompositorLatencyTraceEvents(
+   const auto trace_track =
+       perfetto::Track(base::trace_event::GetNextGlobalTraceId());
+   TRACE_EVENT_BEGIN(
+-      kTraceCategory, "PipelineReporter", trace_track, args_.frame_time,
++      kTraceCategory2, "PipelineReporter", trace_track, args_.frame_time,
+       [&](perfetto::EventContext context) {
+         using perfetto::protos::pbzero::ChromeFrameReporter;
+         ChromeFrameReporter::State state;
+@@ -1226,7 +1226,7 @@ void CompositorFrameReporter::ReportCompositorLatencyTraceEvents(
+ 
+     if (stage.stage_type == StageType::kSendBeginMainFrameToCommit) {
+       TRACE_EVENT_BEGIN(
+-          kTraceCategory, perfetto::StaticString{stage_name}, trace_track,
++          kTraceCategory2, perfetto::StaticString{stage_name}, trace_track,
+           stage.start_time, [&](perfetto::EventContext context) {
+             DCHECK(processed_blink_breakdown_);
+             auto* reporter =
+@@ -1276,7 +1276,7 @@ void CompositorFrameReporter::ReportCompositorLatencyTraceEvents(
+             }
+           });
+     } else {
+-      TRACE_EVENT_BEGIN(kTraceCategory, perfetto::StaticString{stage_name},
++      TRACE_EVENT_BEGIN(kTraceCategory2, perfetto::StaticString{stage_name},
+                         trace_track, stage.start_time);
+     }
+ 
+@@ -1290,16 +1290,16 @@ void CompositorFrameReporter::ReportCompositorLatencyTraceEvents(
+         if (start_time >= end_time)
+           continue;
+         const char* breakdown_name = GetVizBreakdownName(it.GetBreakdown());
+-        TRACE_EVENT_BEGIN(kTraceCategory,
++        TRACE_EVENT_BEGIN(kTraceCategory2,
+                           perfetto::StaticString{breakdown_name}, trace_track,
+                           start_time);
+-        TRACE_EVENT_END(kTraceCategory, trace_track, end_time);
++        TRACE_EVENT_END(kTraceCategory2, trace_track, end_time);
+       }
+     }
+-    TRACE_EVENT_END(kTraceCategory, trace_track, stage.end_time);
++    TRACE_EVENT_END(kTraceCategory2, trace_track, stage.end_time);
+   }
+ 
+-  TRACE_EVENT_END(kTraceCategory, trace_track, frame_termination_time_);
++  TRACE_EVENT_END(kTraceCategory2, trace_track, frame_termination_time_);
+ }
+ 
+ void CompositorFrameReporter::ReportScrollJankMetrics() const {
+diff --git a/cc/metrics/compositor_frame_reporting_controller.cc b/cc/metrics/compositor_frame_reporting_controller.cc
+index b14a9e941..e599d0350 100644
+--- a/cc/metrics/compositor_frame_reporting_controller.cc
++++ b/cc/metrics/compositor_frame_reporting_controller.cc
+@@ -22,10 +22,10 @@ using SmoothThread = CompositorFrameReporter::SmoothThread;
+ using StageType = CompositorFrameReporter::StageType;
+ using FrameTerminationStatus = CompositorFrameReporter::FrameTerminationStatus;
+ 
+-constexpr char kTraceCategory[] = "cc,benchmark";
+-constexpr int kNumOfCompositorStages =
++constexpr char kTraceCategory3[] = "cc,benchmark";
++constexpr int kNumOfCompositorStages3 =
+     static_cast<int>(StageType::kStageTypeCount) - 1;
+-constexpr int kNumDispatchStages =
++constexpr int kNumDispatchStages3 =
+     static_cast<int>(EventMetrics::DispatchStage::kMaxValue);
+ constexpr base::TimeDelta kDefaultLatencyPredictionDeviationThreshold =
+     viz::BeginFrameArgs::DefaultInterval() / 2;
+@@ -41,8 +41,8 @@ CompositorFrameReportingController::CompositorFrameReportingController(
+       previous_latency_predictions_main_(base::Microseconds(-1)),
+       previous_latency_predictions_impl_(base::Microseconds(-1)),
+       event_latency_predictions_(
+-          CompositorFrameReporter::EventLatencyInfo(kNumDispatchStages,
+-                                                    kNumOfCompositorStages)) {
++          CompositorFrameReporter::EventLatencyInfo(kNumDispatchStages3,
++                                                    kNumOfCompositorStages3)) {
+   if (should_report_ukm) {
+     // UKM metrics should be reported if and only if `latency_ukm_reporter` is
+     // set on `global_trackers_`.
+@@ -446,9 +446,9 @@ void CompositorFrameReportingController::ReportMultipleSwaps(
+ 
+       const auto trace_track =
+           perfetto::Track(base::trace_event::GetNextGlobalTraceId());
+-      TRACE_EVENT_BEGIN(kTraceCategory, "MultipleSwaps", trace_track,
++      TRACE_EVENT_BEGIN(kTraceCategory3, "MultipleSwaps", trace_track,
+                         latest_swap_times_.front());
+-      TRACE_EVENT_END(kTraceCategory, trace_track, latest_swap_times_.back());
++      TRACE_EVENT_END(kTraceCategory3, trace_track, latest_swap_times_.back());
+     }
+   }
+ }
+diff --git a/cc/metrics/frame_sequence_tracker.cc b/cc/metrics/frame_sequence_tracker.cc
+index 7d00a3869..640ad838b 100644
+--- a/cc/metrics/frame_sequence_tracker.cc
++++ b/cc/metrics/frame_sequence_tracker.cc
+@@ -38,7 +38,7 @@ namespace cc {
+ 
+ namespace {
+ 
+-constexpr char kTraceCategory[] =
++constexpr char kTraceCategoryFST[] =
+     "cc,benchmark," TRACE_DISABLED_BY_DEFAULT("devtools.timeline.frame");
+ 
+ }  // namespace
+@@ -95,7 +95,7 @@ FrameSequenceTracker::FrameSequenceTracker(
+   // TODO(crbug.com/1158439): remove the trace event once the validation is
+   // completed.
+   TRACE_EVENT_NESTABLE_ASYNC_BEGIN_WITH_TIMESTAMP1(
+-      kTraceCategory, "TrackerValidation", TRACE_ID_LOCAL(this),
++      kTraceCategoryFST, "TrackerValidation", TRACE_ID_LOCAL(this),
+       base::TimeTicks::Now(), "name", GetFrameSequenceTrackerTypeName(type));
+ }
+ 
+@@ -112,7 +112,7 @@ FrameSequenceTracker::FrameSequenceTracker(
+ 
+ FrameSequenceTracker::~FrameSequenceTracker() {
+   TRACE_EVENT_NESTABLE_ASYNC_END_WITH_TIMESTAMP2(
+-      kTraceCategory, "TrackerValidation", TRACE_ID_LOCAL(this),
++      kTraceCategoryFST, "TrackerValidation", TRACE_ID_LOCAL(this),
+       base::TimeTicks::Now(), "aborted_main", aborted_main_frame_,
+       "no_damage_main", no_damage_draw_main_frames_);
+   CleanUp();
+diff --git a/cc/metrics/jank_injector.cc b/cc/metrics/jank_injector.cc
+index 659a87079..4bea2cec6 100644
+--- a/cc/metrics/jank_injector.cc
++++ b/cc/metrics/jank_injector.cc
+@@ -26,7 +26,7 @@ namespace cc {
+ 
+ namespace {
+ 
+-constexpr char kTraceCategory[] =
++constexpr char kTraceCategoryJI[] =
+     "cc,benchmark," TRACE_DISABLED_BY_DEFAULT("devtools.timeline.frame");
+ 
+ const char kJankInjectionAllowedURLs[] = "allowed_urls";
+@@ -93,7 +93,7 @@ bool IsJankInjectionEnabledForURL(const GURL& url) {
+ }
+ 
+ void RunJank(JankInjectionParams params) {
+-  TRACE_EVENT0(kTraceCategory, "Injected Jank");
++  TRACE_EVENT0(kTraceCategoryJI, "Injected Jank");
+   if (params.busy_loop) {
+     // Do some useless work, and prevent any weird compiler optimization from
+     // doing anything here.
+diff --git a/cc/metrics/jank_metrics.cc b/cc/metrics/jank_metrics.cc
+index f2265296c..b11ac934d 100644
+--- a/cc/metrics/jank_metrics.cc
++++ b/cc/metrics/jank_metrics.cc
+@@ -21,10 +21,10 @@ namespace cc {
+ namespace {
+ 
+ constexpr uint64_t kMaxNoUpdateFrameQueueLength = 100;
+-constexpr int kBuiltinSequenceNum =
++constexpr int kBuiltinJankSequenceNum =
+     static_cast<int>(FrameSequenceTrackerType::kMaxType) + 1;
+-constexpr int kMaximumJankHistogramIndex = 2 * kBuiltinSequenceNum;
+-constexpr int kMaximumStaleHistogramIndex = kBuiltinSequenceNum;
++constexpr int kMaximumJankHistogramIndex = 2 * kBuiltinJankSequenceNum;
++constexpr int kMaximumStaleHistogramIndex = kBuiltinJankSequenceNum;
+ 
+ constexpr base::TimeDelta kStaleHistogramMin = base::Microseconds(1);
+ constexpr base::TimeDelta kStaleHistogramMax = base::Milliseconds(1000);
+@@ -57,7 +57,7 @@ int GetIndexForJankMetric(FrameInfo::SmoothEffectDrivingThread thread_type,
+     return static_cast<int>(type);
+ 
+   DCHECK_EQ(thread_type, FrameInfo::SmoothEffectDrivingThread::kCompositor);
+-  return static_cast<int>(type) + kBuiltinSequenceNum;
++  return static_cast<int>(type) + kBuiltinJankSequenceNum;
+ }
+ 
+ int GetIndexForStaleMetric(FrameSequenceTrackerType type) {
+diff --git a/components/guest_view/browser/BUILD.gn b/components/guest_view/browser/BUILD.gn
+index 522080d36..ca05994da 100644
+--- a/components/guest_view/browser/BUILD.gn
++++ b/components/guest_view/browser/BUILD.gn
+@@ -8,7 +8,9 @@
+ # remove this assert.
+ assert(!is_android && !is_ios)
+ 
+-static_library("browser") {
++import("//build/config/jumbo.gni")
++
++jumbo_static_library("browser") {
+   output_name = "guest_view_browser"
+   sources = [
+     "//components/guest_view/browser/bad_message.cc",
+diff --git a/components/guest_view/renderer/BUILD.gn b/components/guest_view/renderer/BUILD.gn
+index d12cd543e..b6d983891 100644
+--- a/components/guest_view/renderer/BUILD.gn
++++ b/components/guest_view/renderer/BUILD.gn
+@@ -8,7 +8,9 @@
+ # remove this assert.
+ assert(!is_android && !is_ios)
+ 
+-static_library("renderer") {
++import("//build/config/jumbo.gni")
++
++jumbo_static_library("renderer") {
+   sources = [
+     "guest_view_container.cc",
+     "guest_view_container.h",
+diff --git a/components/metrics/metrics_log.cc b/components/metrics/metrics_log.cc
+index a5710fd56..6a24d2f0e 100644
+--- a/components/metrics/metrics_log.cc
++++ b/components/metrics/metrics_log.cc
+@@ -305,8 +305,8 @@ void MetricsLog::RecordCoreSystemProfile(MetricsServiceClient* client,
+   // Exclude these switches which are very frequently on the command line but
+   // serve no meaningful purpose.
+   static const char* const kSwitchesToFilter[] = {
+-      switches::kFlagSwitchesBegin,
+-      switches::kFlagSwitchesEnd,
++      ::switches::kFlagSwitchesBegin,
++      ::switches::kFlagSwitchesEnd,
+   };
+ 
+   for (const char* filter_switch : kSwitchesToFilter)
+diff --git a/components/metrics/metrics_state_manager.cc b/components/metrics/metrics_state_manager.cc
+index 7fdd69f29..ac83d6ebf 100644
+--- a/components/metrics/metrics_state_manager.cc
++++ b/components/metrics/metrics_state_manager.cc
+@@ -545,8 +545,8 @@ MetricsStateManager::CreateEntropyProviders() {
+   return std::make_unique<variations::EntropyProviders>(
+       GetHighEntropySource(),
+       variations::ValueInRange{
+-          .value = base::checked_cast<uint32_t>(GetLowEntropySource()),
+-          .range = EntropyState::kMaxLowEntropySize},
++          /*.value =*/ base::checked_cast<uint32_t>(GetLowEntropySource()),
++          /*.range =*/ EntropyState::kMaxLowEntropySize},
+       ShouldEnableBenchmarking(entropy_params_.force_benchmarking_mode));
+ }
+ 
+diff --git a/components/performance_manager/BUILD.gn b/components/performance_manager/BUILD.gn
+index 76794b25e..70974514a 100644
+--- a/components/performance_manager/BUILD.gn
++++ b/components/performance_manager/BUILD.gn
+@@ -2,13 +2,14 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/jumbo.gni")
+ import("//third_party/protobuf/proto_library.gni")
+ 
+ proto_library("site_data_proto") {
+   sources = [ "persistence/site_data/site_data.proto" ]
+ }
+ 
+-static_library("performance_manager") {
++jumbo_static_library("performance_manager") {
+   sources = [
+     "binders.cc",
+     "browser_child_process_host_proxy.cc",
+@@ -244,6 +245,7 @@ static_library("performance_manager") {
+       "graph/policies/bfcache_policy.cc",
+       "graph/policies/bfcache_policy.h",
+     ]
++    jumbo_excluded_sources = [ "decorators/site_data_recorder.cc" ]
+ 
+     public_deps += [
+       ":site_data_proto",
+diff --git a/components/performance_manager/decorators/page_live_state_decorator.cc b/components/performance_manager/decorators/page_live_state_decorator.cc
+index 07c8c7b74..5869fe958 100644
+--- a/components/performance_manager/decorators/page_live_state_decorator.cc
++++ b/components/performance_manager/decorators/page_live_state_decorator.cc
+@@ -236,8 +236,6 @@ class PageLiveStateDataImpl
+   const raw_ptr<const PageNode> page_node_;
+ };
+ 
+-const char kDescriberName[] = "PageLiveStateDecorator";
+-
+ }  // namespace
+ 
+ void PageLiveStateDecorator::Delegate::GetContentSettingsAndReply(
+@@ -356,7 +354,7 @@ void PageLiveStateDecorator::SetContentSettings(
+ 
+ void PageLiveStateDecorator::OnPassedToGraph(Graph* graph) {
+   graph->GetNodeDataDescriberRegistry()->RegisterDescriber(this,
+-                                                           kDescriberName);
++                                                           "PageLiveStateDecorator");
+   graph->AddPageNodeObserver(this);
+ }
+ 
+diff --git a/components/performance_manager/decorators/page_load_tracker_decorator.cc b/components/performance_manager/decorators/page_load_tracker_decorator.cc
+index 9323c673c..3d6b66eda 100644
+--- a/components/performance_manager/decorators/page_load_tracker_decorator.cc
++++ b/components/performance_manager/decorators/page_load_tracker_decorator.cc
+@@ -68,8 +68,6 @@ const char* ToString(LoadIdleState state) {
+   }
+ }
+ 
+-const char kDescriberName[] = "PageLoadTrackerDecorator";
+-
+ }  // namespace
+ 
+ // static
+@@ -94,7 +92,7 @@ void PageLoadTrackerDecorator::OnNetworkAlmostIdleChanged(
+ void PageLoadTrackerDecorator::OnPassedToGraph(Graph* graph) {
+   RegisterObservers(graph);
+   graph->GetNodeDataDescriberRegistry()->RegisterDescriber(this,
+-                                                           kDescriberName);
++                                                           "PageLoadTrackerDecorator");
+ }
+ 
+ void PageLoadTrackerDecorator::OnTakenFromGraph(Graph* graph) {
+diff --git a/components/performance_manager/execution_context_priority/frame_audible_voter.cc b/components/performance_manager/execution_context_priority/frame_audible_voter.cc
+index c1ed0a54a..4eef64fef 100644
+--- a/components/performance_manager/execution_context_priority/frame_audible_voter.cc
++++ b/components/performance_manager/execution_context_priority/frame_audible_voter.cc
+@@ -13,7 +13,7 @@ namespace execution_context_priority {
+ 
+ namespace {
+ 
+-const execution_context::ExecutionContext* GetExecutionContext(
++const execution_context::ExecutionContext* GetExecutionContext2(
+     const FrameNode* frame_node) {
+   return execution_context::ExecutionContextRegistry::GetFromGraph(
+              frame_node->GetGraph())
+@@ -43,16 +43,16 @@ void FrameAudibleVoter::SetVotingChannel(VotingChannel voting_channel) {
+ 
+ void FrameAudibleVoter::OnFrameNodeAdded(const FrameNode* frame_node) {
+   const Vote vote = GetVote(frame_node->IsAudible());
+-  voting_channel_.SubmitVote(GetExecutionContext(frame_node), vote);
++  voting_channel_.SubmitVote(GetExecutionContext2(frame_node), vote);
+ }
+ 
+ void FrameAudibleVoter::OnBeforeFrameNodeRemoved(const FrameNode* frame_node) {
+-  voting_channel_.InvalidateVote(GetExecutionContext(frame_node));
++  voting_channel_.InvalidateVote(GetExecutionContext2(frame_node));
+ }
+ 
+ void FrameAudibleVoter::OnIsAudibleChanged(const FrameNode* frame_node) {
+   const Vote new_vote = GetVote(frame_node->IsAudible());
+-  voting_channel_.ChangeVote(GetExecutionContext(frame_node), new_vote);
++  voting_channel_.ChangeVote(GetExecutionContext2(frame_node), new_vote);
+ }
+ 
+ }  // namespace execution_context_priority
+diff --git a/components/performance_manager/execution_context_priority/frame_visibility_voter.cc b/components/performance_manager/execution_context_priority/frame_visibility_voter.cc
+index 669177017..75a854150 100644
+--- a/components/performance_manager/execution_context_priority/frame_visibility_voter.cc
++++ b/components/performance_manager/execution_context_priority/frame_visibility_voter.cc
+@@ -14,7 +14,7 @@ namespace execution_context_priority {
+ 
+ namespace {
+ 
+-const execution_context::ExecutionContext* GetExecutionContext(
++const execution_context::ExecutionContext* GetExecutionContext5(
+     const FrameNode* frame_node) {
+   return execution_context::ExecutionContextRegistry::GetFromGraph(
+              frame_node->GetGraph())
+@@ -23,7 +23,7 @@ const execution_context::ExecutionContext* GetExecutionContext(
+ 
+ // Returns a vote with the appropriate priority depending on the frame's
+ // |visibility|.
+-Vote GetVote(FrameNode::Visibility visibility) {
++Vote GetVote2(FrameNode::Visibility visibility) {
+   base::TaskPriority priority;
+   switch (visibility) {
+     case FrameNode::Visibility::kUnknown:
+@@ -53,25 +53,25 @@ void FrameVisibilityVoter::SetVotingChannel(VotingChannel voting_channel) {
+ }
+ 
+ void FrameVisibilityVoter::OnFrameNodeAdded(const FrameNode* frame_node) {
+-  const Vote vote = GetVote(frame_node->GetVisibility());
+-  voting_channel_.SubmitVote(GetExecutionContext(frame_node), vote);
++  const Vote vote = GetVote2(frame_node->GetVisibility());
++  voting_channel_.SubmitVote(GetExecutionContext5(frame_node), vote);
+ }
+ 
+ void FrameVisibilityVoter::OnBeforeFrameNodeRemoved(
+     const FrameNode* frame_node) {
+-  voting_channel_.InvalidateVote(GetExecutionContext(frame_node));
++  voting_channel_.InvalidateVote(GetExecutionContext5(frame_node));
+ }
+ 
+ void FrameVisibilityVoter::OnFrameVisibilityChanged(
+     const FrameNode* frame_node,
+     FrameNode::Visibility previous_value) {
+-  const Vote new_vote = GetVote(frame_node->GetVisibility());
++  const Vote new_vote = GetVote2(frame_node->GetVisibility());
+ 
+   // Nothing to change if the new priority is the same as the old one.
+-  if (new_vote == GetVote(previous_value))
++  if (new_vote == GetVote2(previous_value))
+     return;
+ 
+-  voting_channel_.ChangeVote(GetExecutionContext(frame_node), new_vote);
++  voting_channel_.ChangeVote(GetExecutionContext5(frame_node), new_vote);
+ }
+ 
+ }  // namespace execution_context_priority
+diff --git a/components/performance_manager/execution_context_priority/inherit_client_priority_voter.cc b/components/performance_manager/execution_context_priority/inherit_client_priority_voter.cc
+index 3b637f8d0..54a877287 100644
+--- a/components/performance_manager/execution_context_priority/inherit_client_priority_voter.cc
++++ b/components/performance_manager/execution_context_priority/inherit_client_priority_voter.cc
+@@ -16,14 +16,14 @@ namespace execution_context_priority {
+ 
+ namespace {
+ 
+-const execution_context::ExecutionContext* GetExecutionContext(
++const execution_context::ExecutionContext* GetExecutionContext_ICPV(
+     const FrameNode* frame_node) {
+   return execution_context::ExecutionContextRegistry::GetFromGraph(
+              frame_node->GetGraph())
+       ->GetExecutionContextForFrameNode(frame_node);
+ }
+ 
+-const execution_context::ExecutionContext* GetExecutionContext(
++const execution_context::ExecutionContext* GetExecutionContext_ICPV(
+     const WorkerNode* worker_node) {
+   return execution_context::ExecutionContextRegistry::GetFromGraph(
+              worker_node->GetGraph())
+@@ -50,7 +50,7 @@ void InheritClientPriorityVoter::SetVotingChannel(
+ 
+ void InheritClientPriorityVoter::OnFrameNodeAdded(const FrameNode* frame_node) {
+   bool inserted = voting_channels_
+-                      .emplace(GetExecutionContext(frame_node),
++                      .emplace(GetExecutionContext_ICPV(frame_node),
+                                max_vote_aggregator_.GetVotingChannel())
+                       .second;
+   DCHECK(inserted);
+@@ -60,7 +60,7 @@ void InheritClientPriorityVoter::OnFrameNodeAdded(const FrameNode* frame_node) {
+ void InheritClientPriorityVoter::OnBeforeFrameNodeRemoved(
+     const FrameNode* frame_node) {
+   DCHECK(frame_node->GetChildWorkerNodes().empty());
+-  size_t removed = voting_channels_.erase(GetExecutionContext(frame_node));
++  size_t removed = voting_channels_.erase(GetExecutionContext_ICPV(frame_node));
+   DCHECK_EQ(removed, 1u);
+ }
+ 
+@@ -70,7 +70,7 @@ void InheritClientPriorityVoter::OnPriorityAndReasonChanged(
+   // The priority of a frame changed. All its children must inherit the new
+   // priority.
+ 
+-  auto it = voting_channels_.find(GetExecutionContext(frame_node));
++  auto it = voting_channels_.find(GetExecutionContext_ICPV(frame_node));
+ 
+   // Unknown |frame_node|. Just ignore it until we get notified of its existence
+   // via OnFrameNodeAdded(). This can happen because another voter received the
+@@ -86,7 +86,7 @@ void InheritClientPriorityVoter::OnPriorityAndReasonChanged(
+   for (const WorkerNode* child_worker_node :
+        frame_node->GetChildWorkerNodes()) {
+     const ExecutionContext* child_execution_context =
+-        GetExecutionContext(child_worker_node);
++        GetExecutionContext_ICPV(child_worker_node);
+     voting_channel.ChangeVote(child_execution_context, inherited_vote);
+   }
+ }
+@@ -94,7 +94,7 @@ void InheritClientPriorityVoter::OnPriorityAndReasonChanged(
+ void InheritClientPriorityVoter::OnWorkerNodeAdded(
+     const WorkerNode* worker_node) {
+   bool inserted = voting_channels_
+-                      .emplace(GetExecutionContext(worker_node),
++                      .emplace(GetExecutionContext_ICPV(worker_node),
+                                max_vote_aggregator_.GetVotingChannel())
+                       .second;
+   DCHECK(inserted);
+@@ -104,7 +104,7 @@ void InheritClientPriorityVoter::OnWorkerNodeAdded(
+ void InheritClientPriorityVoter::OnBeforeWorkerNodeRemoved(
+     const WorkerNode* worker_node) {
+   DCHECK(worker_node->GetChildWorkers().empty());
+-  size_t removed = voting_channels_.erase(GetExecutionContext(worker_node));
++  size_t removed = voting_channels_.erase(GetExecutionContext_ICPV(worker_node));
+   DCHECK_EQ(removed, 1u);
+ }
+ 
+@@ -115,14 +115,14 @@ void InheritClientPriorityVoter::OnClientFrameAdded(
+   // priority.
+ 
+   // Get the voting channel for the client.
+-  auto it = voting_channels_.find(GetExecutionContext(client_frame_node));
++  auto it = voting_channels_.find(GetExecutionContext_ICPV(client_frame_node));
+   DCHECK(it != voting_channels_.end());
+   auto* voting_channel = &it->second;
+ 
+   const Vote inherited_vote(
+       client_frame_node->GetPriorityAndReason().priority(),
+       kPriorityInheritedReason);
+-  voting_channel->SubmitVote(GetExecutionContext(worker_node), inherited_vote);
++  voting_channel->SubmitVote(GetExecutionContext_ICPV(worker_node), inherited_vote);
+ }
+ 
+ void InheritClientPriorityVoter::OnBeforeClientFrameRemoved(
+@@ -132,11 +132,11 @@ void InheritClientPriorityVoter::OnBeforeClientFrameRemoved(
+   // vote must be invalidated.
+ 
+   // Get the voting channel for the client.
+-  auto it = voting_channels_.find(GetExecutionContext(client_frame_node));
++  auto it = voting_channels_.find(GetExecutionContext_ICPV(client_frame_node));
+   DCHECK(it != voting_channels_.end());
+   auto* voting_channel = &it->second;
+ 
+-  voting_channel->InvalidateVote(GetExecutionContext(worker_node));
++  voting_channel->InvalidateVote(GetExecutionContext_ICPV(worker_node));
+ }
+ 
+ void InheritClientPriorityVoter::OnClientWorkerAdded(
+@@ -146,14 +146,14 @@ void InheritClientPriorityVoter::OnClientWorkerAdded(
+   // priority.
+ 
+   // Get the voting channel for the client.
+-  auto it = voting_channels_.find(GetExecutionContext(client_worker_node));
++  auto it = voting_channels_.find(GetExecutionContext_ICPV(client_worker_node));
+   DCHECK(it != voting_channels_.end());
+   auto* voting_channel = &it->second;
+ 
+   const Vote inherited_vote(
+       client_worker_node->GetPriorityAndReason().priority(),
+       kPriorityInheritedReason);
+-  voting_channel->SubmitVote(GetExecutionContext(worker_node), inherited_vote);
++  voting_channel->SubmitVote(GetExecutionContext_ICPV(worker_node), inherited_vote);
+ }
+ 
+ void InheritClientPriorityVoter::OnBeforeClientWorkerRemoved(
+@@ -163,11 +163,11 @@ void InheritClientPriorityVoter::OnBeforeClientWorkerRemoved(
+   // vote must be invalidated.
+ 
+   // Get the voting channel for the client.
+-  auto it = voting_channels_.find(GetExecutionContext(client_worker_node));
++  auto it = voting_channels_.find(GetExecutionContext_ICPV(client_worker_node));
+   DCHECK(it != voting_channels_.end());
+   auto* voting_channel = &it->second;
+ 
+-  voting_channel->InvalidateVote(GetExecutionContext(worker_node));
++  voting_channel->InvalidateVote(GetExecutionContext_ICPV(worker_node));
+ }
+ 
+ void InheritClientPriorityVoter::OnPriorityAndReasonChanged(
+@@ -176,7 +176,7 @@ void InheritClientPriorityVoter::OnPriorityAndReasonChanged(
+   // The priority of a worker changed. All its children must inherit the new
+   // priority.
+ 
+-  auto it = voting_channels_.find(GetExecutionContext(worker_node));
++  auto it = voting_channels_.find(GetExecutionContext_ICPV(worker_node));
+ 
+   // Unknown |worker_node|. Just ignore it until we get notified of its
+   // existence via OnWorkerNodeAdded().
+@@ -189,7 +189,7 @@ void InheritClientPriorityVoter::OnPriorityAndReasonChanged(
+                             kPriorityInheritedReason);
+   for (const WorkerNode* child_worker_node : worker_node->GetChildWorkers()) {
+     const ExecutionContext* child_execution_context =
+-        GetExecutionContext(child_worker_node);
++        GetExecutionContext_ICPV(child_worker_node);
+     voting_channel.ChangeVote(child_execution_context, inherited_vote);
+   }
+ }
+diff --git a/components/performance_manager/graph/frame_node_impl_describer.cc b/components/performance_manager/graph/frame_node_impl_describer.cc
+index 9cc282c2b..6b49ef634 100644
+--- a/components/performance_manager/graph/frame_node_impl_describer.cc
++++ b/components/performance_manager/graph/frame_node_impl_describer.cc
+@@ -17,8 +17,6 @@ namespace performance_manager {
+ 
+ namespace {
+ 
+-const char kDescriberName[] = "FrameNodeImpl";
+-
+ std::string ViewportIntersectionToString(
+     const absl::optional<gfx::Rect>& viewport_intersection) {
+   if (!viewport_intersection.has_value())
+@@ -45,7 +43,7 @@ FrameNodeImplDescriber::~FrameNodeImplDescriber() = default;
+ 
+ void FrameNodeImplDescriber::OnPassedToGraph(Graph* graph) {
+   graph->GetNodeDataDescriberRegistry()->RegisterDescriber(this,
+-                                                           kDescriberName);
++                                                           "FrameNodeImpl");
+ }
+ 
+ void FrameNodeImplDescriber::OnTakenFromGraph(Graph* graph) {
+diff --git a/components/performance_manager/graph/page_node_impl_describer.cc b/components/performance_manager/graph/page_node_impl_describer.cc
+index 46049ddc0..6af5d681a 100644
+--- a/components/performance_manager/graph/page_node_impl_describer.cc
++++ b/components/performance_manager/graph/page_node_impl_describer.cc
+@@ -15,8 +15,6 @@ namespace performance_manager {
+ 
+ namespace {
+ 
+-const char kDescriberName[] = "PageNodeImpl";
+-
+ const char* FreezingVoteToString(
+     absl::optional<freezing::FreezingVote> freezing_vote) {
+   if (!freezing_vote)
+@@ -32,7 +30,7 @@ PageNodeImplDescriber::~PageNodeImplDescriber() = default;
+ 
+ void PageNodeImplDescriber::OnPassedToGraph(Graph* graph) {
+   graph->GetNodeDataDescriberRegistry()->RegisterDescriber(this,
+-                                                           kDescriberName);
++                                                           "PageNodeImpl");
+ }
+ 
+ void PageNodeImplDescriber::OnTakenFromGraph(Graph* graph) {
+diff --git a/components/performance_manager/graph/process_node_impl_describer.cc b/components/performance_manager/graph/process_node_impl_describer.cc
+index 31cd844d9..d27751643 100644
+--- a/components/performance_manager/graph/process_node_impl_describer.cc
++++ b/components/performance_manager/graph/process_node_impl_describer.cc
+@@ -26,8 +26,6 @@ namespace performance_manager {
+ 
+ namespace {
+ 
+-const char kDescriberName[] = "ProcessNodeImpl";
+-
+ std::string ContentTypeToString(ProcessNode::ContentType content_type) {
+   switch (content_type) {
+     case ProcessNode::ContentType::kExtension:
+@@ -125,7 +123,7 @@ base::Time TicksToTime(base::TimeTicks ticks) {
+ 
+ void ProcessNodeImplDescriber::OnPassedToGraph(Graph* graph) {
+   graph->GetNodeDataDescriberRegistry()->RegisterDescriber(this,
+-                                                           kDescriberName);
++                                                           "ProcessNodeImpl");
+ }
+ 
+ void ProcessNodeImplDescriber::OnTakenFromGraph(Graph* graph) {
+diff --git a/components/performance_manager/graph/worker_node_impl_describer.cc b/components/performance_manager/graph/worker_node_impl_describer.cc
+index 72db192b3..383019b7e 100644
+--- a/components/performance_manager/graph/worker_node_impl_describer.cc
++++ b/components/performance_manager/graph/worker_node_impl_describer.cc
+@@ -12,8 +12,6 @@ namespace performance_manager {
+ 
+ namespace {
+ 
+-const char kDescriberName[] = "WorkerNode";
+-
+ const char* WorkerTypeToString(WorkerNode::WorkerType state) {
+   switch (state) {
+     case WorkerNode::WorkerType::kDedicated:
+@@ -29,7 +27,7 @@ const char* WorkerTypeToString(WorkerNode::WorkerType state) {
+ 
+ void WorkerNodeImplDescriber::OnPassedToGraph(Graph* graph) {
+   graph->GetNodeDataDescriberRegistry()->RegisterDescriber(this,
+-                                                           kDescriberName);
++                                                           "WorkerNode");
+ }
+ 
+ void WorkerNodeImplDescriber::OnTakenFromGraph(Graph* graph) {
+diff --git a/components/performance_manager/performance_manager_registry_impl.cc b/components/performance_manager/performance_manager_registry_impl.cc
+index 51bd4bb57..4fead7728 100644
+--- a/components/performance_manager/performance_manager_registry_impl.cc
++++ b/components/performance_manager/performance_manager_registry_impl.cc
+@@ -27,15 +27,15 @@
+ 
+ namespace performance_manager {
+ 
+-namespace {
++namespace performance_manager_registry_impl {
+ 
+ PerformanceManagerRegistryImpl* g_instance = nullptr;
+ 
+ }  // namespace
+ 
+ PerformanceManagerRegistryImpl::PerformanceManagerRegistryImpl() {
+-  DCHECK(!g_instance);
+-  g_instance = this;
++  DCHECK(!performance_manager_registry_impl::g_instance);
++  performance_manager_registry_impl::g_instance = this;
+ 
+   // The registry should be created after the PerformanceManager.
+   DCHECK(PerformanceManager::IsAvailable());
+@@ -46,7 +46,7 @@ PerformanceManagerRegistryImpl::~PerformanceManagerRegistryImpl() {
+   // TearDown() should have been invoked to reset |g_instance| and clear
+   // |web_contents_| and |render_process_user_data_| prior to destroying the
+   // registry.
+-  DCHECK(!g_instance);
++  DCHECK(!performance_manager_registry_impl::g_instance);
+   DCHECK(web_contents_.empty());
+   DCHECK(render_process_hosts_.empty());
+   DCHECK(pm_owned_.empty());
+@@ -57,7 +57,7 @@ PerformanceManagerRegistryImpl::~PerformanceManagerRegistryImpl() {
+ 
+ // static
+ PerformanceManagerRegistryImpl* PerformanceManagerRegistryImpl::GetInstance() {
+-  return g_instance;
++  return performance_manager_registry_impl::g_instance;
+ }
+ 
+ void PerformanceManagerRegistryImpl::AddObserver(
+@@ -241,8 +241,8 @@ void PerformanceManagerRegistryImpl::TearDown() {
+   for (auto& observer : observers_)
+     observer.OnBeforePerformanceManagerDestroyed();
+ 
+-  DCHECK_EQ(g_instance, this);
+-  g_instance = nullptr;
++  DCHECK_EQ(performance_manager_registry_impl::g_instance, this);
++  performance_manager_registry_impl::g_instance = nullptr;
+ 
+   // Destroy WorkerNodes before ProcessNodes, because ProcessNode checks that it
+   // has no associated WorkerNode when torn down.
+diff --git a/components/performance_manager/persistence/site_data/site_data_cache_factory.cc b/components/performance_manager/persistence/site_data/site_data_cache_factory.cc
+index 9c8f5f591..ecdc53171 100644
+--- a/components/performance_manager/persistence/site_data/site_data_cache_factory.cc
++++ b/components/performance_manager/persistence/site_data/site_data_cache_factory.cc
+@@ -18,29 +18,29 @@
+ 
+ namespace performance_manager {
+ 
+-namespace {
++namespace site_data_cache_factory {
+ SiteDataCacheFactory* g_instance = nullptr;
+ }  // namespace
+ 
+ SiteDataCacheFactory::SiteDataCacheFactory() {
+-  DCHECK(!g_instance);
+-  g_instance = this;
++  DCHECK(!site_data_cache_factory::g_instance);
++  site_data_cache_factory::g_instance = this;
+ }
+ 
+ SiteDataCacheFactory::~SiteDataCacheFactory() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+-  DCHECK_EQ(this, g_instance);
++  DCHECK_EQ(this, site_data_cache_factory::g_instance);
+   // Clear the cache map before unsetting |g_instance| as this will cause some
+   // calls to |SetDataCacheInspectorForBrowserContext|.
+   data_cache_map_.clear();
+   for (const auto& iter : data_cache_map_)
+     DCHECK_EQ(0, iter.second->Size());
+-  g_instance = nullptr;
++  site_data_cache_factory::g_instance = nullptr;
+ }
+ 
+ // static
+ SiteDataCacheFactory* SiteDataCacheFactory::GetInstance() {
+-  return g_instance;
++  return site_data_cache_factory::g_instance;
+ }
+ 
+ SiteDataCache* SiteDataCacheFactory::GetDataCacheForBrowserContext(
+diff --git a/components/policy/core/common/policy_proto_decoders.cc b/components/policy/core/common/policy_proto_decoders.cc
+index 36ad07831..24cd0c900 100644
+--- a/components/policy/core/common/policy_proto_decoders.cc
++++ b/components/policy/core/common/policy_proto_decoders.cc
+@@ -29,7 +29,7 @@ namespace {
+ 
+ const char kValue[] = "Value";
+ const char kLevel[] = "Level";
+-const char kRecommended[] = "Recommended";
++const char kRecommendedLocal[] = "Recommended";
+ 
+ // Returns true and sets |level| to a PolicyLevel if the policy has been set
+ // at that level. Returns false if the policy is not set, or has been set at
+@@ -254,7 +254,7 @@ bool ParseComponentPolicy(base::Value json,
+ 
+     PolicyLevel level = POLICY_LEVEL_MANDATORY;
+     const std::string* level_string = description.FindStringKey(kLevel);
+-    if (level_string && *level_string == kRecommended)
++    if (level_string && *level_string == kRecommendedLocal)
+       level = POLICY_LEVEL_RECOMMENDED;
+ 
+     policy->Set(policy_name, level, scope, source, std::move(value.value()),
+diff --git a/components/printing/browser/BUILD.gn b/components/printing/browser/BUILD.gn
+index cd2f244c1..a5f46dda2 100644
+--- a/components/printing/browser/BUILD.gn
++++ b/components/printing/browser/BUILD.gn
+@@ -2,7 +2,9 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-static_library("browser") {
++import("//build/config/jumbo.gni")
++
++jumbo_static_library("browser") {
+   sources = [
+     "print_composite_client.cc",
+     "print_composite_client.h",
+diff --git a/components/storage_monitor/BUILD.gn b/components/storage_monitor/BUILD.gn
+index 546f194a2..4b2302105 100644
+--- a/components/storage_monitor/BUILD.gn
++++ b/components/storage_monitor/BUILD.gn
+@@ -4,8 +4,9 @@
+ 
+ import("//build/config/chromeos/ui_mode.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ 
+-static_library("storage_monitor") {
++jumbo_static_library("storage_monitor") {
+   sources = [
+     "media_storage_util.cc",
+     "media_storage_util.h",
+diff --git a/components/viz/common/BUILD.gn b/components/viz/common/BUILD.gn
+index d8075e84c..6052363c5 100644
+--- a/components/viz/common/BUILD.gn
++++ b/components/viz/common/BUILD.gn
+@@ -48,6 +48,7 @@ viz_component("resource_format_utils") {
+     "viz_resource_format_export.h",
+   ]
+ 
++  jumbo_excluded_sources = [ "resources/resource_format_utils.cc" ]
+   configs = [ "//third_party/khronos:khronos_headers" ]
+ 
+   public_deps = [ ":resource_format" ]
+diff --git a/components/viz/service/BUILD.gn b/components/viz/service/BUILD.gn
+index bebc21404..c980881f5 100644
+--- a/components/viz/service/BUILD.gn
++++ b/components/viz/service/BUILD.gn
+@@ -222,6 +222,17 @@ viz_component("service") {
+     "viz_service_export.h",
+   ]
+ 
++  jumbo_excluded_sources = [
++    "display/display.cc",
++    "display/overlay_processor_on_gpu.cc",
++    "display_embedder/compositor_gpu_thread.cc",
++    "display_embedder/skia_output_device_gl.cc",
++    "display_embedder/skia_output_device_webview.cc",
++    "display_embedder/skia_output_surface_impl_on_gpu.cc",
++    "frame_sinks/frame_sink_manager_impl.cc",
++    "frame_sinks/video_capture/frame_sink_video_capturer_impl.cc",
++  ]
++
+   defines = [ "VIZ_SERVICE_IMPLEMENTATION" ]
+ 
+   deps = [
+@@ -377,6 +388,9 @@ viz_component("service") {
+       "gl/info_collection_gpu_service_impl.cc",
+       "gl/info_collection_gpu_service_impl.h",
+     ]
++    jumbo_excluded_sources += [
++      "display_embedder/skia_output_device_dcomp.cc",
++    ]
+ 
+     # SkiaOutputDeviceBufferQueue doesn't support Windows.
+     sources -= [
+diff --git a/components/viz/service/display/display_resource_provider.h b/components/viz/service/display/display_resource_provider.h
+index effa9bca4..b054841de 100644
+--- a/components/viz/service/display/display_resource_provider.h
++++ b/components/viz/service/display/display_resource_provider.h
+@@ -28,7 +28,7 @@
+ #include "components/viz/service/display/resource_fence.h"
+ #include "components/viz/service/viz_service_export.h"
+ #include "gpu/command_buffer/common/sync_token.h"
+-#include "third_party/khronos/GLES2/gl2.h"
++//#include "third_party/khronos/GLES2/gl2.h"
+ #include "ui/gfx/geometry/rect_f.h"
+ #include "ui/gfx/geometry/size.h"
+ 
+diff --git a/components/viz/service/display_embedder/skia_output_device_webview.cc b/components/viz/service/display_embedder/skia_output_device_webview.cc
+index 9ad49445e..756d8bb02 100644
+--- a/components/viz/service/display_embedder/skia_output_device_webview.cc
++++ b/components/viz/service/display_embedder/skia_output_device_webview.cc
+@@ -18,7 +18,7 @@
+ namespace viz {
+ 
+ namespace {
+-constexpr auto kSurfaceColorType = kRGBA_8888_SkColorType;
++constexpr auto kMySurfaceColorType = kRGBA_8888_SkColorType;
+ }
+ 
+ SkiaOutputDeviceWebView::SkiaOutputDeviceWebView(
+@@ -43,9 +43,9 @@ SkiaOutputDeviceWebView::SkiaOutputDeviceWebView(
+   DCHECK(context_state_->context());
+ 
+   capabilities_.sk_color_types[static_cast<int>(gfx::BufferFormat::RGBA_8888)] =
+-      kSurfaceColorType;
++      kMySurfaceColorType;
+   capabilities_.sk_color_types[static_cast<int>(gfx::BufferFormat::BGRA_8888)] =
+-      kSurfaceColorType;
++      kMySurfaceColorType;
+ }
+ 
+ SkiaOutputDeviceWebView::~SkiaOutputDeviceWebView() = default;
+@@ -104,7 +104,7 @@ void SkiaOutputDeviceWebView::InitSkiaSurface(unsigned int fbo) {
+   GrGLFramebufferInfo framebuffer_info;
+   framebuffer_info.fFBOID = fbo;
+   framebuffer_info.fFormat = GL_RGBA8;
+-  SkColorType color_type = kSurfaceColorType;
++  SkColorType color_type = kMySurfaceColorType;
+ 
+   GrBackendRenderTarget render_target(size_.width(), size_.height(),
+                                       /*sampleCnt=*/0,
+diff --git a/components/viz/service/transitions/transferable_resource_tracker.cc b/components/viz/service/transitions/transferable_resource_tracker.cc
+index a60e0b588..d801bee73 100644
+--- a/components/viz/service/transitions/transferable_resource_tracker.cc
++++ b/components/viz/service/transitions/transferable_resource_tracker.cc
+@@ -4,7 +4,7 @@
+ 
+ #include "components/viz/service/transitions/transferable_resource_tracker.h"
+ 
+-#include <GLES2/gl2.h>
++#include "third_party/khronos/GLES2/gl2.h"
+ 
+ #include <limits>
+ #include <memory>
+diff --git a/content/browser/BUILD.gn b/content/browser/BUILD.gn
+index 24283757c..41136221f 100644
+--- a/content/browser/BUILD.gn
++++ b/content/browser/BUILD.gn
+@@ -37,6 +37,88 @@ buildflag_header("buildflags") {
+   flags = [ "USE_SOCKET_BROKER=$use_socket_broker" ]
+ }
+ 
++jumbo_static_library("devtools_protocol") {
++  configs += [
++    "//build/config:precompiled_headers",
++    "//content:content_implementation",
++  ]
++
++  deps = [
++    "//base",
++    "//content/browser/devtools:devtools_background_services_proto",
++    "//content/browser/devtools:protocol_sources",
++    "//content/common:buildflags",
++    "//services/viz/privileged/mojom",
++    "//third_party/blink/public/mojom:mojom_platform",
++    "//third_party/inspector_protocol:crdtp",
++  ]
++
++  sources = [
++    "$target_gen_dir/devtools/protocol/audits.cc",
++    "$target_gen_dir/devtools/protocol/audits.h",
++    "$target_gen_dir/devtools/protocol/background_service.cc",
++    "$target_gen_dir/devtools/protocol/background_service.h",
++    "$target_gen_dir/devtools/protocol/browser.cc",
++    "$target_gen_dir/devtools/protocol/browser.h",
++    "$target_gen_dir/devtools/protocol/dom.cc",
++    "$target_gen_dir/devtools/protocol/dom.h",
++    "$target_gen_dir/devtools/protocol/emulation.cc",
++    "$target_gen_dir/devtools/protocol/emulation.h",
++    "$target_gen_dir/devtools/protocol/fetch.cc",
++    "$target_gen_dir/devtools/protocol/fetch.h",
++    "$target_gen_dir/devtools/protocol/forward.h",
++    "$target_gen_dir/devtools/protocol/input.cc",
++    "$target_gen_dir/devtools/protocol/input.h",
++    "$target_gen_dir/devtools/protocol/inspector.cc",
++    "$target_gen_dir/devtools/protocol/inspector.h",
++    "$target_gen_dir/devtools/protocol/io.cc",
++    "$target_gen_dir/devtools/protocol/io.h",
++    "$target_gen_dir/devtools/protocol/log.cc",
++    "$target_gen_dir/devtools/protocol/log.h",
++    "$target_gen_dir/devtools/protocol/memory.cc",
++    "$target_gen_dir/devtools/protocol/memory.h",
++    "$target_gen_dir/devtools/protocol/network.cc",
++    "$target_gen_dir/devtools/protocol/network.h",
++    "$target_gen_dir/devtools/protocol/overlay.cc",
++    "$target_gen_dir/devtools/protocol/overlay.h",
++    "$target_gen_dir/devtools/protocol/page.cc",
++    "$target_gen_dir/devtools/protocol/page.h",
++    "$target_gen_dir/devtools/protocol/protocol.h",
++    "$target_gen_dir/devtools/protocol/runtime.cc",
++    "$target_gen_dir/devtools/protocol/runtime.h",
++    "$target_gen_dir/devtools/protocol/schema.cc",
++    "$target_gen_dir/devtools/protocol/schema.h",
++    "$target_gen_dir/devtools/protocol/security.cc",
++    "$target_gen_dir/devtools/protocol/security.h",
++    "$target_gen_dir/devtools/protocol/service_worker.cc",
++    "$target_gen_dir/devtools/protocol/service_worker.h",
++    "$target_gen_dir/devtools/protocol/storage.cc",
++    "$target_gen_dir/devtools/protocol/storage.h",
++    "$target_gen_dir/devtools/protocol/system_info.cc",
++    "$target_gen_dir/devtools/protocol/system_info.h",
++    "$target_gen_dir/devtools/protocol/target.cc",
++    "$target_gen_dir/devtools/protocol/target.h",
++    "$target_gen_dir/devtools/protocol/tethering.cc",
++    "$target_gen_dir/devtools/protocol/tethering.h",
++    "$target_gen_dir/devtools/protocol/tracing.cc",
++    "$target_gen_dir/devtools/protocol/tracing.h",
++  ]
++  if (!is_android) {
++    # The WebAuthn devtools protocol API is not supported in Android yet.
++    sources += [
++      "$target_gen_dir/devtools/protocol/web_authn.cc",
++      "$target_gen_dir/devtools/protocol/web_authn.h",
++    ]
++  }
++
++  if (use_viz_debugger) {
++    sources += [
++      "$target_gen_dir/devtools/protocol/visual_debugger.cc",
++      "$target_gen_dir/devtools/protocol/visual_debugger.h",
++    ]
++  }
++}
++
+ jumbo_source_set("browser") {
+   # Only the public target should depend on this. All other targets (even
+   # internal content ones) should depend on the public one.
+@@ -134,8 +218,6 @@ jumbo_source_set("browser") {
+     "//content/browser/cache_storage:cache_storage_proto",
+     "//content/browser/content_index:content_index_proto",
+     "//content/browser/cookie_store:cookie_store_proto",
+-    "//content/browser/devtools:devtools_background_services_proto",
+-    "//content/browser/devtools:protocol_sources",
+     "//content/browser/download:proto",
+     "//content/browser/file_system_access:proto",
+     "//content/browser/indexed_db:mojo_bindings",
+@@ -292,6 +374,7 @@ jumbo_source_set("browser") {
+     "//ui/strings:ax_strings",
+     "//ui/touch_selection",
+     "//v8:v8_version",
++    ":devtools_protocol",
+   ]
+ 
+   public_deps = [
+@@ -307,54 +390,6 @@ jumbo_source_set("browser") {
+   ]
+ 
+   sources = [
+-    "$target_gen_dir/devtools/protocol/audits.cc",
+-    "$target_gen_dir/devtools/protocol/audits.h",
+-    "$target_gen_dir/devtools/protocol/background_service.cc",
+-    "$target_gen_dir/devtools/protocol/background_service.h",
+-    "$target_gen_dir/devtools/protocol/browser.cc",
+-    "$target_gen_dir/devtools/protocol/browser.h",
+-    "$target_gen_dir/devtools/protocol/dom.cc",
+-    "$target_gen_dir/devtools/protocol/dom.h",
+-    "$target_gen_dir/devtools/protocol/emulation.cc",
+-    "$target_gen_dir/devtools/protocol/emulation.h",
+-    "$target_gen_dir/devtools/protocol/fetch.cc",
+-    "$target_gen_dir/devtools/protocol/fetch.h",
+-    "$target_gen_dir/devtools/protocol/forward.h",
+-    "$target_gen_dir/devtools/protocol/input.cc",
+-    "$target_gen_dir/devtools/protocol/input.h",
+-    "$target_gen_dir/devtools/protocol/inspector.cc",
+-    "$target_gen_dir/devtools/protocol/inspector.h",
+-    "$target_gen_dir/devtools/protocol/io.cc",
+-    "$target_gen_dir/devtools/protocol/io.h",
+-    "$target_gen_dir/devtools/protocol/log.cc",
+-    "$target_gen_dir/devtools/protocol/log.h",
+-    "$target_gen_dir/devtools/protocol/memory.cc",
+-    "$target_gen_dir/devtools/protocol/memory.h",
+-    "$target_gen_dir/devtools/protocol/network.cc",
+-    "$target_gen_dir/devtools/protocol/network.h",
+-    "$target_gen_dir/devtools/protocol/overlay.cc",
+-    "$target_gen_dir/devtools/protocol/overlay.h",
+-    "$target_gen_dir/devtools/protocol/page.cc",
+-    "$target_gen_dir/devtools/protocol/page.h",
+-    "$target_gen_dir/devtools/protocol/protocol.h",
+-    "$target_gen_dir/devtools/protocol/runtime.cc",
+-    "$target_gen_dir/devtools/protocol/runtime.h",
+-    "$target_gen_dir/devtools/protocol/schema.cc",
+-    "$target_gen_dir/devtools/protocol/schema.h",
+-    "$target_gen_dir/devtools/protocol/security.cc",
+-    "$target_gen_dir/devtools/protocol/security.h",
+-    "$target_gen_dir/devtools/protocol/service_worker.cc",
+-    "$target_gen_dir/devtools/protocol/service_worker.h",
+-    "$target_gen_dir/devtools/protocol/storage.cc",
+-    "$target_gen_dir/devtools/protocol/storage.h",
+-    "$target_gen_dir/devtools/protocol/system_info.cc",
+-    "$target_gen_dir/devtools/protocol/system_info.h",
+-    "$target_gen_dir/devtools/protocol/target.cc",
+-    "$target_gen_dir/devtools/protocol/target.h",
+-    "$target_gen_dir/devtools/protocol/tethering.cc",
+-    "$target_gen_dir/devtools/protocol/tethering.h",
+-    "$target_gen_dir/devtools/protocol/tracing.cc",
+-    "$target_gen_dir/devtools/protocol/tracing.h",
+     "about_url_loader_factory.cc",
+     "about_url_loader_factory.h",
+     "accessibility/accessibility_tree_formatter_blink.cc",
+@@ -2326,6 +2361,8 @@ jumbo_source_set("browser") {
+     ]
+   }
+ 
++  jumbo_excluded_sources = []
++
+   # TODO(crbug.com/1327384): Remove `permissions_common`.
+   # DO NOT add unrelated entries to this block.
+   deps += [ "//components/permissions:permissions_common" ]
+@@ -2339,8 +2376,6 @@ jumbo_source_set("browser") {
+ 
+   if (use_viz_debugger) {
+     sources += [
+-      "$target_gen_dir/devtools/protocol/visual_debugger.cc",
+-      "$target_gen_dir/devtools/protocol/visual_debugger.h",
+       "devtools/protocol/visual_debugger_handler.cc",
+       "devtools/protocol/visual_debugger_handler.h",
+     ]
+@@ -2624,6 +2659,9 @@ jumbo_source_set("browser") {
+       ]
+       public_deps += [ "//ui/base/cursor" ]
+       deps += [ "//third_party/webrtc_overrides:webrtc_component" ]
++      jumbo_excluded_sources += [
++        "media/capture/desktop_capture_device.cc",
++      ]
+     }
+     if (use_aura) {
+       sources += [
+@@ -3068,6 +3106,12 @@ jumbo_source_set("browser") {
+       "webauth/web_authentication_delegate_android.cc",
+     ]
+ 
++    jumbo_excluded_sources += [
++      # Files with kJavaLangClass and similar constants:
++      # Bug https://crbug.com/787557.
++      "android/java/java_method.cc",  # and in gin_java_bound_object.cc.
++    ]
++
+     deps += [
+       ":reflection_jni_headers",
+       "//build/config/freetype",
+@@ -3098,10 +3142,6 @@ jumbo_source_set("browser") {
+   } else {
+     # Not Android.
+     sources += [
+-      # The WebAuthn devtools protocol API is not supported in Android yet.
+-      "$target_gen_dir/devtools/protocol/web_authn.cc",
+-      "$target_gen_dir/devtools/protocol/web_authn.h",
+-
+       # Devtools frontend not included in Android
+       "devtools/devtools_frontend_host_impl.cc",
+       "devtools/devtools_frontend_host_impl.h",
+diff --git a/content/browser/attribution_reporting/attribution_internals_handler_impl.cc b/content/browser/attribution_reporting/attribution_internals_handler_impl.cc
+index 3f7ac7a50..c44d4a5c3 100644
+--- a/content/browser/attribution_reporting/attribution_internals_handler_impl.cc
++++ b/content/browser/attribution_reporting/attribution_internals_handler_impl.cc
+@@ -103,7 +103,7 @@ attribution_internals::mojom::WebUISourcePtr WebUISource(
+       debug_reporting_enabled, attributability);
+ }
+ 
+-void ForwardSourcesToWebUI(
++void ForwardSourcesToWebUI2(
+     attribution_internals::mojom::Handler::GetActiveSourcesCallback
+         web_ui_callback,
+     std::vector<StoredSource> active_sources) {
+@@ -180,7 +180,7 @@ attribution_internals::mojom::WebUIReportPtr WebUIReport(
+             return ai_mojom::WebUIReportData::NewAggregatableAttributionData(
+                 ai_mojom::WebUIReportAggregatableAttributionData::New(
+                     std::move(contributions), std::move(attestation_token),
+-                    aggregation_service::SerializeAggregationCoordinator(
++                    ::aggregation_service::SerializeAggregationCoordinator(
+                         aggregatable_data.aggregation_coordinator)));
+           },
+       },
+@@ -194,7 +194,7 @@ attribution_internals::mojom::WebUIReportPtr WebUIReport(
+       std::move(status), std::move(data));
+ }
+ 
+-void ForwardReportsToWebUI(
++void ForwardReportsToWebUI2(
+     attribution_internals::mojom::Handler::GetReportsCallback web_ui_callback,
+     std::vector<AttributionReport> pending_reports) {
+   std::vector<attribution_internals::mojom::WebUIReportPtr> web_ui_reports;
+@@ -242,7 +242,7 @@ void AttributionInternalsHandlerImpl::GetActiveSources(
+   if (AttributionManager* manager =
+           AttributionManager::FromWebContents(web_ui_->GetWebContents())) {
+     manager->GetActiveSourcesForWebUI(
+-        base::BindOnce(&ForwardSourcesToWebUI, std::move(callback)));
++        base::BindOnce(&ForwardSourcesToWebUI2, std::move(callback)));
+   } else {
+     std::move(callback).Run({});
+   }
+@@ -256,7 +256,7 @@ void AttributionInternalsHandlerImpl::GetReports(
+     manager->GetPendingReportsForInternalUse(
+         AttributionReport::Types{report_type},
+         /*limit=*/1000,
+-        base::BindOnce(&ForwardReportsToWebUI, std::move(callback)));
++        base::BindOnce(&ForwardReportsToWebUI2, std::move(callback)));
+   } else {
+     std::move(callback).Run({});
+   }
+diff --git a/content/browser/attribution_reporting/attribution_storage_sql.cc b/content/browser/attribution_reporting/attribution_storage_sql.cc
+index 70ae8f52f..c8bd2311b 100644
+--- a/content/browser/attribution_reporting/attribution_storage_sql.cc
++++ b/content/browser/attribution_reporting/attribution_storage_sql.cc
+@@ -90,7 +90,7 @@ using EventLevelResult = ::content::AttributionTrigger::EventLevelResult;
+ 
+ using ::attribution_reporting::SuitableOrigin;
+ 
+-const base::FilePath::CharType kDatabasePath[] =
++const base::FilePath::CharType kDatabasePathAttr[] =
+     FILE_PATH_LITERAL("Conversions");
+ 
+ constexpr int64_t kUnsetReportId = -1;
+@@ -429,7 +429,7 @@ absl::optional<StoredSourceData> ReadSourceToAttribute(
+ }
+ 
+ base::FilePath DatabasePath(const base::FilePath& user_data_directory) {
+-  return user_data_directory.Append(kDatabasePath);
++  return user_data_directory.Append(kDatabasePathAttr);
+ }
+ 
+ }  // namespace
+diff --git a/content/browser/cookie_store/cookie_change_subscription.cc b/content/browser/cookie_store/cookie_change_subscription.cc
+index fd51ab0f7..3232ad7ba 100644
+--- a/content/browser/cookie_store/cookie_change_subscription.cc
++++ b/content/browser/cookie_store/cookie_change_subscription.cc
+@@ -14,14 +14,15 @@
+ #include "net/cookies/cookie_util.h"
+ #include "net/first_party_sets/same_party_context.h"
+ #include "services/network/public/cpp/is_potentially_trustworthy.h"
++#include "third_party/blink/renderer/platform/wtf/assertions.h"
+ 
+ namespace content {
+ 
+ namespace {
+ 
+-#define STATIC_ASSERT_ENUM(a, b)                            \
+-  static_assert(static_cast<int>(a) == static_cast<int>(b), \
+-                "mismatching enums: " #a)
++//#define STATIC_ASSERT_ENUM(a, b)                            \
++//  static_assert(static_cast<int>(a) == static_cast<int>(b), \
++//                "mismatching enums: " #a)
+ 
+ STATIC_ASSERT_ENUM(network::mojom::CookieMatchType::EQUALS,
+                    proto::CookieMatchType::EQUALS);
+diff --git a/content/browser/devtools/BUILD.gn b/content/browser/devtools/BUILD.gn
+index 85be27d29..a16c94dce 100644
+--- a/content/browser/devtools/BUILD.gn
++++ b/content/browser/devtools/BUILD.gn
+@@ -82,7 +82,7 @@ action("concatenate_protocols") {
+ }
+ 
+ inspector_protocol_generate("protocol_sources") {
+-  visibility = [ "//content/browser" ]
++  visibility = [ "//content/browser:*" ]
+   deps = [ ":concatenate_protocols" ]
+   inspector_protocol_dir = "//third_party/inspector_protocol"
+   out_dir = target_gen_dir
+diff --git a/content/browser/devtools/protocol/page_handler.cc b/content/browser/devtools/protocol/page_handler.cc
+index bbb8bc041..1206401de 100644
+--- a/content/browser/devtools/protocol/page_handler.cc
++++ b/content/browser/devtools/protocol/page_handler.cc
+@@ -83,7 +83,7 @@ namespace {
+ constexpr const char* kMhtml = "mhtml";
+ constexpr int kDefaultScreenshotQuality = 80;
+ constexpr int kMaxScreencastFramesInFlight = 2;
+-constexpr char kCommandIsOnlyAvailableAtTopTarget[] =
++constexpr char kCommandIsOnlyAvailableAtTopTarget2[] =
+     "Command can only be executed on top-level targets";
+ constexpr char kErrorNotAttached[] = "Not attached to a page";
+ constexpr char kErrorInactivePage[] = "Not attached to an active page";
+@@ -2018,7 +2018,7 @@ Response PageHandler::AssureTopLevelActiveFrame() {
+     return Response::ServerError(kErrorNotAttached);
+ 
+   if (host_->GetParentOrOuterDocument())
+-    return Response::ServerError(kCommandIsOnlyAvailableAtTopTarget);
++    return Response::ServerError(kCommandIsOnlyAvailableAtTopTarget2);
+ 
+   if (!host_->IsActive())
+     return Response::ServerError(kErrorInactivePage);
+diff --git a/content/browser/devtools/web_contents_devtools_agent_host.cc b/content/browser/devtools/web_contents_devtools_agent_host.cc
+index 2b4276b51..28604a064 100644
+--- a/content/browser/devtools/web_contents_devtools_agent_host.cc
++++ b/content/browser/devtools/web_contents_devtools_agent_host.cc
+@@ -17,14 +17,14 @@ namespace content {
+ namespace {
+ using WebContentsDevToolsMap =
+     std::map<WebContents*, WebContentsDevToolsAgentHost*>;
+-base::LazyInstance<WebContentsDevToolsMap>::Leaky g_agent_host_instances =
++base::LazyInstance<WebContentsDevToolsMap>::Leaky g_agent_host_instances2 =
+     LAZY_INSTANCE_INITIALIZER;
+ 
+ WebContentsDevToolsAgentHost* FindAgentHost(WebContents* wc) {
+-  if (!g_agent_host_instances.IsCreated())
++  if (!g_agent_host_instances2.IsCreated())
+     return nullptr;
+-  auto it = g_agent_host_instances.Get().find(wc);
+-  return it == g_agent_host_instances.Get().end() ? nullptr : it->second;
++  auto it = g_agent_host_instances2.Get().find(wc);
++  return it == g_agent_host_instances2.Get().end() ? nullptr : it->second;
+ }
+ 
+ bool ShouldCreateDevToolsAgentHost(WebContents* wc) {
+@@ -146,7 +146,7 @@ WebContentsDevToolsAgentHost::WebContentsDevToolsAgentHost(WebContents* wc)
+       auto_attacher_(std::make_unique<AutoAttacher>(wc)) {
+   DCHECK(web_contents());
+   bool inserted =
+-      g_agent_host_instances.Get().insert(std::make_pair(wc, this)).second;
++      g_agent_host_instances2.Get().insert(std::make_pair(wc, this)).second;
+   DCHECK(inserted);
+   // Once created, persist till underlying WC is destroyed, so that
+   // the target id is retained.
+@@ -160,10 +160,10 @@ void WebContentsDevToolsAgentHost::PortalActivated(const Portal& portal) {
+     WebContents* new_wc = portal.GetPortalContents();
+     // Assure instrumentation calls for the new WC would be routed here.
+     DCHECK(new_wc->GetResponsibleWebContents() == new_wc);
+-    DCHECK(g_agent_host_instances.Get()[old_wc] == this);
++    DCHECK(g_agent_host_instances2.Get()[old_wc] == this);
+ 
+-    g_agent_host_instances.Get().erase(old_wc);
+-    g_agent_host_instances.Get()[new_wc] = this;
++    g_agent_host_instances2.Get().erase(old_wc);
++    g_agent_host_instances2.Get()[new_wc] = this;
+     Observe(portal.GetPortalContents());
+   }
+   DCHECK(auto_attacher_);
+@@ -323,7 +323,7 @@ void WebContentsDevToolsAgentHost::WebContentsDestroyed() {
+   DCHECK_EQ(this, FindAgentHost(web_contents()));
+   ForceDetachAllSessions();
+   auto_attacher_.reset();
+-  g_agent_host_instances.Get().erase(web_contents());
++  g_agent_host_instances2.Get().erase(web_contents());
+   Observe(nullptr);
+   // We may or may not be destruced here, depending on embedders
+   // potentially retaining references.
+diff --git a/content/browser/first_party_sets/first_party_set_parser.cc b/content/browser/first_party_sets/first_party_set_parser.cc
+index 9c15a7d2a..61f7ad8a1 100644
+--- a/content/browser/first_party_sets/first_party_set_parser.cc
++++ b/content/browser/first_party_sets/first_party_set_parser.cc
+@@ -307,7 +307,7 @@ base::expected<SetsAndAliases, ParseError> ParseSet(
+                    exempt_from_limits
+                        ? absl::nullopt
+                        : absl::make_optional(
+-                             features::kFirstPartySetsMaxAssociatedSites.Get()),
++                             ::features::kFirstPartySetsMaxAssociatedSites.Get()),
+            },
+            {
+                .field_name = kFirstPartySetServiceSitesField,
+diff --git a/content/browser/first_party_sets/first_party_sets_handler_impl.cc b/content/browser/first_party_sets/first_party_sets_handler_impl.cc
+index 529537fef..c83ba73fe 100644
+--- a/content/browser/first_party_sets/first_party_sets_handler_impl.cc
++++ b/content/browser/first_party_sets/first_party_sets_handler_impl.cc
+@@ -262,7 +262,7 @@ absl::optional<net::FirstPartySetEntry> FirstPartySetsHandlerImpl::FindEntry(
+     const net::SchemefulSite& site,
+     const net::FirstPartySetsContextConfig& config) const {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+-  if (!base::FeatureList::IsEnabled(features::kFirstPartySets) ||
++  if (!base::FeatureList::IsEnabled(::features::kFirstPartySets) ||
+       !global_sets_.has_value()) {
+     return absl::nullopt;
+   }
+@@ -283,7 +283,7 @@ void FirstPartySetsHandlerImpl::ClearSiteDataOnChangedSetsForContext(
+                             net::FirstPartySetsCacheFilter)> callback) {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+ 
+-  if (!enabled_ || !features::kFirstPartySetsClearSiteDataOnChangedSets.Get()) {
++  if (!enabled_ || !::features::kFirstPartySetsClearSiteDataOnChangedSets.Get()) {
+     std::move(callback).Run(std::move(context_config),
+                             net::FirstPartySetsCacheFilter());
+     return;
+@@ -312,7 +312,7 @@ void FirstPartySetsHandlerImpl::ClearSiteDataOnChangedSetsForContextInternal(
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+   DCHECK(global_sets_.has_value());
+   DCHECK(!browser_context_id.empty());
+-  DCHECK(enabled_ && features::kFirstPartySetsClearSiteDataOnChangedSets.Get());
++  DCHECK(enabled_ && ::features::kFirstPartySetsClearSiteDataOnChangedSets.Get());
+ 
+   if (db_helper_.is_null()) {
+     VLOG(1) << "Invalid First-Party Sets database. Failed to clear site data "
+diff --git a/content/browser/gpu/compositor_util.cc b/content/browser/gpu/compositor_util.cc
+index 4c013275a..1cae7beb4 100644
+--- a/content/browser/gpu/compositor_util.cc
++++ b/content/browser/gpu/compositor_util.cc
+@@ -108,7 +108,7 @@ const GpuFeatureData GetGpuFeatureData(
+     {"canvas_oop_rasterization",
+      SafeGetFeatureStatus(gpu_feature_info,
+                           gpu::GPU_FEATURE_TYPE_CANVAS_OOP_RASTERIZATION),
+-     !base::FeatureList::IsEnabled(features::kCanvasOopRasterization) ||
++     !base::FeatureList::IsEnabled(::features::kCanvasOopRasterization) ||
+          command_line.HasSwitch(switches::kDisableAccelerated2dCanvas),
+ #if 0
+      // TODO(crbug.com/1240756): Remove the "#if 0" once OOPR-Canvas is fully
+@@ -184,7 +184,7 @@ const GpuFeatureData GetGpuFeatureData(
+ #if BUILDFLAG(ENABLE_VULKAN)
+     {"vulkan",
+      SafeGetFeatureStatus(gpu_feature_info, gpu::GPU_FEATURE_TYPE_VULKAN),
+-     !features::IsUsingVulkan() &&
++     !::features::IsUsingVulkan() &&
+          !command_line.HasSwitch(switches::kUseVulkan) /* disabled */,
+      DisableInfo::NotProblem(), false /* fallback_to_software */},
+ #endif
+@@ -195,7 +195,7 @@ const GpuFeatureData GetGpuFeatureData(
+     {"surface_control",
+      SafeGetFeatureStatus(gpu_feature_info,
+                           gpu::GPU_FEATURE_TYPE_ANDROID_SURFACE_CONTROL),
+-     !features::IsAndroidSurfaceControlEnabled(),
++     !::features::IsAndroidSurfaceControlEnabled(),
+      DisableInfo::Problem(
+          "Surface Control has been disabled by Finch trial or command line."),
+      false},
+@@ -208,15 +208,15 @@ const GpuFeatureData GetGpuFeatureData(
+      DisableInfo::Problem(
+          "WebGL2 has been disabled via blocklist or the command line."),
+      false},
+-    {"raw_draw", gpu::kGpuFeatureStatusEnabled, !features::IsUsingRawDraw(),
++    {"raw_draw", gpu::kGpuFeatureStatusEnabled, !::features::IsUsingRawDraw(),
+      DisableInfo::NotProblem(), false},
+     {"direct_rendering_display_compositor", gpu::kGpuFeatureStatusEnabled,
+-     !features::IsDrDcEnabled(), DisableInfo::NotProblem(), false},
++     !::features::IsDrDcEnabled(), DisableInfo::NotProblem(), false},
+     {"webgpu",
+      SafeGetFeatureStatus(gpu_feature_info,
+                           gpu::GPU_FEATURE_TYPE_ACCELERATED_WEBGPU),
+      !command_line.HasSwitch(switches::kEnableUnsafeWebGPU) &&
+-         !base::FeatureList::IsEnabled(features::kWebGPUService),
++         !base::FeatureList::IsEnabled(::features::kWebGPUService),
+      DisableInfo::Problem(
+          "WebGPU has been disabled via blocklist or the command line."),
+      false},
+@@ -448,7 +448,7 @@ bool IsZeroCopyUploadEnabled() {
+ 
+ bool IsPartialRasterEnabled() {
+   // Partial raster is not supported with RawDraw.
+-  if (features::IsUsingRawDraw())
++  if (::features::IsUsingRawDraw())
+     return false;
+   const auto& command_line = *base::CommandLine::ForCurrentProcess();
+   return !command_line.HasSwitch(blink::switches::kDisablePartialRaster);
+@@ -457,7 +457,7 @@ bool IsPartialRasterEnabled() {
+ bool IsGpuMemoryBufferCompositorResourcesEnabled() {
+   // To use Raw Draw, the Raw Draw shared image backing should be used, so
+   // not use GPU memory buffer shared image backings for compositor resources.
+-  if (features::IsUsingRawDraw()) {
++  if (::features::IsUsingRawDraw()) {
+     return false;
+   }
+   const base::CommandLine& command_line =
+diff --git a/content/browser/gpu/gpu_process_host.cc b/content/browser/gpu/gpu_process_host.cc
+index 9f1efcdd0..4c798248d 100644
+--- a/content/browser/gpu/gpu_process_host.cc
++++ b/content/browser/gpu/gpu_process_host.cc
+@@ -721,7 +721,7 @@ GpuProcessHost::GpuProcessHost(int host_id, GpuProcessKind kind)
+ #if !BUILDFLAG(IS_ANDROID)
+   if (!in_process_ && kind != GPU_PROCESS_KIND_INFO_COLLECTION &&
+       base::FeatureList::IsEnabled(
+-          features::kForwardMemoryPressureEventsToGpuProcess)) {
++          ::features::kForwardMemoryPressureEventsToGpuProcess)) {
+     memory_pressure_listener_ = std::make_unique<base::MemoryPressureListener>(
+         FROM_HERE, base::BindRepeating(&GpuProcessHost::OnMemoryPressure,
+                                        base::Unretained(this)));
+diff --git a/content/browser/interest_group/interest_group_manager_impl.cc b/content/browser/interest_group/interest_group_manager_impl.cc
+index bd0493b0a..d3593bc84 100644
+--- a/content/browser/interest_group/interest_group_manager_impl.cc
++++ b/content/browser/interest_group/interest_group_manager_impl.cc
+@@ -43,7 +43,7 @@ constexpr base::TimeDelta kMaxReportingRoundDuration = base::Minutes(10);
+ // The time interval to wait before sending the next report after sending one.
+ constexpr base::TimeDelta kReportingInterval = base::Milliseconds(50);
+ 
+-constexpr net::NetworkTrafficAnnotationTag kTrafficAnnotation =
++constexpr net::NetworkTrafficAnnotationTag kTrafficAnnotationIGMI =
+     net::DefineNetworkTrafficAnnotation("auction_report_sender", R"(
+         semantics {
+           sender: "Interest group based Ad Auction report"
+@@ -85,7 +85,7 @@ std::unique_ptr<network::SimpleURLLoader> BuildSimpleUrlLoader(
+   resource_request->trusted_params->client_security_state =
+       std::move(client_security_state);
+   auto simple_url_loader = network::SimpleURLLoader::Create(
+-      std::move(resource_request), kTrafficAnnotation);
++      std::move(resource_request), kTrafficAnnotationIGMI);
+   simple_url_loader->SetTimeoutDuration(base::Seconds(30));
+   return simple_url_loader;
+ }
+diff --git a/content/browser/interest_group/interest_group_permissions_checker.cc b/content/browser/interest_group/interest_group_permissions_checker.cc
+index 476d997dc..1ef941343 100644
+--- a/content/browser/interest_group/interest_group_permissions_checker.cc
++++ b/content/browser/interest_group/interest_group_permissions_checker.cc
+@@ -28,7 +28,7 @@ namespace content {
+ 
+ namespace {
+ 
+-constexpr net::NetworkTrafficAnnotationTag kTrafficAnnotation =
++constexpr net::NetworkTrafficAnnotationTag kTrafficAnnotationIGPC =
+     net::DefineNetworkTrafficAnnotation("interest_group_well_known_fetcher", R"(
+         semantics {
+           sender: "Interest group well-known fetcher"
+@@ -142,7 +142,7 @@ void InterestGroupPermissionsChecker::CheckPermissions(
+ 
+     active_request->second->simple_url_loader =
+         network::SimpleURLLoader::Create(std::move(resource_request),
+-                                         kTrafficAnnotation);
++                                         kTrafficAnnotationIGPC);
+     active_request->second->simple_url_loader->SetTimeoutDuration(
+         kRequestTimeout);
+     active_request->second->simple_url_loader->SetRequestID(
+diff --git a/content/browser/media/media_internals_cdm_helper.cc b/content/browser/media/media_internals_cdm_helper.cc
+index 9b7e9b27c..2d6172898 100644
+--- a/content/browser/media/media_internals_cdm_helper.cc
++++ b/content/browser/media/media_internals_cdm_helper.cc
+@@ -116,7 +116,7 @@ base::Value::Dict CdmInfoToDict(const CdmInfo& cdm_info) {
+   return dict;
+ }
+ 
+-std::u16string SerializeUpdate(base::StringPiece function,
++std::u16string SerializeUpdate2(base::StringPiece function,
+                                const base::Value::List& value) {
+   base::ValueView args[] = {value};
+   return content::WebUI::GetJavascriptCall(function, args);
+@@ -147,7 +147,7 @@ void MediaInternalsCdmHelper::OnKeySystemCapabilitiesUpdated(
+   }
+ 
+   return MediaInternals::GetInstance()->SendUpdate(
+-      SerializeUpdate("media.updateRegisteredCdms", cdm_list));
++      SerializeUpdate2("media.updateRegisteredCdms", cdm_list));
+ }
+ 
+ }  // namespace content
+diff --git a/content/browser/network/cross_origin_embedder_policy_reporter.cc b/content/browser/network/cross_origin_embedder_policy_reporter.cc
+index c6e078400..3ad7a82a1 100644
+--- a/content/browser/network/cross_origin_embedder_policy_reporter.cc
++++ b/content/browser/network/cross_origin_embedder_policy_reporter.cc
+@@ -14,7 +14,7 @@ namespace content {
+ 
+ namespace {
+ 
+-constexpr char kType[] = "coep";
++constexpr char kTypeCoep[] = "coep";
+ 
+ GURL StripUsernameAndPassword(const GURL& url) {
+   GURL::Replacements replacements;
+@@ -109,7 +109,7 @@ void CrossOriginEmbedderPolicyReporter::QueueAndNotify(
+         blink::mojom::ReportBodyElement::New("disposition", disposition));
+ 
+     observer_->Notify(blink::mojom::Report::New(
+-        kType, context_url_, blink::mojom::ReportBody::New(std::move(list))));
++        kTypeCoep, context_url_, blink::mojom::ReportBody::New(std::move(list))));
+   }
+   if (endpoint) {
+     base::Value::Dict body_to_pass;
+@@ -120,7 +120,7 @@ void CrossOriginEmbedderPolicyReporter::QueueAndNotify(
+ 
+     if (auto* storage_partition = storage_partition_.get()) {
+       storage_partition->GetNetworkContext()->QueueReport(
+-          kType, *endpoint, context_url_, reporting_source_,
++          kTypeCoep, *endpoint, context_url_, reporting_source_,
+           network_anonymization_key_,
+           /*user_agent=*/absl::nullopt, std::move(body_to_pass));
+     }
+diff --git a/content/browser/preloading/prerender/prerender_host_registry.cc b/content/browser/preloading/prerender/prerender_host_registry.cc
+index 1061f157c..940f00897 100644
+--- a/content/browser/preloading/prerender/prerender_host_registry.cc
++++ b/content/browser/preloading/prerender/prerender_host_registry.cc
+@@ -235,7 +235,7 @@ int PrerenderHostRegistry::CreateAndStartHost(
+         initiator_rfh &&
+         RenderFrameDevToolsAgentHost::GetFor(initiator_rfh) != nullptr;
+     if (!should_prerender2holdback_be_overridden &&
+-        base::FeatureList::IsEnabled(features::kPrerender2Holdback)) {
++        base::FeatureList::IsEnabled(::features::kPrerender2Holdback)) {
+       if (attempt)
+         attempt->SetHoldbackStatus(PreloadingHoldbackStatus::kHoldback);
+       return RenderFrameHost::kNoFrameTreeNodeId;
+diff --git a/content/browser/push_messaging/push_messaging_router.cc b/content/browser/push_messaging/push_messaging_router.cc
+index f88e11c5c..4a74837a5 100644
+--- a/content/browser/push_messaging/push_messaging_router.cc
++++ b/content/browser/push_messaging/push_messaging_router.cc
+@@ -257,7 +257,7 @@ void PushMessagingRouter::FireSubscriptionChangeEvent(
+     blink::mojom::PushSubscriptionPtr old_subscription,
+     PushEventCallback subscription_change_callback) {
+   DCHECK_CURRENTLY_ON(BrowserThread::UI);
+-  DCHECK(base::FeatureList::IsEnabled(features::kPushSubscriptionChangeEvent));
++  DCHECK(base::FeatureList::IsEnabled(::features::kPushSubscriptionChangeEvent));
+ 
+   StartServiceWorkerForDispatch(
+       ServiceWorkerMetrics::EventType::PUSH_SUBSCRIPTION_CHANGE,
+@@ -276,7 +276,7 @@ void PushMessagingRouter::FireSubscriptionChangeEventToWorker(
+     scoped_refptr<DevToolsBackgroundServicesContextImpl> devtools_context,
+     blink::ServiceWorkerStatusCode status) {
+   DCHECK_CURRENTLY_ON(BrowserThread::UI);
+-  DCHECK(base::FeatureList::IsEnabled(features::kPushSubscriptionChangeEvent));
++  DCHECK(base::FeatureList::IsEnabled(::features::kPushSubscriptionChangeEvent));
+ 
+   if (!service_worker) {
+     DCHECK_NE(blink::ServiceWorkerStatusCode::kOk, status);
+diff --git a/content/browser/renderer_host/agent_scheduling_group_host.cc b/content/browser/renderer_host/agent_scheduling_group_host.cc
+index a6d974dce..d6a445355 100644
+--- a/content/browser/renderer_host/agent_scheduling_group_host.cc
++++ b/content/browser/renderer_host/agent_scheduling_group_host.cc
+@@ -31,14 +31,6 @@ namespace {
+ using ::IPC::ChannelMojo;
+ using ::IPC::ChannelProxy;
+ using ::IPC::Listener;
+-using ::mojo::AssociatedReceiver;
+-using ::mojo::AssociatedRemote;
+-using ::mojo::PendingAssociatedReceiver;
+-using ::mojo::PendingAssociatedRemote;
+-using ::mojo::PendingReceiver;
+-using ::mojo::PendingRemote;
+-using ::mojo::Receiver;
+-using ::mojo::Remote;
+ 
+ static constexpr char kAgentSchedulingGroupHostDataKey[] =
+     "AgentSchedulingGroupHostUserDataKey";
+@@ -63,10 +55,10 @@ struct AgentSchedulingGroupHostUserData : public base::SupportsUserData::Data {
+ #endif
+ };
+ 
+-static features::MBIMode GetMBIMode() {
+-  return base::FeatureList::IsEnabled(features::kMBIMode)
+-             ? features::kMBIModeParam.Get()
+-             : features::MBIMode::kLegacy;
++static ::features::MBIMode GetMBIMode() {
++  return base::FeatureList::IsEnabled(::features::kMBIMode)
++             ? ::features::kMBIModeParam.Get()
++             : ::features::MBIMode::kLegacy;
+ }
+ 
+ }  // namespace
+@@ -88,8 +80,8 @@ AgentSchedulingGroupHost* AgentSchedulingGroupHost::GetOrCreate(
+ 
+   DCHECK(data);
+ 
+-  if (GetMBIMode() == features::MBIMode::kLegacy ||
+-      GetMBIMode() == features::MBIMode::kEnabledPerRenderProcessHost) {
++  if (GetMBIMode() == ::features::MBIMode::kLegacy ||
++      GetMBIMode() == ::features::MBIMode::kEnabledPerRenderProcessHost) {
+     // We don't use |data->site_instance_groups| at all when
+     // AgentSchedulingGroupHost is 1:1 with RenderProcessHost.
+ #if DCHECK_IS_ON()
+@@ -113,7 +105,7 @@ AgentSchedulingGroupHost* AgentSchedulingGroupHost::GetOrCreate(
+     return data->owned_host_set.begin()->get();
+   }
+ 
+-  DCHECK_EQ(GetMBIMode(), features::MBIMode::kEnabledPerSiteInstance);
++  DCHECK_EQ(GetMBIMode(), ::features::MBIMode::kEnabledPerSiteInstance);
+ 
+   // If we're in an MBI mode that creates multiple AgentSchedulingGroupHosts
+   // per RenderProcessHost, then this will be called whenever SiteInstance needs
+@@ -231,7 +223,7 @@ void AgentSchedulingGroupHost::AddFilter(BrowserMessageFilter* filter) {
+   DCHECK(filter);
+   // When MBI mode is disabled, we forward these kinds of requests straight to
+   // the underlying `RenderProcessHost`.
+-  if (GetMBIMode() == features::MBIMode::kLegacy) {
++  if (GetMBIMode() == ::features::MBIMode::kLegacy) {
+     process_->AddFilter(filter);
+     return;
+   }
+@@ -272,7 +264,7 @@ base::SafeRef<AgentSchedulingGroupHost> AgentSchedulingGroupHost::GetSafeRef()
+ ChannelProxy* AgentSchedulingGroupHost::GetChannel() {
+   DCHECK_EQ(state_, LifecycleState::kBound);
+ 
+-  if (GetMBIMode() == features::MBIMode::kLegacy)
++  if (GetMBIMode() == ::features::MBIMode::kLegacy)
+     return process_->GetChannel();
+ 
+   DCHECK(channel_);
+@@ -284,7 +276,7 @@ bool AgentSchedulingGroupHost::Send(IPC::Message* message) {
+ 
+   std::unique_ptr<IPC::Message> msg(message);
+ 
+-  if (GetMBIMode() == features::MBIMode::kLegacy)
++  if (GetMBIMode() == ::features::MBIMode::kLegacy)
+     return process_->Send(msg.release());
+ 
+   // This DCHECK is too idealistic for now - messages that are handled by
+@@ -414,7 +406,7 @@ void AgentSchedulingGroupHost::SetUpIPC() {
+   // 3. All the ASGH's other associated interfaces can now be initialized via
+   //    `mojo_remote_`, and will be transitively associated with the appropriate
+   //    IPC channel/pipe.
+-  if (GetMBIMode() == features::MBIMode::kLegacy) {
++  if (GetMBIMode() == ::features::MBIMode::kLegacy) {
+     process_->GetRendererInterface()->CreateAssociatedAgentSchedulingGroup(
+         mojo_remote_.BindNewEndpointAndPassReceiver(),
+         broker_receiver_.BindNewPipeAndPassRemote());
+@@ -422,7 +414,7 @@ void AgentSchedulingGroupHost::SetUpIPC() {
+     auto io_task_runner = GetIOThreadTaskRunner({});
+ 
+     // Empty interface endpoint to pass pipes more easily.
+-    PendingRemote<IPC::mojom::ChannelBootstrap> bootstrap;
++    mojo::PendingRemote<IPC::mojom::ChannelBootstrap> bootstrap;
+ 
+     process_->GetRendererInterface()->CreateAgentSchedulingGroup(
+         bootstrap.InitWithNewPipeAndPassReceiver(),
+diff --git a/content/browser/renderer_host/code_cache_host_impl.h b/content/browser/renderer_host/code_cache_host_impl.h
+index d6742b024..b9f34730a 100644
+--- a/content/browser/renderer_host/code_cache_host_impl.h
++++ b/content/browser/renderer_host/code_cache_host_impl.h
+@@ -12,6 +12,8 @@
+ #include "base/memory/weak_ptr.h"
+ #include "build/build_config.h"
+ #include "components/services/storage/public/mojom/cache_storage_control.mojom.h"
++#include "content/browser/code_cache/generated_code_cache.h"
++#include "content/browser/code_cache/generated_code_cache_context.h"
+ #include "content/common/content_export.h"
+ #include "mojo/public/cpp/base/big_buffer.h"
+ #include "mojo/public/cpp/bindings/pending_receiver.h"
+@@ -28,8 +30,8 @@ class Origin;
+ 
+ namespace content {
+ 
+-class GeneratedCodeCache;
+-class GeneratedCodeCacheContext;
++// class GeneratedCodeCache;
++// class GeneratedCodeCacheContext;
+ 
+ // The implementation of a CodeCacheHost, which stores and retrieves resource
+ // metadata, either bytecode or native code, generated by a renderer process.
+diff --git a/content/browser/renderer_host/media/media_stream_manager.cc b/content/browser/renderer_host/media/media_stream_manager.cc
+index b45f3f65a..f7c81e687 100644
+--- a/content/browser/renderer_host/media/media_stream_manager.cc
++++ b/content/browser/renderer_host/media/media_stream_manager.cc
+@@ -201,7 +201,7 @@ MediaDeviceType ConvertToMediaDeviceType(MediaStreamType stream_type) {
+   return MediaDeviceType::NUM_MEDIA_DEVICE_TYPES;
+ }
+ 
+-const char* DeviceTypeToString(MediaDeviceType type) {
++const char* DeviceTypeToStringMSM(MediaDeviceType type) {
+   switch (type) {
+     case MediaDeviceType::MEDIA_AUDIO_INPUT:
+       return "DEVICE_AUDIO_INPUT";
+@@ -366,7 +366,7 @@ std::string GetStopStreamDeviceLogString(
+       session_id.ToString().c_str());
+ }
+ 
+-void SendLogMessage(const std::string& message) {
++void SendLogMessageMSM(const std::string& message) {
+   MediaStreamManager::SendMessageToNativeLog("MSM::" + message);
+ }
+ 
+@@ -762,7 +762,7 @@ class MediaStreamManager::DeviceRequest {
+         video_type_(MediaStreamType::NO_SERVICE),
+         target_process_id_(-1),
+         target_frame_id_(-1) {
+-    SendLogMessage(base::StringPrintf(
++    SendLogMessageMSM(base::StringPrintf(
+         "DR::DeviceRequest({requesting_process_id=%d}, "
+         "{requesting_frame_id=%d}, {requester_id=%d}, {request_type=%s})",
+         requesting_process_id, requesting_frame_id, requester_id,
+@@ -779,7 +779,7 @@ class MediaStreamManager::DeviceRequest {
+   void SetAudioType(MediaStreamType audio_type) {
+     DCHECK(blink::IsAudioInputMediaType(audio_type) ||
+            audio_type == MediaStreamType::NO_SERVICE);
+-    SendLogMessage(base::StringPrintf(
++    SendLogMessageMSM(base::StringPrintf(
+         "DR::SetAudioType([requester_id=%d] {audio_type=%s})", requester_id,
+         StreamTypeToString(audio_type)));
+     audio_type_ = audio_type;
+@@ -800,7 +800,7 @@ class MediaStreamManager::DeviceRequest {
+   void CreateUIRequest(const std::string& requested_audio_device_id,
+                        const std::string& requested_video_device_id) {
+     DCHECK(!ui_request_);
+-    SendLogMessage(base::StringPrintf(
++    SendLogMessageMSM(base::StringPrintf(
+         "DR::CreateUIRequest([requester_id=%d] {requested_audio_device_id=%s}, "
+         "{requested_video_device_id=%s})",
+         requester_id, requested_audio_device_id.c_str(),
+@@ -844,7 +844,7 @@ class MediaStreamManager::DeviceRequest {
+ 
+   // Update the request state and notify observers.
+   void SetState(MediaStreamType stream_type, MediaRequestState new_state) {
+-    SendLogMessage(base::StringPrintf(
++    SendLogMessageMSM(base::StringPrintf(
+         "DR::SetState([requester_id=%d] {stream_type=%s}, {new_state=%s})",
+         requester_id, StreamTypeToString(stream_type),
+         RequestStateToString(new_state)));
+@@ -1136,7 +1136,7 @@ class MediaStreamManager::MediaAccessRequest
+       const blink::mojom::StreamDevicesSet& stream_devices_set) override {
+     DCHECK_CURRENTLY_ON(BrowserThread::IO);
+     DCHECK(media_access_request_cb_);
+-    SendLogMessage(base::StringPrintf(
++    SendLogMessageMSM(base::StringPrintf(
+         "FinalizeMediaAccessRequest({label=%s}, {requester_id="
+         "%d}, {request_type=%s})",
+         label.c_str(), requester_id, RequestTypeToString(request_type())));
+@@ -1202,7 +1202,7 @@ class MediaStreamManager::CreateDeviceRequest
+     const blink::mojom::StreamDevices& new_devices =
+         *stream_devices_set.stream_devices[0];
+ 
+-    SendLogMessage(base::StringPrintf(
++    SendLogMessageMSM(base::StringPrintf(
+         "FinalizeChangeDevice({label=%s}, {requester_id="
+         "%d}, {request_type=%s})",
+         label.c_str(), requester_id, RequestTypeToString(request_type())));
+@@ -1486,7 +1486,7 @@ class MediaStreamManager::OpenDeviceRequest
+   void FinalizeRequest(const std::string& label) override {
+     DCHECK_CURRENTLY_ON(BrowserThread::IO);
+     DCHECK(open_device_cb_);
+-    SendLogMessage(base::StringPrintf(
++    SendLogMessageMSM(base::StringPrintf(
+         "FinalizeOpenDevice({label=%s}, {requester_id="
+         "%d}, {request_type=%s})",
+         label.c_str(), requester_id, RequestTypeToString(request_type())));
+@@ -1530,7 +1530,7 @@ void MediaStreamManager::SendMessageToNativeLog(const std::string& message) {
+ 
+ MediaStreamManager::MediaStreamManager(media::AudioSystem* audio_system)
+     : MediaStreamManager(audio_system, nullptr) {
+-  SendLogMessage(base::StringPrintf("MediaStreamManager([this=%p]))", this));
++  SendLogMessageMSM(base::StringPrintf("MediaStreamManager([this=%p]))", this));
+ }
+ 
+ MediaStreamManager::MediaStreamManager(
+@@ -1709,7 +1709,7 @@ void MediaStreamManager::GenerateStreams(
+     DeviceRequestStateChangeCallback device_request_state_change_cb,
+     DeviceCaptureHandleChangeCallback device_capture_handle_change_cb) {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+-  SendLogMessage(GetGenerateStreamsLogString(render_process_id, render_frame_id,
++  SendLogMessageMSM(GetGenerateStreamsLogString(render_process_id, render_frame_id,
+                                              requester_id, page_request_id));
+   std::unique_ptr<DeviceRequest> request =
+       std::make_unique<GenerateStreamsRequest>(
+@@ -1828,7 +1828,7 @@ void MediaStreamManager::CancelRequest(const std::string& label) {
+ 
+   const DeviceRequests::const_iterator request_it = FindRequestIterator(label);
+   if (request_it == requests_.end()) {
+-    SendLogMessage(
++    SendLogMessageMSM(
+         base::StringPrintf("CancelRequest({label=%s})", label.c_str()));
+     LOG(ERROR) << "The request with label = " << label << " does not exist.";
+     return;
+@@ -1847,7 +1847,7 @@ void MediaStreamManager::CancelRequest(
+   const std::string& label = request_it->first;
+   DeviceRequest* const request = request_it->second.get();
+ 
+-  SendLogMessage(
++  SendLogMessageMSM(
+       base::StringPrintf("CancelRequest({label=%s})", label.c_str()));
+ 
+   // This is a request for closing one or more devices.
+@@ -1906,7 +1906,7 @@ void MediaStreamManager::StopStreamDevice(
+     const std::string& device_id,
+     const base::UnguessableToken& session_id) {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+-  SendLogMessage(GetStopStreamDeviceLogString(
++  SendLogMessageMSM(GetStopStreamDeviceLogString(
+       render_process_id, render_frame_id, requester_id, device_id, session_id));
+ 
+   // Find the first request for this |render_process_id| and |render_frame_id|
+@@ -2007,7 +2007,7 @@ base::UnguessableToken MediaStreamManager::VideoDeviceIdToSessionId(
+ void MediaStreamManager::StopDevice(MediaStreamType type,
+                                     const base::UnguessableToken& session_id) {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+-  SendLogMessage(base::StringPrintf("StopDevice({type=%s}, {session_id=%s})",
++  SendLogMessageMSM(base::StringPrintf("StopDevice({type=%s}, {session_id=%s})",
+                                     StreamTypeToString(type),
+                                     session_id.ToString().c_str()));
+   DeviceRequests::const_iterator request_it = requests_.begin();
+@@ -2070,7 +2070,7 @@ void MediaStreamManager::StopDevice(MediaStreamType type,
+ void MediaStreamManager::CloseDevice(MediaStreamType type,
+                                      const base::UnguessableToken& session_id) {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+-  SendLogMessage(base::StringPrintf("CloseDevice({type=%s}, {session_id=%s})",
++  SendLogMessageMSM(base::StringPrintf("CloseDevice({type=%s}, {session_id=%s})",
+                                     StreamTypeToString(type),
+                                     session_id.ToString().c_str()));
+   GetDeviceManager(type)->Close(session_id);
+@@ -2127,7 +2127,7 @@ void MediaStreamManager::OpenDevice(int render_process_id,
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+   DCHECK(type == MediaStreamType::DEVICE_AUDIO_CAPTURE ||
+          type == MediaStreamType::DEVICE_VIDEO_CAPTURE);
+-  SendLogMessage(GetOpenDeviceLogString(render_process_id, render_frame_id,
++  SendLogMessageMSM(GetOpenDeviceLogString(render_process_id, render_frame_id,
+                                         requester_id, page_request_id,
+                                         device_id, type));
+   StreamControls controls;
+@@ -2197,9 +2197,9 @@ void MediaStreamManager::StopRemovedDevice(
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+   DCHECK(type == MediaDeviceType::MEDIA_AUDIO_INPUT ||
+          type == MediaDeviceType::MEDIA_VIDEO_INPUT);
+-  SendLogMessage(base::StringPrintf(
++  SendLogMessageMSM(base::StringPrintf(
+                      "StopRemovedDevice({type=%s}, {device=[id: %s, name: %s]}",
+-                     DeviceTypeToString(type),
++                     DeviceTypeToStringMSM(type),
+                      media_device_info.device_id.c_str(),
+                      media_device_info.label.c_str())
+                      .c_str());
+@@ -2289,7 +2289,7 @@ void MediaStreamManager::TranslateDeviceIdToSourceId(
+ void MediaStreamManager::StartEnumeration(DeviceRequest* request,
+                                           const std::string& label) {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+-  SendLogMessage(
++  SendLogMessageMSM(
+       base::StringPrintf("StartEnumeration({requester_id=%d}, {label=%s})",
+                          request->requester_id, label.c_str()));
+ 
+@@ -2334,7 +2334,7 @@ MediaStreamManager::AddRequest(std::unique_ptr<DeviceRequest> request) {
+     unique_label = base::GenerateGUID();
+   } while (FindRequest(unique_label) != nullptr);
+ 
+-  SendLogMessage(
++  SendLogMessageMSM(
+       base::StringPrintf("AddRequest([requester_id=%d]) => (label=%s)",
+                          request->requester_id, unique_label.c_str()));
+   request->SetLabel(unique_label);
+@@ -2449,7 +2449,7 @@ void MediaStreamManager::DeleteRequest(
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+   DCHECK(request_it != requests_.end());
+ 
+-  SendLogMessage(base::StringPrintf("DeleteRequest([label=%s])",
++  SendLogMessageMSM(base::StringPrintf("DeleteRequest([label=%s])",
+                                     request_it->first.c_str()));
+ #if BUILDFLAG(IS_CHROMEOS)
+   if (request_it->second->IsGetDisplayMediaSet()) {
+@@ -2505,7 +2505,7 @@ void MediaStreamManager::PostRequestToUI(
+     return;
+   }
+   DCHECK(request->HasUIRequest());
+-  SendLogMessage(
++  SendLogMessageMSM(
+       base::StringPrintf("PostRequestToUI({label=%s}, ", label.c_str()));
+ 
+   const MediaStreamType audio_type = request->audio_type();
+@@ -2543,7 +2543,7 @@ void MediaStreamManager::SetUpRequest(const std::string& label) {
+   }
+   DeviceRequest* const request = request_it->second.get();
+ 
+-  SendLogMessage(
++  SendLogMessageMSM(
+       base::StringPrintf("SetUpRequest([requester_id=%d] {label=%s})",
+                          request->requester_id, label.c_str()));
+ 
+@@ -2650,7 +2650,7 @@ bool MediaStreamManager::SetUpDeviceCaptureRequest(
+           request->audio_type() == MediaStreamType::NO_SERVICE) &&
+          (request->video_type() == MediaStreamType::DEVICE_VIDEO_CAPTURE ||
+           request->video_type() == MediaStreamType::NO_SERVICE));
+-  SendLogMessage(base::StringPrintf(
++  SendLogMessageMSM(base::StringPrintf(
+       "SetUpDeviceCaptureRequest([requester_id=%d])", request->requester_id));
+   std::string audio_device_id;
+   if (request->stream_controls().audio.requested() &&
+@@ -2904,7 +2904,7 @@ void MediaStreamManager::FinalizeGenerateStreams(const std::string& label,
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+   DCHECK(request);
+   DCHECK_EQ(request->request_type(), blink::MEDIA_GENERATE_STREAM);
+-  SendLogMessage(
++  SendLogMessageMSM(
+       base::StringPrintf("FinalizeGenerateStreams({label=%s}, {requester_id="
+                          "%d}, {request_type=%s})",
+                          label.c_str(), request->requester_id,
+@@ -2947,7 +2947,7 @@ void MediaStreamManager::FinalizeGetOpenDevice(const std::string& label,
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+   DCHECK(request);
+   DCHECK_EQ(request->request_type(), blink::MEDIA_GET_OPEN_DEVICE);
+-  SendLogMessage(
++  SendLogMessageMSM(
+       base::StringPrintf("FinalizeGetOpenDevice({label=%s}, {requester_id="
+                          "%d}, {request_type=%s})",
+                          label.c_str(), request->requester_id,
+@@ -2987,7 +2987,7 @@ void MediaStreamManager::PanTiltZoomPermissionChecked(
+     return;
+   }
+ 
+-  SendLogMessage(base::StringPrintf(
++  SendLogMessageMSM(base::StringPrintf(
+       "PanTiltZoomPermissionChecked({label=%s}, {requester_id="
+       "%d}, {request_type=%s}, {pan_tilt_zoom_allowed=%d})",
+       label.c_str(), request->requester_id,
+@@ -3039,7 +3039,7 @@ void MediaStreamManager::FinalizeRequestFailed(
+ 
+   DeviceRequest* const request = request_it->second.get();
+ 
+-  SendLogMessage(base::StringPrintf(
++  SendLogMessageMSM(base::StringPrintf(
+       "FinalizeRequestFailed({label=%s}, {requester_id=%d}, {result=%s})",
+       request_it->first.c_str(), request->requester_id,
+       RequestResultToString(result)));
+@@ -3132,7 +3132,7 @@ void MediaStreamManager::InitializeMaybeAsync(
+                                   std::move(video_capture_provider)));
+     return;
+   }
+-  SendLogMessage(base::StringPrintf("InitializeMaybeAsync([this=%p])", this));
++  SendLogMessageMSM(base::StringPrintf("InitializeMaybeAsync([this=%p])", this));
+ 
+   // Store a pointer to |this| on the IO thread to avoid having to jump to
+   // the UI thread to fetch a pointer to the MSM. In particular on Android,
+@@ -3169,7 +3169,7 @@ void MediaStreamManager::Opened(
+     MediaStreamType stream_type,
+     const base::UnguessableToken& capture_session_id) {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+-  SendLogMessage(base::StringPrintf("Opened({stream_type=%s}, {session_id=%s})",
++  SendLogMessageMSM(base::StringPrintf("Opened({stream_type=%s}, {session_id=%s})",
+                                     StreamTypeToString(stream_type),
+                                     capture_session_id.ToString().c_str()));
+ 
+@@ -3282,7 +3282,7 @@ void MediaStreamManager::Closed(
+     MediaStreamType stream_type,
+     const base::UnguessableToken& capture_session_id) {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+-  SendLogMessage(base::StringPrintf("Closed({stream_type=%s}, {session_id=%s})",
++  SendLogMessageMSM(base::StringPrintf("Closed({stream_type=%s}, {session_id=%s})",
+                                     StreamTypeToString(stream_type),
+                                     capture_session_id.ToString().c_str()));
+ }
+@@ -3300,7 +3300,7 @@ void MediaStreamManager::DevicesEnumerated(
+   }
+   DeviceRequest* const request = request_it->second.get();
+ 
+-  SendLogMessage(base::StringPrintf(
++  SendLogMessageMSM(base::StringPrintf(
+       "DevicesEnumerated({label=%s}, {requester_id=%d}, {request_type=%s})",
+       label.c_str(), request->requester_id,
+       RequestTypeToString(request->request_type())));
+@@ -3331,7 +3331,7 @@ void MediaStreamManager::Aborted(
+     MediaStreamType stream_type,
+     const base::UnguessableToken& capture_session_id) {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+-  SendLogMessage(base::StringPrintf(
++  SendLogMessageMSM(base::StringPrintf(
+       "Aborted({stream_type=%s}, {session_id=%s})",
+       StreamTypeToString(stream_type), capture_session_id.ToString().c_str()));
+   StopDevice(stream_type, capture_session_id);
+@@ -3397,7 +3397,7 @@ void MediaStreamManager::HandleAccessRequestResponse(
+   }
+   DeviceRequest* const request = request_it->second.get();
+ 
+-  SendLogMessage(base::StringPrintf(
++  SendLogMessageMSM(base::StringPrintf(
+       "HandleAccessRequestResponse({label=%s}, {request=%s}, {result=%s})",
+       label.c_str(), RequestTypeToString(request->request_type()),
+       RequestResultToString(result)));
+@@ -3493,7 +3493,7 @@ void MediaStreamManager::HandleAccessRequestResponse(
+               *request->stream_devices_set.stream_devices[stream_index],
+               device);
+           request->SetState(device.type, state);
+-          SendLogMessage(base::StringPrintf(
++          SendLogMessageMSM(base::StringPrintf(
+               "HandleAccessRequestResponse([label=%s]) => "
+               "(already opened device: [id: %s, session_id: %s])",
+               label.c_str(), device.id.c_str(),
+@@ -3510,7 +3510,7 @@ void MediaStreamManager::HandleAccessRequestResponse(
+           current_state != MEDIA_REQUEST_STATE_ERROR) {
+         request->SetState(device.type, MEDIA_REQUEST_STATE_OPENING);
+       }
+-      SendLogMessage(
++      SendLogMessageMSM(
+           base::StringPrintf("HandleAccessRequestResponse([label=%s]) => "
+                              "(opening device: [id: %s, session_id: %s])",
+                              label.c_str(), device.id.c_str(),
+@@ -3589,7 +3589,7 @@ void MediaStreamManager::StopMediaStreamFromBrowser(const std::string& label) {
+   }
+   DeviceRequest* const request = request_it->second.get();
+ 
+-  SendLogMessage(base::StringPrintf("StopMediaStreamFromBrowser({label=%s})",
++  SendLogMessageMSM(base::StringPrintf("StopMediaStreamFromBrowser({label=%s})",
+                                     label.c_str()));
+ 
+   // Notify renderers that the devices in the stream will be stopped.
+@@ -3643,7 +3643,7 @@ void MediaStreamManager::ChangeMediaStreamSourceFromBrowser(
+     }
+   }
+ 
+-  SendLogMessage(base::StringPrintf(
++  SendLogMessageMSM(base::StringPrintf(
+       "ChangeMediaStreamSourceFromBrowser({label=%s})", label.c_str()));
+ 
+   SetUpDesktopCaptureChangeSourceRequest(request, label, media_id);
+@@ -3661,7 +3661,7 @@ void MediaStreamManager::OnRequestStateChangeFromBrowser(
+     return;
+   }
+ 
+-  SendLogMessage(base::StringPrintf("RequestStateChangeFromBrowser({label=%s})",
++  SendLogMessageMSM(base::StringPrintf("RequestStateChangeFromBrowser({label=%s})",
+                                     label.c_str()));
+ 
+   request->OnRequestStateChangeFromBrowser(label, media_id, new_state);
+@@ -3692,8 +3692,8 @@ void MediaStreamManager::NotifyDevicesChanged(
+     MediaDeviceType device_type,
+     const blink::WebMediaDeviceInfoArray& devices) {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+-  SendLogMessage(base::StringPrintf("NotifyDevicesChanged({device_type=%s})",
+-                                    DeviceTypeToString(device_type)));
++  SendLogMessageMSM(base::StringPrintf("NotifyDevicesChanged({device_type=%s})",
++                                    DeviceTypeToStringMSM(device_type)));
+ 
+   MediaObserver* media_observer =
+       GetContentClient()->browser()->GetMediaObserver();
+@@ -3721,7 +3721,7 @@ void MediaStreamManager::NotifyDevicesChanged(
+ 
+ bool MediaStreamManager::RequestDone(const DeviceRequest& request) const {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+-  SendLogMessage(base::StringPrintf(
++  SendLogMessageMSM(base::StringPrintf(
+       "RequestDone({requester_id=%d}, {request_type=%s})", request.requester_id,
+       RequestTypeToString(request.request_type())));
+ 
+@@ -3985,7 +3985,7 @@ void MediaStreamManager::OnStreamStarted(const std::string& label) {
+   if (!request) {
+     return;
+   }
+-  SendLogMessage(base::StringPrintf(
++  SendLogMessageMSM(base::StringPrintf(
+       "OnStreamStarted({label=%s}, {requester_id=%d}, {request_type=%s})",
+       label.c_str(), request->requester_id,
+       RequestTypeToString(request->request_type())));
+diff --git a/content/browser/renderer_host/media/media_stream_power_logger.cc b/content/browser/renderer_host/media/media_stream_power_logger.cc
+index 733d66510..450a1eb28 100644
+--- a/content/browser/renderer_host/media/media_stream_power_logger.cc
++++ b/content/browser/renderer_host/media/media_stream_power_logger.cc
+@@ -11,7 +11,7 @@
+ namespace content {
+ 
+ namespace {
+-void SendLogMessage(const std::string& message) {
++void SendLogMessageMSPL(const std::string& message) {
+   MediaStreamManager::SendMessageToNativeLog("MSPL::" + message);
+ }
+ }  // namespace
+@@ -27,23 +27,23 @@ MediaStreamPowerLogger::~MediaStreamPowerLogger() {
+ }
+ 
+ void MediaStreamPowerLogger::OnSuspend() {
+-  SendLogMessage(base::StringPrintf("OnSuspend([this=%p])", this));
++  SendLogMessageMSPL(base::StringPrintf("OnSuspend([this=%p])", this));
+ }
+ 
+ void MediaStreamPowerLogger::OnResume() {
+-  SendLogMessage(base::StringPrintf("OnResume([this=%p])", this));
++  SendLogMessageMSPL(base::StringPrintf("OnResume([this=%p])", this));
+ }
+ 
+ void MediaStreamPowerLogger::OnThermalStateChange(
+     base::PowerThermalObserver::DeviceThermalState new_state) {
+   const char* state_name =
+       base::PowerMonitorSource::DeviceThermalStateToString(new_state);
+-  SendLogMessage(base::StringPrintf(
++  SendLogMessageMSPL(base::StringPrintf(
+       "OnThermalStateChange({this=%p}, {new_state=%s})", this, state_name));
+ }
+ 
+ void MediaStreamPowerLogger::OnSpeedLimitChange(int new_limit) {
+-  SendLogMessage(base::StringPrintf(
++  SendLogMessageMSPL(base::StringPrintf(
+       "OnSpeedLimitChange({this=%p}, {new_limit=%d})", this, new_limit));
+ }
+ 
+diff --git a/content/browser/renderer_host/pepper/pepper_internal_file_ref_backend.cc b/content/browser/renderer_host/pepper/pepper_internal_file_ref_backend.cc
+index a1e16c8e7..09a6976d1 100644
+--- a/content/browser/renderer_host/pepper/pepper_internal_file_ref_backend.cc
++++ b/content/browser/renderer_host/pepper/pepper_internal_file_ref_backend.cc
+@@ -81,7 +81,7 @@ void CallRemove(scoped_refptr<storage::FileSystemContext> file_system_context,
+                                                   std::move(callback));
+ }
+ 
+-void CallTouchFile(
++void CallTouchFile2(
+     scoped_refptr<storage::FileSystemContext> file_system_context,
+     const storage::FileSystemURL& url,
+     const base::Time& last_access_time,
+@@ -246,7 +246,7 @@ int32_t PepperInternalFileRefBackend::Touch(
+   GetIOThreadTaskRunner({})->PostTask(
+       FROM_HERE,
+       base::BindOnce(
+-          CallTouchFile, GetFileSystemContext(), GetFileSystemURL(),
++          CallTouchFile2, GetFileSystemContext(), GetFileSystemURL(),
+           last_access_time, last_modified_time,
+           base::BindOnce(&PepperInternalFileRefBackend::DidFinishOnIOThread,
+                          weak_factory_.GetWeakPtr(), reply_context,
+diff --git a/content/browser/renderer_host/render_frame_proxy_host.cc b/content/browser/renderer_host/render_frame_proxy_host.cc
+index 9fe6bf4e2..20d2ee941 100644
+--- a/content/browser/renderer_host/render_frame_proxy_host.cc
++++ b/content/browser/renderer_host/render_frame_proxy_host.cc
+@@ -65,10 +65,10 @@ typedef std::unordered_map<RenderFrameProxyHostID,
+ base::LazyInstance<RoutingIDFrameProxyMap>::DestructorAtExit
+     g_routing_id_frame_proxy_map = LAZY_INSTANCE_INITIALIZER;
+ 
+-using TokenFrameMap = std::unordered_map<blink::RemoteFrameToken,
+-                                         RenderFrameProxyHost*,
+-                                         blink::RemoteFrameToken::Hasher>;
+-base::LazyInstance<TokenFrameMap>::Leaky g_token_frame_proxy_map =
++using TokenFrameProxyMap = std::unordered_map<blink::RemoteFrameToken,
++                                              RenderFrameProxyHost*,
++                                              blink::RemoteFrameToken::Hasher>;
++base::LazyInstance<TokenFrameProxyMap>::Leaky g_token_frame_proxy_map =
+     LAZY_INSTANCE_INITIALIZER;
+ 
+ }  // namespace
+@@ -94,7 +94,7 @@ RenderFrameProxyHost* RenderFrameProxyHost::FromFrameToken(
+     int process_id,
+     const blink::RemoteFrameToken& frame_token) {
+   DCHECK_CURRENTLY_ON(BrowserThread::UI);
+-  TokenFrameMap* frames = g_token_frame_proxy_map.Pointer();
++  TokenFrameProxyMap* frames = g_token_frame_proxy_map.Pointer();
+   auto it = frames->find(frame_token);
+   // The check against |process_id| isn't strictly necessary, but represents
+   // an extra level of protection against a renderer trying to force a frame
+@@ -108,7 +108,7 @@ RenderFrameProxyHost* RenderFrameProxyHost::FromFrameToken(
+ bool RenderFrameProxyHost::IsFrameTokenInUse(
+     const blink::RemoteFrameToken& frame_token) {
+   DCHECK_CURRENTLY_ON(BrowserThread::UI);
+-  TokenFrameMap* frames = g_token_frame_proxy_map.Pointer();
++  TokenFrameProxyMap* frames = g_token_frame_proxy_map.Pointer();
+   return frames->find(frame_token) != frames->end();
+ }
+ 
+diff --git a/content/browser/service_worker/embedded_worker_instance.cc b/content/browser/service_worker/embedded_worker_instance.cc
+index 2f01803d5..3e817c255 100644
+--- a/content/browser/service_worker/embedded_worker_instance.cc
++++ b/content/browser/service_worker/embedded_worker_instance.cc
+@@ -872,7 +872,7 @@ EmbeddedWorkerInstance::CreateFactoryBundle(
+   non_network_factories[url::kDataScheme] = DataURLLoaderFactory::Create();
+   // Allow service workers for chrome:// or chrome-untrusted:// based on flags.
+   if (base::FeatureList::IsEnabled(
+-          features::kEnableServiceWorkersForChromeScheme) &&
++          ::features::kEnableServiceWorkersForChromeScheme) &&
+       origin.scheme() == content::kChromeUIScheme) {
+     non_network_factories.emplace(
+         content::kChromeUIScheme,
+@@ -880,7 +880,7 @@ EmbeddedWorkerInstance::CreateFactoryBundle(
+                                               content::kChromeUIScheme,
+                                               base::flat_set<std::string>()));
+   } else if (base::FeatureList::IsEnabled(
+-                 features::kEnableServiceWorkersForChromeUntrusted) &&
++                 ::features::kEnableServiceWorkersForChromeUntrusted) &&
+              origin.scheme() == content::kChromeUIUntrustedScheme) {
+     non_network_factories.emplace(
+         content::kChromeUIUntrustedScheme,
+diff --git a/content/browser/service_worker/service_worker_context_wrapper.cc b/content/browser/service_worker/service_worker_context_wrapper.cc
+index 88a5ecbb0..eb845c720 100644
+--- a/content/browser/service_worker/service_worker_context_wrapper.cc
++++ b/content/browser/service_worker/service_worker_context_wrapper.cc
+@@ -1699,7 +1699,7 @@ ServiceWorkerContextWrapper::GetLoaderFactoryForBrowserInitiatedRequest(
+   } else {
+     DCHECK(storage_partition());
+     if (base::FeatureList::IsEnabled(
+-            features::kPrivateNetworkAccessForWorkers)) {
++            ::features::kPrivateNetworkAccessForWorkers)) {
+       if (g_loader_factory_interceptor.Get()) {
+         g_loader_factory_interceptor.Get().Run(&pending_receiver);
+       }
+@@ -1740,7 +1740,7 @@ ServiceWorkerContextWrapper::GetLoaderFactoryForBrowserInitiatedRequest(
+     // create a `WebUI` or a `WebUIController` for WebUI Service Workers so we
+     // register the URLDataSource directly.
+     if (base::FeatureList::IsEnabled(
+-            features::kEnableServiceWorkersForChromeScheme) &&
++            ::features::kEnableServiceWorkersForChromeScheme) &&
+         scope.scheme_piece() == kChromeUIScheme) {
+       config->RegisterURLDataSource(browser_context());
+       static_cast<blink::PendingURLLoaderFactoryBundle*>(
+@@ -1750,7 +1750,7 @@ ServiceWorkerContextWrapper::GetLoaderFactoryForBrowserInitiatedRequest(
+                                         browser_context(), kChromeUIScheme,
+                                         base::flat_set<std::string>()));
+     } else if (base::FeatureList::IsEnabled(
+-                   features::kEnableServiceWorkersForChromeUntrusted) &&
++                   ::features::kEnableServiceWorkersForChromeUntrusted) &&
+                scope.scheme_piece() == kChromeUIUntrustedScheme) {
+       config->RegisterURLDataSource(browser_context());
+       static_cast<blink::PendingURLLoaderFactoryBundle*>(
+diff --git a/content/browser/service_worker/service_worker_controllee_request_handler.cc b/content/browser/service_worker/service_worker_controllee_request_handler.cc
+index e82496b98..7b273e0ac 100644
+--- a/content/browser/service_worker/service_worker_controllee_request_handler.cc
++++ b/content/browser/service_worker/service_worker_controllee_request_handler.cc
+@@ -89,7 +89,7 @@ const char* FetchHandlerTypeToString(
+ const base::flat_set<std::string> FetchHandlerBypassedHashStrings() {
+   const static base::NoDestructor<base::flat_set<std::string>> result(
+       base::SplitString(
+-          features::kServiceWorkerBypassFetchHandlerBypassedHashStrings.Get(),
++          ::features::kServiceWorkerBypassFetchHandlerBypassedHashStrings.Get(),
+           ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY));
+ 
+   return *result;
+@@ -98,22 +98,22 @@ const base::flat_set<std::string> FetchHandlerBypassedHashStrings() {
+ bool ShouldBypassFetchHandlerForMainResource(
+     const std::string& sha256_script_checksum) {
+   if (!base::FeatureList::IsEnabled(
+-          features::kServiceWorkerBypassFetchHandler)) {
++          ::features::kServiceWorkerBypassFetchHandler)) {
+     return false;
+   }
+ 
+-  if (features::kServiceWorkerBypassFetchHandlerTarget.Get() !=
+-      features::ServiceWorkerBypassFetchHandlerTarget::kMainResource) {
++  if (::features::kServiceWorkerBypassFetchHandlerTarget.Get() !=
++      ::features::ServiceWorkerBypassFetchHandlerTarget::kMainResource) {
+     return false;
+   }
+ 
+   // If the feature is enabled, the main resource request bypasses ServiceWorker
+   // and starts the worker in parallel for subsequent subresources.
+-  switch (features::kServiceWorkerBypassFetchHandlerStrategy.Get()) {
++  switch (::features::kServiceWorkerBypassFetchHandlerStrategy.Get()) {
+     // kFeatureOptIn means that the feature relies on the manual feature
+     // toggle from about://flags etc, which is triggered by developers. We
+     // bypass fetch handler regardless of the url matching in this case.
+-    case features::ServiceWorkerBypassFetchHandlerStrategy::kFeatureOptIn:
++    case ::features::ServiceWorkerBypassFetchHandlerStrategy::kFeatureOptIn:
+       RecordSkipReason(
+           ServiceWorkerControlleeRequestHandler::FetchHandlerSkipReason::
+               kMainResourceSkippedDueToFeatureFlag);
+@@ -121,7 +121,7 @@ bool ShouldBypassFetchHandlerForMainResource(
+     // If kAllowList, the allowlist should be specified. In this case, main
+     // resource fetch handlers are bypassed only when the sha256 checksum of the
+     // script is in the allowlist.
+-    case features::ServiceWorkerBypassFetchHandlerStrategy::kAllowList:
++    case ::features::ServiceWorkerBypassFetchHandlerStrategy::kAllowList:
+       if (FetchHandlerBypassedHashStrings().contains(sha256_script_checksum)) {
+         RecordSkipReason(
+             ServiceWorkerControlleeRequestHandler::FetchHandlerSkipReason::
+@@ -535,7 +535,7 @@ void ServiceWorkerControlleeRequestHandler::ContinueWithActivatedVersion(
+       registration->active_version()->CountFeature(
+           blink::mojom::WebFeature::kServiceWorkerSkippedForEmptyFetchHandler);
+       CompleteWithoutLoader();
+-      if (!features::kStartServiceWorkerForEmptyFetchHandler.Get()) {
++      if (!::features::kStartServiceWorkerForEmptyFetchHandler.Get()) {
+         return;
+       }
+       // Start service worker if it is not running so that we run the code
+diff --git a/content/child/BUILD.gn b/content/child/BUILD.gn
+index 2a07e5889..e8fb5d7af 100644
+--- a/content/child/BUILD.gn
++++ b/content/child/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//device/vr/buildflags/buildflags.gni")
+ import("//ppapi/buildflags/buildflags.gni")
+@@ -12,9 +13,9 @@ if (is_android) {
+ }
+ 
+ if (is_component_build) {
+-  link_target_type = "source_set"
++  link_target_type = "jumbo_source_set"
+ } else {
+-  link_target_type = "static_library"
++  link_target_type = "jumbo_static_library"
+ }
+ target(link_target_type, "child") {
+   # Targets external to content should always link to the public API.
+diff --git a/content/common/BUILD.gn b/content/common/BUILD.gn
+index d01ad9dbe..4b04d2463 100644
+--- a/content/common/BUILD.gn
++++ b/content/common/BUILD.gn
+@@ -4,6 +4,7 @@
+ 
+ import("//build/buildflag_header.gni")
+ import("//build/config/features.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//content/public/common/zygote/features.gni")
+ import("//ipc/features.gni")
+@@ -59,7 +60,7 @@ if (is_linux || is_chromeos) {
+   }
+ }
+ 
+-source_set("common") {
++jumbo_source_set("common") {
+   # Targets external to content should always link to the public API.
+   # In addition, targets outside of the content component (shell and tests)
+   # must not link to this because it will duplicate the code in the component
+@@ -165,6 +166,11 @@ source_set("common") {
+     "webid/identity_url_loader_throttle.cc",
+     "webid/identity_url_loader_throttle.h",
+   ]
++  jumbo_excluded_sources = [
++    "common_param_traits.cc",
++    "content_message_generator.cc",
++    "content_param_traits.cc",
++  ]
+ 
+   configs += [
+     "//content:content_implementation",
+diff --git a/content/renderer/pepper/pepper_plugin_instance_impl.h b/content/renderer/pepper/pepper_plugin_instance_impl.h
+index a3f99906e..0c4e9ede8 100644
+--- a/content/renderer/pepper/pepper_plugin_instance_impl.h
++++ b/content/renderer/pepper/pepper_plugin_instance_impl.h
+@@ -66,6 +66,11 @@
+ #include "v8/include/v8-forward.h"
+ #include "v8/include/v8-persistent-handle.h"
+ 
++// Windows defines 'PostMessage', so we have to undef it.
++#ifdef PostMessage
++#undef PostMessage
++#endif
++
+ struct PP_Point;
+ 
+ namespace blink {
+diff --git a/content/renderer/service_worker/web_service_worker_provider_impl.cc b/content/renderer/service_worker/web_service_worker_provider_impl.cc
+index fa4ee1380..f834261cd 100644
+--- a/content/renderer/service_worker/web_service_worker_provider_impl.cc
++++ b/content/renderer/service_worker/web_service_worker_provider_impl.cc
+@@ -32,7 +32,7 @@ const char kLostConnectionErrorMessage[] =
+     "Lost connection to the service worker system.";
+ 
+ template <typename T>
+-static std::string MojoEnumToString(T mojo_enum) {
++static std::string MojoEnumToString2(T mojo_enum) {
+   std::ostringstream oss;
+   oss << mojo_enum;
+   return oss.str();
+@@ -232,7 +232,7 @@ void WebServiceWorkerProviderImpl::OnRegistered(
+     blink::mojom::ServiceWorkerRegistrationObjectInfoPtr registration) {
+   TRACE_EVENT_NESTABLE_ASYNC_END2(
+       "ServiceWorker", "WebServiceWorkerProviderImpl::RegisterServiceWorker",
+-      TRACE_ID_LOCAL(this), "Error", MojoEnumToString(error), "Message",
++      TRACE_ID_LOCAL(this), "Error", MojoEnumToString2(error), "Message",
+       error_msg ? *error_msg : "Success");
+   if (error != blink::mojom::ServiceWorkerErrorType::kNone) {
+     DCHECK(error_msg);
+@@ -258,7 +258,7 @@ void WebServiceWorkerProviderImpl::OnDidGetRegistration(
+     blink::mojom::ServiceWorkerRegistrationObjectInfoPtr registration) {
+   TRACE_EVENT_NESTABLE_ASYNC_END2(
+       "ServiceWorker", "WebServiceWorkerProviderImpl::GetRegistration",
+-      TRACE_ID_LOCAL(this), "Error", MojoEnumToString(error), "Message",
++      TRACE_ID_LOCAL(this), "Error", MojoEnumToString2(error), "Message",
+       error_msg ? *error_msg : "Success");
+   if (error != blink::mojom::ServiceWorkerErrorType::kNone) {
+     DCHECK(error_msg);
+@@ -288,7 +288,7 @@ void WebServiceWorkerProviderImpl::OnDidGetRegistrations(
+         infos) {
+   TRACE_EVENT_NESTABLE_ASYNC_END2(
+       "ServiceWorker", "WebServiceWorkerProviderImpl::GetRegistrations",
+-      TRACE_ID_LOCAL(this), "Error", MojoEnumToString(error), "Message",
++      TRACE_ID_LOCAL(this), "Error", MojoEnumToString2(error), "Message",
+       error_msg ? *error_msg : "Success");
+   if (error != blink::mojom::ServiceWorkerErrorType::kNone) {
+     DCHECK(error_msg);
+diff --git a/dbus/message.cc b/dbus/message.cc
+index 949ee5d59..47d73816d 100644
+--- a/dbus/message.cc
++++ b/dbus/message.cc
+@@ -767,7 +767,7 @@ bool MessageReader::PopBool(bool* value) {
+   // Like MessageWriter::AppendBool(), we should copy |value| to
+   // dbus_bool_t, as dbus_message_iter_get_basic() used in PopBasic()
+   // expects four bytes for DBUS_TYPE_BOOLEAN.
+-  dbus_bool_t dbus_value = FALSE;
++  dbus_bool_t dbus_value = 0; //FALSE;
+   const bool success = PopBasic(DBUS_TYPE_BOOLEAN, &dbus_value);
+   *value = static_cast<bool>(dbus_value);
+   return success;
+@@ -962,7 +962,7 @@ bool MessageReader::PopVariantOfByte(uint8_t* value) {
+ 
+ bool MessageReader::PopVariantOfBool(bool* value) {
+   // See the comment at MessageReader::PopBool().
+-  dbus_bool_t dbus_value = FALSE;
++  dbus_bool_t dbus_value = 0; //FALSE;
+   const bool success = PopVariantOfBasic(DBUS_TYPE_BOOLEAN, &dbus_value);
+   *value = static_cast<bool>(dbus_value);
+   return success;
+diff --git a/device/fido/cable/cable_discovery_data.h b/device/fido/cable/cable_discovery_data.h
+index 66aa16179..8efe2e3f5 100644
+--- a/device/fido/cable/cable_discovery_data.h
++++ b/device/fido/cable/cable_discovery_data.h
+@@ -139,7 +139,7 @@ struct COMPONENT_EXPORT(DEVICE_FIDO) Pairing {
+   // within the structure is validated by using `local_identity_seed` and
+   // `handshake_hash`.
+   static absl::optional<std::unique_ptr<Pairing>> Parse(
+-      const cbor::Value& cbor,
++      const ::cbor::Value& cbor,
+       tunnelserver::KnownDomainID domain,
+       base::span<const uint8_t, kQRSeedSize> local_identity_seed,
+       base::span<const uint8_t, 32> handshake_hash);
+diff --git a/device/fido/public_key_credential_descriptor.h b/device/fido/public_key_credential_descriptor.h
+index d6b40f93e..9ba5c7456 100644
+--- a/device/fido/public_key_credential_descriptor.h
++++ b/device/fido/public_key_credential_descriptor.h
+@@ -25,7 +25,7 @@ namespace device {
+ class COMPONENT_EXPORT(DEVICE_FIDO) PublicKeyCredentialDescriptor {
+  public:
+   static absl::optional<PublicKeyCredentialDescriptor> CreateFromCBORValue(
+-      const cbor::Value& cbor);
++      const ::cbor::Value& cbor);
+ 
+   PublicKeyCredentialDescriptor();
+   PublicKeyCredentialDescriptor(CredentialType credential_type,
+@@ -54,7 +54,7 @@ class COMPONENT_EXPORT(DEVICE_FIDO) PublicKeyCredentialDescriptor {
+ };
+ 
+ COMPONENT_EXPORT(DEVICE_FIDO)
+-cbor::Value AsCBOR(const PublicKeyCredentialDescriptor&);
++::cbor::Value AsCBOR(const PublicKeyCredentialDescriptor&);
+ 
+ }  // namespace device
+ 
+diff --git a/device/fido/public_key_credential_params.h b/device/fido/public_key_credential_params.h
+index fe0c3b063..34a266efb 100644
+--- a/device/fido/public_key_credential_params.h
++++ b/device/fido/public_key_credential_params.h
+@@ -31,7 +31,7 @@ class COMPONENT_EXPORT(DEVICE_FIDO) PublicKeyCredentialParams {
+   };
+ 
+   static absl::optional<PublicKeyCredentialParams> CreateFromCBORValue(
+-      const cbor::Value& cbor_value);
++      const ::cbor::Value& cbor_value);
+ 
+   explicit PublicKeyCredentialParams(
+       std::vector<CredentialInfo> credential_params);
+@@ -49,7 +49,7 @@ class COMPONENT_EXPORT(DEVICE_FIDO) PublicKeyCredentialParams {
+   std::vector<CredentialInfo> public_key_credential_params_;
+ };
+ 
+-cbor::Value AsCBOR(const PublicKeyCredentialParams&);
++::cbor::Value AsCBOR(const PublicKeyCredentialParams&);
+ 
+ }  // namespace device
+ 
+diff --git a/device/fido/public_key_credential_rp_entity.h b/device/fido/public_key_credential_rp_entity.h
+index d59250fd1..5a3c194b0 100644
+--- a/device/fido/public_key_credential_rp_entity.h
++++ b/device/fido/public_key_credential_rp_entity.h
+@@ -21,7 +21,7 @@ namespace device {
+ struct COMPONENT_EXPORT(DEVICE_FIDO) PublicKeyCredentialRpEntity {
+  public:
+   static absl::optional<PublicKeyCredentialRpEntity> CreateFromCBORValue(
+-      const cbor::Value& cbor);
++      const ::cbor::Value& cbor);
+ 
+   PublicKeyCredentialRpEntity();
+   explicit PublicKeyCredentialRpEntity(std::string id);
+@@ -38,7 +38,7 @@ struct COMPONENT_EXPORT(DEVICE_FIDO) PublicKeyCredentialRpEntity {
+   absl::optional<std::string> name;
+ };
+ 
+-cbor::Value AsCBOR(const PublicKeyCredentialRpEntity&);
++::cbor::Value AsCBOR(const PublicKeyCredentialRpEntity&);
+ 
+ }  // namespace device
+ 
+diff --git a/device/fido/public_key_credential_user_entity.h b/device/fido/public_key_credential_user_entity.h
+index 88e554744..87a3febf4 100644
+--- a/device/fido/public_key_credential_user_entity.h
++++ b/device/fido/public_key_credential_user_entity.h
+@@ -23,7 +23,7 @@ namespace device {
+ class COMPONENT_EXPORT(DEVICE_FIDO) PublicKeyCredentialUserEntity {
+  public:
+   static absl::optional<PublicKeyCredentialUserEntity> CreateFromCBORValue(
+-      const cbor::Value& cbor);
++      const ::cbor::Value& cbor);
+ 
+   PublicKeyCredentialUserEntity();
+   explicit PublicKeyCredentialUserEntity(std::vector<uint8_t> id);
+@@ -44,7 +44,7 @@ class COMPONENT_EXPORT(DEVICE_FIDO) PublicKeyCredentialUserEntity {
+   absl::optional<std::string> display_name;
+ };
+ 
+-cbor::Value AsCBOR(const PublicKeyCredentialUserEntity&);
++::cbor::Value AsCBOR(const PublicKeyCredentialUserEntity&);
+ 
+ }  // namespace device
+ 
+diff --git a/extensions/browser/api/declarative_webrequest/webrequest_condition.cc b/extensions/browser/api/declarative_webrequest/webrequest_condition.cc
+index 4023f6750..36345455c 100644
+--- a/extensions/browser/api/declarative_webrequest/webrequest_condition.cc
++++ b/extensions/browser/api/declarative_webrequest/webrequest_condition.cc
+@@ -18,8 +18,6 @@ using url_matcher::URLMatcherConditionFactory;
+ using url_matcher::URLMatcherConditionSet;
+ using url_matcher::URLMatcherFactory;
+ 
+-namespace keys = extensions::declarative_webrequest_constants;
+-
+ namespace {
+ static base::MatcherStringPattern::ID g_next_id = 0;
+ 
+@@ -38,7 +36,7 @@ const char kConditionCannotBeFulfilled[] = "A condition can never be "
+ 
+ namespace extensions {
+ 
+-namespace keys = declarative_webrequest_constants;
++namespace keys_wrc = declarative_webrequest_constants;
+ 
+ //
+ // WebRequestData
+@@ -128,12 +126,12 @@ std::unique_ptr<WebRequestCondition> WebRequestCondition::Create(
+ 
+   // Verify that we are dealing with a Condition whose type we understand.
+   const std::string* instance_type =
+-      condition_dict->FindString(keys::kInstanceTypeKey);
++      condition_dict->FindString(keys_wrc::kInstanceTypeKey);
+   if (!instance_type) {
+     *error = kConditionWithoutInstanceType;
+     return nullptr;
+   }
+-  if (*instance_type != keys::kRequestMatcherType) {
++  if (*instance_type != keys_wrc::kRequestMatcherType) {
+     *error = kExpectedOtherConditionType;
+     return nullptr;
+   }
+@@ -144,12 +142,12 @@ std::unique_ptr<WebRequestCondition> WebRequestCondition::Create(
+   for (const auto entry : *condition_dict) {
+     const std::string& condition_attribute_name = entry.first;
+     const base::Value& condition_attribute_value = entry.second;
+-    if (condition_attribute_name == keys::kInstanceTypeKey ||
++    if (condition_attribute_name == keys_wrc::kInstanceTypeKey ||
+         condition_attribute_name ==
+-            keys::kDeprecatedFirstPartyForCookiesUrlKey ||
+-        condition_attribute_name == keys::kDeprecatedThirdPartyKey) {
++            keys_wrc::kDeprecatedFirstPartyForCookiesUrlKey ||
++        condition_attribute_name == keys_wrc::kDeprecatedThirdPartyKey) {
+       // Skip this.
+-    } else if (condition_attribute_name == keys::kUrlKey) {
++    } else if (condition_attribute_name == keys_wrc::kUrlKey) {
+       const base::Value::Dict* dict = condition_attribute_value.GetIfDict();
+       if (!dict) {
+         *error = base::StringPrintf(kInvalidTypeOfParamter,
+diff --git a/extensions/browser/api/declarative_webrequest/webrequest_condition_attribute.cc b/extensions/browser/api/declarative_webrequest/webrequest_condition_attribute.cc
+index 89d1208d8..5c7237de0 100644
+--- a/extensions/browser/api/declarative_webrequest/webrequest_condition_attribute.cc
++++ b/extensions/browser/api/declarative_webrequest/webrequest_condition_attribute.cc
+@@ -35,7 +35,7 @@ using base::CaseInsensitiveCompareASCII;
+ using base::Value;
+ 
+ namespace helpers = extension_web_request_api_helpers;
+-namespace keys = extensions::declarative_webrequest_constants;
++namespace keys_wrca = extensions::declarative_webrequest_constants;
+ 
+ namespace extensions {
+ 
+@@ -50,31 +50,31 @@ struct WebRequestConditionAttributeFactory {
+ 
+   WebRequestConditionAttributeFactory() : factory(5) {
+     factory.RegisterFactoryMethod(
+-        keys::kResourceTypeKey, FactoryT::IS_PARAMETERIZED,
++        keys_wrca::kResourceTypeKey, FactoryT::IS_PARAMETERIZED,
+         &WebRequestConditionAttributeResourceType::Create);
+ 
+     factory.RegisterFactoryMethod(
+-        keys::kContentTypeKey, FactoryT::IS_PARAMETERIZED,
++        keys_wrca::kContentTypeKey, FactoryT::IS_PARAMETERIZED,
+         &WebRequestConditionAttributeContentType::Create);
+     factory.RegisterFactoryMethod(
+-        keys::kExcludeContentTypeKey, FactoryT::IS_PARAMETERIZED,
++        keys_wrca::kExcludeContentTypeKey, FactoryT::IS_PARAMETERIZED,
+         &WebRequestConditionAttributeContentType::Create);
+ 
+     factory.RegisterFactoryMethod(
+-        keys::kRequestHeadersKey, FactoryT::IS_PARAMETERIZED,
++        keys_wrca::kRequestHeadersKey, FactoryT::IS_PARAMETERIZED,
+         &WebRequestConditionAttributeRequestHeaders::Create);
+     factory.RegisterFactoryMethod(
+-        keys::kExcludeRequestHeadersKey, FactoryT::IS_PARAMETERIZED,
++        keys_wrca::kExcludeRequestHeadersKey, FactoryT::IS_PARAMETERIZED,
+         &WebRequestConditionAttributeRequestHeaders::Create);
+ 
+     factory.RegisterFactoryMethod(
+-        keys::kResponseHeadersKey, FactoryT::IS_PARAMETERIZED,
++        keys_wrca::kResponseHeadersKey, FactoryT::IS_PARAMETERIZED,
+         &WebRequestConditionAttributeResponseHeaders::Create);
+     factory.RegisterFactoryMethod(
+-        keys::kExcludeResponseHeadersKey, FactoryT::IS_PARAMETERIZED,
++        keys_wrca::kExcludeResponseHeadersKey, FactoryT::IS_PARAMETERIZED,
+         &WebRequestConditionAttributeResponseHeaders::Create);
+ 
+-    factory.RegisterFactoryMethod(keys::kStagesKey, FactoryT::IS_PARAMETERIZED,
++    factory.RegisterFactoryMethod(keys_wrca::kStagesKey, FactoryT::IS_PARAMETERIZED,
+                                   &WebRequestConditionAttributeStages::Create);
+   }
+ };
+@@ -128,10 +128,10 @@ WebRequestConditionAttributeResourceType::Create(
+     const base::Value* value,
+     std::string* error,
+     bool* bad_message) {
+-  DCHECK(instance_type == keys::kResourceTypeKey);
++  DCHECK(instance_type == keys_wrca::kResourceTypeKey);
+   if (!value->is_list()) {
+     *error = ErrorUtils::FormatErrorMessage(kInvalidValue,
+-                                            keys::kResourceTypeKey);
++                                            keys_wrca::kResourceTypeKey);
+     return nullptr;
+   }
+   const base::Value::List& list = value->GetList();
+@@ -147,7 +147,7 @@ WebRequestConditionAttributeResourceType::Create(
+         !ParseWebRequestResourceType(resource_type_string,
+                                      &passed_types.back())) {
+       *error = ErrorUtils::FormatErrorMessage(kInvalidValue,
+-                                              keys::kResourceTypeKey);
++                                              keys_wrca::kResourceTypeKey);
+       return nullptr;
+     }
+   }
+@@ -175,7 +175,7 @@ WebRequestConditionAttributeResourceType::GetType() const {
+ }
+ 
+ std::string WebRequestConditionAttributeResourceType::GetName() const {
+-  return keys::kResourceTypeKey;
++  return keys_wrca::kResourceTypeKey;
+ }
+ 
+ bool WebRequestConditionAttributeResourceType::Equals(
+@@ -208,7 +208,7 @@ WebRequestConditionAttributeContentType::Create(
+       const base::Value* value,
+       std::string* error,
+       bool* bad_message) {
+-  DCHECK(name == keys::kContentTypeKey || name == keys::kExcludeContentTypeKey);
++  DCHECK(name == keys_wrca::kContentTypeKey || name == keys_wrca::kExcludeContentTypeKey);
+ 
+   if (!value->is_list()) {
+     *error = ErrorUtils::FormatErrorMessage(kInvalidValue, name);
+@@ -225,7 +225,7 @@ WebRequestConditionAttributeContentType::Create(
+ 
+   return scoped_refptr<const WebRequestConditionAttribute>(
+       new WebRequestConditionAttributeContentType(
+-          content_types, name == keys::kContentTypeKey));
++          content_types, name == keys_wrca::kContentTypeKey));
+ }
+ 
+ int WebRequestConditionAttributeContentType::GetStages() const {
+@@ -259,7 +259,7 @@ WebRequestConditionAttributeContentType::GetType() const {
+ }
+ 
+ std::string WebRequestConditionAttributeContentType::GetName() const {
+-  return (inclusive_ ? keys::kContentTypeKey : keys::kExcludeContentTypeKey);
++  return (inclusive_ ? keys_wrca::kContentTypeKey : keys_wrca::kExcludeContentTypeKey);
+ }
+ 
+ bool WebRequestConditionAttributeContentType::Equals(
+@@ -458,25 +458,25 @@ HeaderMatcher::HeaderMatchTest::Create(const base::Value::Dict& tests) {
+   for (const auto entry : tests) {
+     bool is_name = false;  // Is this test for header name?
+     StringMatchTest::MatchType match_type;
+-    if (entry.first == keys::kNamePrefixKey) {
++    if (entry.first == keys_wrca::kNamePrefixKey) {
+       is_name = true;
+       match_type = StringMatchTest::kPrefix;
+-    } else if (entry.first == keys::kNameSuffixKey) {
++    } else if (entry.first == keys_wrca::kNameSuffixKey) {
+       is_name = true;
+       match_type = StringMatchTest::kSuffix;
+-    } else if (entry.first == keys::kNameContainsKey) {
++    } else if (entry.first == keys_wrca::kNameContainsKey) {
+       is_name = true;
+       match_type = StringMatchTest::kContains;
+-    } else if (entry.first == keys::kNameEqualsKey) {
++    } else if (entry.first == keys_wrca::kNameEqualsKey) {
+       is_name = true;
+       match_type = StringMatchTest::kEquals;
+-    } else if (entry.first == keys::kValuePrefixKey) {
++    } else if (entry.first == keys_wrca::kValuePrefixKey) {
+       match_type = StringMatchTest::kPrefix;
+-    } else if (entry.first == keys::kValueSuffixKey) {
++    } else if (entry.first == keys_wrca::kValueSuffixKey) {
+       match_type = StringMatchTest::kSuffix;
+-    } else if (entry.first == keys::kValueContainsKey) {
++    } else if (entry.first == keys_wrca::kValueContainsKey) {
+       match_type = StringMatchTest::kContains;
+-    } else if (entry.first == keys::kValueEqualsKey) {
++    } else if (entry.first == keys_wrca::kValueEqualsKey) {
+       match_type = StringMatchTest::kEquals;
+     } else {
+       NOTREACHED();  // JSON schema type checking should prevent this.
+@@ -566,8 +566,8 @@ WebRequestConditionAttributeRequestHeaders::Create(
+     const base::Value* value,
+     std::string* error,
+     bool* bad_message) {
+-  DCHECK(name == keys::kRequestHeadersKey ||
+-         name == keys::kExcludeRequestHeadersKey);
++  DCHECK(name == keys_wrca::kRequestHeadersKey ||
++         name == keys_wrca::kExcludeRequestHeadersKey);
+ 
+   std::unique_ptr<const HeaderMatcher> header_matcher(
+       PrepareHeaderMatcher(name, value, error));
+@@ -576,7 +576,7 @@ WebRequestConditionAttributeRequestHeaders::Create(
+ 
+   return scoped_refptr<const WebRequestConditionAttribute>(
+       new WebRequestConditionAttributeRequestHeaders(
+-          std::move(header_matcher), name == keys::kRequestHeadersKey));
++          std::move(header_matcher), name == keys_wrca::kRequestHeadersKey));
+ }
+ 
+ int WebRequestConditionAttributeRequestHeaders::GetStages() const {
+@@ -609,8 +609,8 @@ WebRequestConditionAttributeRequestHeaders::GetType() const {
+ }
+ 
+ std::string WebRequestConditionAttributeRequestHeaders::GetName() const {
+-  return (positive_ ? keys::kRequestHeadersKey
+-                    : keys::kExcludeRequestHeadersKey);
++  return (positive_ ? keys_wrca::kRequestHeadersKey
++                    : keys_wrca::kExcludeRequestHeadersKey);
+ }
+ 
+ bool WebRequestConditionAttributeRequestHeaders::Equals(
+@@ -639,8 +639,8 @@ WebRequestConditionAttributeResponseHeaders::Create(
+     const base::Value* value,
+     std::string* error,
+     bool* bad_message) {
+-  DCHECK(name == keys::kResponseHeadersKey ||
+-         name == keys::kExcludeResponseHeadersKey);
++  DCHECK(name == keys_wrca::kResponseHeadersKey ||
++         name == keys_wrca::kExcludeResponseHeadersKey);
+ 
+   std::unique_ptr<const HeaderMatcher> header_matcher(
+       PrepareHeaderMatcher(name, value, error));
+@@ -649,7 +649,7 @@ WebRequestConditionAttributeResponseHeaders::Create(
+ 
+   return scoped_refptr<const WebRequestConditionAttribute>(
+       new WebRequestConditionAttributeResponseHeaders(
+-          std::move(header_matcher), name == keys::kResponseHeadersKey));
++          std::move(header_matcher), name == keys_wrca::kResponseHeadersKey));
+ }
+ 
+ int WebRequestConditionAttributeResponseHeaders::GetStages() const {
+@@ -689,8 +689,8 @@ WebRequestConditionAttributeResponseHeaders::GetType() const {
+ }
+ 
+ std::string WebRequestConditionAttributeResponseHeaders::GetName() const {
+-  return (positive_ ? keys::kResponseHeadersKey
+-                    : keys::kExcludeResponseHeadersKey);
++  return (positive_ ? keys_wrca::kResponseHeadersKey
++                    : keys_wrca::kExcludeResponseHeadersKey);
+ }
+ 
+ bool WebRequestConditionAttributeResponseHeaders::Equals(
+@@ -723,13 +723,13 @@ bool ParseListOfStages(const base::Value& value, int* out_stages) {
+     if (!entry.is_string())
+       return false;
+     const std::string& stage_name = entry.GetString();
+-    if (stage_name == keys::kOnBeforeRequestEnum) {
++    if (stage_name == keys_wrca::kOnBeforeRequestEnum) {
+       stages |= ON_BEFORE_REQUEST;
+-    } else if (stage_name == keys::kOnBeforeSendHeadersEnum) {
++    } else if (stage_name == keys_wrca::kOnBeforeSendHeadersEnum) {
+       stages |= ON_BEFORE_SEND_HEADERS;
+-    } else if (stage_name == keys::kOnHeadersReceivedEnum) {
++    } else if (stage_name == keys_wrca::kOnHeadersReceivedEnum) {
+       stages |= ON_HEADERS_RECEIVED;
+-    } else if (stage_name == keys::kOnAuthRequiredEnum) {
++    } else if (stage_name == keys_wrca::kOnAuthRequiredEnum) {
+       stages |= ON_AUTH_REQUIRED;
+     } else {
+       NOTREACHED();  // JSON schema checks prevent getting here.
+@@ -749,12 +749,12 @@ WebRequestConditionAttributeStages::Create(const std::string& name,
+                                            const base::Value* value,
+                                            std::string* error,
+                                            bool* bad_message) {
+-  DCHECK(name == keys::kStagesKey);
++  DCHECK(name == keys_wrca::kStagesKey);
+ 
+   int allowed_stages = 0;
+   if (!ParseListOfStages(*value, &allowed_stages)) {
+     *error = ErrorUtils::FormatErrorMessage(kInvalidValue,
+-                                                     keys::kStagesKey);
++                                                     keys_wrca::kStagesKey);
+     return nullptr;
+   }
+ 
+@@ -778,7 +778,7 @@ WebRequestConditionAttributeStages::GetType() const {
+ }
+ 
+ std::string WebRequestConditionAttributeStages::GetName() const {
+-  return keys::kStagesKey;
++  return keys_wrca::kStagesKey;
+ }
+ 
+ bool WebRequestConditionAttributeStages::Equals(
+diff --git a/extensions/browser/api/hid/hid_connection_resource.cc b/extensions/browser/api/hid/hid_connection_resource.cc
+index 3105a0d20..337747d59 100644
+--- a/extensions/browser/api/hid/hid_connection_resource.cc
++++ b/extensions/browser/api/hid/hid_connection_resource.cc
+@@ -13,14 +13,14 @@
+ namespace extensions {
+ 
+ static base::LazyInstance<BrowserContextKeyedAPIFactory<
+-    ApiResourceManager<HidConnectionResource>>>::DestructorAtExit g_factory =
++    ApiResourceManager<HidConnectionResource>>>::DestructorAtExit g_factoryHCR =
+     LAZY_INSTANCE_INITIALIZER;
+ 
+ // static
+ template <>
+ BrowserContextKeyedAPIFactory<ApiResourceManager<HidConnectionResource> >*
+ ApiResourceManager<HidConnectionResource>::GetFactoryInstance() {
+-  return &g_factory.Get();
++  return &g_factoryHCR.Get();
+ }
+ 
+ HidConnectionResource::HidConnectionResource(
+diff --git a/extensions/browser/api/hid/hid_device_manager.cc b/extensions/browser/api/hid/hid_device_manager.cc
+index 7c189966f..633879bdf 100644
+--- a/extensions/browser/api/hid/hid_device_manager.cc
++++ b/extensions/browser/api/hid/hid_device_manager.cc
+@@ -89,7 +89,7 @@ bool WillDispatchDeviceEvent(
+   return false;
+ }
+ 
+-HidDeviceManager::HidManagerBinder& GetHidManagerBinderOverride() {
++HidDeviceManager::HidManagerBinder& GetHidDeviceManagerBinderOverride() {
+   static base::NoDestructor<HidDeviceManager::HidManagerBinder> binder;
+   return *binder;
+ }
+@@ -293,7 +293,7 @@ void HidDeviceManager::LazyInitialize() {
+ 
+     DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+     auto receiver = hid_manager_.BindNewPipeAndPassReceiver();
+-    const auto& binder = GetHidManagerBinderOverride();
++    const auto& binder = GetHidDeviceManagerBinderOverride();
+     if (binder)
+       binder.Run(std::move(receiver));
+     else
+@@ -314,7 +314,7 @@ void HidDeviceManager::LazyInitialize() {
+ // static
+ void HidDeviceManager::OverrideHidManagerBinderForTesting(
+     HidManagerBinder binder) {
+-  GetHidManagerBinderOverride() = std::move(binder);
++  GetHidDeviceManagerBinderOverride() = std::move(binder);
+ }
+ 
+ base::Value::List HidDeviceManager::CreateApiDeviceList(
+diff --git a/extensions/browser/api/usb/usb_device_manager.cc b/extensions/browser/api/usb/usb_device_manager.cc
+index 46bdeb624..3153f20c3 100644
+--- a/extensions/browser/api/usb/usb_device_manager.cc
++++ b/extensions/browser/api/usb/usb_device_manager.cc
+@@ -68,7 +68,7 @@ bool ShouldExposeDevice(const device::mojom::UsbDeviceInfo& device_info) {
+ 
+ // Returns true if the given extension has permission to receive events
+ // regarding this device.
+-bool WillDispatchDeviceEvent(
++bool MyWillDispatchDeviceEvent(
+     const device::mojom::UsbDeviceInfo& device_info,
+     content::BrowserContext* browser_context,
+     Feature::Context target_context,
+@@ -390,7 +390,7 @@ void UsbDeviceManager::DispatchEvent(
+     }
+ 
+     event->will_dispatch_callback =
+-        base::BindRepeating(&WillDispatchDeviceEvent, std::cref(device_info));
++        base::BindRepeating(&MyWillDispatchDeviceEvent, std::cref(device_info));
+     event_router->BroadcastEvent(std::move(event));
+   }
+ }
+diff --git a/extensions/browser/api/usb/usb_device_resource.cc b/extensions/browser/api/usb/usb_device_resource.cc
+index 78116ed87..b720bd492 100644
+--- a/extensions/browser/api/usb/usb_device_resource.cc
++++ b/extensions/browser/api/usb/usb_device_resource.cc
+@@ -21,14 +21,14 @@ using content::BrowserThread;
+ namespace extensions {
+ 
+ static base::LazyInstance<BrowserContextKeyedAPIFactory<
+-    ApiResourceManager<UsbDeviceResource>>>::DestructorAtExit g_factory =
++    ApiResourceManager<UsbDeviceResource>>>::DestructorAtExit g_factory2 =
+     LAZY_INSTANCE_INITIALIZER;
+ 
+ // static
+ template <>
+ BrowserContextKeyedAPIFactory<ApiResourceManager<UsbDeviceResource> >*
+ ApiResourceManager<UsbDeviceResource>::GetFactoryInstance() {
+-  return g_factory.Pointer();
++  return g_factory2.Pointer();
+ }
+ 
+ UsbDeviceResource::UsbDeviceResource(
+diff --git a/extensions/browser/api/web_request/upload_data_presenter.cc b/extensions/browser/api/web_request/upload_data_presenter.cc
+index 7ace7a2a2..c48eb8184 100644
+--- a/extensions/browser/api/web_request/upload_data_presenter.cc
++++ b/extensions/browser/api/web_request/upload_data_presenter.cc
+@@ -15,7 +15,7 @@
+ #include "extensions/browser/api/web_request/web_request_api_constants.h"
+ #include "net/base/upload_file_element_reader.h"
+ 
+-namespace keys = extension_web_request_api_constants;
++namespace keys_udp = extension_web_request_api_constants;
+ 
+ namespace {
+ 
+@@ -69,13 +69,13 @@ absl::optional<base::Value> RawDataPresenter::TakeResult() {
+ 
+ void RawDataPresenter::FeedNextBytes(const char* bytes, size_t size) {
+   subtle::AppendKeyValuePair(
+-      keys::kRequestBodyRawBytesKey,
++      keys_udp::kRequestBodyRawBytesKey,
+       base::Value(base::as_bytes(base::make_span(bytes, size))), list_);
+ }
+ 
+ void RawDataPresenter::FeedNextFile(const std::string& filename) {
+   // Insert the file path instead of the contents, which may be too large.
+-  subtle::AppendKeyValuePair(keys::kRequestBodyRawFileKey,
++  subtle::AppendKeyValuePair(keys_udp::kRequestBodyRawFileKey,
+                              base::Value(filename), list_);
+ }
+ 
+diff --git a/extensions/browser/api/web_request/web_request_api.cc b/extensions/browser/api/web_request/web_request_api.cc
+index 21ba17ede..72af15032 100644
+--- a/extensions/browser/api/web_request/web_request_api.cc
++++ b/extensions/browser/api/web_request/web_request_api.cc
+@@ -102,7 +102,7 @@ using extensions::mojom::APIPermissionID;
+ 
+ namespace activity_log = activity_log_web_request_constants;
+ namespace helpers = extension_web_request_api_helpers;
+-namespace keys = extension_web_request_api_constants;
++namespace keys_wra = extension_web_request_api_constants;
+ using URLLoaderFactoryType =
+     content::ContentBrowserClient::URLLoaderFactoryType;
+ using DNRRequestAction = extensions::declarative_net_request::RequestAction;
+@@ -144,15 +144,15 @@ const char kWebRequestEventPrefix[] = "webRequest.";
+ // handled as a normal event (as opposed to a WebRequestEvent at the bindings
+ // layer).
+ const char* const kWebRequestEvents[] = {
+-    keys::kOnBeforeRedirectEvent,
++    keys_wra::kOnBeforeRedirectEvent,
+     web_request::OnBeforeRequest::kEventName,
+-    keys::kOnBeforeSendHeadersEvent,
+-    keys::kOnCompletedEvent,
++    keys_wra::kOnBeforeSendHeadersEvent,
++    keys_wra::kOnCompletedEvent,
+     web_request::OnErrorOccurred::kEventName,
+-    keys::kOnSendHeadersEvent,
+-    keys::kOnAuthRequiredEvent,
+-    keys::kOnResponseStartedEvent,
+-    keys::kOnHeadersReceivedEvent,
++    keys_wra::kOnSendHeadersEvent,
++    keys_wra::kOnAuthRequiredEvent,
++    keys_wra::kOnResponseStartedEvent,
++    keys_wra::kOnHeadersReceivedEvent,
+ };
+ 
+ const char* GetRequestStageAsString(
+@@ -161,23 +161,23 @@ const char* GetRequestStageAsString(
+     case ExtensionWebRequestEventRouter::kInvalidEvent:
+       return "Invalid";
+     case ExtensionWebRequestEventRouter::kOnBeforeRequest:
+-      return keys::kOnBeforeRequest;
++      return keys_wra::kOnBeforeRequest;
+     case ExtensionWebRequestEventRouter::kOnBeforeSendHeaders:
+-      return keys::kOnBeforeSendHeaders;
++      return keys_wra::kOnBeforeSendHeaders;
+     case ExtensionWebRequestEventRouter::kOnSendHeaders:
+-      return keys::kOnSendHeaders;
++      return keys_wra::kOnSendHeaders;
+     case ExtensionWebRequestEventRouter::kOnHeadersReceived:
+-      return keys::kOnHeadersReceived;
++      return keys_wra::kOnHeadersReceived;
+     case ExtensionWebRequestEventRouter::kOnBeforeRedirect:
+-      return keys::kOnBeforeRedirect;
++      return keys_wra::kOnBeforeRedirect;
+     case ExtensionWebRequestEventRouter::kOnAuthRequired:
+-      return keys::kOnAuthRequired;
++      return keys_wra::kOnAuthRequired;
+     case ExtensionWebRequestEventRouter::kOnResponseStarted:
+-      return keys::kOnResponseStarted;
++      return keys_wra::kOnResponseStarted;
+     case ExtensionWebRequestEventRouter::kOnErrorOccurred:
+-      return keys::kOnErrorOccurred;
++      return keys_wra::kOnErrorOccurred;
+     case ExtensionWebRequestEventRouter::kOnCompleted:
+-      return keys::kOnCompleted;
++      return keys_wra::kOnCompleted;
+   }
+   NOTREACHED();
+   return "Not reached";
+@@ -197,23 +197,23 @@ ExtensionWebRequestEventRouter::EventTypes GetEventTypeFromEventName(
+   static base::NoDestructor<const base::flat_map<
+       base::StringPiece, ExtensionWebRequestEventRouter::EventTypes>>
+       kRequestStageMap(
+-          {{keys::kOnBeforeRequest,
++          {{keys_wra::kOnBeforeRequest,
+             ExtensionWebRequestEventRouter::kOnBeforeRequest},
+-           {keys::kOnBeforeSendHeaders,
++           {keys_wra::kOnBeforeSendHeaders,
+             ExtensionWebRequestEventRouter::kOnBeforeSendHeaders},
+-           {keys::kOnSendHeaders,
++           {keys_wra::kOnSendHeaders,
+             ExtensionWebRequestEventRouter::kOnSendHeaders},
+-           {keys::kOnHeadersReceived,
++           {keys_wra::kOnHeadersReceived,
+             ExtensionWebRequestEventRouter::kOnHeadersReceived},
+-           {keys::kOnBeforeRedirect,
++           {keys_wra::kOnBeforeRedirect,
+             ExtensionWebRequestEventRouter::kOnBeforeRedirect},
+-           {keys::kOnAuthRequired,
++           {keys_wra::kOnAuthRequired,
+             ExtensionWebRequestEventRouter::kOnAuthRequired},
+-           {keys::kOnResponseStarted,
++           {keys_wra::kOnResponseStarted,
+             ExtensionWebRequestEventRouter::kOnResponseStarted},
+-           {keys::kOnErrorOccurred,
++           {keys_wra::kOnErrorOccurred,
+             ExtensionWebRequestEventRouter::kOnErrorOccurred},
+-           {keys::kOnCompleted, ExtensionWebRequestEventRouter::kOnCompleted}});
++           {keys_wra::kOnCompleted, ExtensionWebRequestEventRouter::kOnCompleted}});
+ 
+   DCHECK_EQ(kRequestStageMap->size(), std::size(kWebRequestEvents));
+ 
+@@ -271,15 +271,15 @@ bool IsRequestFromExtension(const WebRequestInfo& request,
+ bool FromHeaderDictionary(const base::Value::Dict& header_value,
+                           std::string* name,
+                           std::string* out_value) {
+-  const std::string* name_ptr = header_value.FindString(keys::kHeaderNameKey);
++  const std::string* name_ptr = header_value.FindString(keys_wra::kHeaderNameKey);
+   if (!name)
+     return false;
+   *name = *name_ptr;
+ 
+   // We require either a "value" or a "binaryValue" entry.
+-  const base::Value* value = header_value.Find(keys::kHeaderValueKey);
++  const base::Value* value = header_value.Find(keys_wra::kHeaderValueKey);
+   const base::Value* binary_value =
+-      header_value.Find(keys::kHeaderBinaryValueKey);
++      header_value.Find(keys_wra::kHeaderBinaryValueKey);
+   if (!((value != nullptr) ^ (binary_value != nullptr))) {
+     return false;
+   }
+@@ -380,18 +380,18 @@ events::HistogramValue GetEventHistogramValue(const std::string& event_name) {
+     events::HistogramValue histogram_value;
+     const char* const event_name;
+   } values_and_names[] = {
+-      {events::WEB_REQUEST_ON_BEFORE_REDIRECT, keys::kOnBeforeRedirectEvent},
++      {events::WEB_REQUEST_ON_BEFORE_REDIRECT, keys_wra::kOnBeforeRedirectEvent},
+       {events::WEB_REQUEST_ON_BEFORE_REQUEST,
+        web_request::OnBeforeRequest::kEventName},
+       {events::WEB_REQUEST_ON_BEFORE_SEND_HEADERS,
+-       keys::kOnBeforeSendHeadersEvent},
+-      {events::WEB_REQUEST_ON_COMPLETED, keys::kOnCompletedEvent},
++       keys_wra::kOnBeforeSendHeadersEvent},
++      {events::WEB_REQUEST_ON_COMPLETED, keys_wra::kOnCompletedEvent},
+       {events::WEB_REQUEST_ON_ERROR_OCCURRED,
+        web_request::OnErrorOccurred::kEventName},
+-      {events::WEB_REQUEST_ON_SEND_HEADERS, keys::kOnSendHeadersEvent},
+-      {events::WEB_REQUEST_ON_AUTH_REQUIRED, keys::kOnAuthRequiredEvent},
+-      {events::WEB_REQUEST_ON_RESPONSE_STARTED, keys::kOnResponseStartedEvent},
+-      {events::WEB_REQUEST_ON_HEADERS_RECEIVED, keys::kOnHeadersReceivedEvent}};
++      {events::WEB_REQUEST_ON_SEND_HEADERS, keys_wra::kOnSendHeadersEvent},
++      {events::WEB_REQUEST_ON_AUTH_REQUIRED, keys_wra::kOnAuthRequiredEvent},
++      {events::WEB_REQUEST_ON_RESPONSE_STARTED, keys_wra::kOnResponseStartedEvent},
++      {events::WEB_REQUEST_ON_HEADERS_RECEIVED, keys_wra::kOnHeadersReceivedEvent}};
+   static_assert(std::size(kWebRequestEvents) == std::size(values_and_names),
+                 "kWebRequestEvents and values_and_names must be the same");
+   for (const ValueAndName& value_and_name : values_and_names) {
+@@ -651,13 +651,13 @@ void WebRequestAPI::Shutdown() {
+ }
+ 
+ static base::LazyInstance<
+-    BrowserContextKeyedAPIFactory<WebRequestAPI>>::DestructorAtExit g_factory =
++    BrowserContextKeyedAPIFactory<WebRequestAPI>>::DestructorAtExit g_factory_wra =
+     LAZY_INSTANCE_INITIALIZER;
+ 
+ // static
+ BrowserContextKeyedAPIFactory<WebRequestAPI>*
+ WebRequestAPI::GetFactoryInstance() {
+-  return g_factory.Pointer();
++  return g_factory_wra.Pointer();
+ }
+ 
+ void WebRequestAPI::OnListenerRemoved(const EventListenerInfo& details) {
+@@ -1030,7 +1030,7 @@ bool ExtensionWebRequestEventRouter::RequestFilter::InitFromValue(
+         if (url.empty() ||
+             pattern.Parse(url) != URLPattern::ParseResult::kSuccess) {
+           *error = ErrorUtils::FormatErrorMessage(
+-              keys::kInvalidRequestFilterUrl, url);
++              keys_wra::kInvalidRequestFilterUrl, url);
+           return false;
+         }
+         urls.AddPattern(pattern);
+@@ -1285,7 +1285,7 @@ int ExtensionWebRequestEventRouter::OnBeforeSendHeaders(
+   bool initialize_blocked_requests = false;
+ 
+   initialize_blocked_requests |=
+-      ProcessDeclarativeRules(browser_context, keys::kOnBeforeSendHeadersEvent,
++      ProcessDeclarativeRules(browser_context, keys_wra::kOnBeforeSendHeadersEvent,
+                               request, ON_BEFORE_SEND_HEADERS, nullptr);
+ 
+   DCHECK(request->dnr_actions);
+@@ -1297,7 +1297,7 @@ int ExtensionWebRequestEventRouter::OnBeforeSendHeaders(
+ 
+   int extra_info_spec = 0;
+   RawListeners listeners =
+-      GetMatchingListeners(browser_context, keys::kOnBeforeSendHeadersEvent,
++      GetMatchingListeners(browser_context, keys_wra::kOnBeforeSendHeadersEvent,
+                            request, &extra_info_spec);
+   if (!listeners.empty() &&
+       !GetAndSetSignaled(request->id, kOnBeforeSendHeaders)) {
+@@ -1341,7 +1341,7 @@ void ExtensionWebRequestEventRouter::OnSendHeaders(
+ 
+   int extra_info_spec = 0;
+   RawListeners listeners = GetMatchingListeners(
+-      browser_context, keys::kOnSendHeadersEvent, request, &extra_info_spec);
++      browser_context, keys_wra::kOnSendHeadersEvent, request, &extra_info_spec);
+   if (listeners.empty())
+     return;
+ 
+@@ -1372,12 +1372,12 @@ int ExtensionWebRequestEventRouter::OnHeadersReceived(
+       });
+ 
+   initialize_blocked_requests |= ProcessDeclarativeRules(
+-      browser_context, keys::kOnHeadersReceivedEvent, request,
++      browser_context, keys_wra::kOnHeadersReceivedEvent, request,
+       ON_HEADERS_RECEIVED, original_response_headers);
+ 
+   int extra_info_spec = 0;
+   RawListeners listeners =
+-      GetMatchingListeners(browser_context, keys::kOnHeadersReceivedEvent,
++      GetMatchingListeners(browser_context, keys_wra::kOnHeadersReceivedEvent,
+                            request, &extra_info_spec);
+ 
+   if (!listeners.empty() &&
+@@ -1427,7 +1427,7 @@ ExtensionWebRequestEventRouter::OnAuthRequired(
+ 
+   int extra_info_spec = 0;
+   RawListeners listeners = GetMatchingListeners(
+-      browser_context, keys::kOnAuthRequiredEvent, request, &extra_info_spec);
++      browser_context, keys_wra::kOnAuthRequiredEvent, request, &extra_info_spec);
+   if (listeners.empty())
+     return AuthRequiredResponse::AUTH_REQUIRED_RESPONSE_NO_ACTION;
+ 
+@@ -1466,7 +1466,7 @@ void ExtensionWebRequestEventRouter::OnBeforeRedirect(
+ 
+   int extra_info_spec = 0;
+   RawListeners listeners = GetMatchingListeners(
+-      browser_context, keys::kOnBeforeRedirectEvent, request, &extra_info_spec);
++      browser_context, keys_wra::kOnBeforeRedirectEvent, request, &extra_info_spec);
+   if (listeners.empty())
+     return;
+ 
+@@ -1474,7 +1474,7 @@ void ExtensionWebRequestEventRouter::OnBeforeRedirect(
+       CreateEventDetails(*request, extra_info_spec));
+   event_details->SetResponseHeaders(*request, request->response_headers.get());
+   event_details->SetResponseSource(*request);
+-  event_details->SetString(keys::kRedirectUrlKey, new_location.spec());
++  event_details->SetString(keys_wra::kRedirectUrlKey, new_location.spec());
+ 
+   DispatchEvent(browser_context, request, listeners, std::move(event_details));
+ }
+@@ -1494,7 +1494,7 @@ void ExtensionWebRequestEventRouter::OnResponseStarted(
+ 
+   int extra_info_spec = 0;
+   RawListeners listeners =
+-      GetMatchingListeners(browser_context, keys::kOnResponseStartedEvent,
++      GetMatchingListeners(browser_context, keys_wra::kOnResponseStartedEvent,
+                            request, &extra_info_spec);
+   if (listeners.empty())
+     return;
+@@ -1533,7 +1533,7 @@ void ExtensionWebRequestEventRouter::OnCompleted(
+ 
+   int extra_info_spec = 0;
+   RawListeners listeners = GetMatchingListeners(
+-      browser_context, keys::kOnCompletedEvent, request, &extra_info_spec);
++      browser_context, keys_wra::kOnCompletedEvent, request, &extra_info_spec);
+   if (listeners.empty())
+     return;
+ 
+@@ -1595,8 +1595,8 @@ void ExtensionWebRequestEventRouter::OnErrorOccurred(
+   if (started)
+     event_details->SetResponseSource(*request);
+   else
+-    event_details->SetBoolean(keys::kFromCache, request->response_from_cache);
+-  event_details->SetString(keys::kErrorKey, net::ErrorToString(net_error));
++    event_details->SetBoolean(keys_wra::kFromCache, request->response_from_cache);
++  event_details->SetString(keys_wra::kErrorKey, net::ErrorToString(net_error));
+ 
+   DispatchEvent(browser_context, request, listeners, std::move(event_details));
+ }
+@@ -2557,8 +2557,8 @@ void ExtensionWebRequestEventRouter::SendMessages(
+     for (const std::string& message : messages) {
+       std::unique_ptr<WebRequestEventDetails> event_details(CreateEventDetails(
+           *blocked_request.request, /* extra_info_spec */ 0));
+-      event_details->SetString(keys::kMessageKey, message);
+-      event_details->SetString(keys::kStageKey,
++      event_details->SetString(keys_wra::kMessageKey, message);
++      event_details->SetString(keys_wra::kStageKey,
+                                GetRequestStageAsString(blocked_request.event));
+       SendOnMessageEventOnUI(browser_context, delta.extension_id,
+                              blocked_request.request->is_web_view,
+@@ -2936,7 +2936,7 @@ WebRequestInternalAddEventListenerFunction::Run() {
+         return true;
+       }
+ 
+-      return event_name == keys::kOnAuthRequiredEvent &&
++      return event_name == keys_wra::kOnAuthRequiredEvent &&
+              extension->permissions_data()->HasAPIPermission(
+                  APIPermissionID::kWebRequestAuthProvider);
+     };
+@@ -2947,7 +2947,7 @@ WebRequestInternalAddEventListenerFunction::Run() {
+     bool is_blocking = extra_info_spec & (ExtraInfoSpec::BLOCKING |
+                                           ExtraInfoSpec::ASYNC_BLOCKING);
+     if (is_blocking && !has_blocking_permission()) {
+-      return RespondNow(Error(keys::kBlockingPermissionRequired));
++      return RespondNow(Error(keys_wra::kBlockingPermissionRequired));
+     }
+ 
+     // We allow to subscribe to patterns that are broader than the host
+@@ -2963,7 +2963,7 @@ WebRequestInternalAddEventListenerFunction::Run() {
+             ->withheld_permissions()
+             .explicit_hosts()
+             .is_empty()) {
+-      return RespondNow(Error(keys::kHostPermissionsRequired));
++      return RespondNow(Error(keys_wra::kHostPermissionsRequired));
+     }
+   }
+ 
+@@ -3031,7 +3031,7 @@ WebRequestInternalEventHandledFunction::Run() {
+ 
+     const base::Value* redirect_url_value = dict_value.Find("redirectUrl");
+     const base::Value* auth_credentials_value =
+-        dict_value.Find(keys::kAuthCredentialsKey);
++        dict_value.Find(keys_wra::kAuthCredentialsKey);
+     const base::Value* request_headers_value =
+         dict_value.Find("requestHeaders");
+     const base::Value* response_headers_value =
+@@ -3043,7 +3043,7 @@ WebRequestInternalEventHandledFunction::Run() {
+       if (dict_value.size() != 1) {
+         OnError(event_name, sub_event_name, request_id, render_process_id,
+                 web_view_instance_id, std::move(response));
+-        return RespondNow(Error(keys::kInvalidBlockingResponse));
++        return RespondNow(Error(keys_wra::kInvalidBlockingResponse));
+       }
+ 
+       EXTENSION_FUNCTION_VALIDATE(cancel_value->is_bool());
+@@ -3057,7 +3057,7 @@ WebRequestInternalEventHandledFunction::Run() {
+       if (!response->new_url.is_valid()) {
+         OnError(event_name, sub_event_name, request_id, render_process_id,
+                 web_view_instance_id, std::move(response));
+-        return RespondNow(Error(keys::kInvalidRedirectUrl, new_url_str));
++        return RespondNow(Error(keys_wra::kInvalidRedirectUrl, new_url_str));
+       }
+     }
+ 
+@@ -3068,7 +3068,7 @@ WebRequestInternalEventHandledFunction::Run() {
+         // Allow only one of the keys, not both.
+         OnError(event_name, sub_event_name, request_id, render_process_id,
+                 web_view_instance_id, std::move(response));
+-        return RespondNow(Error(keys::kInvalidHeaderKeyCombination));
++        return RespondNow(Error(keys_wra::kInvalidHeaderKeyCombination));
+       }
+ 
+       const base::Value::List* headers_value = nullptr;
+@@ -3076,10 +3076,10 @@ WebRequestInternalEventHandledFunction::Run() {
+       std::unique_ptr<helpers::ResponseHeaders> response_headers;
+       if (has_request_headers) {
+         request_headers = std::make_unique<net::HttpRequestHeaders>();
+-        headers_value = dict_value.FindList(keys::kRequestHeadersKey);
++        headers_value = dict_value.FindList(keys_wra::kRequestHeadersKey);
+       } else {
+         response_headers = std::make_unique<helpers::ResponseHeaders>();
+-        headers_value = dict_value.FindList(keys::kResponseHeadersKey);
++        headers_value = dict_value.FindList(keys_wra::kResponseHeadersKey);
+       }
+       EXTENSION_FUNCTION_VALIDATE(headers_value);
+ 
+@@ -3093,17 +3093,17 @@ WebRequestInternalEventHandledFunction::Run() {
+           base::JSONWriter::Write(header_value, &serialized_header);
+           OnError(event_name, sub_event_name, request_id, render_process_id,
+                   web_view_instance_id, std::move(response));
+-          return RespondNow(Error(keys::kInvalidHeader, serialized_header));
++          return RespondNow(Error(keys_wra::kInvalidHeader, serialized_header));
+         }
+         if (!net::HttpUtil::IsValidHeaderName(name)) {
+           OnError(event_name, sub_event_name, request_id, render_process_id,
+                   web_view_instance_id, std::move(response));
+-          return RespondNow(Error(keys::kInvalidHeaderName));
++          return RespondNow(Error(keys_wra::kInvalidHeaderName));
+         }
+         if (!net::HttpUtil::IsValidHeaderValue(value)) {
+           OnError(event_name, sub_event_name, request_id, render_process_id,
+                   web_view_instance_id, std::move(response));
+-          return RespondNow(Error(keys::kInvalidHeaderValue, name));
++          return RespondNow(Error(keys_wra::kInvalidHeaderValue, name));
+         }
+         if (has_request_headers) {
+           request_headers->SetHeader(name, value);
+@@ -3123,9 +3123,9 @@ WebRequestInternalEventHandledFunction::Run() {
+           auth_credentials_value->GetIfDict();
+       EXTENSION_FUNCTION_VALIDATE(credentials_value);
+       const std::string* username =
+-          credentials_value->FindString(keys::kUsernameKey);
++          credentials_value->FindString(keys_wra::kUsernameKey);
+       const std::string* password =
+-          credentials_value->FindString(keys::kPasswordKey);
++          credentials_value->FindString(keys_wra::kPasswordKey);
+       EXTENSION_FUNCTION_VALIDATE(username);
+       EXTENSION_FUNCTION_VALIDATE(password);
+       response->auth_credentials = net::AuthCredentials(
+diff --git a/extensions/browser/api/web_request/web_request_info.cc b/extensions/browser/api/web_request/web_request_info.cc
+index 7863345bc..9eb1c999e 100644
+--- a/extensions/browser/api/web_request/web_request_info.cc
++++ b/extensions/browser/api/web_request/web_request_info.cc
+@@ -29,7 +29,7 @@
+ #include "services/network/url_loader.h"
+ #include "third_party/abseil-cpp/absl/types/optional.h"
+ 
+-namespace keys = extension_web_request_api_constants;
++namespace keys_wri = extension_web_request_api_constants;
+ 
+ namespace extensions {
+ 
+@@ -129,8 +129,8 @@ absl::optional<base::Value::Dict> CreateRequestBodyData(
+       &raw_data_presenter      // 2: any data at all? (Non-specific.)
+   };
+   // Keys for the results of the corresponding presenters.
+-  static const char* const kKeys[] = {keys::kRequestBodyFormDataKey,
+-                                      keys::kRequestBodyRawKey};
++  static const char* const kKeys[] = {keys_wri::kRequestBodyFormDataKey,
++                                      keys_wri::kRequestBodyRawKey};
+   bool some_succeeded = false;
+   if (!data_sources.empty()) {
+     for (size_t i = 0; i < std::size(presenters); ++i) {
+@@ -145,7 +145,7 @@ absl::optional<base::Value::Dict> CreateRequestBodyData(
+   }
+ 
+   if (!some_succeeded) {
+-    request_body_data.Set(keys::kRequestBodyErrorKey, "Unknown error.");
++    request_body_data.Set(keys_wri::kRequestBodyErrorKey, "Unknown error.");
+   }
+ 
+   return request_body_data;
+diff --git a/extensions/browser/api/web_request/web_request_proxying_url_loader_factory.cc b/extensions/browser/api/web_request/web_request_proxying_url_loader_factory.cc
+index 09437c18a..987128531 100644
+--- a/extensions/browser/api/web_request/web_request_proxying_url_loader_factory.cc
++++ b/extensions/browser/api/web_request/web_request_proxying_url_loader_factory.cc
+@@ -78,26 +78,26 @@ constexpr char kWebRequestProxyingURLLoaderFactoryScope[] =
+ // This shutdown notifier makes sure the proxy is destroyed if an incognito
+ // browser context is destroyed. This is needed because WebRequestAPI only
+ // clears the proxies when the original browser context is destroyed.
+-class ShutdownNotifierFactory
++class ShutdownNotifierFactory2
+     : public BrowserContextKeyedServiceShutdownNotifierFactory {
+  public:
+-  ShutdownNotifierFactory(const ShutdownNotifierFactory&) = delete;
+-  ShutdownNotifierFactory& operator=(const ShutdownNotifierFactory&) = delete;
++  ShutdownNotifierFactory2(const ShutdownNotifierFactory2&) = delete;
++  ShutdownNotifierFactory2& operator=(const ShutdownNotifierFactory2&) = delete;
+ 
+-  static ShutdownNotifierFactory* GetInstance() {
+-    static base::NoDestructor<ShutdownNotifierFactory> factory;
++  static ShutdownNotifierFactory2* GetInstance() {
++    static base::NoDestructor<ShutdownNotifierFactory2> factory;
+     return factory.get();
+   }
+ 
+  private:
+-  friend class base::NoDestructor<ShutdownNotifierFactory>;
++  friend class base::NoDestructor<ShutdownNotifierFactory2>;
+ 
+-  ShutdownNotifierFactory()
++  ShutdownNotifierFactory2()
+       : BrowserContextKeyedServiceShutdownNotifierFactory(
+             "WebRequestProxyingURLLoaderFactory") {
+     DependsOn(PermissionHelper::GetFactoryInstance());
+   }
+-  ~ShutdownNotifierFactory() override {}
++  ~ShutdownNotifierFactory2() override {}
+ };
+ 
+ // Creates simulated net::RedirectInfo when an extension redirects a request,
+@@ -1443,7 +1443,7 @@ WebRequestProxyingURLLoaderFactory::WebRequestProxyingURLLoaderFactory(
+   // canceled when |shutdown_notifier_subscription_| is destroyed, and
+   // |proxies_| owns this.
+   shutdown_notifier_subscription_ =
+-      ShutdownNotifierFactory::GetInstance()
++      ShutdownNotifierFactory2::GetInstance()
+           ->Get(browser_context)
+           ->Subscribe(base::BindRepeating(&WebRequestAPI::ProxySet::RemoveProxy,
+                                           base::Unretained(proxies_), this));
+diff --git a/extensions/browser/api/web_request/web_request_proxying_url_loader_factory.h b/extensions/browser/api/web_request/web_request_proxying_url_loader_factory.h
+index 11c58337e..c53676bab 100644
+--- a/extensions/browser/api/web_request/web_request_proxying_url_loader_factory.h
++++ b/extensions/browser/api/web_request/web_request_proxying_url_loader_factory.h
+@@ -39,7 +39,7 @@
+ #include "url/gurl.h"
+ #include "url/origin.h"
+ 
+-namespace {
++namespace content {
+ class BrowserContext;
+ }
+ 
+diff --git a/extensions/browser/app_window/app_window.cc b/extensions/browser/app_window/app_window.cc
+index 7546c00df..a1328f641 100644
+--- a/extensions/browser/app_window/app_window.cc
++++ b/extensions/browser/app_window/app_window.cc
+@@ -235,7 +235,7 @@ gfx::Size AppWindow::CreateParams::GetWindowMaximumSize(
+ 
+ // AppWindow
+ 
+-AppWindow::AppWindow(BrowserContext* context,
++AppWindow::AppWindow(content::BrowserContext* context,
+                      std::unique_ptr<AppDelegate> app_delegate,
+                      const Extension* extension)
+     : browser_context_(context),
+@@ -954,7 +954,7 @@ content::WebContents* AppWindow::GetAssociatedWebContents() const {
+   return web_contents();
+ }
+ 
+-void AppWindow::OnExtensionUnloaded(BrowserContext* browser_context,
++void AppWindow::OnExtensionUnloaded(content::BrowserContext* browser_context,
+                                     const Extension* extension,
+                                     UnloadedExtensionReason reason) {
+   if (extension_id_ == extension->id())
+diff --git a/extensions/browser/extension_message_filter.cc b/extensions/browser/extension_message_filter.cc
+index 9e24cefb4..d08c9f4d6 100644
+--- a/extensions/browser/extension_message_filter.cc
++++ b/extensions/browser/extension_message_filter.cc
+@@ -18,25 +18,25 @@ namespace extensions {
+ 
+ namespace {
+ 
+-class ShutdownNotifierFactory
++class ShutdownNotifierFactoryForExtensionMessageFilter
+     : public BrowserContextKeyedServiceShutdownNotifierFactory {
+  public:
+-  ShutdownNotifierFactory(const ShutdownNotifierFactory&) = delete;
+-  ShutdownNotifierFactory& operator=(const ShutdownNotifierFactory&) = delete;
++  ShutdownNotifierFactoryForExtensionMessageFilter(const ShutdownNotifierFactoryForExtensionMessageFilter&) = delete;
++  ShutdownNotifierFactoryForExtensionMessageFilter& operator=(const ShutdownNotifierFactoryForExtensionMessageFilter&) = delete;
+ 
+-  static ShutdownNotifierFactory* GetInstance() {
+-    return base::Singleton<ShutdownNotifierFactory>::get();
++  static ShutdownNotifierFactoryForExtensionMessageFilter* GetInstance() {
++    return base::Singleton<ShutdownNotifierFactoryForExtensionMessageFilter>::get();
+   }
+ 
+  private:
+-  friend struct base::DefaultSingletonTraits<ShutdownNotifierFactory>;
++  friend struct base::DefaultSingletonTraits<ShutdownNotifierFactoryForExtensionMessageFilter>;
+ 
+-  ShutdownNotifierFactory()
++  ShutdownNotifierFactoryForExtensionMessageFilter()
+       : BrowserContextKeyedServiceShutdownNotifierFactory(
+             "ExtensionMessageFilter") {
+     DependsOn(ProcessManagerFactory::GetInstance());
+   }
+-  ~ShutdownNotifierFactory() override {}
++  ~ShutdownNotifierFactoryForExtensionMessageFilter() override {}
+ };
+ 
+ }  // namespace
+@@ -48,13 +48,13 @@ ExtensionMessageFilter::ExtensionMessageFilter(int render_process_id,
+       browser_context_(context) {
+   DCHECK_CURRENTLY_ON(BrowserThread::UI);
+   shutdown_notifier_subscription_ =
+-      ShutdownNotifierFactory::GetInstance()->Get(context)->Subscribe(
++      ShutdownNotifierFactoryForExtensionMessageFilter::GetInstance()->Get(context)->Subscribe(
+           base::BindRepeating(&ExtensionMessageFilter::ShutdownOnUIThread,
+                               base::Unretained(this)));
+ }
+ 
+ void ExtensionMessageFilter::EnsureShutdownNotifierFactoryBuilt() {
+-  ShutdownNotifierFactory::GetInstance();
++  ShutdownNotifierFactoryForExtensionMessageFilter::GetInstance();
+ }
+ 
+ ExtensionMessageFilter::~ExtensionMessageFilter() {
+diff --git a/extensions/browser/extension_service_worker_message_filter.cc b/extensions/browser/extension_service_worker_message_filter.cc
+index 5fca5696a..11321038d 100644
+--- a/extensions/browser/extension_service_worker_message_filter.cc
++++ b/extensions/browser/extension_service_worker_message_filter.cc
+@@ -28,27 +28,27 @@ namespace extensions {
+ 
+ namespace {
+ 
+-class ShutdownNotifierFactory
++class ShutdownNotifierFactoryForExtensionServiceWorkerMessageFilter
+     : public BrowserContextKeyedServiceShutdownNotifierFactory {
+  public:
+-  ShutdownNotifierFactory(const ShutdownNotifierFactory&) = delete;
+-  ShutdownNotifierFactory& operator=(const ShutdownNotifierFactory&) = delete;
++  ShutdownNotifierFactoryForExtensionServiceWorkerMessageFilter(const ShutdownNotifierFactoryForExtensionServiceWorkerMessageFilter&) = delete;
++  ShutdownNotifierFactoryForExtensionServiceWorkerMessageFilter& operator=(const ShutdownNotifierFactoryForExtensionServiceWorkerMessageFilter&) = delete;
+ 
+-  static ShutdownNotifierFactory* GetInstance() {
+-    return base::Singleton<ShutdownNotifierFactory>::get();
++  static ShutdownNotifierFactoryForExtensionServiceWorkerMessageFilter* GetInstance() {
++    return base::Singleton<ShutdownNotifierFactoryForExtensionServiceWorkerMessageFilter>::get();
+   }
+ 
+  private:
+-  friend struct base::DefaultSingletonTraits<ShutdownNotifierFactory>;
++  friend struct base::DefaultSingletonTraits<ShutdownNotifierFactoryForExtensionServiceWorkerMessageFilter>;
+ 
+-  ShutdownNotifierFactory()
++  ShutdownNotifierFactoryForExtensionServiceWorkerMessageFilter()
+       : BrowserContextKeyedServiceShutdownNotifierFactory(
+             "ExtensionServiceWorkerMessageFilter") {
+     DependsOn(ExtensionRegistryFactory::GetInstance());
+     DependsOn(EventRouterFactory::GetInstance());
+     DependsOn(ProcessManagerFactory::GetInstance());
+   }
+-  ~ShutdownNotifierFactory() override = default;
++  ~ShutdownNotifierFactoryForExtensionServiceWorkerMessageFilter() override = default;
+ };
+ 
+ }  // namespace
+@@ -64,7 +64,7 @@ ExtensionServiceWorkerMessageFilter::ExtensionServiceWorkerMessageFilter(
+       dispatcher_(new ExtensionFunctionDispatcher(context)) {
+   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+   shutdown_notifier_subscription_ =
+-      ShutdownNotifierFactory::GetInstance()->Get(context)->Subscribe(
++      ShutdownNotifierFactoryForExtensionServiceWorkerMessageFilter::GetInstance()->Get(context)->Subscribe(
+           base::BindRepeating(
+               &ExtensionServiceWorkerMessageFilter::ShutdownOnUIThread,
+               base::Unretained(this)));
+@@ -80,7 +80,7 @@ void ExtensionServiceWorkerMessageFilter::OnDestruct() const {
+ }
+ 
+ void ExtensionServiceWorkerMessageFilter::EnsureShutdownNotifierFactoryBuilt() {
+-  ShutdownNotifierFactory::GetInstance();
++  ShutdownNotifierFactoryForExtensionServiceWorkerMessageFilter::GetInstance();
+ }
+ 
+ ExtensionServiceWorkerMessageFilter::~ExtensionServiceWorkerMessageFilter() {}
+diff --git a/extensions/common/BUILD.gn b/extensions/common/BUILD.gn
+index 97c23c3ae..1297328ef 100644
+--- a/extensions/common/BUILD.gn
++++ b/extensions/common/BUILD.gn
+@@ -476,6 +476,11 @@ jumbo_static_library("common") {
+   # from mojom/permission_set_mojom_traits.cc.
+   allow_circular_includes_from = [ ":mojom" ]
+ 
++  jumbo_excluded_sources = [
++    "manifest_handlers/file_handler_info.cc",
++    "manifest_handlers/permissions_parser.cc",
++  ]
++
+   deps = [
+     "//base",
+     "//build:branding_buildflags",
+diff --git a/extensions/common/manifest_handlers/shared_module_info.cc b/extensions/common/manifest_handlers/shared_module_info.cc
+index 0661cbb80..b19c778c5 100644
+--- a/extensions/common/manifest_handlers/shared_module_info.cc
++++ b/extensions/common/manifest_handlers/shared_module_info.cc
+@@ -35,7 +35,7 @@ namespace {
+ 
+ const char kSharedModule[] = "shared_module";
+ 
+-using ManifestKeys = api::shared_module::ManifestKeys;
++using ManifestKeys2 = api::shared_module::ManifestKeys;
+ 
+ static base::LazyInstance<SharedModuleInfo>::DestructorAtExit
+     g_empty_shared_module_info = LAZY_INSTANCE_INITIALIZER;
+@@ -130,8 +130,8 @@ SharedModuleHandler::SharedModuleHandler() = default;
+ SharedModuleHandler::~SharedModuleHandler() = default;
+ 
+ bool SharedModuleHandler::Parse(Extension* extension, std::u16string* error) {
+-  ManifestKeys manifest_keys;
+-  if (!ManifestKeys::ParseFromDictionary(
++  ManifestKeys2 manifest_keys;
++  if (!ManifestKeys2::ParseFromDictionary(
+           extension->manifest()->available_values(), &manifest_keys, error)) {
+     return false;
+   }
+@@ -210,8 +210,8 @@ bool SharedModuleHandler::Validate(
+ }
+ 
+ base::span<const char* const> SharedModuleHandler::Keys() const {
+-  static constexpr const char* kKeys[] = {ManifestKeys::kImport,
+-                                          ManifestKeys::kExport};
++  static constexpr const char* kKeys[] = {ManifestKeys2::kImport,
++                                          ManifestKeys2::kExport};
+   return kKeys;
+ }
+ 
+diff --git a/gpu/command_buffer/service/BUILD.gn b/gpu/command_buffer/service/BUILD.gn
+index 2e0a3176b..375215e6b 100644
+--- a/gpu/command_buffer/service/BUILD.gn
++++ b/gpu/command_buffer/service/BUILD.gn
+@@ -2,7 +2,6 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//gpu/vulkan/features.gni")
+ import("//skia/features.gni")
+@@ -27,9 +26,9 @@ group("gles2") {
+ }
+ 
+ if (is_component_build) {
+-  link_target_type = "jumbo_source_set"
++  link_target_type = "source_set"
+ } else {
+-  link_target_type = "jumbo_static_library"
++  link_target_type = "static_library"
+ }
+ target(link_target_type, "service_sources") {
+   # External code should depend on this via //gpu/command_buffer/service above
+@@ -594,7 +593,7 @@ proto_library("disk_cache_proto") {
+ }
+ 
+ if (is_android) {
+-  jumbo_static_library("android_texture_owner_test_support") {
++  static_library("android_texture_owner_test_support") {
+     testonly = true
+     sources = [
+       "mock_abstract_texture.cc",
+diff --git a/gpu/config/BUILD.gn b/gpu/config/BUILD.gn
+index 4f552bc9f..d8ee27329 100644
+--- a/gpu/config/BUILD.gn
++++ b/gpu/config/BUILD.gn
+@@ -5,7 +5,6 @@
+ import("//build/config/chrome_build.gni")
+ import("//build/config/chromecast_build.gni")
+ import("//build/config/chromeos/ui_mode.gni")
+-import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//gpu/vulkan/features.gni")
+ import("//skia/features.gni")
+@@ -114,7 +113,7 @@ if (enable_vulkan) {
+   }
+ }
+ 
+-jumbo_source_set("config_sources") {
++source_set("config_sources") {
+   # External code should depend on this via //gpu/config above rather than
+   # depending on this directly or the component build will break.
+   visibility = [ "//gpu/*" ]
+diff --git a/media/filters/h265_to_annex_b_bitstream_converter.cc b/media/filters/h265_to_annex_b_bitstream_converter.cc
+index 60af198f9..4bc2033a1 100644
+--- a/media/filters/h265_to_annex_b_bitstream_converter.cc
++++ b/media/filters/h265_to_annex_b_bitstream_converter.cc
+@@ -14,12 +14,12 @@
+ namespace media {
+ namespace {
+ 
+-static const uint8_t kStartCodePrefix[3] = {0, 0, 1};
+-static const uint32_t kParamSetStartCodeSize = 1 + sizeof(kStartCodePrefix);
++static const uint8_t kStartCodePrefix2[3] = {0, 0, 1};
++static const uint32_t kParamSetStartCodeSize2 = 1 + sizeof(kStartCodePrefix2);
+ 
+ // Helper function which determines whether NAL unit of given type marks
+ // access unit boundary.
+-static bool IsAccessUnitBoundaryNal(int nal_unit_type) {
++static bool IsAccessUnitBoundaryNal2(int nal_unit_type) {
+   // Spec 7.4.2.4.4
+   // Check if this packet marks access unit boundary by checking the
+   // packet type.
+@@ -64,7 +64,7 @@ uint32_t H265ToAnnexBBitstreamConverter::GetConfigSize(
+ 
+   for (auto& nalu_array : hevc_config.arrays) {
+     for (auto& nalu : nalu_array.units) {
+-      config_size += kParamSetStartCodeSize + nalu.size();
++      config_size += kParamSetStartCodeSize2 + nalu.size();
+     }
+   }
+   return config_size;
+@@ -118,12 +118,12 @@ uint32_t H265ToAnnexBBitstreamConverter::CalculateNeededOutputBufferSize(
+     // nal_unit_type.
+     int nal_unit_type = (*input >> 1) & 0x3F;
+     if (first_nal_in_this_access_unit ||
+-        IsAccessUnitBoundaryNal(nal_unit_type)) {
++        IsAccessUnitBoundaryNal2(nal_unit_type)) {
+       output_size += 1;  // Extra zero_byte for these nal units
+       first_nal_in_this_access_unit = false;
+     }
+     // Start code prefix
+-    output_size += sizeof(kStartCodePrefix);
++    output_size += sizeof(kStartCodePrefix2);
+     // Actual NAL unit size
+     output_size += nal_unit_length;
+     input += nal_unit_length;
+@@ -218,8 +218,8 @@ bool H265ToAnnexBBitstreamConverter::ConvertNalUnitStreamToByteStream(
+     }
+     uint32_t start_code_len;
+     first_nal_unit_in_access_unit_
+-        ? start_code_len = sizeof(kStartCodePrefix) + 1
+-        : start_code_len = sizeof(kStartCodePrefix);
++        ? start_code_len = sizeof(kStartCodePrefix2) + 1
++        : start_code_len = sizeof(kStartCodePrefix2);
+     if (static_cast<uint32_t>(outscan - output) + start_code_len +
+             nal_unit_length >
+         *output_size) {
+@@ -229,7 +229,7 @@ bool H265ToAnnexBBitstreamConverter::ConvertNalUnitStreamToByteStream(
+ 
+     // Check if this packet marks access unit boundary by checking the
+     // packet type.
+-    if (IsAccessUnitBoundaryNal(nal_unit_type)) {
++    if (IsAccessUnitBoundaryNal2(nal_unit_type)) {
+       first_nal_unit_in_access_unit_ = true;
+     }
+ 
+@@ -243,8 +243,8 @@ bool H265ToAnnexBBitstreamConverter::ConvertNalUnitStreamToByteStream(
+ 
+     // No need to write leading zero bits.
+     // Write start-code prefix.
+-    memcpy(outscan, kStartCodePrefix, sizeof(kStartCodePrefix));
+-    outscan += sizeof(kStartCodePrefix);
++    memcpy(outscan, kStartCodePrefix2, sizeof(kStartCodePrefix2));
++    outscan += sizeof(kStartCodePrefix2);
+     // Then write the actual NAL unit from the input buffer.
+     memcpy(outscan, inscan, nal_unit_length);
+     inscan += nal_unit_length;
+@@ -270,8 +270,8 @@ bool H265ToAnnexBBitstreamConverter::WriteParamSet(
+ 
+   // Verify space.
+   uint32_t bytes_left = *out_size;
+-  if (bytes_left < kParamSetStartCodeSize ||
+-      bytes_left - kParamSetStartCodeSize < size) {
++  if (bytes_left < kParamSetStartCodeSize2 ||
++      bytes_left - kParamSetStartCodeSize2 < size) {
+     return false;
+   }
+ 
+@@ -280,8 +280,8 @@ bool H265ToAnnexBBitstreamConverter::WriteParamSet(
+ 
+   // Write the 4 byte Annex B start code.
+   *buf++ = 0;  // zero byte
+-  memcpy(buf, kStartCodePrefix, sizeof(kStartCodePrefix));
+-  buf += sizeof(kStartCodePrefix);
++  memcpy(buf, kStartCodePrefix2, sizeof(kStartCodePrefix2));
++  buf += sizeof(kStartCodePrefix2);
+ 
+   // Copy the data.
+   memcpy(buf, &param_set[0], size);
+diff --git a/media/filters/mac/audio_toolbox_audio_encoder.cc b/media/filters/mac/audio_toolbox_audio_encoder.cc
+index c1875279f..0329077f8 100644
+--- a/media/filters/mac/audio_toolbox_audio_encoder.cc
++++ b/media/filters/mac/audio_toolbox_audio_encoder.cc
+@@ -20,7 +20,7 @@ namespace media {
+ 
+ namespace {
+ 
+-struct InputData {
++struct InputData2 {
+   raw_ptr<const AudioBus> bus = nullptr;
+   bool flushing = false;
+ };
+@@ -28,12 +28,12 @@ struct InputData {
+ constexpr int kAacFramesPerBuffer = 1024;
+ 
+ // Callback used to provide input data to the AudioConverter.
+-OSStatus ProvideInputCallback(AudioConverterRef decoder,
++OSStatus ProvideInputCallback2(AudioConverterRef decoder,
+                               UInt32* num_packets,
+                               AudioBufferList* buffer_list,
+                               AudioStreamPacketDescription** packets,
+                               void* user_data) {
+-  auto* input_data = reinterpret_cast<InputData*>(user_data);
++  auto* input_data = reinterpret_cast<InputData2*>(user_data);
+   if (input_data->flushing) {
+     *num_packets = 0;
+     return noErr;
+@@ -294,7 +294,7 @@ bool AudioToolboxAudioEncoder::CreateEncoder(
+ void AudioToolboxAudioEncoder::DoEncode(AudioBus* input_bus) {
+   bool is_flushing = !input_bus;
+ 
+-  InputData input_data;
++  InputData2 input_data;
+   input_data.bus = input_bus;
+   input_data.flushing = is_flushing;
+ 
+diff --git a/media/filters/media_file_checker.cc b/media/filters/media_file_checker.cc
+index dca328bc6..a2d475758 100644
+--- a/media/filters/media_file_checker.cc
++++ b/media/filters/media_file_checker.cc
+@@ -29,7 +29,7 @@ void OnMediaFileCheckerError(bool* called) {
+   *called = false;
+ }
+ 
+-struct Decoder {
++struct DecoderStruct {
+   std::unique_ptr<AVCodecContext, ScopedPtrAVFreeContext> context;
+   std::unique_ptr<FFmpegDecodingLoop> loop;
+ };
+@@ -59,7 +59,7 @@ bool MediaFileChecker::Start(base::TimeDelta check_time) {
+ 
+   // Remember the codec context for any decodable audio or video streams.
+   bool found_streams = false;
+-  std::vector<Decoder> stream_contexts(format_context->nb_streams);
++  std::vector<DecoderStruct> stream_contexts(format_context->nb_streams);
+   for (size_t i = 0; i < format_context->nb_streams; ++i) {
+     AVCodecParameters* cp = format_context->streams[i]->codecpar;
+ 
+diff --git a/media/mojo/services/gpu_mojo_media_client_cros.cc b/media/mojo/services/gpu_mojo_media_client_cros.cc
+index 7cc7e9d60..389b71b7b 100644
+--- a/media/mojo/services/gpu_mojo_media_client_cros.cc
++++ b/media/mojo/services/gpu_mojo_media_client_cros.cc
+@@ -10,6 +10,7 @@
+ #include "build/build_config.h"
+ #include "media/base/audio_decoder.h"
+ #include "media/base/audio_encoder.h"
++#include "media/base/cdm_factory.h"
+ #include "media/base/media_switches.h"
+ #include "media/gpu/chromeos/mailbox_video_frame_converter.h"
+ #include "media/gpu/chromeos/platform_video_frame_pool.h"
+@@ -224,10 +225,6 @@ std::unique_ptr<AudioEncoder> CreatePlatformAudioEncoder(
+   return nullptr;
+ }
+ 
+-#if !BUILDFLAG(IS_CHROMEOS)
+-class CdmFactory {};
+-#endif  // !BUILDFLAG(IS_CHROMEOS)
+-
+ std::unique_ptr<CdmFactory> CreatePlatformCdmFactory(
+     mojom::FrameInterfaceFactory* frame_interfaces) {
+ #if BUILDFLAG(IS_CHROMEOS)
+diff --git a/media/mojo/services/gpu_mojo_media_client_mac.cc b/media/mojo/services/gpu_mojo_media_client_mac.cc
+index 7ddaadc74..cc7a68134 100644
+--- a/media/mojo/services/gpu_mojo_media_client_mac.cc
++++ b/media/mojo/services/gpu_mojo_media_client_mac.cc
+@@ -6,6 +6,7 @@
+ #include "base/task/single_thread_task_runner.h"
+ #include "base/task/thread_pool.h"
+ #include "media/base/audio_decoder.h"
++#include "media/base/cdm_factory.h"
+ #include "media/base/offloading_audio_encoder.h"
+ #include "media/filters/mac/audio_toolbox_audio_decoder.h"
+ #include "media/filters/mac/audio_toolbox_audio_encoder.h"
+@@ -46,7 +47,7 @@ std::unique_ptr<AudioEncoder> CreatePlatformAudioEncoder(
+ }
+ 
+ // This class doesn't exist on mac, so we need a stub for unique_ptr.
+-class CdmFactory {};
++//class CdmFactory {};
+ 
+ std::unique_ptr<CdmFactory> CreatePlatformCdmFactory(
+     mojom::FrameInterfaceFactory* frame_interfaces) {
+diff --git a/media/mojo/services/gpu_mojo_media_client_stubs.cc b/media/mojo/services/gpu_mojo_media_client_stubs.cc
+index 990226164..fd8fc1032 100644
+--- a/media/mojo/services/gpu_mojo_media_client_stubs.cc
++++ b/media/mojo/services/gpu_mojo_media_client_stubs.cc
+@@ -6,6 +6,7 @@
+ #include "base/task/single_thread_task_runner.h"
+ #include "media/base/audio_decoder.h"
+ #include "media/base/audio_encoder.h"
++#include "media/base/cdm_factory.h"
+ #include "media/base/video_decoder.h"
+ #include "media/mojo/services/gpu_mojo_media_client.h"
+ 
+@@ -35,9 +36,6 @@ std::unique_ptr<AudioEncoder> CreatePlatformAudioEncoder(
+   return nullptr;
+ }
+ 
+-// This class doesn't exist on any of the platforms that use the stubs.
+-class CdmFactory {};
+-
+ std::unique_ptr<CdmFactory> CreatePlatformCdmFactory(
+     mojom::FrameInterfaceFactory* frame_interfaces) {
+   return nullptr;
+diff --git a/media/mojo/services/gpu_mojo_media_client_win.cc b/media/mojo/services/gpu_mojo_media_client_win.cc
+index 624f1950e..4bfe1dd04 100644
+--- a/media/mojo/services/gpu_mojo_media_client_win.cc
++++ b/media/mojo/services/gpu_mojo_media_client_win.cc
+@@ -8,6 +8,7 @@
+ #include "base/task/single_thread_task_runner.h"
+ #include "base/task/thread_pool.h"
+ #include "media/base/audio_decoder.h"
++#include "media/base/cdm_factory.h"
+ #include "media/base/media_switches.h"
+ #include "media/base/offloading_audio_encoder.h"
+ #if BUILDFLAG(ENABLE_PLATFORM_DTS_AUDIO)
+@@ -98,7 +99,7 @@ VideoDecoderType GetPlatformDecoderImplementationType(
+ }
+ 
+ // There is no CdmFactory on windows, so just stub it out.
+-class CdmFactory {};
++//class CdmFactory {};
+ std::unique_ptr<CdmFactory> CreatePlatformCdmFactory(
+     mojom::FrameInterfaceFactory* frame_interfaces) {
+   return nullptr;
+diff --git a/mojo/public/tools/bindings/mojom.gni b/mojo/public/tools/bindings/mojom.gni
+index 6b29f9c12..496934eeb 100644
+--- a/mojo/public/tools/bindings/mojom.gni
++++ b/mojo/public/tools/bindings/mojom.gni
+@@ -2,7 +2,6 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-import("//build/config/jumbo.gni")
+ import("//third_party/closure_compiler/closure_args.gni")
+ import("//third_party/closure_compiler/compile_js.gni")
+ import("//third_party/protobuf/proto_library.gni")
+@@ -947,7 +946,7 @@ template("mojom") {
+   }
+ 
+   shared_cpp_sources_target_name = "${target_name}_shared_cpp_sources"
+-  jumbo_source_set(shared_cpp_sources_target_name) {
++  source_set(shared_cpp_sources_target_name) {
+     if (defined(invoker.testonly)) {
+       testonly = invoker.testonly
+     }
+@@ -1567,7 +1566,7 @@ template("mojom") {
+       sources_target_name = output_target_name
+     }
+ 
+-    target("jumbo_" + sources_target_type, sources_target_name) {
++    target(sources_target_type, sources_target_name) {
+       if (defined(output_name_override)) {
+         output_name = output_name_override
+       }
+diff --git a/services/network/public/cpp/BUILD.gn b/services/network/public/cpp/BUILD.gn
+index 8d757bb4e..ca0babdb0 100644
+--- a/services/network/public/cpp/BUILD.gn
++++ b/services/network/public/cpp/BUILD.gn
+@@ -377,6 +377,10 @@ jumbo_component("cpp_base") {
+     "web_transport_error_mojom_traits.cc",
+     "web_transport_error_mojom_traits.h",
+   ]
++  jumbo_excluded_sources = [
++    "network_ipc_param_traits.cc",
++    "url_request_mojom_traits.cc"
++  ]
+ 
+   configs += [ "//build/config/compiler:wexit_time_destructors" ]
+ 
+@@ -413,6 +417,7 @@ jumbo_component("cpp_base") {
+       "p2p_param_traits.h",
+       "p2p_socket_type.h",
+     ]
++    jumbo_excluded_sources += [ "p2p_param_traits.cc" ]
+ 
+     public_deps += [ "//third_party/webrtc_overrides:webrtc_component" ]
+   }
+diff --git a/services/network/web_bundle/web_bundle_url_loader_factory.cc b/services/network/web_bundle/web_bundle_url_loader_factory.cc
+index eba6b4fba..036cab919 100644
+--- a/services/network/web_bundle/web_bundle_url_loader_factory.cc
++++ b/services/network/web_bundle/web_bundle_url_loader_factory.cc
+@@ -34,7 +34,7 @@ namespace network {
+ 
+ namespace {
+ 
+-constexpr size_t kBlockedBodyAllocationSize = 1;
++constexpr size_t kBlockedBodyAllocationSize2 = 1;
+ 
+ void DeleteProducerAndRunCallback(
+     std::unique_ptr<mojo::DataPipeProducer> producer,
+@@ -86,7 +86,7 @@ class WebBundleURLLoaderClient : public network::mojom::URLLoaderClient {
+     options.struct_size = sizeof(MojoCreateDataPipeOptions);
+     options.flags = MOJO_CREATE_DATA_PIPE_FLAG_NONE;
+     options.element_num_bytes = 1;
+-    options.capacity_num_bytes = kBlockedBodyAllocationSize;
++    options.capacity_num_bytes = kBlockedBodyAllocationSize2;
+     mojo::ScopedDataPipeProducerHandle producer;
+     mojo::ScopedDataPipeConsumerHandle consumer;
+     MojoResult result = mojo::CreateDataPipe(&options, producer, consumer);
+diff --git a/storage/browser/BUILD.gn b/storage/browser/BUILD.gn
+index e30e9df29..e4768078a 100644
+--- a/storage/browser/BUILD.gn
++++ b/storage/browser/BUILD.gn
+@@ -226,6 +226,10 @@ jumbo_component("browser") {
+     "quota/usage_tracker.h",
+   ]
+ 
++  jumbo_excluded_sources = [
++    "file_system/local_file_stream_reader.cc",
++  ]
++
+   defines = [ "IS_STORAGE_BROWSER_IMPL" ]
+   configs += [
+     "//build/config:precompiled_headers",
+diff --git a/storage/browser/blob/blob_url_registry.cc b/storage/browser/blob/blob_url_registry.cc
+index 95072bc21..2a0f7ea39 100644
+--- a/storage/browser/blob/blob_url_registry.cc
++++ b/storage/browser/blob/blob_url_registry.cc
+@@ -15,7 +15,7 @@ namespace storage {
+ 
+ namespace {
+ 
+-BlobUrlRegistry::URLStoreCreationHook* g_url_store_creation_hook = nullptr;
++BlobUrlRegistry::URLStoreCreationHook* g_url_store_creation_hook2 = nullptr;
+ 
+ }
+ 
+@@ -35,8 +35,8 @@ void BlobUrlRegistry::AddReceiver(
+       std::make_unique<storage::BlobURLStoreImpl>(storage_key, AsWeakPtr()),
+       std::move(receiver));
+ 
+-  if (g_url_store_creation_hook) {
+-    g_url_store_creation_hook->Run(this, receiver_id);
++  if (g_url_store_creation_hook2) {
++    g_url_store_creation_hook2->Run(this, receiver_id);
+   }
+ }
+ 
+@@ -180,7 +180,7 @@ void BlobUrlRegistry::SetURLStoreCreationHookForTesting(
+     URLStoreCreationHook* hook) {
+   DCHECK(
+       base::FeatureList::IsEnabled(net::features::kSupportPartitionedBlobUrl));
+-  g_url_store_creation_hook = hook;
++  g_url_store_creation_hook2 = hook;
+ }
+ 
+ }  // namespace storage
+diff --git a/storage/browser/quota/quota_settings.cc b/storage/browser/quota/quota_settings.cc
+index b90b65552..88ae48f60 100644
+--- a/storage/browser/quota/quota_settings.cc
++++ b/storage/browser/quota/quota_settings.cc
+@@ -24,14 +24,14 @@ namespace storage {
+ 
+ namespace {
+ 
+-const int64_t kMBytes = 1024 * 1024;
++const int64_t _kMBytes = 1024 * 1024;
+ const int kRandomizedPercentage = 10;
+ const double kDefaultPerStorageKeyRatio = 0.75;
+ const double kIncognitoQuotaRatioLowerBound = 0.15;
+ const double kIncognitoQuotaRatioUpperBound = 0.2;
+ 
+ // Skews |value| by +/- |percent|.
+-int64_t RandomizeByPercent(int64_t value, int percent) {
++int64_t MyRandomizeByPercent(int64_t value, int percent) {
+   double random_percent = (base::RandDouble() - 0.5) * percent * 2;
+   return value + (value * (random_percent / 100.0));
+ }
+@@ -117,7 +117,7 @@ absl::optional<QuotaSettings> CalculateNominalDynamicSettings(
+   // SessionOnly (or ephemeral) origins are allotted a fraction of what
+   // normal origins are provided, and the amount is capped to a hard limit.
+   const double kSessionOnlyStorageKeyQuotaRatio = 0.1;  // 10%
+-  const int64_t kMaxSessionOnlyStorageKeyQuota = 300 * kMBytes;
++  const int64_t kMaxSessionOnlyStorageKeyQuota = 300 * _kMBytes;
+ 
+   QuotaSettings settings;
+ 
+@@ -144,10 +144,9 @@ absl::optional<QuotaSettings> CalculateNominalDynamicSettings(
+                static_cast<int64_t>(total * kMustRemainAvailableRatio));
+   settings.per_storage_key_quota = pool_size * kPerStorageKeyTemporaryRatio;
+   settings.session_only_per_storage_key_quota = std::min(
+-      RandomizeByPercent(kMaxSessionOnlyStorageKeyQuota, kRandomizedPercentage),
++      MyRandomizeByPercent(kMaxSessionOnlyStorageKeyQuota, kRandomizedPercentage),
+       static_cast<int64_t>(settings.per_storage_key_quota *
+                            kSessionOnlyStorageKeyQuotaRatio));
+-  settings.refresh_interval = base::Seconds(60);
+   return settings;
+ }
+ 
+diff --git a/third_party/blink/common/frame/user_activation_state.cc b/third_party/blink/common/frame/user_activation_state.cc
+index de3b52d4b..e80da3f8b 100644
+--- a/third_party/blink/common/frame/user_activation_state.cc
++++ b/third_party/blink/common/frame/user_activation_state.cc
+@@ -31,7 +31,7 @@ bool IsRestricted(UserActivationNotificationType notification_type) {
+ // The expiry time should be long enough to allow network round trips even in a
+ // very slow connection (to support xhr-like calls with user activation), yet
+ // not too long to make an "unattended" page feel activated.
+-constexpr base::TimeDelta kActivationLifespan = base::Seconds(5);
++constexpr base::TimeDelta kActivationLifespan2 = base::Seconds(5);
+ 
+ UserActivationState::UserActivationState()
+     : first_notification_type_(UserActivationNotificationType::kNone),
+@@ -101,7 +101,7 @@ void UserActivationState::RecordPreconsumptionUma() const {
+ }
+ 
+ void UserActivationState::ActivateTransientState() {
+-  transient_state_expiry_time_ = base::TimeTicks::Now() + kActivationLifespan;
++  transient_state_expiry_time_ = base::TimeTicks::Now() + kActivationLifespan2;
+ }
+ 
+ void UserActivationState::DeactivateTransientState() {
+diff --git a/third_party/blink/common/user_agent/user_agent_metadata.cc b/third_party/blink/common/user_agent/user_agent_metadata.cc
+index 3b99c66c4..935b02967 100644
+--- a/third_party/blink/common/user_agent/user_agent_metadata.cc
++++ b/third_party/blink/common/user_agent/user_agent_metadata.cc
+@@ -11,7 +11,7 @@
+ namespace blink {
+ 
+ namespace {
+-constexpr uint32_t kVersion = 2u;
++constexpr uint32_t kVersionUA = 2u;
+ }  // namespace
+ 
+ UserAgentBrandVersion::UserAgentBrandVersion(const std::string& ua_brand,
+@@ -56,7 +56,7 @@ absl::optional<std::string> UserAgentMetadata::Marshal(
+   if (!in)
+     return absl::nullopt;
+   base::Pickle out;
+-  out.WriteUInt32(kVersion);
++  out.WriteUInt32(kVersionUA);
+ 
+   out.WriteUInt32(in->brand_version_list.size());
+   for (const auto& brand_version : in->brand_version_list) {
+@@ -92,7 +92,7 @@ absl::optional<UserAgentMetadata> UserAgentMetadata::Demarshal(
+ 
+   uint32_t version;
+   UserAgentMetadata out;
+-  if (!in.ReadUInt32(&version) || version != kVersion)
++  if (!in.ReadUInt32(&version) || version != kVersionUA)
+     return absl::nullopt;
+ 
+   uint32_t brand_version_size;
+diff --git a/third_party/blink/renderer/bindings/scripts/bind_gen/callback_interface.py b/third_party/blink/renderer/bindings/scripts/bind_gen/callback_interface.py
+index 6703feeb0..7478af1ef 100644
+--- a/third_party/blink/renderer/bindings/scripts/bind_gen/callback_interface.py
++++ b/third_party/blink/renderer/bindings/scripts/bind_gen/callback_interface.py
+@@ -185,6 +185,7 @@ def generate_callback_interface(callback_interface_identifier):
+          cg_context,
+          FN_INSTALL_INTERFACE_TEMPLATE,
+          class_name=class_name,
++         api_class_name=class_name,
+          trampoline_var_name=None,
+          constructor_entries=[],
+          supplemental_install_node=SequenceNode(),
+diff --git a/third_party/blink/renderer/bindings/scripts/bind_gen/interface.py b/third_party/blink/renderer/bindings/scripts/bind_gen/interface.py
+index 1c163ff51..af714c4c6 100644
+--- a/third_party/blink/renderer/bindings/scripts/bind_gen/interface.py
++++ b/third_party/blink/renderer/bindings/scripts/bind_gen/interface.py
+@@ -5689,7 +5689,7 @@ ${prototype_object}->GetPrototype().As<v8::Object>()->Delete(
+     return SequenceNode(nodes) if nodes else None
+ 
+ 
+-def make_install_interface_template(cg_context, function_name, class_name,
++def make_install_interface_template(cg_context, function_name, class_name, api_class_name,
+                                     trampoline_var_name, constructor_entries,
+                                     supplemental_install_node,
+                                     install_unconditional_func_name,
+@@ -5813,7 +5813,7 @@ def make_install_interface_template(cg_context, function_name, class_name,
+     for entry in constructor_entries:
+         nodes = [
+             FormatNode("${interface_function_template}->SetCallHandler({});",
+-                       entry.ctor_callback_name),
++                       api_class_name + "Callbacks::" + entry.ctor_callback_name),
+             FormatNode("${interface_function_template}->SetLength({});",
+                        entry.ctor_func_length),
+         ]
+@@ -6208,6 +6208,7 @@ ${instance_object} = ${v8_context}->Global()->GetPrototype().As<v8::Object>();\
+         if unconditional_entries:
+             body.append(
+                 CxxBlockNode([
++                    TextNode("using namespace ${class_name}Callbacks;"),
+                     make_table_func(table_name, unconditional_entries),
+                     TextNode(installer_call_text),
+                 ]))
+@@ -6217,6 +6218,7 @@ ${instance_object} = ${v8_context}->Global()->GetPrototype().As<v8::Object>();\
+                 CxxUnlikelyIfNode(
+                     cond=conditional,
+                     body=[
++                        TextNode("using namespace ${class_name}Callbacks;"),
+                         make_table_func(table_name, entries),
+                         TextNode(installer_call_text),
+                     ]))
+@@ -6368,6 +6370,8 @@ def make_indexed_and_named_property_callbacks_and_install_node(cg_context):
+                 map(lambda flag: "int32_t({})".format(flag), flags))))
+         pattern = """\
+ // Named interceptors
++{{
++using namespace ${class_name}Callbacks;
+ ${instance_object_template}->SetHandler(
+     v8::NamedPropertyHandlerConfiguration(
+         {impl_bridge}::NamedPropertyGetterCallback,
+@@ -6388,7 +6392,9 @@ interface.indexed_and_named_properties.named_getter.extended_attributes:
+         {impl_bridge}::NamedPropertyDefinerCallback,
+         {impl_bridge}::NamedPropertyDescriptorCallback,
+         v8::Local<v8::Value>(),
+-        {property_handler_flags}));"""
++        {property_handler_flags}));
++}}
++"""
+         install_node.append(
+             F(pattern,
+               impl_bridge=impl_bridge,
+@@ -6428,6 +6434,8 @@ interface.indexed_and_named_properties.named_getter.extended_attributes:
+         property_handler_flags = flags[0]
+         pattern = """\
+ // Indexed interceptors
++{{
++using namespace ${class_name}Callbacks;
+ ${instance_object_template}->SetHandler(
+     v8::IndexedPropertyHandlerConfiguration(
+         {impl_bridge}::IndexedPropertyGetterCallback,
+@@ -6442,7 +6450,8 @@ ${instance_object_template}->SetHandler(
+         {impl_bridge}::IndexedPropertyDefinerCallback,
+         {impl_bridge}::IndexedPropertyDescriptorCallback,
+         v8::Local<v8::Value>(),
+-        {property_handler_flags}));"""
++        {property_handler_flags}));
++}}"""
+         install_node.append(
+             F(pattern,
+               impl_bridge=impl_bridge,
+@@ -6503,6 +6512,8 @@ def make_named_properties_object_callbacks_and_install_node(cg_context):
+         callback_defs.append(EmptyNode())
+ 
+     text = """\
++{{
++using namespace ${class_name}Callbacks;
+ // Named interceptors
+ ${npo_prototype_template}->SetHandler(
+     v8::NamedPropertyHandlerConfiguration(
+@@ -6528,7 +6539,8 @@ ${npo_prototype_template}->SetHandler(
+         NamedPropsObjIndexedDefinerCallback,
+         NamedPropsObjIndexedDescriptorCallback,
+         v8::Local<v8::Value>(),
+-        v8::PropertyHandlerFlags::kNone));"""
++        v8::PropertyHandlerFlags::kNone));
++}}"""
+     install_node.append(TextNode(text))
+ 
+     return callback_defs, install_node
+@@ -6667,6 +6679,8 @@ def make_cross_origin_property_callbacks_and_install_node(
+ 
+     text = """\
+ // Cross origin properties
++{{
++using namespace ${class_name}Callbacks;
+ ${instance_object_template}->SetAccessCheckCallbackAndHandler(
+     CrossOriginAccessCheckCallback,
+     v8::NamedPropertyHandlerConfiguration(
+@@ -6692,6 +6706,7 @@ ${instance_object_template}->SetAccessCheckCallbackAndHandler(
+     v8::External::New(
+         ${isolate},
+         const_cast<WrapperTypeInfo*>(${class_name}::GetWrapperTypeInfo())));
++}}
+ """
+     install_node.append(TextNode(text))
+     install_node.accumulate(
+@@ -6724,6 +6739,8 @@ ${instance_object_template}->SetAccessCheckCallbackAndHandler(
+         callback_defs.append(EmptyNode())
+ 
+     text = """\
++{{
++using namespace ${class_name}Callbacks;
+ // Same origin interceptors
+ ${instance_object_template}->SetHandler(
+     v8::IndexedPropertyHandlerConfiguration(
+@@ -6736,6 +6753,7 @@ ${instance_object_template}->SetHandler(
+         SameOriginIndexedDescriptorCallback,
+         v8::Local<v8::Value>(),
+         v8::PropertyHandlerFlags::kNone));
++}}
+ """
+     install_node.append(TextNode(text))
+ 
+@@ -6905,6 +6923,7 @@ def make_wrapper_type_info(cg_context, function_name,
+         ]))
+ 
+     pattern = """\
++namespace ${class_name}Callbacks {{ }}
+ // Construction of WrapperTypeInfo may require non-trivial initialization due
+ // to cross-component address resolution in order to load the pointer to the
+ // parent interface's WrapperTypeInfo.  We ignore this issue because the issue
+@@ -7112,6 +7131,7 @@ def _make_v8_context_snapshot_get_reference_table_function(
+                                                                            )),
+             filter(None, callback_names)))
+     table_node = ListNode([
++        TextNode("using namespace ${class_name}Callbacks;"),
+         TextNode("static const intptr_t kReferenceTable[] = {"),
+         ListNode(entry_nodes),
+         TextNode("};"),
+@@ -7568,6 +7588,7 @@ def generate_class_like(class_like,
+          cg_context,
+          FN_INSTALL_INTERFACE_TEMPLATE,
+          class_name=impl_class_name,
++         api_class_name=api_class_name,
+          trampoline_var_name=tp_install_interface_template,
+          constructor_entries=constructor_entries,
+          supplemental_install_node=supplemental_install_node,
+@@ -7820,7 +7841,7 @@ def generate_class_like(class_like,
+                                                     class_like.identifier)
+     impl_source_blink_ns.body.extend([
+         CxxNamespaceNode(
+-            name="",
++            name=api_class_name + "Callbacks",
+             body=[
+                 # Enclose the implementations with a namespace just in order to
+                 # include the class_like name in a stacktrace, such as
+diff --git a/third_party/blink/renderer/core/BUILD.gn b/third_party/blink/renderer/core/BUILD.gn
+index e1234cafb..b5867d2da 100644
+--- a/third_party/blink/renderer/core/BUILD.gn
++++ b/third_party/blink/renderer/core/BUILD.gn
+@@ -5,6 +5,7 @@
+ import("//build/config/chromecast_build.gni")
+ import("//build/config/compiler/compiler.gni")
+ import("//build/config/dcheck_always_on.gni")
++import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//build/toolchain/toolchain.gni")
+ import("//media/media_options.gni")
+@@ -144,7 +145,7 @@ source_set("core_common") {
+   sources = [ "core_export.h" ]
+ }
+ 
+-source_set("prerequisites") {
++jumbo_source_set("prerequisites") {
+   public_deps = [
+     "//services/network/public/cpp:cpp",
+     "//services/network/public/mojom",
+@@ -186,7 +187,7 @@ source_set("prerequisites") {
+   ]
+ }
+ 
+-component("core") {
++jumbo_component("core") {
+   output_name = "blink_core"
+ 
+   visibility = []  # Allow re-assignment of list.
+@@ -361,6 +362,14 @@ component("core") {
+     "//third_party/blink/renderer/core/url_pattern",
+     "//third_party/blink/renderer/core/xml:xpath_generated",
+   ]
++  jumbo_excluded_sources = [ ]
++  jumbo_excluded_sources += rebase_path([ "frame_fetch_context.cc" ], "", "loader")
++  jumbo_excluded_sources += rebase_path([ "image_loader.cc" ], "", "loader")
++  jumbo_excluded_sources += rebase_path([ "create_window.cc" ], "", "page")
++  jumbo_excluded_sources += rebase_path([ "link_highlight_impl.cc" ], "", "paint")
++  jumbo_excluded_sources += rebase_path([ "scroll_animator.cc" ], "", "scroll")
++  jumbo_excluded_sources += rebase_path([ "grid_baseline_alignment.cc" ], "", "layout")
++  jumbo_excluded_sources += rebase_path([ "grid_track_sizing_algorithm.cc" ], "", "layout")
+ 
+   public_configs = [ ":core_include_dirs" ]
+ 
+diff --git a/third_party/blink/renderer/core/animation/BUILD.gn b/third_party/blink/renderer/core/animation/BUILD.gn
+index 4ce94baab..97a1f8811 100644
+--- a/third_party/blink/renderer/core/animation/BUILD.gn
++++ b/third_party/blink/renderer/core/animation/BUILD.gn
+@@ -300,6 +300,9 @@ blink_core_sources("animation") {
+     "worklet_animation_controller.cc",
+     "worklet_animation_controller.h",
+   ]
++  jumbo_excluded_sources = [
++    "css_transform_interpolation_type.cc",
++  ]
+ 
+   deps = [
+     ":buildflags",
+diff --git a/third_party/blink/renderer/core/animation/css_shadow_list_interpolation_type.cc b/third_party/blink/renderer/core/animation/css_shadow_list_interpolation_type.cc
+index 47ec7902e..6beb54e33 100644
+--- a/third_party/blink/renderer/core/animation/css_shadow_list_interpolation_type.cc
++++ b/third_party/blink/renderer/core/animation/css_shadow_list_interpolation_type.cc
+@@ -207,7 +207,7 @@ CSSShadowListInterpolationType::PreInterpolationCompositeIfNeeded(
+   // to disable that caching in this case.
+   // TODO(crbug.com/1009230): Remove this once our interpolation code isn't
+   // caching composited values.
+-  conversion_checkers.push_back(std::make_unique<AlwaysInvalidateChecker>());
++  conversion_checkers.push_back(std::make_unique<blink::AlwaysInvalidateChecker>());
+   auto interpolable_list = std::unique_ptr<InterpolableList>(
+       To<InterpolableList>(value.interpolable_value.release()));
+   if (composite == EffectModel::CompositeOperation::kCompositeAdd) {
+diff --git a/third_party/blink/renderer/core/css/box_shadow_paint_image_generator.cc b/third_party/blink/renderer/core/css/box_shadow_paint_image_generator.cc
+index 8554ef066..50ad55bc8 100644
+--- a/third_party/blink/renderer/core/css/box_shadow_paint_image_generator.cc
++++ b/third_party/blink/renderer/core/css/box_shadow_paint_image_generator.cc
+@@ -11,22 +11,22 @@ namespace blink {
+ namespace {
+ 
+ BoxShadowPaintImageGenerator::BoxShadowPaintImageGeneratorCreateFunction*
+-    g_create_function = nullptr;
++    g_create_function_bspig = nullptr;
+ 
+ }  // namespace
+ 
+ // static
+ void BoxShadowPaintImageGenerator::Init(
+     BoxShadowPaintImageGeneratorCreateFunction* create_function) {
+-  DCHECK(!g_create_function);
+-  g_create_function = create_function;
++  DCHECK(!g_create_function_bspig);
++  g_create_function_bspig = create_function;
+ }
+ 
+ BoxShadowPaintImageGenerator* BoxShadowPaintImageGenerator::Create(
+     LocalFrame& local_root) {
+-  DCHECK(g_create_function);
++  DCHECK(g_create_function_bspig);
+   DCHECK(local_root.IsLocalRoot());
+-  return g_create_function(local_root);
++  return g_create_function_bspig(local_root);
+ }
+ 
+ }  // namespace blink
+diff --git a/third_party/blink/renderer/core/css/clip_path_paint_image_generator.cc b/third_party/blink/renderer/core/css/clip_path_paint_image_generator.cc
+index 84cae256f..f365766dd 100644
+--- a/third_party/blink/renderer/core/css/clip_path_paint_image_generator.cc
++++ b/third_party/blink/renderer/core/css/clip_path_paint_image_generator.cc
+@@ -11,22 +11,22 @@ namespace blink {
+ namespace {
+ 
+ ClipPathPaintImageGenerator::ClipPathPaintImageGeneratorCreateFunction*
+-    g_create_function = nullptr;
++    g_create_function2 = nullptr;
+ 
+ }  // namespace
+ 
+ // static
+ void ClipPathPaintImageGenerator::Init(
+     ClipPathPaintImageGeneratorCreateFunction* create_function) {
+-  DCHECK(!g_create_function);
+-  g_create_function = create_function;
++  DCHECK(!g_create_function2);
++  g_create_function2 = create_function;
+ }
+ 
+ ClipPathPaintImageGenerator* ClipPathPaintImageGenerator::Create(
+     LocalFrame& local_root) {
+-  DCHECK(g_create_function);
++  DCHECK(g_create_function2);
+   DCHECK(local_root.IsLocalRoot());
+-  return g_create_function(local_root);
++  return g_create_function2(local_root);
+ }
+ 
+ }  // namespace blink
+diff --git a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
+index a9437500d..2029ebfbc 100644
+--- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
++++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
+@@ -90,7 +90,7 @@ size_t GetCurrentCursorPositionInFrame(LocalFrame* local_frame) {
+ }
+ #endif
+ 
+-RemoteFrame* SourceFrameForOptionalToken(
++RemoteFrame* SourceFrameForOptionalToken2(
+     const absl::optional<RemoteFrameToken>& source_frame_token) {
+   if (!source_frame_token)
+     return nullptr;
+@@ -710,7 +710,7 @@ void LocalFrameMojoHandler::AdvanceFocusInFrame(
+     mojom::blink::FocusType focus_type,
+     const absl::optional<RemoteFrameToken>& source_frame_token) {
+   RemoteFrame* source_frame =
+-      source_frame_token ? SourceFrameForOptionalToken(*source_frame_token)
++      source_frame_token ? SourceFrameForOptionalToken2(*source_frame_token)
+                          : nullptr;
+   if (!source_frame) {
+     SetInitialFocus(focus_type == mojom::blink::FocusType::kBackward);
+diff --git a/third_party/blink/renderer/core/frame/sticky_ad_detector.cc b/third_party/blink/renderer/core/frame/sticky_ad_detector.cc
+index efaeba07b..f108d589a 100644
+--- a/third_party/blink/renderer/core/frame/sticky_ad_detector.cc
++++ b/third_party/blink/renderer/core/frame/sticky_ad_detector.cc
+@@ -22,8 +22,8 @@ namespace blink {
+ 
+ namespace {
+ 
+-constexpr base::TimeDelta kFireInterval = base::Seconds(1);
+-constexpr double kLargeAdSizeToViewportSizeThreshold = 0.3;
++constexpr base::TimeDelta kFireInterval2 = base::Seconds(1);
++constexpr double kLargeAdSizeToViewportSizeThreshold2 = 0.3;
+ 
+ // An sticky element should have a non-default position w.r.t. the viewport. The
+ // main page should also be scrollable.
+@@ -71,7 +71,7 @@ void StickyAdDetector::MaybeFireDetection(LocalFrame* outermost_main_frame) {
+   if (last_detection_time_.has_value() &&
+       base::FeatureList::IsEnabled(
+           features::kFrequencyCappingForLargeStickyAdDetection) &&
+-      current_time < last_detection_time_.value() + kFireInterval) {
++      current_time < last_detection_time_.value() + kFireInterval2) {
+     return;
+   }
+ 
+@@ -127,7 +127,7 @@ void StickyAdDetector::MaybeFireDetection(LocalFrame* outermost_main_frame) {
+ 
+   bool is_large =
+       (overlay_rect.size().Area64() > outermost_main_frame_size.Area64() *
+-                                          kLargeAdSizeToViewportSizeThreshold);
++                                          kLargeAdSizeToViewportSizeThreshold2);
+ 
+   bool is_main_page_scrollable =
+       element->GetDocument().GetLayoutView()->HasScrollableOverflowY();
+diff --git a/third_party/blink/renderer/core/html/forms/html_input_element.cc b/third_party/blink/renderer/core/html/forms/html_input_element.cc
+index 475a7a583..bc81c05b4 100644
+--- a/third_party/blink/renderer/core/html/forms/html_input_element.cc
++++ b/third_party/blink/renderer/core/html/forms/html_input_element.cc
+@@ -102,7 +102,7 @@ namespace {
+ 
+ const unsigned kMaxEmailFieldLength = 254;
+ 
+-static bool is_default_font_prewarmed_ = false;
++static bool is_default_font_prewarmed_hie = false;
+ 
+ }  // namespace
+ 
+@@ -415,10 +415,10 @@ void HTMLInputElement::InitializeTypeInParsing() {
+   // Prewarm the default font family. Do this while parsing because the style
+   // recalc calls |TextControlInnerEditorElement::CreateInnerEditorStyle| which
+   // needs the primary font.
+-  if (!is_default_font_prewarmed_ && new_type_name == input_type_names::kText) {
++  if (!is_default_font_prewarmed_hie && new_type_name == input_type_names::kText) {
+     FontCache::PrewarmFamily(LayoutThemeFontProvider::SystemFontFamily(
+         CSSValueID::kWebkitSmallControl));
+-    is_default_font_prewarmed_ = true;
++    is_default_font_prewarmed_hie = true;
+   }
+ }
+ 
+diff --git a/third_party/blink/renderer/core/html/forms/html_text_area_element.cc b/third_party/blink/renderer/core/html/forms/html_text_area_element.cc
+index e2799c952..4d7c468c8 100644
+--- a/third_party/blink/renderer/core/html/forms/html_text_area_element.cc
++++ b/third_party/blink/renderer/core/html/forms/html_text_area_element.cc
+@@ -67,7 +67,7 @@ namespace blink {
+ static const unsigned kDefaultRows = 2;
+ static const unsigned kDefaultCols = 20;
+ 
+-static bool is_default_font_prewarmed_ = false;
++static bool is_default_font_prewarmed_htae = false;
+ 
+ static inline unsigned ComputeLengthForAPIValue(const String& text) {
+   unsigned length = text.length();
+@@ -93,14 +93,14 @@ HTMLTextAreaElement::HTMLTextAreaElement(Document& document)
+       is_placeholder_visible_(false) {
+   EnsureUserAgentShadowRoot();
+ 
+-  if (!is_default_font_prewarmed_) {
++  if (!is_default_font_prewarmed_htae) {
+     if (Settings* settings = document.GetSettings()) {
+       // Prewarm 'monospace', the default font family for `<textarea>`. The
+       // default language should be fine for this purpose because most users set
+       // the same family for all languages.
+       FontCache::PrewarmFamily(settings->GetGenericFontFamilySettings().Fixed(
+           LayoutLocale::GetDefault().GetScript()));
+-      is_default_font_prewarmed_ = true;
++      is_default_font_prewarmed_htae = true;
+     }
+   }
+ }
+diff --git a/third_party/blink/renderer/core/html/parser/html_tree_builder.cc b/third_party/blink/renderer/core/html/parser/html_tree_builder.cc
+index 0210b7530..5dd7a4e13 100644
+--- a/third_party/blink/renderer/core/html/parser/html_tree_builder.cc
++++ b/third_party/blink/renderer/core/html/parser/html_tree_builder.cc
+@@ -78,7 +78,7 @@ static TextPosition UninitializedPositionValue1() {
+                       OrdinalNumber::First());
+ }
+ 
+-static inline bool IsAllWhitespace(const StringView& string_view) {
++static inline bool IsAllWhitespaceHTB(const StringView& string_view) {
+   return string_view.IsAllSpecialCharacters<IsHTMLSpace<UChar>>();
+ }
+ 
+@@ -2783,7 +2783,7 @@ void HTMLTreeBuilder::DefaultForAfterHead() {
+ void HTMLTreeBuilder::DefaultForInTableText() {
+   String characters = pending_table_characters_.ToString();
+   pending_table_characters_.Clear();
+-  if (!IsAllWhitespace(characters)) {
++  if (!IsAllWhitespaceHTB(characters)) {
+     // FIXME: parse error
+     HTMLConstructionSite::RedirectToFosterParentGuard redirecter(tree_);
+     tree_.ReconstructTheActiveFormattingElements();
+diff --git a/third_party/blink/renderer/core/html/track/cue_timeline.cc b/third_party/blink/renderer/core/html/track/cue_timeline.cc
+index a0acee282..ccad139a8 100644
+--- a/third_party/blink/renderer/core/html/track/cue_timeline.cc
++++ b/third_party/blink/renderer/core/html/track/cue_timeline.cc
+@@ -358,7 +358,7 @@ void CueTimeline::TimeMarchesOn() {
+           is_enter_event ? event_type_names::kEnter : event_type_names::kExit;
+       media_element.ScheduleEvent(
+           CreateEventWithTarget(event_name, task.second.Get()));
+-      if (features::IsTextBasedAudioDescriptionEnabled()) {
++      if (::features::IsTextBasedAudioDescriptionEnabled()) {
+         if (is_enter_event) {
+           cue->OnEnter(MediaElement());
+         } else {
+diff --git a/third_party/blink/renderer/core/html/track/text_track.cc b/third_party/blink/renderer/core/html/track/text_track.cc
+index e93831d87..3737f2b71 100644
+--- a/third_party/blink/renderer/core/html/track/text_track.cc
++++ b/third_party/blink/renderer/core/html/track/text_track.cc
+@@ -321,7 +321,7 @@ void TextTrack::InvalidateTrackIndex() {
+ }
+ 
+ bool TextTrack::IsRendered() const {
+-  if (features::IsTextBasedAudioDescriptionEnabled()) {
++  if (::features::IsTextBasedAudioDescriptionEnabled()) {
+     return mode_ == TextTrackMode::kShowing &&
+            (IsVisualKind() || IsSpokenKind());
+   }
+@@ -331,7 +331,7 @@ bool TextTrack::IsRendered() const {
+ bool TextTrack::CanBeRendered() const {
+   // A track can be displayed when it's of kind captions, subtitles, or
+   // descriptions and hasn't failed to load.
+-  if (features::IsTextBasedAudioDescriptionEnabled()) {
++  if (::features::IsTextBasedAudioDescriptionEnabled()) {
+     return GetReadinessState() != kFailedToLoad &&
+            (IsVisualKind() || IsSpokenKind());
+   }
+diff --git a/third_party/blink/renderer/core/imagebitmap/image_bitmap_source.cc b/third_party/blink/renderer/core/imagebitmap/image_bitmap_source.cc
+index 6bb17ceef..58a65cdfa 100644
+--- a/third_party/blink/renderer/core/imagebitmap/image_bitmap_source.cc
++++ b/third_party/blink/renderer/core/imagebitmap/image_bitmap_source.cc
+@@ -14,7 +14,7 @@
+ 
+ namespace blink {
+ 
+-constexpr const char* kImageBitmapOptionNone = "none";
++constexpr const char* kImageBitmapOptionNone2 = "none";
+ 
+ ScriptPromise ImageBitmapSource::FulfillImageBitmap(
+     ScriptState* script_state,
+@@ -31,7 +31,7 @@ ScriptPromise ImageBitmapSource::FulfillImageBitmap(
+   // imageOrientation: 'from-image' will be used to replace imageOrientation:
+   // 'none'. Adding a deprecation warning when 'none' is called in
+   // createImageBitmap.
+-  if (options->imageOrientation() == kImageBitmapOptionNone) {
++  if (options->imageOrientation() == kImageBitmapOptionNone2) {
+     auto* execution_context =
+         ExecutionContext::From(script_state->GetContext());
+     Deprecation::CountDeprecation(
+diff --git a/third_party/blink/renderer/core/layout/flexible_box_algorithm.cc b/third_party/blink/renderer/core/layout/flexible_box_algorithm.cc
+index 94dabe8c2..fed94e161 100644
+--- a/third_party/blink/renderer/core/layout/flexible_box_algorithm.cc
++++ b/third_party/blink/renderer/core/layout/flexible_box_algorithm.cc
+@@ -87,7 +87,7 @@ FlexItem::FlexItem(const FlexLayoutAlgorithm* algorithm,
+                    NGPhysicalBoxStrut physical_margins,
+                    NGBoxStrut scrollbars,
+                    WritingMode baseline_writing_mode,
+-                   BaselineGroup baseline_group,
++                   BaselineGroupType baseline_group,
+                    bool depends_on_min_max_sizes)
+     : algorithm_(algorithm),
+       line_number_(0),
+@@ -202,7 +202,7 @@ LayoutUnit FlexItem::MarginBoxAscent(bool is_last_baseline,
+   if (is_wrap_reverse != is_last_baseline)
+     baseline = baseline_fragment.BlockSize() - baseline;
+ 
+-  return baseline_group_ == BaselineGroup::kMajor
++  return baseline_group_ == BaselineGroupType::kMajor
+              ? FlowAwareMarginBefore() + baseline
+              : FlowAwareMarginAfter() + baseline;
+ }
+@@ -583,7 +583,7 @@ void FlexLine::ComputeLineItemsPosition(LayoutUnit main_axis_start_offset,
+       LayoutUnit descent =
+           (flex_item.CrossAxisMarginExtent() + flex_item.cross_axis_size_) -
+           ascent;
+-      if (flex_item.baseline_group_ == BaselineGroup::kMajor) {
++      if (flex_item.baseline_group_ == BaselineGroupType::kMajor) {
+         max_major_ascent_ = std::max(max_major_ascent_, ascent);
+         max_major_descent = std::max(max_major_descent, descent);
+         child_cross_axis_margin_box_extent =
+@@ -913,7 +913,7 @@ void FlexLayoutAlgorithm::AlignChildren() {
+       LayoutUnit baseline_offset;
+       if (position == ItemPosition::kBaseline ||
+           position == ItemPosition::kLastBaseline) {
+-        bool is_major = flex_item.baseline_group_ == BaselineGroup::kMajor;
++        bool is_major = flex_item.baseline_group_ == BaselineGroupType::kMajor;
+         LayoutUnit ascent = flex_item.MarginBoxAscent(
+             position == ItemPosition::kLastBaseline, is_wrap_reverse);
+         LayoutUnit max_ascent = is_major ? line_context.max_major_ascent_
+diff --git a/third_party/blink/renderer/core/layout/flexible_box_algorithm.h b/third_party/blink/renderer/core/layout/flexible_box_algorithm.h
+index 34695087e..278d27743 100644
+--- a/third_party/blink/renderer/core/layout/flexible_box_algorithm.h
++++ b/third_party/blink/renderer/core/layout/flexible_box_algorithm.h
+@@ -136,7 +136,7 @@ class FlexItem {
+            NGPhysicalBoxStrut physical_margins,
+            NGBoxStrut scrollbars,
+            WritingMode baseline_writing_mode,
+-           BaselineGroup baseline_group = BaselineGroup::kMajor,
++           BaselineGroupType baseline_group = BaselineGroupType::kMajor,
+            bool depends_on_min_max_sizes = false);
+ 
+   LayoutUnit HypotheticalMainAxisMarginBoxSize() const {
+@@ -211,7 +211,7 @@ class FlexItem {
+   NGPhysicalBoxStrut physical_margins_;
+   const NGBoxStrut scrollbars_;
+   const WritingDirectionMode baseline_writing_direction_;
+-  const BaselineGroup baseline_group_;
++  const BaselineGroupType baseline_group_;
+ 
+   LayoutUnit flexed_content_size_;
+ 
+diff --git a/third_party/blink/renderer/core/layout/ng/flex/ng_flex_layout_algorithm.cc b/third_party/blink/renderer/core/layout/ng/flex/ng_flex_layout_algorithm.cc
+index d2eb9aca5..e71d054d4 100644
+--- a/third_party/blink/renderer/core/layout/ng/flex/ng_flex_layout_algorithm.cc
++++ b/third_party/blink/renderer/core/layout/ng/flex/ng_flex_layout_algorithm.cc
+@@ -45,11 +45,11 @@ namespace blink {
+ 
+ namespace {
+ 
+-class BaselineAccumulator {
++class BaselineAccumulatorFlex {
+   STACK_ALLOCATED();
+ 
+  public:
+-  explicit BaselineAccumulator(const ComputedStyle& style)
++  explicit BaselineAccumulatorFlex(const ComputedStyle& style)
+       : font_baseline_(style.GetFontBaseline()) {}
+ 
+   void AccumulateItem(const NGBoxFragment& fragment,
+@@ -187,10 +187,10 @@ LayoutUnit NGFlexLayoutAlgorithm::MainAxisContentExtent(
+ 
+ namespace {
+ 
+-enum AxisEdge { kStart, kCenter, kEnd };
++enum class LocalAxisEdge { kStart, kCenter, kEnd };
+ 
+ // Maps the resolved justify-content value to a static-position edge.
+-AxisEdge MainAxisStaticPositionEdge(const ComputedStyle& style,
++LocalAxisEdge MainAxisStaticPositionEdge(const ComputedStyle& style,
+                                     bool is_column) {
+   const StyleContentAlignmentData justify =
+       FlexLayoutAlgorithm::ResolvedJustifyContent(style);
+@@ -202,23 +202,23 @@ AxisEdge MainAxisStaticPositionEdge(const ComputedStyle& style,
+   DCHECK_NE(content_position, ContentPosition::kLeft);
+   DCHECK_NE(content_position, ContentPosition::kRight);
+   if (content_position == ContentPosition::kFlexEnd)
+-    return is_reverse_flex ? AxisEdge::kStart : AxisEdge::kEnd;
++    return is_reverse_flex ? LocalAxisEdge::kStart : LocalAxisEdge::kEnd;
+ 
+   if (content_position == ContentPosition::kCenter ||
+       justify.Distribution() == ContentDistributionType::kSpaceAround ||
+       justify.Distribution() == ContentDistributionType::kSpaceEvenly)
+-    return AxisEdge::kCenter;
++    return LocalAxisEdge::kCenter;
+ 
+   if (content_position == ContentPosition::kStart)
+-    return AxisEdge::kStart;
++    return LocalAxisEdge::kStart;
+   if (content_position == ContentPosition::kEnd)
+-    return AxisEdge::kEnd;
++    return LocalAxisEdge::kEnd;
+ 
+-  return is_reverse_flex ? AxisEdge::kEnd : AxisEdge::kStart;
++  return is_reverse_flex ? LocalAxisEdge::kEnd : LocalAxisEdge::kStart;
+ }
+ 
+ // Maps the resolved alignment value to a static-position edge.
+-AxisEdge CrossAxisStaticPositionEdge(const ComputedStyle& style,
++LocalAxisEdge CrossAxisStaticPositionEdge(const ComputedStyle& style,
+                                      const ComputedStyle& child_style) {
+   ItemPosition alignment =
+       FlexLayoutAlgorithm::AlignmentForChild(style, child_style);
+@@ -226,17 +226,17 @@ AxisEdge CrossAxisStaticPositionEdge(const ComputedStyle& style,
+   // kFlexEnd, but not kStretch. kStretch is supposed to act like kFlexStart.
+   if (style.FlexWrap() == EFlexWrap::kWrapReverse &&
+       alignment == ItemPosition::kStretch) {
+-    return AxisEdge::kEnd;
++    return LocalAxisEdge::kEnd;
+   }
+ 
+   if (alignment == ItemPosition::kFlexEnd ||
+       alignment == ItemPosition::kLastBaseline)
+-    return AxisEdge::kEnd;
++    return LocalAxisEdge::kEnd;
+ 
+   if (alignment == ItemPosition::kCenter)
+-    return AxisEdge::kCenter;
++    return LocalAxisEdge::kCenter;
+ 
+-  return AxisEdge::kStart;
++  return LocalAxisEdge::kStart;
+ }
+ 
+ }  // namespace
+@@ -289,8 +289,8 @@ void NGFlexLayoutAlgorithm::HandleOutOfFlowPositionedItems(
+   for (LayoutBox* oof_child : oofs) {
+     NGBlockNode child(oof_child);
+ 
+-    AxisEdge main_axis_edge = MainAxisStaticPositionEdge(Style(), is_column_);
+-    AxisEdge cross_axis_edge =
++    LocalAxisEdge main_axis_edge = MainAxisStaticPositionEdge(Style(), is_column_);
++    LocalAxisEdge cross_axis_edge =
+         CrossAxisStaticPositionEdge(Style(), child.Style());
+ 
+     // This code block just collects UMA stats.
+@@ -321,7 +321,7 @@ void NGFlexLayoutAlgorithm::HandleOutOfFlowPositionedItems(
+                             WebFeature::kFlexboxNewAbsPos);
+         }
+       }
+-      if (main_axis_edge != AxisEdge::kStart) {
++      if (main_axis_edge != LocalAxisEdge::kStart) {
+         const bool are_main_axis_insets_auto =
+             is_column_
+                 ? insets_in_flexbox_writing_mode.BlockStart().IsAuto() &&
+@@ -335,18 +335,18 @@ void NGFlexLayoutAlgorithm::HandleOutOfFlowPositionedItems(
+       }
+     }
+ 
+-    AxisEdge inline_axis_edge = is_column_ ? cross_axis_edge : main_axis_edge;
+-    AxisEdge block_axis_edge = is_column_ ? main_axis_edge : cross_axis_edge;
++    LocalAxisEdge inline_axis_edge = is_column_ ? cross_axis_edge : main_axis_edge;
++    LocalAxisEdge block_axis_edge = is_column_ ? main_axis_edge : cross_axis_edge;
+ 
+     InlineEdge inline_edge;
+     BlockEdge block_edge;
+     LogicalOffset offset = border_scrollbar_padding.StartOffset();
+ 
+     // Determine the static-position based off the axis-edge.
+-    if (block_axis_edge == AxisEdge::kStart) {
++    if (block_axis_edge == LocalAxisEdge::kStart) {
+       DCHECK(!IsBreakInside(BreakToken()));
+       block_edge = BlockEdge::kBlockStart;
+-    } else if (block_axis_edge == AxisEdge::kCenter) {
++    } else if (block_axis_edge == LocalAxisEdge::kCenter) {
+       if (!should_process_block_center) {
+         oof_children.emplace_back(oof_child);
+         continue;
+@@ -362,9 +362,9 @@ void NGFlexLayoutAlgorithm::HandleOutOfFlowPositionedItems(
+       offset.block_offset += total_fragment_size.block_size;
+     }
+ 
+-    if (inline_axis_edge == AxisEdge::kStart) {
++    if (inline_axis_edge == LocalAxisEdge::kStart) {
+       inline_edge = InlineEdge::kInlineStart;
+-    } else if (inline_axis_edge == AxisEdge::kCenter) {
++    } else if (inline_axis_edge == LocalAxisEdge::kCenter) {
+       inline_edge = InlineEdge::kInlineCenter;
+       offset.inline_offset += total_fragment_size.inline_size / 2;
+     } else {
+@@ -1431,7 +1431,7 @@ NGLayoutResult::EStatus NGFlexLayoutAlgorithm::GiveItemsFinalPositionAndSize(
+     }
+   }
+ 
+-  BaselineAccumulator baseline_accumulator(Style());
++  BaselineAccumulatorFlex baseline_accumulator(Style());
+   NGLayoutResult::EStatus status = NGLayoutResult::kSuccess;
+ 
+   for (wtf_size_t flex_line_idx = 0; flex_line_idx < flex_line_outputs->size();
+@@ -1578,7 +1578,7 @@ NGFlexLayoutAlgorithm::GiveItemsFinalPositionAndSizeForFragmentation(
+   if (BreakToken())
+     previously_consumed_block_size = BreakToken()->ConsumedBlockSize();
+ 
+-  BaselineAccumulator baseline_accumulator(Style());
++  BaselineAccumulatorFlex baseline_accumulator(Style());
+   for (auto entry = item_iterator.NextItem(*broke_before_row);
+        NGFlexItem* flex_item = entry.flex_item;
+        entry = item_iterator.NextItem(*broke_before_row)) {
+diff --git a/third_party/blink/renderer/core/layout/ng/grid/ng_grid_item.cc b/third_party/blink/renderer/core/layout/ng/grid/ng_grid_item.cc
+index 535785221..88d3ca2d7 100644
+--- a/third_party/blink/renderer/core/layout/ng/grid/ng_grid_item.cc
++++ b/third_party/blink/renderer/core/layout/ng/grid/ng_grid_item.cc
+@@ -241,12 +241,12 @@ void GridItemData::SetAlignmentFallback(
+   if (!CanParticipateInBaselineAlignment()) {
+     const auto baseline_group = BaselineGroup(track_direction);
+     if (track_direction == kForColumns) {
+-      inline_axis_alignment_fallback = baseline_group == BaselineGroup::kMajor
++      inline_axis_alignment_fallback = baseline_group == BaselineGroupType::kMajor
+                                            ? AxisEdge::kStart
+                                            : AxisEdge::kEnd;
+       is_inline_axis_overflow_safe_fallback = true;
+     } else {
+-      block_axis_alignment_fallback = baseline_group == BaselineGroup::kMajor
++      block_axis_alignment_fallback = baseline_group == BaselineGroupType::kMajor
+                                           ? AxisEdge::kStart
+                                           : AxisEdge::kEnd;
+       is_block_axis_overflow_safe_fallback = true;
+diff --git a/third_party/blink/renderer/core/layout/ng/grid/ng_grid_item.h b/third_party/blink/renderer/core/layout/ng/grid/ng_grid_item.h
+index c331808b7..927a5b423 100644
+--- a/third_party/blink/renderer/core/layout/ng/grid/ng_grid_item.h
++++ b/third_party/blink/renderer/core/layout/ng/grid/ng_grid_item.h
+@@ -94,7 +94,7 @@ struct CORE_EXPORT GridItemData {
+       const NGGridPlacementData& placement_data,
+       const ComputedStyle& grid_style);
+ 
+-  enum BaselineGroup BaselineGroup(
++  enum BaselineGroupType BaselineGroup(
+       GridTrackSizingDirection track_direction) const {
+     return (track_direction == kForColumns) ? column_baseline_group
+                                             : row_baseline_group;
+@@ -213,8 +213,8 @@ struct CORE_EXPORT GridItemData {
+   NGAutoBehavior inline_auto_behavior;
+   NGAutoBehavior block_auto_behavior;
+ 
+-  enum BaselineGroup column_baseline_group;
+-  enum BaselineGroup row_baseline_group;
++  enum BaselineGroupType column_baseline_group;
++  enum BaselineGroupType row_baseline_group;
+ 
+   WritingMode column_baseline_writing_mode;
+   WritingMode row_baseline_writing_mode;
+diff --git a/third_party/blink/renderer/core/layout/ng/grid/ng_grid_layout_algorithm.cc b/third_party/blink/renderer/core/layout/ng/grid/ng_grid_layout_algorithm.cc
+index feca36f0e..268492cfd 100644
+--- a/third_party/blink/renderer/core/layout/ng/grid/ng_grid_layout_algorithm.cc
++++ b/third_party/blink/renderer/core/layout/ng/grid/ng_grid_layout_algorithm.cc
+@@ -692,13 +692,13 @@ LayoutUnit NGGridLayoutAlgorithm::Baseline(
+   //  alignment context along that axis"
+   // https://www.w3.org/TR/css-align-3/#baseline-sharing-group
+   if (track_direction == kForColumns) {
+-    return (grid_item.column_baseline_group == BaselineGroup::kMajor)
++    return (grid_item.column_baseline_group == BaselineGroupType::kMajor)
+                ? layout_data.Columns().MajorBaseline(
+                      grid_item.column_set_indices.begin)
+                : layout_data.Columns().MinorBaseline(
+                      grid_item.column_set_indices.end - 1);
+   } else {
+-    return (grid_item.row_baseline_group == BaselineGroup::kMajor)
++    return (grid_item.row_baseline_group == BaselineGroupType::kMajor)
+                ? layout_data.Rows().MajorBaseline(
+                      grid_item.row_set_indices.begin)
+                : layout_data.Rows().MinorBaseline(
+@@ -1487,7 +1487,7 @@ void NGGridLayoutAlgorithm::CalculateAlignmentBaselines(
+     //  in first/last baseline alignment within its start-most/end-most shared
+     //  alignment context along that axis"
+     // https://www.w3.org/TR/css-align-3/#baseline-sharing-group
+-    if (grid_item.BaselineGroup(track_direction) == BaselineGroup::kMajor) {
++    if (grid_item.BaselineGroup(track_direction) == BaselineGroupType::kMajor) {
+       track_collection->SetMajorBaseline(
+           grid_item.SetIndices(track_direction).begin, baseline);
+     } else {
+@@ -2893,11 +2893,11 @@ namespace {
+ // opposed to DOM order). The baseline of the grid is determined by the first
+ // grid item with baseline alignment in the first row. If no items have
+ // baseline alignment, fall back to the first item in row-major order.
+-class BaselineAccumulator {
++class BaselineAccumulatorGrid {
+   STACK_ALLOCATED();
+ 
+  public:
+-  explicit BaselineAccumulator(FontBaseline font_baseline)
++  explicit BaselineAccumulatorGrid(FontBaseline font_baseline)
+       : font_baseline_(font_baseline) {}
+ 
+   void Accumulate(const GridItemData& grid_item,
+@@ -3041,7 +3041,7 @@ void NGGridLayoutAlgorithm::PlaceGridItems(
+         layout_data.Rows().GetSetCount() + 1, EBreakBetween::kAuto);
+   }
+ 
+-  BaselineAccumulator baseline_accumulator(Style().GetFontBaseline());
++  BaselineAccumulatorGrid baseline_accumulator(Style().GetFontBaseline());
+ 
+   for (const auto& grid_item : grid_items) {
+     LogicalRect containing_grid_area;
+@@ -3071,7 +3071,7 @@ void NGGridLayoutAlgorithm::PlaceGridItems(
+           GetLogicalBaseline(
+               baseline_fragment,
+               grid_item.IsLastBaselineSpecifiedForDirection(track_direction));
+-      if (grid_item.BaselineGroup(track_direction) == BaselineGroup::kMajor)
++      if (grid_item.BaselineGroup(track_direction) == BaselineGroupType::kMajor)
+         return baseline_delta;
+ 
+       // BaselineGroup::kMinor
+@@ -3239,7 +3239,7 @@ void NGGridLayoutAlgorithm::PlaceGridItemsForFragmentation(
+ 
+   HeapVector<ResultAndOffsets> result_and_offsets;
+   HeapVector<GridItemPlacementData*> out_of_fragmentainer_space_item_placement;
+-  BaselineAccumulator baseline_accumulator(Style().GetFontBaseline());
++  BaselineAccumulatorGrid baseline_accumulator(Style().GetFontBaseline());
+   LayoutUnit max_row_expansion;
+   wtf_size_t expansion_row_set_index;
+   wtf_size_t breakpoint_row_set_index;
+@@ -3265,7 +3265,7 @@ void NGGridLayoutAlgorithm::PlaceGridItemsForFragmentation(
+     // Reset our state.
+     result_and_offsets.clear();
+     out_of_fragmentainer_space_item_placement.clear();
+-    baseline_accumulator = BaselineAccumulator(Style().GetFontBaseline());
++    baseline_accumulator = BaselineAccumulatorGrid(Style().GetFontBaseline());
+     max_row_expansion = LayoutUnit();
+     expansion_row_set_index = kNotFound;
+     breakpoint_row_set_index = kNotFound;
+diff --git a/third_party/blink/renderer/core/layout/ng/mathml/ng_math_scripts_layout_algorithm.cc b/third_party/blink/renderer/core/layout/ng/mathml/ng_math_scripts_layout_algorithm.cc
+index 624faa207..be8ae12f6 100644
+--- a/third_party/blink/renderer/core/layout/ng/mathml/ng_math_scripts_layout_algorithm.cc
++++ b/third_party/blink/renderer/core/layout/ng/mathml/ng_math_scripts_layout_algorithm.cc
+@@ -15,7 +15,7 @@ namespace {
+ 
+ using MathConstants = OpenTypeMathSupport::MathConstants;
+ 
+-static bool IsPrescriptDelimiter(const NGBlockNode& blockNode) {
++bool MyIsPrescriptDelimiter(const NGBlockNode& blockNode) {
+   auto* node = blockNode.GetDOMNode();
+   return node && IsA<MathMLElement>(node) &&
+          node->HasTagName(mathml_names::kMprescriptsTag);
+@@ -147,7 +147,7 @@ void NGMathScriptsLayoutAlgorithm::GatherChildren(
+       case MathScriptType::kMultiscripts: {
+         // The structure of mmultiscripts is specified here:
+         // https://w3c.github.io/mathml-core/#prescripts-and-tensor-indices-mmultiscripts
+-        if (IsPrescriptDelimiter(block_child)) {
++        if (MyIsPrescriptDelimiter(block_child)) {
+           if (!number_of_scripts_is_even || *prescripts) {
+             NOTREACHED();
+             return;
+diff --git a/third_party/blink/renderer/core/layout/ng/ng_baseline_utils.h b/third_party/blink/renderer/core/layout/ng/ng_baseline_utils.h
+index 252a3c761..99f7a5275 100644
+--- a/third_party/blink/renderer/core/layout/ng/ng_baseline_utils.h
++++ b/third_party/blink/renderer/core/layout/ng/ng_baseline_utils.h
+@@ -9,7 +9,7 @@
+ 
+ namespace blink {
+ 
+-enum class BaselineGroup { kMajor, kMinor };
++enum class BaselineGroupType { kMajor, kMinor };
+ 
+ // Determines the writing-mode to read a baseline from a fragment.
+ inline WritingMode DetermineBaselineWritingMode(
+@@ -48,7 +48,7 @@ inline WritingMode DetermineBaselineWritingMode(
+ //
+ // We label these "major"/"minor" to separate them. The "major" group should be
+ // aligned to the appropriate "start" axis.
+-inline BaselineGroup DetermineBaselineGroup(
++inline BaselineGroupType DetermineBaselineGroup(
+     const WritingDirectionMode container_writing_direction,
+     const WritingMode baseline_writing_mode,
+     bool is_parallel_context,
+@@ -57,8 +57,8 @@ inline BaselineGroup DetermineBaselineGroup(
+   const auto container_writing_mode =
+       container_writing_direction.GetWritingMode();
+ 
+-  auto start_group = BaselineGroup::kMajor;
+-  auto end_group = BaselineGroup::kMinor;
++  auto start_group = BaselineGroupType::kMajor;
++  auto end_group = BaselineGroupType::kMinor;
+   if (is_last_baseline)
+     std::swap(start_group, end_group);
+   if (is_flipped)
+@@ -86,7 +86,7 @@ inline BaselineGroup DetermineBaselineGroup(
+   }
+ 
+   NOTREACHED();
+-  return BaselineGroup::kMinor;
++  return BaselineGroupType::kMinor;
+ }
+ 
+ }  // namespace blink
+diff --git a/third_party/blink/renderer/core/page/drag_image.cc b/third_party/blink/renderer/core/page/drag_image.cc
+index d4be264a7..92a0f5372 100644
+--- a/third_party/blink/renderer/core/page/drag_image.cc
++++ b/third_party/blink/renderer/core/page/drag_image.cc
+@@ -53,6 +53,9 @@
+ #include "ui/gfx/geometry/point_f.h"
+ #include "ui/gfx/geometry/rect_f.h"
+ 
++// To avoid conflicts with the DrawText macro from the Windows SDK...
++#undef DrawText
++
+ namespace blink {
+ 
+ namespace {
+diff --git a/third_party/blink/renderer/core/paint/ng/ng_highlight_painter.cc b/third_party/blink/renderer/core/paint/ng/ng_highlight_painter.cc
+index ef4e16c90..cf52e521b 100644
+--- a/third_party/blink/renderer/core/paint/ng/ng_highlight_painter.cc
++++ b/third_party/blink/renderer/core/paint/ng/ng_highlight_painter.cc
+@@ -63,7 +63,7 @@ DocumentMarkerVector MarkersFor(Node* node, DocumentMarker::MarkerType type) {
+   return controller.MarkersFor(*text_node, DocumentMarker::MarkerTypes{type});
+ }
+ 
+-unsigned GetTextContentOffset(const Text& text, unsigned offset) {
++unsigned GetTextContentOffset2(const Text& text, unsigned offset) {
+   // TODO(yoichio): Sanitize DocumentMarker around text length.
+   const Position position(text, std::min(offset, text.length()));
+   const NGOffsetMapping* const offset_mapping =
+@@ -607,9 +607,9 @@ void NGHighlightPainter::Paint(Phase phase) {
+ 
+   for (const DocumentMarker* marker : markers_) {
+     const unsigned marker_start_offset =
+-        GetTextContentOffset(text_node, marker->StartOffset());
++        GetTextContentOffset2(text_node, marker->StartOffset());
+     const unsigned marker_end_offset =
+-        GetTextContentOffset(text_node, marker->EndOffset());
++        GetTextContentOffset2(text_node, marker->EndOffset());
+     const unsigned paint_start_offset =
+         ClampOffset(marker_start_offset, fragment_item_);
+     const unsigned paint_end_offset =
+@@ -842,9 +842,9 @@ void NGHighlightPainter::FastPaintSpellingGrammarDecorations(
+     const DocumentMarkerVector& markers) {
+   for (const DocumentMarker* marker : markers) {
+     const unsigned marker_start_offset =
+-        GetTextContentOffset(text_node, marker->StartOffset());
++        GetTextContentOffset2(text_node, marker->StartOffset());
+     const unsigned marker_end_offset =
+-        GetTextContentOffset(text_node, marker->EndOffset());
++        GetTextContentOffset2(text_node, marker->EndOffset());
+     const unsigned paint_start_offset =
+         ClampOffset(marker_start_offset, fragment_item_);
+     const unsigned paint_end_offset =
+@@ -995,9 +995,9 @@ void NGHighlightPainter::PaintHighlightOverlays(
+       }
+ 
+       const unsigned content_start =
+-          GetTextContentOffset(*text_node, marker->StartOffset());
++          GetTextContentOffset2(*text_node, marker->StartOffset());
+       const unsigned content_end =
+-          GetTextContentOffset(*text_node, marker->EndOffset());
++          GetTextContentOffset2(*text_node, marker->EndOffset());
+       const unsigned clamped_start = ClampOffset(content_start, fragment_item_);
+       const unsigned clamped_end = ClampOffset(content_end, fragment_item_);
+       const unsigned length = clamped_end - clamped_start;
+diff --git a/third_party/blink/renderer/core/paint/pre_paint_tree_walk.cc b/third_party/blink/renderer/core/paint/pre_paint_tree_walk.cc
+index 9de1b3087..1cb167945 100644
+--- a/third_party/blink/renderer/core/paint/pre_paint_tree_walk.cc
++++ b/third_party/blink/renderer/core/paint/pre_paint_tree_walk.cc
+@@ -33,7 +33,7 @@ namespace blink {
+ 
+ namespace {
+ 
+-bool IsLinkHighlighted(const LayoutObject& object) {
++bool IsLinkHighlightedPPTW(const LayoutObject& object) {
+   return object.GetFrame()->GetPage()->GetLinkHighlight().IsHighlighting(
+       object);
+ }
+@@ -421,7 +421,7 @@ FragmentData* PrePaintTreeWalk::GetOrCreateFragmentData(
+       // is the highlighted link (in which case even culled inlines get paint
+       // effects).
+       if (!object.IsBox() && !object.HasInlineFragments() &&
+-          !IsLinkHighlighted(object))
++          !IsLinkHighlightedPPTW(object))
+         return nullptr;
+ 
+       DCHECK(allow_update);
+diff --git a/third_party/blink/renderer/core/speculation_rules/speculation_rule_set.cc b/third_party/blink/renderer/core/speculation_rules/speculation_rule_set.cc
+index c0087c50c..f5d0e7307 100644
+--- a/third_party/blink/renderer/core/speculation_rules/speculation_rule_set.cc
++++ b/third_party/blink/renderer/core/speculation_rules/speculation_rule_set.cc
+@@ -53,7 +53,7 @@ bool IsValidBrowsingContextNameOrKeyword(const String& name_or_keyword) {
+ 
+ // If `out_error` is provided and hasn't already had a message set, sets it to
+ // `message`.
+-void SetParseErrorMessage(String* out_error, String message) {
++void SetParseErrorMessage2(String* out_error, String message) {
+   if (out_error && out_error->IsNull()) {
+     *out_error = message;
+   }
+@@ -85,7 +85,7 @@ SpeculationRule* ParseSpeculationRule(JSONObject* input,
+     const String& input_key = input->at(i).first;
+     if (!base::Contains(kKnownKeys, input_key) &&
+         !base::Contains(kConditionalKnownKeys, input_key)) {
+-      SetParseErrorMessage(
++      SetParseErrorMessage2(
+           out_error, "A rule contains an unknown key: \"" + input_key + "\".");
+       return nullptr;
+     }
+@@ -101,11 +101,11 @@ SpeculationRule* ParseSpeculationRule(JSONObject* input,
+   // string "document", then return null.
+   String source;
+   if (!input->GetString("source", &source)) {
+-    SetParseErrorMessage(out_error, "A rule must have a source.");
++    SetParseErrorMessage2(out_error, "A rule must have a source.");
+     return nullptr;
+   }
+   if (!(source == "list" || (document_rules_enabled && source == "document"))) {
+-    SetParseErrorMessage(out_error,
++    SetParseErrorMessage2(out_error,
+                          "A rule has an unknown source: \"" + source + "\".");
+     return nullptr;
+   }
+@@ -114,7 +114,7 @@ SpeculationRule* ParseSpeculationRule(JSONObject* input,
+   if (source == "list") {
+     // If input["where"] exists, then return null.
+     if (input->Get("where")) {
+-      SetParseErrorMessage(out_error,
++      SetParseErrorMessage2(out_error,
+                            "A list rule may not have document rule matchers.");
+       return nullptr;
+     }
+@@ -129,7 +129,7 @@ SpeculationRule* ParseSpeculationRule(JSONObject* input,
+       // "document", then return null.
+       if (!relative_to_enabled || !relative_to->AsString(&value) ||
+           !base::Contains(kKnownRelativeToValues, value)) {
+-        SetParseErrorMessage(out_error,
++        SetParseErrorMessage2(out_error,
+                              "A rule has an unknown \"relative_to\" value.");
+         return nullptr;
+       }
+@@ -145,7 +145,7 @@ SpeculationRule* ParseSpeculationRule(JSONObject* input,
+     // is not a string, then return null.
+     JSONArray* input_urls = input->GetArray("urls");
+     if (!input_urls) {
+-      SetParseErrorMessage(out_error,
++      SetParseErrorMessage2(out_error,
+                            "A list rule must have a \"urls\" array.");
+       return nullptr;
+     }
+@@ -155,7 +155,7 @@ SpeculationRule* ParseSpeculationRule(JSONObject* input,
+     for (wtf_size_t i = 0; i < input_urls->size(); ++i) {
+       String url_string;
+       if (!input_urls->at(i)->AsString(&url_string)) {
+-        SetParseErrorMessage(out_error, "URLs must be given as strings.");
++        SetParseErrorMessage2(out_error, "URLs must be given as strings.");
+         return nullptr;
+       }
+ 
+@@ -174,7 +174,7 @@ SpeculationRule* ParseSpeculationRule(JSONObject* input,
+     DCHECK(document_rules_enabled);
+     // If input["urls"] exists, then return null.
+     if (input->Get("urls")) {
+-      SetParseErrorMessage(out_error,
++      SetParseErrorMessage2(out_error,
+                            "A document rule cannot have a \"urls\" key.");
+       return nullptr;
+     }
+@@ -182,7 +182,7 @@ SpeculationRule* ParseSpeculationRule(JSONObject* input,
+     // "relative_to" outside the "href_matches" clause is not allowed for
+     // document rules.
+     if (input->Get("relative_to")) {
+-      SetParseErrorMessage(out_error,
++      SetParseErrorMessage2(out_error,
+                            "A document rule cannot have \"relative_to\" "
+                            "outside the \"where\" clause.");
+       return nullptr;
+@@ -208,7 +208,7 @@ SpeculationRule* ParseSpeculationRule(JSONObject* input,
+   // If input["requires"] exists, but is not a list, then return null.
+   JSONValue* requirements = input->Get("requires");
+   if (requirements && requirements->GetType() != JSONValue::kTypeArray) {
+-    SetParseErrorMessage(out_error, "\"requires\" must be an array.");
++    SetParseErrorMessage2(out_error, "\"requires\" must be an array.");
+     return nullptr;
+   }
+ 
+@@ -219,7 +219,7 @@ SpeculationRule* ParseSpeculationRule(JSONObject* input,
+     for (wtf_size_t i = 0; i < requirements_array->size(); ++i) {
+       String requirement;
+       if (!requirements_array->at(i)->AsString(&requirement)) {
+-        SetParseErrorMessage(out_error, "Requirements must be strings.");
++        SetParseErrorMessage2(out_error, "Requirements must be strings.");
+         return nullptr;
+       }
+ 
+@@ -227,7 +227,7 @@ SpeculationRule* ParseSpeculationRule(JSONObject* input,
+         requires_anonymous_client_ip =
+             SpeculationRule::RequiresAnonymousClientIPWhenCrossOrigin(true);
+       } else {
+-        SetParseErrorMessage(
++        SetParseErrorMessage2(
+             out_error,
+             "A rule has an unknown requirement: \"" + requirement + "\".");
+         return nullptr;
+@@ -246,11 +246,11 @@ SpeculationRule* ParseSpeculationRule(JSONObject* input,
+     // Set targetHint to input["target_hint"].
+     String target_hint_str;
+     if (!target_hint_value->AsString(&target_hint_str)) {
+-      SetParseErrorMessage(out_error, "\"target_hint\" must be a string.");
++      SetParseErrorMessage2(out_error, "\"target_hint\" must be a string.");
+       return nullptr;
+     }
+     if (!IsValidBrowsingContextNameOrKeyword(target_hint_str)) {
+-      SetParseErrorMessage(out_error,
++      SetParseErrorMessage2(out_error,
+                            "A rule has an invalid \"target_hint\": \"" +
+                                target_hint_str + "\".");
+       return nullptr;
+@@ -276,7 +276,7 @@ SpeculationRule* ParseSpeculationRule(JSONObject* input,
+ 
+     String referrer_policy_str;
+     if (!referrer_policy_value->AsString(&referrer_policy_str)) {
+-      SetParseErrorMessage(out_error, "A referrer policy must be a string.");
++      SetParseErrorMessage2(out_error, "A referrer policy must be a string.");
+       return nullptr;
+     }
+ 
+@@ -286,7 +286,7 @@ SpeculationRule* ParseSpeculationRule(JSONObject* input,
+       if (!SecurityPolicy::ReferrerPolicyFromString(
+               referrer_policy_str, kDoNotSupportReferrerPolicyLegacyKeywords,
+               &referrer_policy_out)) {
+-        SetParseErrorMessage(out_error,
++        SetParseErrorMessage2(out_error,
+                              "A rule has an invalid referrer policy: \"" +
+                                  referrer_policy_str + "\".");
+         return nullptr;
+@@ -303,7 +303,7 @@ SpeculationRule* ParseSpeculationRule(JSONObject* input,
+ 
+     String eagerness_str;
+     if (!eagerness_value->AsString(&eagerness_str)) {
+-      SetParseErrorMessage(out_error, "Eagerness value must be a string.");
++      SetParseErrorMessage2(out_error, "Eagerness value must be a string.");
+       return nullptr;
+     }
+ 
+@@ -314,7 +314,7 @@ SpeculationRule* ParseSpeculationRule(JSONObject* input,
+     } else if (eagerness_str == "conservative") {
+       eagerness = mojom::blink::SpeculationEagerness::kConservative;
+     } else {
+-      SetParseErrorMessage(
++      SetParseErrorMessage2(
+           out_error, "Eagerness value: \"" + eagerness_str + "\" is invalid.");
+       return nullptr;
+     }
+@@ -389,7 +389,7 @@ SpeculationRuleSet* SpeculationRuleSet::Parse(Source* source,
+ 
+   // If parsed is not a map, then return null.
+   if (!parsed) {
+-    SetParseErrorMessage(out_error,
++    SetParseErrorMessage2(out_error,
+                          parse_error.type != JSONParseErrorType::kNoError
+                              ? parse_error.message
+                              : "Parsed JSON must be an object.");
+@@ -412,7 +412,7 @@ SpeculationRuleSet* SpeculationRuleSet::Parse(Source* source,
+           // If prefetch/prerenderRule is not a map, then continue.
+           JSONObject* input_rule = JSONObject::Cast(array->at(i));
+           if (!input_rule) {
+-            SetParseErrorMessage(out_error, "A rule must be an object.");
++            SetParseErrorMessage2(out_error, "A rule must be an object.");
+             continue;
+           }
+ 
+@@ -429,7 +429,7 @@ SpeculationRuleSet* SpeculationRuleSet::Parse(Source* source,
+           // continue.
+           if (!allow_target_hint &&
+               rule->target_browsing_context_name_hint().has_value()) {
+-            SetParseErrorMessage(
++            SetParseErrorMessage2(
+                 out_error, "\"target_hint\" may not be set for " + String(key) +
+                                " rules.");
+             continue;
+diff --git a/third_party/blink/renderer/core/timing/performance_timing.cc b/third_party/blink/renderer/core/timing/performance_timing.cc
+index 3e35c36b1..cc909e28d 100644
+--- a/third_party/blink/renderer/core/timing/performance_timing.cc
++++ b/third_party/blink/renderer/core/timing/performance_timing.cc
+@@ -25,7 +25,7 @@
+ // Legacy support for NT1(https://www.w3.org/TR/navigation-timing/).
+ namespace blink {
+ 
+-static uint64_t ToIntegerMilliseconds(base::TimeDelta duration,
++static uint64_t ToIntegerMilliseconds2(base::TimeDelta duration,
+                                       bool cross_origin_isolated_capability) {
+   // TODO(npm): add histograms to understand when/why |duration| is sometimes
+   // negative.
+@@ -345,8 +345,8 @@ uint64_t PerformanceTiming::MonotonicTimeToIntegerMilliseconds(
+   if (!timing)
+     return 0;
+ 
+-  return ToIntegerMilliseconds(timing->MonotonicTimeToPseudoWallTime(time),
+-                               cross_origin_isolated_capability_);
++  return ToIntegerMilliseconds2(timing->MonotonicTimeToPseudoWallTime(time),
++                                cross_origin_isolated_capability_);
+ }
+ 
+ // static
+diff --git a/third_party/blink/renderer/modules/accessibility/inspector_type_builder_helper.cc b/third_party/blink/renderer/modules/accessibility/inspector_type_builder_helper.cc
+index 48bbff80c..2dedfd18b 100644
+--- a/third_party/blink/renderer/modules/accessibility/inspector_type_builder_helper.cc
++++ b/third_party/blink/renderer/modules/accessibility/inspector_type_builder_helper.cc
+@@ -18,7 +18,7 @@ std::unique_ptr<AXProperty> CreateProperty(const String& name,
+   return AXProperty::create().setName(name).setValue(std::move(value)).build();
+ }
+ 
+-String IgnoredReasonName(AXIgnoredReason reason) {
++static String IgnoredReasonName_ITBH(AXIgnoredReason reason) {
+   switch (reason) {
+     case kAXActiveFullscreenElement:
+       return "activeFullscreenElement";
+@@ -60,10 +60,10 @@ String IgnoredReasonName(AXIgnoredReason reason) {
+ std::unique_ptr<AXProperty> CreateProperty(IgnoredReason reason) {
+   if (reason.related_object)
+     return CreateProperty(
+-        IgnoredReasonName(reason.reason),
++        IgnoredReasonName_ITBH(reason.reason),
+         CreateRelatedNodeListValue(*(reason.related_object), nullptr,
+                                    AXValueTypeEnum::Idref));
+-  return CreateProperty(IgnoredReasonName(reason.reason),
++  return CreateProperty(IgnoredReasonName_ITBH(reason.reason),
+                         CreateBooleanValue(true));
+ }
+ 
+diff --git a/third_party/blink/renderer/modules/bluetooth/bluetooth_device.cc b/third_party/blink/renderer/modules/bluetooth/bluetooth_device.cc
+index 18baec1da..e40ea6b14 100644
+--- a/third_party/blink/renderer/modules/bluetooth/bluetooth_device.cc
++++ b/third_party/blink/renderer/modules/bluetooth/bluetooth_device.cc
+@@ -27,7 +27,7 @@
+ namespace blink {
+ 
+ const char kAbortErrorMessage[] = "The Bluetooth operation was cancelled.";
+-const char kInactiveDocumentError[] = "Document not active";
++const char kInactiveDocumentError2[] = "Document not active";
+ const char kInvalidStateErrorMessage[] =
+     "Pending watch advertisements operation.";
+ 
+@@ -113,7 +113,7 @@ ScriptPromise BluetoothDevice::watchAdvertisements(
+     ExceptionState& exception_state) {
+   ExecutionContext* context = GetExecutionContext();
+   if (!context) {
+-    exception_state.ThrowTypeError(kInactiveDocumentError);
++    exception_state.ThrowTypeError(kInactiveDocumentError2);
+     return ScriptPromise();
+   }
+ 
+@@ -204,7 +204,7 @@ void BluetoothDevice::AbortWatchAdvertisements(AbortSignal* signal) {
+ ScriptPromise BluetoothDevice::forget(ScriptState* script_state,
+                                       ExceptionState& exception_state) {
+   if (!GetExecutionContext()) {
+-    exception_state.ThrowTypeError(kInactiveDocumentError);
++    exception_state.ThrowTypeError(kInactiveDocumentError2);
+     return ScriptPromise();
+   }
+ 
+diff --git a/third_party/blink/renderer/modules/breakout_box/media_stream_video_track_underlying_sink.cc b/third_party/blink/renderer/modules/breakout_box/media_stream_video_track_underlying_sink.cc
+index f9f383bf5..d2f08a988 100644
+--- a/third_party/blink/renderer/modules/breakout_box/media_stream_video_track_underlying_sink.cc
++++ b/third_party/blink/renderer/modules/breakout_box/media_stream_video_track_underlying_sink.cc
+@@ -37,9 +37,9 @@ BASE_FEATURE(kBreakoutBoxEagerConversion,
+ #endif
+ );
+ 
+-class TransferringOptimizer : public WritableStreamTransferringOptimizer {
++class TransferringOptimizerMSVTUS : public WritableStreamTransferringOptimizer {
+  public:
+-  explicit TransferringOptimizer(
++  explicit TransferringOptimizerMSVTUS(
+       scoped_refptr<PushableMediaStreamVideoSource::Broker> source_broker)
+       : source_broker_(std::move(source_broker)) {}
+   UnderlyingSinkBase* PerformInProcessOptimization(
+@@ -145,7 +145,7 @@ ScriptPromise MediaStreamVideoTrackUnderlyingSink::close(
+ std::unique_ptr<WritableStreamTransferringOptimizer>
+ MediaStreamVideoTrackUnderlyingSink::GetTransferringOptimizer() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+-  return std::make_unique<TransferringOptimizer>(source_broker_);
++  return std::make_unique<TransferringOptimizerMSVTUS>(source_broker_);
+ }
+ 
+ void MediaStreamVideoTrackUnderlyingSink::Disconnect() {
+diff --git a/third_party/blink/renderer/modules/canvas/BUILD.gn b/third_party/blink/renderer/modules/canvas/BUILD.gn
+index cc8359ffa..9ca8ad525 100644
+--- a/third_party/blink/renderer/modules/canvas/BUILD.gn
++++ b/third_party/blink/renderer/modules/canvas/BUILD.gn
+@@ -53,6 +53,10 @@ blink_modules_sources("canvas") {
+     "offscreencanvas2d/offscreen_canvas_rendering_context_2d.h",
+     "testing/canvas_test_utils.cc",
+   ]
++  jumbo_excluded_sources = [
++    "imagebitmap/image_bitmap_rendering_context_base.cc",
++    "offscreencanvas2d/offscreen_canvas_rendering_context_2d.cc",
++  ]
+ 
+   deps = [
+     "//third_party/blink/renderer/modules/formatted_text",
+diff --git a/third_party/blink/renderer/modules/credentialmanagement/credentials_container.cc b/third_party/blink/renderer/modules/credentialmanagement/credentials_container.cc
+index aa578c429..f0b81e9f5 100644
+--- a/third_party/blink/renderer/modules/credentialmanagement/credentials_container.cc
++++ b/third_party/blink/renderer/modules/credentialmanagement/credentials_container.cc
+@@ -599,7 +599,7 @@ void OnGetComplete(std::unique_ptr<ScopedPromiseResolver> scoped_resolver,
+   resolver->Resolve(mojo::ConvertTo<Credential*>(std::move(credential_info)));
+ }
+ 
+-DOMArrayBuffer* VectorToDOMArrayBuffer(const Vector<uint8_t> buffer) {
++static DOMArrayBuffer* VectorToDOMArrayBuffer_CC(const Vector<uint8_t> buffer) {
+   return DOMArrayBuffer::Create(static_cast<const void*>(buffer.data()),
+                                 buffer.size());
+ }
+@@ -653,17 +653,17 @@ void OnMakePublicKeyCredentialComplete(
+                       WebFeature::kWebAuthnRkRequiredCreationSuccess);
+   }
+   DOMArrayBuffer* client_data_buffer =
+-      VectorToDOMArrayBuffer(std::move(credential->info->client_data_json));
++      VectorToDOMArrayBuffer_CC(std::move(credential->info->client_data_json));
+   DOMArrayBuffer* raw_id =
+-      VectorToDOMArrayBuffer(std::move(credential->info->raw_id));
++      VectorToDOMArrayBuffer_CC(std::move(credential->info->raw_id));
+   DOMArrayBuffer* attestation_buffer =
+-      VectorToDOMArrayBuffer(std::move(credential->attestation_object));
++      VectorToDOMArrayBuffer_CC(std::move(credential->attestation_object));
+   DOMArrayBuffer* authenticator_data =
+-      VectorToDOMArrayBuffer(std::move(credential->info->authenticator_data));
++      VectorToDOMArrayBuffer_CC(std::move(credential->info->authenticator_data));
+   DOMArrayBuffer* public_key_der = nullptr;
+   if (credential->public_key_der) {
+     public_key_der =
+-        VectorToDOMArrayBuffer(std::move(credential->public_key_der.value()));
++        VectorToDOMArrayBuffer_CC(std::move(credential->public_key_der.value()));
+   }
+   auto* authenticator_response =
+       MakeGarbageCollected<AuthenticatorAttestationResponse>(
+@@ -697,9 +697,9 @@ void OnMakePublicKeyCredentialComplete(
+   if (credential->device_public_key) {
+     AuthenticationExtensionsDevicePublicKeyOutputs* device_public_key_outputs =
+         AuthenticationExtensionsDevicePublicKeyOutputs::Create();
+-    device_public_key_outputs->setAuthenticatorOutput(VectorToDOMArrayBuffer(
++    device_public_key_outputs->setAuthenticatorOutput(VectorToDOMArrayBuffer_CC(
+         std::move(credential->device_public_key->authenticator_output)));
+-    device_public_key_outputs->setSignature(VectorToDOMArrayBuffer(
++    device_public_key_outputs->setSignature(VectorToDOMArrayBuffer_CC(
+         std::move(credential->device_public_key->signature)));
+     extension_outputs->setDevicePubKey(device_public_key_outputs);
+   }
+@@ -830,7 +830,7 @@ void OnGetAssertionComplete(
+           AuthenticationExtensionsLargeBlobOutputs::Create();
+       if (credential->large_blob) {
+         large_blob_outputs->setBlob(
+-            VectorToDOMArrayBuffer(std::move(*credential->large_blob)));
++            VectorToDOMArrayBuffer_CC(std::move(*credential->large_blob)));
+       }
+       if (credential->echo_large_blob_written) {
+         large_blob_outputs->setWritten(credential->large_blob_written);
+@@ -839,15 +839,15 @@ void OnGetAssertionComplete(
+     }
+     if (credential->get_cred_blob) {
+       extension_outputs->setGetCredBlob(
+-          VectorToDOMArrayBuffer(std::move(*credential->get_cred_blob)));
++          VectorToDOMArrayBuffer_CC(std::move(*credential->get_cred_blob)));
+     }
+     if (credential->device_public_key) {
+       AuthenticationExtensionsDevicePublicKeyOutputs*
+           device_public_key_outputs =
+               AuthenticationExtensionsDevicePublicKeyOutputs::Create();
+-      device_public_key_outputs->setAuthenticatorOutput(VectorToDOMArrayBuffer(
++      device_public_key_outputs->setAuthenticatorOutput(VectorToDOMArrayBuffer_CC(
+           std::move(credential->device_public_key->authenticator_output)));
+-      device_public_key_outputs->setSignature(VectorToDOMArrayBuffer(
++      device_public_key_outputs->setSignature(VectorToDOMArrayBuffer_CC(
+           std::move(credential->device_public_key->signature)));
+       extension_outputs->setDevicePubKey(device_public_key_outputs);
+     }
+@@ -856,9 +856,9 @@ void OnGetAssertionComplete(
+       if (credential->prf_results) {
+         auto* values = AuthenticationExtensionsPRFValues::Create();
+         values->setFirst(
+-            VectorToDOMArrayBuffer(std::move(credential->prf_results->first)));
++            VectorToDOMArrayBuffer_CC(std::move(credential->prf_results->first)));
+         if (credential->prf_results->second) {
+-          values->setSecond(VectorToDOMArrayBuffer(
++          values->setSecond(VectorToDOMArrayBuffer_CC(
+               std::move(credential->prf_results->second.value())));
+         }
+         prf_outputs->setResults(values);
+@@ -867,7 +867,7 @@ void OnGetAssertionComplete(
+     }
+     resolver->Resolve(MakeGarbageCollected<PublicKeyCredential>(
+         credential->info->id,
+-        VectorToDOMArrayBuffer(std::move(credential->info->raw_id)),
++        VectorToDOMArrayBuffer_CC(std::move(credential->info->raw_id)),
+         authenticator_response, credential->authenticator_attachment,
+         extension_outputs));
+     return;
+diff --git a/third_party/blink/renderer/modules/credentialmanagement/federated_credential.cc b/third_party/blink/renderer/modules/credentialmanagement/federated_credential.cc
+index 3e2b1812d..e2e86c10a 100644
+--- a/third_party/blink/renderer/modules/credentialmanagement/federated_credential.cc
++++ b/third_party/blink/renderer/modules/credentialmanagement/federated_credential.cc
+@@ -19,7 +19,7 @@
+ namespace blink {
+ 
+ namespace {
+-constexpr char kFederatedCredentialType[] = "federated";
++constexpr char kFederatedCredentialTypeFC[] = "federated";
+ }  // namespace
+ 
+ FederatedCredential* FederatedCredential::Create(
+@@ -67,7 +67,7 @@ FederatedCredential::FederatedCredential(
+     scoped_refptr<const SecurityOrigin> provider_origin,
+     const String& name,
+     const KURL& icon_url)
+-    : Credential(id, kFederatedCredentialType),
++    : Credential(id, kFederatedCredentialTypeFC),
+       provider_origin_(provider_origin),
+       name_(name),
+       icon_url_(icon_url) {
+diff --git a/third_party/blink/renderer/modules/credentialmanagement/identity_credential.cc b/third_party/blink/renderer/modules/credentialmanagement/identity_credential.cc
+index f9c13a814..f98229752 100644
+--- a/third_party/blink/renderer/modules/credentialmanagement/identity_credential.cc
++++ b/third_party/blink/renderer/modules/credentialmanagement/identity_credential.cc
+@@ -21,7 +21,7 @@ namespace {
+ using mojom::blink::LogoutRpsStatus;
+ using mojom::blink::RequestTokenStatus;
+ 
+-constexpr char kIdentityCredentialType[] = "identity";
++constexpr char kIdentityCredentialType2[] = "identity";
+ 
+ // These values are persisted to logs. Entries should not be renumbered and
+ // numeric values should never be reused.
+@@ -88,7 +88,7 @@ bool IdentityCredential::IsRejectingPromiseDueToCSP(
+ }
+ 
+ IdentityCredential::IdentityCredential(const String& token)
+-    : Credential(/* id = */ "", kIdentityCredentialType), token_(token) {}
++    : Credential(/* id = */ "", kIdentityCredentialType2), token_(token) {}
+ 
+ bool IdentityCredential::IsIdentityCredential() const {
+   return true;
+diff --git a/third_party/blink/renderer/modules/credentialmanagement/otp_credential.cc b/third_party/blink/renderer/modules/credentialmanagement/otp_credential.cc
+index 517ef6eb1..dd11eef62 100644
+--- a/third_party/blink/renderer/modules/credentialmanagement/otp_credential.cc
++++ b/third_party/blink/renderer/modules/credentialmanagement/otp_credential.cc
+@@ -9,12 +9,12 @@
+ 
+ namespace blink {
+ 
+-namespace {
+-constexpr char kOtpCredentialType[] = "otp";
++namespace i {
++constexpr static char kOtpCredentialType[] = "otp";
+ }
+ 
+ OTPCredential::OTPCredential(const String& code)
+-    : Credential(String(), kOtpCredentialType), code_(code) {}
++    : Credential(String(), i::kOtpCredentialType), code_(code) {}
+ 
+ bool OTPCredential::IsOTPCredential() const {
+   return true;
+diff --git a/third_party/blink/renderer/modules/hid/hid_device.cc b/third_party/blink/renderer/modules/hid/hid_device.cc
+index 544b39df2..559b76731 100644
+--- a/third_party/blink/renderer/modules/hid/hid_device.cc
++++ b/third_party/blink/renderer/modules/hid/hid_device.cc
+@@ -34,7 +34,7 @@ const char kReceiveFeatureReportFailed[] =
+ const char kUnexpectedClose[] = "The device was closed unexpectedly.";
+ const char kArrayBufferTooBig[] =
+     "The provided ArrayBuffer exceeds the maximum allowed size.";
+-const char kContextGone[] = "Script context has shut down.";
++const char kContextGone2[] = "Script context has shut down.";
+ 
+ bool IsProtected(
+     const device::mojom::blink::HidUsageAndPage& hid_usage_and_page) {
+@@ -248,7 +248,7 @@ ScriptPromise HIDDevice::open(ScriptState* script_state,
+                               ExceptionState& exception_state) {
+   if (!GetExecutionContext()) {
+     exception_state.ThrowDOMException(DOMExceptionCode::kNotSupportedError,
+-                                      kContextGone);
++                                      kContextGone2);
+     return ScriptPromise();
+   }
+ 
+@@ -298,7 +298,7 @@ ScriptPromise HIDDevice::forget(ScriptState* script_state,
+                                 ExceptionState& exception_state) {
+   if (!GetExecutionContext()) {
+     exception_state.ThrowDOMException(DOMExceptionCode::kNotSupportedError,
+-                                      kContextGone);
++                                      kContextGone2);
+     return ScriptPromise();
+   }
+ 
+diff --git a/third_party/blink/renderer/modules/mediarecorder/h264_encoder.cc b/third_party/blink/renderer/modules/mediarecorder/h264_encoder.cc
+index 0aac5f9eb..4253f3280 100644
+--- a/third_party/blink/renderer/modules/mediarecorder/h264_encoder.cc
++++ b/third_party/blink/renderer/modules/mediarecorder/h264_encoder.cc
+@@ -122,15 +122,15 @@ void H264Encoder::EncodeFrame(scoped_refptr<media::VideoFrame> frame,
+   picture.iColorFormat = EVideoFormatType::videoFormatI420;
+   picture.uiTimeStamp =
+       (capture_timestamp - first_frame_timestamp_).InMilliseconds();
+-  picture.iStride[0] = frame->stride(VideoFrame::kYPlane);
+-  picture.iStride[1] = frame->stride(VideoFrame::kUPlane);
+-  picture.iStride[2] = frame->stride(VideoFrame::kVPlane);
++  picture.iStride[0] = frame->stride(media::VideoFrame::kYPlane);
++  picture.iStride[1] = frame->stride(media::VideoFrame::kUPlane);
++  picture.iStride[2] = frame->stride(media::VideoFrame::kVPlane);
+   picture.pData[0] =
+-      const_cast<uint8_t*>(frame->visible_data(VideoFrame::kYPlane));
++      const_cast<uint8_t*>(frame->visible_data(media::VideoFrame::kYPlane));
+   picture.pData[1] =
+-      const_cast<uint8_t*>(frame->visible_data(VideoFrame::kUPlane));
++      const_cast<uint8_t*>(frame->visible_data(media::VideoFrame::kUPlane));
+   picture.pData[2] =
+-      const_cast<uint8_t*>(frame->visible_data(VideoFrame::kVPlane));
++      const_cast<uint8_t*>(frame->visible_data(media::VideoFrame::kVPlane));
+ 
+   SFrameBSInfo info = {};
+   if (openh264_encoder_->EncodeFrame(&picture, &info) != cmResultSuccess) {
+diff --git a/third_party/blink/renderer/modules/mediarecorder/vpx_encoder.cc b/third_party/blink/renderer/modules/mediarecorder/vpx_encoder.cc
+index bc8f2d648..e20c67ee1 100644
+--- a/third_party/blink/renderer/modules/mediarecorder/vpx_encoder.cc
++++ b/third_party/blink/renderer/modules/mediarecorder/vpx_encoder.cc
+@@ -14,8 +14,6 @@
+ #include "third_party/blink/renderer/platform/instrumentation/tracing/trace_event.h"
+ #include "ui/gfx/geometry/size.h"
+ 
+-using media::VideoFrameMetadata;
+-
+ namespace blink {
+ 
+ void VpxEncoder::VpxCodecDeleter::operator()(vpx_codec_ctx_t* codec) {
+@@ -78,25 +76,25 @@ void VpxEncoder::EncodeFrame(scoped_refptr<media::VideoFrame> frame,
+   switch (frame->format()) {
+     case media::PIXEL_FORMAT_NV12: {
+       last_frame_had_alpha_ = false;
+-      DoEncode(encoder_.get(), frame_size, frame->data(VideoFrame::kYPlane),
+-               frame->visible_data(VideoFrame::kYPlane),
+-               frame->stride(VideoFrame::kYPlane),
+-               frame->visible_data(VideoFrame::kUVPlane),
+-               frame->stride(VideoFrame::kUVPlane),
+-               frame->visible_data(VideoFrame::kUVPlane) + 1,
+-               frame->stride(VideoFrame::kUVPlane), duration, force_keyframe,
++      DoEncode(encoder_.get(), frame_size, frame->data(media::VideoFrame::kYPlane),
++               frame->visible_data(media::VideoFrame::kYPlane),
++               frame->stride(media::VideoFrame::kYPlane),
++               frame->visible_data(media::VideoFrame::kUVPlane),
++               frame->stride(media::VideoFrame::kUVPlane),
++               frame->visible_data(media::VideoFrame::kUVPlane) + 1,
++               frame->stride(media::VideoFrame::kUVPlane), duration, force_keyframe,
+                data, &keyframe, VPX_IMG_FMT_NV12);
+       break;
+     }
+     case media::PIXEL_FORMAT_I420: {
+       last_frame_had_alpha_ = false;
+-      DoEncode(encoder_.get(), frame_size, frame->data(VideoFrame::kYPlane),
+-               frame->visible_data(VideoFrame::kYPlane),
+-               frame->stride(VideoFrame::kYPlane),
+-               frame->visible_data(VideoFrame::kUPlane),
+-               frame->stride(VideoFrame::kUPlane),
+-               frame->visible_data(VideoFrame::kVPlane),
+-               frame->stride(VideoFrame::kVPlane), duration, force_keyframe,
++      DoEncode(encoder_.get(), frame_size, frame->data(media::VideoFrame::kYPlane),
++               frame->visible_data(media::VideoFrame::kYPlane),
++               frame->stride(media::VideoFrame::kYPlane),
++               frame->visible_data(media::VideoFrame::kUPlane),
++               frame->stride(media::VideoFrame::kUPlane),
++               frame->visible_data(media::VideoFrame::kVPlane),
++               frame->stride(media::VideoFrame::kVPlane), duration, force_keyframe,
+                data, &keyframe, VPX_IMG_FMT_I420);
+       break;
+     }
+@@ -111,15 +109,15 @@ void VpxEncoder::EncodeFrame(scoped_refptr<media::VideoFrame> frame,
+           return;
+         }
+         u_plane_stride_ = media::VideoFrame::RowBytes(
+-            VideoFrame::kUPlane, frame->format(), frame_size.width());
++            media::VideoFrame::kUPlane, frame->format(), frame_size.width());
+         v_plane_stride_ = media::VideoFrame::RowBytes(
+-            VideoFrame::kVPlane, frame->format(), frame_size.width());
++            media::VideoFrame::kVPlane, frame->format(), frame_size.width());
+         v_plane_offset_ = media::VideoFrame::PlaneSize(
+-                              frame->format(), VideoFrame::kUPlane, frame_size)
++                              frame->format(), media::VideoFrame::kUPlane, frame_size)
+                               .GetArea();
+         alpha_dummy_planes_.resize(base::checked_cast<wtf_size_t>(
+             v_plane_offset_ + media::VideoFrame::PlaneSize(frame->format(),
+-                                                           VideoFrame::kVPlane,
++                                                           media::VideoFrame::kVPlane,
+                                                            frame_size)
+                                   .GetArea()));
+         // It is more expensive to encode 0x00, so use 0x80 instead.
+@@ -129,19 +127,19 @@ void VpxEncoder::EncodeFrame(scoped_refptr<media::VideoFrame> frame,
+       force_keyframe = !last_frame_had_alpha_;
+       last_frame_had_alpha_ = true;
+ 
+-      DoEncode(encoder_.get(), frame_size, frame->data(VideoFrame::kYPlane),
+-               frame->visible_data(VideoFrame::kYPlane),
+-               frame->stride(VideoFrame::kYPlane),
+-               frame->visible_data(VideoFrame::kUPlane),
+-               frame->stride(VideoFrame::kUPlane),
+-               frame->visible_data(VideoFrame::kVPlane),
+-               frame->stride(VideoFrame::kVPlane), duration, force_keyframe,
++      DoEncode(encoder_.get(), frame_size, frame->data(media::VideoFrame::kYPlane),
++               frame->visible_data(media::VideoFrame::kYPlane),
++               frame->stride(media::VideoFrame::kYPlane),
++               frame->visible_data(media::VideoFrame::kUPlane),
++               frame->stride(media::VideoFrame::kUPlane),
++               frame->visible_data(media::VideoFrame::kVPlane),
++               frame->stride(media::VideoFrame::kVPlane), duration, force_keyframe,
+                data, &keyframe, VPX_IMG_FMT_I420);
+ 
+       DoEncode(alpha_encoder_.get(), frame_size,
+-               frame->data(VideoFrame::kAPlane),
+-               frame->visible_data(VideoFrame::kAPlane),
+-               frame->stride(VideoFrame::kAPlane), alpha_dummy_planes_.data(),
++               frame->data(media::VideoFrame::kAPlane),
++               frame->visible_data(media::VideoFrame::kAPlane),
++               frame->stride(media::VideoFrame::kAPlane), alpha_dummy_planes_.data(),
+                base::checked_cast<int>(u_plane_stride_),
+                alpha_dummy_planes_.data() + v_plane_offset_,
+                base::checked_cast<int>(v_plane_stride_), duration, keyframe,
+diff --git a/third_party/blink/renderer/modules/mediastream/BUILD.gn b/third_party/blink/renderer/modules/mediastream/BUILD.gn
+index 8ce74e0a7..5697ae09c 100644
+--- a/third_party/blink/renderer/modules/mediastream/BUILD.gn
++++ b/third_party/blink/renderer/modules/mediastream/BUILD.gn
+@@ -113,6 +113,13 @@ blink_modules_sources("mediastream") {
+     "webmediaplayer_ms_compositor.cc",
+     "webmediaplayer_ms_compositor.h",
+   ]
++
++  jumbo_excluded_sources = [
++    "input_device_info.cc",
++    "processed_local_audio_source.cc",
++    "user_media_processor.cc",
++  ]
++
+   deps = [
+     "//build:chromecast_buildflags",
+     "//build:chromeos_buildflags",
+diff --git a/third_party/blink/renderer/modules/payments/payment_instruments.cc b/third_party/blink/renderer/modules/payments/payment_instruments.cc
+index f77fa0005..bf9474da7 100644
+--- a/third_party/blink/renderer/modules/payments/payment_instruments.cc
++++ b/third_party/blink/renderer/modules/payments/payment_instruments.cc
+@@ -78,7 +78,7 @@ bool rejectError(ScriptPromiseResolver* resolver,
+   return false;
+ }
+ 
+-bool AllowedToUsePaymentFeatures(ScriptState* script_state) {
++bool AllowedToUsePaymentFeatures2(ScriptState* script_state) {
+   if (!script_state->ContextIsValid())
+     return false;
+   return ExecutionContext::From(script_state)
+@@ -107,7 +107,7 @@ ScriptPromise PaymentInstruments::deleteInstrument(
+     ScriptState* script_state,
+     const String& instrument_key,
+     ExceptionState& exception_state) {
+-  if (!AllowedToUsePaymentFeatures(script_state))
++  if (!AllowedToUsePaymentFeatures2(script_state))
+     return RejectNotAllowedToUsePaymentFeatures(script_state, exception_state);
+ 
+   if (!manager_.is_bound()) {
+@@ -129,7 +129,7 @@ ScriptPromise PaymentInstruments::deleteInstrument(
+ ScriptPromise PaymentInstruments::get(ScriptState* script_state,
+                                       const String& instrument_key,
+                                       ExceptionState& exception_state) {
+-  if (!AllowedToUsePaymentFeatures(script_state))
++  if (!AllowedToUsePaymentFeatures2(script_state))
+     return RejectNotAllowedToUsePaymentFeatures(script_state, exception_state);
+ 
+   if (!manager_.is_bound()) {
+@@ -150,7 +150,7 @@ ScriptPromise PaymentInstruments::get(ScriptState* script_state,
+ 
+ ScriptPromise PaymentInstruments::keys(ScriptState* script_state,
+                                        ExceptionState& exception_state) {
+-  if (!AllowedToUsePaymentFeatures(script_state))
++  if (!AllowedToUsePaymentFeatures2(script_state))
+     return RejectNotAllowedToUsePaymentFeatures(script_state, exception_state);
+ 
+   if (!manager_.is_bound()) {
+@@ -171,7 +171,7 @@ ScriptPromise PaymentInstruments::keys(ScriptState* script_state,
+ ScriptPromise PaymentInstruments::has(ScriptState* script_state,
+                                       const String& instrument_key,
+                                       ExceptionState& exception_state) {
+-  if (!AllowedToUsePaymentFeatures(script_state))
++  if (!AllowedToUsePaymentFeatures2(script_state))
+     return RejectNotAllowedToUsePaymentFeatures(script_state, exception_state);
+ 
+   if (!manager_.is_bound()) {
+@@ -194,7 +194,7 @@ ScriptPromise PaymentInstruments::set(ScriptState* script_state,
+                                       const String& instrument_key,
+                                       const PaymentInstrument* details,
+                                       ExceptionState& exception_state) {
+-  if (!AllowedToUsePaymentFeatures(script_state))
++  if (!AllowedToUsePaymentFeatures2(script_state))
+     return RejectNotAllowedToUsePaymentFeatures(script_state, exception_state);
+ 
+   if (!manager_.is_bound()) {
+@@ -228,7 +228,7 @@ ScriptPromise PaymentInstruments::set(ScriptState* script_state,
+ 
+ ScriptPromise PaymentInstruments::clear(ScriptState* script_state,
+                                         ExceptionState& exception_state) {
+-  if (!AllowedToUsePaymentFeatures(script_state))
++  if (!AllowedToUsePaymentFeatures2(script_state))
+     return RejectNotAllowedToUsePaymentFeatures(script_state, exception_state);
+ 
+   if (!manager_.is_bound()) {
+diff --git a/third_party/blink/renderer/modules/peerconnection/BUILD.gn b/third_party/blink/renderer/modules/peerconnection/BUILD.gn
+index a3434145e..8800a986e 100644
+--- a/third_party/blink/renderer/modules/peerconnection/BUILD.gn
++++ b/third_party/blink/renderer/modules/peerconnection/BUILD.gn
+@@ -159,6 +159,12 @@ blink_modules_sources("peerconnection") {
+     "webrtc_video_perf_reporter.h",
+   ]
+ 
++  jumbo_excluded_sources = [
++    "peer_connection_tracker.cc",
++    "rtc_data_channel.cc",
++    "rtc_rtp_sender_impl.cc",
++  ]
++
+   public_deps = [ "//third_party/webrtc_overrides:webrtc_component" ]
+   deps = [
+     "//build:chromecast_buildflags",
+diff --git a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
+index 6830ce391..9d9977573 100644
+--- a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
++++ b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
+@@ -239,7 +239,7 @@ RTCIceCandidatePlatform* ConvertToRTCIceCandidatePlatform(
+       candidate->usernameFragment());
+ }
+ 
+-webrtc::PeerConnectionInterface::IceTransportsType IceTransportPolicyFromString(
++webrtc::PeerConnectionInterface::IceTransportsType IceTransportPolicyFromString2(
+     const String& policy) {
+   if (policy == "relay")
+     return webrtc::PeerConnectionInterface::kRelay;
+@@ -282,11 +282,11 @@ webrtc::PeerConnectionInterface::RTCConfiguration ParseConfiguration(
+   if (configuration->hasIceTransportPolicy()) {
+     UseCounter::Count(context, WebFeature::kRTCConfigurationIceTransportPolicy);
+     web_configuration.type =
+-        IceTransportPolicyFromString(configuration->iceTransportPolicy());
++        IceTransportPolicyFromString2(configuration->iceTransportPolicy());
+   } else if (configuration->hasIceTransports()) {
+     UseCounter::Count(context, WebFeature::kRTCConfigurationIceTransports);
+     web_configuration.type =
+-        IceTransportPolicyFromString(configuration->iceTransports());
++        IceTransportPolicyFromString2(configuration->iceTransports());
+   }
+ 
+   if (configuration->bundlePolicy() == "max-compat") {
+diff --git a/third_party/blink/renderer/modules/permissions/BUILD.gn b/third_party/blink/renderer/modules/permissions/BUILD.gn
+index 2e4b14e09..ab20f6efd 100644
+--- a/third_party/blink/renderer/modules/permissions/BUILD.gn
++++ b/third_party/blink/renderer/modules/permissions/BUILD.gn
+@@ -15,4 +15,5 @@ blink_modules_sources("permissions") {
+     "permissions.cc",
+     "permissions.h",
+   ]
++  jumbo_excluded_sources = [ "permission_utils.cc" ]
+ }
+diff --git a/third_party/blink/renderer/modules/webaudio/analyser_handler.cc b/third_party/blink/renderer/modules/webaudio/analyser_handler.cc
+index a3ef095cd..c823c923a 100644
+--- a/third_party/blink/renderer/modules/webaudio/analyser_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/analyser_handler.cc
+@@ -14,8 +14,8 @@ namespace blink {
+ 
+ namespace {
+ 
+-constexpr unsigned kDefaultNumberOfInputChannels = 2;
+-constexpr unsigned kDefaultNumberOfOutputChannels = 1;
++constexpr unsigned kDefaultNumberOfInputChannels2 = 2;
++constexpr unsigned kDefaultNumberOfOutputChannels2 = 1;
+ 
+ }  // namespace
+ 
+@@ -23,8 +23,8 @@ AnalyserHandler::AnalyserHandler(AudioNode& node, float sample_rate)
+     : AudioBasicInspectorHandler(kNodeTypeAnalyser, node, sample_rate),
+       analyser_(
+           node.context()->GetDeferredTaskHandler().RenderQuantumFrames()) {
+-  channel_count_ = kDefaultNumberOfInputChannels;
+-  AddOutput(kDefaultNumberOfOutputChannels);
++  channel_count_ = kDefaultNumberOfInputChannels2;
++  AddOutput(kDefaultNumberOfOutputChannels2);
+ 
+   Initialize();
+ }
+diff --git a/third_party/blink/renderer/modules/webaudio/audio_buffer_source_handler.cc b/third_party/blink/renderer/modules/webaudio/audio_buffer_source_handler.cc
+index c2dd0776b..645ad54f8 100644
+--- a/third_party/blink/renderer/modules/webaudio/audio_buffer_source_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/audio_buffer_source_handler.cc
+@@ -32,7 +32,7 @@ constexpr double kMaxRate = 1024.0;
+ 
+ // Default to mono. A call to setBuffer() will set the number of output
+ // channels to that of the buffer.
+-constexpr unsigned kDefaultNumberOfOutputChannels = 1;
++constexpr unsigned kDefaultNumberOfOutputChannelsABSH = 1;
+ 
+ }  // namespace
+ 
+@@ -47,7 +47,7 @@ AudioBufferSourceHandler::AudioBufferSourceHandler(
+       playback_rate_(&playback_rate),
+       detune_(&detune),
+       grain_duration_(kDefaultGrainDuration) {
+-  AddOutput(kDefaultNumberOfOutputChannels);
++  AddOutput(kDefaultNumberOfOutputChannelsABSH);
+ 
+   Initialize();
+ }
+diff --git a/third_party/blink/renderer/modules/webaudio/audio_worklet_handler.cc b/third_party/blink/renderer/modules/webaudio/audio_worklet_handler.cc
+index b7e7359ee..7f591531a 100644
+--- a/third_party/blink/renderer/modules/webaudio/audio_worklet_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/audio_worklet_handler.cc
+@@ -35,7 +35,7 @@ namespace blink {
+ 
+ namespace {
+ 
+-constexpr unsigned kDefaultNumberOfOutputChannels = 1;
++constexpr unsigned kDefaultNumberOfOutputChannels_QWH = 1;
+ 
+ }  // namespace
+ 
+@@ -69,7 +69,7 @@ AudioWorkletHandler::AudioWorkletHandler(
+   for (unsigned i = 0; i < options->numberOfOutputs(); ++i) {
+     // If `options->outputChannelCount` unspecified, all outputs are mono.
+     AddOutput(is_output_channel_count_given_ ? options->outputChannelCount()[i]
+-                                             : kDefaultNumberOfOutputChannels);
++                                             : kDefaultNumberOfOutputChannels_QWH);
+   }
+   // Same for the outputs as well.
+   outputs_.ReserveInitialCapacity(options->numberOfOutputs());
+diff --git a/third_party/blink/renderer/modules/webaudio/biquad_filter_node.cc b/third_party/blink/renderer/modules/webaudio/biquad_filter_node.cc
+index 79aff99e1..11dedaaf7 100644
+--- a/third_party/blink/renderer/modules/webaudio/biquad_filter_node.cc
++++ b/third_party/blink/renderer/modules/webaudio/biquad_filter_node.cc
+@@ -43,7 +43,7 @@ constexpr float kMinFrequencyValue = 0.0f;
+ constexpr double kDefaultQValue = 1.0;
+ constexpr double kDefaultGainValue = 0.0;
+ constexpr float kMinGainValue = std::numeric_limits<float>::lowest();
+-constexpr double kDefaultDetuneValue = 0.0;
++constexpr double kDefaultDetuneValueBFN = 0.0;
+ 
+ }  // namespace
+ 
+@@ -77,7 +77,7 @@ BiquadFilterNode::BiquadFilterNode(BaseAudioContext& context)
+           context,
+           Uuid(),
+           AudioParamHandler::kParamTypeBiquadFilterDetune,
+-          kDefaultDetuneValue,
++          kDefaultDetuneValueBFN,
+           AudioParamHandler::AutomationRate::kAudio,
+           AudioParamHandler::AutomationRateMode::kVariable,
+           /*min_value=*/-1200 * log2f(std::numeric_limits<float>::max()),
+diff --git a/third_party/blink/renderer/modules/webaudio/constant_source_handler.cc b/third_party/blink/renderer/modules/webaudio/constant_source_handler.cc
+index e346f5c00..e20500c75 100644
+--- a/third_party/blink/renderer/modules/webaudio/constant_source_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/constant_source_handler.cc
+@@ -13,7 +13,7 @@ namespace blink {
+ namespace {
+ 
+ // A ConstantSource is always mono.
+-constexpr unsigned kNumberOfOutputChannels = 1;
++constexpr unsigned kNumberOfOutputChannelsCSH = 1;
+ 
+ }  // namespace
+ 
+@@ -23,7 +23,7 @@ ConstantSourceHandler::ConstantSourceHandler(AudioNode& node,
+     : AudioScheduledSourceHandler(kNodeTypeConstantSource, node, sample_rate),
+       offset_(&offset),
+       sample_accurate_values_(GetDeferredTaskHandler().RenderQuantumFrames()) {
+-  AddOutput(kNumberOfOutputChannels);
++  AddOutput(kNumberOfOutputChannelsCSH);
+ 
+   Initialize();
+ }
+diff --git a/third_party/blink/renderer/modules/webaudio/convolver_handler.cc b/third_party/blink/renderer/modules/webaudio/convolver_handler.cc
+index 325e3fde4..78468d18a 100644
+--- a/third_party/blink/renderer/modules/webaudio/convolver_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/convolver_handler.cc
+@@ -31,14 +31,14 @@ namespace {
+ constexpr unsigned kMaxFftSize = 32768;
+ 
+ constexpr unsigned kDefaultNumberOfInputChannels = 2;
+-constexpr unsigned kDefaultNumberOfOutputChannels = 1;
++constexpr unsigned kDefaultNumberOfOutputChannelsCH = 1;
+ 
+ }  // namespace
+ 
+ ConvolverHandler::ConvolverHandler(AudioNode& node, float sample_rate)
+     : AudioHandler(kNodeTypeConvolver, node, sample_rate) {
+   AddInput();
+-  AddOutput(kDefaultNumberOfOutputChannels);
++  AddOutput(kDefaultNumberOfOutputChannelsCH);
+ 
+   // Node-specific default mixing rules.
+   channel_count_ = kDefaultNumberOfInputChannels;
+diff --git a/third_party/blink/renderer/modules/webaudio/dynamics_compressor_handler.cc b/third_party/blink/renderer/modules/webaudio/dynamics_compressor_handler.cc
+index 8b80f6da6..fd74e43af 100644
+--- a/third_party/blink/renderer/modules/webaudio/dynamics_compressor_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/dynamics_compressor_handler.cc
+@@ -19,7 +19,7 @@ namespace blink {
+ namespace {
+ 
+ // Set output to stereo by default.
+-constexpr unsigned kDefaultNumberOfOutputChannels = 2;
++constexpr unsigned kDefaultNumberOfOutputChannelsDCH = 2;
+ 
+ }  // namespace
+ 
+@@ -39,7 +39,7 @@ DynamicsCompressorHandler::DynamicsCompressorHandler(
+       attack_(&attack),
+       release_(&release) {
+   AddInput();
+-  AddOutput(kDefaultNumberOfOutputChannels);
++  AddOutput(kDefaultNumberOfOutputChannelsDCH);
+ 
+   SetInternalChannelCountMode(kClampedMax);
+ 
+@@ -108,7 +108,7 @@ void DynamicsCompressorHandler::Initialize() {
+ 
+   AudioHandler::Initialize();
+   dynamics_compressor_ = std::make_unique<DynamicsCompressor>(
+-      Context()->sampleRate(), kDefaultNumberOfOutputChannels);
++      Context()->sampleRate(), kDefaultNumberOfOutputChannelsDCH);
+ }
+ 
+ bool DynamicsCompressorHandler::RequiresTailProcessing() const {
+diff --git a/third_party/blink/renderer/modules/webaudio/iir_filter_handler.cc b/third_party/blink/renderer/modules/webaudio/iir_filter_handler.cc
+index fc982fa3e..357ef5314 100644
+--- a/third_party/blink/renderer/modules/webaudio/iir_filter_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/iir_filter_handler.cc
+@@ -18,7 +18,7 @@ namespace blink {
+ 
+ namespace {
+ 
+-constexpr uint32_t kNumberOfChannels = 1;
++constexpr uint32_t kNumberOfChannelsIFH = 1;
+ 
+ }  // namespace
+ 
+@@ -33,7 +33,7 @@ IIRFilterHandler::IIRFilterHandler(AudioNode& node,
+           sample_rate,
+           std::make_unique<IIRProcessor>(
+               sample_rate,
+-              kNumberOfChannels,
++              kNumberOfChannelsIFH,
+               node.context()->GetDeferredTaskHandler().RenderQuantumFrames(),
+               feedforward_coef,
+               feedback_coef,
+diff --git a/third_party/blink/renderer/modules/webaudio/media_element_audio_source_handler.cc b/third_party/blink/renderer/modules/webaudio/media_element_audio_source_handler.cc
+index cae58d329..9d748d711 100644
+--- a/third_party/blink/renderer/modules/webaudio/media_element_audio_source_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/media_element_audio_source_handler.cc
+@@ -27,7 +27,7 @@ namespace {
+ 
+ // Default to stereo. This could change depending on what the media element
+ // .src is set to.
+-constexpr unsigned kDefaultNumberOfOutputChannels = 2;
++constexpr unsigned kDefaultNumberOfOutputChannelsMEASH = 2;
+ 
+ }  // namespace
+ 
+@@ -61,7 +61,7 @@ MediaElementAudioSourceHandler::MediaElementAudioSourceHandler(
+       media_element_(media_element) {
+   DCHECK(IsMainThread());
+ 
+-  AddOutput(kDefaultNumberOfOutputChannels);
++  AddOutput(kDefaultNumberOfOutputChannelsMEASH);
+ 
+   if (Context()->GetExecutionContext()) {
+     task_runner_ = Context()->GetExecutionContext()->GetTaskRunner(
+diff --git a/third_party/blink/renderer/modules/webaudio/oscillator_handler.cc b/third_party/blink/renderer/modules/webaudio/oscillator_handler.cc
+index c8e12f5ef..db68ca93b 100644
+--- a/third_party/blink/renderer/modules/webaudio/oscillator_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/oscillator_handler.cc
+@@ -26,7 +26,7 @@ namespace blink {
+ namespace {
+ 
+ // An oscillator is always mono.
+-constexpr unsigned kNumberOfOutputChannels = 1;
++constexpr unsigned kNumberOfOutputChannelsOH = 1;
+ 
+ // Convert the detune value (in cents) to a frequency scale multiplier:
+ // 2^(d/1200)
+@@ -184,7 +184,7 @@ OscillatorHandler::OscillatorHandler(AudioNode& node,
+     }
+   }
+ 
+-  AddOutput(kNumberOfOutputChannels);
++  AddOutput(kNumberOfOutputChannelsOH);
+ 
+   Initialize();
+ }
+diff --git a/third_party/blink/renderer/modules/webaudio/realtime_audio_worklet_thread.cc b/third_party/blink/renderer/modules/webaudio/realtime_audio_worklet_thread.cc
+index 92fad010f..6e27beff3 100644
+--- a/third_party/blink/renderer/modules/webaudio/realtime_audio_worklet_thread.cc
++++ b/third_party/blink/renderer/modules/webaudio/realtime_audio_worklet_thread.cc
+@@ -16,11 +16,11 @@ namespace {
+ 
+ // Use for ref-counting of all RealtimeAudioWorkletThread instances in a
+ // process. Incremented by the constructor and decremented by destructor.
+-int ref_count = 0;
++int ref_count_RAWT = 0;
+ 
+-void EnsureSharedBackingThread(const ThreadCreationParams& params) {
++void EnsureSharedBackingThread_RAWT(const ThreadCreationParams& params) {
+   DCHECK(IsMainThread());
+-  DCHECK_EQ(ref_count, 1);
++  DCHECK_EQ(ref_count_RAWT, 1);
+   WorkletThreadHolder<RealtimeAudioWorkletThread>::EnsureInstance(params);
+ }
+ 
+@@ -54,15 +54,15 @@ RealtimeAudioWorkletThread::RealtimeAudioWorkletThread(
+                  "RealtimeAudioWorkletThread() - kNormal");
+   }
+ 
+-  if (++ref_count == 1) {
+-    EnsureSharedBackingThread(params);
++  if (++ref_count_RAWT == 1) {
++    EnsureSharedBackingThread_RAWT(params);
+   }
+ }
+ 
+ RealtimeAudioWorkletThread::~RealtimeAudioWorkletThread() {
+   DCHECK(IsMainThread());
+-  DCHECK_GT(ref_count, 0);
+-  if (--ref_count == 0) {
++  DCHECK_GT(ref_count_RAWT, 0);
++  if (--ref_count_RAWT == 0) {
+     ClearSharedBackingThread();
+   }
+ }
+@@ -74,7 +74,7 @@ WorkerBackingThread& RealtimeAudioWorkletThread::GetWorkerBackingThread() {
+ 
+ void RealtimeAudioWorkletThread::ClearSharedBackingThread() {
+   DCHECK(IsMainThread());
+-  CHECK_EQ(ref_count, 0);
++  CHECK_EQ(ref_count_RAWT, 0);
+   WorkletThreadHolder<RealtimeAudioWorkletThread>::ClearInstance();
+ }
+ 
+diff --git a/third_party/blink/renderer/modules/webaudio/semi_realtime_audio_worklet_thread.cc b/third_party/blink/renderer/modules/webaudio/semi_realtime_audio_worklet_thread.cc
+index 6fdc6a038..5357fcd15 100644
+--- a/third_party/blink/renderer/modules/webaudio/semi_realtime_audio_worklet_thread.cc
++++ b/third_party/blink/renderer/modules/webaudio/semi_realtime_audio_worklet_thread.cc
+@@ -16,11 +16,11 @@ namespace {
+ 
+ // Use for ref-counting of all SemiRealtimeAudioWorkletThread instances in a
+ // process. Incremented by the constructor and decremented by destructor.
+-int ref_count = 0;
++int ref_count_SRAWT = 0;
+ 
+-void EnsureSharedBackingThread(const ThreadCreationParams& params) {
++void EnsureSharedBackingThreadSRAWT(const ThreadCreationParams& params) {
+   DCHECK(IsMainThread());
+-  DCHECK_EQ(ref_count, 1);
++  DCHECK_EQ(ref_count_SRAWT, 1);
+   WorkletThreadHolder<SemiRealtimeAudioWorkletThread>::EnsureInstance(params);
+ }
+ 
+@@ -49,15 +49,15 @@ SemiRealtimeAudioWorkletThread::SemiRealtimeAudioWorkletThread(
+     params.base_thread_type = base::ThreadType::kDefault;
+   }
+ 
+-  if (++ref_count == 1) {
+-    EnsureSharedBackingThread(params);
++  if (++ref_count_SRAWT == 1) {
++    EnsureSharedBackingThreadSRAWT(params);
+   }
+ }
+ 
+ SemiRealtimeAudioWorkletThread::~SemiRealtimeAudioWorkletThread() {
+   DCHECK(IsMainThread());
+-  DCHECK_GT(ref_count, 0);
+-  if (--ref_count == 0) {
++  DCHECK_GT(ref_count_SRAWT, 0);
++  if (--ref_count_SRAWT == 0) {
+     ClearSharedBackingThread();
+   }
+ }
+@@ -69,7 +69,7 @@ WorkerBackingThread& SemiRealtimeAudioWorkletThread::GetWorkerBackingThread() {
+ 
+ void SemiRealtimeAudioWorkletThread::ClearSharedBackingThread() {
+   DCHECK(IsMainThread());
+-  CHECK_EQ(ref_count, 0);
++  CHECK_EQ(ref_count_SRAWT, 0);
+   WorkletThreadHolder<SemiRealtimeAudioWorkletThread>::ClearInstance();
+ }
+ 
+diff --git a/third_party/blink/renderer/modules/webaudio/stereo_panner_handler.cc b/third_party/blink/renderer/modules/webaudio/stereo_panner_handler.cc
+index 2c199fb02..2f4b24a1c 100644
+--- a/third_party/blink/renderer/modules/webaudio/stereo_panner_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/stereo_panner_handler.cc
+@@ -20,8 +20,8 @@ namespace blink {
+ namespace {
+ 
+ // A PannerNode only supports 1 or 2 channels
+-constexpr unsigned kMinimumOutputChannels = 1;
+-constexpr unsigned kMaximumOutputChannels = 2;
++constexpr unsigned kMinimumOutputChannels_SPH = 1;
++constexpr unsigned kMaximumOutputChannels_SPH = 2;
+ 
+ }  // namespace
+ 
+@@ -33,11 +33,11 @@ StereoPannerHandler::StereoPannerHandler(AudioNode& node,
+       sample_accurate_pan_values_(
+           GetDeferredTaskHandler().RenderQuantumFrames()) {
+   AddInput();
+-  AddOutput(kMaximumOutputChannels);
++  AddOutput(kMaximumOutputChannels_SPH);
+ 
+   // The node-specific default mixing rules declare that StereoPannerNode
+   // can handle mono to stereo and stereo to stereo conversion.
+-  channel_count_ = kMaximumOutputChannels;
++  channel_count_ = kMaximumOutputChannels_SPH;
+   SetInternalChannelCountMode(kClampedMax);
+   SetInternalChannelInterpretation(AudioBus::kSpeakers);
+ 
+@@ -112,8 +112,8 @@ void StereoPannerHandler::SetChannelCount(unsigned channel_count,
+   DCHECK(IsMainThread());
+   BaseAudioContext::GraphAutoLocker locker(Context());
+ 
+-  if (channel_count >= kMinimumOutputChannels &&
+-      channel_count <= kMaximumOutputChannels) {
++  if (channel_count >= kMinimumOutputChannels_SPH &&
++      channel_count <= kMaximumOutputChannels_SPH) {
+     if (channel_count_ != channel_count) {
+       channel_count_ = channel_count;
+       if (InternalChannelCountMode() != kMax) {
+@@ -124,8 +124,8 @@ void StereoPannerHandler::SetChannelCount(unsigned channel_count,
+     exception_state.ThrowDOMException(
+         DOMExceptionCode::kNotSupportedError,
+         ExceptionMessages::IndexOutsideRange<uint32_t>(
+-            "channelCount", channel_count, kMinimumOutputChannels,
+-            ExceptionMessages::kInclusiveBound, kMaximumOutputChannels,
++            "channelCount", channel_count, kMinimumOutputChannels_SPH,
++            ExceptionMessages::kInclusiveBound, kMaximumOutputChannels_SPH,
+             ExceptionMessages::kInclusiveBound));
+   }
+ }
+diff --git a/third_party/blink/renderer/modules/webaudio/wave_shaper_handler.cc b/third_party/blink/renderer/modules/webaudio/wave_shaper_handler.cc
+index 761140006..b341934b6 100644
+--- a/third_party/blink/renderer/modules/webaudio/wave_shaper_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/wave_shaper_handler.cc
+@@ -14,7 +14,7 @@ namespace blink {
+ 
+ namespace {
+ 
+-constexpr unsigned kNumberOfChannels = 1;
++constexpr unsigned kNumberOfChannelsWSH = 1;
+ 
+ }  // namespace
+ 
+@@ -25,7 +25,7 @@ WaveShaperHandler::WaveShaperHandler(AudioNode& node, float sample_rate)
+           sample_rate,
+           std::make_unique<WaveShaperProcessor>(
+               sample_rate,
+-              kNumberOfChannels,
++              kNumberOfChannelsWSH,
+               node.context()->GetDeferredTaskHandler().RenderQuantumFrames())) {
+   Initialize();
+ }
+diff --git a/third_party/blink/renderer/modules/webcodecs/BUILD.gn b/third_party/blink/renderer/modules/webcodecs/BUILD.gn
+index 70f30624d..28205ad14 100644
+--- a/third_party/blink/renderer/modules/webcodecs/BUILD.gn
++++ b/third_party/blink/renderer/modules/webcodecs/BUILD.gn
+@@ -93,6 +93,11 @@ blink_modules_sources("webcodecs") {
+     "webcodecs_logger.cc",
+     "webcodecs_logger.h",
+   ]
++  jumbo_excluded_sources = [
++    "video_decoder_broker.cc",
++    "video_encoder.cc",
++    "video_frame.cc",
++  ]
+   deps = [
+     "//build:chromeos_buildflags",
+     "//media",
+diff --git a/third_party/blink/renderer/modules/webcodecs/decoder_template.cc b/third_party/blink/renderer/modules/webcodecs/decoder_template.cc
+index 011a44722..40f359ec2 100644
+--- a/third_party/blink/renderer/modules/webcodecs/decoder_template.cc
++++ b/third_party/blink/renderer/modules/webcodecs/decoder_template.cc
+@@ -55,7 +55,7 @@
+ namespace blink {
+ 
+ namespace {
+-constexpr const char kCategory[] = "media";
++constexpr const char kCategory2[] = "media";
+ 
+ base::AtomicSequenceNumber g_sequence_num_for_counters;
+ }  // namespace
+@@ -492,7 +492,7 @@ void DecoderTemplate<Traits>::Shutdown(DOMException* exception) {
+   if (IsClosed())
+     return;
+ 
+-  TRACE_EVENT1(kCategory, GetTraceNames()->shutdown.c_str(), "has_exception",
++  TRACE_EVENT1(kCategory2, GetTraceNames()->shutdown.c_str(), "has_exception",
+                !!exception);
+ 
+   shutting_down_ = true;
+@@ -550,7 +550,7 @@ void DecoderTemplate<Traits>::Shutdown(DOMException* exception) {
+   }
+ 
+   bool trace_enabled = false;
+-  TRACE_EVENT_CATEGORY_GROUP_ENABLED(kCategory, &trace_enabled);
++  TRACE_EVENT_CATEGORY_GROUP_ENABLED(kCategory2, &trace_enabled);
+   if (trace_enabled) {
+     for (auto& pending_decode : pending_decodes_)
+       pending_decode.value->decode_trace.reset();
+@@ -754,12 +754,12 @@ void DecoderTemplate<Traits>::OnOutput(uint32_t reset_generation,
+ 
+   OutputType* blink_output = std::move(output_or_error).value();
+ 
+-  TRACE_EVENT_BEGIN1(kCategory, GetTraceNames()->output.c_str(), "timestamp",
++  TRACE_EVENT_BEGIN1(kCategory2, GetTraceNames()->output.c_str(), "timestamp",
+                      blink_output->timestamp());
+ 
+   output_cb_->InvokeAndReportException(nullptr, blink_output);
+ 
+-  TRACE_EVENT_END0(kCategory, GetTraceNames()->output.c_str());
++  TRACE_EVENT_END0(kCategory2, GetTraceNames()->output.c_str());
+ 
+   MarkCodecActive();
+ }
+@@ -767,7 +767,7 @@ void DecoderTemplate<Traits>::OnOutput(uint32_t reset_generation,
+ template <typename Traits>
+ void DecoderTemplate<Traits>::TraceQueueSizes() const {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+-  TRACE_COUNTER_ID2(kCategory, GetTraceNames()->requests_counter.c_str(),
++  TRACE_COUNTER_ID2(kCategory2, GetTraceNames()->requests_counter.c_str(),
+                     trace_counter_id_, "decodes", num_pending_decodes_, "other",
+                     requests_.size() - num_pending_decodes_);
+ }
+@@ -830,7 +830,7 @@ void DecoderTemplate<Traits>::Trace(Visitor* visitor) const {
+ 
+ template <typename Traits>
+ void DecoderTemplate<Traits>::OnCodecReclaimed(DOMException* exception) {
+-  TRACE_EVENT0(kCategory, GetTraceNames()->reclaimed.c_str());
++  TRACE_EVENT0(kCategory2, GetTraceNames()->reclaimed.c_str());
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+   DCHECK(is_applying_codec_pressure());
+ 
+@@ -883,7 +883,7 @@ void DecoderTemplate<Traits>::Request::StartTracing() {
+   DCHECK(!is_tracing);
+   is_tracing = true;
+ #endif
+-  TRACE_EVENT_NESTABLE_ASYNC_BEGIN0(kCategory, TraceNameFromType(), this);
++  TRACE_EVENT_NESTABLE_ASYNC_BEGIN0(kCategory2, TraceNameFromType(), this);
+ }
+ 
+ template <typename Traits>
+@@ -892,7 +892,7 @@ void DecoderTemplate<Traits>::Request::EndTracing(bool shutting_down) {
+   DCHECK(is_tracing);
+   is_tracing = false;
+ #endif
+-  TRACE_EVENT_NESTABLE_ASYNC_END1(kCategory, TraceNameFromType(), this,
++  TRACE_EVENT_NESTABLE_ASYNC_END1(kCategory2, TraceNameFromType(), this,
+                                   "completed", !shutting_down);
+ }
+ 
+diff --git a/third_party/blink/renderer/modules/webcodecs/encoder_base.cc b/third_party/blink/renderer/modules/webcodecs/encoder_base.cc
+index 671758b63..936bfdd09 100644
+--- a/third_party/blink/renderer/modules/webcodecs/encoder_base.cc
++++ b/third_party/blink/renderer/modules/webcodecs/encoder_base.cc
+@@ -45,9 +45,9 @@
+ namespace blink {
+ 
+ namespace {
+-constexpr const char kCategory[] = "media";
++constexpr const char kCategory3[] = "media";
+ 
+-base::AtomicSequenceNumber g_sequence_num_for_counters;
++base::AtomicSequenceNumber g_sequence_num_for_counters2;
+ }  // namespace
+ 
+ // static
+@@ -66,7 +66,7 @@ EncoderBase<Traits>::EncoderBase(ScriptState* script_state,
+                        ExecutionContext::From(script_state)),
+       state_(V8CodecState::Enum::kUnconfigured),
+       script_state_(script_state),
+-      trace_counter_id_(g_sequence_num_for_counters.GetNext()) {
++      trace_counter_id_(g_sequence_num_for_counters2.GetNext()) {
+   auto* context = ExecutionContext::From(script_state);
+   callback_runner_ = context->GetTaskRunner(TaskType::kInternalMediaRealTime);
+ 
+@@ -204,7 +204,7 @@ void EncoderBase<Traits>::reset(ExceptionState& exception_state) {
+   if (ThrowIfCodecStateClosed(state_, "reset", exception_state))
+     return;
+ 
+-  TRACE_EVENT0(kCategory, GetTraceNames()->reset.c_str());
++  TRACE_EVENT0(kCategory3, GetTraceNames()->reset.c_str());
+ 
+   state_ = V8CodecState(V8CodecState::Enum::kUnconfigured);
+   ResetInternal();
+@@ -253,7 +253,7 @@ void EncoderBase<Traits>::HandleError(DOMException* ex) {
+   if (state_.AsEnum() == V8CodecState::Enum::kClosed)
+     return;
+ 
+-  TRACE_EVENT0(kCategory, GetTraceNames()->handle_error.c_str());
++  TRACE_EVENT0(kCategory3, GetTraceNames()->handle_error.c_str());
+ 
+   // Save a temp before we clear the callback.
+   V8WebCodecsErrorCallback* error_callback = error_callback_.Get();
+@@ -362,7 +362,7 @@ void EncoderBase<Traits>::ProcessFlush(Request* request) {
+ 
+ template <typename Traits>
+ void EncoderBase<Traits>::OnCodecReclaimed(DOMException* exception) {
+-  TRACE_EVENT0(kCategory, GetTraceNames()->reclaimed.c_str());
++  TRACE_EVENT0(kCategory3, GetTraceNames()->reclaimed.c_str());
+   DCHECK_EQ(state_.AsEnum(), V8CodecState::Enum::kConfigured);
+   HandleError(exception);
+ }
+@@ -381,7 +381,7 @@ bool EncoderBase<Traits>::HasPendingActivity() const {
+ 
+ template <typename Traits>
+ void EncoderBase<Traits>::TraceQueueSizes() const {
+-  TRACE_COUNTER_ID2(kCategory, GetTraceNames()->requests_counter.c_str(),
++  TRACE_COUNTER_ID2(kCategory3, GetTraceNames()->requests_counter.c_str(),
+                     trace_counter_id_, "encodes", requested_encodes_, "other",
+                     requests_.size() - requested_encodes_);
+ }
+@@ -467,7 +467,7 @@ void EncoderBase<Traits>::Request::StartTracingVideoEncode(
+   DCHECK(!is_tracing);
+   is_tracing = true;
+ #endif
+-  TRACE_EVENT_NESTABLE_ASYNC_BEGIN2(kCategory, TraceNameFromType(), this,
++  TRACE_EVENT_NESTABLE_ASYNC_BEGIN2(kCategory3, TraceNameFromType(), this,
+                                     "key_frame", is_keyframe, "timestamp",
+                                     timestamp);
+ }
+@@ -478,7 +478,7 @@ void EncoderBase<Traits>::Request::StartTracing() {
+   DCHECK(!is_tracing);
+   is_tracing = true;
+ #endif
+-  TRACE_EVENT_NESTABLE_ASYNC_BEGIN0(kCategory, TraceNameFromType(), this);
++  TRACE_EVENT_NESTABLE_ASYNC_BEGIN0(kCategory3, TraceNameFromType(), this);
+ }
+ 
+ template <typename Traits>
+@@ -487,7 +487,7 @@ void EncoderBase<Traits>::Request::EndTracing(bool aborted) {
+   DCHECK(is_tracing);
+   is_tracing = false;
+ #endif
+-  TRACE_EVENT_NESTABLE_ASYNC_END1(kCategory, TraceNameFromType(), this,
++  TRACE_EVENT_NESTABLE_ASYNC_END1(kCategory3, TraceNameFromType(), this,
+                                   "aborted", aborted);
+ }
+ 
+diff --git a/third_party/blink/renderer/modules/webcodecs/gpu_factories_retriever.cc b/third_party/blink/renderer/modules/webcodecs/gpu_factories_retriever.cc
+index e829dea84..8cf583fc5 100644
+--- a/third_party/blink/renderer/modules/webcodecs/gpu_factories_retriever.cc
++++ b/third_party/blink/renderer/modules/webcodecs/gpu_factories_retriever.cc
+@@ -20,14 +20,14 @@ MainThreadTaskRunnerRestricted AccessMainThreadForGpuFactories() {
+ 
+ namespace {
+ 
+-media::GpuVideoAcceleratorFactories* GetGpuFactoriesOnMainThread() {
++media::GpuVideoAcceleratorFactories* GetGpuFactoriesOnMainThread2() {
+   DCHECK(IsMainThread());
+   return Platform::Current()->GetGpuFactories();
+ }
+ 
+ void RetrieveGpuFactories(OutputCB result_callback) {
+   if (IsMainThread()) {
+-    std::move(result_callback).Run(GetGpuFactoriesOnMainThread());
++    std::move(result_callback).Run(GetGpuFactoriesOnMainThread2());
+     return;
+   }
+ 
+@@ -36,7 +36,7 @@ void RetrieveGpuFactories(OutputCB result_callback) {
+       ->PostTaskAndReplyWithResult(
+           FROM_HERE,
+           ConvertToBaseOnceCallback(
+-              CrossThreadBindOnce(&GetGpuFactoriesOnMainThread)),
++              CrossThreadBindOnce(&GetGpuFactoriesOnMainThread2)),
+           ConvertToBaseOnceCallback(std::move(result_callback)));
+ }
+ 
+diff --git a/third_party/blink/renderer/modules/webgpu/BUILD.gn b/third_party/blink/renderer/modules/webgpu/BUILD.gn
+index c91cc379b..ab934a25d 100644
+--- a/third_party/blink/renderer/modules/webgpu/BUILD.gn
++++ b/third_party/blink/renderer/modules/webgpu/BUILD.gn
+@@ -96,6 +96,8 @@ blink_modules_sources("webgpu") {
+     "texture_utils.cc",
+     "texture_utils.h",
+   ]
++  jumbo_excluded_sources = [ "dawn_enum_conversions.cc" ]
++
+   deps = [
+     "//gpu/command_buffer/client:webgpu_interface",
+     "//services/metrics/public/cpp:ukm_builders",
+diff --git a/third_party/blink/renderer/platform/BUILD.gn b/third_party/blink/renderer/platform/BUILD.gn
+index 415d024f2..88d991149 100644
+--- a/third_party/blink/renderer/platform/BUILD.gn
++++ b/third_party/blink/renderer/platform/BUILD.gn
+@@ -1590,6 +1590,15 @@ jumbo_component("platform") {
+     }
+   }
+ 
++  jumbo_excluded_sources = [
++    "bindings/parkable_string_manager.cc",
++    "fonts/font_matching_metrics.cc",
++    "mediastream/media_stream_audio_source.cc",
++    "mediastream/media_stream_audio_track.cc",
++    "peerconnection/rtc_video_decoder_adapter.cc",
++    "peerconnection/rtc_video_decoder_factory.cc",
++  ]
++
+   if (is_mac) {
+     sources += [
+       "audio/mac/fft_frame_mac.cc",
+diff --git a/third_party/blink/renderer/platform/audio/cpu/x86/audio_delay_dsp_kernel_sse2.cc b/third_party/blink/renderer/platform/audio/cpu/x86/audio_delay_dsp_kernel_sse2.cc
+index 0dc2d90f2..a7e6ee53b 100644
+--- a/third_party/blink/renderer/platform/audio/cpu/x86/audio_delay_dsp_kernel_sse2.cc
++++ b/third_party/blink/renderer/platform/audio/cpu/x86/audio_delay_dsp_kernel_sse2.cc
+@@ -4,7 +4,9 @@
+ 
+ #include "third_party/blink/renderer/platform/audio/audio_delay_dsp_kernel.h"
+ 
++#include <emmintrin.h>
+ #include <xmmintrin.h>
++#include <tuple>
+ 
+ namespace blink {
+ 
+diff --git a/third_party/blink/renderer/platform/audio/hrtf_panner.cc b/third_party/blink/renderer/platform/audio/hrtf_panner.cc
+index 363fcdd01..a8c258362 100644
+--- a/third_party/blink/renderer/platform/audio/hrtf_panner.cc
++++ b/third_party/blink/renderer/platform/audio/hrtf_panner.cc
+@@ -40,7 +40,7 @@ namespace {
+ // The value of 2 milliseconds is larger than the largest delay which exists in
+ // any HRTFKernel from the default HRTFDatabase (0.0136 seconds).
+ // We ASSERT the delay values used in process() with this value.
+-constexpr double kMaxDelayTimeSeconds = 0.002;
++constexpr double kMaxDelayTimeSeconds2 = 0.002;
+ 
+ constexpr int kUninitializedAzimuth = -1;
+ 
+@@ -85,8 +85,8 @@ HRTFPanner::HRTFPanner(float sample_rate,
+       convolver_r1_(FftSizeForSampleRate(sample_rate)),
+       convolver_l2_(FftSizeForSampleRate(sample_rate)),
+       convolver_r2_(FftSizeForSampleRate(sample_rate)),
+-      delay_line_l_(kMaxDelayTimeSeconds, sample_rate, render_quantum_frames),
+-      delay_line_r_(kMaxDelayTimeSeconds, sample_rate, render_quantum_frames),
++      delay_line_l_(kMaxDelayTimeSeconds2, sample_rate, render_quantum_frames),
++      delay_line_r_(kMaxDelayTimeSeconds2, sample_rate, render_quantum_frames),
+       temp_l1_(render_quantum_frames),
+       temp_r1_(render_quantum_frames),
+       temp_l2_(render_quantum_frames),
+@@ -253,10 +253,10 @@ void HRTFPanner::Pan(double desired_azimuth,
+     DCHECK(kernel_r1);
+     DCHECK(kernel_l2);
+     DCHECK(kernel_r2);
+-    DCHECK_LT(frame_delay_l1 / SampleRate(), kMaxDelayTimeSeconds);
+-    DCHECK_LT(frame_delay_r1 / SampleRate(), kMaxDelayTimeSeconds);
+-    DCHECK_LT(frame_delay_l2 / SampleRate(), kMaxDelayTimeSeconds);
+-    DCHECK_LT(frame_delay_r2 / SampleRate(), kMaxDelayTimeSeconds);
++    DCHECK_LT(frame_delay_l1 / SampleRate(), kMaxDelayTimeSeconds2);
++    DCHECK_LT(frame_delay_r1 / SampleRate(), kMaxDelayTimeSeconds2);
++    DCHECK_LT(frame_delay_l2 / SampleRate(), kMaxDelayTimeSeconds2);
++    DCHECK_LT(frame_delay_r2 / SampleRate(), kMaxDelayTimeSeconds2);
+ 
+     // Crossfade inter-aural delays based on transitions.
+     const double frame_delay_l =
+@@ -369,7 +369,7 @@ double HRTFPanner::TailTime() const {
+   // the tailTime of the HRTFPanner is the sum of the tailTime of the
+   // DelayKernel and the tailTime of the FFTConvolver, which is
+   // MaxDelayTimeSeconds and fftSize() / 2, respectively.
+-  return kMaxDelayTimeSeconds +
++  return kMaxDelayTimeSeconds2 +
+          (FftSize() / 2) / static_cast<double>(SampleRate());
+ }
+ 
+diff --git a/third_party/blink/renderer/platform/fonts/shaping/harfbuzz_shaper.cc b/third_party/blink/renderer/platform/fonts/shaping/harfbuzz_shaper.cc
+index c165a1703..6b5937647 100644
+--- a/third_party/blink/renderer/platform/fonts/shaping/harfbuzz_shaper.cc
++++ b/third_party/blink/renderer/platform/fonts/shaping/harfbuzz_shaper.cc
+@@ -61,11 +61,11 @@ namespace blink {
+ 
+ namespace {
+ 
+-constexpr hb_feature_t CreateFeature(char c1,
+-                                     char c2,
+-                                     char c3,
+-                                     char c4,
+-                                     uint32_t value = 0) {
++constexpr hb_feature_t CreateFeature2(char c1,
++                                      char c2,
++                                      char c3,
++                                      char c4,
++                                      uint32_t value = 0) {
+   return {HB_TAG(c1, c2, c3, c4), value, 0 /* start */,
+           static_cast<unsigned>(-1) /* end */};
+ }
+@@ -720,12 +720,12 @@ CapsFeatureSettingsScopedOverlay::CapsFeatureSettingsScopedOverlay(
+ 
+ void CapsFeatureSettingsScopedOverlay::OverlayCapsFeatures(
+     FontDescription::FontVariantCaps variant_caps) {
+-  static constexpr hb_feature_t smcp = CreateFeature('s', 'm', 'c', 'p', 1);
+-  static constexpr hb_feature_t pcap = CreateFeature('p', 'c', 'a', 'p', 1);
+-  static constexpr hb_feature_t c2sc = CreateFeature('c', '2', 's', 'c', 1);
+-  static constexpr hb_feature_t c2pc = CreateFeature('c', '2', 'p', 'c', 1);
+-  static constexpr hb_feature_t unic = CreateFeature('u', 'n', 'i', 'c', 1);
+-  static constexpr hb_feature_t titl = CreateFeature('t', 'i', 't', 'l', 1);
++  static constexpr hb_feature_t smcp = CreateFeature2('s', 'm', 'c', 'p', 1);
++  static constexpr hb_feature_t pcap = CreateFeature2('p', 'c', 'a', 'p', 1);
++  static constexpr hb_feature_t c2sc = CreateFeature2('c', '2', 's', 'c', 1);
++  static constexpr hb_feature_t c2pc = CreateFeature2('c', '2', 'p', 'c', 1);
++  static constexpr hb_feature_t unic = CreateFeature2('u', 'n', 'i', 'c', 1);
++  static constexpr hb_feature_t titl = CreateFeature2('t', 'i', 't', 'l', 1);
+   if (variant_caps == FontDescription::kSmallCaps ||
+       variant_caps == FontDescription::kAllSmallCaps) {
+     PrependCounting(smcp);
+diff --git a/third_party/blink/renderer/platform/graphics/compositing/paint_artifact_compositor.cc b/third_party/blink/renderer/platform/graphics/compositing/paint_artifact_compositor.cc
+index c8704ddeb..2e6ac4b5f 100644
+--- a/third_party/blink/renderer/platform/graphics/compositing/paint_artifact_compositor.cc
++++ b/third_party/blink/renderer/platform/graphics/compositing/paint_artifact_compositor.cc
+@@ -637,7 +637,7 @@ void PaintArtifactCompositor::Update(
+     const Vector<const TransformPaintPropertyNode*>& scroll_translation_nodes,
+     Vector<std::unique_ptr<cc::ViewTransitionRequest>> transition_requests) {
+   const bool unification_enabled =
+-      base::FeatureList::IsEnabled(features::kScrollUnification);
++      base::FeatureList::IsEnabled(::features::kScrollUnification);
+   // See: |UpdateRepaintedLayers| for repaint updates.
+   DCHECK(needs_update_);
+   DCHECK(scroll_translation_nodes.empty() || unification_enabled);
+diff --git a/third_party/blink/renderer/platform/image-decoders/jpeg/jpeg_image_decoder.cc b/third_party/blink/renderer/platform/image-decoders/jpeg/jpeg_image_decoder.cc
+index bbf10abdb..31c24ada0 100644
+--- a/third_party/blink/renderer/platform/image-decoders/jpeg/jpeg_image_decoder.cc
++++ b/third_party/blink/renderer/platform/image-decoders/jpeg/jpeg_image_decoder.cc
+@@ -49,6 +49,10 @@
+ #include "third_party/blink/renderer/platform/runtime_enabled_features.h"
+ #include "third_party/skia/include/core/SkColorSpace.h"
+ 
++#if defined(OS_WIN)
++#include <basetsd.h>  // Included before jpeglib.h because of INT32 clash
++#endif                // OS_WIN
++
+ extern "C" {
+ #include <stdio.h>  // jpeglib.h needs stdio FILE.
+ #include "jpeglib.h"
+diff --git a/third_party/blink/renderer/platform/loader/web_url_request_util.cc b/third_party/blink/renderer/platform/loader/web_url_request_util.cc
+index 209565038..c6f33cfc4 100644
+--- a/third_party/blink/renderer/platform/loader/web_url_request_util.cc
++++ b/third_party/blink/renderer/platform/loader/web_url_request_util.cc
+@@ -28,6 +28,7 @@
+ #include "third_party/blink/public/platform/web_string.h"
+ #include "third_party/blink/public/platform/web_url_request.h"
+ #include "third_party/blink/renderer/platform/loader/mixed_content.h"
++#include "third_party/blink/renderer/platform/wtf/assertions.h"
+ #include "third_party/blink/renderer/platform/wtf/std_lib_extras.h"
+ #include "third_party/blink/renderer/platform/wtf/text/string_builder.h"
+ #include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
+diff --git a/third_party/blink/renderer/platform/peerconnection/stats_collecting_decoder.cc b/third_party/blink/renderer/platform/peerconnection/stats_collecting_decoder.cc
+index 142fdccf2..3b727c6bb 100644
+--- a/third_party/blink/renderer/platform/peerconnection/stats_collecting_decoder.cc
++++ b/third_party/blink/renderer/platform/peerconnection/stats_collecting_decoder.cc
+@@ -22,7 +22,7 @@ constexpr base::TimeDelta kCheckSimultaneousDecodersInterval = base::Seconds(5);
+ 
+ // Number of StatsCollectingDecoder instances right now that have started
+ // decoding.
+-std::atomic_int* GetDecoderCounter() {
++std::atomic_int* GetDecoderCounter2() {
+   static std::atomic_int s_counter(0);
+   return &s_counter;
+ }
+@@ -59,7 +59,7 @@ int32_t StatsCollectingDecoder::Decode(const webrtc::EncodedImage& input_image,
+   DCHECK_CALLED_ON_VALID_SEQUENCE(decoding_sequence_checker_);
+   if (!first_frame_decoded_) {
+     first_frame_decoded_ = true;
+-    ++(*GetDecoderCounter());
++    ++(*GetDecoderCounter2());
+   }
+   {
+     base::AutoLock auto_lock(lock_);
+@@ -92,7 +92,7 @@ int32_t StatsCollectingDecoder::Release() {
+   }
+ 
+   if (first_frame_decoded_) {
+-    --(*GetDecoderCounter());
++    --(*GetDecoderCounter2());
+     first_frame_decoded_ = false;
+   }
+ 
+@@ -132,13 +132,13 @@ void StatsCollectingDecoder::Decoded(webrtc::VideoFrame& decodedImage,
+   if ((now - last_check_for_simultaneous_decoders_) >
+       kCheckSimultaneousDecodersInterval) {
+     last_check_for_simultaneous_decoders_ = now;
+-    DVLOG(3) << "Simultaneous decoders: " << *GetDecoderCounter();
++    DVLOG(3) << "Simultaneous decoders: " << *GetDecoderCounter2();
+     if (active_stats_collection()) {
+-      if (*GetDecoderCounter() > kMaximumDecodersToCollectStats) {
++      if (*GetDecoderCounter2() > kMaximumDecodersToCollectStats) {
+         // Too many decoders, cancel stats collection.
+         ClearStatsCollection();
+       }
+-    } else if (*GetDecoderCounter() <= kMaximumDecodersToCollectStats) {
++    } else if (*GetDecoderCounter2() <= kMaximumDecodersToCollectStats) {
+       // Start up stats collection since there's only a single decoder active.
+       StartStatsCollection();
+     }
+diff --git a/third_party/blink/renderer/platform/widget/compositing/layer_tree_view.cc b/third_party/blink/renderer/platform/widget/compositing/layer_tree_view.cc
+index 3c828c7b1..83c3638a2 100644
+--- a/third_party/blink/renderer/platform/widget/compositing/layer_tree_view.cc
++++ b/third_party/blink/renderer/platform/widget/compositing/layer_tree_view.cc
+@@ -291,7 +291,7 @@ void LayerTreeView::WillCommit(const cc::CommitState&) {
+   if (!delegate_)
+     return;
+   delegate_->WillCommitCompositorFrame();
+-  if (base::FeatureList::IsEnabled(features::kNonBlockingCommit)) {
++  if (base::FeatureList::IsEnabled(::features::kNonBlockingCommit)) {
+     widget_scheduler_->DidCommitFrameToCompositor();
+   }
+ }
+@@ -301,7 +301,7 @@ void LayerTreeView::DidCommit(base::TimeTicks commit_start_time,
+   if (!delegate_)
+     return;
+   delegate_->DidCommitCompositorFrame(commit_start_time, commit_finish_time);
+-  if (!base::FeatureList::IsEnabled(features::kNonBlockingCommit)) {
++  if (!base::FeatureList::IsEnabled(::features::kNonBlockingCommit)) {
+     widget_scheduler_->DidCommitFrameToCompositor();
+   }
+ }
+diff --git a/third_party/blink/renderer/platform/widget/input/elastic_overscroll_controller.cc b/third_party/blink/renderer/platform/widget/input/elastic_overscroll_controller.cc
+index 29eb15839..f1989a299 100644
+--- a/third_party/blink/renderer/platform/widget/input/elastic_overscroll_controller.cc
++++ b/third_party/blink/renderer/platform/widget/input/elastic_overscroll_controller.cc
+@@ -69,7 +69,7 @@ ElasticOverscrollController::ElasticOverscrollController(
+ std::unique_ptr<ElasticOverscrollController>
+ ElasticOverscrollController::Create(cc::ScrollElasticityHelper* helper) {
+ #if BUILDFLAG(IS_WIN)
+-  return base::FeatureList::IsEnabled(features::kElasticOverscroll)
++  return base::FeatureList::IsEnabled(::features::kElasticOverscroll)
+              ? std::make_unique<ElasticOverscrollControllerBezier>(helper)
+              : nullptr;
+ #else
+diff --git a/third_party/blink/renderer/platform/widget/input/widget_base_input_handler.cc b/third_party/blink/renderer/platform/widget/input/widget_base_input_handler.cc
+index 89ae9b11d..c1d46cd85 100644
+--- a/third_party/blink/renderer/platform/widget/input/widget_base_input_handler.cc
++++ b/third_party/blink/renderer/platform/widget/input/widget_base_input_handler.cc
+@@ -161,7 +161,7 @@ mojom::InputEventResultState GetAckResult(WebInputEventResult processed) {
+              : mojom::InputEventResultState::kConsumed;
+ }
+ 
+-bool IsGestureScroll(WebInputEvent::Type type) {
++bool IsGestureScrollWBIH(WebInputEvent::Type type) {
+   switch (type) {
+     case WebGestureEvent::Type::kGestureScrollBegin:
+     case WebGestureEvent::Type::kGestureScrollUpdate:
+@@ -565,7 +565,7 @@ void WidgetBaseInputHandler::InjectGestureScrollEvent(
+     ui::ScrollGranularity granularity,
+     cc::ElementId scrollable_area_element_id,
+     WebInputEvent::Type injected_type) {
+-  DCHECK(IsGestureScroll(injected_type));
++  DCHECK(IsGestureScrollWBIH(injected_type));
+   // If we're currently handling an input event, cache the appropriate
+   // parameters so we can dispatch the events directly once blink finishes
+   // handling the event.
+diff --git a/ui/base/BUILD.gn b/ui/base/BUILD.gn
+index b2e7e5a28..d7b0b902a 100644
+--- a/ui/base/BUILD.gn
++++ b/ui/base/BUILD.gn
+@@ -214,6 +214,10 @@ jumbo_component("base") {
+ 
+   libs = []
+ 
++  jumbo_excluded_sources = [
++    "resource/resource_bundle.cc",
++  ]
++
+   if (is_android) {
+     sources += [
+       "device_form_factor_android.cc",
+diff --git a/ui/base/ime/win/BUILD.gn b/ui/base/ime/win/BUILD.gn
+index 67ff94a8c..68f32bf48 100644
+--- a/ui/base/ime/win/BUILD.gn
++++ b/ui/base/ime/win/BUILD.gn
+@@ -34,6 +34,7 @@ jumbo_component("win") {
+     "virtual_keyboard_debounce_timer.cc",
+     "virtual_keyboard_debounce_timer.h",
+   ]
++  jumbo_excluded_sources = [ "tsf_text_store.cc" ]
+ 
+   defines = [ "IS_UI_BASE_IME_WIN_IMPL" ]
+ 
+diff --git a/ui/base/x/BUILD.gn b/ui/base/x/BUILD.gn
+index 70b57c65c..67a3aae27 100644
+--- a/ui/base/x/BUILD.gn
++++ b/ui/base/x/BUILD.gn
+@@ -2,7 +2,6 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-import("//build/config/jumbo.gni")
+ import("//build/config/linux/gtk/gtk.gni")
+ import("//build/config/ozone.gni")
+ import("//build/config/ui.gni")
+@@ -10,7 +9,7 @@ import("//testing/libfuzzer/fuzzer_test.gni")
+ 
+ assert(ozone_platform_x11)
+ 
+-jumbo_component("x") {
++component("x") {
+   output_name = "ui_base_x"
+ 
+   sources = [
+diff --git a/ui/color/BUILD.gn b/ui/color/BUILD.gn
+index 1179f2721..3a9623e34 100644
+--- a/ui/color/BUILD.gn
++++ b/ui/color/BUILD.gn
+@@ -4,12 +4,11 @@
+ 
+ import("//build/buildflag_header.gni")
+ import("//build/config/chromeos/ui_mode.gni")
+-import("//build/config/jumbo.gni")
+ import("//mojo/public/tools/bindings/mojom.gni")
+ import("//testing/test.gni")
+ import("//ui/base/ui_features.gni")
+ 
+-jumbo_source_set("color_headers") {
++source_set("color_headers") {
+   sources = [
+     "color_id.h",
+     "color_id_macros.inc",
+@@ -30,7 +29,7 @@ jumbo_source_set("color_headers") {
+   ]
+ }
+ 
+-jumbo_component("color") {
++component("color") {
+   sources = [
+     "color_metrics.cc",
+     "color_mixer.cc",
+@@ -123,7 +122,7 @@ if (is_win) {
+   }
+ }
+ 
+-jumbo_component("mixers") {
++component("mixers") {
+   sources = [
+     "color_mixers.cc",
+     "color_mixers.h",
+diff --git a/ui/gfx/geometry/transform_operations.cc b/ui/gfx/geometry/transform_operations.cc
+index f9c2ee1b1..316b1aa68 100644
+--- a/ui/gfx/geometry/transform_operations.cc
++++ b/ui/gfx/geometry/transform_operations.cc
+@@ -139,7 +139,7 @@ bool TransformOperations::IsTranslation() const {
+   return true;
+ }
+ 
+-static SkScalar TanDegrees(double degrees) {
++static SkScalar TanDegrees2(double degrees) {
+   return SkDoubleToScalar(std::tan(DegToRad(degrees)));
+ }
+ 
+@@ -163,8 +163,8 @@ bool TransformOperations::ScaleComponent(SkScalar* scale) const {
+       case TransformOperation::TRANSFORM_OPERATION_SKEWX:
+       case TransformOperation::TRANSFORM_OPERATION_SKEWY:
+       case TransformOperation::TRANSFORM_OPERATION_SKEW: {
+-        SkScalar x_component = TanDegrees(operation.skew.x);
+-        SkScalar y_component = TanDegrees(operation.skew.y);
++        SkScalar x_component = TanDegrees2(operation.skew.x);
++        SkScalar y_component = TanDegrees2(operation.skew.y);
+         SkScalar x_scale = std::sqrt(x_component * x_component + 1);
+         SkScalar y_scale = std::sqrt(y_component * y_component + 1);
+         operations_scale *= std::max(x_scale, y_scale);
+diff --git a/ui/gl/BUILD.gn b/ui/gl/BUILD.gn
+index a7fa6c74c..da1cf1e74 100644
+--- a/ui/gl/BUILD.gn
++++ b/ui/gl/BUILD.gn
+@@ -223,6 +223,10 @@ jumbo_component("gl") {
+         "gl_angle_util_vulkan.cc",
+         "gl_angle_util_vulkan.h",
+       ]
++
++      jumbo_excluded_sources = [
++        "gl_angle_util_vulkan.cc",
++      ]
+     }
+ 
+     if (is_linux || is_chromeos || use_ozone) {
+diff --git a/ui/gl/direct_composition_surface_win.cc b/ui/gl/direct_composition_surface_win.cc
+index 4db92d7da..4cd7637cf 100644
+--- a/ui/gl/direct_composition_surface_win.cc
++++ b/ui/gl/direct_composition_surface_win.cc
+@@ -24,7 +24,7 @@ namespace gl {
+ 
+ namespace {
+ 
+-bool SupportsLowLatencyPresentation() {
++bool SupportsLowLatencyPresentation2() {
+   return base::FeatureList::IsEnabled(
+       features::kDirectCompositionLowLatencyPresentation);
+ }
+@@ -172,7 +172,7 @@ void DirectCompositionSurfaceWin::SetVSyncEnabled(bool enabled) {
+ void DirectCompositionSurfaceWin::OnVSync(base::TimeTicks vsync_time,
+                                           base::TimeDelta interval) {
+   // Main thread will run vsync callback in low latency presentation mode.
+-  if (VSyncCallbackEnabled() && !SupportsLowLatencyPresentation()) {
++  if (VSyncCallbackEnabled() && !SupportsLowLatencyPresentation2()) {
+     DCHECK(vsync_callback_);
+     vsync_callback_.Run(vsync_time, interval);
+   }
+@@ -299,7 +299,7 @@ void DirectCompositionSurfaceWin::HandleVSyncOnMainThread(
+   UMA_HISTOGRAM_COUNTS_100("GPU.DirectComposition.NumPendingFrames",
+                            pending_frames_.size());
+ 
+-  if (SupportsLowLatencyPresentation() && VSyncCallbackEnabled() &&
++  if (SupportsLowLatencyPresentation2() && VSyncCallbackEnabled() &&
+       pending_frames_.size() < max_pending_frames_) {
+     DCHECK(vsync_callback_);
+     vsync_callback_.Run(vsync_time, interval);
+diff --git a/ui/native_theme/BUILD.gn b/ui/native_theme/BUILD.gn
+index b714e00e0..6b022564c 100644
+--- a/ui/native_theme/BUILD.gn
++++ b/ui/native_theme/BUILD.gn
+@@ -2,7 +2,6 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-import("//build/config/jumbo.gni")
+ import("//build/config/ui.gni")
+ import("//testing/test.gni")
+ 
+@@ -23,7 +22,7 @@ component("features") {
+   ]
+ }
+ 
+-jumbo_component("native_theme") {
++component("native_theme") {
+   sources = [
+     "caption_style.cc",
+     "caption_style.h",
+@@ -104,7 +103,7 @@ jumbo_component("native_theme") {
+ }
+ 
+ if (is_win) {
+-  jumbo_component("native_theme_browser") {
++  component("native_theme_browser") {
+     defines = [ "NATIVE_THEME_IMPLEMENTATION" ]
+ 
+     # These files cannot work in the renderer on Windows.
+@@ -126,11 +125,11 @@ if (is_win) {
+     libs = [ "uxtheme.lib" ]
+   }
+ } else {
+-  jumbo_source_set("native_theme_browser") {
++  source_set("native_theme_browser") {
+   }
+ }
+ 
+-jumbo_source_set("test_support") {
++source_set("test_support") {
+   testonly = true
+ 
+   deps = [
+-- 
+2.43.0
+

--- a/x11-packages/carbonyl-host-tools/patches/0102-fixes-for-jumbo-build-2.patch
+++ b/x11-packages/carbonyl-host-tools/patches/0102-fixes-for-jumbo-build-2.patch
@@ -1,0 +1,68 @@
+From 5fe61dff78202d8a3c738741c60ec4a08752e6ea Mon Sep 17 00:00:00 2001
+From: Chongyun Lee <licy183@termux.dev>
+Date: Thu, 30 Jan 2025 15:50:50 +0800
+Subject: [PATCH] Fixes for jumbo build 2
+
+To fix the following errors
+
+[34/999] CXX host/obj/third_party/blink/renderer/core/core/core_jumbo_16.o
+  In file included from host/gen/third_party/blink/renderer/core/core_jumbo_16.cc:26:
+  In file included from ./../../../src/chromium/src/third_party/blink/renderer/core/fetch/request.cc:15:
+  host/gen/third_party/blink/public/mojom/permissions_policy/permissions_policy_feature.mojom-blink.h:39:8: error: explicit specialization of 'WTF::HashTraits<blink::mojom::PermissionsPolicyFeature>' after instantiation
+    39 | struct HashTraits<::blink::mojom::PermissionsPolicyFeature>
+        |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ../../../src/chromium/src/third_party/blink/renderer/platform/wtf/hash_map.h:92:20: note: implicit instantiation first required here
+    92 |   typedef typename MappedTraits::TraitType MappedType;
+        |                    ^
+  4 warnings and 1 error generated.
+[1/965] CXX host/obj/third_party/blink/renderer/core/core/core_jumbo_16.o
+  In file included from host/gen/third_party/blink/renderer/core/core_jumbo_16.cc:53:
+  In file included from ./../../../src/chromium/src/third_party/blink/renderer/core/frame/attribution_src_loader.cc:37:
+  host/gen/third_party/blink/public/mojom/permissions_policy/permissions_policy_feature.mojom-blink.h:39:8: error: explicit specialization of 'WTF::HashTraits<blink::mojom::PermissionsPolicyFeature>' after instantiation
+    39 | struct HashTraits<::blink::mojom::PermissionsPolicyFeature>
+        |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ../../../src/chromium/src/third_party/blink/renderer/platform/wtf/hash_map.h:92:20: note: implicit instantiation first required here
+    92 |   typedef typename MappedTraits::TraitType MappedType;
+        |                    ^
+  4 warnings and 1 error generated.
+[1/889] CXX host/obj/third_party/blink/renderer/core/core/core_jumbo_30.o
+  In file included from host/gen/third_party/blink/renderer/core/core_jumbo_30.cc:62:
+  In file included from ./../../../src/chromium/src/third_party/blink/renderer/core/layout/ng/layout_ng_view.cc:5:
+  ../../../src/chromium/src/third_party/blink/renderer/core/layout/ng/layout_ng_view.h:15:5: error: explicit instantiation declaration (with 'extern') follows explicit instantiation definition (without 'extern')
+    15 |     LayoutNGBlockFlowMixin<LayoutView>;
+        |     ^
+  ./../../../src/chromium/src/third_party/blink/renderer/core/layout/ng/layout_ng_block_flow_mixin.cc:297:37: note: explicit instantiation definition is here
+    297 | template class CORE_TEMPLATE_EXPORT LayoutNGBlockFlowMixin<LayoutView>;
+        |                                     ^
+  In file included from host/gen/third_party/blink/renderer/core/core_jumbo_30.cc:62:
+  In file included from ./../../../src/chromium/src/third_party/blink/renderer/core/layout/ng/layout_ng_view.cc:5:
+  ../../../src/chromium/src/third_party/blink/renderer/core/layout/ng/layout_ng_view.h:16:51: error: explicit instantiation declaration (with 'extern') follows explicit instantiation definition (without 'extern')
+    16 | extern template class CORE_EXTERN_TEMPLATE_EXPORT LayoutNGMixin<LayoutView>;
+        |                                                   ^
+  ../../../src/chromium/src/third_party/blink/renderer/core/layout/ng/layout_ng_block_flow_mixin.h:37:39: note: explicit instantiation definition is here
+    37 | class LayoutNGBlockFlowMixin : public LayoutNGMixin<Base> {
+        |                                       ^
+  2 errors generated.
+
+---
+ third_party/blink/renderer/core/BUILD.gn | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/third_party/blink/renderer/core/BUILD.gn b/third_party/blink/renderer/core/BUILD.gn
+index b5867d2da..9880bc00f 100644
+--- a/third_party/blink/renderer/core/BUILD.gn
++++ b/third_party/blink/renderer/core/BUILD.gn
+@@ -370,6 +370,10 @@ jumbo_component("core") {
+   jumbo_excluded_sources += rebase_path([ "scroll_animator.cc" ], "", "scroll")
+   jumbo_excluded_sources += rebase_path([ "grid_baseline_alignment.cc" ], "", "layout")
+   jumbo_excluded_sources += rebase_path([ "grid_track_sizing_algorithm.cc" ], "", "layout")
++  jumbo_excluded_sources += rebase_path([ "request.cc" ], "", "fetch")
++  jumbo_excluded_sources += rebase_path([ "attribution_src_loader.cc" ], "", "frame")
++  jumbo_excluded_sources += rebase_path([ "ng/layout_ng_block_flow_mixin.cc" ], "", "layout")
++  jumbo_excluded_sources += rebase_path([ "ng/layout_ng_view.cc" ], "", "layout")
+ 
+   public_configs = [ ":core_include_dirs" ]
+ 
+-- 
+2.43.0
+

--- a/x11-packages/carbonyl-host-tools/patches/0103-fixes-for-jumbo-build-3.patch
+++ b/x11-packages/carbonyl-host-tools/patches/0103-fixes-for-jumbo-build-3.patch
@@ -1,0 +1,271 @@
+From edf64ae7d8a49b9ff1aad0e8a4e2ab60f13cfeb5 Mon Sep 17 00:00:00 2001
+From: Chongyun Lee <licy183@termux.dev>
+Date: Thu, 30 Jan 2025 15:57:52 +0800
+Subject: [PATCH] Fixes for jumbo build 3
+
+To fix the following errors
+
+[2/427] CXX host/obj/third_party/blink/renderer/modules/webaudio/webaudio/webaudio_jumbo_2.o
+  In file included from host/gen/third_party/blink/renderer/modules/webaudio/webaudio_jumbo_2.cc:40:
+  ./../../../src/chromium/src/third_party/blink/renderer/modules/webaudio/delay_handler.cc:17:20: error: redefinition of 'kNumberOfChannels'
+    17 | constexpr unsigned kNumberOfChannels = 1;
+        |                    ^
+  ./../../../src/chromium/src/third_party/blink/renderer/modules/webaudio/biquad_filter_handler.cc:22:20: note: previous definition is here
+    22 | constexpr uint32_t kNumberOfChannels = 1;
+        |                    ^
+  In file included from host/gen/third_party/blink/renderer/modules/webaudio/webaudio_jumbo_2.cc:45:
+  ./../../../src/chromium/src/third_party/blink/renderer/modules/webaudio/gain_handler.cc:16:20: error: redefinition of 'kNumberOfOutputChannels'
+    16 | constexpr unsigned kNumberOfOutputChannels = 1;
+        |                    ^
+  ./../../../src/chromium/src/third_party/blink/renderer/modules/webaudio/channel_splitter_handler.cc:16:20: note: previous definition is here
+    16 | constexpr unsigned kNumberOfOutputChannels = 1;
+        |                    ^
+  In file included from host/gen/third_party/blink/renderer/modules/webaudio/webaudio_jumbo_2.cc:46:
+  ./../../../src/chromium/src/third_party/blink/renderer/modules/webaudio/gain_node.cc:36:18: error: redefinition of 'kDefaultGainValue'
+    36 | constexpr double kDefaultGainValue = 1.0;
+        |                  ^
+  ./../../../src/chromium/src/third_party/blink/renderer/modules/webaudio/biquad_filter_node.cc:44:18: note: previous definition is here
+    44 | constexpr double kDefaultGainValue = 0.0;
+        |                  ^
+  In file included from host/gen/third_party/blink/renderer/modules/webaudio/webaudio_jumbo_2.cc:65:
+  ./../../../src/chromium/src/third_party/blink/renderer/modules/webaudio/oscillator_node.cc:47:18: error: redefinition of 'kDefaultFrequencyValue'
+    47 | constexpr double kDefaultFrequencyValue = 440.0;
+        |                  ^
+  ./../../../src/chromium/src/third_party/blink/renderer/modules/webaudio/biquad_filter_node.cc:41:18: note: previous definition is here
+    41 | constexpr double kDefaultFrequencyValue = 350.0;
+        |                  ^
+  In file included from host/gen/third_party/blink/renderer/modules/webaudio/webaudio_jumbo_2.cc:70:
+  ./../../../src/chromium/src/third_party/blink/renderer/modules/webaudio/realtime_audio_destination_handler.cc:28:20: error: redefinition of 'kDefaultNumberOfInputChannels'
+    28 | constexpr unsigned kDefaultNumberOfInputChannels = 2;
+        |                    ^
+  ./../../../src/chromium/src/third_party/blink/renderer/modules/webaudio/convolver_handler.cc:33:20: note: previous definition is here
+    33 | constexpr unsigned kDefaultNumberOfInputChannels = 2;
+        |                    ^
+  5 errors generated.
+
+---
+ .../renderer/modules/webaudio/biquad_filter_handler.cc    | 4 ++--
+ .../blink/renderer/modules/webaudio/biquad_filter_node.cc | 8 ++++----
+ .../renderer/modules/webaudio/channel_splitter_handler.cc | 4 ++--
+ .../blink/renderer/modules/webaudio/convolver_handler.cc  | 4 ++--
+ .../blink/renderer/modules/webaudio/delay_handler.cc      | 4 ++--
+ .../blink/renderer/modules/webaudio/gain_handler.cc       | 4 ++--
+ third_party/blink/renderer/modules/webaudio/gain_node.cc  | 4 ++--
+ .../blink/renderer/modules/webaudio/oscillator_node.cc    | 4 ++--
+ .../webaudio/realtime_audio_destination_handler.cc        | 4 ++--
+ 9 files changed, 20 insertions(+), 20 deletions(-)
+
+diff --git a/third_party/blink/renderer/modules/webaudio/biquad_filter_handler.cc b/third_party/blink/renderer/modules/webaudio/biquad_filter_handler.cc
+index 075eb4d79..974f6a3b0 100644
+--- a/third_party/blink/renderer/modules/webaudio/biquad_filter_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/biquad_filter_handler.cc
+@@ -19,7 +19,7 @@ namespace blink {
+ 
+ namespace {
+ 
+-constexpr uint32_t kNumberOfChannels = 1;
++constexpr uint32_t kNumberOfChannels_BFH = 1;
+ 
+ }  // namespace
+ 
+@@ -35,7 +35,7 @@ BiquadFilterHandler::BiquadFilterHandler(AudioNode& node,
+           sample_rate,
+           std::make_unique<BiquadProcessor>(
+               sample_rate,
+-              kNumberOfChannels,
++              kNumberOfChannels_BFH,
+               node.context()->GetDeferredTaskHandler().RenderQuantumFrames(),
+               frequency,
+               q,
+diff --git a/third_party/blink/renderer/modules/webaudio/biquad_filter_node.cc b/third_party/blink/renderer/modules/webaudio/biquad_filter_node.cc
+index 11dedaaf7..ff6ea6b20 100644
+--- a/third_party/blink/renderer/modules/webaudio/biquad_filter_node.cc
++++ b/third_party/blink/renderer/modules/webaudio/biquad_filter_node.cc
+@@ -38,10 +38,10 @@ namespace blink {
+ 
+ namespace {
+ 
+-constexpr double kDefaultFrequencyValue = 350.0;
++constexpr double kDefaultFrequencyValue_BFN = 350.0;
+ constexpr float kMinFrequencyValue = 0.0f;
+ constexpr double kDefaultQValue = 1.0;
+-constexpr double kDefaultGainValue = 0.0;
++constexpr double kDefaultGainValue_BFN = 0.0;
+ constexpr float kMinGainValue = std::numeric_limits<float>::lowest();
+ constexpr double kDefaultDetuneValueBFN = 0.0;
+ 
+@@ -53,7 +53,7 @@ BiquadFilterNode::BiquadFilterNode(BaseAudioContext& context)
+           AudioParam::Create(context,
+                              Uuid(),
+                              AudioParamHandler::kParamTypeBiquadFilterFrequency,
+-                             kDefaultFrequencyValue,
++                             kDefaultFrequencyValue_BFN,
+                              AudioParamHandler::AutomationRate::kAudio,
+                              AudioParamHandler::AutomationRateMode::kVariable,
+                              kMinFrequencyValue,
+@@ -68,7 +68,7 @@ BiquadFilterNode::BiquadFilterNode(BaseAudioContext& context)
+           context,
+           Uuid(),
+           AudioParamHandler::kParamTypeBiquadFilterGain,
+-          kDefaultGainValue,
++          kDefaultGainValue_BFN,
+           AudioParamHandler::AutomationRate::kAudio,
+           AudioParamHandler::AutomationRateMode::kVariable,
+           kMinGainValue,
+diff --git a/third_party/blink/renderer/modules/webaudio/channel_splitter_handler.cc b/third_party/blink/renderer/modules/webaudio/channel_splitter_handler.cc
+index c39602210..3dc85800b 100644
+--- a/third_party/blink/renderer/modules/webaudio/channel_splitter_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/channel_splitter_handler.cc
+@@ -13,7 +13,7 @@ namespace blink {
+ 
+ namespace {
+ 
+-constexpr unsigned kNumberOfOutputChannels = 1;
++constexpr unsigned kNumberOfOutputChannels_CSH = 1;
+ 
+ }  // namespace
+ 
+@@ -30,7 +30,7 @@ ChannelSplitterHandler::ChannelSplitterHandler(AudioNode& node,
+   // Create a fixed number of outputs (able to handle the maximum number of
+   // channels fed to an input).
+   for (unsigned i = 0; i < number_of_outputs; ++i) {
+-    AddOutput(kNumberOfOutputChannels);
++    AddOutput(kNumberOfOutputChannels_CSH);
+   }
+ 
+   Initialize();
+diff --git a/third_party/blink/renderer/modules/webaudio/convolver_handler.cc b/third_party/blink/renderer/modules/webaudio/convolver_handler.cc
+index 78468d18a..5a214778f 100644
+--- a/third_party/blink/renderer/modules/webaudio/convolver_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/convolver_handler.cc
+@@ -30,7 +30,7 @@ namespace {
+ // worse phase errors. Given these constraints 32768 is a good compromise.
+ constexpr unsigned kMaxFftSize = 32768;
+ 
+-constexpr unsigned kDefaultNumberOfInputChannels = 2;
++constexpr unsigned kDefaultNumberOfInputChannels_CH = 2;
+ constexpr unsigned kDefaultNumberOfOutputChannelsCH = 1;
+ 
+ }  // namespace
+@@ -41,7 +41,7 @@ ConvolverHandler::ConvolverHandler(AudioNode& node, float sample_rate)
+   AddOutput(kDefaultNumberOfOutputChannelsCH);
+ 
+   // Node-specific default mixing rules.
+-  channel_count_ = kDefaultNumberOfInputChannels;
++  channel_count_ = kDefaultNumberOfInputChannels_CH;
+   SetInternalChannelCountMode(kClampedMax);
+   SetInternalChannelInterpretation(AudioBus::kSpeakers);
+ 
+diff --git a/third_party/blink/renderer/modules/webaudio/delay_handler.cc b/third_party/blink/renderer/modules/webaudio/delay_handler.cc
+index 8c9263833..7b4e47066 100644
+--- a/third_party/blink/renderer/modules/webaudio/delay_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/delay_handler.cc
+@@ -14,7 +14,7 @@ namespace blink {
+ 
+ namespace {
+ 
+-constexpr unsigned kNumberOfChannels = 1;
++constexpr unsigned kNumberOfChannels_DH = 1;
+ 
+ }  // namespace
+ 
+@@ -28,7 +28,7 @@ DelayHandler::DelayHandler(AudioNode& node,
+           sample_rate,
+           std::make_unique<DelayProcessor>(
+               sample_rate,
+-              kNumberOfChannels,
++              kNumberOfChannels_DH,
+               node.context()->GetDeferredTaskHandler().RenderQuantumFrames(),
+               delay_time,
+               max_delay_time)) {
+diff --git a/third_party/blink/renderer/modules/webaudio/gain_handler.cc b/third_party/blink/renderer/modules/webaudio/gain_handler.cc
+index e1d023096..09701f3dc 100644
+--- a/third_party/blink/renderer/modules/webaudio/gain_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/gain_handler.cc
+@@ -13,7 +13,7 @@ namespace blink {
+ 
+ namespace {
+ 
+-constexpr unsigned kNumberOfOutputChannels = 1;
++constexpr unsigned kNumberOfOutputChannels_GH = 1;
+ 
+ }  // namespace
+ 
+@@ -25,7 +25,7 @@ GainHandler::GainHandler(AudioNode& node,
+       sample_accurate_gain_values_(
+           GetDeferredTaskHandler().RenderQuantumFrames()) {
+   AddInput();
+-  AddOutput(kNumberOfOutputChannels);
++  AddOutput(kNumberOfOutputChannels_GH);
+ 
+   Initialize();
+ }
+diff --git a/third_party/blink/renderer/modules/webaudio/gain_node.cc b/third_party/blink/renderer/modules/webaudio/gain_node.cc
+index 5e697cc6a..0f3bd73b0 100644
+--- a/third_party/blink/renderer/modules/webaudio/gain_node.cc
++++ b/third_party/blink/renderer/modules/webaudio/gain_node.cc
+@@ -33,7 +33,7 @@ namespace blink {
+ 
+ namespace {
+ 
+-constexpr double kDefaultGainValue = 1.0;
++constexpr double kDefaultGainValue_GN = 1.0;
+ 
+ }  // namespace
+ 
+@@ -43,7 +43,7 @@ GainNode::GainNode(BaseAudioContext& context)
+           context,
+           Uuid(),
+           AudioParamHandler::kParamTypeGainGain,
+-          kDefaultGainValue,
++          kDefaultGainValue_GN,
+           AudioParamHandler::AutomationRate::kAudio,
+           AudioParamHandler::AutomationRateMode::kVariable)) {
+   SetHandler(
+diff --git a/third_party/blink/renderer/modules/webaudio/oscillator_node.cc b/third_party/blink/renderer/modules/webaudio/oscillator_node.cc
+index 11ed26b4a..8a4df6ad3 100644
+--- a/third_party/blink/renderer/modules/webaudio/oscillator_node.cc
++++ b/third_party/blink/renderer/modules/webaudio/oscillator_node.cc
+@@ -44,7 +44,7 @@ namespace blink {
+ 
+ namespace {
+ 
+-constexpr double kDefaultFrequencyValue = 440.0;
++constexpr double kDefaultFrequencyValue_ON = 440.0;
+ constexpr double kDefaultDetuneValue = 0.0;
+ 
+ }  // namespace
+@@ -58,7 +58,7 @@ OscillatorNode::OscillatorNode(BaseAudioContext& context,
+           AudioParam::Create(context,
+                              Uuid(),
+                              AudioParamHandler::kParamTypeOscillatorFrequency,
+-                             kDefaultFrequencyValue,
++                             kDefaultFrequencyValue_ON,
+                              AudioParamHandler::AutomationRate::kAudio,
+                              AudioParamHandler::AutomationRateMode::kVariable,
+                              /*min_value=*/-context.sampleRate() / 2,
+diff --git a/third_party/blink/renderer/modules/webaudio/realtime_audio_destination_handler.cc b/third_party/blink/renderer/modules/webaudio/realtime_audio_destination_handler.cc
+index 12b6b5ae1..d13600c7d 100644
+--- a/third_party/blink/renderer/modules/webaudio/realtime_audio_destination_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/realtime_audio_destination_handler.cc
+@@ -25,7 +25,7 @@ namespace blink {
+ 
+ namespace {
+ 
+-constexpr unsigned kDefaultNumberOfInputChannels = 2;
++constexpr unsigned kDefaultNumberOfInputChannels_RADH = 2;
+ 
+ }  // namespace
+ 
+@@ -53,7 +53,7 @@ RealtimeAudioDestinationHandler::RealtimeAudioDestinationHandler(
+       task_runner_(Context()->GetExecutionContext()->GetTaskRunner(
+           TaskType::kInternalMediaRealTime)) {
+   // Node-specific default channel count and mixing rules.
+-  channel_count_ = kDefaultNumberOfInputChannels;
++  channel_count_ = kDefaultNumberOfInputChannels_RADH;
+   SetInternalChannelCountMode(kExplicit);
+   SetInternalChannelInterpretation(AudioBus::kSpeakers);
+ }
+-- 
+2.43.0
+

--- a/x11-packages/carbonyl-host-tools/patches/0104-fixes-for-jumbo-build-4.patch
+++ b/x11-packages/carbonyl-host-tools/patches/0104-fixes-for-jumbo-build-4.patch
@@ -1,0 +1,324 @@
+From edaf98260d3e284d4501e2656bec4ea028ce97b3 Mon Sep 17 00:00:00 2001
+From: Chongyun Lee <licy183@termux.dev>
+Date: Thu, 30 Jan 2025 19:16:52 +0800
+Subject: [PATCH] Fixes for jumbo build 4
+
+To fix the following errors
+
+[1/436] CXX obj/content/browser/browser/browser_jumbo_12.o
+  In file included from gen/content/browser/browser_jumbo_12.cc:73:
+  ./../../../src/chromium/src/content/browser/renderer_host/browsing_context_state.cc:70:11: error: no member named 'BrowsingContextStateImplementationType' in namespace 'content::features'; did you mean '::features::BrowsingContextStateImplementationType'?
+    70 |           features::BrowsingContextStateImplementationType::
+        |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        |           ::features::BrowsingContextStateImplementationType
+  ../../../src/chromium/src/content/browser/renderer_host/browsing_context_state.h:26:12: note: '::features::BrowsingContextStateImplementationType' declared here
+    26 | enum class BrowsingContextStateImplementationType {
+        |            ^
+  In file included from gen/content/browser/browser_jumbo_12.cc:73:
+  ./../../../src/chromium/src/content/browser/renderer_host/browsing_context_state.cc:69:7: error: no member named 'GetBrowsingContextMode' in namespace 'content::features'; did you mean '::features::GetBrowsingContextMode'?
+    69 |   if (features::GetBrowsingContextMode() ==
+        |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        |       ::features::GetBrowsingContextMode
+  ./../../../src/chromium/src/content/browser/renderer_host/browsing_context_state.cc:21:40: note: '::features::GetBrowsingContextMode' declared here
+    21 | BrowsingContextStateImplementationType GetBrowsingContextMode() {
+        |                                        ^
+  ./../../../src/chromium/src/content/browser/renderer_host/browsing_context_state.cc:102:11: error: no member named 'BrowsingContextStateImplementationType' in namespace 'content::features'; did you mean '::features::BrowsingContextStateImplementationType'?
+    102 |           features::BrowsingContextStateImplementationType::
+        |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        |           ::features::BrowsingContextStateImplementationType
+  ../../../src/chromium/src/content/browser/renderer_host/browsing_context_state.h:26:12: note: '::features::BrowsingContextStateImplementationType' declared here
+    26 | enum class BrowsingContextStateImplementationType {
+        |            ^
+  In file included from gen/content/browser/browser_jumbo_12.cc:73:
+  ./../../../src/chromium/src/content/browser/renderer_host/browsing_context_state.cc:101:7: error: no member named 'GetBrowsingContextMode' in namespace 'content::features'; did you mean '::features::GetBrowsingContextMode'?
+    101 |   if (features::GetBrowsingContextMode() ==
+        |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        |       ::features::GetBrowsingContextMode
+  ./../../../src/chromium/src/content/browser/renderer_host/browsing_context_state.cc:21:40: note: '::features::GetBrowsingContextMode' declared here
+    21 | BrowsingContextStateImplementationType GetBrowsingContextMode() {
+        |                                        ^
+  ./../../../src/chromium/src/content/browser/renderer_host/browsing_context_state.cc:130:7: error: no member named 'BrowsingContextStateImplementationType' in namespace 'content::features'; did you mean '::features::BrowsingContextStateImplementationType'?
+    130 |       features::BrowsingContextStateImplementationType::
+        |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        |       ::features::BrowsingContextStateImplementationType
+  ../../../src/chromium/src/content/browser/renderer_host/browsing_context_state.h:26:12: note: '::features::BrowsingContextStateImplementationType' declared here
+    26 | enum class BrowsingContextStateImplementationType {
+        |            ^
+  In file included from gen/content/browser/browser_jumbo_12.cc:73:
+  ./../../../src/chromium/src/content/browser/renderer_host/browsing_context_state.cc:129:7: error: no member named 'GetBrowsingContextMode' in namespace 'content::features'; did you mean '::features::GetBrowsingContextMode'?
+    129 |   if (features::GetBrowsingContextMode() ==
+        |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        |       ::features::GetBrowsingContextMode
+  ./../../../src/chromium/src/content/browser/renderer_host/browsing_context_state.cc:21:40: note: '::features::GetBrowsingContextMode' declared here
+    21 | BrowsingContextStateImplementationType GetBrowsingContextMode() {
+        |                                        ^
+  ./../../../src/chromium/src/content/browser/renderer_host/browsing_context_state.cc:137:11: error: no member named 'BrowsingContextStateImplementationType' in namespace 'content::features'; did you mean '::features::BrowsingContextStateImplementationType'?
+    137 |           features::BrowsingContextStateImplementationType::
+        |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        |           ::features::BrowsingContextStateImplementationType
+  ../../../src/chromium/src/content/browser/renderer_host/browsing_context_state.h:26:12: note: '::features::BrowsingContextStateImplementationType' declared here
+    26 | enum class BrowsingContextStateImplementationType {
+        |            ^
+  In file included from gen/content/browser/browser_jumbo_12.cc:73:
+  ./../../../src/chromium/src/content/browser/renderer_host/browsing_context_state.cc:136:7: error: no member named 'GetBrowsingContextMode' in namespace 'content::features'; did you mean '::features::GetBrowsingContextMode'?
+    136 |   if (features::GetBrowsingContextMode() ==
+        |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        |       ::features::GetBrowsingContextMode
+  ./../../../src/chromium/src/content/browser/renderer_host/browsing_context_state.cc:21:40: note: '::features::GetBrowsingContextMode' declared here
+    21 | BrowsingContextStateImplementationType GetBrowsingContextMode() {
+        |                                        ^
+  8 errors generated.
+
+---
+ .../renderer_host/ancestor_throttle.cc        |  4 +--
+ ...forward_cache_can_store_document_result.cc |  2 +-
+ .../renderer_host/back_forward_cache_impl.cc  | 34 +++++++++----------
+ .../blocked_scheme_navigation_throttle.cc     |  2 +-
+ .../renderer_host/browsing_context_state.cc   | 16 ++++-----
+ 5 files changed, 29 insertions(+), 29 deletions(-)
+
+diff --git a/content/browser/renderer_host/ancestor_throttle.cc b/content/browser/renderer_host/ancestor_throttle.cc
+index 2f17a736a..705ce7567 100644
+--- a/content/browser/renderer_host/ancestor_throttle.cc
++++ b/content/browser/renderer_host/ancestor_throttle.cc
+@@ -169,7 +169,7 @@ void AncestorThrottle::ParseXFrameOptionsError(
+ }
+ 
+ void AncestorThrottle::ConsoleErrorEmbeddingRequiresOptIn() {
+-  DCHECK(base::FeatureList::IsEnabled(features::kEmbeddingRequiresOptIn));
++  DCHECK(base::FeatureList::IsEnabled(::features::kEmbeddingRequiresOptIn));
+   std::string message = base::StringPrintf(
+       "Refused to display '%s' in a frame: It did not opt-into cross-origin "
+       "embedding by setting either an 'X-Frame-Options' header, or a "
+@@ -291,7 +291,7 @@ AncestorThrottle::CheckResult AncestorThrottle::EvaluateEmbeddingOptIn(
+             parent, blink::mojom::WebFeature::
+                         kEmbeddedCrossOriginFrameWithoutFrameAncestorsOrXFO);
+ 
+-        if (!base::FeatureList::IsEnabled(features::kEmbeddingRequiresOptIn))
++        if (!base::FeatureList::IsEnabled(::features::kEmbeddingRequiresOptIn))
+           return CheckResult::PROCEED;
+ 
+         if (logging == LoggingDisposition::LOG_TO_CONSOLE)
+diff --git a/content/browser/renderer_host/back_forward_cache_can_store_document_result.cc b/content/browser/renderer_host/back_forward_cache_can_store_document_result.cc
+index cd2e8d2a6..6dcdd3c70 100644
+--- a/content/browser/renderer_host/back_forward_cache_can_store_document_result.cc
++++ b/content/browser/renderer_host/back_forward_cache_can_store_document_result.cc
+@@ -593,7 +593,7 @@ void BackForwardCacheCanStoreDocumentResult::NoDueToDisallowActivation(
+ 
+ void BackForwardCacheCanStoreDocumentResult::NoDueToAXEvents(
+     const std::vector<ui::AXEvent>& events) {
+-  DCHECK(base::FeatureList::IsEnabled(features::kEvictOnAXEvents));
++  DCHECK(base::FeatureList::IsEnabled(::features::kEvictOnAXEvents));
+   for (auto& event : events) {
+     ax_events_.insert(event.event_type);
+   }
+diff --git a/content/browser/renderer_host/back_forward_cache_impl.cc b/content/browser/renderer_host/back_forward_cache_impl.cc
+index 4b9902548..6c9e49034 100644
+--- a/content/browser/renderer_host/back_forward_cache_impl.cc
++++ b/content/browser/renderer_host/back_forward_cache_impl.cc
+@@ -96,7 +96,7 @@ bool IsProcessBindingEnabled() {
+   if (!IsBackForwardCacheEnabled())
+     return false;
+   const std::string process_binding_param =
+-      base::GetFieldTrialParamValueByFeature(features::kBackForwardCache,
++      base::GetFieldTrialParamValueByFeature(::features::kBackForwardCache,
+                                              "process_binding_strength");
+   return process_binding_param.empty() || process_binding_param == "DISABLE";
+ }
+@@ -114,7 +114,7 @@ const base::FeatureParam<ChildProcessImportance>::Option
+ // background tabs so that the OS will hopefully kill the foreground tab last.
+ // The default importance is set to MODERATE.
+ const base::FeatureParam<ChildProcessImportance> kChildProcessImportanceParam{
+-    &features::kBackForwardCache, "process_binding_strength",
++    &::features::kBackForwardCache, "process_binding_strength",
+     ChildProcessImportance::MODERATE, &child_process_importance_options};
+ #endif
+ 
+@@ -122,7 +122,7 @@ bool IsContentInjectionSupported() {
+   if (!IsBackForwardCacheEnabled())
+     return false;
+   static constexpr base::FeatureParam<bool> content_injection_supported(
+-      &features::kBackForwardCache, "content_injection_supported", true);
++      &::features::kBackForwardCache, "content_injection_supported", true);
+   return content_injection_supported.Get();
+ }
+ 
+@@ -132,7 +132,7 @@ WebSchedulerTrackedFeatures SupportedFeaturesImpl() {
+     return features;
+ 
+   static constexpr base::FeatureParam<std::string> supported_features(
+-      &features::kBackForwardCache, "supported_features", "");
++      &::features::kBackForwardCache, "supported_features", "");
+   std::vector<std::string> tokens =
+       base::SplitString(supported_features.Get(), ",", base::TRIM_WHITESPACE,
+                         base::SPLIT_WANT_NONEMPTY);
+@@ -159,7 +159,7 @@ bool IgnoresOutstandingNetworkRequestForTesting() {
+     return false;
+   static constexpr base::FeatureParam<bool>
+       outstanding_network_request_supported(
+-          &features::kBackForwardCache,
++          &::features::kBackForwardCache,
+           "ignore_outstanding_network_request_for_testing", false);
+   return outstanding_network_request_supported.Get();
+ }
+@@ -171,7 +171,7 @@ bool ShouldIgnoreBlocklists() {
+   if (!IsBackForwardCacheEnabled())
+     return false;
+   static constexpr base::FeatureParam<bool> should_ignore_blocklists(
+-      &features::kBackForwardCache, "should_ignore_blocklists", false);
++      &::features::kBackForwardCache, "should_ignore_blocklists", false);
+   return should_ignore_blocklists.Get();
+ }
+ 
+@@ -253,7 +253,7 @@ std::string GetAllowedURLList() {
+     return "";
+   }
+ 
+-  return base::GetFieldTrialParamValueByFeature(features::kBackForwardCache,
++  return base::GetFieldTrialParamValueByFeature(::features::kBackForwardCache,
+                                                 "allowed_websites");
+ }
+ 
+@@ -261,7 +261,7 @@ std::string GetAllowedURLList() {
+ std::string GetBlockedURLList() {
+   return IsBackForwardCacheEnabled()
+              ? base::GetFieldTrialParamValueByFeature(
+-                   features::kBackForwardCache, "blocked_websites")
++                   ::features::kBackForwardCache, "blocked_websites")
+              : "";
+ }
+ 
+@@ -269,7 +269,7 @@ std::string GetBlockedURLList() {
+ std::string GetBlockedCgiParams() {
+   return IsBackForwardCacheEnabled()
+              ? base::GetFieldTrialParamValueByFeature(
+-                   features::kBackForwardCache, "blocked_cgi_params")
++                   ::features::kBackForwardCache, "blocked_cgi_params")
+              : "";
+ }
+ 
+@@ -466,7 +466,7 @@ BackForwardCacheImpl::GetChannelAssociatedMessageHandlingPolicy() {
+ 
+   static constexpr char kFieldTrialParam[] = "message_handling_when_cached";
+   auto param = base::GetFieldTrialParamValueByFeature(
+-      features::kBackForwardCache, kFieldTrialParam);
++      ::features::kBackForwardCache, kFieldTrialParam);
+   if (param.empty() || param == "log") {
+     return kMessagePolicyLog;
+   } else if (param == "none") {
+@@ -477,7 +477,7 @@ BackForwardCacheImpl::GetChannelAssociatedMessageHandlingPolicy() {
+     DLOG(WARNING) << "Failed to parse field trial param " << kFieldTrialParam
+                   << " with string value " << param
+                   << " under feature kBackForwardCache"
+-                  << features::kBackForwardCache.name;
++                  << ::features::kBackForwardCache.name;
+     return kMessagePolicyLog;
+   }
+ }
+@@ -563,9 +563,9 @@ base::TimeDelta BackForwardCacheImpl::GetTimeToLiveInBackForwardCache() {
+   // - Default value otherwise, kDefaultTimeToLiveInBackForwardCacheInSeconds.
+ 
+   if (base::FeatureList::IsEnabled(
+-          features::kBackForwardCacheTimeToLiveControl)) {
++          ::features::kBackForwardCacheTimeToLiveControl)) {
+     absl::optional<int> time_to_live = GetFieldTrialParamByFeatureAsOptionalInt(
+-        features::kBackForwardCacheTimeToLiveControl, "time_to_live_seconds");
++        ::features::kBackForwardCacheTimeToLiveControl, "time_to_live_seconds");
+     if (time_to_live.has_value()) {
+       return base::Seconds(time_to_live.value());
+     }
+@@ -586,7 +586,7 @@ size_t BackForwardCacheImpl::GetCacheSize() {
+     return kBackForwardCacheSizeCacheSize.Get();
+   }
+   return base::GetFieldTrialParamByFeatureAsInt(
+-      features::kBackForwardCache, "cache_size", kDefaultBackForwardCacheSize);
++      ::features::kBackForwardCache, "cache_size", kDefaultBackForwardCacheSize);
+ }
+ 
+ // static
+@@ -597,7 +597,7 @@ size_t BackForwardCacheImpl::GetForegroundedEntriesCacheSize() {
+     return kBackForwardCacheSizeForegroundCacheSize.Get();
+   }
+   return base::GetFieldTrialParamByFeatureAsInt(
+-      features::kBackForwardCache, "foreground_cache_size",
++      ::features::kBackForwardCache, "foreground_cache_size",
+       kDefaultForegroundBackForwardCacheSize);
+ }
+ 
+@@ -1443,12 +1443,12 @@ bool BackForwardCacheImpl::IsProxyInBackForwardCacheForDebugging(
+ 
+ bool BackForwardCacheImpl::IsMediaSessionServiceAllowed() {
+   return base::FeatureList::IsEnabled(
+-      features::kBackForwardCacheMediaSessionService);
++      ::features::kBackForwardCacheMediaSessionService);
+ }
+ 
+ bool BackForwardCacheImpl::IsScreenReaderAllowed() {
+   return base::FeatureList::IsEnabled(
+-      features::kEnableBackForwardCacheForScreenReader);
++      ::features::kEnableBackForwardCacheForScreenReader);
+ }
+ 
+ // static
+diff --git a/content/browser/renderer_host/blocked_scheme_navigation_throttle.cc b/content/browser/renderer_host/blocked_scheme_navigation_throttle.cc
+index 7111c0795..6ca2a8918 100644
+--- a/content/browser/renderer_host/blocked_scheme_navigation_throttle.cc
++++ b/content/browser/renderer_host/blocked_scheme_navigation_throttle.cc
+@@ -96,7 +96,7 @@ BlockedSchemeNavigationThrottle::CreateThrottleForNavigation(
+       (request->GetURL().SchemeIs(url::kDataScheme) ||
+        request->GetURL().SchemeIs(url::kFileSystemScheme)) &&
+       !base::FeatureList::IsEnabled(
+-          features::kAllowContentInitiatedDataUrlNavigations)) {
++          ::features::kAllowContentInitiatedDataUrlNavigations)) {
+     return std::make_unique<BlockedSchemeNavigationThrottle>(request);
+   }
+   // Block all renderer initiated navigations to filesystem: URLs except for
+diff --git a/content/browser/renderer_host/browsing_context_state.cc b/content/browser/renderer_host/browsing_context_state.cc
+index 46a2cc2cc..bd983816a 100644
+--- a/content/browser/renderer_host/browsing_context_state.cc
++++ b/content/browser/renderer_host/browsing_context_state.cc
+@@ -66,8 +66,8 @@ RenderFrameProxyHost* BrowsingContextState::GetRenderFrameProxyHost(
+ RenderFrameProxyHost* BrowsingContextState::GetRenderFrameProxyHostImpl(
+     SiteInstanceGroup* site_instance_group,
+     ProxyAccessMode proxy_access_mode) const {
+-  if (features::GetBrowsingContextMode() ==
+-          features::BrowsingContextStateImplementationType::
++  if (::features::GetBrowsingContextMode() ==
++          ::features::BrowsingContextStateImplementationType::
+               kSwapForCrossBrowsingInstanceNavigations &&
+       proxy_access_mode == ProxyAccessMode::kRegular) {
+     // CHECK to verify that the proxy is being accessed from the correct
+@@ -98,8 +98,8 @@ RenderFrameProxyHost* BrowsingContextState::GetRenderFrameProxyHostImpl(
+ void BrowsingContextState::DeleteRenderFrameProxyHost(
+     SiteInstanceGroup* site_instance_group,
+     ProxyAccessMode proxy_access_mode) {
+-  if (features::GetBrowsingContextMode() ==
+-          features::BrowsingContextStateImplementationType::
++  if (::features::GetBrowsingContextMode() ==
++          ::features::BrowsingContextStateImplementationType::
+               kSwapForCrossBrowsingInstanceNavigations &&
+       proxy_access_mode == ProxyAccessMode::kRegular) {
+     // See comments in GetRenderFrameProxyHost for why this check is needed.
+@@ -126,15 +126,15 @@ RenderFrameProxyHost* BrowsingContextState::CreateRenderFrameProxyHost(
+       ChromeTrackEvent::kRenderViewHost, rvh ? rvh.get() : nullptr,
+       ChromeTrackEvent::kFrameTreeNodeInfo, frame_tree_node);
+ 
+-  if (features::GetBrowsingContextMode() ==
+-      features::BrowsingContextStateImplementationType::
++  if (::features::GetBrowsingContextMode() ==
++      ::features::BrowsingContextStateImplementationType::
+           kLegacyOneToOneWithFrameTreeNode) {
+     DCHECK_EQ(this,
+               frame_tree_node->current_frame_host()->browsing_context_state());
+   }
+ 
+-  if (features::GetBrowsingContextMode() ==
+-          features::BrowsingContextStateImplementationType::
++  if (::features::GetBrowsingContextMode() ==
++          ::features::BrowsingContextStateImplementationType::
+               kSwapForCrossBrowsingInstanceNavigations &&
+       proxy_access_mode == ProxyAccessMode::kRegular) {
+     // See comments in GetRenderFrameProxyHost for why this check is needed.
+-- 
+2.43.0
+

--- a/x11-packages/carbonyl-host-tools/patches/0105-fixes-for-jumbo-build-5.patch
+++ b/x11-packages/carbonyl-host-tools/patches/0105-fixes-for-jumbo-build-5.patch
@@ -1,0 +1,90 @@
+From 100f93f2fe5edcad2901369523e5550eff57e61a Mon Sep 17 00:00:00 2001
+From: Chongyun Lee <licy183@termux.dev>
+Date: Thu, 30 Jan 2025 19:34:12 +0800
+Subject: [PATCH] Fixes for jumbo build 5
+
+To fix the following errors
+
+[3/437] CXX obj/content/browser/browser/browser_jumbo_18.o
+  In file included from gen/content/browser/browser_jumbo_18.cc:40:
+  ./../../../src/chromium/src/content/browser/web_package/web_bundle_blob_data_source.cc:25:7: error: redefinition of 'MojoBlobReaderDelegate'
+    25 | class MojoBlobReaderDelegate : public storage::MojoBlobReader::Delegate {
+        |       ^
+  ./../../../src/chromium/src/content/browser/web_package/prefetched_signed_exchange_cache.cc:110:7: note: previous definition is here
+    110 | class MojoBlobReaderDelegate : public storage::MojoBlobReader::Delegate {
+        |       ^
+  1 error generated.
+
+---
+ .../web_package/prefetched_signed_exchange_cache.cc       | 6 +++---
+ .../browser/web_package/web_bundle_blob_data_source.cc    | 8 ++++----
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/content/browser/web_package/prefetched_signed_exchange_cache.cc b/content/browser/web_package/prefetched_signed_exchange_cache.cc
+index 0d5b2f609..b221667a5 100644
+--- a/content/browser/web_package/prefetched_signed_exchange_cache.cc
++++ b/content/browser/web_package/prefetched_signed_exchange_cache.cc
+@@ -107,9 +107,9 @@ bool IsValidRequestInitiator(const network::ResourceRequest& request,
+ 
+ // A utility subclass of MojoBlobReader::Delegate that calls the passed callback
+ // in OnComplete().
+-class MojoBlobReaderDelegate : public storage::MojoBlobReader::Delegate {
++class MojoBlobReaderDelegate_PSEC : public storage::MojoBlobReader::Delegate {
+  public:
+-  explicit MojoBlobReaderDelegate(base::OnceCallback<void(net::Error)> callback)
++  explicit MojoBlobReaderDelegate_PSEC(base::OnceCallback<void(net::Error)> callback)
+       : callback_(std::move(callback)) {}
+ 
+  private:
+@@ -368,7 +368,7 @@ class InnerResponseURLLoader : public network::mojom::URLLoader {
+       std::unique_ptr<storage::BlobDataHandle> blob_data_handle) {
+     storage::MojoBlobReader::Create(
+         blob_data_handle.get(), net::HttpByteRange(),
+-        std::make_unique<MojoBlobReaderDelegate>(
++        std::make_unique<MojoBlobReaderDelegate_PSEC>(
+             base::BindOnce(&InnerResponseURLLoader::BlobReaderCompleteOnIO,
+                            std::move(loader))),
+         std::move(pipe_producer_handle));
+diff --git a/content/browser/web_package/web_bundle_blob_data_source.cc b/content/browser/web_package/web_bundle_blob_data_source.cc
+index 91f5e93d7..5887e4177 100644
+--- a/content/browser/web_package/web_bundle_blob_data_source.cc
++++ b/content/browser/web_package/web_bundle_blob_data_source.cc
+@@ -20,7 +20,7 @@
+ #include "storage/browser/blob/mojo_blob_reader.h"
+ 
+ namespace content {
+-namespace {
++namespace wbbds_impl {
+ 
+ class MojoBlobReaderDelegate : public storage::MojoBlobReader::Delegate {
+  public:
+@@ -94,7 +94,7 @@ void OnCalculateSizeComplete(
+   auto io_buf =
+       base::MakeRefCounted<net::IOBufferWithSize>(static_cast<size_t>(length));
+   auto split_callback = base::SplitOnceCallback(base::BindOnce(
+-      &OnReadComplete, std::move(callback), std::move(blob_reader), io_buf));
++      &wbbds_impl::OnReadComplete, std::move(callback), std::move(blob_reader), io_buf));
+   int bytes_read;
+   storage::BlobReader::Status read_status =
+       raw_blob_reader->Read(io_buf.get(), io_buf->size(), &bytes_read,
+@@ -354,7 +354,7 @@ void WebBundleBlobDataSource::BlobDataSourceCore::OnBlobReadyForRead(
+   auto blob_reader = blob_->CreateReader();
+   auto* raw_blob_reader = blob_reader.get();
+   auto split_callback = base::SplitOnceCallback(
+-      base::BindOnce(&OnCalculateSizeComplete, offset, length,
++      base::BindOnce(&wbbds_impl::OnCalculateSizeComplete, offset, length,
+                      std::move(callback), std::move(blob_reader)));
+   auto status = raw_blob_reader->CalculateSize(std::move(split_callback.first));
+   if (status != storage::BlobReader::Status::IO_PENDING) {
+@@ -377,7 +377,7 @@ void WebBundleBlobDataSource::BlobDataSourceCore::OnBlobReadyForReadToDataPipe(
+   }
+   storage::MojoBlobReader::Create(
+       blob_.get(), net::HttpByteRange::Bounded(offset, offset + length - 1),
+-      std::make_unique<MojoBlobReaderDelegate>(std::move(callback)),
++      std::make_unique<wbbds_impl::MojoBlobReaderDelegate>(std::move(callback)),
+       std::move(producer_handle));
+ }
+ 
+-- 
+2.43.0
+

--- a/x11-packages/carbonyl-host-tools/patches/1001-chromium-disable-sandbox.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1001-chromium-disable-sandbox.patch
@@ -1,0 +1,95 @@
+--- a/content/shell/app/shell_main_delegate.cc
++++ b/content/shell/app/shell_main_delegate.cc
+@@ -80,6 +80,10 @@
+ #include "v8/include/v8-wasm-trap-handler-posix.h"
+ #endif
+ 
++#ifdef __TERMUX__
++#include "sandbox/policy/switches.h"
++#endif
++
+ namespace {
+ 
+ #if !BUILDFLAG(IS_FUCHSIA)
+@@ -200,6 +204,15 @@
+   base::CPU cpu_info;
+ #endif
+ 
++#ifdef __TERMUX__
++// Disable sandbox on Termux.
++  if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
++          sandbox::policy::switches::kNoSandbox)) {
++    base::CommandLine::ForCurrentProcess()->AppendSwitch(
++          sandbox::policy::switches::kNoSandbox);
++  }
++#endif
++
+ // Disable platform crash handling and initialize the crash reporter, if
+ // requested.
+ // TODO(crbug.com/1226159): Implement crash reporter integration for Fuchsia.
+--- a/chrome/browser/ui/startup/bad_flags_prompt.cc
++++ b/chrome/browser/ui/startup/bad_flags_prompt.cc
+@@ -60,10 +60,12 @@
+ static const char* kBadFlags[] = {
+     network::switches::kIgnoreCertificateErrorsSPKIList,
+     // These flags disable sandbox-related security.
++#ifndef __TERMUX__
+     sandbox::policy::switches::kDisableGpuSandbox,
+     sandbox::policy::switches::kDisableSeccompFilterSandbox,
+     sandbox::policy::switches::kDisableSetuidSandbox,
+     sandbox::policy::switches::kNoSandbox,
++#endif
+ #if BUILDFLAG(IS_WIN)
+     sandbox::policy::switches::kAllowThirdPartyModules,
+ #endif
+--- a/chrome/app/chrome_main_delegate.cc
++++ b/chrome/app/chrome_main_delegate.cc
+@@ -228,6 +228,10 @@
+ #include "ui/base/resource/data_pack_with_resource_sharing_lacros.h"
+ #endif
+ 
++#ifdef __TERMUX__
++#include "sandbox/policy/switches.h"
++#endif
++
+ base::LazyInstance<ChromeContentGpuClient>::DestructorAtExit
+     g_chrome_content_gpu_client = LAZY_INSTANCE_INITIALIZER;
+ base::LazyInstance<ChromeContentRendererClient>::DestructorAtExit
+@@ -932,6 +936,14 @@
+   const base::CommandLine& command_line =
+       *base::CommandLine::ForCurrentProcess();
+ 
++#ifdef __TERMUX__
++// Disable sandbox on Termux.
++  if (!command_line.HasSwitch(sandbox::policy::switches::kNoSandbox)) {
++    base::CommandLine::ForCurrentProcess()->AppendSwitch(
++        sandbox::policy::switches::kNoSandbox);
++  }
++#endif
++
+   // Only allow disabling web security via the command-line flag if the user has
+   // specified a distinct profile directory. This still enables tests to disable
+   // web security by setting the kWebKitWebSecurityEnabled pref directly.
+--- a/content/shell/browser/shell_content_browser_client.cc
++++ b/content/shell/browser/shell_content_browser_client.cc
+@@ -107,6 +107,10 @@
+ #include "media/mojo/services/media_service_factory.h"  // nogncheck
+ #endif
+ 
++#ifdef __TERMUX__
++#include "sandbox/policy/switches.h"
++#endif
++
+ namespace content {
+ 
+ namespace {
+@@ -339,6 +343,9 @@
+     // to shell_main.cc that it's a browser test.
+     switches::kBrowserTest,
+ #endif
++#ifdef __TERMUX__
++    sandbox::policy::switches::kNoSandbox
++#endif
+     switches::kCrashDumpsDir,
+     switches::kEnableCrashReporter,
+     switches::kExposeInternalsForTesting,

--- a/x11-packages/carbonyl-host-tools/patches/1002-chromium-disable-shm.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1002-chromium-disable-shm.patch
@@ -1,0 +1,11 @@
+--- a/base/files/file_util_posix.cc
++++ b/base/files/file_util_posix.cc
+@@ -1111,7 +1111,7 @@
+ #if !BUILDFLAG(IS_ANDROID)
+ // This is implemented in file_util_android.cc for that platform.
+ bool GetShmemTempDir(bool executable, FilePath* path) {
+-#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_AIX)
++#if (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_AIX)) && !defined(__TERMUX__)
+   bool disable_dev_shm = false;
+ #if !BUILDFLAG(IS_CHROMEOS)
+   disable_dev_shm = CommandLine::ForCurrentProcess()->HasSwitch(

--- a/x11-packages/carbonyl-host-tools/patches/1003-chromium-fix-type-for-inotify.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1003-chromium-fix-type-for-inotify.patch
@@ -1,0 +1,11 @@
+--- a/base/files/file_path_watcher_inotify.cc
++++ b/base/files/file_path_watcher_inotify.cc
+@@ -114,7 +114,7 @@
+ class InotifyReader {
+  public:
+   // Watch descriptor used by AddWatch() and RemoveWatch().
+-#if BUILDFLAG(IS_ANDROID)
++#if BUILDFLAG(IS_ANDROID) || defined(__TERMUX__)
+   using Watch = uint32_t;
+ #else
+   using Watch = int;

--- a/x11-packages/carbonyl-host-tools/patches/1004-chromium-headless-disable-sandbox-by-default.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1004-chromium-headless-disable-sandbox-by-default.patch
@@ -1,0 +1,14 @@
+--- a/headless/lib/headless_content_main_delegate.cc
++++ b/headless/lib/headless_content_main_delegate.cc
+@@ -176,6 +176,11 @@
+   if (!command_line->HasSwitch(::switches::kHeadless))
+     command_line->AppendSwitch(::switches::kHeadless);
+ 
++#ifdef __TERMUX__
++  // Always pass no sandbox on Termux.
++  command_line->AppendSwitch(sandbox::policy::switches::kNoSandbox);
++#endif
++
+   // Use software rendering by default, but don't mess with gl and angle
+   // switches if user is overriding them.
+   if (!command_line->HasSwitch(::switches::kUseGL) &&

--- a/x11-packages/carbonyl-host-tools/patches/1005-chromium-impl-dns.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1005-chromium-impl-dns.patch
@@ -1,0 +1,114 @@
+diff -uNr a/net/dns/dns_config_service_linux.cc b/net/dns/dns_config_service_linux.cc
+--- a/net/dns/dns_config_service_linux.cc	2022-11-12 14:25:14.461410400 +0800
++++ b/net/dns/dns_config_service_linux.cc	2022-11-12 14:26:52.521409106 +0800
+@@ -38,6 +38,8 @@
+ #include "net/dns/serial_worker.h"
+ #include "third_party/abseil-cpp/absl/types/optional.h"
+ 
++#ifndef __TERMUX__
++
+ namespace net {
+ 
+ namespace internal {
+@@ -535,3 +537,8 @@
+ }
+ 
+ }  // namespace net
++
++#else
++// XXX: Actually, Termux has no DNS config, fallback to use the stub of fushsia.
++#include "./dns_config_service_fuchsia.cc"
++#endif // __TERMUX__
+diff -uNr a/net/dns/dns_reloader.cc b/net/dns/dns_reloader.cc
+--- a/net/dns/dns_reloader.cc	2022-11-09 09:28:47.021899000 +0800
++++ b/net/dns/dns_reloader.cc	2022-11-13 00:51:15.528054804 +0800
+@@ -7,7 +7,7 @@
+ #include "build/build_config.h"
+ 
+ #if BUILDFLAG(IS_POSIX) && !BUILDFLAG(IS_APPLE) && !BUILDFLAG(IS_OPENBSD) && \
+-    !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_FUCHSIA)
++    !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_FUCHSIA) && !defined(__TERMUX__)
+ 
+ #include <resolv.h>
+ 
+diff -uNr a/net/dns/dns_reloader.h b/net/dns/dns_reloader.h
+--- a/net/dns/dns_reloader.h	2022-11-09 09:28:47.021899000 +0800
++++ b/net/dns/dns_reloader.h	2022-11-13 00:52:05.818055468 +0800
+@@ -7,7 +7,7 @@
+ 
+ #include "build/build_config.h"
+ 
+-#if BUILDFLAG(IS_POSIX) && !BUILDFLAG(IS_APPLE) && !BUILDFLAG(IS_OPENBSD)
++#if BUILDFLAG(IS_POSIX) && !BUILDFLAG(IS_APPLE) && !BUILDFLAG(IS_OPENBSD) && !defined(__TERMUX__)
+ namespace net {
+ 
+ // Call on the network thread before calling DnsReloaderMaybeReload() anywhere.
+--- a/net/dns/host_resolver_system_task.cc	2022-12-14 01:28:26.229861500 +0000
++++ b/net/dns/host_resolver_system_task.cc	2022-12-30 16:55:04.659958063 +0000
+@@ -311,7 +311,7 @@
+ 
+ void EnsureSystemHostResolverCallReady() {
+ #if BUILDFLAG(IS_POSIX) && !BUILDFLAG(IS_APPLE) && !BUILDFLAG(IS_OPENBSD) && \
+-    !BUILDFLAG(IS_ANDROID)
++    !BUILDFLAG(IS_ANDROID) && !defined(__TERMUX__)
+   EnsureDnsReloaderInit();
+ #elif BUILDFLAG(IS_WIN)
+   EnsureWinsockInit();
+@@ -397,7 +397,7 @@
+                                                 base::BlockingType::WILL_BLOCK);
+ 
+ #if BUILDFLAG(IS_POSIX) && \
+-    !(BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_OPENBSD) || BUILDFLAG(IS_ANDROID))
++    !(BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_OPENBSD) || BUILDFLAG(IS_ANDROID) || defined(__TERMUX__))
+   DnsReloaderMaybeReload();
+ #endif
+   auto [ai, err, os_error] = AddressInfo::Get(host, hints, nullptr, network);
+diff -uNr a/net/dns/public/resolv_reader.cc b/net/dns/public/resolv_reader.cc
+--- a/net/dns/public/resolv_reader.cc	2022-11-09 09:28:47.037900400 +0800
++++ b/net/dns/public/resolv_reader.cc	2022-11-12 14:30:45.431406055 +0800
+@@ -32,6 +32,8 @@
+     const struct __res_state& res) {
+   std::vector<IPEndPoint> nameservers;
+ 
++#ifndef __TERMUX__
++
+   if (!(res.options & RES_INIT))
+     return absl::nullopt;
+ 
+@@ -88,6 +90,12 @@
+   }
+ #endif
+ 
++#else // __TERMUX__
++  // From Android 8, getprop of net.dns%d has been invalid. So just
++  // assume the nameserver is 8.8.8.8.
++  nameservers.push_back(IPEndPoint(IPAddress(8, 8, 8, 8), 53));
++#endif
++
+   return nameservers;
+ }
+ 
+diff -uNr a/net/dns/public/scoped_res_state.h b/net/dns/public/scoped_res_state.h
+--- a/net/dns/public/scoped_res_state.h	2022-11-09 09:28:47.037900400 +0800
++++ b/net/dns/public/scoped_res_state.h	2022-11-13 00:50:25.928054149 +0800
+@@ -11,6 +11,20 @@
+ #include "net/base/net_export.h"
+ #include "third_party/abseil-cpp/absl/types/optional.h"
+ 
++#ifdef __TERMUX__
++// On Android NDK without JNI, there is no valid way to get nameservers.
++// So just provide a dummy struct and functions.
++struct __res_state {
++  int _dummy_state;
++};
++static int res_ninit(struct __res_state*) {
++  return 0;
++}
++static void res_nclose(struct __res_state*) {
++  return;
++}
++#endif
++
+ namespace net {
+ 
+ // Helper class to open, read and close a __res_state.

--- a/x11-packages/carbonyl-host-tools/patches/1006-chromium-impl-scoped-file.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1006-chromium-impl-scoped-file.patch
@@ -1,0 +1,52 @@
+--- a/base/files/scoped_file_linux.cc
++++ b/base/files/scoped_file_linux.cc
+@@ -14,6 +14,26 @@
+ #include "base/logging.h"
+ #include "base/strings/string_piece.h"
+ 
++#ifdef __TERMUX__
++#include <android/fdsan.h>
++#include <dlfcn.h>
++#include <sys/syscall.h>
++static inline void termux_disable_fdsan() {
++  typedef void (*android_fdsan_error_level_ptr_t)(enum android_fdsan_error_level);
++  // For Android 11+.
++  void *lib_handle = dlopen("libc.so", RTLD_LAZY);
++  if (lib_handle) {
++    android_fdsan_error_level_ptr_t set_fdsan_error_level = 
++      reinterpret_cast<android_fdsan_error_level_ptr_t>(
++        dlsym(lib_handle, "android_fdsan_set_error_level"));
++    if (set_fdsan_error_level != nullptr) {
++      set_fdsan_error_level(ANDROID_FDSAN_ERROR_LEVEL_DISABLED);
++    }
++    dlclose(lib_handle);
++  }
++}
++#endif
++
+ namespace {
+ 
+ // We want to avoid any kind of allocations in our close() implementation, so we
+@@ -65,6 +85,10 @@
+ 
+ void EnableFDOwnershipEnforcement(bool enabled) {
+   g_is_ownership_enforced = enabled;
++#ifdef __TERMUX__
++  // Disable the Android native fdsan.
++  termux_disable_fdsan();
++#endif
+ }
+ 
+ void ResetFDOwnership() {
+@@ -81,7 +105,11 @@
+ 
+ extern "C" {
+ 
++#ifndef __TERMUX__
+ int __close(int);
++#else
++#define __close(fd) syscall(__NR_close, fd)
++#endif
+ 
+ __attribute__((visibility("default"), noinline)) int close(int fd) {
+   if (base::IsFDOwned(fd) && g_is_ownership_enforced)

--- a/x11-packages/carbonyl-host-tools/patches/1007-chromium-impl-sysinfo.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1007-chromium-impl-sysinfo.patch
@@ -1,0 +1,104 @@
+--- a/base/system/sys_info_linux.cc
++++ b/base/system/sys_info_linux.cc
+@@ -126,7 +126,7 @@
+   return std::string();
+ }
+ 
+-#if !BUILDFLAG(IS_CHROMEOS) && !BUILDFLAG(IS_ANDROID)
++#if !BUILDFLAG(IS_CHROMEOS) && !BUILDFLAG(IS_ANDROID) && !defined(__TERMUX__)
+ // static
+ SysInfo::HardwareInfo SysInfo::GetHardwareInfoSync() {
+   static const size_t kMaxStringSize = 100u;
+@@ -149,3 +149,81 @@
+ #endif
+ 
+ }  // namespace base
++
++#ifdef __TERMUX__
++
++#include <dlfcn.h>
++#include <sys/system_properties.h>
++
++#include "base/logging.h"
++
++#if 0 // (__ANDROID_API__ >= 21 /* 5.0 - Lollipop */)
++
++namespace {
++
++typedef int(SystemPropertyGetFunction)(const char*, char*);
++
++SystemPropertyGetFunction* DynamicallyLoadRealSystemPropertyGet() {
++  // libc.so should already be open, get a handle to it.
++  void* handle = dlopen("libc.so", RTLD_NOLOAD);
++  if (!handle) {
++    LOG(FATAL) << "Cannot dlopen libc.so: " << dlerror();
++  }
++  SystemPropertyGetFunction* real_system_property_get =
++      reinterpret_cast<SystemPropertyGetFunction*>(
++          dlsym(handle, "__system_property_get"));
++  if (!real_system_property_get) {
++    LOG(FATAL) << "Cannot resolve __system_property_get(): " << dlerror();
++  }
++  return real_system_property_get;
++}
++
++static base::LazyInstance<base::internal::LazySysInfoValue<
++    SystemPropertyGetFunction*,
++    DynamicallyLoadRealSystemPropertyGet>>::Leaky
++    g_lazy_real_system_property_get = LAZY_INSTANCE_INITIALIZER;
++
++}  // namespace
++
++// Android 'L' removes __system_property_get from the NDK, however it is still
++// a hidden symbol in libc. Until we remove all calls of __system_property_get
++// from Chrome we work around this by defining a weak stub here, which uses
++// dlsym to but ensures that Chrome uses the real system
++// implementatation when loaded.  http://crbug.com/392191.
++BASE_EXPORT int __system_property_get(const char* name, char* value) {
++  return g_lazy_real_system_property_get.Get().value()(name, value);
++}
++
++#endif
++
++namespace {
++
++std::string HardwareManufacturerName() {
++  char device_model_str[PROP_VALUE_MAX];
++  __system_property_get("ro.product.manufacturer", device_model_str);
++  return std::string(device_model_str);
++}
++
++}  // anonymous namespace
++
++namespace base {
++
++std::string SysInfo::HardwareModelName() {
++  char device_model_str[PROP_VALUE_MAX];
++  __system_property_get("ro.product.model", device_model_str);
++  return std::string(device_model_str);
++}
++
++// static
++SysInfo::HardwareInfo SysInfo::GetHardwareInfoSync() {
++  HardwareInfo info;
++  info.manufacturer = HardwareManufacturerName();
++  info.model = HardwareModelName();
++  DCHECK(IsStringUTF8(info.manufacturer));
++  DCHECK(IsStringUTF8(info.model));
++  return info;
++}
++
++}
++
++#endif // __TERMUX__
+--- ./base/system/sys_info.cc	2022-11-13 00:36:18.488042961 +0800
++++ /home/uchkks/Desktop/sys_info.cc	2022-11-13 00:36:06.418042900 +0800
+@@ -94,7 +94,7 @@
+ #endif
+ 
+ #if !BUILDFLAG(IS_APPLE) && !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_WIN) && \
+-    !BUILDFLAG(IS_CHROMEOS)
++    !BUILDFLAG(IS_CHROMEOS) && !defined(__TERMUX__)
+ std::string SysInfo::HardwareModelName() {
+   return std::string();
+ }

--- a/x11-packages/carbonyl-host-tools/patches/1008-chromium-no-futimes.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1008-chromium-no-futimes.patch
@@ -1,0 +1,11 @@
+--- a/base/files/file_posix.cc
++++ b/base/files/file_posix.cc
+@@ -50,7 +50,7 @@
+ }
+ 
+ int CallFutimes(PlatformFile file, const struct timeval times[2]) {
+-#ifdef __USE_XOPEN2K8
++#if defined(__USE_XOPEN2K8) || (defined(__ANDROID__) && __ANDROID_API__ < 26)
+   // futimens should be available, but futimes might not be
+   // http://pubs.opengroup.org/onlinepubs/9699919799/
+ 

--- a/x11-packages/carbonyl-host-tools/patches/1009-chromium-no-glibc-version.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1009-chromium-no-glibc-version.patch
@@ -1,0 +1,14 @@
+--- a/chrome/browser/metrics/chrome_browser_main_extra_parts_metrics.cc
++++ b/chrome/browser/metrics/chrome_browser_main_extra_parts_metrics.cc
+@@ -61,8 +61,10 @@
+
+ // TODO(crbug.com/1052397): Revisit the macro expression once build flag switch
+ // of lacros-chrome is complete.
+-#if defined(__GLIBC__) && (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS_LACROS))
++#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS_LACROS)
++#ifdef __GLIBC__
+ #include <gnu/libc-version.h>
++#endif
+
+ #include "base/linux_util.h"
+ #include "base/strings/string_split.h"

--- a/x11-packages/carbonyl-host-tools/patches/1010-chromium-no-priority-inheritance-locks.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1010-chromium-no-priority-inheritance-locks.patch
@@ -1,0 +1,11 @@
+--- a/base/synchronization/lock_impl_posix.cc
++++ b/base/synchronization/lock_impl_posix.cc
+@@ -59,7 +59,7 @@
+ // Lock::PriorityInheritanceAvailable still must be checked as the code may
+ // compile but the underlying platform still may not correctly support priority
+ // inheritance locks.
+-#if BUILDFLAG(IS_NACL) || BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_FUCHSIA)
++#if BUILDFLAG(IS_NACL) || BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_FUCHSIA) || defined(__TERMUX__)
+ #define PRIORITY_INHERITANCE_LOCKS_POSSIBLE() 0
+ #else
+ #define PRIORITY_INHERITANCE_LOCKS_POSSIBLE() 1

--- a/x11-packages/carbonyl-host-tools/patches/1011-chromium-no-set-process-title.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1011-chromium-no-set-process-title.patch
@@ -1,0 +1,11 @@
+--- a/content/common/set_process_title.cc
++++ b/content/common/set_process_title.cc
+@@ -44,7 +44,7 @@
+ 
+ // TODO(jrg): Find out if setproctitle or equivalent is available on Android.
+ #if BUILDFLAG(IS_POSIX) && !BUILDFLAG(IS_MAC) && !BUILDFLAG(IS_SOLARIS) && \
+-    !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_FUCHSIA)
++    !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_FUCHSIA) && !defined(__TERMUX__)
+ 
+ void SetProcessTitleFromCommandLine(const char** main_argv) {
+   // Build a single string which consists of all the arguments separated

--- a/x11-packages/carbonyl-host-tools/patches/1012-chromium-redefine-termios2.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1012-chromium-redefine-termios2.patch
@@ -1,0 +1,11 @@
+--- a/services/device/serial/serial_io_handler_posix.cc
++++ b/services/device/serial/serial_io_handler_posix.cc
+@@ -16,7 +16,7 @@
+ #include "build/build_config.h"
+ #include "components/device_event_log/device_event_log.h"
+ 
+-#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS)
++#if (BUILDFLAG(IS_LINUX) && !defined(__TERMUX__)) || BUILDFLAG(IS_CHROMEOS)
+ #include <asm-generic/ioctls.h>
+ #include <linux/serial.h>
+ 

--- a/x11-packages/carbonyl-host-tools/patches/1013-chromium-crypt-fix-dynamic-loaded-libraries.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1013-chromium-crypt-fix-dynamic-loaded-libraries.patch
@@ -1,0 +1,28 @@
+--- a/components/os_crypt/keyring_util_linux.cc
++++ b/components/os_crypt/keyring_util_linux.cc
+@@ -68,7 +68,11 @@
+   if (keyring_loaded)
+     return true;
+ 
++#ifdef __TERMUX__
++  void* handle = dlopen("libgnome-keyring.so", RTLD_NOW | RTLD_GLOBAL);
++#else
+   void* handle = dlopen("libgnome-keyring.so.0", RTLD_NOW | RTLD_GLOBAL);
++#endif
+   if (!handle) {
+     // We wanted to use GNOME Keyring, but we couldn't load it. Warn, because
+     // either the user asked for this, or we autodetected it incorrectly. (Or
+--- a/components/os_crypt/libsecret_util_linux.cc
++++ b/components/os_crypt/libsecret_util_linux.cc
+@@ -102,7 +102,11 @@
+   if (libsecret_loaded_)
+     return true;
+ 
++#ifdef __TERMUX__
++  static void* handle = dlopen("libsecret-1.so", RTLD_NOW | RTLD_GLOBAL);
++#else
+   static void* handle = dlopen("libsecret-1.so.0", RTLD_NOW | RTLD_GLOBAL);
++#endif
+   if (!handle) {
+     // We wanted to use libsecret, but we couldn't load it. Warn, because
+     // either the user asked for this, or we autodetected it incorrectly. (Or

--- a/x11-packages/carbonyl-host-tools/patches/1014-chromium-unity-fix-dynamic-loaded-libraries.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1014-chromium-unity-fix-dynamic-loaded-libraries.patch
@@ -1,0 +1,11 @@
+--- a/chrome/browser/download/download_status_updater_linux.cc
++++ b/chrome/browser/download/download_status_updater_linux.cc
+@@ -77,6 +77,8 @@
+   if (!unity_lib)
+     unity_lib = dlopen("libunity.so.9", RTLD_LAZY);
+   if (!unity_lib)
++    unity_lib = dlopen("libunity.so", RTLD_LAZY);
++  if (!unity_lib)
+     return;
+ 
+   unity_inspector_get_default_func inspector_get_default =

--- a/x11-packages/carbonyl-host-tools/patches/1015-chromium-gtk-fix-dynamic-loaded-libraries.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1015-chromium-gtk-fix-dynamic-loaded-libraries.patch
@@ -1,0 +1,50 @@
+--- a/ui/gtk/gtk_compat.cc
++++ b/ui/gtk/gtk_compat.cc
+@@ -62,27 +62,47 @@
+ }
+ 
+ void* GetLibGio() {
++#ifdef __TERMUX__
++  static void* libgio = DlOpen("libgio-2.0.so");
++#else
+   static void* libgio = DlOpen("libgio-2.0.so.0");
++#endif
+   return libgio;
+ }
+ 
+ void* GetLibGdkPixbuf() {
++#ifdef __TERMUX__
++  static void* libgdk_pixbuf = DlOpen("libgdk_pixbuf-2.0.so");
++#else
+   static void* libgdk_pixbuf = DlOpen("libgdk_pixbuf-2.0.so.0");
++#endif
+   return libgdk_pixbuf;
+ }
+ 
+ void* GetLibGdk3() {
++#ifdef __TERMUX__
++  static void* libgdk3 = DlOpen("libgdk-3.so");
++#else
+   static void* libgdk3 = DlOpen("libgdk-3.so.0");
++#endif
+   return libgdk3;
+ }
+ 
+ void* GetLibGtk3(bool check = true) {
++#ifdef __TERMUX__
++  static void* libgtk3 = DlOpen("libgtk-3.so", check);
++#else
+   static void* libgtk3 = DlOpen("libgtk-3.so.0", check);
++#endif
+   return libgtk3;
+ }
+ 
+ void* GetLibGtk4(bool check = true) {
++#ifdef __TERMUX__
++  static void* libgtk4 = DlOpen("libgtk-4.so", check);
++#else
+   static void* libgtk4 = DlOpen("libgtk-4.so.1", check);
++#endif
+   return libgtk4;
+ }
+ 

--- a/x11-packages/carbonyl-host-tools/patches/1016-chromium-x11-fix-dynamic-loaded-libraries.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1016-chromium-x11-fix-dynamic-loaded-libraries.patch
@@ -1,0 +1,28 @@
+--- a/ui/base/x/x11_cursor_loader.cc
++++ b/ui/base/x/x11_cursor_loader.cc
+@@ -139,7 +139,11 @@
+     void operator()(void* ptr) const { dlclose(ptr); }
+   };
+ 
++#ifdef __TERMUX__
++  std::unique_ptr<void, DlCloser> lib(dlopen("libXcursor.so", RTLD_LAZY));
++#else
+   std::unique_ptr<void, DlCloser> lib(dlopen("libXcursor.so.1", RTLD_LAZY));
++#endif
+   if (!lib)
+     return "";
+ 
+--- a/ui/gfx/x/xlib_support.cc
++++ b/ui/gfx/x/xlib_support.cc
+@@ -41,7 +41,11 @@
+   CHECK(xlib_loader->Load("libX11.so.6"));
+ 
+   auto* xlib_xcb_loader = GetXlibXcbLoader();
++#ifndef __TERMUX__
+   CHECK(xlib_xcb_loader->Load("libX11-xcb.so.1"));
++#else
++  CHECK(xlib_xcb_loader->Load("libX11-xcb.so"));
++#endif
+ 
+   CHECK(xlib_loader->XInitThreads());
+ 

--- a/x11-packages/carbonyl-host-tools/patches/1017-chromium-dummy-hid-service.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1017-chromium-dummy-hid-service.patch
@@ -1,0 +1,51 @@
+--- a/services/device/hid/hid_service.cc
++++ b/services/device/hid/hid_service.cc
+@@ -26,6 +26,39 @@
+ #include "services/device/hid/hid_service_win.h"
+ #elif BUILDFLAG(IS_FUCHSIA)
+ #include "services/device/hid/hid_service_fuchsia.h"
++#elif defined(__TERMUX__)
++
++#include "base/notreached.h"
++#include "services/device/hid/hid_connection.h"
++ 
++namespace device {
++
++class HidServiceDummy : public HidService {
++ public:
++  HidServiceDummy() = default;
++  ~HidServiceDummy() = default;
++
++  HidServiceDummy(const HidServiceDummy&) = delete;
++  HidServiceDummy& operator=(const HidServiceDummy&) = delete;
++
++ private:
++  // HidService implementation.
++  void Connect(const std::string& device_id,
++               bool allow_protected_reports,
++               bool allow_fido_reports,
++               ConnectCallback callback) override {
++    // TODO(https://crbug.com/1311019): Implement this.
++    NOTIMPLEMENTED_LOG_ONCE();
++    std::move(callback).Run(nullptr);
++  }
++  base::WeakPtr<HidService> GetWeakPtr() override {
++    return weak_factory_.GetWeakPtr();
++  }
++
++  base::WeakPtrFactory<HidServiceDummy> weak_factory_{this};
++};
++
++}  // namespace device
+ #endif
+ 
+ namespace device {
+@@ -74,6 +107,8 @@
+   return std::make_unique<HidServiceWin>();
+ #elif BUILDFLAG(IS_FUCHSIA)
+   return std::make_unique<HidServiceFuchsia>();
++#elif defined(__TERMUX__)
++  return std::make_unique<HidServiceDummy>();
+ #else
+   return nullptr;
+ #endif

--- a/x11-packages/carbonyl-host-tools/patches/1018-chromium-fix-compile-errors-when-allocator-shim-is-disabled.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1018-chromium-fix-compile-errors-when-allocator-shim-is-disabled.patch
@@ -1,0 +1,21 @@
+Origin: https://bitbucket.org/chromiumembedded/cef/pull-requests/380/linux-fix-compile-errors-when-allocator
+
+--- a/base/process/memory_linux.cc
++++ b/base/process/memory_linux.cc
+@@ -18,6 +18,16 @@
+ #include "base/threading/thread_restrictions.h"
+ #include "build/build_config.h"
+ 
++#if !BUILDFLAG(USE_ALLOCATOR_SHIM) && defined(LIBC_GLIBC)
++extern "C" {
++void* __libc_malloc(size_t size);
++void* __libc_calloc(size_t n, size_t size);
++void* __libc_realloc(void* address, size_t size);
++void* __libc_memalign(size_t alignment, size_t size);
++void __libc_free(void* ptr);
++}  // extern "C"
++#endif
++
+ namespace base {
+ 
+ namespace {

--- a/x11-packages/carbonyl-host-tools/patches/1501-v8-fix-compress-pointer-offset.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1501-v8-fix-compress-pointer-offset.patch
@@ -1,0 +1,11 @@
+--- a/v8/include/v8-internal.h
++++ b/v8/include/v8-internal.h
+@@ -242,7 +242,7 @@
+ 
+ #ifdef V8_COMPRESS_POINTERS
+ 
+-#ifdef V8_TARGET_OS_ANDROID
++#if defined(V8_TARGET_OS_ANDROID) && !defined(__TERMUX__)
+ // The size of the virtual memory reservation for an external pointer table.
+ // This determines the maximum number of entries in a table. Using a maximum
+ // size allows omitting bounds checks on table accesses if the indices are

--- a/x11-packages/carbonyl-host-tools/patches/1502-v8-reimpl-page-allocator.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1502-v8-reimpl-page-allocator.patch
@@ -1,0 +1,13 @@
+--- a/v8/include/v8-platform.h
++++ b/v8/include/v8-platform.h
+@@ -925,7 +925,9 @@
+    * Allows the embedder to manage memory page allocations.
+    * Returning nullptr will cause V8 to use the default page allocator.
+    */
+-  virtual PageAllocator* GetPageAllocator() = 0;
++  virtual PageAllocator* GetPageAllocator() {
++    return nullptr;
++  }
+ 
+   /**
+    * Allows the embedder to specify a custom allocator used for zones.

--- a/x11-packages/carbonyl-host-tools/patches/1503-v8-fix-trap-handler.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1503-v8-fix-trap-handler.patch
@@ -1,0 +1,26 @@
+--- a/v8/src/trap-handler/trap-handler.h
++++ b/v8/src/trap-handler/trap-handler.h
+@@ -19,7 +19,7 @@
+ 
+ // X64 on Linux, Windows, MacOS, FreeBSD.
+ #if V8_HOST_ARCH_X64 && V8_TARGET_ARCH_X64 &&                        \
+-    ((V8_OS_LINUX && !V8_OS_ANDROID) || V8_OS_WIN || V8_OS_DARWIN || \
++    (V8_OS_LINUX || V8_OS_WIN || V8_OS_DARWIN || \
+      V8_OS_FREEBSD)
+ #define V8_TRAP_HANDLER_SUPPORTED true
+ // Arm64 (non-simulator) on Mac.
+@@ -41,14 +41,6 @@
+ #define V8_TRAP_HANDLER_SUPPORTED false
+ #endif
+ 
+-#if V8_OS_ANDROID && V8_TRAP_HANDLER_SUPPORTED
+-// It would require some careful security review before the trap handler
+-// can be enabled on Android.  Android may do unexpected things with signal
+-// handling and crash reporting that could open up security holes in V8's
+-// trap handling.
+-#error "The V8 trap handler should not be enabled on Android"
+-#endif
+-
+ // Setup for shared library export.
+ #if defined(BUILDING_V8_SHARED) && defined(V8_OS_WIN)
+ #define TH_EXPORT_PRIVATE __declspec(dllexport)

--- a/x11-packages/carbonyl-host-tools/patches/1504-v8-do-not-use-builtin-mul.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1504-v8-do-not-use-builtin-mul.patch
@@ -1,0 +1,19 @@
+We use `clang-13` as host CC, `libgcc` as compiler runtime. `clang-13` will make
+`__builtin_mul_overflow` link against `__mulodi4`, which doesn't exist in `libgcc`.
+
+Break since commit v8/v8@2301870e757aac6148fd9f7508201d5a8217110c
+
+See also:
+[1] https://github.com/ClangBuiltLinux/linux/issues/1438#issuecomment-908551114
+[2] https://reviews.llvm.org/D108928
+--- a/v8/include/v8config.h
++++ b/v8/include/v8config.h
+@@ -366,7 +366,7 @@
+ # define V8_HAS_BUILTIN_POPCOUNT (__has_builtin(__builtin_popcount))
+ # define V8_HAS_BUILTIN_ADD_OVERFLOW (__has_builtin(__builtin_add_overflow))
+ # define V8_HAS_BUILTIN_SUB_OVERFLOW (__has_builtin(__builtin_sub_overflow))
+-# define V8_HAS_BUILTIN_MUL_OVERFLOW (__has_builtin(__builtin_mul_overflow))
++# define V8_HAS_BUILTIN_MUL_OVERFLOW (0)
+ # define V8_HAS_BUILTIN_SADD_OVERFLOW (__has_builtin(__builtin_sadd_overflow))
+ # define V8_HAS_BUILTIN_SSUB_OVERFLOW (__has_builtin(__builtin_ssub_overflow))
+ # define V8_HAS_BUILTIN_UADD_OVERFLOW (__has_builtin(__builtin_uadd_overflow))

--- a/x11-packages/carbonyl-host-tools/patches/1601-angle-no-android-jni.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1601-angle-no-android-jni.patch
@@ -1,0 +1,11 @@
+--- a/third_party/angle/src/common/platform.h
++++ b/third_party/angle/src/common/platform.h
+@@ -17,7 +17,7 @@
+ #elif defined(__APPLE__)
+ #    define ANGLE_PLATFORM_APPLE 1
+ #    define ANGLE_PLATFORM_POSIX 1
+-#elif defined(ANDROID)
++#elif (defined(ANDROID) && !defined(__TERMUX__))
+ #    define ANGLE_PLATFORM_ANDROID 1
+ #    define ANGLE_PLATFORM_POSIX 1
+ #elif defined(__ggp__)

--- a/x11-packages/carbonyl-host-tools/patches/1701-swiftshader-no-spawn.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1701-swiftshader-no-spawn.patch
@@ -1,0 +1,11 @@
+--- a/third_party/swiftshader/third_party/llvm-subzero/build/Linux/include/llvm/Config/config.h
++++ b/third_party/swiftshader/third_party/llvm-subzero/build/Linux/include/llvm/Config/config.h
+@@ -166,7 +166,7 @@
+ #define HAVE_POSIX_FALLOCATE 1
+ 
+ /* Define to 1 if you have the `posix_spawn' function. */
+-#define HAVE_POSIX_SPAWN 1
++/* #define HAVE_POSIX_SPAWN 1 */
+ 
+ /* Define to 1 if you have the `pread' function. */
+ #define HAVE_PREAD 1

--- a/x11-packages/carbonyl-host-tools/patches/1702-swiftshader-fix-dynamic-loaded-libraries.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1702-swiftshader-fix-dynamic-loaded-libraries.patch
@@ -1,0 +1,40 @@
+--- a/third_party/swiftshader/src/WSI/libWaylandClient.cpp
++++ b/third_party/swiftshader/src/WSI/libWaylandClient.cpp
+@@ -56,7 +56,11 @@
+ 		}
+ 		else
+ 		{
++#ifdef __TERMUX__
++			libwl = loadLibrary("libwayland-client.so");
++#else
+ 			libwl = loadLibrary("libwayland-client.so.0");
++#endif
+ 		}
+
+ 		return LibWaylandClientExports(libwl);
+--- a/third_party/swiftshader/src/WSI/libXCB.cpp
++++ b/third_party/swiftshader/src/WSI/libXCB.cpp
+@@ -55,7 +55,11 @@
+ 		}
+ 		else
+ 		{
++#ifdef __TERMUX__
++			libxcb = loadLibrary("libxcb.so");
++#else
+ 			libxcb = loadLibrary("libxcb.so.1");
++#endif
+ 		}
+
+ 		if(getProcAddress(RTLD_DEFAULT, "xcb_shm_query_version"))  // Search the global scope for pre-loaded XCB library.
+@@ -64,7 +68,11 @@
+ 		}
+ 		else
+ 		{
++#ifdef __TERMUX__
++			libshm = loadLibrary("libxcb-shm.so");
++#else
+ 			libshm = loadLibrary("libxcb-shm.so.0");
++#endif
+ 		}
+
+ 		return LibXcbExports(libxcb, libshm);

--- a/x11-packages/carbonyl-host-tools/patches/1703-swiftshader-no-android.patch
+++ b/x11-packages/carbonyl-host-tools/patches/1703-swiftshader-no-android.patch
@@ -1,0 +1,415 @@
+diff -uNr a/third_party/swiftshader/src/Vulkan/VkGetProcAddress.cpp b/third_party/swiftshader/src/Vulkan/VkGetProcAddress.cpp
+--- a/third_party/swiftshader/src/Vulkan/VkGetProcAddress.cpp	2022-11-09 09:30:26.242905400 +0800
++++ b/third_party/swiftshader/src/Vulkan/VkGetProcAddress.cpp	2022-11-11 20:35:03.121029060 +0800
+@@ -19,7 +19,7 @@
+ #include <unordered_map>
+ #include <vector>
+ 
+-#ifdef __ANDROID__
++#if (defined(__ANDROID__) && !defined(__TERMUX__))
+ #	include <hardware/hwvulkan.h>
+ #	include <vulkan/vk_android_native_buffer.h>
+ #	include <cerrno>
+@@ -105,7 +105,7 @@
+ 	MAKE_VULKAN_INSTANCE_ENTRY(vkSubmitDebugUtilsMessageEXT),
+ 	// VK_EXT_tooling_info
+ 	MAKE_VULKAN_INSTANCE_ENTRY(vkGetPhysicalDeviceToolProperties),
+-#ifndef __ANDROID__
++#if !(defined(__ANDROID__) && !defined(__TERMUX__))
+ 	// VK_KHR_surface
+ 	MAKE_VULKAN_INSTANCE_ENTRY(vkDestroySurfaceKHR),
+ 	MAKE_VULKAN_INSTANCE_ENTRY(vkGetPhysicalDeviceSurfaceSupportKHR),
+@@ -310,7 +310,7 @@
+ 	MAKE_VULKAN_DEVICE_ENTRY(vkQueueInsertDebugUtilsLabelEXT),
+ 	MAKE_VULKAN_DEVICE_ENTRY(vkSetDebugUtilsObjectNameEXT),
+ 	MAKE_VULKAN_DEVICE_ENTRY(vkSetDebugUtilsObjectTagEXT),
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ 	MAKE_VULKAN_DEVICE_ENTRY(vkGetSwapchainGrallocUsageANDROID),
+ 	MAKE_VULKAN_DEVICE_ENTRY(vkGetSwapchainGrallocUsage2ANDROID),
+ 	MAKE_VULKAN_DEVICE_ENTRY(vkAcquireImageANDROID),
+@@ -535,7 +535,7 @@
+ 	        MAKE_VULKAN_DEVICE_ENTRY(vkCmdWriteTimestamp2KHR),
+ 	        MAKE_VULKAN_DEVICE_ENTRY(vkQueueSubmit2KHR),
+ 	    } },
+-#ifndef __ANDROID__
++#if !(defined(__ANDROID__) && !defined(__TERMUX__))
+ 	// VK_KHR_swapchain
+ 	{
+ 	    VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+@@ -680,7 +680,7 @@
+ 
+ }  // namespace vk
+ 
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ 
+ extern "C" hwvulkan_module_t HAL_MODULE_INFO_SYM;
+ 
+diff -uNr a/third_party/swiftshader/src/Vulkan/VkImage.cpp b/third_party/swiftshader/src/Vulkan/VkImage.cpp
+--- a/third_party/swiftshader/src/Vulkan/VkImage.cpp	2022-11-09 09:30:26.242905400 +0800
++++ b/third_party/swiftshader/src/Vulkan/VkImage.cpp	2022-11-11 20:35:15.231028902 +0800
+@@ -25,7 +25,7 @@
+ #include "Device/Blitter.hpp"
+ #include "Device/ETC_Decoder.hpp"
+ 
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ #	include "System/GrallocAndroid.hpp"
+ #	include "VkDeviceMemoryExternalAndroid.hpp"
+ #endif
+@@ -134,7 +134,7 @@
+ 		// VK_STRUCTURE_TYPE_SWAPCHAIN_IMAGE_CREATE_INFO_ANDROID, are not enumerated in the official Vulkan headers.
+ 		switch((int)(nextInfo->sType))
+ 		{
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ 		case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID:
+ 			{
+ 				const VkExternalFormatANDROID *externalFormatAndroid = reinterpret_cast<const VkExternalFormatANDROID *>(nextInfo);
+@@ -311,7 +311,7 @@
+ 	}
+ }
+ 
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ VkResult Image::prepareForExternalUseANDROID() const
+ {
+ 	void *nativeBuffer = nullptr;
+diff -uNr a/third_party/swiftshader/src/Vulkan/VkImage.hpp b/third_party/swiftshader/src/Vulkan/VkImage.hpp
+--- a/third_party/swiftshader/src/Vulkan/VkImage.hpp	2022-11-09 09:30:26.242905400 +0800
++++ b/third_party/swiftshader/src/Vulkan/VkImage.hpp	2022-11-11 20:35:31.971028682 +0800
+@@ -20,7 +20,7 @@
+ 
+ #include "marl/mutex.h"
+ 
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ #	include <vulkan/vk_android_native_buffer.h>  // For VkSwapchainImageUsageFlagsANDROID and buffer_handle_t
+ #endif
+ 
+@@ -33,7 +33,7 @@
+ class DeviceMemory;
+ class ImageView;
+ 
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ struct BackingMemory
+ {
+ 	int stride = 0;
+@@ -49,7 +49,7 @@
+ 	Image(const VkImageCreateInfo *pCreateInfo, void *mem, Device *device);
+ 	void destroy(const VkAllocationCallbacks *pAllocator);
+ 
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ 	VkResult prepareForExternalUseANDROID() const;
+ #endif
+ 
+@@ -107,7 +107,7 @@
+ 	void contentsChanged(const VkImageSubresourceRange &subresourceRange, ContentsChangedContext contentsChangedContext = DIRECT_MEMORY_ACCESS);
+ 	const Image *getSampledImage(const vk::Format &imageViewFormat) const;
+ 
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ 	void setBackingMemory(BackingMemory &bm)
+ 	{
+ 		backingMemory = bm;
+@@ -153,7 +153,7 @@
+ 	VkImageTiling tiling = VK_IMAGE_TILING_OPTIMAL;
+ 	VkImageUsageFlags usage = (VkImageUsageFlags)0;
+ 	Image *decompressedImage = nullptr;
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ 	BackingMemory backingMemory = {};
+ #endif
+ 
+diff -uNr a/third_party/swiftshader/src/Vulkan/VkPhysicalDevice.cpp b/third_party/swiftshader/src/Vulkan/VkPhysicalDevice.cpp
+--- a/third_party/swiftshader/src/Vulkan/VkPhysicalDevice.cpp	2022-11-09 09:30:26.242905400 +0800
++++ b/third_party/swiftshader/src/Vulkan/VkPhysicalDevice.cpp	2022-11-11 20:35:42.081028550 +0800
+@@ -22,7 +22,7 @@
+ #include <cstring>
+ #include <limits>
+ 
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ #	include <android/hardware_buffer.h>
+ #endif
+ 
+@@ -971,7 +971,7 @@
+ 	properties->combinedImageSamplerDescriptorCount = 1;  // Need only one descriptor for YCbCr sampling.
+ }
+ 
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ void PhysicalDevice::getProperties(VkPhysicalDevicePresentationPropertiesANDROID *properties) const
+ {
+ 	properties->sharedImage = VK_FALSE;
+diff -uNr a/third_party/swiftshader/src/Vulkan/VkPhysicalDevice.hpp b/third_party/swiftshader/src/Vulkan/VkPhysicalDevice.hpp
+--- a/third_party/swiftshader/src/Vulkan/VkPhysicalDevice.hpp	2022-11-09 09:30:26.242905400 +0800
++++ b/third_party/swiftshader/src/Vulkan/VkPhysicalDevice.hpp	2022-11-11 20:35:45.861028500 +0800
+@@ -69,7 +69,7 @@
+ 	void getProperties(const VkExternalMemoryHandleTypeFlagBits *handleType, VkExternalImageFormatProperties *properties) const;
+ 	void getProperties(const VkExternalMemoryHandleTypeFlagBits *handleType, VkExternalBufferProperties *properties) const;
+ 	void getProperties(VkSamplerYcbcrConversionImageFormatProperties *properties) const;
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ 	void getProperties(VkPhysicalDevicePresentationPropertiesANDROID *properties) const;
+ 	void getProperties(const VkPhysicalDeviceImageFormatInfo2 *pImageFormatInfo, VkAndroidHardwareBufferUsageANDROID *properties) const;
+ #endif
+diff -uNr a/third_party/swiftshader/src/Vulkan/VkQueue.cpp b/third_party/swiftshader/src/Vulkan/VkQueue.cpp
+--- a/third_party/swiftshader/src/Vulkan/VkQueue.cpp	2022-11-09 09:30:26.242905400 +0800
++++ b/third_party/swiftshader/src/Vulkan/VkQueue.cpp	2022-11-11 20:35:52.181028418 +0800
+@@ -189,7 +189,7 @@
+ 	}
+ }
+ 
+-#ifndef __ANDROID__
++#if !(defined(__ANDROID__) && !defined(__TERMUX__))
+ VkResult Queue::present(const VkPresentInfoKHR *presentInfo)
+ {
+ 	// This is a hack to deal with screen tearing for now.
+diff -uNr a/third_party/swiftshader/src/Vulkan/VkQueue.hpp b/third_party/swiftshader/src/Vulkan/VkQueue.hpp
+--- a/third_party/swiftshader/src/Vulkan/VkQueue.hpp	2022-11-09 09:30:26.242905400 +0800
++++ b/third_party/swiftshader/src/Vulkan/VkQueue.hpp	2022-11-11 21:03:39.721006571 +0800
+@@ -53,7 +53,7 @@
+ 
+ 	VkResult submit(uint32_t submitCount, SubmitInfo *pSubmits, Fence *fence);
+ 	VkResult waitIdle();
+-#ifndef __ANDROID__
++#if !(defined(__ANDROID__) && !defined(__TERMUX__))
+ 	VkResult present(const VkPresentInfoKHR *presentInfo);
+ #endif
+ 
+diff -uNr a/third_party/swiftshader/src/Vulkan/libVulkan.cpp b/third_party/swiftshader/src/Vulkan/libVulkan.cpp
+--- a/third_party/swiftshader/src/Vulkan/libVulkan.cpp	2022-11-09 09:30:26.246905800 +0800
++++ b/third_party/swiftshader/src/Vulkan/libVulkan.cpp	2022-11-11 20:33:50.481030012 +0800
+@@ -81,7 +81,7 @@
+ #include "marl/thread.h"
+ #include "marl/tsa.h"
+ 
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ #	include "commit.h"
+ #	include "System/GrallocAndroid.hpp"
+ #	include <android/log.h>
+@@ -102,7 +102,7 @@
+ namespace {
+ 
+ // Enable commit_id.py and #include commit.h for other platforms.
+-#if defined(__ANDROID__) && defined(ENABLE_BUILD_VERSION_OUTPUT)
++#if defined(__ANDROID__) && !defined(__TERMUX__) && defined(ENABLE_BUILD_VERSION_OUTPUT)
+ void logBuildVersionInformation()
+ {
+ 	// TODO(b/144093703): Don't call __android_log_print() directly
+@@ -137,7 +137,7 @@
+ void initializeLibrary()
+ {
+ 	static bool doOnce = [] {
+-#if defined(__ANDROID__) && defined(ENABLE_BUILD_VERSION_OUTPUT)
++#if defined(__ANDROID__) && !defined(__TERMUX__) && defined(ENABLE_BUILD_VERSION_OUTPUT)
+ 		logBuildVersionInformation();
+ #endif  // __ANDROID__ && ENABLE_BUILD_VERSION_OUTPUT
+ 		return true;
+@@ -284,7 +284,7 @@
+ 	{ { VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_SPEC_VERSION } },
+ 	{ { VK_EXT_DEBUG_UTILS_EXTENSION_NAME, VK_EXT_DEBUG_UTILS_SPEC_VERSION } },
+ 	{ { VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME, VK_EXT_HEADLESS_SURFACE_SPEC_VERSION } },
+-#ifndef __ANDROID__
++#if !(defined(__ANDROID__) && !defined(__TERMUX__))
+ 	{ { VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_SURFACE_SPEC_VERSION } },
+ #endif
+ #ifdef VK_USE_PLATFORM_XCB_KHR
+@@ -336,7 +336,7 @@
+ 	// Only 1.1 core version of this is supported. The extension has additional requirements
+ 	//{{ VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME, VK_KHR_VARIABLE_POINTERS_SPEC_VERSION }},
+ 	{ { VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME, VK_EXT_QUEUE_FAMILY_FOREIGN_SPEC_VERSION } },
+-#ifndef __ANDROID__
++#if !(defined(__ANDROID__) && !defined(__TERMUX__))
+ 	// We fully support the KHR_swapchain v70 additions, so just track the spec version.
+ 	{ { VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_KHR_SWAPCHAIN_SPEC_VERSION } },
+ #else
+@@ -364,7 +364,7 @@
+ 	{ { VK_FUCHSIA_EXTERNAL_MEMORY_EXTENSION_NAME, VK_FUCHSIA_EXTERNAL_MEMORY_SPEC_VERSION } },
+ #endif
+ 	{ { VK_EXT_PROVOKING_VERTEX_EXTENSION_NAME, VK_EXT_PROVOKING_VERTEX_SPEC_VERSION } },
+-#if !defined(__ANDROID__)
++#if !(defined(__ANDROID__) && !defined(__TERMUX__))
+ 	{ { VK_GOOGLE_SAMPLER_FILTERING_PRECISION_EXTENSION_NAME, VK_GOOGLE_SAMPLER_FILTERING_PRECISION_SPEC_VERSION } },
+ #endif
+ 	{ { VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME, VK_EXT_DEPTH_RANGE_UNRESTRICTED_SPEC_VERSION } },
+@@ -1891,7 +1891,7 @@
+ 
+ 	const VkBaseInStructure *extensionCreateInfo = reinterpret_cast<const VkBaseInStructure *>(pCreateInfo->pNext);
+ 
+-#ifdef __ANDROID__
++#if (defined(__ANDROID__) && !defined(__TERMUX__))
+ 	vk::BackingMemory backmem;
+ 	bool swapchainImage = false;
+ #endif
+@@ -1902,7 +1902,7 @@
+ 		// VK_STRUCTURE_TYPE_NATIVE_BUFFER_ANDROID, are not enumerated in the official Vulkan headers.
+ 		switch((int)(extensionCreateInfo->sType))
+ 		{
+-#ifdef __ANDROID__
++#if (defined(__ANDROID__) && !defined(__TERMUX__))
+ 		case VK_STRUCTURE_TYPE_SWAPCHAIN_IMAGE_CREATE_INFO_ANDROID:
+ 			{
+ 				const VkSwapchainImageCreateInfoANDROID *swapImageCreateInfo = reinterpret_cast<const VkSwapchainImageCreateInfoANDROID *>(extensionCreateInfo);
+@@ -1956,7 +1956,7 @@
+ 
+ 	VkResult result = vk::Image::Create(pAllocator, pCreateInfo, pImage, vk::Cast(device));
+ 
+-#ifdef __ANDROID__
++#if (defined(__ANDROID__) && !defined(__TERMUX__))
+ 	if(swapchainImage)
+ 	{
+ 		if(result != VK_SUCCESS)
+@@ -1994,7 +1994,7 @@
+ 	TRACE("(VkDevice device = %p, VkImage image = %p, const VkAllocationCallbacks* pAllocator = %p)",
+ 	      device, static_cast<void *>(image), pAllocator);
+ 
+-#ifdef __ANDROID__
++#if (defined(__ANDROID__) && !defined(__TERMUX__))
+ 	vk::Image *img = vk::Cast(image);
+ 	if(img && img->hasExternalMemory())
+ 	{
+@@ -2333,7 +2333,7 @@
+ 				ycbcrConversion = vk::Cast(samplerYcbcrConversionInfo->conversion);
+ 			}
+ 			break;
+-#if !defined(__ANDROID__)
++#if !(defined(__ANDROID__) && !defined(__TERMUX__))
+ 		case VK_STRUCTURE_TYPE_SAMPLER_FILTERING_PRECISION_GOOGLE:
+ 			{
+ 				const VkSamplerFilteringPrecisionGOOGLE *filteringInfo =
+@@ -3376,7 +3376,7 @@
+ 				/* Do nothing */
+ 				break;
+ 
+-#ifndef __ANDROID__
++#if !(defined(__ANDROID__) && !defined(__TERMUX__))
+ 			case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_SWAPCHAIN_INFO_KHR:
+ 				{
+ 					auto swapchainInfo = reinterpret_cast<VkBindImageMemorySwapchainInfoKHR const *>(extInfo);
+@@ -3583,7 +3583,7 @@
+ 				vk::Cast(physicalDevice)->getProperties(properties);
+ 			}
+ 			break;
+-#ifdef __ANDROID__
++#if (defined(__ANDROID__) && !defined(__TERMUX__))
+ 		case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENTATION_PROPERTIES_ANDROID:
+ 			{
+ 				auto properties = reinterpret_cast<VkPhysicalDevicePresentationPropertiesANDROID *>(extensionProperties);
+@@ -3831,7 +3831,7 @@
+ 
+ 	VkBaseOutStructure *extensionProperties = reinterpret_cast<VkBaseOutStructure *>(pImageFormatProperties->pNext);
+ 
+-#ifdef __ANDROID__
++#if !(defined(__ANDROID__) && !defined(__TERMUX__))
+ 	bool hasAHBUsage = false;
+ #endif
+ 
+@@ -3857,7 +3857,7 @@
+ 				ASSERT(!hasDeviceExtension(VK_AMD_TEXTURE_GATHER_BIAS_LOD_EXTENSION_NAME));
+ 			}
+ 			break;
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ 		case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID:
+ 			{
+ 				auto properties = reinterpret_cast<VkAndroidHardwareBufferUsageANDROID *>(extensionProperties);
+@@ -3984,7 +3984,7 @@
+ 
+ 	vk::Cast(physicalDevice)->getImageFormatProperties(format, type, tiling, usage, flags, &pImageFormatProperties->imageFormatProperties);
+ 
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ 	if(hasAHBUsage)
+ 	{
+ 		// AHardwareBuffer_lock may only be called with a single layer.
+@@ -4117,7 +4117,7 @@
+ 	{
+ 		switch(extInfo->sType)
+ 		{
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ 		case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID:
+ 			break;
+ #endif
+@@ -4570,7 +4570,7 @@
+ 	return vk::HeadlessSurfaceKHR::Create(pAllocator, pCreateInfo, pSurface);
+ }
+ 
+-#ifndef __ANDROID__
++#if !(defined(__ANDROID__) && !defined(__TERMUX__))
+ VKAPI_ATTR void VKAPI_CALL vkDestroySurfaceKHR(VkInstance instance, VkSurfaceKHR surface, const VkAllocationCallbacks *pAllocator)
+ {
+ 	TRACE("(VkInstance instance = %p, VkSurfaceKHR surface = %p, const VkAllocationCallbacks* pAllocator = %p)",
+@@ -4742,7 +4742,7 @@
+ 
+ #endif  // ! __ANDROID__
+ 
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ 
+ VKAPI_ATTR VkResult VKAPI_CALL vkGetSwapchainGrallocUsage2ANDROID(VkDevice device, VkFormat format, VkImageUsageFlags imageUsage, VkSwapchainImageUsageFlagsANDROID swapchainUsage, uint64_t *grallocConsumerUsage, uint64_t *grallocProducerUsage)
+ {
+--- a/third_party/swiftshader/src/System/Debug.cpp
++++ b/third_party/swiftshader/src/System/Debug.cpp
+@@ -14,7 +14,7 @@
+ 
+ #include "Debug.hpp"
+ 
+-#if __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ #	include <android/log.h>
+ #endif
+ 
+@@ -55,7 +55,7 @@
+ 	Disabled,
+ };
+ 
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ void logv_android(Level level, const char *msg)
+ {
+ 	switch(level)
+@@ -107,7 +107,7 @@
+ 		char buffer[2048];
+ 		vsnprintf(buffer, sizeof(buffer), format, args);
+ 
+-#	if defined(__ANDROID__)
++#	if defined(__ANDROID__) && !defined(__TERMUX__)
+ 		logv_android(level, buffer);
+ #	elif defined(_WIN32)
+ 		logv_std(level, buffer);
+--- a/third_party/swiftshader/src/Reactor/Debug.cpp
++++ b/third_party/swiftshader/src/Reactor/Debug.cpp
+@@ -19,7 +19,7 @@
+ #include <cstdio>
+ #include <string>
+ 
+-#if __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ #	include <android/log.h>
+ #endif
+ 
+@@ -105,7 +105,7 @@
+ 	Fatal,
+ };
+ 
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ void logv_android(Level level, const char *msg)
+ {
+ 	switch(level)
+@@ -156,7 +156,7 @@
+ 	char buffer[2048];
+ 	vsnprintf(buffer, sizeof(buffer), format, args);
+ 
+-#	if defined(__ANDROID__)
++#	if defined(__ANDROID__) && !defined(__TERMUX__)
+ 	logv_android(level, buffer);
+ #	elif defined(_WIN32)
+ 	logv_std(level, buffer);

--- a/x11-packages/carbonyl-host-tools/patches/2001-weston-memfd_create.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2001-weston-memfd_create.patch
@@ -1,0 +1,14 @@
+--- a/third_party/weston/src/shared/os-compatibility.c
++++ b/third_party/weston/src/shared/os-compatibility.c
+@@ -38,6 +38,11 @@
+ 
+ #include "os-compatibility.h"
+ 
++#if defined(__ANDROID__) && __ANDROID_API__ < 26
++#include <sys/syscall.h>
++#define memfd_create(name,flags) syscall(SYS_memfd_create,name,flags)
++#endif
++
+ #define READONLY_SEALS (F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE)
+ 
+ int

--- a/x11-packages/carbonyl-host-tools/patches/2002-weston-fix-dynamic-loaded-libraries.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2002-weston-fix-dynamic-loaded-libraries.patch
@@ -1,0 +1,14 @@
+--- a/third_party/weston/src/libweston/backend-drm/drm-gbm.c
++++ b/third_party/weston/src/libweston/backend-drm/drm-gbm.c
+@@ -61,7 +61,11 @@
+ 	 * only the gl-renderer module links to it, the call above won't make
+ 	 * these symbols globally available, and loading the DRI driver fails.
+ 	 * Workaround this by dlopen()'ing libglapi with RTLD_GLOBAL. */
++#ifdef __TERMUX__
++	dlopen("libglapi.so", RTLD_LAZY | RTLD_GLOBAL);
++#else
+ 	dlopen("libglapi.so.0", RTLD_LAZY | RTLD_GLOBAL);
++#endif
+ 
+ 	gbm = gbm_create_device(fd);
+ 

--- a/x11-packages/carbonyl-host-tools/patches/2003-wayland-memfd_create.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2003-wayland-memfd_create.patch
@@ -1,0 +1,14 @@
+--- a/third_party/wayland/src/cursor/os-compatibility.c
++++ b/third_party/wayland/src/cursor/os-compatibility.c
+@@ -42,6 +42,11 @@
+ 
+ #include "os-compatibility.h"
+ 
++#if defined(__ANDROID__) && __ANDROID_API__ < 26
++#include <sys/syscall.h>
++#define memfd_create(name,flags) syscall(SYS_memfd_create,name,flags)
++#endif
++
+ #ifndef HAVE_MKOSTEMP
+ static int
+ set_cloexec_or_close(int fd)

--- a/x11-packages/carbonyl-host-tools/patches/2004-breakpad-no-elf_prstatus.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2004-breakpad-no-elf_prstatus.patch
@@ -1,0 +1,18 @@
+--- a/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_core_dumper.cc
++++ b/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_core_dumper.cc
+@@ -194,6 +194,7 @@
+     //
+     // The following code only works if notes are ordered as expected.
+     switch (type) {
++#if !defined(__ANDROID__)
+       case NT_PRSTATUS: {
+         if (description.length() != sizeof(elf_prstatus)) {
+           fprintf(stderr, "Found NT_PRSTATUS descriptor of unexpected size\n");
+@@ -231,6 +232,7 @@
+         thread_infos_.push_back(info);
+         break;
+       }
++#endif
+       case NT_SIGINFO: {
+         if (description.length() != sizeof(siginfo_t)) {
+           fprintf(stderr, "Found NT_SIGINFO descriptor of unexpected size\n");

--- a/x11-packages/carbonyl-host-tools/patches/2005-crashpad-fill-elf.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2005-crashpad-fill-elf.patch
@@ -1,0 +1,18 @@
+--- a/third_party/crashpad/crashpad/snapshot/elf/elf_symbol_table_reader.cc
++++ b/third_party/crashpad/crashpad/snapshot/elf/elf_symbol_table_reader.cc
+@@ -17,6 +17,15 @@
+ #include <elf.h>
+ 
+ #include "snapshot/elf/elf_image_reader.h"
++ 
++#ifndef ELF32_ST_VISIBILITY
++#define ELF32_ST_VISIBILITY(o)	((o) & 0x03)
++#endif
++ 
++/* For ELF64 the definitions are the same.  */
++#ifndef ELF64_ST_VISIBILITY
++#define ELF64_ST_VISIBILITY(o)	ELF32_ST_VISIBILITY (o)
++#endif
+ 
+ namespace crashpad {
+ 

--- a/x11-packages/carbonyl-host-tools/patches/2006-crashpad-no-getdtablesize.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2006-crashpad-no-getdtablesize.patch
@@ -1,0 +1,11 @@
+--- a/third_party/crashpad/crashpad/util/posix/close_multiple.cc
++++ b/third_party/crashpad/crashpad/util/posix/close_multiple.cc
+@@ -134,7 +134,7 @@
+   // bionic/libc/bionic/ndk_cruft.cpp getdtablesize().
+   int max_fd = implicit_cast<int>(sysconf(_SC_OPEN_MAX));
+ 
+-#if !BUILDFLAG(IS_ANDROID)
++#if !BUILDFLAG(IS_ANDROID) && !defined(__TERMUX__)
+   // getdtablesize() was removed effective Android 5.0.0 (API 21). Since it
+   // returns the same thing as the sysconf() above, just skip it. See
+   // https://android.googlesource.com/platform/bionic/+/462abab12b074c62c0999859e65d5a32ebb41951.

--- a/x11-packages/carbonyl-host-tools/patches/2007-crashpad-no-memfd.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2007-crashpad-no-memfd.patch
@@ -1,0 +1,22 @@
+--- a/third_party/crashpad/crashpad/util/file/file_io_posix.cc
++++ b/third_party/crashpad/crashpad/util/file/file_io_posix.cc
+@@ -19,6 +19,7 @@
+ #include <sys/file.h>
+ #include <sys/mman.h>
+ #include <sys/stat.h>
++#include <sys/syscall.h>
+ #include <unistd.h>
+ 
+ #include <algorithm>
+@@ -154,6 +155,11 @@
+ }
+ 
+ #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS)
++
++#if defined __ANDROID__ && __ANDROID_API__ < 30
++#define memfd_create(name,flags) syscall(SYS_memfd_create,name,flags)
++#endif
++
+ FileHandle LoggingOpenMemoryFileForReadAndWrite(const base::FilePath& name) {
+   DCHECK(name.value().find('/') == std::string::npos);
+ 

--- a/x11-packages/carbonyl-host-tools/patches/2008-crashpad-no-spawn.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2008-crashpad-no-spawn.patch
@@ -1,0 +1,28 @@
+--- a/third_party/crashpad/crashpad/util/posix/spawn_subprocess.cc
++++ b/third_party/crashpad/crashpad/util/posix/spawn_subprocess.cc
+@@ -15,12 +15,15 @@
+ #include "util/posix/spawn_subprocess.h"
+ 
+ #include <errno.h>
+-#include <spawn.h>
+ #include <stdlib.h>
+ #include <string.h>
+ #include <sys/wait.h>
+ #include <unistd.h>
+ 
++#ifndef __TERMUX__
++#include <spawn.h>
++#endif
++
+ #include "base/check.h"
+ #include "base/check_op.h"
+ #include "base/logging.h"
+@@ -171,7 +174,7 @@
+     char* const* envp_for_spawn =
+         envp ? const_cast<char* const*>(envp_c.data()) : environ;
+ 
+-#if BUILDFLAG(IS_ANDROID) && __ANDROID_API__ < 28
++#if (BUILDFLAG(IS_ANDROID) || defined(__TERMUX__)) && __ANDROID_API__ < 28
+     pid = fork();
+     if (pid < 0) {
+       PLOG(FATAL) << "fork";

--- a/x11-packages/carbonyl-host-tools/patches/2009-cpuinfo-android-arm.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2009-cpuinfo-android-arm.patch
@@ -1,0 +1,12 @@
+--- a/third_party/cpuinfo/src/src/arm/linux/init.c
++++ b/third_party/cpuinfo/src/src/arm/linux/init.c
+@@ -14,6 +14,9 @@
+ #include <cpuinfo/internal-api.h>
+ #include <cpuinfo/log.h>
+ 
++#ifdef __TERMUX__
++#include <arm/android/properties.c>
++#endif
+ 
+ struct cpuinfo_arm_isa cpuinfo_isa = { 0 };
+ 

--- a/x11-packages/carbonyl-host-tools/patches/2010-dav1d-no-get-affinity.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2010-dav1d-no-get-affinity.patch
@@ -1,0 +1,11 @@
+--- a/third_party/dav1d/libdav1d/src/cpu.c
++++ b/third_party/dav1d/libdav1d/src/cpu.c
+@@ -87,7 +87,7 @@
+     GetNativeSystemInfo(&system_info);
+     return system_info.dwNumberOfProcessors;
+ #endif
+-#elif defined(HAVE_PTHREAD_GETAFFINITY_NP) && defined(CPU_COUNT)
++#elif defined(HAVE_PTHREAD_GETAFFINITY_NP) && defined(CPU_COUNT) && !defined(__ANDROID__)
+     cpu_set_t affinity;
+     if (!pthread_getaffinity_np(pthread_self(), sizeof(affinity), &affinity))
+         return CPU_COUNT(&affinity);

--- a/x11-packages/carbonyl-host-tools/patches/2011-dawn-fix-dynamic-loaded-libraries.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2011-dawn-fix-dynamic-loaded-libraries.patch
@@ -1,0 +1,14 @@
+--- a/third_party/dawn/src/dawn/native/XlibXcbFunctions.cpp	
++++ b/third_party/dawn/src/dawn/native/XlibXcbFunctions.cpp
+@@ -17,7 +17,11 @@
+ namespace dawn::native {
+ 
+ XlibXcbFunctions::XlibXcbFunctions() {
++#ifdef __TERMUX__
++    if (!mLib.Open("libX11-xcb.so") || !mLib.GetProc(&xGetXCBConnection, "XGetXCBConnection")) {
++#else
+     if (!mLib.Open("libX11-xcb.so.1") || !mLib.GetProc(&xGetXCBConnection, "XGetXCBConnection")) {
++#endif
+         mLib.Close();
+     }
+ }

--- a/x11-packages/carbonyl-host-tools/patches/2012-dawn-no-android-jni.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2012-dawn-no-android-jni.patch
@@ -1,0 +1,22 @@
+--- a/third_party/dawn/include/dawn/native/VulkanBackend.h
++++ b/third_party/dawn/include/dawn/native/VulkanBackend.h
+@@ -126,7 +126,7 @@
+     ExternalImageExportInfoDmaBuf();
+ };
+ 
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ 
+ // Descriptor for AHardwareBuffer image import
+ struct DAWN_NATIVE_EXPORT ExternalImageDescriptorAHardwareBuffer : ExternalImageDescriptorVk {
+--- a/third_party/dawn/src/dawn/common/Platform.h
++++ b/third_party/dawn/src/dawn/common/Platform.h
+@@ -48,7 +48,7 @@
+ #elif defined(__linux__)
+ #define DAWN_PLATFORM_IS_LINUX 1
+ #define DAWN_PLATFORM_IS_POSIX 1
+-#if defined(__ANDROID__)
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ #define DAWN_PLATFORM_IS_ANDROID 1
+ #endif
+ 

--- a/x11-packages/carbonyl-host-tools/patches/2013-minigbm-no-android-log.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2013-minigbm-no-android-log.patch
@@ -1,0 +1,20 @@
+--- a/third_party/minigbm/src/drv.c
++++ b/third_party/minigbm/src/drv.c
+@@ -15,7 +15,7 @@
+ #include <unistd.h>
+ #include <xf86drm.h>
+ 
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ #include <cutils/log.h>
+ #include <libgen.h>
+ #endif
+@@ -752,7 +752,7 @@
+ 
+ 	va_list args;
+ 	va_start(args, format);
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ 	int prio = ANDROID_LOG_ERROR;
+ 	switch (level) {
+ 	case DRV_LOGV:

--- a/x11-packages/carbonyl-host-tools/patches/2014-perfetto-no-android-jni.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2014-perfetto-no-android-jni.patch
@@ -1,0 +1,11 @@
+--- a/third_party/perfetto/include/perfetto/base/build_config.h
++++ b/third_party/perfetto/include/perfetto/base/build_config.h
+@@ -24,7 +24,7 @@
+ #define PERFETTO_BUILDFLAG(flag) \
+   (PERFETTO_BUILDFLAG_CAT(PERFETTO_BUILDFLAG_DEFINE_, flag)())
+ 
+-#if defined(__ANDROID__)
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ #define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_OS_ANDROID() 1
+ #define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_OS_LINUX() 0
+ #define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_OS_WIN() 0

--- a/x11-packages/carbonyl-host-tools/patches/2015-vk-layers-no-android-log.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2015-vk-layers-no-android-log.patch
@@ -1,0 +1,18 @@
+--- a/third_party/vulkan-deps/vulkan-validation-layers/src/layers/vk_layer_logging.h
++++ b/third_party/vulkan-deps/vulkan-validation-layers/src/layers/vk_layer_logging.h
+@@ -59,7 +59,15 @@
+ 
+ #if defined __ANDROID__
+ #include <android/log.h>
++#if !defined(__TERMUX__)
+ #define LOGCONSOLE(...) ((void)__android_log_print(ANDROID_LOG_INFO, "VALIDATION", __VA_ARGS__))
++#else
++#define LOGCONSOLE(...)      \
++    {                        \
++        printf(__VA_ARGS__); \
++        printf("\n");        \
++    }
++#endif
+ [[maybe_unused]] static const char *kForceDefaultCallbackKey = "debug.vvl.forcelayerlog";
+ #else
+ #define LOGCONSOLE(...)      \

--- a/x11-packages/carbonyl-host-tools/patches/2016-unrar-no-lutimes.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2016-unrar-no-lutimes.patch
@@ -1,0 +1,14 @@
+Origin: https://github.com/termux/termux-packages/blob/b6a1362cec0f5432629b433b389a70357059f79b/packages/unrar/os.hpp.patch
+
+diff -u -r ../unrar/os.hpp ./os.hpp
+--- a/third_party/unrar/src/os.hpp	2017-06-10 13:59:52.000000000 +0000
++++ b/third_party/unrar/src/os.hpp	2017-06-12 00:11:04.591100580 +0000
+@@ -154,7 +154,7 @@
+ #define SAVE_LINKS
+ #endif
+ 
+-#if defined(__linux) || defined(__FreeBSD__)
++#if (defined(__linux) && !defined(__ANDROID__)) || defined(__FreeBSD__)
+ #include <sys/time.h>
+ #define USE_LUTIMES
+ #endif

--- a/x11-packages/carbonyl-host-tools/patches/2017-tflite-no-atrace.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2017-tflite-no-atrace.patch
@@ -1,0 +1,20 @@
+--- a/third_party/tflite/src/tensorflow/lite/profiling/platform_profiler.cc
++++ b/third_party/tflite/src/tensorflow/lite/profiling/platform_profiler.cc
+@@ -18,7 +18,7 @@
+ 
+ #include "tensorflow/lite/core/api/profiler.h"
+ 
+-#if defined(__ANDROID__)
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ #include "tensorflow/lite/profiling/atrace_profiler.h"
+ #elif defined(__APPLE__)
+ #include "TargetConditionals.h"
+@@ -34,7 +34,7 @@
+ namespace profiling {
+ 
+ std::unique_ptr<tflite::Profiler> MaybeCreatePlatformProfiler() {
+-#if defined(__ANDROID__)
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+   return MaybeCreateATraceProfiler();
+ #elif defined(SIGNPOST_PLATFORM_PROFILER)
+   return MaybeCreateSignpostProfiler();

--- a/x11-packages/carbonyl-host-tools/patches/2101-mix-no-execinfo.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2101-mix-no-execinfo.patch
@@ -1,0 +1,81 @@
+Origin: https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/chromium/no-execinfo.patch
+
+musl does not have execinfo.h, and hence no implementation of
+. backtrace()
+. backtrace_symbols()
+for discussion about this, see https://www.openwall.com/lists/musl/2021/07/16/1
+--
+--- a/v8/src/codegen/external-reference-table.cc
++++ b/v8/src/codegen/external-reference-table.cc
+@@ -11,7 +11,9 @@
+
+ #if defined(DEBUG) && defined(V8_OS_LINUX) && !defined(V8_OS_ANDROID)
+ #define SYMBOLIZE_FUNCTION
++#if defined(__GLIBC__)
+ #include <execinfo.h>
++#endif
+
+ #include <vector>
+
+@@ -96,7 +98,7 @@
+ }
+
+ const char* ExternalReferenceTable::ResolveSymbol(void* address) {
+-#ifdef SYMBOLIZE_FUNCTION
++#if defined(SYMBOLIZE_FUNCTION) && defined(__GLIBC__)
+   char** names = backtrace_symbols(&address, 1);
+   const char* name = names[0];
+   // The array of names is malloc'ed. However, each name string is static
+--- a/third_party/swiftshader/third_party/llvm-subzero/build/Linux/include/llvm/Config/config.h
++++ b/third_party/swiftshader/third_party/llvm-subzero/build/Linux/include/llvm/Config/config.h
+@@ -58,7 +58,7 @@
+ #define HAVE_ERRNO_H 1
+
+ /* Define to 1 if you have the <execinfo.h> header file. */
+-#define HAVE_EXECINFO_H 1
++/* #define HAVE_EXECINFO_H 1 */
+
+ /* Define to 1 if you have the <fcntl.h> header file. */
+ #define HAVE_FCNTL_H 1
+--- a/base/debug/stack_trace.cc
++++ b/base/debug/stack_trace.cc
+@@ -251,7 +253,9 @@
+ }
+
+ void StackTrace::OutputToStream(std::ostream* os) const {
++#if defined(__GLIBC__) && !defined(_AIX)
+   OutputToStreamWithPrefix(os, nullptr);
++#endif
+ }
+
+ std::string StackTrace::ToString() const {
+@@ -281,7 +281,7 @@
+ }
+ std::string StackTrace::ToStringWithPrefix(const char* prefix_string) const {
+   std::stringstream stream;
+-#if !defined(__UCLIBC__) && !defined(_AIX)
++#if defined(__GLIBC__) && !defined(_AIX)
+   OutputToStreamWithPrefix(&stream, prefix_string);
+ #endif
+   return stream.str();
+--- a/base/debug/stack_trace_unittest.cc
++++ b/base/debug/stack_trace_unittest.cc
+@@ -33,7 +33,7 @@
+ typedef testing::Test StackTraceTest;
+ #endif
+
+-#if !defined(__UCLIBC__) && !defined(_AIX)
++#if !defined(__UCLIBC__) && !defined(_AIX) && defined(__GLIBC__)
+ // StackTrace::OutputToStream() is not implemented under uclibc, nor AIX.
+ // See https://crbug.com/706728
+
+@@ -156,7 +156,7 @@
+
+ #endif  // !defined(__UCLIBC__) && !defined(_AIX)
+
+-#if BUILDFLAG(IS_POSIX) && !BUILDFLAG(IS_ANDROID)
++#if (BUILDFLAG(IS_POSIX) && defined(__GLIBC__)) && !BUILDFLAG(IS_ANDROID)
+ #if !BUILDFLAG(IS_IOS)
+ static char* newArray() {
+   // Clang warns about the mismatched new[]/delete if they occur in the same
+ 

--- a/x11-packages/carbonyl-host-tools/patches/2102-mix-egl-fix-include.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2102-mix-egl-fix-include.patch
@@ -1,0 +1,47 @@
+--- a/third_party/dawn/third_party/khronos/EGL/eglplatform.h
++++ b/third_party/dawn/third_party/khronos/EGL/eglplatform.h
+@@ -88,7 +88,7 @@
+ typedef struct gbm_bo      *EGLNativePixmapType;
+ typedef void               *EGLNativeWindowType;
+ 
+-#elif defined(__ANDROID__) || defined(ANDROID)
++#elif (defined(__ANDROID__) || defined(ANDROID)) && !defined(__TERMUX__)
+ 
+ struct ANativeWindow;
+ struct egl_native_pixmap_t;
+
+--- a/third_party/khronos/EGL/eglplatform.h
++++ b/third_party/khronos/EGL/eglplatform.h
+@@ -88,7 +88,7 @@
+ typedef struct gbm_bo      *EGLNativePixmapType;
+ typedef void               *EGLNativeWindowType;
+ 
+-#elif defined(__ANDROID__) || defined(ANDROID)
++#elif (defined(__ANDROID__) || defined(ANDROID)) && !defined(__TERMUX__)
+ 
+ struct ANativeWindow;
+ struct egl_native_pixmap_t;
+
+--- a/third_party/angle/third_party/glmark2/src/src/glad/include/EGL/eglplatform.h
++++ b/third_party/angle/third_party/glmark2/src/src/glad/include/EGL/eglplatform.h
+@@ -88,7 +88,7 @@
+ typedef struct gbm_bo      *EGLNativePixmapType;
+ typedef void               *EGLNativeWindowType;
+ 
+-#elif defined(__ANDROID__) || defined(ANDROID)
++#elif (defined(__ANDROID__) || defined(ANDROID)) && !defined(__TERMUX__)
+ 
+ struct ANativeWindow;
+ struct egl_native_pixmap_t;
+
+--- a/third_party/angle/include/EGL/eglplatform.h
++++ b/third_party/angle/include/EGL/eglplatform.h
+@@ -88,7 +88,7 @@
+ typedef struct gbm_bo      *EGLNativePixmapType;
+ typedef void               *EGLNativeWindowType;
+ 
+-#elif defined(__ANDROID__) || defined(ANDROID)
++#elif (defined(__ANDROID__) || defined(ANDROID)) && !defined(__TERMUX__)
+ 
+ struct ANativeWindow;
+ struct egl_native_pixmap_t;

--- a/x11-packages/carbonyl-host-tools/patches/2103-pulse-fix-dynamic-loaded-libraries.patch
+++ b/x11-packages/carbonyl-host-tools/patches/2103-pulse-fix-dynamic-loaded-libraries.patch
@@ -1,0 +1,29 @@
+--- a/media/audio/pulse/pulse_util.cc
++++ b/media/audio/pulse/pulse_util.cc
+@@ -44,8 +44,12 @@
+ 
+ #if defined(DLOPEN_PULSEAUDIO)
+ static const base::FilePath::CharType kPulseLib[] =
++#ifdef __TERMUX__
++    FILE_PATH_LITERAL("libpulse.so");
++#else
+     FILE_PATH_LITERAL("libpulse.so.0");
+ #endif
++#endif
+ 
+ void DestroyMainloop(pa_threaded_mainloop* mainloop) {
+   pa_threaded_mainloop_stop(mainloop);
+--- a/third_party/webrtc/modules/audio_device/linux/pulseaudiosymboltable_linux.cc
++++ b/third_party/webrtc/modules/audio_device/linux/pulseaudiosymboltable_linux.cc
+@@ -30,7 +30,11 @@
+ namespace webrtc {
+ namespace adm_linux_pulse {
+ 
++#ifdef __TERMUX__
++LATE_BINDING_SYMBOL_TABLE_DEFINE_BEGIN(PulseAudioSymbolTable, "libpulse.so")
++#else
+ LATE_BINDING_SYMBOL_TABLE_DEFINE_BEGIN(PulseAudioSymbolTable, "libpulse.so.0")
++#endif
+ #define X(sym) \
+   LATE_BINDING_SYMBOL_TABLE_DEFINE_ENTRY(PulseAudioSymbolTable, sym)
+ PULSE_AUDIO_SYMBOLS_LIST

--- a/x11-packages/carbonyl-host-tools/patches/6001-checked_iterators-libstdcxx.patch
+++ b/x11-packages/carbonyl-host-tools/patches/6001-checked_iterators-libstdcxx.patch
@@ -1,0 +1,72 @@
+From 5b5551edd3961481e617e510276b9f015a35b861 Mon Sep 17 00:00:00 2001
+From: Piotr Tworek <piotr.tworek@xperi.com>
+Date: Fri, 26 May 2023 08:43:14 +0000
+Subject: [PATCH] Make CheckedContiguousIterator work correctly for libstdc++.
+
+The implementation of this iterator relies of specific operation
+of to_address. To accomplish this the code provides a specialization
+of std::pointer_traits. Unfortunately this specialization is gated
+behind _LIBCPP_VERSION ifdefs. As result its not enabled for libstdc++
+based builds. This results in SpanTest.Empty gtest failure when using
+libstdc++. The test explicitly tests for this custom to_address
+behavior, see [1]. The fun part is most of the ifdeffed code is not
+libc++ specific. It does work for libstdc++, with the tiny exception
+of __is_cpp17_contiguous_iterator which seems to be libc++
+implementation detail.
+
+Ref:
+[1] https://chromium-review.googlesource.com/c/chromium/src/+/3921496
+
+Bug: 957519
+Change-Id: I440bf2c3964ce9d99880dd3fda9faf832a1ba178
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4561265
+Commit-Queue: Piotr Tworek <piotr.tworek@xperi.com>
+Reviewed-by: Arthur Sonzogni <arthursonzogni@chromium.org>
+Reviewed-by: Daniel Cheng <dcheng@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1149606}
+---
+ base/containers/checked_iterators.h | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/base/containers/checked_iterators.h b/base/containers/checked_iterators.h
+index 0c98b8fab4d003..5c8292bd68a2a4 100644
+--- a/base/containers/checked_iterators.h
++++ b/base/containers/checked_iterators.h
+@@ -31,10 +31,8 @@ class CheckedContiguousIterator {
+ 
+   // Required for certain libc++ algorithm optimizations that are not available
+   // for NaCl.
+-#if defined(_LIBCPP_VERSION) && !BUILDFLAG(IS_NACL)
+   template <typename Ptr>
+   friend struct std::pointer_traits;
+-#endif
+ 
+   constexpr CheckedContiguousIterator() = default;
+ 
+@@ -224,7 +222,6 @@ using CheckedContiguousConstIterator = CheckedContiguousIterator<const T>;
+ 
+ }  // namespace base
+ 
+-#if defined(_LIBCPP_VERSION) && !BUILDFLAG(IS_NACL)
+ // Specialize both std::__is_cpp17_contiguous_iterator and std::pointer_traits
+ // for CCI in case we compile with libc++ outside of NaCl. The former is
+ // required to enable certain algorithm optimizations (e.g. std::copy can be a
+@@ -244,9 +241,11 @@ using CheckedContiguousConstIterator = CheckedContiguousIterator<const T>;
+ // [3] https://wg21.link/pointer.traits.optmem
+ namespace std {
+ 
++#if defined(_LIBCPP_VERSION)
+ template <typename T>
+ struct __is_cpp17_contiguous_iterator<::base::CheckedContiguousIterator<T>>
+     : true_type {};
++#endif
+ 
+ template <typename T>
+ struct pointer_traits<::base::CheckedContiguousIterator<T>> {
+@@ -267,6 +266,5 @@ struct pointer_traits<::base::CheckedContiguousIterator<T>> {
+ };
+ 
+ }  // namespace std
+-#endif
+ 
+ #endif  // BASE_CONTAINERS_CHECKED_ITERATORS_H_

--- a/x11-packages/carbonyl-host-tools/patches/6002-checked_iterators-libcxx.patch
+++ b/x11-packages/carbonyl-host-tools/patches/6002-checked_iterators-libcxx.patch
@@ -1,0 +1,144 @@
+From 9bfbbffdba73668fdb483e5a850911d2b64c35d7 Mon Sep 17 00:00:00 2001
+From: Daniel Cheng <dcheng@chromium.org>
+Date: Tue, 30 May 2023 20:22:27 +0000
+Subject: [PATCH] Disable usage of `__is_cpp17_contiguous_iterator` until
+ libc++ rolls.
+
+Though names prefixed with `__` are reserved for implementation use,
+specializing `__is_cpp17_contiguous_iterator` is currently the only way
+to tell libc++ that `memcpy()` can be safe to use with a custom
+iterator.  Without this workaround, there are noticeable regressions,
+e.g. when using std::copy() with spans of trivially copyable types (see
+https://crbug.com/994174).
+
+However, https://reviews.llvm.org/D150801 renames this template to
+`__libcpp_is_contiguous_iterator`, which blocks rolling past this libc++
+revision. As a workaround, temporarily forward declare and specialize
+both variants.
+`
+In addition, C++20 provides an official way for a custom iterator to opt
+into these types of optimizations, using `iterator_concept`, so also go
+ahead and opt `CheckedContiguousIterator` into using this.
+
+Bug: 1449299
+Bug: b/284031070
+Change-Id: If4e667fca8d1475ce5ced76b6072134686d12f4a
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4570684
+Commit-Queue: Daniel Cheng <dcheng@chromium.org>
+Reviewed-by: Nico Weber <thakis@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1150815}
+---
+ base/containers/checked_iterators.h           | 25 +++++++++++++++-
+ base/containers/checked_iterators_unittest.cc | 29 +++++++++++++------
+ 2 files changed, 44 insertions(+), 10 deletions(-)
+
+diff --git a/base/containers/checked_iterators.h b/base/containers/checked_iterators.h
+index 5c8292bd68a2a4..b67a2db4bfa3be 100644
+--- a/base/containers/checked_iterators.h
++++ b/base/containers/checked_iterators.h
+@@ -24,6 +24,9 @@ class CheckedContiguousIterator {
+   using pointer = T*;
+   using reference = T&;
+   using iterator_category = std::random_access_iterator_tag;
++#if __cplusplus >= 202002L
++  using iterator_concept = std::contiguous_iterator_tag;
++#endif
+ 
+   // Required for converting constructor below.
+   template <typename U>
+@@ -239,14 +242,34 @@ using CheckedContiguousConstIterator = CheckedContiguousIterator<const T>;
+ // [1] https://wg21.link/iterator.concept.contiguous
+ // [2] https://wg21.link/std.iterator.tags
+ // [3] https://wg21.link/pointer.traits.optmem
+-namespace std {
+ 
+ #if defined(_LIBCPP_VERSION)
++
++// TODO(crbug.com/1284275): Remove when C++20 is on by default, as the use
++// of `iterator_concept` above should suffice.
++_LIBCPP_BEGIN_NAMESPACE_STD
++
++// TODO(crbug.com/1449299): https://reviews.llvm.org/D150801 renamed this from
++// `__is_cpp17_contiguous_iterator` to `__libcpp_is_contiguous_iterator`. Clean
++// up the old spelling after libc++ rolls.
++template <typename T>
++struct __is_cpp17_contiguous_iterator;
+ template <typename T>
+ struct __is_cpp17_contiguous_iterator<::base::CheckedContiguousIterator<T>>
+     : true_type {};
++
++template <typename T>
++struct __libcpp_is_contiguous_iterator;
++template <typename T>
++struct __libcpp_is_contiguous_iterator<::base::CheckedContiguousIterator<T>>
++    : true_type {};
++
++_LIBCPP_END_NAMESPACE_STD
++
+ #endif
+ 
++namespace std {
++
+ template <typename T>
+ struct pointer_traits<::base::CheckedContiguousIterator<T>> {
+   using pointer = ::base::CheckedContiguousIterator<T>;
+diff --git a/base/containers/checked_iterators_unittest.cc b/base/containers/checked_iterators_unittest.cc
+index 4d7cffa1630314..07e628a10bafbd 100644
+--- a/base/containers/checked_iterators_unittest.cc
++++ b/base/containers/checked_iterators_unittest.cc
+@@ -85,11 +85,8 @@ TEST(CheckedContiguousIterator, ConvertingComparisonOperators) {
+ 
+ }  // namespace base
+ 
+-// ChromeOS does not use the in-tree libc++, but rather a shared library that
+-// lags a bit behind.
+-// TODO(crbug.com/1166360): Enable this test on ChromeOS once the shared libc++
+-// is sufficiently modern.
+-#if defined(_LIBCPP_VERSION) && !BUILDFLAG(IS_NACL) && !BUILDFLAG(IS_CHROMEOS)
++#if defined(_LIBCPP_VERSION)
++
+ namespace {
+ 
+ // Helper template that wraps an iterator and disables its dereference and
+@@ -101,6 +98,8 @@ namespace {
+ template <typename Iterator>
+ struct DisableDerefAndIncr : Iterator {
+   using Iterator::Iterator;
++
++  // NOLINTNEXTLINE(google-explicit-constructor)
+   constexpr DisableDerefAndIncr(const Iterator& iter) : Iterator(iter) {}
+ 
+   constexpr typename Iterator::reference operator*() {
+@@ -121,16 +120,28 @@ struct DisableDerefAndIncr : Iterator {
+ 
+ }  // namespace
+ 
+-// Inherit `__is_cpp17_contiguous_iterator` and `pointer_traits` specializations
+-// from the base class.
+-namespace std {
++// Inherit `__libcpp_is_contiguous_iterator` and `pointer_traits`
++// specializations from the base class.
++
++// TODO(crbug.com/1284275): Remove when C++20 is on by default, as the use
++// of `iterator_concept` should suffice.
++_LIBCPP_BEGIN_NAMESPACE_STD
++
++// TODO(crbug.com/1449299): https://reviews.llvm.org/D150801 renamed this from
++// `__is_cpp17_contiguous_iterator` to `__libcpp_is_contiguous_iterator`. Clean
++// up the old spelling after libc++ rolls.
+ template <typename Iter>
+ struct __is_cpp17_contiguous_iterator<DisableDerefAndIncr<Iter>>
+     : __is_cpp17_contiguous_iterator<Iter> {};
+ 
++template <typename Iter>
++struct __libcpp_is_contiguous_iterator<DisableDerefAndIncr<Iter>>
++    : __libcpp_is_contiguous_iterator<Iter> {};
++
+ template <typename Iter>
+ struct pointer_traits<DisableDerefAndIncr<Iter>> : pointer_traits<Iter> {};
+-}  // namespace std
++
++_LIBCPP_END_NAMESPACE_STD
+ 
+ namespace base {
+ 

--- a/x11-packages/carbonyl-host-tools/patches/6003-py312-script-mojo.patch
+++ b/x11-packages/carbonyl-host-tools/patches/6003-py312-script-mojo.patch
@@ -1,0 +1,42 @@
+From f5f6e361d037c31630661186e7bd7b31d2784cb8 Mon Sep 17 00:00:00 2001
+From: Bruno Pitrus <brunopitrus@hotmail.com>
+Date: Tue, 25 Jul 2023 18:34:09 +0000
+Subject: [PATCH] Remove unused python import
+
+The `imp` module has been removed in Python 3.12 causing these scripts to error out.
+
+Change-Id: Ic7c038d21b86052bdda13015f80934db52a2143e
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4714859
+Auto-Submit: Bruno Pitrus <brunopitrus@hotmail.com>
+Reviewed-by: Ken Rockot <rockot@google.com>
+Commit-Queue: Ken Rockot <rockot@google.com>
+Cr-Commit-Position: refs/heads/main@{#1174966}
+---
+ mojo/public/tools/mojom/mojom/fileutil.py    | 1 -
+ mojo/public/tools/mojom/mojom/parse/lexer.py | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/mojo/public/tools/mojom/mojom/fileutil.py b/mojo/public/tools/mojom/mojom/fileutil.py
+index 29daec367c5dc1..124f12c134b9d3 100644
+--- a/mojo/public/tools/mojom/mojom/fileutil.py
++++ b/mojo/public/tools/mojom/mojom/fileutil.py
+@@ -3,7 +3,6 @@
+ # found in the LICENSE file.
+ 
+ import errno
+-import imp
+ import os.path
+ import sys
+ 
+diff --git a/mojo/public/tools/mojom/mojom/parse/lexer.py b/mojo/public/tools/mojom/mojom/parse/lexer.py
+index 73ca15df94c9d0..1083a1af7bb25e 100644
+--- a/mojo/public/tools/mojom/mojom/parse/lexer.py
++++ b/mojo/public/tools/mojom/mojom/parse/lexer.py
+@@ -2,7 +2,6 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-import imp
+ import os.path
+ import sys
+ 

--- a/x11-packages/carbonyl-host-tools/patches/6004-cxx11-narrowing-webrtc.patch
+++ b/x11-packages/carbonyl-host-tools/patches/6004-cxx11-narrowing-webrtc.patch
@@ -1,0 +1,116 @@
+From 267f9bdd53a37d1cbee760d5af07880198e1beef Mon Sep 17 00:00:00 2001
+From: Tommi <tommi@webrtc.org>
+Date: Thu, 21 Dec 2023 14:08:26 +0100
+Subject: [PATCH] Update LegacyStatsCollector to conform with Wc++11-narrowing
+
+Bug: none
+Change-Id: Ida6a1af5c324473a55ea4f3b143862ea016ff50a
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/332240
+Commit-Queue: Tomas Gunnarsson <tommi@webrtc.org>
+Reviewed-by: Harald Alvestrand <hta@webrtc.org>
+Auto-Submit: Tomas Gunnarsson <tommi@webrtc.org>
+Reviewed-by: Alexander Kornienko <alexfh@google.com>
+Reviewed-by: Henrik Boström <hbos@webrtc.org>
+Cr-Commit-Position: refs/heads/main@{#41432}
+---
+
+diff --git a/third_party/webrtc/pc/legacy_stats_collector.cc b/third_party/webrtc/pc/legacy_stats_collector.cc
+index 98b7cb9..a6a6945 100644
+--- a/third_party/webrtc/pc/legacy_stats_collector.cc
++++ b/third_party/webrtc/pc/legacy_stats_collector.cc
+@@ -189,9 +189,10 @@
+       {StatsReport::kStatsValueNameAccelerateRate, info.accelerate_rate},
+       {StatsReport::kStatsValueNamePreemptiveExpandRate,
+        info.preemptive_expand_rate},
+-      {StatsReport::kStatsValueNameTotalAudioEnergy, info.total_output_energy},
++      {StatsReport::kStatsValueNameTotalAudioEnergy,
++       static_cast<float>(info.total_output_energy)},
+       {StatsReport::kStatsValueNameTotalSamplesDuration,
+-       info.total_output_duration}};
++       static_cast<float>(info.total_output_duration)}};
+ 
+   const IntForAdd ints[] = {
+       {StatsReport::kStatsValueNameCurrentDelayMs, info.delay_estimate_ms},
+@@ -245,9 +246,10 @@
+   SetAudioProcessingStats(report, info.apm_statistics);
+ 
+   const FloatForAdd floats[] = {
+-      {StatsReport::kStatsValueNameTotalAudioEnergy, info.total_input_energy},
++      {StatsReport::kStatsValueNameTotalAudioEnergy,
++       static_cast<float>(info.total_input_energy)},
+       {StatsReport::kStatsValueNameTotalSamplesDuration,
+-       info.total_input_duration}};
++       static_cast<float>(info.total_input_duration)}};
+ 
+   RTC_DCHECK_GE(info.audio_level, 0);
+   const IntForAdd ints[] = {
+@@ -341,7 +343,8 @@
+       {StatsReport::kStatsValueNamePlisSent, info.plis_sent},
+       {StatsReport::kStatsValueNameRenderDelayMs, info.render_delay_ms},
+       {StatsReport::kStatsValueNameTargetDelayMs, info.target_delay_ms},
+-      {StatsReport::kStatsValueNameFramesDecoded, info.frames_decoded},
++      {StatsReport::kStatsValueNameFramesDecoded,
++       static_cast<int>(info.frames_decoded)},
+   };
+ 
+   for (const auto& i : ints)
+@@ -385,15 +388,19 @@
+        info.encode_usage_percent},
+       {StatsReport::kStatsValueNameFirsReceived, info.firs_rcvd},
+       {StatsReport::kStatsValueNameFrameHeightSent, info.send_frame_height},
+-      {StatsReport::kStatsValueNameFrameRateInput, round(info.framerate_input)},
++      {StatsReport::kStatsValueNameFrameRateInput, 
++       static_cast<int>(round(info.framerate_input))},
+       {StatsReport::kStatsValueNameFrameRateSent, info.framerate_sent},
+       {StatsReport::kStatsValueNameFrameWidthSent, info.send_frame_width},
+-      {StatsReport::kStatsValueNameNacksReceived, info.nacks_rcvd},
++      {StatsReport::kStatsValueNameNacksReceived, 
++       static_cast<int>(info.nacks_rcvd)},
+       {StatsReport::kStatsValueNamePacketsLost, info.packets_lost},
+       {StatsReport::kStatsValueNamePacketsSent, info.packets_sent},
+       {StatsReport::kStatsValueNamePlisReceived, info.plis_rcvd},
+-      {StatsReport::kStatsValueNameFramesEncoded, info.frames_encoded},
+-      {StatsReport::kStatsValueNameHugeFramesSent, info.huge_frames_sent},
++      {StatsReport::kStatsValueNameFramesEncoded, 
++       static_cast<int>(info.frames_encoded)},
++      {StatsReport::kStatsValueNameHugeFramesSent, 
++       static_cast<int>(info.huge_frames_sent)},
+   };
+ 
+   for (const auto& i : ints)
+@@ -782,19 +789,25 @@
+                 AddCandidateReport(remote_candidate_stats, false)->id());
+ 
+   const Int64ForAdd int64s[] = {
+-      {StatsReport::kStatsValueNameBytesReceived, info.recv_total_bytes},
+-      {StatsReport::kStatsValueNameBytesSent, info.sent_total_bytes},
+-      {StatsReport::kStatsValueNamePacketsSent, info.sent_total_packets},
+-      {StatsReport::kStatsValueNameRtt, info.rtt},
++      {StatsReport::kStatsValueNameBytesReceived,
++       static_cast<int64_t>(info.recv_total_bytes)},
++      {StatsReport::kStatsValueNameBytesSent,
++       static_cast<int64_t>(info.sent_total_bytes)},
++      {StatsReport::kStatsValueNamePacketsSent,
++       static_cast<int64_t>(info.sent_total_packets)},
++      {StatsReport::kStatsValueNameRtt, static_cast<int64_t>(info.rtt)},
+       {StatsReport::kStatsValueNameSendPacketsDiscarded,
+-       info.sent_discarded_packets},
++       static_cast<int64_t>(info.sent_discarded_packets)},
+       {StatsReport::kStatsValueNameSentPingRequestsTotal,
+-       info.sent_ping_requests_total},
++       static_cast<int64_t>(info.sent_ping_requests_total)},
+       {StatsReport::kStatsValueNameSentPingRequestsBeforeFirstResponse,
+-       info.sent_ping_requests_before_first_response},
+-      {StatsReport::kStatsValueNameSentPingResponses, info.sent_ping_responses},
+-      {StatsReport::kStatsValueNameRecvPingRequests, info.recv_ping_requests},
+-      {StatsReport::kStatsValueNameRecvPingResponses, info.recv_ping_responses},
++       static_cast<int64_t>(info.sent_ping_requests_before_first_response)},
++      {StatsReport::kStatsValueNameSentPingResponses,
++       static_cast<int64_t>(info.sent_ping_responses)},
++      {StatsReport::kStatsValueNameRecvPingRequests,
++       static_cast<int64_t>(info.recv_ping_requests)},
++      {StatsReport::kStatsValueNameRecvPingResponses,
++       static_cast<int64_t>(info.recv_ping_responses)},
+   };
+   for (const auto& i : int64s)
+     report->AddInt64(i.name, i.value);

--- a/x11-packages/carbonyl-host-tools/patches/6005-cxx11-narrowing-cc.patch
+++ b/x11-packages/carbonyl-host-tools/patches/6005-cxx11-narrowing-cc.patch
@@ -1,0 +1,54 @@
+https://github.com/chromium/chromium/commit/5e9fb4130a537d1a36ab0f8db705a498abeb5d57
+
+From 5e9fb4130a537d1a36ab0f8db705a498abeb5d57 Mon Sep 17 00:00:00 2001
+From: Ho Cheung <uioptt24@gmail.com>
+Date: Tue, 9 Jan 2024 03:05:37 +0000
+Subject: [PATCH] [ToTLinux] Fix some narrowing errors
+
+The compilation errors mentioned in the issue can be reproduced on the
+local ToT, and the following new errors are found, which will be fixed
+in this CL.
+
+In file included from ../../cc/layers/mirror_layer_impl.cc:5:
+../../cc/layers/mirror_layer_impl.h:59:40: error: non-constant-expressi
+on cannot be narrowed from type 'int' to 'unsigned long' in initializer
+list [-Wc++11-narrowing-const-reference]
+   59 |     return viz::CompositorRenderPassId{mirrored_layer_id()};
+      |                                        ^~~~~~~~~~~~~~~~~~~
+1 error generated.
+
+Fixed: 1513724
+Change-Id: I562534d13f82824dfac0fe3e78a45c8c49d5841a
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5150303
+Reviewed-by: Etienne Pierre-Doray <etiennep@chromium.org>
+Reviewed-by: David Bokan <bokan@chromium.org>
+Commit-Queue: Ho Cheung <uioptt24@gmail.com>
+Cr-Commit-Position: refs/heads/main@{#1244427}
+---
+
+ cc/layers/mirror_layer_impl.h                             | 4 +++-
+ components/power_metrics/energy_metrics_provider_linux.cc | 4 ++--
+ 2 files changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/cc/layers/mirror_layer_impl.h b/cc/layers/mirror_layer_impl.h
+index e68b1f6392a67c..b1355f8d22f8f3 100644
+--- a/cc/layers/mirror_layer_impl.h
++++ b/cc/layers/mirror_layer_impl.h
+@@ -5,6 +5,7 @@
+ #ifndef CC_LAYERS_MIRROR_LAYER_IMPL_H_
+ #define CC_LAYERS_MIRROR_LAYER_IMPL_H_
+ 
++#include <cstdint>
+ #include <memory>
+ 
+ #include "base/memory/ptr_util.h"
+@@ -56,7 +57,8 @@ class CC_EXPORT MirrorLayerImpl : public LayerImpl {
+  private:
+   const char* LayerTypeAsString() const override;
+   viz::CompositorRenderPassId mirrored_layer_render_pass_id() const {
+-    return viz::CompositorRenderPassId{mirrored_layer_id()};
++    return viz::CompositorRenderPassId{
++        static_cast<uint64_t>(mirrored_layer_id())};
+   }
+ 
+   int mirrored_layer_id_ = 0;

--- a/x11-packages/carbonyl-host-tools/patches/6006-py312-script-components-pb.patch
+++ b/x11-packages/carbonyl-host-tools/patches/6006-py312-script-components-pb.patch
@@ -1,0 +1,50 @@
+From 9e0c89a3b5638ba2b9b107fea34a01c774aa7805 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jacobo=20Aragunde=20P=C3=A9rez?= <jaragunde@igalia.com>
+Date: Wed, 25 Oct 2023 06:20:54 +0000
+Subject: [PATCH] Replace imp.load_source with importlib equivalent.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The imp module has been deprecated for years and the function
+load_source was even removed from the documentation long ago.
+
+It will be removed in Python 3.12, which will be part of Fedora
+version 39, due in late October 2023.
+
+Bug: 1487454
+Change-Id: If06a2f139225b62c7bdc70c3eaef6e5acb8972d2
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4894238
+Reviewed-by: Mustafa Emre Acer <meacer@chromium.org>
+Commit-Queue: Jacobo Aragunde Pérez <jaragunde@igalia.com>
+Cr-Commit-Position: refs/heads/main@{#1214660}
+---
+ components/resources/protobufs/binary_proto_generator.py | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/components/resources/protobufs/binary_proto_generator.py b/components/resources/protobufs/binary_proto_generator.py
+index 2a1802dccdc1e1..8b9de65ed0b78d 100755
+--- a/components/resources/protobufs/binary_proto_generator.py
++++ b/components/resources/protobufs/binary_proto_generator.py
+@@ -9,7 +9,7 @@
+ """
+ from __future__ import print_function
+ import abc
+-import imp
++from importlib import util as imp_util
+ import optparse
+ import os
+ import re
+@@ -68,7 +68,11 @@ def load_module(self, fullname):
+       raise ImportError(fullname)
+ 
+     filepath = self._fullname_to_filepath(fullname)
+-    return imp.load_source(fullname, filepath)
++    spec = imp_util.spec_from_file_location(fullname, filepath)
++    loaded = imp_util.module_from_spec(spec)
++    spec.loader.exec_module(loaded)
++
++    return loaded
+ 
+ class BinaryProtoGenerator:
+ 

--- a/x11-packages/carbonyl-host-tools/patches/6007-catapult-update-fix.patch
+++ b/x11-packages/carbonyl-host-tools/patches/6007-catapult-update-fix.patch
@@ -1,0 +1,170 @@
+From 8cf7c46ad7ea03bf5d5588d0ed63be3df4baaf1f Mon Sep 17 00:00:00 2001
+From: Ho Cheung <uioptt24@gmail.com>
+Date: Wed, 6 Dec 2023 15:29:25 +0800
+Subject: [PATCH] [six] Update vendored copy of six to 1.16.0.
+
+Bug: chromium:1487454
+Fixed: chromium:1497068
+Change-Id: I270fd864504c714a178d4d42e6547c8e109edd7f
+Reviewed-on: https://chromium-review.googlesource.com/c/catapult/+/5092950
+Commit-Queue: John Chen <johnchen@chromium.org>
+Auto-Submit: Ho Cheung <uioptt24@gmail.com>
+Reviewed-by: John Chen <johnchen@chromium.org>
+---
+ third_party/six/CHANGES               | 10 ++++++++--
+ third_party/six/PKG-INFO              |  2 +-
+ third_party/six/README                | 17 ++++-------------
+ third_party/six/README.chromium       |  4 ++--
+ third_party/six/six.egg-info/PKG-INFO |  2 +-
+ third_party/six/six.py                | 18 +++++++++++++++++-
+ 6 files changed, 33 insertions(+), 20 deletions(-)
+
+diff --git a/third_party/catapult/third_party/six/CHANGES b/third_party/catapult/third_party/six/CHANGES
+index ad4cbaa147e..f3bf6a4a7f9 100644
+--- a/third_party/catapult/third_party/six/CHANGES
++++ b/third_party/catapult/third_party/six/CHANGES
+@@ -3,6 +3,12 @@ Changelog for six
+ 
+ This file lists the changes in each six version.
+ 
++1.16.0
++------
++
++- Pull request #343, issue #341, pull request #349: Port _SixMetaPathImporter to
++  Python 3.10.
++
+ 1.15.0
+ ------
+ 
+@@ -100,7 +106,7 @@ This file lists the changes in each six version.
+ 
+ - Issue #98: Fix `six.moves` race condition in multi-threaded code.
+ 
+-- Pull request #51: Add `six.view(keys|values|itmes)`, which provide dictionary
++- Pull request #51: Add `six.view(keys|values|items)`, which provide dictionary
+   views on Python 2.7+.
+ 
+ - Issue #112: `six.moves.reload_module` now uses the importlib module on
+@@ -227,7 +233,7 @@ This file lists the changes in each six version.
+ - Issue #40: Add import mapping for the Python 2 gdbm module.
+ 
+ - Issue #35: On Python versions less than 2.7, print_ now encodes unicode
+-  strings when outputing to standard streams. (Python 2.7 handles this
++  strings when outputting to standard streams. (Python 2.7 handles this
+   automatically.)
+ 
+ 1.4.1
+diff --git a/third_party/catapult/third_party/six/PKG-INFO b/third_party/catapult/third_party/six/PKG-INFO
+index 75aba67d2fe..1e57620bb60 100644
+--- a/third_party/catapult/third_party/six/PKG-INFO
++++ b/third_party/catapult/third_party/six/PKG-INFO
+@@ -1,6 +1,6 @@
+ Metadata-Version: 1.2
+ Name: six
+-Version: 1.15.0
++Version: 1.16.0
+ Summary: Python 2 and 3 compatibility utilities
+ Home-page: https://github.com/benjaminp/six
+ Author: Benjamin Peterson
+diff --git a/third_party/catapult/third_party/six/README b/third_party/catapult/third_party/six/README
+index ee628a9db6b..560a773d9e1 100644
+--- a/third_party/catapult/third_party/six/README
++++ b/third_party/catapult/third_party/six/README
+@@ -1,16 +1,7 @@
+-Six is a Python 2 and 3 compatibility library.  It provides utility functions
+-for smoothing over the differences between the Python versions with the goal of
+-writing Python code that is compatible on both Python versions.  See the
+-documentation for more information on what is provided.
++Six is a Python 2 and 3 compatibility library. It provides utility functions for smoothing over the differences between the Python versions with the goal of writing Python code that is compatible on both Python versions. See the documentation for more information on what is provided.
+ 
+-Six supports every Python version since 2.6.  It is contained in only one Python
+-file, so it can be easily copied into your project. (The copyright and license
+-notice must be retained.)
++Six supports Python 2.7 and 3.3+. It is contained in only one Python file, so it can be easily copied into your project. (The copyright and license notice must be retained.)
+ 
+-Online documentation is at https://pythonhosted.org/six/.
++Online documentation is at https://six.readthedocs.io/.
+ 
+-Bugs can be reported to https://bitbucket.org/gutworth/six.  The code can also
+-be found there.
+-
+-For questions about six or porting in general, email the python-porting mailing
+-list: https://mail.python.org/mailman/listinfo/python-porting
++Bugs can be reported to https://github.com/benjaminp/six. The code can also be found there.
+\ No newline at end of file
+diff --git a/third_party/catapult/third_party/six/README.chromium b/third_party/catapult/third_party/six/README.chromium
+index 6f7a9cb533f..3021912dd2d 100644
+--- a/third_party/catapult/third_party/six/README.chromium
++++ b/third_party/catapult/third_party/six/README.chromium
+@@ -1,7 +1,7 @@
+ Name: six
+ URL: https://pypi.org/project/six/
+-Version: 1.15.0
+-Date: 2021-03-02
++Version: 1.16.0
++Date: 2021-05-05
+ License: MIT
+ License File: LICENSE
+ Security Critical: no
+diff --git a/third_party/catapult/third_party/six/six.egg-info/PKG-INFO b/third_party/catapult/third_party/six/six.egg-info/PKG-INFO
+index 75aba67d2fe..1e57620bb60 100644
+--- a/third_party/catapult/third_party/six/six.egg-info/PKG-INFO
++++ b/third_party/catapult/third_party/six/six.egg-info/PKG-INFO
+@@ -1,6 +1,6 @@
+ Metadata-Version: 1.2
+ Name: six
+-Version: 1.15.0
++Version: 1.16.0
+ Summary: Python 2 and 3 compatibility utilities
+ Home-page: https://github.com/benjaminp/six
+ Author: Benjamin Peterson
+diff --git a/third_party/catapult/third_party/six/six.py b/third_party/catapult/third_party/six/six.py
+index 83f69783d1a..4e15675d8b5 100644
+--- a/third_party/catapult/third_party/six/six.py
++++ b/third_party/catapult/third_party/six/six.py
+@@ -29,7 +29,7 @@
+ import types
+ 
+ __author__ = "Benjamin Peterson <benjamin@python.org>"
+-__version__ = "1.15.0"
++__version__ = "1.16.0"
+ 
+ 
+ # Useful for very coarse version differentiation.
+@@ -71,6 +71,11 @@ def __len__(self):
+             MAXSIZE = int((1 << 63) - 1)
+         del X
+ 
++if PY34:
++    from importlib.util import spec_from_loader
++else:
++    spec_from_loader = None
++
+ 
+ def _add_doc(func, doc):
+     """Add documentation to a function."""
+@@ -186,6 +191,11 @@ def find_module(self, fullname, path=None):
+             return self
+         return None
+ 
++    def find_spec(self, fullname, path, target=None):
++        if fullname in self.known_modules:
++            return spec_from_loader(fullname, self)
++        return None
++
+     def __get_module(self, fullname):
+         try:
+             return self.known_modules[fullname]
+@@ -223,6 +233,12 @@ def get_code(self, fullname):
+         return None
+     get_source = get_code  # same as get_code
+ 
++    def create_module(self, spec):
++        return self.load_module(spec.name)
++
++    def exec_module(self, module):
++        pass
++
+ _importer = _SixMetaPathImporter(__name__)
+ 
+ 

--- a/x11-packages/carbonyl-host-tools/patches/6008-is_pod-base.patch
+++ b/x11-packages/carbonyl-host-tools/patches/6008-is_pod-base.patch
@@ -1,0 +1,63 @@
+From 7d9c63161041b1fb68fb65cf55a57fcba1ee50de Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Fri, 17 Nov 2023 16:53:30 +0000
+Subject: [PATCH] libstdc++: replace deprecated std::is_pod<T> in //base
+
+std::is_pod is deprecated since C++20. Replace with std::trivial and
+std::is_standard_layout. Avoids a lot of warnings.
+
+Bug: 957519
+Change-Id: Idc06ac91a4363bb61b71f1e3b3646422856b25d5
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4994566
+Reviewed-by: Benoit Lize <lizeb@chromium.org>
+Reviewed-by: Stephen Nusko <nuskos@chromium.org>
+Commit-Queue: Stephan Hartmann <stha09@googlemail.com>
+Cr-Commit-Position: refs/heads/main@{#1226170}
+---
+ .../src/partition_alloc/shim/malloc_zone_functions_apple.cc   | 3 ++-
+ base/trace_event/category_registry.cc                         | 4 +++-
+ base/trace_event/trace_arguments.cc                           | 2 +-
+ 3 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/base/allocator/partition_allocator/src/partition_alloc/shim/malloc_zone_functions_apple.cc b/base/allocator/partition_allocator/src/partition_alloc/shim/malloc_zone_functions_apple.cc
+index 5d42dbe42d86d3..c233df30fc86c1 100644
+--- a/base/allocator/partition_allocator/shim/malloc_zone_functions_mac.cc
++++ b/base/allocator/partition_allocator/shim/malloc_zone_functions_mac.cc
+@@ -12,7 +12,8 @@
+ namespace allocator_shim {
+ 
+ MallocZoneFunctions g_malloc_zones[kMaxZoneCount];
+-static_assert(std::is_pod<MallocZoneFunctions>::value,
++static_assert(std::is_trivial<MallocZoneFunctions>::value &&
++              std::is_standard_layout<MallocZoneFunctions>::value,
+               "MallocZoneFunctions must be POD");
+ 
+ void StoreZoneFunctions(const ChromeMallocZone* zone,
+diff --git a/base/trace_event/category_registry.cc b/base/trace_event/category_registry.cc
+index e9fc8903028adb..cc4770de3517b3 100644
+--- a/base/trace_event/category_registry.cc
++++ b/base/trace_event/category_registry.cc
+@@ -20,7 +20,9 @@
+ namespace {
+ 
+ // |categories_| might end up causing creating dynamic initializers if not POD.
+-static_assert(std::is_pod<TraceCategory>::value, "TraceCategory must be POD");
++static_assert(std::is_trivial<TraceCategory>::value &&
++              std::is_standard_layout<TraceCategory>::value,
++              "TraceCategory must be POD");
+ 
+ }  // namespace
+ 
+diff --git a/base/trace_event/trace_arguments.cc b/base/trace_event/trace_arguments.cc
+index e0081df7312f73..81c53061b4b5dd 100644
+--- a/base/trace_event/trace_arguments.cc
++++ b/base/trace_event/trace_arguments.cc
+@@ -164,7 +164,7 @@
+ }
+ 
+ static_assert(
+-    std::is_pod<TraceValue>::value,
++    std::is_trivial<TraceValue>::value && std::is_standard_layout<TraceValue>::value,
+     "TraceValue must be plain-old-data type for performance reasons!");
+ 
+ void TraceValue::AppendAsJSON(unsigned char type, std::string* out) const {

--- a/x11-packages/carbonyl-host-tools/patches/6009-is_pod-webrtc.patch
+++ b/x11-packages/carbonyl-host-tools/patches/6009-is_pod-webrtc.patch
@@ -1,0 +1,77 @@
+From fa4d7c92b770e2375b14b4c53edf262534415ab8 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Tue, 31 Oct 2023 15:43:33 +0100
+Subject: [PATCH] libstdc++: replace deprecated std::is_pod<T>
+
+std::is_pod is deprecated since C++20. Replace with std::trivial and
+std::is_standard_layout. Avoids a lot of warnings.
+
+Bug: chromium:957519
+Change-Id: Idb4bde7401c14c0896a84c357ec668b9916f613e
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/325484
+Reviewed-by: Philip Eliasson <philipel@webrtc.org>
+Reviewed-by: Danil Chapovalov <danilchap@webrtc.org>
+Commit-Queue: Philip Eliasson <philipel@webrtc.org>
+Cr-Commit-Position: refs/heads/main@{#41117}
+---
+
+diff --git a/third_party/webrtc/modules/video_coding/include/video_codec_interface.h b/third_party/webrtc/modules/video_coding/include/video_codec_interface.h
+index c6522fc..987e1b6 100644
+--- a/third_party/webrtc/modules/video_coding/include/video_codec_interface.h
++++ b/third_party/webrtc/modules/video_coding/include/video_codec_interface.h
+@@ -50,7 +50,9 @@
+   size_t updatedBuffers[kBuffersCount];
+   size_t updatedBuffersCount;
+ };
+-static_assert(std::is_pod<CodecSpecificInfoVP8>::value, "");
++static_assert(std::is_trivial_v<CodecSpecificInfoVP8> &&
++                  std::is_standard_layout_v<CodecSpecificInfoVP8>,
++              "");
+ 
+ // Hack alert - the code assumes that thisstruct is memset when constructed.
+ struct CodecSpecificInfoVP9 {
+@@ -79,7 +81,9 @@
+   uint8_t num_ref_pics;
+   uint8_t p_diff[kMaxVp9RefPics];
+ };
+-static_assert(std::is_pod<CodecSpecificInfoVP9>::value, "");
++static_assert(std::is_trivial_v<CodecSpecificInfoVP9> &&
++                  std::is_standard_layout_v<CodecSpecificInfoVP9>,
++              "");
+ 
+ // Hack alert - the code assumes that thisstruct is memset when constructed.
+ struct CodecSpecificInfoH264 {
+@@ -88,14 +92,18 @@
+   bool base_layer_sync;
+   bool idr_frame;
+ };
+-static_assert(std::is_pod<CodecSpecificInfoH264>::value, "");
++static_assert(std::is_trivial_v<CodecSpecificInfoH264> &&
++                  std::is_standard_layout_v<CodecSpecificInfoH264>,
++              "");
+ 
+ union CodecSpecificInfoUnion {
+   CodecSpecificInfoVP8 VP8;
+   CodecSpecificInfoVP9 VP9;
+   CodecSpecificInfoH264 H264;
+ };
+-static_assert(std::is_pod<CodecSpecificInfoUnion>::value, "");
++static_assert(std::is_trivial_v<CodecSpecificInfoUnion> &&
++                  std::is_standard_layout_v<CodecSpecificInfoUnion>,
++              "");
+ 
+ // Note: if any pointers are added to this struct or its sub-structs, it
+ // must be fitted with a copy-constructor. This is because it is copied
+diff --git a/third_party/webrtc/test/fuzzers/rtp_frame_reference_finder_fuzzer.cc b/third_party/webrtc/test/fuzzers/rtp_frame_reference_finder_fuzzer.cc
+index ea66c4a..93673f0 100644
+--- a/third_party/webrtc/test/fuzzers/rtp_frame_reference_finder_fuzzer.cc
++++ b/third_party/webrtc/test/fuzzers/rtp_frame_reference_finder_fuzzer.cc
+@@ -23,7 +23,7 @@
+ 
+   template <typename T>
+   void CopyTo(T* object) {
+-    static_assert(std::is_pod<T>(), "");
++    static_assert(std::is_trivial_v<T> && std::is_standard_layout_v<T>, "");
+     uint8_t* destination = reinterpret_cast<uint8_t*>(object);
+     size_t object_size = sizeof(T);
+     size_t num_bytes = std::min(size_ - offset_, object_size);

--- a/x11-packages/carbonyl-host-tools/patches/6010-is_pod-skia.patch
+++ b/x11-packages/carbonyl-host-tools/patches/6010-is_pod-skia.patch
@@ -1,0 +1,33 @@
+Upstream relaxes this assertion from `is_pod` to `is_trivially_copyable` in commit [1]
+
+[1] https://skia.googlesource.com/skia/+/a27bf1bfee7af30321e108e7f149213bc27ca866
+
+--- a/third_party/skia/src/gpu/BufferWriter.h
++++ b/third_party/skia/src/gpu/BufferWriter.h
+@@ -264,7 +264,7 @@
+ 
+ template <typename T>
+ inline VertexWriter& operator<<(VertexWriter& w, const T& val) {
+-    static_assert(std::is_pod<T>::value, "");
++    static_assert(std::is_trivial_v<T> && std::is_standard_layout_v<T>, "");
+     w.validate(sizeof(T));
+     memcpy(w.fPtr, &val, sizeof(T));
+     w = w.makeOffset(sizeof(T));
+@@ -273,7 +273,7 @@
+ 
+ template <typename T>
+ inline VertexWriter& operator<<(VertexWriter& w, const VertexWriter::Conditional<T>& val) {
+-    static_assert(std::is_pod<T>::value, "");
++    static_assert(std::is_trivial_v<T> && std::is_standard_layout_v<T>, "");
+     if (val.fCondition) {
+         w << val.fValue;
+     }
+@@ -288,7 +288,7 @@
+ 
+ template <typename T>
+ inline VertexWriter& operator<<(VertexWriter& w, const VertexWriter::ArrayDesc<T>& array) {
+-    static_assert(std::is_pod<T>::value, "");
++    static_assert(std::is_trivial_v<T> && std::is_standard_layout_v<T>, "");
+     w.validate(array.fCount * sizeof(T));
+     memcpy(w.fPtr, array.fArray, array.fCount * sizeof(T));
+     w = w.makeOffset(sizeof(T) * array.fCount);

--- a/x11-packages/carbonyl-host-tools/patches/6011-is_pod-crashpad.patch
+++ b/x11-packages/carbonyl-host-tools/patches/6011-is_pod-crashpad.patch
@@ -1,0 +1,37 @@
+From da189353b60611dd7089aa2a14441893460ebcdb Mon Sep 17 00:00:00 2001
+From: Andrew Williams <awillia@chromium.org>
+Date: Mon, 22 Apr 2024 22:18:50 +0000
+Subject: [PATCH] Replace std::is_pod usage
+
+Replacing std::is_pod usage as per the following compilation error:
+```
+../../util/misc/uuid.cc:44:20: error: 'is_pod<crashpad::UUID>' is deprecated: use 'is_standard_layout && is_trivial' instead [-Werror,-Wdeprecated-declarations]
+static_assert(std::is_pod<UUID>::value, "UUID must be POD");
+                   ^
+/usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/type_traits:818:5: note: 'is_pod<crashpad::UUID>' has been explicitly marked deprecated here
+    _GLIBCXX20_DEPRECATED_SUGGEST("is_standard_layout && is_trivial")
+
+```
+
+Bug: None
+Change-Id: I1d61ee12261877f7f1f84f0ea15d262d22959766
+Reviewed-on: https://chromium-review.googlesource.com/c/crashpad/crashpad/+/5472885
+Commit-Queue: Andrew Williams <awillia@chromium.org>
+Reviewed-by: Mark Mentovai <mark@chromium.org>
+---
+
+diff --git a/third_party/crashpad/crashpad/util/misc/uuid.cc b/third_party/crashpad/crashpad/util/misc/uuid.cc
+index 3013d7b..af33df5 100644
+--- a/third_party/crashpad/crashpad/util/misc/uuid.cc
++++ b/third_party/crashpad/crashpad/util/misc/uuid.cc
+@@ -41,7 +41,9 @@
+ namespace crashpad {
+ 
+ static_assert(sizeof(UUID) == 16, "UUID must be 16 bytes");
+-static_assert(std::is_pod<UUID>::value, "UUID must be POD");
++static_assert(std::is_standard_layout<UUID>::value,
++              "UUID must be a standard-layout type");
++static_assert(std::is_trivial<UUID>::value, "UUID must be a trivial type");
+ 
+ bool UUID::operator==(const UUID& that) const {
+   return memcmp(this, &that, sizeof(*this)) == 0;

--- a/x11-packages/carbonyl-host-tools/patches/6012-is_pod-blink.patch
+++ b/x11-packages/carbonyl-host-tools/patches/6012-is_pod-blink.patch
@@ -1,0 +1,57 @@
+From 900a85c1c1361624756aeb56b0e17659e6476399 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Fri, 13 Oct 2023 08:57:49 +0000
+Subject: [PATCH] libstdc++: replace deprecated std::is_pod<T> in blink
+
+std::is_pod is deprecated since C++20. Replace with std::trivial and
+std::is_standard_layout. Avoids a lot of warnings.
+
+Bug: 957519
+Change-Id: Ia5ffac10b68420eb68eb34b2eeb8afb574c039a6
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4936811
+Reviewed-by: Michael Lippautz <mlippautz@chromium.org>
+Commit-Queue: Stephan Hartmann <stha09@googlemail.com>
+Cr-Commit-Position: refs/heads/main@{#1209300}
+---
+ third_party/blink/renderer/platform/wtf/hash_traits.h       | 3 ++-
+ .../blink/renderer/platform/wtf/text/string_hasher.h        | 6 ++++--
+ 2 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/third_party/blink/renderer/platform/wtf/hash_traits.h b/third_party/blink/renderer/platform/wtf/hash_traits.h
+index fe7a96a5a5b9b6..de5d2e085a55fc 100644
+--- a/third_party/blink/renderer/platform/wtf/hash_traits.h
++++ b/third_party/blink/renderer/platform/wtf/hash_traits.h
+@@ -194,7 +194,8 @@ struct GenericHashTraitsBase {
+   struct NeedsToForbidGCOnMove {
+     // TODO(yutak): Consider using of std:::is_trivially_move_constructible
+     // when it is accessible.
+-    static constexpr bool value = !std::is_pod<T>::value;
++    static constexpr bool value =
++        !std::is_trivial_v<U> || !std::is_standard_layout_v<U>;
+   };
+ 
+   // The kCanTraceConcurrently value is used by Oilpan concurrent marking. Only
+diff --git a/third_party/blink/renderer/platform/wtf/text/string_hasher.h b/third_party/blink/renderer/platform/wtf/text/string_hasher.h
+index c74ff61975a6f3..70993eaeb83653 100644
+--- a/third_party/blink/renderer/platform/wtf/text/string_hasher.h
++++ b/third_party/blink/renderer/platform/wtf/text/string_hasher.h
+@@ -191,7 +191,8 @@ class StringHasher {
+   void AddCharactersAssumingAligned_internal(const unsigned char* data, unsigned length) {
+     DCHECK(!has_pending_character_);
+ 
+-    static_assert(std::is_pod<T>::value, "we only support hashing POD types");
++    static_assert(std::is_trivial_v<T> && std::is_standard_layout_v<T>,
++                  "we only support hashing POD types");
+     bool remainder = length & 1;
+     length >>= 1;
+ 
+@@ -216,7 +217,8 @@ class StringHasher {
+ 
+   template <typename T, UChar Converter(T)>
+   void AddCharacters_internal(const unsigned char* data, unsigned length) {
+-    static_assert(std::is_pod<T>::value, "we only support hashing POD types");
++    static_assert(std::is_trivial_v<T> && std::is_standard_layout_v<T>,
++                  "we only support hashing POD types");
+ 
+     if (has_pending_character_ && length) {
+       has_pending_character_ = false;

--- a/x11-packages/carbonyl-host-tools/patches/6013-is_pod-gpu.patch
+++ b/x11-packages/carbonyl-host-tools/patches/6013-is_pod-gpu.patch
@@ -1,0 +1,36 @@
+From 2ea81f956140f83355cab20a51b1a8c49d885cde Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Tue, 31 Oct 2023 16:28:09 +0000
+Subject: [PATCH] libstdc++: replace deprecated std::is_pod<T> in //gpu
+
+std::is_pod is deprecated since C++20. Replace with std::trivial and
+std::is_standard_layout. Avoids a lot of warnings.
+
+Bug: 957519
+Change-Id: I8f5cb8b9d7db564a3ee9025897d8a8ac4602092f
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4994246
+Reviewed-by: Austin Eng <enga@chromium.org>
+Commit-Queue: Austin Eng <enga@chromium.org>
+Auto-Submit: Stephan Hartmann <stha09@googlemail.com>
+Cr-Commit-Position: refs/heads/main@{#1217649}
+---
+ gpu/command_buffer/service/dawn_platform.cc | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/gpu/command_buffer/service/dawn_platform.cc b/gpu/command_buffer/service/dawn_platform.cc
+index f095e62759293b..e792075337da53 100644
+--- a/gpu/command_buffer/service/dawn_platform.cc
++++ b/gpu/command_buffer/service/dawn_platform.cc
+@@ -127,8 +127,10 @@ uint64_t DawnPlatform::AddTraceEvent(
+   uint64_t result = 0;
+   static_assert(sizeof(base::trace_event::TraceEventHandle) <= sizeof(result),
+                 "TraceEventHandle must be at most the size of uint64_t");
+-  static_assert(std::is_pod<base::trace_event::TraceEventHandle>(),
+-                "TraceEventHandle must be memcpy'able");
++  static_assert(
++      std::is_trivial_v<base::trace_event::TraceEventHandle> &&
++          std::is_standard_layout_v<base::trace_event::TraceEventHandle>,
++      "TraceEventHandle must be memcpy'able");
+   memcpy(&result, &handle, sizeof(base::trace_event::TraceEventHandle));
+   return result;
+ }

--- a/x11-packages/carbonyl-host-tools/patches/7001-sql-VirtualCursor-standard-layout.patch
+++ b/x11-packages/carbonyl-host-tools/patches/7001-sql-VirtualCursor-standard-layout.patch
@@ -1,0 +1,231 @@
+From 80368f8ba7a8bab13440463a254888311efe3986 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Tue, 04 May 2021 15:00:19 +0000
+Subject: [PATCH] sql: make VirtualCursor standard layout type
+
+sql::recover::VirtualCursor needs to be a standard layout type, but
+has members of type std::unique_ptr. However, std::unique_ptr is not
+guaranteed to be standard layout. Compiling with clang combined with
+gcc-11 libstdc++ fails because of this. Replace std::unique_ptr with
+raw pointers.
+
+Bug: 1189788
+Change-Id: Ia6dc388cc5ef1c0f2afc75f8ca45b9f12687ca9c
+---
+
+diff --git a/sql/recover_module/btree.cc b/sql/recover_module/btree.cc
+index 9ecaafe..839318a 100644
+--- a/sql/recover_module/btree.cc
++++ b/sql/recover_module/btree.cc
+@@ -135,16 +135,25 @@
+               "Move the destructor to the .cc file if it's non-trival");
+ #endif  // !DCHECK_IS_ON()
+ 
+-LeafPageDecoder::LeafPageDecoder(DatabasePageReader* db_reader) noexcept
+-    : page_id_(db_reader->page_id()),
+-      db_reader_(db_reader),
+-      cell_count_(ComputeCellCount(db_reader)),
+-      next_read_index_(0),
+-      last_record_size_(0) {
++void LeafPageDecoder::Initialize(DatabasePageReader* db_reader) {
++  DCHECK(db_reader);
+   DCHECK(IsOnValidPage(db_reader));
++  page_id_ = db_reader->page_id();
++  db_reader_ = db_reader;
++  cell_count_ = ComputeCellCount(db_reader);
++  next_read_index_ = 0;
++  last_record_size_ = 0;
+   DCHECK(DatabasePageReader::IsValidPageId(page_id_));
+ }
+ 
++void LeafPageDecoder::Reset() {
++  db_reader_ = nullptr;
++  page_id_ = 0;
++  cell_count_ = 0;
++  next_read_index_ = 0;
++  last_record_size_ = 0;
++}
++
+ bool LeafPageDecoder::TryAdvance() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+   DCHECK(CanAdvance());
+diff --git a/sql/recover_module/btree.h b/sql/recover_module/btree.h
+index d76d076..33114b0 100644
+--- a/sql/recover_module/btree.h
++++ b/sql/recover_module/btree.h
+@@ -102,7 +102,7 @@
+   //
+   // |db_reader| must have been used to read an inner page of a table B-tree.
+   // |db_reader| must outlive this instance.
+-  explicit LeafPageDecoder(DatabasePageReader* db_reader) noexcept;
++  explicit LeafPageDecoder() noexcept = default;
+   ~LeafPageDecoder() noexcept = default;
+ 
+   LeafPageDecoder(const LeafPageDecoder&) = delete;
+@@ -150,6 +150,15 @@
+   // read as long as CanAdvance() returns true.
+   bool TryAdvance();
+ 
++  // Initialize with DatabasePageReader
++  void Initialize(DatabasePageReader* db_reader);
++
++  // Reset internal DatabasePageReader
++  void Reset();
++
++  // True if DatabasePageReader is valid
++  bool IsValid() { return (db_reader_ != nullptr); }
++
+   // True if the given reader may point to an inner page in a table B-tree.
+   //
+   // The last ReadPage() call on |db_reader| must have succeeded.
+@@ -163,14 +172,14 @@
+   static int ComputeCellCount(DatabasePageReader* db_reader);
+ 
+   // The number of the B-tree page this reader is reading.
+-  const int64_t page_id_;
++  int64_t page_id_;
+   // Used to read the tree page.
+   //
+   // Raw pointer usage is acceptable because this instance's owner is expected
+   // to ensure that the DatabasePageReader outlives this.
+-  DatabasePageReader* const db_reader_;
++  DatabasePageReader* db_reader_;
+   // Caches the ComputeCellCount() value for this reader's page.
+-  const int cell_count_ = ComputeCellCount(db_reader_);
++  int cell_count_;
+ 
+   // The reader's cursor state.
+   //
+diff --git a/sql/recover_module/cursor.cc b/sql/recover_module/cursor.cc
+index 0029ff9..42548bc 100644
+--- a/sql/recover_module/cursor.cc
++++ b/sql/recover_module/cursor.cc
+@@ -26,7 +26,7 @@
+ int VirtualCursor::First() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+   inner_decoders_.clear();
+-  leaf_decoder_ = nullptr;
++  leaf_decoder_.Reset();
+ 
+   AppendPageDecoder(table_->root_page_id());
+   return Next();
+@@ -36,18 +36,18 @@
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+   record_reader_.Reset();
+ 
+-  while (!inner_decoders_.empty() || leaf_decoder_.get()) {
+-    if (leaf_decoder_.get()) {
+-      if (!leaf_decoder_->CanAdvance()) {
++  while (!inner_decoders_.empty() || leaf_decoder_.IsValid()) {
++    if (leaf_decoder_.IsValid()) {
++      if (!leaf_decoder_.CanAdvance()) {
+         // The leaf has been exhausted. Remove it from the DFS stack.
+-        leaf_decoder_ = nullptr;
++        leaf_decoder_.Reset();
+         continue;
+       }
+-      if (!leaf_decoder_->TryAdvance())
++      if (!leaf_decoder_.TryAdvance())
+         continue;
+ 
+-      if (!payload_reader_.Initialize(leaf_decoder_->last_record_size(),
+-                                      leaf_decoder_->last_record_offset())) {
++      if (!payload_reader_.Initialize(leaf_decoder_.last_record_size(),
++                                      leaf_decoder_.last_record_offset())) {
+         continue;
+       }
+       if (!record_reader_.Initialize())
+@@ -99,13 +99,13 @@
+ int64_t VirtualCursor::RowId() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+   DCHECK(record_reader_.IsInitialized());
+-  DCHECK(leaf_decoder_.get());
+-  return leaf_decoder_->last_record_rowid();
++  DCHECK(leaf_decoder_.IsValid());
++  return leaf_decoder_.last_record_rowid();
+ }
+ 
+ void VirtualCursor::AppendPageDecoder(int page_id) {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+-  DCHECK(leaf_decoder_.get() == nullptr)
++  DCHECK(!leaf_decoder_.IsValid())
+       << __func__
+       << " must only be called when the current path has no leaf decoder";
+ 
+@@ -113,7 +113,7 @@
+     return;
+ 
+   if (LeafPageDecoder::IsOnValidPage(&db_reader_)) {
+-    leaf_decoder_ = std::make_unique<LeafPageDecoder>(&db_reader_);
++    leaf_decoder_.Initialize(&db_reader_);
+     return;
+   }
+ 
+diff --git a/sql/recover_module/cursor.h b/sql/recover_module/cursor.h
+index afcd690..b15c31d 100644
+--- a/sql/recover_module/cursor.h
++++ b/sql/recover_module/cursor.h
+@@ -129,7 +129,7 @@
+   std::vector<std::unique_ptr<InnerPageDecoder>> inner_decoders_;
+ 
+   // Decodes the leaf page containing records.
+-  std::unique_ptr<LeafPageDecoder> leaf_decoder_;
++  LeafPageDecoder leaf_decoder_;
+ 
+   SEQUENCE_CHECKER(sequence_checker_);
+ };
+diff --git a/sql/recover_module/pager.cc b/sql/recover_module/pager.cc
+index 58e75de..5fe9620 100644
+--- a/sql/recover_module/pager.cc
++++ b/sql/recover_module/pager.cc
+@@ -23,8 +23,7 @@
+               "ints are not appropriate for representing page IDs");
+ 
+ DatabasePageReader::DatabasePageReader(VirtualTable* table)
+-    : page_data_(std::make_unique<uint8_t[]>(table->page_size())),
+-      table_(table) {
++    : page_data_(), table_(table) {
+   DCHECK(table != nullptr);
+   DCHECK(IsValidPageSize(table->page_size()));
+ }
+@@ -57,8 +56,8 @@
+                     std::numeric_limits<int64_t>::max(),
+                 "The |read_offset| computation above may overflow");
+ 
+-  int sqlite_status =
+-      RawRead(sqlite_file, read_size, read_offset, page_data_.get());
++  int sqlite_status = RawRead(sqlite_file, read_size, read_offset,
++                              const_cast<uint8_t*>(page_data_.data()));
+ 
+   // |page_id_| needs to be set to kInvalidPageId if the read failed.
+   // Otherwise, future ReadPage() calls with the previous |page_id_| value
+diff --git a/sql/recover_module/pager.h b/sql/recover_module/pager.h
+index 0e388ddc..99314e3 100644
+--- a/sql/recover_module/pager.h
++++ b/sql/recover_module/pager.h
+@@ -5,6 +5,7 @@
+ #ifndef SQL_RECOVER_MODULE_PAGER_H_
+ #define SQL_RECOVER_MODULE_PAGER_H_
+ 
++#include <array>
+ #include <cstdint>
+ #include <memory>
+ 
+@@ -70,7 +71,7 @@
+     DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+     DCHECK_NE(page_id_, kInvalidPageId)
+         << "Successful ReadPage() required before accessing pager state";
+-    return page_data_.get();
++    return page_data_.data();
+   }
+ 
+   // The number of bytes in the page read by the last ReadPage() call.
+@@ -137,7 +138,7 @@
+   int page_id_ = kInvalidPageId;
+   // Stores the bytes of the last page successfully read by ReadPage().
+   // The content is undefined if the last call to ReadPage() did not succeed.
+-  const std::unique_ptr<uint8_t[]> page_data_;
++  const std::array<uint8_t, kMaxPageSize> page_data_;
+   // Raw pointer usage is acceptable because this instance's owner is expected
+   // to ensure that the VirtualTable outlives this.
+   VirtualTable* const table_;

--- a/x11-packages/carbonyl-host-tools/patches/8001-chromium-include-cmath.patch
+++ b/x11-packages/carbonyl-host-tools/patches/8001-chromium-include-cmath.patch
@@ -1,0 +1,11 @@
+--- a/extensions/renderer/bindings/argument_spec.cc
++++ b/extensions/renderer/bindings/argument_spec.cc
+@@ -16,6 +16,8 @@
+ #include "gin/data_object_builder.h"
+ #include "gin/dictionary.h"
+ 
++#include <cmath>
++
+ namespace extensions {
+ 
+ namespace {

--- a/x11-packages/carbonyl-host-tools/toolchain-template/host-toolchain.gn.in
+++ b/x11-packages/carbonyl-host-tools/toolchain-template/host-toolchain.gn.in
@@ -1,0 +1,18 @@
+import("//build/config/sysroot.gni")
+import("//build/toolchain/gcc_toolchain.gni")
+
+gcc_toolchain("host") {
+  cc = "@HOST_CC@"
+  cxx = "@HOST_CXX@"
+  ld = "@HOST_LD@"
+  ar = "@HOST_AR@"
+  nm = "@HOST_NM@"
+  toolchain_args = {
+    current_os = "linux"
+    current_cpu = "x64"
+    v8_current_cpu = "@V8_CURRENT_CPU@"
+    is_clang = @HOST_IS_CLANG@
+    use_gold = @HOST_USE_GOLD@
+    sysroot = "@HOST_SYSROOT@"
+  }
+}

--- a/x11-packages/carbonyl-host-tools/toolchain-template/v8-toolchain.gn.in
+++ b/x11-packages/carbonyl-host-tools/toolchain-template/v8-toolchain.gn.in
@@ -1,0 +1,15 @@
+gcc_toolchain("@V8_TOOLCHAIN_NAME@") {
+  cc = "@V8_CC@"
+  cxx = "@V8_CXX@"
+  ld = "@V8_LD@"
+  ar = "@V8_AR@"
+  nm = "@V8_NM@"
+  toolchain_args = {
+    current_os = "linux"
+    current_cpu = "@V8_CURRENT_CPU@"
+    v8_current_cpu = "@V8_V8_CURRENT_CPU@"
+    is_clang = @V8_IS_CLANG@
+    use_gold = @V8_USE_GOLD@
+    sysroot = "@V8_SYSROOT@"
+  }
+}


### PR DESCRIPTION
This PR adds some components that are built using host-toolchain when building carbonyl, as well as some relatively independent components. Mainly include:
1. v8 host tools. Mainly include `torque`, `mksnapshot`, `gen-regexp-special-case`, `bytecode_builtins_list_generator`.
2. v8 snapshot files. Mainly include `snapshot_blob.bin`, `v8_context_snapshot.bin`
3. some host tools. Mainly include `make_top_domain_list_variables`, `generate_colors_info`, `character_data_generator`, `root_store_tool`, `transport_security_state_generator`, `top_domain_generator`
4. swiftshader

Splitting these time-consuming but relatively independent operations from the carbonyl main binary build process will make it possible to complete the build progress within 2*6 hours.