### PR TITLE
addpkg(x11/lxqt-wayland-session): 0.1.1

### DIFF
--- a/x11-packages/lxqt-wayland-session/0001-fix-hardcoded-paths.patch
+++ b/x11-packages/lxqt-wayland-session/0001-fix-hardcoded-paths.patch
@@ -1,0 +1,65 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -40,11 +40,11 @@
+ 
+ # startlxqtwayland script
+ set(PREDEF_XDG_DATA_DIRS "$XDG_DATA_HOME")
+-if(NOT("${LXQT_DATA_DIR}" MATCHES "^/usr(/local)?/share$"))
++if(NOT("${LXQT_DATA_DIR}" MATCHES "^@TERMUX_PREFIX@(/local)?/share$"))
+     set(PREDEF_XDG_DATA_DIRS "${PREDEF_XDG_DATA_DIRS}:${LXQT_DATA_DIR}")
+ endif()
+-set(PREDEF_XDG_DATA_DIRS "${PREDEF_XDG_DATA_DIRS}:/usr/local/share:/usr/share")
+-set(PREDEF_XDG_CONFIG_DIRS "/etc:${LXQT_ETC_XDG_DIR}:/usr/share")
++set(PREDEF_XDG_DATA_DIRS "${PREDEF_XDG_DATA_DIRS}:@TERMUX_PREFIX@/local/share:@TERMUX_PREFIX@/share")
++set(PREDEF_XDG_CONFIG_DIRS "@TERMUX_PREFIX@/etc:${LXQT_ETC_XDG_DIR}:@TERMUX_PREFIX@/share")
+ configure_file(startlxqtwayland.in startlxqtwayland @ONLY)
+ install(PROGRAMS
+     "${CMAKE_CURRENT_BINARY_DIR}/startlxqtwayland"
+--- a/configurations/labwc/autostart
++++ b/configurations/labwc/autostart
+@@ -3,7 +3,7 @@
+ # Preferred place for starting wayland-only applications
+ 
+ # Set background color or image (below the desktop):
+-swaybg -i /usr/share/lxqt/wallpapers/origami-dark-labwc.png  >/dev/null 2>&1 &
++swaybg -i @TERMUX_PREFIX@/share/lxqt/wallpapers/origami-dark-labwc.png  >/dev/null 2>&1 &
+ 
+ # Faster startup for GTK apps:
+ dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY > /dev/null 2>&1 &
+--- a/startlxqtwayland.in
++++ b/startlxqtwayland.in
+@@ -16,19 +16,19 @@
+ fi
+ 
+ if [ -z "$XDG_DATA_DIRS" ]; then
+-    XDG_DATA_DIRS="$XDG_DATA_HOME:/usr/local/share:/usr/share"
++    XDG_DATA_DIRS="$XDG_DATA_HOME:@TERMUX_PREFIX@/local/share:@TERMUX_PREFIX@/share"
+ else
+-    if ! contains "$XDG_DATA_DIRS" "/usr/share"; then
+-        XDG_DATA_DIRS="$XDG_DATA_DIRS:/usr/share"
++    if ! contains "$XDG_DATA_DIRS" "@TERMUX_PREFIX@/share"; then
++        XDG_DATA_DIRS="$XDG_DATA_DIRS:@TERMUX_PREFIX@/share"
+     fi
+ fi
+ export XDG_DATA_DIRS
+ 
+ if [ -z "$XDG_CONFIG_DIRS" ]; then
+-    export XDG_CONFIG_DIRS="/etc:/etc/xdg:/usr/share"
++    export XDG_CONFIG_DIRS="@TERMUX_PREFIX@/etc:@TERMUX_PREFIX@/etc/xdg:@TERMUX_PREFIX@/share"
+ else
+-    if ! contains "$XDG_CONFIG_DIRS" '/etc/xdg'; then
+-        XDG_CONFIG_DIRS="$XDG_CONFIG_DIRS:/etc/xdg"
++    if ! contains "$XDG_CONFIG_DIRS" '@TERMUX_PREFIX@/etc/xdg'; then
++        XDG_CONFIG_DIRS="$XDG_CONFIG_DIRS:@TERMUX_PREFIX@/etc/xdg"
+     fi
+ fi
+ 
+@@ -79,7 +79,7 @@
+ 
+ share_dir="$(dirname $(dirname "$0"))"/share
+ 
+-valid_layouts=$(grep -A98 '! layout' /usr/share/X11/xkb/rules/base.lst | awk '{print $1}' | grep -v '!')
++valid_layouts=$(grep -A98 '! layout' @TERMUX_PREFIX@/share/X11/xkb/rules/base.lst | awk '{print $1}' | grep -v '!')
+ trylayout=$(echo $LANG | cut -c 1,2)
+ 
+ if  [ -z "$COMPOSITOR" ]; then

--- a/x11-packages/lxqt-wayland-session/build.sh
+++ b/x11-packages/lxqt-wayland-session/build.sh
@@ -1,0 +1,12 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/lxqt/lxqt-wayland-session
+TERMUX_PKG_DESCRIPTION="Files needed for the LXQt Wayland Session"
+TERMUX_PKG_LICENSE="BSD 3-Clause, GPL-2.0, GPL-3.0, LGPL-2.1, MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.1.1"
+TERMUX_PKG_SRCURL=https://github.com/lxqt/lxqt-wayland-session/releases/download/${TERMUX_PKG_VERSION}/lxqt-wayland-session-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=34e9441a7d4bdf243e4a380a10d00e746e4ef43a1a6ccda1c8e6c6bc3c513fbc
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_DEPENDS="layer-shell-qt, lxqt-session, qtxdg-tools"
+TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt6-qttools"
+TERMUX_PKG_SUGGESTS="labwc, sway"


### PR DESCRIPTION
* Screenshot of qterminal in lxqt wayland session

![image](https://github.com/user-attachments/assets/0e2e68d9-a0fb-40ec-9206-f5a163c98dc1)

xfce4 already works in wayland session in termux-x11. This would allow to do so with lxqt now. Also, this help to test basic features in labwc and sway compositors in termux-x11.