### PR TITLE
fix(main/texinfo): bump debian tar revision to 7.2-2

### DIFF
--- a/packages/texinfo/build.sh
+++ b/packages/texinfo/build.sh
@@ -3,14 +3,15 @@ TERMUX_PKG_DESCRIPTION="Documentation system for on-line information and printed
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="7.2"
-_DEBIAN_REVISION="-1"
+TERMUX_PKG_REVISION=1
+_DEBIAN_REVISION="-2"
 TERMUX_PKG_SRCURL=(
 	https://mirrors.kernel.org/gnu/texinfo/texinfo-${TERMUX_PKG_VERSION}.tar.xz
 	https://deb.debian.org/debian/pool/main/t/texinfo/texinfo_${TERMUX_PKG_VERSION}${_DEBIAN_REVISION}.debian.tar.xz
 )
 TERMUX_PKG_SHA256=(
 	0329d7788fbef113fa82cb80889ca197a344ce0df7646fe000974c5d714363a6
-	1d0c8ad2a7614595b13e690a423505f10c90f4ede222d2915eab66de5aa51117
+	8654692fcc7f8b4bb042a3412ca3c9fa862ff65482896ef1ea50d59d08934824
 )
 TERMUX_PKG_AUTO_UPDATE=true
 # gawk is used by texindex:


### PR DESCRIPTION
https://deb.debian.org/debian/pool/main/t/texinfo/texinfo_7.2-1.debian.tar.xz currently has 404, so this replaces it with https://deb.debian.org/debian/pool/main/t/texinfo/texinfo_7.2-2.debian.tar.xz which is not 404.
