### PR TITLE
rebuild(main/rizin): Rebuild for tree-sitter 0.25

### DIFF
--- a/packages/rizin/build.sh
+++ b/packages/rizin/build.sh
@@ -3,9 +3,10 @@ TERMUX_PKG_DESCRIPTION="UNIX-like reverse engineering framework and command-line
 TERMUX_PKG_LICENSE="GPL-3.0, LGPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.7.4"
+TERMUX_PKG_REVISION=1
 # Use source tarball from release assets to get all bundled projects
 TERMUX_PKG_SRCURL=https://github.com/rizinorg/rizin/releases/download/v${TERMUX_PKG_VERSION}/rizin-src-v${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_DEPENDS="capstone, file, liblz4, liblzma, libzip, openssl, tree-sitter, xxhash, zlib, zstd"
+TERMUX_PKG_DEPENDS="capstone, file, libandroid-execinfo, liblz4, liblzma, libzip, openssl, tree-sitter, xxhash, zlib, zstd"
 TERMUX_PKG_SUGGESTS="python, apk-tools, apktool, apksigner"
 TERMUX_PKG_SHA256=f7118910e5dc843c38baa3e00b30ec019a1cdd5c132ba2bc16cf0c7497631201
 TERMUX_PKG_AUTO_UPDATE=true
@@ -27,3 +28,8 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Duse_sys_zlib=enabled
 -Duse_zlib=true
 "
+
+termux_step_pre_configure() {
+	# for backtrace and backtrace_symbols_fd
+	LDFLAGS+=" -landroid-execinfo"
+}


### PR DESCRIPTION
Add libandroid-execinfo dependency which fixes linking error.

ld.lld: error: undefined symbol: backtrace
ld.lld: error: undefined symbol: backtrace_symbols_fd

* See #23422 