### PR TITLE
fix|bump({main/swift,main/openjdk-17,x11/qt5-qtwebengine}): finish migration to clang 18

### DIFF
--- a/packages/openjdk-17/build.sh
+++ b/packages/openjdk-17/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Java development kit and runtime"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=17.0
-TERMUX_PKG_REVISION=37
+TERMUX_PKG_REVISION=38
 _COMMIT=82234f890786d49c49cf4ecbcb09c47bd9bea7ed
 TERMUX_PKG_SRCURL=https://github.com/openjdk/mobile/archive/$_COMMIT.tar.gz
 TERMUX_PKG_SHA256=5b298148a26e754120c6dfe699056d0609fc6ed92bfc858dc2ba4909ef6e791b
@@ -50,12 +50,12 @@ termux_step_configure() {
 		OBJDUMP="$OBJDUMP" \
 		STRIP="$STRIP" \
 		CXXFILT="llvm-cxxfilt" \
-		BUILD_CC="/usr/bin/clang-17" \
-		BUILD_CXX="/usr/bin/clang++-17" \
-		BUILD_NM="/usr/bin/llvm-nm-17" \
-		BUILD_AR="/usr/bin/llvm-ar-17" \
-		BUILD_OBJCOPY="/usr/bin/llvm-objcopy-17" \
-		BUILD_STRIP="/usr/bin/llvm-strip-17"
+		BUILD_CC="/usr/bin/clang-18" \
+		BUILD_CXX="/usr/bin/clang++-18" \
+		BUILD_NM="/usr/bin/llvm-nm-18" \
+		BUILD_AR="/usr/bin/llvm-ar-18" \
+		BUILD_OBJCOPY="/usr/bin/llvm-objcopy-18" \
+		BUILD_STRIP="/usr/bin/llvm-strip-18"
 }
 
 termux_step_make() {

--- a/packages/swift/build.sh
+++ b/packages/swift/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Swift is a high-performance system programming language"
 TERMUX_PKG_LICENSE="Apache-2.0, NCSA"
 TERMUX_PKG_MAINTAINER="@finagolfin"
 TERMUX_PKG_VERSION=6.0.3
+TERMUX_PKG_REVISION=1
 SWIFT_RELEASE="RELEASE"
 TERMUX_PKG_SRCURL=https://github.com/swiftlang/swift/archive/swift-$TERMUX_PKG_VERSION-$SWIFT_RELEASE.tar.gz
 TERMUX_PKG_SHA256=eef9f312d00540cfabc35cb1da9221dd15d3aaca546497a14f29a641ee6484e3
@@ -12,6 +13,8 @@ TERMUX_PKG_DEPENDS="clang, libandroid-execinfo, libandroid-glob, libandroid-posi
 TERMUX_PKG_BUILD_DEPENDS="rsync"
 TERMUX_PKG_BLACKLISTED_ARCHES="i686"
 TERMUX_PKG_NO_STATICSPLIT=true
+# avoids ld.lld: error: unable to find library -lswiftCore when building locally
+TERMUX_PKG_MAKE_PROCESSES=4
 # Temporary hack only needed for x86_64
 TERMUX_PKG_UNDEF_SYMBOLS_FILES="
 ./opt/ndk-multilib/arm-linux-androideabi/lib/libFoundation.so
@@ -120,8 +123,8 @@ termux_step_host_build() {
 		# The Ubuntu CI may not have clang/clang++ in its path so explicitly set it
 		# to clang-17 instead.
 		if [ -z "$CLANG" ]; then
-			CLANG=$(command -v clang-17)
-			CLANGXX=$(command -v clang++-17)
+			CLANG=$(command -v clang-18)
+			CLANGXX=$(command -v clang++-18)
 		fi
 
 		# Natively compile llvm-tblgen and some other files needed later.

--- a/x11-packages/qt5-qtwebengine/0030-remove-imp-for-python-312.patch
+++ b/x11-packages/qt5-qtwebengine/0030-remove-imp-for-python-312.patch
@@ -1,0 +1,22 @@
+Cherry-pick from https://github.com/chromium/chromium/commit/f5f6e361d037c31630661186e7bd7b31d2784cb8
+
+--- a/src/3rdparty/chromium/mojo/public/tools/mojom/mojom/fileutil.py
++++ b/src/3rdparty/chromium/mojo/public/tools/mojom/mojom/fileutil.py
+@@ -3,7 +3,6 @@
+ # found in the LICENSE file.
+ 
+ import errno
+-import imp
+ import os.path
+ import sys
+ 
+--- a/src/3rdparty/chromium/mojo/public/tools/mojom/mojom/parse/lexer.py
++++ b/src/3rdparty/chromium/mojo/public/tools/mojom/mojom/parse/lexer.py
+@@ -2,7 +2,6 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-import imp
+ import os.path
+ import sys
+ 

--- a/x11-packages/qt5-qtwebengine/0031-fix-six-for-python-312.patch
+++ b/x11-packages/qt5-qtwebengine/0031-fix-six-for-python-312.patch
@@ -1,0 +1,57 @@
+Patch from Arch Linux: https://gitlab.archlinux.org/archlinux/packaging/packages/qt5-webengine/-/blob/ee7fd7639a1ab69fc9b1eeff3dabdb52c8bd231f/python3.12-six.patch
+
+Cherry-pick from https://github.com/benjaminp/six/commit/25916292d96f5f09
+
+--- a/src/3rdparty/chromium/third_party/protobuf/third_party/six/six.py
++++ b/src/3rdparty/chromium/third_party/protobuf/third_party/six/six.py
+@@ -71,6 +71,11 @@ else:
+             MAXSIZE = int((1 << 63) - 1)
+         del X
+ 
++if PY34:
++    from importlib.util import spec_from_loader
++else:
++    spec_from_loader = None
++
+ 
+ def _add_doc(func, doc):
+     """Add documentation to a function."""
+@@ -186,6 +191,11 @@ class _SixMetaPathImporter(object):
+             return self
+         return None
+ 
++    def find_spec(self, fullname, path, target=None):
++        if fullname in self.known_modules:
++            return spec_from_loader(fullname, self)
++        return None
++
+     def __get_module(self, fullname):
+         try:
+             return self.known_modules[fullname]
+--- a/src/3rdparty/chromium/tools/grit/third_party/six/__init__.py
++++ b/src/3rdparty/chromium/tools/grit/third_party/six/__init__.py
+@@ -71,6 +71,11 @@ else:
+             MAXSIZE = int((1 << 63) - 1)
+         del X
+ 
++if PY34:
++    from importlib.util import spec_from_loader
++else:
++    spec_from_loader = None
++
+ 
+ def _add_doc(func, doc):
+     """Add documentation to a function."""
+@@ -186,6 +191,11 @@ class _SixMetaPathImporter(object):
+             return self
+         return None
+ 
++    def find_spec(self, fullname, path, target=None):
++        if fullname in self.known_modules:
++            return spec_from_loader(fullname, self)
++        return None
++
+     def __get_module(self, fullname):
+         try:
+             return self.known_modules[fullname]
+

--- a/x11-packages/qt5-qtwebengine/build.sh
+++ b/x11-packages/qt5-qtwebengine/build.sh
@@ -3,8 +3,7 @@ TERMUX_PKG_DESCRIPTION="Qt 5 Web Engine Library"
 TERMUX_PKG_LICENSE="LGPL-3.0, GPL-2.0, GPL-3.0, BSD 3-Clause"
 TERMUX_PKG_LICENSE_FILE="LICENSE.LGPL3, LICENSE.GPL2, LICENSE.GPL3, LICENSE.Chromium"
 TERMUX_PKG_MAINTAINER="@licy183"
-TERMUX_PKG_VERSION="5.15.17"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="5.15.18"
 TERMUX_PKG_SRCURL=git+https://github.com/qt/qtwebengine
 TERMUX_PKG_GIT_BRANCH=v$TERMUX_PKG_VERSION-lts
 TERMUX_PKG_AUTO_UPDATE=false
@@ -16,8 +15,8 @@ TERMUX_PKG_HOSTBUILD=true
 termux_step_host_build() {
 	# Generate ffmpeg headers for i686
 	mkdir -p fake-bin
-	ln -s $(command -v clang-17) fake-bin/clang
-	ln -s $(command -v clang++-17) fake-bin/clang++
+	ln -s $(command -v clang-18) fake-bin/clang
+	ln -s $(command -v clang++-18) fake-bin/clang++
 
 	# Remove python3 compatibility file preventing using newer python3 versions:
 	rm $TERMUX_PKG_SRCDIR/src/3rdparty/chromium/third_party/ffmpeg/chromium/scripts/enum.py


### PR DESCRIPTION
- like https://github.com/termux/termux-packages/commit/a3d556ea4a09a592baa69715fa1cb2b522652a70, but for the three other packages that still contained references to clang 17 in their `build.sh` files.

- progress on #21130

- `qt5-qtwebengine`
  - bump to 5.15.18
  - fix build with clang 18
  - fix build with python 3.12
- `swift`
  - fix local docker build with clang 18
  - fix local docker build on computers that have more than 4 logical processors
- `openjdk-17`
  - fix build with clang 18
