### PR TITLE
fix(main/pass-otp): Rename `$PREFIX` variable to `$PASS_PREFIX`

### DIFF
--- a/packages/pass-otp/build.sh
+++ b/packages/pass-otp/build.sh
@@ -1,9 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/tadfisher/pass-otp
 TERMUX_PKG_DESCRIPTION="A pass extension for managing one-time-password (OTP) tokens"
-TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_LICENSE="GPL-3.0-or-later"
 TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
 TERMUX_PKG_VERSION=1.2.0
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=https://github.com/tadfisher/pass-otp/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=5720a649267a240a4f7ba5a6445193481070049c1d08ba38b00d20fc551c3a67
 TERMUX_PKG_AUTO_UPDATE=true
@@ -14,4 +14,11 @@ TERMUX_PKG_PLATFORM_INDEPENDENT=true
 
 termux_step_pre_configure() {
 	export BASHCOMPDIR=$TERMUX_PREFIX/etc/bash_completion.d
+}
+
+termux_step_post_configure() {
+	# Replace $PREFIX with $PASS_PREFIX
+	# to avoid variable name conflicts with Termux's $PREFIX
+	# See: https://github.com/termux/termux-packages/issues/23569
+	sed -i "s|PREFIX|PASS_PREFIX|g" otp.bash
 }


### PR DESCRIPTION
When `$PREFIX` (an internal `pass` variable, not to be confused with Termux's `$PREFIX`) was renamed to `$PASS_PREFIX` in ddf79220de5650775849b294c6f02f304d0d83bc, `pass-otp` was not modified to reflect that, which caused all `pass otp` commands to look for the password file in Termux's `$PREFIX` instead of `$PASS_PREFIX`, resulting in `passfile not found` errors.

I have also updated the license as the source code says that using a later version is permitted.

See also: #23569