### PR TITLE
bump(main/geth): 1.15.2

### DIFF
--- a/packages/geth/build.sh
+++ b/packages/geth/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://geth.ethereum.org/
 TERMUX_PKG_DESCRIPTION="Go implementation of the Ethereum protocol"
 TERMUX_PKG_LICENSE="LGPL-3.0, GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.14.13"
+TERMUX_PKG_VERSION="1.15.2"
 TERMUX_PKG_SRCURL=https://github.com/ethereum/go-ethereum/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=55b63fb34ef0bcadd438ec3311f9e4b6e584220d2f4465386afbd377ad5ab1bd
+TERMUX_PKG_SHA256=1728ae14d728d4ce86a840ee783d73dd9cffe9e1dbb82ecc032e8b93a9841cc4
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_SUGGESTS="geth-utils"
 
@@ -16,14 +16,14 @@ termux_step_make() {
 	ln -sf "$TERMUX_PKG_SRCDIR" "$GOPATH"/src/github.com/ethereum/go-ethereum
 
 	cd "$GOPATH"/src/github.com/ethereum/go-ethereum
-	for applet in abidump abigen blsync bootnode clef devp2p era ethkey evm geth rlpdump; do
+	for applet in abidump abigen blsync clef devp2p era ethkey evm geth rlpdump; do
 		go -C ./cmd/"$applet" build -v
 	done
 	unset applet
 }
 
 termux_step_make_install() {
-	for applet in abidump abigen blsync bootnode clef devp2p era ethkey evm geth rlpdump; do
+	for applet in abidump abigen blsync clef devp2p era ethkey evm geth rlpdump; do
 		install -Dm700 \
 			"$TERMUX_PKG_SRCDIR/cmd/$applet/$applet" \
 			"$TERMUX_PREFIX"/bin/

--- a/packages/geth/geth-utils.subpackage.sh
+++ b/packages/geth/geth-utils.subpackage.sh
@@ -3,7 +3,6 @@ TERMUX_SUBPKG_INCLUDE="
 bin/abidump
 bin/abigen
 bin/blsync
-bin/bootnode
 bin/clef
 bin/devp2p
 bin/era


### PR DESCRIPTION
bootnode tool was removed in the following commit in upstream. https://github.com/ethereum/go-ethereum/commit/53f66c1b03d5880fa807e088c865b31d144fabd0

* Fixes #23411 