### PR TITLE
rmpkg(main/libutf8-range): merge back into libprotobuf

### DIFF
--- a/packages/libprotobuf/build.sh
+++ b/packages/libprotobuf/build.sh
@@ -9,12 +9,13 @@ TERMUX_PKG_MAINTAINER="@termux"
 #     $TERMUX_SCRIPTDIR/scripts/build/setup/termux_setup_protobuf.sh
 # - ALWAYS bump revision of reverse dependencies and rebuild them.
 TERMUX_PKG_VERSION="2:30.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/protocolbuffers/protobuf/archive/v${TERMUX_PKG_VERSION#*:}.tar.gz
 TERMUX_PKG_SHA256=9df0e9e8ebe39f4fbbb9cf7db3d811287fe3616b2f191eb2bf5eaa12539c881f
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_DEPENDS="abseil-cpp, libc++, zlib"
-TERMUX_PKG_BREAKS="libprotobuf-dev, protobuf-static (<< ${TERMUX_PKG_VERSION#*:})"
-TERMUX_PKG_REPLACES="libprotobuf-dev"
+TERMUX_PKG_BREAKS="libprotobuf-dev, protobuf-static (<< ${TERMUX_PKG_VERSION#*:}), libutf8-range"
+TERMUX_PKG_REPLACES="libprotobuf-dev, libutf8-range"
 TERMUX_PKG_FORCE_CMAKE=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dprotobuf_ABSL_PROVIDER=package

--- a/packages/libprotobuf/libutf8-range.subpackage.sh
+++ b/packages/libprotobuf/libutf8-range.subpackage.sh
@@ -1,7 +1,0 @@
-TERMUX_SUBPKG_INCLUDE="
-include/utf8_*
-lib/cmake/utf8_*
-lib/libutf8_*
-share/doc/libutf8-range
-"
-TERMUX_SUBPKG_DESCRIPTION="Fast UTF-8 validation with Range algorithm"

--- a/x11-packages/opencv/build.sh
+++ b/x11-packages/opencv/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Open Source Computer Vision Library"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="4.11.0"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=(
 	https://github.com/opencv/opencv/archive/${TERMUX_PKG_VERSION}/opencv-${TERMUX_PKG_VERSION}.tar.gz
 	https://github.com/opencv/opencv_contrib/archive/${TERMUX_PKG_VERSION}/opencv_contrib-${TERMUX_PKG_VERSION}.tar.gz
@@ -16,7 +16,7 @@ TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="abseil-cpp, ffmpeg, libc++, libjpeg-turbo, libopenblas, libpng, libtiff, libwebp, openjpeg, openjpeg-tools, qt6-qtbase, qt6-qt5compat, zlib"
 # For static libprotobuf see
 # https://github.com/termux/termux-packages/issues/16979
-TERMUX_PKG_BUILD_DEPENDS="libutf8-range, protobuf-static, python-numpy-static"
+TERMUX_PKG_BUILD_DEPENDS="protobuf-static, python-numpy-static"
 TERMUX_PKG_PYTHON_COMMON_DEPS="Cython, wheel"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DANDROID_NO_TERMUX=OFF
@@ -45,7 +45,6 @@ termux_step_pre_configure() {
 
 	# Keep this the same version which abseil-cpp requires
 	CXXFLAGS+=" -std=c++17"
-	LDFLAGS+=" -lutf8_range -lutf8_validity"
 	LDFLAGS+=" $($TERMUX_SCRIPTDIR/packages/libprotobuf/interface_link_libraries.sh)"
 	LDFLAGS+=" -llog"
 


### PR DESCRIPTION
- Fixes #23668

Testing locally confirms that when `scripts/run-docker.sh ./build-package.sh -I -f libprotobuf` is run in a clean docker container, the resulting `libprotobuf.so` is linked to the `libutf8_validity.so`.