### PR TITLE
remive LD preload check: useless  lecture for the choir

### DIFF
--- a/scripts/build/termux_step_setup_variables.sh
+++ b/scripts/build/termux_step_setup_variables.sh
@@ -50,13 +50,6 @@ termux_step_setup_variables() {
 		# store information about built packages under $TERMUX_TOPDIR.
 		TERMUX_BUILT_PACKAGES_DIRECTORY="$TERMUX_TOPDIR/.built-packages"
 		TERMUX_NO_CLEAN="true"
-
-		if [ "$TERMUX_PACKAGE_LIBRARY" = "bionic" ]; then
-			# On-device builds without termux-exec are unsupported.
-			if ! grep -q "${TERMUX_PREFIX}/lib/libtermux-exec.so" <<< "${LD_PRELOAD-x}"; then
-				termux_error_exit "On-device builds without termux-exec are not supported."
-			fi
-		fi
 	else
 		TERMUX_BUILT_PACKAGES_DIRECTORY="/data/data/.built-packages"
 	fi


### PR DESCRIPTION
none of it makes any sense either you suddenly worry if I build GNU libc completely irrelevant . the whole block is useless take it somewhere else. the shell doctor. I don't need a doctor I have my own

I use ld.so.preload instead because i need two settings simultaneously for bionic,(pos,) and the mighty GNU   LD_PRELOAD just breaks the entire shell

I use all app in the same shell no useless P root or magic roots just plain old do it all shell  mesa g libc is light years ahead of bionic it doesn't even work with the most important driver VIRPIPE

anyhow I am working on real problems now wine Vulkan has a hash collision and hangs ... sigh
