### PR TITLE
bump(main/coreutils): 9.6

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -183,10 +183,13 @@
 /packages/bash-completion/ @TomJo2000
 /packages/bash/ @TomJo2000
 /packages/borgbackup/ @TomJo2000
+/packages/coreutils/ @TomJo2000
 /packages/eza/ @TomJo2000
 /packages/git-delta/ @TomJo2000
 /packages/gopass/ @TomJo2000
+/packages/gopls/ @TomJo2000
 /packages/less/ @TomJo2000
+/packages/lesspipe/ @TomJo2000
 /packages/lua-language-server/ @TomJo2000
 /packages/lua-lpeg/ @TomJo2000
 /packages/moreutils/ @TomJo2000
@@ -198,13 +201,15 @@
 /packages/openssh/ @TomJo2000
 /packages/rip2/ @TomJo2000
 /packages/rsgain/ @TomJo2000
+/packages/rsync/ @TomJo2000
 /packages/shellcheck/ @TomJo2000
 /packages/starship/ @TomJo2000
 /packages/taplo/ @TomJo2000
+/packages/tinymist/ @TomJo2000
 /packages/tmux/ @TomJo2000
 /packages/tree-sitter* @TomJo2000
-/packages/typst-lsp/ @TomJo2000
 /packages/typstfmt/ @TomJo2000
+/packages/vim/ @TomJo2000
 /packages/zls/ @TomJo2000
 /packages/zrok/ @TomJo2000
 /packages/zsh/ @TomJo2000
@@ -212,6 +217,7 @@
 /x11-packages/jwm/ @TomJo2000
 /x11-packages/mpv-x/ @TomJo2000
 /x11-packages/qbittorrent/ @TomJo2000
+/x11-packages/vim-gtk/ @TomJo2000
 
 # Packages owned by @PeroSar
 /packages/gitui/ @PeroSar

