### PR TITLE
fix(main/libmp3lame): provide libmp3lame.so.0

### DIFF
--- a/packages/libmp3lame/build.sh
+++ b/packages/libmp3lame/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="High quality MPEG Audio Layer III (MP3) encoder"
 TERMUX_PKG_LICENSE="LGPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.100
-TERMUX_PKG_REVISION=5
+TERMUX_PKG_REVISION=6
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/project/lame/lame/${TERMUX_PKG_VERSION}/lame-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e
 TERMUX_PKG_BREAKS="libmp3lame-dev"
@@ -30,4 +30,12 @@ termux_step_post_make_install() {
 		Libs: -L\${libdir} -lmp3lame
 		Cflags: -I\${includedir}
 	EOF
+}
+
+termux_step_post_massage() {
+	# Some programs, e.g. Audacity, try to dlopen(3) `libmp3lame.so.0`.
+	cd ${TERMUX_PKG_MASSAGEDIR}/${TERMUX_PREFIX}/lib || exit 1
+	if [ ! -e "./libmp3lame.so.0" ]; then
+		ln -sf libmp3lame.so libmp3lame.so.0
+	fi
 }


### PR DESCRIPTION
Audacity attempts to `dlopen()` `libmp3lame.so.0` by default on all linux distros, not `libmp3lame.so`

https://github.com/audacity/audacity/blob/d1f7b507a0d919dcd9d58588ac85ce6dbea527e5/au3/modules/import-export/mod-mp3/ExportMP3.cpp#L1485

This solution is based on the example seen in the `pulseaudio` package:

https://github.com/termux/termux-packages/blob/aec99dd11b9b8e50bf6260348d82385e819558c5/packages/pulseaudio/build.sh#L64-L70

- Fixes #23100