### PR TITLE
enhance(x11/termux-x11): add service script

### DIFF
--- a/x11-packages/termux-x11-nightly/build.sh
+++ b/x11-packages/termux-x11-nightly/build.sh
@@ -10,6 +10,8 @@ TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_DEPENDS="xkeyboard-config"
+# We provide a termux-x11-xfce4 service script, so let's suggest xfce4
+TERMUX_PKG_SUGGESTS="xfce4"
 TERMUX_PKG_BREAKS="termux-x11"
 TERMUX_PKG_REPLACES="termux-x11"
 TERMUX_PKG_PROVIDES="termux-x11"
@@ -35,6 +37,13 @@ termux_step_post_make_install() {
 		$TERMUX_PKG_BUILDER_DIR/sv/tx11.run.in > $TERMUX_PREFIX/var/service/tx11/run
 	chmod 700 $TERMUX_PREFIX/var/service/tx11/run
 	touch $TERMUX_PREFIX/var/service/tx11/down
+
+	mkdir -p $TERMUX_PREFIX/var/service/tx11-xfce4/log
+	ln -sf $TERMUX_PREFIX/share/termux-services/svlogger $TERMUX_PREFIX/var/service/tx11-xfce4/log/run
+	sed "s%@TERMUX_PREFIX@%$TERMUX_PREFIX%g" \
+		$TERMUX_PKG_BUILDER_DIR/sv/tx11-xfce4.run.in > $TERMUX_PREFIX/var/service/tx11-xfce4/run
+	chmod 700 $TERMUX_PREFIX/var/service/tx11-xfce4/run
+	touch $TERMUX_PREFIX/var/service/tx11-xfce4/down
 }
 
 termux_step_create_debscripts() {

--- a/x11-packages/termux-x11-nightly/build.sh
+++ b/x11-packages/termux-x11-nightly/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Termux X11 add-on."
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="Twaik Yont @twaik"
 TERMUX_PKG_VERSION=1.03.01
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=https://github.com/termux/termux-x11/archive/efb2d97a46adf1657bacf395c38166a648260066.tar.gz
 TERMUX_PKG_SHA256=49f635b0aa731b72ad5f5fb78f770d47bc86eeab37b80a2e7a31e93e77e183b3
 TERMUX_PKG_AUTO_UPDATE=false
@@ -24,6 +24,17 @@ termux_step_make_install() {
 	install -t $TERMUX_PREFIX/bin -m 755 termux-x11 termux-x11-preference
 	mkdir -p $TERMUX_PREFIX/libexec/termux-x11
 	wget -qO- $LOADER_URL | tar -OJxf - --wildcards "*loader.apk" > $TERMUX_PREFIX/libexec/termux-x11/loader.apk
+}
+
+termux_step_post_make_install() {
+	# Setup termux-services scripts
+	mkdir -p $TERMUX_PREFIX/var/service/tx11/log
+	ln -sf $TERMUX_PREFIX/share/termux-services/svlogger $TERMUX_PREFIX/var/service/tx11/log/run
+	sed -e "s%@TERMUX_PREFIX@%$TERMUX_PREFIX%g" \
+		-e "s%@TERMUX_HOME@%$TERMUX_ANDROID_HOME%g" \
+		$TERMUX_PKG_BUILDER_DIR/sv/tx11.run.in > $TERMUX_PREFIX/var/service/tx11/run
+	chmod 700 $TERMUX_PREFIX/var/service/tx11/run
+	touch $TERMUX_PREFIX/var/service/tx11/down
 }
 
 termux_step_create_debscripts() {

--- a/x11-packages/termux-x11-nightly/sv/tx11-xfce4.run.in
+++ b/x11-packages/termux-x11-nightly/sv/tx11-xfce4.run.in
@@ -1,0 +1,7 @@
+#!@TERMUX_PREFIX@/bin/sh
+
+# Create a file for DISPLAY number. Users can do something like
+# export DISPLAY=":$(cat $PREFIX/var/run/tx11-xfce4.display)"
+# to use it.
+exec 3<> @TERMUX_PREFIX@/var/run/tx11-xfce4.display
+exec termux-x11 -displayfd 3 -xstartup "dbus-launch --exit-with-session xfce4-session" 2>&1

--- a/x11-packages/termux-x11-nightly/sv/tx11.run.in
+++ b/x11-packages/termux-x11-nightly/sv/tx11.run.in
@@ -1,0 +1,7 @@
+#!@TERMUX_PREFIX@/bin/sh
+
+# Create a file for DISPLAY number. Users can do something like
+# export DISPLAY=":$(cat $PREFIX/var/run/tx11.display)"
+# to use it.
+exec 3<> @TERMUX_PREFIX@/var/run/tx11.display
+exec termux-x11 -displayfd 3 2>&1


### PR DESCRIPTION
Install termux-services and then run `sv up termux-x11` to start the service, or sv-enable termux-x11 to run it by default.

Requested in termux/termux-x11#800.

As @twaik noted it would be more useful/user-friendly to have a service script to start an entire desktop environment. That can be added separately to for example xfce4, I think there is some benefit to having being able to run just termux-x11 though, since that allows up run single gui applications without all the desktop environment overhead.  