### PR TITLE
fix(ci): slowdown graphql requests to avoid being ratelimited

### DIFF
--- a/scripts/updates/api/termux_github_api_get_tag.sh
+++ b/scripts/updates/api/termux_github_api_get_tag.sh
@@ -48,6 +48,9 @@ termux_github_api_get_tag() {
 	)
 
 	if [[ "${TAG_TYPE}" == "newest-tag" ]]; then
+		# We use graphql intensively so we should slowdown our requests to avoid hitting github ratelimits.
+		sleep 1
+
 		api_url="${api_url}/graphql"
 		jq_filter='.data.repository.refs.edges[0].node.name'
 		curl_opts+=(-X POST)
@@ -86,6 +89,7 @@ termux_github_api_get_tag() {
 			Allowed values: 'newest-tag', 'latest-release-tag'.
 		EndOfError
 	fi
+
 
 	local response
 	response="$(curl "${curl_opts[@]}" "${api_url}")"

--- a/scripts/updates/internal/termux_github_graphql.sh
+++ b/scripts/updates/internal/termux_github_graphql.sh
@@ -43,6 +43,9 @@ termux_github_graphql() {
 		# echo "// Batch: $BATCH" >> /tmp/query-12345 # Uncomment for debugging GraphQL queries
 		# printf '%s' "${QUERY}"  >> /tmp/query-12345 # Uncomment for debugging GraphQL queries
 
+		# We use graphql intensively so we should slowdown our requests to avoid hitting github ratelimits.
+		sleep 1
+
 		local response
 		response="$(printf '{ "query": "%s" }' "${QUERY//$'\n'/ }" | curl -fL \
 			--no-progress-meter \


### PR DESCRIPTION
And avoid shadowbanning of our dear @termuxbot2. They suffer when they can not work.

Fixes #23511, fixes #23510, fixes #23509, fixes #23507, fixes #23506, fixes #23505, fixes #23504, fixes #23503, fixes #23502, fixes #23501, fixes #23500, fixes #23498, fixes #23497

I'd like to merge this before the next auto-update cycle.
Since it is harmless and affects only auto-updater script execution time I will merge it in 6 hours if nobody minds.