### PR TITLE
fix(main/bgrep): fix build in 2025 (gnulib master branch)

### DIFF
--- a/packages/bgrep/build.sh
+++ b/packages/bgrep/build.sh
@@ -3,12 +3,16 @@ TERMUX_PKG_DESCRIPTION="Binary string grep tool"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.0
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=https://github.com/rsharo/bgrep/archive/bgrep-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=ba5ddae672e84bf2d8ce91429a4ce8a5e3a154ee7e64d1016420f7dc7481ec0a
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+"
 TERMUX_PKG_BUILD_IN_SRC=true
+
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+gl_cv_func_strcasecmp_works=yes
+"
 
 termux_step_pre_configure() {
 	./bootstrap


### PR DESCRIPTION
this software's build system, by default, clones the newest possible commit of gnulib, and then uses that during the build process. https://github.com/rsharo/bgrep/blob/440164692a52bac654eb75de7d16087d87649520/bootstrap#L638

that had been working up until recently, when the package began failing to build because of some changes entering the gnulib repository related to the `strcasecmp()` function. https://github.com/coreutils/gnulib/commit/b2927d1b1fa3fb09a2210a3df5691f7d48d6151b

That is not handled by the current version of `termux_step_configure_autotools()`, so an error began appearing, `configure: error: cannot run test program while cross compiling`. https://github.com/termux/termux-packages/blob/c2f2312c0894c85b68b671563a333205e0871f3d/scripts/build/configure/termux_step_configure_autotools.sh#L46-L101

As far as I am aware, `strcasecmp()` has always worked OK in bionic libc, so since this change works to prevent the build error, it seems like a reasonable way to proceed to me.