### PR TITLE
fix(main/termux-exec): the checksum has changed because the repository was renamed

### DIFF
--- a/packages/termux-exec/build.sh
+++ b/packages/termux-exec/build.sh
@@ -1,10 +1,11 @@
-TERMUX_PKG_HOMEPAGE=https://github.com/termux/termux-exec
+TERMUX_PKG_HOMEPAGE=https://github.com/termux/termux-exec-package
 TERMUX_PKG_DESCRIPTION="An execve() wrapper to make /bin and /usr/bin shebangs work"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1:1.0
-TERMUX_PKG_SRCURL=https://github.com/termux/termux-exec/archive/v${TERMUX_PKG_VERSION:2}.tar.gz
-TERMUX_PKG_SHA256=b977592f197bf3a87e8a005ea0ccefb3e144edc81d5e3dc8d1ad1a12512f4a68
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=https://github.com/termux/termux-exec-package/archive/v${TERMUX_PKG_VERSION:2}.tar.gz
+TERMUX_PKG_SHA256=175d7c9eac6f9fc3b949d1a2cee5f5d3ace61420d418d8213369eb6aff18d28f
 TERMUX_PKG_ESSENTIAL=true
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_MAKE_ARGS="TERMUX_PREFIX=${TERMUX_PREFIX} TERMUX_BASE_DIR=${TERMUX_BASE_DIR}"


### PR DESCRIPTION
the repository name being changed from github.com/termux/termux-exec to github.com/termux/termux-exec-package causes the source archive checksum to change, because previously the archive contained a folder named "termux-exec-1.0" and now it contains a folder named "termux-exec-package-1.0" instead.