### PR TITLE
new package: diff-so-fancy

### DIFF
--- a/packages/diff-so-fancy/build.sh
+++ b/packages/diff-so-fancy/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://github.com/so-fancy/diff-so-fancy"
+TERMUX_PKG_DESCRIPTION="Good-lookin' diffs. Actually... nah... The best-lookin' diffs"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_VERSION="1.4.4"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_SRCURL="https://github.com/so-fancy/diff-so-fancy/archive/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256="3eac2cfb3b1de9d14b6a712941985d6b240b7f3726c94a5e337317c7161e869d"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="perl"
+TERMUX_PKG_RECOMMENDS="git"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+
+termux_step_make_install() {
+	# relative paths of vendored libs to absolute system lib paths
+	sed "s#^use lib .*\$#use lib \"$TERMUX_PREFIX/share/diff-so-fancy\";#" -i diff-so-fancy
+
+	install -Dm700 diff-so-fancy        "$TERMUX_PREFIX/bin/diff-so-fancy"
+	install -Dm700 lib/DiffHighlight.pm "$TERMUX_PREFIX/share/diff-so-fancy/DiffHighlight.pm"
+	install -Dm600 README.md            "$TERMUX_PREFIX/share/doc/diff-so-fancy/README.md"
+}

--- a/packages/lazygit/build.sh
+++ b/packages/lazygit/build.sh
@@ -3,10 +3,12 @@ TERMUX_PKG_DESCRIPTION="Simple terminal UI for git commands"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Krishna kanhaiya @kcubeterm"
 TERMUX_PKG_VERSION="0.45.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/jesseduffield/lazygit/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=dd3d6645ee429f0c554338c1fdb940733793ad915ae72653132664aa7c26bbcb
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_RECOMMENDS=git
+TERMUX_PKG_SUGGESTS=diff-so-fancy
 
 termux_step_make() {
 	termux_setup_golang


### PR DESCRIPTION
3f36bc80c new package: diff-so-fancy

-----

d8c7334da Suggest `diff-so-fancy` for `lazygit` as [it can integrate with it](https://github.com/jesseduffield/lazygit/blob/master/docs/Custom_Pagers.md#diff-so-fancy).

Perhaps `git` should suggest either `git-delta` or `diff-so-fancy` if Termux's infrastructure allows for building packages which suggest one of a few packages.

-----

Review note: I could not locally build and test the package as the build environment required to install all possible build dependencies even if completely unused.