### PR TITLE
bump(main/which): 2.23

### DIFF
--- a/packages/which/build.sh
+++ b/packages/which/build.sh
@@ -1,8 +1,9 @@
-TERMUX_PKG_HOMEPAGE=https://carlowood.github.io/which/
+TERMUX_PKG_HOMEPAGE=https://savannah.gnu.org/projects/which/
 TERMUX_PKG_DESCRIPTION="Shows the full path of (shell) commands"
-TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=2.21
-TERMUX_PKG_SRCURL=https://carlowood.github.io/which/which-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=f4a245b94124b377d8b49646bf421f9155d36aa7614b6ebf83705d3ffc76eaad
+TERMUX_PKG_VERSION=2.23
+TERMUX_PKG_SRCURL=https://ftp.gnu.org/gnu/which/which-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=a2c558226fc4d9e4ce331bd2fd3c3f17f955115d2c00e447618a4ef9978a2a73
 TERMUX_PKG_CONFLICTS="debianutils (<< 5.7-1)"
+TERMUX_PKG_AUTO_UPDATE=true


### PR DESCRIPTION
Change srcurl and homepage to the GNU upstream since the Github.io page for `which` has not been updated with the new version yet.
Also enables auto updates and fixes the license specifier.