### PR TITLE
fix(main/{libncnn,opencv}): revert 'trap mv' libprotobuf.so workaroud change to previous construction

### DIFF
--- a/packages/libncnn/build.sh
+++ b/packages/libncnn/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=4b97730b0d033b4dc2a790e5c35745e0dbf51569
 TERMUX_PKG_VERSION="20230627"
-TERMUX_PKG_REVISION=8
+TERMUX_PKG_REVISION=9
 TERMUX_PKG_SRCURL=git+https://github.com/Tencent/ncnn
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_SHA256=a81ee5b6df97830919f8ed8554c99a4f223976ed82eee0cc9f214de0ce53dd2a
@@ -68,7 +68,6 @@ termux_step_pre_configure() {
 
 	# restoring file in termux_step_post_make_install
 	# will not be performed in the case of build errors
-	trap 'mv -f $TERMUX_PREFIX/lib/libprotobuf.so{.tmp,} || :' EXIT
 	mv $TERMUX_PREFIX/lib/libprotobuf.so{,.tmp}
 }
 
@@ -86,6 +85,8 @@ termux_step_post_make_install() {
 	pushd python
 	pip install --no-deps . --prefix "${TERMUX_PREFIX}"
 	popd
+
+	mv -v "${TERMUX_PREFIX}"/lib/libprotobuf.so{.tmp,}
 
 	return
 

--- a/packages/libprotobuf/build.sh
+++ b/packages/libprotobuf/build.sh
@@ -9,7 +9,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 #     $TERMUX_SCRIPTDIR/scripts/build/setup/termux_setup_protobuf.sh
 # - ALWAYS bump revision of reverse dependencies and rebuild them.
 TERMUX_PKG_VERSION="2:30.0"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/protocolbuffers/protobuf/archive/v${TERMUX_PKG_VERSION#*:}.tar.gz
 TERMUX_PKG_SHA256=9df0e9e8ebe39f4fbbb9cf7db3d811287fe3616b2f191eb2bf5eaa12539c881f
 TERMUX_PKG_AUTO_UPDATE=false

--- a/x11-packages/opencv/build.sh
+++ b/x11-packages/opencv/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Open Source Computer Vision Library"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="4.11.0"
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=(
 	https://github.com/opencv/opencv/archive/${TERMUX_PKG_VERSION}/opencv-${TERMUX_PKG_VERSION}.tar.gz
 	https://github.com/opencv/opencv_contrib/archive/${TERMUX_PKG_VERSION}/opencv_contrib-${TERMUX_PKG_VERSION}.tar.gz
@@ -61,8 +61,11 @@ termux_step_pre_configure() {
 
 	# restoring file in termux_step_post_make_install
 	# will not be performed in the case of build errors
-	trap 'mv -f $TERMUX_PREFIX/lib/libprotobuf.so{.tmp,}  || :' EXIT
 	mv $TERMUX_PREFIX/lib/libprotobuf.so{,.tmp}
+}
+
+termux_step_post_make_install() {
+	mv $TERMUX_PREFIX/lib/libprotobuf.so{.tmp,}
 }
 
 termux_step_post_massage() {


### PR DESCRIPTION


- Fixes #23681

- Tested locally:

```
docker container kill termux-package-builder
docker container rm termux-package-builder
scripts/run-docker.sh ./build-package.sh -I -f libprotobuf libncnn opencv
```

```
~ $ pkg install ./opencv_4.11.0-4_aarch64.deb ./libncnn_20230627-9_aarch64.deb
...
Get:1 /data/data/com.termux/files/home/opencv_4.11.0-4_aarch64.deb opencv aarch64 4.11.0-4 [13.4 MB]
Get:2 /data/data/com.termux/files/home/libncnn_20230627-9_aarch64.deb libncnn aarch64 20230627-9 [2418 kB]
(Reading database ... 228480 files and directories currently installed.)
Preparing to unpack .../opencv_4.11.0-4_aarch64.deb ...
Unpacking opencv (4.11.0-4) over (4.11.0-3) ...
Preparing to unpack .../libncnn_20230627-9_aarch64.deb ...
Unpacking libncnn (20230627-9) ...
Setting up glslang (15.1.0) ...
Setting up libncnn (20230627-9) ...
Setting up opencv (4.11.0-4) ...
```

- partial revert of https://github.com/termux/termux-packages/commit/ebc10e1ab05dbb6acd04c9344ce25b250e15c185 and https://github.com/termux/termux-packages/commit/be433c037374a108832bb6a7e4e9ec4b10925928