### PR TITLE
enhance(main/ffmpeg): suggest installing `libandroid-stub` if ffmpeg segfaults

### DIFF
--- a/packages/ffmpeg/build.sh
+++ b/packages/ffmpeg/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # Please align version with `ffplay` package.
 TERMUX_PKG_VERSION="7.1"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://www.ffmpeg.org/releases/ffmpeg-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=40973d44970dbc83ef302b0609f2e74982be2d85916dd2ee7472d30678a7abe6
 TERMUX_PKG_DEPENDS="fontconfig, freetype, fribidi, game-music-emu, harfbuzz, libaom, libandroid-glob, libass, libbluray, libbz2, libdav1d, libgnutls, libiconv, liblzma, libmp3lame, libopencore-amr, libopenmpt, libopus, librav1e, libsoxr, libsrt, libssh, libtheora, libv4l, libvidstab, libvmaf, libvo-amrwbenc, libvorbis, libvpx, libwebp, libx264, libx265, libxml2, libzimg, littlecms, ocl-icd, rubberband, svt-av1, xvidcore, zlib"
@@ -132,4 +132,12 @@ termux_step_post_massage() {
 			ln -sf libav${f}.so libav${f}.so.${s}
 		fi
 	done
+}
+
+termux_step_create_debscripts() {
+	# See: https://github.com/termux/termux-packages/issues/23189#issuecomment-2663464359
+	# See also: https://github.com/termux/termux-packages/wiki/Termux-execution-environment#dynamic-library-linking-errors
+	sed -e "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|g" \
+		"$TERMUX_PKG_BUILDER_DIR/postinst.sh.in" > ./postinst
+	chmod +x ./postinst
 }

--- a/packages/ffmpeg/postinst.sh.in
+++ b/packages/ffmpeg/postinst.sh.in
@@ -1,0 +1,31 @@
+#!$TERMUX_PREFIX/bin/sh
+
+# shellcheck disable=SC3043
+check_command() {
+	local command="$1"
+
+	local errors
+	if ! errors="$("$@" 2>&1 1>/dev/null)"; then
+		echo "$errors"
+		echo "Failed to run the '$command' command."
+		case "$errors" in
+			# - https://github.com/termux/termux-packages/wiki/Termux-execution-environment#system-libraries-are-missing
+			*"CANNOT LINK EXECUTABLE"*)
+				printf '%s\n' \
+					"To fix the '$command' command, manually upgrade all packages by running: \`pkg upgrade\`" \
+					"If upgrading packages does not fix it, then you may be able to fix the error by running: \`pkg install libandroid-stub\`" \
+					"See also: https://github.com/termux/termux-packages/wiki/Termux-execution-environment#dynamic-library-linking-errors"
+			;;
+			# - https://github.com/termux/termux-packages/issues/23189#issuecomment-2663464359
+			# - https://cs.android.com/android/platform/superproject/+/android15-qpr1-release:external/boringssl/src/crypto/fipsmodule/bcm.c;l=141
+			*"FIPS module doesn't span expected symbol"*)
+				printf '%s\n' \
+					"You should be able to fix the error by running: \`pkg install libandroid-stub\`" \
+					"See also: https://github.com/termux/termux-packages/wiki/Termux-execution-environment#dynamic-library-linking-errors"
+			;;
+		esac
+		return 1
+	fi
+} 1>&2
+
+check_command ffmpeg -version


### PR DESCRIPTION
closes #23189

CC: @licy183
This should only show the note if `ffmpeg -version` (which should exit 0) fails to run.
Which should trigger a segfault if the symbol conflict is present on the device.

We can also just show it unconditionally if that doesn't work.