--- a/packages/coreutils/backport-915004f.patch
+++ b/packages/coreutils/backport-915004f.patch
@@ -1,0 +1,98 @@
+From 915004f403cb25fadb207ddfdbe6a2f43bd44fac Mon Sep 17 00:00:00 2001
+From: =?utf8?q?P=C3=A1draig=20Brady?= <P@draigBrady.com>
+Date: Fri, 17 Jan 2025 17:29:34 +0000
+Subject: [PATCH] ls: fix crash with --context
+
+* src/ls.c (main): Flag that we need to stat()
+if we're going to get security context (call file_has_aclinfo_cache).
+(file_has_aclinfo_cache): Be defensive and only lookup the device
+for the file if the stat has been performed.
+(has_capability_cache): Likewise.
+* tests/ls/selinux-segfault.sh: Add a test case.
+* NEWS: Mention the bug fix.
+Reported by Bruno Haible.
+---
+ NEWS                         |  5 +++++
+ src/ls.c                     | 10 +++++-----
+ tests/ls/selinux-segfault.sh |  3 +++
+ 3 files changed, 13 insertions(+), 5 deletions(-)
+
+diff --git a/NEWS b/NEWS
+index 9be61e4c4..c9ba5f196 100644
+--- a/NEWS
++++ b/NEWS
+@@ -2,6 +2,11 @@ GNU coreutils NEWS                                    -*- outline -*-
+ 
+ * Noteworthy changes in release ?.? (????-??-??) [?]
+ 
++** Bug fixes
++
++  `ls -Z dir` would crash.
++  [bug introduced in coreutils-9.6]
++
+ 
+ * Noteworthy changes in release 9.6 (2025-01-17) [stable]
+ 
+diff --git a/src/ls.c b/src/ls.c
+index 321536021..f67167f16 100644
+--- a/src/ls.c
++++ b/src/ls.c
+@@ -1768,7 +1768,7 @@ main (int argc, char **argv)
+ 
+   format_needs_stat = ((sort_type == sort_time) | (sort_type == sort_size)
+                        | (format == long_format)
+-                       | print_block_size | print_hyperlink);
++                       | print_block_size | print_hyperlink | print_scontext);
+   format_needs_type = ((! format_needs_stat)
+                        & (recursive | print_with_color | print_scontext
+                           | directories_first
+@@ -3309,7 +3309,7 @@ file_has_aclinfo_cache (char const *file, struct fileinfo *f,
+   static int unsupported_scontext_err;
+   static dev_t unsupported_device;
+ 
+-  if (f->stat.st_dev == unsupported_device)
++  if (f->stat_ok && f->stat.st_dev == unsupported_device)
+     {
+       ai->buf = ai->u.__gl_acl_ch;
+       ai->size = 0;
+@@ -3322,7 +3322,7 @@ file_has_aclinfo_cache (char const *file, struct fileinfo *f,
+   errno = 0;
+   int n = file_has_aclinfo (file, ai, flags);
+   int err = errno;
+-  if (n <= 0 && !acl_errno_valid (err))
++  if (f->stat_ok && n <= 0 && !acl_errno_valid (err))
+     {
+       unsupported_return = n;
+       unsupported_scontext = ai->scontext;
+@@ -3342,14 +3342,14 @@ has_capability_cache (char const *file, struct fileinfo *f)
+      found that has_capability fails indicating lack of support.  */
+   static dev_t unsupported_device;
+ 
+-  if (f->stat.st_dev == unsupported_device)
++  if (f->stat_ok && f->stat.st_dev == unsupported_device)
+     {
+       errno = ENOTSUP;
+       return 0;
+     }
+ 
+   bool b = has_capability (file);
+-  if ( !b && !acl_errno_valid (errno))
++  if (f->stat_ok && !b && !acl_errno_valid (errno))
+     unsupported_device = f->stat.st_dev;
+   return b;
+ }
+diff --git a/tests/ls/selinux-segfault.sh b/tests/ls/selinux-segfault.sh
+index 11623acb3..1cac2b5fc 100755
+--- a/tests/ls/selinux-segfault.sh
++++ b/tests/ls/selinux-segfault.sh
+@@ -30,4 +30,7 @@ mkdir sedir || framework_failure_
+ ln -sf missing sedir/broken || framework_failure_
+ returns_ 1 ls -L -R -Z -m sedir > out || fail=1
+ 
++# ls 9.6 would segfault with the following
++ls -Z . > out || fail=1
++
+ Exit $fail
+-- 
+2.17.1
+

--- a/packages/coreutils/build.sh
+++ b/packages/coreutils/build.sh
@@ -1,11 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/coreutils/
 TERMUX_PKG_DESCRIPTION="Basic file, shell and text manipulation utilities from the GNU project"
 TERMUX_PKG_LICENSE="GPL-3.0"
-TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=9.5
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
+TERMUX_PKG_VERSION=9.6
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/coreutils/coreutils-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=cd328edeac92f6a665de9f323c93b712af1858bc2e0d88f3f7100469470a1b8a
+TERMUX_PKG_SHA256=7a0124327b398fd9eb1a6abde583389821422c744ffa10734b24f557610d3283
 TERMUX_PKG_DEPENDS="libandroid-selinux, libandroid-support, libgmp, libiconv"
 TERMUX_PKG_BREAKS="chroot, busybox (<< 1.30.1-4)"
 TERMUX_PKG_REPLACES="chroot, busybox (<< 1.30.1-4)"

--- a/packages/coreutils/selinux.patch
+++ b/packages/coreutils/selinux.patch
@@ -1,6 +1,8 @@
---- coreutils-9.5.orig/src/cp.c
-+++ coreutils-9.5/src/cp.c
-@@ -994,7 +992,7 @@
+diff --git a/src/cp.c b/src/cp.c
+index a0ec06714..da3f6a8a7 100644
+--- a/src/cp.c
++++ b/src/cp.c
+@@ -993,7 +993,7 @@ main (int argc, char **argv)
  
    atexit (close_stdin);
  
@@ -9,7 +11,7 @@
    cp_option_init (&x);
  
    while ((c = getopt_long (argc, argv, "abdfHilLnprst:uvxPRS:TZ",
-@@ -1201,7 +1197,7 @@
+@@ -1174,7 +1174,7 @@ main (int argc, char **argv)
              {
                error (0, 0,
                       _("warning: ignoring --context; "
@@ -18,7 +20,7 @@
              }
            break;
  
-@@ -1277,7 +1273,7 @@
+@@ -1253,7 +1253,7 @@ main (int argc, char **argv)
    if (x.require_preserve_context && ! selinux_enabled)
      error (EXIT_FAILURE, 0,
             _("cannot preserve security context "
@@ -27,9 +29,53 @@
  
    /* FIXME: This handles new files.  But what about existing files?
       I.e., if updating a tree, new files would have the specified context,
---- coreutils-9.5.orig/src/mkdir.c
-+++ coreutils-9.5/src/mkdir.c
-@@ -228,7 +228,7 @@
+diff --git a/src/install.c b/src/install.c
+index b3b26abdb..11caa873b 100644
+--- a/src/install.c
++++ b/src/install.c
+@@ -325,6 +325,10 @@ setdefaultfilecon (char const *file)
+   struct stat st;
+   char *scontext_raw = nullptr;
+ 
++  /* NOTE: Return early, before `install`'s selinux logic,
++   * because we do not have suitable workaround for it */
++  return;
++
+   if (selinux_enabled != 1)
+     {
+       /* Indicate no context found. */
+@@ -789,7 +793,7 @@ main (int argc, char **argv)
+   bool strip_program_specified = false;
+   char const *scontext = nullptr;
+   /* set iff kernel has extra selinux system calls */
+-  selinux_enabled = (0 < is_selinux_enabled ());
++  selinux_enabled = (0 < is_selinux_enabled () && geteuid () == 0);
+ 
+   initialize_main (&argc, &argv);
+   set_program_name (argv[0]);
+@@ -876,7 +880,7 @@ main (int argc, char **argv)
+           if (! selinux_enabled)
+             {
+               error (0, 0, _("WARNING: ignoring --preserve-context; "
+-                             "this kernel is not SELinux-enabled"));
++                             "this kernel is not SELinux-enabled, or you are using Termux and not running as root"));
+               break;
+             }
+           x.preserve_security_context = true;
+@@ -902,7 +906,7 @@ main (int argc, char **argv)
+             {
+               error (0, 0,
+                      _("warning: ignoring --context; "
+-                       "it requires an SELinux-enabled kernel"));
++                       "it requires an SELinux-enabled kernel and root access"));
+             }
+           break;
+         case_GETOPT_HELP_CHAR;
+diff --git a/src/mkdir.c b/src/mkdir.c
+index df4c81976..7225c21b7 100644
+--- a/src/mkdir.c
++++ b/src/mkdir.c
+@@ -228,7 +228,7 @@ main (int argc, char **argv)
                /* We don't yet support -Z to restore context with SMACK.  */
                scontext = optarg;
              }
@@ -38,7 +84,7 @@
              {
                if (optarg)
                  scontext = optarg;
-@@ -244,7 +244,7 @@
+@@ -244,7 +244,7 @@ main (int argc, char **argv)
              {
                error (0, 0,
                       _("warning: ignoring --context; "
@@ -47,9 +93,11 @@
              }
            break;
          case_GETOPT_HELP_CHAR;
---- coreutils-9.5.orig/src/mkfifo.c
-+++ coreutils-9.5/src/mkfifo.c
-@@ -102,7 +102,7 @@
+diff --git a/src/mkfifo.c b/src/mkfifo.c
+index 52bfa566a..fad605386 100644
+--- a/src/mkfifo.c
++++ b/src/mkfifo.c
+@@ -102,7 +102,7 @@ main (int argc, char **argv)
                /* We don't yet support -Z to restore context with SMACK.  */
                scontext = optarg;
              }
@@ -58,7 +106,7 @@
              {
                if (optarg)
                  scontext = optarg;
-@@ -118,7 +118,7 @@
+@@ -118,7 +118,7 @@ main (int argc, char **argv)
              {
                error (0, 0,
                       _("warning: ignoring --context; "
@@ -67,9 +115,11 @@
              }
            break;
          case_GETOPT_HELP_CHAR;
---- coreutils-9.5.orig/src/mknod.c
-+++ coreutils-9.5/src/mknod.c
-@@ -119,7 +119,7 @@
+diff --git a/src/mknod.c b/src/mknod.c
+index 6bfa0f7f7..6ff36f21c 100644
+--- a/src/mknod.c
++++ b/src/mknod.c
+@@ -119,7 +119,7 @@ main (int argc, char **argv)
                /* We don't yet support -Z to restore context with SMACK.  */
                scontext = optarg;
              }
@@ -78,7 +128,7 @@
              {
                if (optarg)
                  scontext = optarg;
-@@ -135,7 +135,7 @@
+@@ -135,7 +135,7 @@ main (int argc, char **argv)
              {
                error (0, 0,
                       _("warning: ignoring --context; "
@@ -87,9 +137,11 @@
              }
            break;
          case_GETOPT_HELP_CHAR;
---- coreutils-9.5.orig/src/mv.c
-+++ coreutils-9.5/src/mv.c
-@@ -120,7 +120,7 @@
+diff --git a/src/mv.c b/src/mv.c
+index cf1ac56e8..4b68574e0 100644
+--- a/src/mv.c
++++ b/src/mv.c
+@@ -120,7 +120,7 @@ rm_option_init (struct rm_options *x)
  static void
  cp_option_init (struct cp_options *x)
  {
@@ -98,18 +150,20 @@
  
    cp_options_default (x);
    x->copy_as_regular = false;  /* FIXME: maybe make this an option */
-@@ -326,7 +326,7 @@
+@@ -326,7 +326,7 @@ main (int argc, char **argv)
    bool no_target_directory = false;
    int n_files;
    char **file;
 -  bool selinux_enabled = (0 < is_selinux_enabled ());
 +  bool selinux_enabled = (0 < is_selinux_enabled () && geteuid () == 0);
-   bool no_clobber = false;
  
    initialize_main (&argc, &argv);
---- coreutils-9.5.orig/src/runcon.c
-+++ coreutils-9.5/src/runcon.c
-@@ -190,8 +190,8 @@
+   set_program_name (argv[0]);
+diff --git a/src/runcon.c b/src/runcon.c
+index 32c419427..b62538a41 100644
+--- a/src/runcon.c
++++ b/src/runcon.c
+@@ -190,8 +190,8 @@ main (int argc, char **argv)
        usage (EXIT_CANCELED);
      }
  
@@ -120,42 +174,3 @@
             program_name);
  
    if (context)
---- coreutils-9.5.orig/src/install.c
-+++ coreutils-9.5/src/install.c
-@@ -325,6 +325,9 @@
-   struct stat st;
-   char *scontext_raw = nullptr;
- 
-+  /* FIXME: Return early for now until a suitable workaround has been found */
-+  return;
-+
-   if (selinux_enabled != 1)
-     {
-       /* Indicate no context found. */
-@@ -789,7 +792,7 @@
-   bool strip_program_specified = false;
-   char const *scontext = nullptr;
-   /* set iff kernel has extra selinux system calls */
--  selinux_enabled = (0 < is_selinux_enabled ());
-+  selinux_enabled = (0 < is_selinux_enabled () && geteuid () == 0);
- 
-   initialize_main (&argc, &argv);
-   set_program_name (argv[0]);
-@@ -876,7 +879,7 @@
-           if (! selinux_enabled)
-             {
-               error (0, 0, _("WARNING: ignoring --preserve-context; "
--                             "this kernel is not SELinux-enabled"));
-+                             "it requires an SELinux-enabled kernel and root access"));
-               break;
-             }
-           x.preserve_security_context = true;
-@@ -902,7 +905,7 @@
-             {
-               error (0, 0,
-                      _("warning: ignoring --context; "
--                       "it requires an SELinux-enabled kernel"));
-+                       "it requires an SELinux-enabled kernel and root access"));
-             }
-           break;
-         case_GETOPT_HELP_CHAR;


### PR DESCRIPTION
- Add maintainer so we hopefully get this done in a more timely manner next time.
- Ported `selinux.patch`.
Having it as a `git diff` patch should hopefully make porting it easier in the future since it allows `git apply -3` to create a merge conflict out of the conflicting hunks.

> [!IMPORTANT]
> Essential package update checklist 
> - [x] Builds locally
> - [x] Builds on CI
> - [x] Tested on device (AArch64, Android 14, Fairphone 5)
