### PR TITLE
fix(main/libsndfile): link to libmp3lame

### DIFF
--- a/packages/libsndfile/build.sh
+++ b/packages/libsndfile/build.sh
@@ -3,16 +3,16 @@ TERMUX_PKG_DESCRIPTION="Library for reading/writing audio files"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.2.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/libsndfile/libsndfile/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=ffe12ef8add3eaca876f04087734e6e8e029350082f3251f565fa9da55b52121
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="libflac, libogg, libopus, libvorbis"
+TERMUX_PKG_DEPENDS="libflac, libmp3lame, libogg, libopus, libvorbis"
 TERMUX_PKG_BREAKS="libsndfile-dev"
 TERMUX_PKG_REPLACES="libsndfile-dev"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-sqlite
 --disable-alsa
---disable-mpeg
 "
 TERMUX_PKG_RM_AFTER_INSTALL="bin/ share/man/man1/"
 


### PR DESCRIPTION
- Fixes #23114

Before:

```
External MPEG Lame/MPG123 : ........... no
```

`libsndfile` reverse dependency example: **`rubberband`**:

```
~ $ rubberband -t 2 example.mp3 example_out.mp3
Using R2 (faster) engine
Using crispness level: 5 (Crisp monophonic instrumental)
ERROR: Failed to open input file "example.mp3": File contains data in an unimplemented format.
```

After:

```
External MPEG Lame/MPG123 : ........... yes
```

`libsndfile` reverse dependency example: **`rubberband`**:

```
~ $ rubberband -t 2 example.mp3 example_out.mp3
Using R2 (faster) engine
Using crispness level: 5 (Crisp monophonic instrumental)
Using time ratio 2 and frequency ratio 1
Pass 1: Studying...
Calculating profile...
Pass 2: Processing...

in: 2557062, out: 5114124, ratio: 2, ideal output: 5114124, error: 0

[...]

~ $ mplayer example_out.mp3 # slowed audio
```

Additional Side Effect: this dependency change **replicates the way Debian's `audacity` package pulls in Debian's `libmp3lame0`**:

In Debian:

`audacity` depends by dynamic linking on: `libsndfile1`
`libsndfile1` depends by dynamic linking on: `libmp3lame0`
`audacity` `dlopen()`s: `libmp3lame.so.0` (without going through `libsndfile1`)