### PR TITLE
testing to see if github actions can build main/swift unmodified

### DIFF
--- a/packages/swift/build.sh
+++ b/packages/swift/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Swift is a high-performance system programming language"
 TERMUX_PKG_LICENSE="Apache-2.0, NCSA"
 TERMUX_PKG_MAINTAINER="@finagolfin"
 TERMUX_PKG_VERSION=6.0.3
+TERMUX_PKG_REVISION=1
 SWIFT_RELEASE="RELEASE"
 TERMUX_PKG_SRCURL=https://github.com/swiftlang/swift/archive/swift-$TERMUX_PKG_VERSION-$SWIFT_RELEASE.tar.gz
 TERMUX_PKG_SHA256=eef9f312d00540cfabc35cb1da9221dd15d3aaca546497a14f29a641ee6484e3


### PR DESCRIPTION
When finagolfin compiles the `swift` package on December 12 2024, they are [able to make it pass CI](https://github.com/termux/termux-packages/actions/runs/12297629421/job/34319202733),

but I cannot reproduce that in local docker clean container. 

this is a test to check whether there is a real difference between github actions and local docker for this package.