### PR TITLE
addpkg(main/hidapi): package for accessing HID usb devices (with libusb)

### DIFF
--- a/packages/hidapi/build.sh
+++ b/packages/hidapi/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE=https://libusb.info/hidapi
+TERMUX_PKG_DESCRIPTION="Simple cross-platform library for communicating with HID devices"
+TERMUX_PKG_LICENSE="GPL-3.0, BSD 3-Clause, custom"
+TERMUX_PKG_LICENSE_FILE="LICENSE.txt, LICENSE-gpl3.txt, LICENSE-bsd.txt, LICENSE-orig.txt"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=0.14.0
+TERMUX_PKG_SRCURL="https://github.com/libusb/hidapi/archive/refs/tags/hidapi-${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=a5714234abe6e1f53647dd8cba7d69f65f71c558b7896ed218864ffcf405bcbd
+TERMUX_PKG_DEPENDS="libiconv, libusb"

--- a/packages/hidapi/libusb-iconv-CMakeLists.txt.patch
+++ b/packages/hidapi/libusb-iconv-CMakeLists.txt.patch
@@ -1,0 +1,20 @@
+--- ./libusb/CMakeLists.txt~	2025-02-01 13:16:49.669029267 +0000
++++ ./libusb/CMakeLists.txt	2025-02-01 13:18:12.309030989 +0000
+@@ -22,7 +22,6 @@
+ if(HIDAPI_NO_ICONV)
+     target_compile_definitions(hidapi_libusb PRIVATE NO_ICONV)
+ else()
+-    if(NOT ANDROID)
+         include(CheckCSourceCompiles)
+ 
+         if(NOT CMAKE_VERSION VERSION_LESS 3.11)
+@@ -77,9 +76,6 @@
+         if(HIDAPI_ICONV_CONST)
+             target_compile_definitions(hidapi_libusb PRIVATE "ICONV_CONST=const")
+         endif()
+-    else()
+-        # On Android Iconv is disabled on the code level anyway, so no issue;
+-    endif()
+ endif()
+ 
+ set_target_properties(hidapi_libusb

--- a/packages/hidapi/termux-iconv-hid.c.patch
+++ b/packages/hidapi/termux-iconv-hid.c.patch
@@ -1,0 +1,29 @@
+--- ./libusb/hid.c~	2023-05-22 10:50:06.000000000 +0000
++++ ./libusb/hid.c	2025-02-01 13:13:05.412357928 +0000
+@@ -42,7 +42,7 @@
+ 
+ /* GNU / LibUSB */
+ #include <libusb.h>
+-#if !defined(__ANDROID__) && !defined(NO_ICONV)
++#if (!defined(__ANDROID__) || defined(__TERMUX__)) && !defined(NO_ICONV)
+ #include <iconv.h>
+ #ifndef ICONV_CONST
+ #define ICONV_CONST
+@@ -406,7 +406,7 @@
+ 	int len;
+ 	wchar_t *str = NULL;
+ 
+-#if !defined(__ANDROID__) && !defined(NO_ICONV) /* we don't use iconv on Android, or when it is explicitly disabled */
++#if (!defined(__ANDROID__) || defined(__TERMUX__)) && !defined(NO_ICONV) /* we don't use iconv on non-Termux Android, or when it is explicitly disabled */
+ 	wchar_t wbuf[256];
+ 	/* iconv variables */
+ 	iconv_t ic;
+@@ -432,7 +432,7 @@
+ 	if (len < 2) /* we always skip first 2 bytes */
+ 		return NULL;
+ 
+-#if defined(__ANDROID__) || defined(NO_ICONV)
++#if (defined(__ANDROID__) || defined(NO_ICONV)) && !defined(__TERMUX__)
+ 
+ 	/* Bionic does not have iconv support nor wcsdup() function, so it
+ 	   has to be done manually.  The following code will only work for


### PR DESCRIPTION
hidapi can be used with libusb, or the kernel driver "hidraw" (likely only relevant for rooted devices), to access HID devices. Goal is to patch it further and use it together with termux-usb.

Add it now for testing and development purposes.