### PR TITLE
fix(x11/luanti): force-link to libOpenSLES.so

### DIFF
--- a/x11-packages/luanti/build.sh
+++ b/x11-packages/luanti/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="An open source voxel game engine."
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1:5.11.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/luanti-org/luanti/archive/refs/tags/${TERMUX_PKG_VERSION:2}.tar.gz
 TERMUX_PKG_SHA256=70e531d0776988ce6e579ea5490fdf6be3e349a4ade5281f5111aa4fdd8ee510
 TERMUX_PKG_AUTO_UPDATE=true
@@ -16,4 +17,8 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 
 termux_step_pre_configure() {
 	export LDFLAGS+=" -landroid-spawn"
+	# successful application-side workaround of
+	# https://github.com/kcat/openal-soft/issues/1111
+	# https://github.com/termux/termux-packages/issues/23148
+	export LDFLAGS+=" -Wl,--no-as-needed,-lOpenSLES,--as-needed"
 }


### PR DESCRIPTION
- This is a potential alternative solution to #23148

- compared to #23149
  - **Potential advantages**: does not require editing the `openal-soft` package
  - **Potential disadvantages**: would require editing any other reverse dependency of `openal-soft` that could in the future be found to be affected by the same issue, by copying and pasting these `LDFLAGS` to its `build.sh`.