### PR TITLE
fix(main/doge): update checksum after repository name changed

### DIFF
--- a/packages/doge/build.sh
+++ b/packages/doge/build.sh
@@ -1,11 +1,12 @@
-TERMUX_PKG_HOMEPAGE=https://github.com/Dj-Codeman/doge
+TERMUX_PKG_HOMEPAGE=https://github.com/Dj-Codeman/dog_community
 TERMUX_PKG_DESCRIPTION="A command-line DNS client"
 TERMUX_PKG_LICENSE="EUPL-1.2"
 TERMUX_PKG_LICENSE_FILE="LICENCE"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.2.8
-TERMUX_PKG_SRCURL=https://github.com/Dj-Codeman/doge/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_SHA256=4cc82936a7258aa182de9ff48562d7423e8afe1dfd1095e1fe9114e636a67f96
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=https://github.com/Dj-Codeman/dog_community/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=4ad82572271bc4601ac3b9b5f68be83f2659bdb5370c1b19297ecf3bd964f957
 TERMUX_PKG_REPLACES="dog"
 TERMUX_PKG_DEPENDS="openssl, resolv-conf"
 TERMUX_PKG_BUILD_IN_SRC=true


### PR DESCRIPTION
- Progress on #23492

The GitHub repository name has been changed by its author from "doge" to "dog_community", which is an action that changes the checksum of the already-released archives retroactively.