### PR TITLE
fix(main/tree-sitter): fix typo is SOGUARD function name

### DIFF
--- a/packages/tree-sitter/build.sh
+++ b/packages/tree-sitter/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="An incremental parsing system for programming tools"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION="0.25.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=26791f69182192fef179cd58501c3226011158823557a86fe42682cb4a138523
 TERMUX_PKG_BREAKS="libtreesitter"
@@ -10,12 +11,12 @@ TERMUX_PKG_REPLACES="libtreesitter"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
 
-termux_step_pre_get_source() {
+termux_step_post_get_source() {
 	# Do not forget to bump revision of reverse dependencies and rebuild them
 	# after SOVERSION is changed.
 	local _SOVERSION=0.25
 
-	# New SO version is the major version of the package
+	# This blocks auto-updates to an incompatible SO version.
 	if [[ "$TERMUX_PKG_VERSION" != "${_SOVERSION}".* ]]; then
 		termux_error_exit "SOVERSION guard check failed."
 	fi


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/termux/termux-packages/commit/3d26ef1d9bb8dac0b84c67e199a3e81a99a8ee84