### PR TITLE
chore(main/libandroid-stub): turn libandroid-stub into library-wrapper

### DIFF
--- a/packages/libandroid-stub/build.sh
+++ b/packages/libandroid-stub/build.sh
@@ -5,41 +5,16 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Version should be equal to TERMUX_NDK_{VERSION_NUM,REVISION} in
 # scripts/properties.sh
 TERMUX_PKG_VERSION=27c
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://dl.google.com/android/repository/android-ndk-r${TERMUX_PKG_VERSION}-linux.zip
-TERMUX_PKG_SHA256=59c2f6dc96743b5daf5d1626684640b20a6bd2b1d85b13156b90333741bad5cc
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_CONFLICTS="libandroid"
 TERMUX_PKG_REPLACES="libandroid"
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_SKIP_SRC_EXTRACT=true
+TERMUX_PKG_API_LEVEL=28
 
-termux_step_get_source() {
-	mkdir -p "$TERMUX_PKG_SRCDIR"
-	if [ "$TERMUX_ON_DEVICE_BUILD" = "true" ]; then
-		termux_download_src_archive
-		cd $TERMUX_PKG_TMPDIR
-		termux_extract_src_archive
-	else
-		local lib_path="toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/${TERMUX_HOST_PLATFORM}/${TERMUX_PKG_API_LEVEL}"
-		mkdir -p "$TERMUX_PKG_SRCDIR"/"$lib_path"
-		cp "$NDK"/"$lib_path"/libandroid.so "$TERMUX_PKG_SRCDIR"/"$lib_path"
-		cp "$NDK"/"$lib_path"/libmediandk.so "$TERMUX_PKG_SRCDIR"/"$lib_path"
-	fi
+termux_step_make() {
+	"${CC}" -shared -fPIC -o "${TERMUX_PREFIX}/lib/libandroid.so" "$TERMUX_PKG_BUILDER_DIR/libandroid-wrapper.c" -Wno-deprecated-declarations
+	"${CC}" -shared -fPIC -o "${TERMUX_PREFIX}/lib/libmediandk.so" "$TERMUX_PKG_BUILDER_DIR/libmediandk-wrapper.c" -Wno-deprecated-declarations
+	"${CC}" -shared -fPIC -o "${TERMUX_PREFIX}/lib/libOpenSLES.so" "$TERMUX_PKG_BUILDER_DIR/libOpenSLES-wrapper.c" -Wno-deprecated-declarations
 }
-
-termux_step_post_make_install() {
-	install -v -Dm644 \
-		"toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/${TERMUX_HOST_PLATFORM}/${TERMUX_PKG_API_LEVEL}/libandroid.so" \
-		"${TERMUX_PREFIX}/lib/libandroid.so"
-	install -v -Dm644 \
-		"toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/${TERMUX_HOST_PLATFORM}/${TERMUX_PKG_API_LEVEL}/libmediandk.so" \
-		"${TERMUX_PREFIX}/lib/libmediandk.so"
-}
-
-# Please do NOT depend on this package; do NOT include this package in
-# TERMUX_PKG_{DEPENDS,RECOMMENDS} of other packages.
-#
-# This package is useful for:
-# 1. filling missing libandroid.so in environments like Termux Docker
-# 2. workaround package issues caused by pulling system libs that
-#    conflict Termux libs as a result of pulling system libandroid.so

--- a/packages/libandroid-stub/libOpenSLES-wrapper.c
+++ b/packages/libandroid-stub/libOpenSLES-wrapper.c
@@ -1,0 +1,111 @@
+#include <dlfcn.h>
+#include <stdio.h>
+
+// const attribute will not let us modify our variables
+#define const
+
+#include <SLES/OpenSLES.h>
+#include <SLES/OpenSLES_Android.h>
+
+#ifdef __LP64__
+#define LIB "/system/lib64/libOpenSLES.so"
+#else
+#define LIB "/system/lib/libOpenSLES.so"
+#endif
+
+#define IIDS(s) \
+    s(SL_IID_3DCOMMIT) \
+    s(SL_IID_3DDOPPLER) \
+    s(SL_IID_3DGROUPING) \
+    s(SL_IID_3DLOCATION) \
+    s(SL_IID_3DMACROSCOPIC) \
+    s(SL_IID_3DSOURCE) \
+    s(SL_IID_ANDROIDACOUSTICECHOCANCELLATION) \
+    s(SL_IID_ANDROIDAUTOMATICGAINCONTROL) \
+    s(SL_IID_ANDROIDBUFFERQUEUESOURCE) \
+    s(SL_IID_ANDROIDCONFIGURATION) \
+    s(SL_IID_ANDROIDEFFECT) \
+    s(SL_IID_ANDROIDEFFECTCAPABILITIES) \
+    s(SL_IID_ANDROIDEFFECTSEND) \
+    s(SL_IID_ANDROIDNOISESUPPRESSION) \
+    s(SL_IID_ANDROIDSIMPLEBUFFERQUEUE) \
+    s(SL_IID_AUDIODECODERCAPABILITIES) \
+    s(SL_IID_AUDIOENCODER) \
+    s(SL_IID_AUDIOENCODERCAPABILITIES) \
+    s(SL_IID_AUDIOIODEVICECAPABILITIES) \
+    s(SL_IID_BASSBOOST) \
+    s(SL_IID_BUFFERQUEUE) \
+    s(SL_IID_DEVICEVOLUME) \
+    s(SL_IID_DYNAMICINTERFACEMANAGEMENT) \
+    s(SL_IID_DYNAMICSOURCE) \
+    s(SL_IID_EFFECTSEND) \
+    s(SL_IID_ENGINE) \
+    s(SL_IID_ENGINECAPABILITIES) \
+    s(SL_IID_ENVIRONMENTALREVERB) \
+    s(SL_IID_EQUALIZER) \
+    s(SL_IID_LED) \
+    s(SL_IID_METADATAEXTRACTION) \
+    s(SL_IID_METADATATRAVERSAL) \
+    s(SL_IID_MIDIMESSAGE) \
+    s(SL_IID_MIDIMUTESOLO) \
+    s(SL_IID_MIDITEMPO) \
+    s(SL_IID_MIDITIME) \
+    s(SL_IID_MUTESOLO) \
+    s(SL_IID_NULL) \
+    s(SL_IID_OBJECT) \
+    s(SL_IID_OUTPUTMIX) \
+    s(SL_IID_PITCH) \
+    s(SL_IID_PLAY) \
+    s(SL_IID_PLAYBACKRATE) \
+    s(SL_IID_PREFETCHSTATUS) \
+    s(SL_IID_PRESETREVERB) \
+    s(SL_IID_RATEPITCH) \
+    s(SL_IID_RECORD) \
+    s(SL_IID_SEEK) \
+    s(SL_IID_THREADSYNC) \
+    s(SL_IID_VIBRA) \
+    s(SL_IID_VIRTUALIZER) \
+    s(SL_IID_VISUALIZATION) \
+    s(SL_IID_VOLUME)
+
+#define IID(s) __typeof__(s) s;
+IIDS(IID)
+#undef IID
+
+#define FUNCTIONS(f) \
+    f(slCreateEngine) \
+    f(slQueryNumSupportedEngineInterfaces) \
+    f(slQuerySupportedEngineInterfaces)
+
+#define STUB(s) __typeof__(s)* s;
+static struct {
+    FUNCTIONS(STUB)
+} stubs;
+#undef STUB
+
+__attribute__((constructor)) static void init() {
+    void* handle = dlopen(LIB, RTLD_LOCAL);
+    // Nothing bad happened, normal case for termux-docker.
+    if (!handle)
+        return;
+    #define IID(s) s = *((SLInterfaceID*) dlsym(handle, #s));
+    IIDS(IID)
+    #undef IID
+    #define LOAD(s) stubs.s = dlsym(handle, #s);
+    FUNCTIONS(LOAD)
+    #undef LOAD
+}
+
+#define CALL(f, def, ...) if (!stubs.f) return def; else return (stubs.f)(__VA_ARGS__)
+
+SL_API SLresult SLAPIENTRY slCreateEngine(SLObjectItf *pEngine, SLuint32 numOptions, const SLEngineOption *pEngineOptions, SLuint32 numInterfaces, const SLInterfaceID *pInterfaceIds, const SLboolean* pInterfaceRequired) {
+    CALL(slCreateEngine, SL_RESULT_FEATURE_UNSUPPORTED, pEngine, numOptions, pEngineOptions, numInterfaces, pInterfaceIds, pInterfaceRequired);
+}
+
+SL_API SLresult SLAPIENTRY slQueryNumSupportedEngineInterfaces(SLuint32* pNumSupportedInterfaces) {
+    CALL(slQueryNumSupportedEngineInterfaces, SL_RESULT_FEATURE_UNSUPPORTED, pNumSupportedInterfaces);
+}
+
+SL_API SLresult SLAPIENTRY slQuerySupportedEngineInterfaces(SLuint32 index, SLInterfaceID* pInterfaceId) {
+    CALL(slQuerySupportedEngineInterfaces, SL_RESULT_FEATURE_UNSUPPORTED, index, pInterfaceId);
+}

--- a/packages/libandroid-stub/libandroid-wrapper.c
+++ b/packages/libandroid-stub/libandroid-wrapper.c
@@ -1,0 +1,1147 @@
+#include <dlfcn.h>
+#include <android/asset_manager.h>
+#include <android/asset_manager_jni.h>
+#include <android/choreographer.h>
+#include <android/configuration.h>
+#include <android/hardware_buffer.h>
+#include <android/hardware_buffer_jni.h>
+#include <android/input.h>
+#include <android/looper.h>
+#include <android/multinetwork.h>
+#include <android/native_activity.h>
+#include <android/native_window.h>
+#include <android/native_window_jni.h>
+#include <android/obb.h>
+#include <android/sensor.h>
+#include <android/sharedmem.h>
+#include <android/sharedmem_jni.h>
+#include <android/storage_manager.h>
+#include <android/surface_texture.h>
+#include <android/surface_texture_jni.h>
+#include <android/trace.h>
+
+#ifdef __LP64__
+#define LIB "/system/lib64/libandroid.so"
+#else
+#define LIB "/system/lib/libandroid.so"
+#endif
+
+#define FUNCTIONS(f) \
+    f(AAssetManager_openDir) \
+    f(AAssetManager_open) \
+    f(AAssetDir_getNextFileName) \
+    f(AAssetDir_rewind) \
+    f(AAssetDir_close) \
+    f(AAsset_read) \
+    f(AAsset_seek) \
+    f(AAsset_seek64) \
+    f(AAsset_close) \
+    f(AAsset_getBuffer) \
+    f(AAsset_getLength) \
+    f(AAsset_getLength64) \
+    f(AAsset_getRemainingLength) \
+    f(AAsset_getRemainingLength64) \
+    f(AAsset_openFileDescriptor) \
+    f(AAsset_openFileDescriptor64) \
+    f(AAsset_isAllocated) \
+    f(AAssetManager_fromJava) \
+    f(AChoreographer_getInstance) \
+    f(AChoreographer_postFrameCallback) \
+    f(AChoreographer_postFrameCallbackDelayed) \
+    f(AConfiguration_new) \
+    f(AConfiguration_delete) \
+    f(AConfiguration_fromAssetManager) \
+    f(AConfiguration_copy) \
+    f(AConfiguration_getMcc) \
+    f(AConfiguration_setMcc) \
+    f(AConfiguration_getMnc) \
+    f(AConfiguration_setMnc) \
+    f(AConfiguration_getLanguage) \
+    f(AConfiguration_setLanguage) \
+    f(AConfiguration_getCountry) \
+    f(AConfiguration_setCountry) \
+    f(AConfiguration_getOrientation) \
+    f(AConfiguration_setOrientation) \
+    f(AConfiguration_getTouchscreen) \
+    f(AConfiguration_setTouchscreen) \
+    f(AConfiguration_getDensity) \
+    f(AConfiguration_setDensity) \
+    f(AConfiguration_getKeyboard) \
+    f(AConfiguration_setKeyboard) \
+    f(AConfiguration_getNavigation) \
+    f(AConfiguration_setNavigation) \
+    f(AConfiguration_getKeysHidden) \
+    f(AConfiguration_setKeysHidden) \
+    f(AConfiguration_getNavHidden) \
+    f(AConfiguration_setNavHidden) \
+    f(AConfiguration_getSdkVersion) \
+    f(AConfiguration_setSdkVersion) \
+    f(AConfiguration_getScreenSize) \
+    f(AConfiguration_setScreenSize) \
+    f(AConfiguration_getScreenLong) \
+    f(AConfiguration_setScreenLong) \
+    f(AConfiguration_setScreenRound) \
+    f(AConfiguration_getUiModeType) \
+    f(AConfiguration_setUiModeType) \
+    f(AConfiguration_getUiModeNight) \
+    f(AConfiguration_setUiModeNight) \
+    f(AConfiguration_getScreenWidthDp) \
+    f(AConfiguration_setScreenWidthDp) \
+    f(AConfiguration_getScreenHeightDp) \
+    f(AConfiguration_setScreenHeightDp) \
+    f(AConfiguration_getSmallestScreenWidthDp) \
+    f(AConfiguration_setSmallestScreenWidthDp) \
+    f(AConfiguration_getLayoutDirection) \
+    f(AConfiguration_setLayoutDirection) \
+    f(AConfiguration_diff) \
+    f(AConfiguration_match) \
+    f(AConfiguration_isBetterThan) \
+    f(AHardwareBuffer_fromHardwareBuffer) \
+    f(AHardwareBuffer_toHardwareBuffer) \
+    f(AHardwareBuffer_allocate) \
+    f(AHardwareBuffer_acquire) \
+    f(AHardwareBuffer_release) \
+    f(AHardwareBuffer_describe) \
+    f(AHardwareBuffer_lock) \
+    f(AHardwareBuffer_unlock) \
+    f(AHardwareBuffer_sendHandleToUnixSocket) \
+    f(AHardwareBuffer_recvHandleFromUnixSocket) \
+    f(AInputEvent_getType) \
+    f(AInputEvent_getDeviceId) \
+    f(AInputEvent_getSource) \
+    f(AKeyEvent_getAction) \
+    f(AKeyEvent_getFlags) \
+    f(AKeyEvent_getKeyCode) \
+    f(AKeyEvent_getScanCode) \
+    f(AKeyEvent_getMetaState) \
+    f(AKeyEvent_getRepeatCount) \
+    f(AKeyEvent_getDownTime) \
+    f(AKeyEvent_getEventTime) \
+    f(AMotionEvent_getAction) \
+    f(AMotionEvent_getFlags) \
+    f(AMotionEvent_getMetaState) \
+    f(AMotionEvent_getButtonState) \
+    f(AMotionEvent_getEdgeFlags) \
+    f(AMotionEvent_getDownTime) \
+    f(AMotionEvent_getEventTime) \
+    f(AMotionEvent_getXOffset) \
+    f(AMotionEvent_getYOffset) \
+    f(AMotionEvent_getXPrecision) \
+    f(AMotionEvent_getYPrecision) \
+    f(AMotionEvent_getPointerCount) \
+    f(AMotionEvent_getPointerId) \
+    f(AMotionEvent_getToolType) \
+    f(AMotionEvent_getRawX) \
+    f(AMotionEvent_getRawY) \
+    f(AMotionEvent_getX) \
+    f(AMotionEvent_getY) \
+    f(AMotionEvent_getPressure) \
+    f(AMotionEvent_getSize) \
+    f(AMotionEvent_getTouchMajor) \
+    f(AMotionEvent_getTouchMinor) \
+    f(AMotionEvent_getToolMajor) \
+    f(AMotionEvent_getToolMinor) \
+    f(AMotionEvent_getOrientation) \
+    f(AMotionEvent_getAxisValue) \
+    f(AMotionEvent_getHistorySize) \
+    f(AMotionEvent_getHistoricalEventTime) \
+    f(AMotionEvent_getHistoricalRawX) \
+    f(AMotionEvent_getHistoricalRawY) \
+    f(AMotionEvent_getHistoricalX) \
+    f(AMotionEvent_getHistoricalY) \
+    f(AMotionEvent_getHistoricalPressure) \
+    f(AMotionEvent_getHistoricalSize) \
+    f(AMotionEvent_getHistoricalTouchMajor) \
+    f(AMotionEvent_getHistoricalTouchMinor) \
+    f(AMotionEvent_getHistoricalToolMajor) \
+    f(AMotionEvent_getHistoricalToolMinor) \
+    f(AMotionEvent_getHistoricalOrientation) \
+    f(AMotionEvent_getHistoricalAxisValue) \
+    f(AInputQueue_attachLooper) \
+    f(AInputQueue_detachLooper) \
+    f(AInputQueue_hasEvents) \
+    f(AInputQueue_getEvent) \
+    f(AInputQueue_preDispatchEvent) \
+    f(AInputQueue_finishEvent) \
+    f(ALooper_forThread) \
+    f(ALooper_prepare) \
+    f(ALooper_acquire) \
+    f(ALooper_release) \
+    f(ALooper_pollOnce) \
+    f(ALooper_wake) \
+    f(ALooper_addFd) \
+    f(ALooper_removeFd) \
+    f(ANativeActivity_finish) \
+    f(ANativeActivity_setWindowFormat) \
+    f(ANativeActivity_setWindowFlags) \
+    f(ANativeActivity_showSoftInput) \
+    f(ANativeActivity_hideSoftInput) \
+    f(ANativeWindow_fromSurface) \
+    f(ANativeWindow_toSurface) \
+    f(ANativeWindow_acquire) \
+    f(ANativeWindow_release) \
+    f(ANativeWindow_getWidth) \
+    f(ANativeWindow_getHeight) \
+    f(ANativeWindow_getFormat) \
+    f(ANativeWindow_setBuffersGeometry) \
+    f(ANativeWindow_lock) \
+    f(ANativeWindow_unlockAndPost) \
+    f(ANativeWindow_setBuffersTransform) \
+    f(ANativeWindow_setBuffersDataSpace) \
+    f(ANativeWindow_getBuffersDataSpace) \
+    f(AObbScanner_getObbInfo) \
+    f(AObbInfo_delete) \
+    f(AObbInfo_getPackageName) \
+    f(AObbInfo_getVersion) \
+    f(AObbInfo_getFlags) \
+    f(ASensorManager_getInstance) \
+    f(ASensorManager_getInstanceForPackage) \
+    f(ASensorManager_getSensorList) \
+    f(ASensorManager_getDefaultSensor) \
+    f(ASensorManager_getDefaultSensorEx) \
+    f(ASensorManager_createEventQueue) \
+    f(ASensorManager_destroyEventQueue) \
+    f(ASensorManager_createSharedMemoryDirectChannel) \
+    f(ASensorManager_createHardwareBufferDirectChannel) \
+    f(ASensorManager_destroyDirectChannel) \
+    f(ASensorManager_configureDirectReport) \
+    f(ASensorEventQueue_registerSensor) \
+    f(ASensorEventQueue_enableSensor) \
+    f(ASensorEventQueue_disableSensor) \
+    f(ASensorEventQueue_setEventRate) \
+    f(ASensorEventQueue_hasEvents) \
+    f(ASensorEventQueue_getEvents) \
+    f(ASensor_getName) \
+    f(ASensor_getVendor) \
+    f(ASensor_getType) \
+    f(ASensor_getResolution) \
+    f(ASensor_getMinDelay) \
+    f(ASensor_getFifoMaxEventCount) \
+    f(ASensor_getFifoReservedEventCount) \
+    f(ASensor_getStringType) \
+    f(ASensor_getReportingMode) \
+    f(ASensor_isWakeUpSensor) \
+    f(ASensor_isDirectChannelTypeSupported) \
+    f(ASensor_getHighestDirectReportRateLevel) \
+    f(ASharedMemory_dupFromJava) \
+    f(ASharedMemory_create) \
+    f(ASharedMemory_getSize) \
+    f(ASharedMemory_setProt) \
+    f(AStorageManager_new) \
+    f(AStorageManager_delete) \
+    f(AStorageManager_mountObb) \
+    f(AStorageManager_unmountObb) \
+    f(AStorageManager_isObbMounted) \
+    f(AStorageManager_getMountedObbPath) \
+    f(ASurfaceTexture_fromSurfaceTexture) \
+    f(ASurfaceTexture_release) \
+    f(ASurfaceTexture_acquireANativeWindow) \
+    f(ASurfaceTexture_attachToGLContext) \
+    f(ASurfaceTexture_detachFromGLContext) \
+    f(ASurfaceTexture_updateTexImage) \
+    f(ASurfaceTexture_getTransformMatrix) \
+    f(ASurfaceTexture_getTimestamp) \
+    f(ATrace_isEnabled) \
+    f(ATrace_beginSection) \
+    f(ATrace_endSection) \
+    f(android_setsocknetwork) \
+    f(android_setprocnetwork) \
+    f(android_getaddrinfofornetwork)
+
+#define STUB(s) __typeof__(s)* s;
+static struct {
+    FUNCTIONS(STUB)
+} stubs;
+#undef STUB
+
+__attribute__((constructor)) static void init() {
+    void* handle = dlopen(LIB, RTLD_LOCAL);
+    // Nothing bad happened, normal case for termux-docker.
+    if (!handle)
+        return;
+#define LOAD(s) stubs.s = dlsym(handle, #s);
+    FUNCTIONS(LOAD)
+#undef LOAD
+}
+
+#define CALL(f, def, ...) if (!stubs.f) return def; else return (stubs.f)(__VA_ARGS__)
+
+AAssetDir* AAssetManager_openDir(AAssetManager* mgr, const char* dirName) {
+    CALL(AAssetManager_openDir, NULL, mgr, dirName);
+}
+
+AAsset* AAssetManager_open(AAssetManager* mgr, const char* filename, int mode) {
+    CALL(AAssetManager_open, NULL, mgr, filename, mode);
+}
+
+const char* AAssetDir_getNextFileName(AAssetDir* assetDir) {
+    CALL(AAssetDir_getNextFileName, NULL, assetDir);
+}
+
+void AAssetDir_rewind(AAssetDir* assetDir) {
+    CALL(AAssetDir_rewind,, assetDir);
+}
+
+void AAssetDir_close(AAssetDir* assetDir) {
+    CALL(AAssetDir_close,, assetDir);
+}
+
+int AAsset_read(AAsset* asset, void* buf, size_t count) {
+    CALL(AAsset_read, 0, asset, buf, count);
+}
+
+off_t AAsset_seek(AAsset* asset, off_t offset, int whence) {
+    CALL(AAsset_seek, 0, asset, offset, whence);
+}
+
+off64_t AAsset_seek64(AAsset* asset, off64_t offset, int whence) {
+    CALL(AAsset_seek64, 0, asset, offset, whence);
+}
+
+void AAsset_close(AAsset* asset) {
+    CALL(AAsset_close,, asset);
+}
+
+const void* AAsset_getBuffer(AAsset* asset) {
+    CALL(AAsset_getBuffer, NULL, asset);
+}
+
+off_t AAsset_getLength(AAsset* asset) {
+    CALL(AAsset_getLength, 0, asset);
+}
+
+off64_t AAsset_getLength64(AAsset* asset) {
+    CALL(AAsset_getLength64, 0, asset);
+}
+
+off_t AAsset_getRemainingLength(AAsset* asset) {
+    CALL(AAsset_getRemainingLength, 0, asset);
+}
+
+off64_t AAsset_getRemainingLength64(AAsset* asset) {
+    CALL(AAsset_getRemainingLength64, 0, asset);
+}
+
+int AAsset_openFileDescriptor(AAsset* asset, off_t* outStart, off_t* outLength) {
+    CALL(AAsset_openFileDescriptor, 0, asset, outStart, outLength);
+}
+
+int AAsset_openFileDescriptor64(AAsset* asset, off64_t* outStart, off64_t* outLength) {
+    CALL(AAsset_openFileDescriptor64, 0, asset, outStart, outLength);
+}
+
+int AAsset_isAllocated(AAsset* asset) {
+    CALL(AAsset_isAllocated, 0, asset);
+}
+
+AAssetManager* AAssetManager_fromJava(JNIEnv* env, jobject assetManager) {
+    CALL(AAssetManager_fromJava, NULL, env, assetManager);
+}
+
+AChoreographer* AChoreographer_getInstance() {
+    CALL(AChoreographer_getInstance, NULL);
+}
+
+void AChoreographer_postFrameCallback(AChoreographer* choreographer, AChoreographer_frameCallback callback, void* data) {
+    CALL(AChoreographer_postFrameCallback,, choreographer, callback, data);
+}
+
+void AChoreographer_postFrameCallbackDelayed(AChoreographer* choreographer, AChoreographer_frameCallback callback, void* data, long delayMillis) {
+    CALL(AChoreographer_postFrameCallbackDelayed,, choreographer, callback, data, delayMillis);
+}
+
+AConfiguration* AConfiguration_new() {
+    CALL(AConfiguration_new, NULL);
+}
+
+void AConfiguration_delete(AConfiguration* config) {
+    CALL(AConfiguration_delete,, config);
+}
+
+void AConfiguration_fromAssetManager(AConfiguration* out, AAssetManager* am) {
+    CALL(AConfiguration_fromAssetManager,, out, am);
+}
+
+void AConfiguration_copy(AConfiguration* dest, AConfiguration* src) {
+    CALL(AConfiguration_copy,, dest, src);
+}
+
+int32_t AConfiguration_getMcc(AConfiguration* config) {
+    CALL(AConfiguration_getMcc, 0, config);
+}
+
+void AConfiguration_setMcc(AConfiguration* config, int32_t mcc) {
+    CALL(AConfiguration_setMcc,, config, mcc);
+}
+
+int32_t AConfiguration_getMnc(AConfiguration* config) {
+    CALL(AConfiguration_getMnc, 0, config);
+}
+
+void AConfiguration_setMnc(AConfiguration* config, int32_t mnc) {
+    CALL(AConfiguration_setMnc,, config, mnc);
+}
+
+void AConfiguration_getLanguage(AConfiguration* config, char* outLanguage) {
+    CALL(AConfiguration_getLanguage,, config, outLanguage);
+}
+
+void AConfiguration_setLanguage(AConfiguration* config, const char* language) {
+    CALL(AConfiguration_setLanguage,, config, language);
+}
+
+void AConfiguration_getCountry(AConfiguration* config, char* outCountry) {
+    CALL(AConfiguration_getCountry,, config, outCountry);
+}
+
+void AConfiguration_setCountry(AConfiguration* config, const char* country) {
+    CALL(AConfiguration_setCountry,, config, country);
+}
+
+int32_t AConfiguration_getOrientation(AConfiguration* config) {
+    CALL(AConfiguration_getOrientation, 0, config);
+}
+
+void AConfiguration_setOrientation(AConfiguration* config, int32_t orientation) {
+    CALL(AConfiguration_setOrientation,, config, orientation);
+}
+
+int32_t AConfiguration_getTouchscreen(AConfiguration* config) {
+    CALL(AConfiguration_getTouchscreen, 0, config);
+}
+
+void AConfiguration_setTouchscreen(AConfiguration* config, int32_t touchscreen) {
+    CALL(AConfiguration_setTouchscreen,, config, touchscreen);
+}
+
+int32_t AConfiguration_getDensity(AConfiguration* config) {
+    CALL(AConfiguration_getDensity, 0, config);
+}
+
+void AConfiguration_setDensity(AConfiguration* config, int32_t density) {
+    CALL(AConfiguration_setDensity,, config, density);
+}
+
+int32_t AConfiguration_getKeyboard(AConfiguration* config) {
+    CALL(AConfiguration_getKeyboard, 0, config);
+}
+
+void AConfiguration_setKeyboard(AConfiguration* config, int32_t keyboard) {
+    CALL(AConfiguration_setKeyboard,, config, keyboard);
+}
+
+int32_t AConfiguration_getNavigation(AConfiguration* config) {
+    CALL(AConfiguration_getNavigation, 0, config);
+}
+
+void AConfiguration_setNavigation(AConfiguration* config, int32_t navigation) {
+    CALL(AConfiguration_setNavigation,, config, navigation);
+}
+
+int32_t AConfiguration_getKeysHidden(AConfiguration* config) {
+    CALL(AConfiguration_getKeysHidden, 0, config);
+}
+
+void AConfiguration_setKeysHidden(AConfiguration* config, int32_t keysHidden) {
+    CALL(AConfiguration_setKeysHidden,, config, keysHidden);
+}
+
+int32_t AConfiguration_getNavHidden(AConfiguration* config) {
+    CALL(AConfiguration_getNavHidden, 0, config);
+}
+
+void AConfiguration_setNavHidden(AConfiguration* config, int32_t navHidden) {
+    CALL(AConfiguration_setNavHidden,, config, navHidden);
+}
+
+int32_t AConfiguration_getSdkVersion(AConfiguration* config) {
+    CALL(AConfiguration_getSdkVersion, 0, config);
+}
+
+void AConfiguration_setSdkVersion(AConfiguration* config, int32_t sdkVersion) {
+    CALL(AConfiguration_setSdkVersion,, config, sdkVersion);
+}
+
+int32_t AConfiguration_getScreenSize(AConfiguration* config) {
+    CALL(AConfiguration_getScreenSize, 0, config);
+}
+
+void AConfiguration_setScreenSize(AConfiguration* config, int32_t screenSize) {
+    CALL(AConfiguration_setScreenSize,, config, screenSize);
+}
+
+int32_t AConfiguration_getScreenLong(AConfiguration* config) {
+    CALL(AConfiguration_getScreenLong, 0, config);
+}
+
+void AConfiguration_setScreenLong(AConfiguration* config, int32_t screenLong) {
+    CALL(AConfiguration_setScreenLong,, config, screenLong);
+}
+
+void AConfiguration_setScreenRound(AConfiguration* config, int32_t screenRound) {
+    CALL(AConfiguration_setScreenRound,, config, screenRound);
+}
+
+int32_t AConfiguration_getUiModeType(AConfiguration* config) {
+    CALL(AConfiguration_getUiModeType, 0, config);
+}
+
+void AConfiguration_setUiModeType(AConfiguration* config, int32_t uiModeType) {
+    CALL(AConfiguration_setUiModeType,, config, uiModeType);
+}
+
+int32_t AConfiguration_getUiModeNight(AConfiguration* config) {
+    CALL(AConfiguration_getUiModeNight, 0, config);
+}
+
+void AConfiguration_setUiModeNight(AConfiguration* config, int32_t uiModeNight) {
+    CALL(AConfiguration_setUiModeNight,, config, uiModeNight);
+}
+
+int32_t AConfiguration_getScreenWidthDp(AConfiguration* config) {
+    CALL(AConfiguration_getScreenWidthDp, 0, config);
+}
+
+void AConfiguration_setScreenWidthDp(AConfiguration* config, int32_t value) {
+    CALL(AConfiguration_setScreenWidthDp,, config, value);
+}
+
+int32_t AConfiguration_getScreenHeightDp(AConfiguration* config) {
+    CALL(AConfiguration_getScreenHeightDp, 0, config);
+}
+
+void AConfiguration_setScreenHeightDp(AConfiguration* config, int32_t value) {
+    CALL(AConfiguration_setScreenHeightDp,, config, value);
+}
+
+int32_t AConfiguration_getSmallestScreenWidthDp(AConfiguration* config) {
+    CALL(AConfiguration_getSmallestScreenWidthDp, 0, config);
+}
+
+void AConfiguration_setSmallestScreenWidthDp(AConfiguration* config, int32_t value) {
+    CALL(AConfiguration_setSmallestScreenWidthDp,, config, value);
+}
+
+int32_t AConfiguration_getLayoutDirection(AConfiguration* config) {
+    CALL(AConfiguration_getLayoutDirection, 0, config);
+}
+
+void AConfiguration_setLayoutDirection(AConfiguration* config, int32_t value) {
+    CALL(AConfiguration_setLayoutDirection,, config, value);
+}
+
+int32_t AConfiguration_diff(AConfiguration* config1, AConfiguration* config2) {
+    CALL(AConfiguration_diff, 0, config1, config2);
+}
+
+int32_t AConfiguration_match(AConfiguration* base, AConfiguration* requested) {
+    CALL(AConfiguration_match, 0, base, requested);
+}
+
+int32_t AConfiguration_isBetterThan(AConfiguration* base, AConfiguration* test, AConfiguration* requested) {
+    CALL(AConfiguration_isBetterThan, 0, base, test, requested);
+}
+
+AHardwareBuffer* AHardwareBuffer_fromHardwareBuffer(JNIEnv* env, jobject hardwareBufferObj) {
+    CALL(AHardwareBuffer_fromHardwareBuffer, NULL, env, hardwareBufferObj);
+}
+
+jobject AHardwareBuffer_toHardwareBuffer(JNIEnv* env, AHardwareBuffer* hardwareBuffer) {
+    CALL(AHardwareBuffer_toHardwareBuffer, NULL, env, hardwareBuffer);
+}
+
+int AHardwareBuffer_allocate(const AHardwareBuffer_Desc* _Nonnull desc, AHardwareBuffer* _Nullable* _Nonnull outBuffer) {
+    CALL(AHardwareBuffer_allocate, 0, desc, outBuffer);
+}
+
+void AHardwareBuffer_acquire(AHardwareBuffer* _Nonnull buffer) {
+    CALL(AHardwareBuffer_acquire,, buffer);
+}
+
+void AHardwareBuffer_release(AHardwareBuffer* _Nonnull buffer) {
+    CALL(AHardwareBuffer_release,, buffer);
+}
+
+void AHardwareBuffer_describe(const AHardwareBuffer* _Nonnull buffer, AHardwareBuffer_Desc* _Nonnull outDesc) {
+    CALL(AHardwareBuffer_describe,, buffer, outDesc);
+}
+
+int AHardwareBuffer_lock(AHardwareBuffer* _Nonnull buffer, uint64_t usage, int32_t fence, const ARect* _Nullable rect, void* _Nullable* _Nonnull outVirtualAddress) {
+    CALL(AHardwareBuffer_lock, 0, buffer, usage, fence, rect, outVirtualAddress);
+}
+
+int AHardwareBuffer_unlock(AHardwareBuffer* _Nonnull buffer, int32_t* _Nullable fence) {
+    CALL(AHardwareBuffer_unlock, 0, buffer, fence);
+}
+
+int AHardwareBuffer_sendHandleToUnixSocket(const AHardwareBuffer* _Nonnull buffer, int socketFd) {
+    CALL(AHardwareBuffer_sendHandleToUnixSocket, 0, buffer, socketFd);
+}
+
+int AHardwareBuffer_recvHandleFromUnixSocket(int socketFd, AHardwareBuffer* _Nullable* _Nonnull outBuffer) {
+    CALL(AHardwareBuffer_recvHandleFromUnixSocket, 0, socketFd, outBuffer);
+}
+
+int32_t AInputEvent_getType(const AInputEvent* event) {
+    CALL(AInputEvent_getType, 0, event);
+}
+
+int32_t AInputEvent_getDeviceId(const AInputEvent* event) {
+    CALL(AInputEvent_getType, 0, event);
+}
+
+int32_t AInputEvent_getSource(const AInputEvent* event) {
+    CALL(AInputEvent_getSource, 0, event);
+}
+
+int32_t AKeyEvent_getAction(const AInputEvent* key_event) {
+    CALL(AKeyEvent_getAction, 0, key_event);
+}
+
+int32_t AKeyEvent_getFlags(const AInputEvent* key_event) {
+    CALL(AKeyEvent_getFlags, 0, key_event);
+}
+
+int32_t AKeyEvent_getKeyCode(const AInputEvent* key_event) {
+    CALL(AKeyEvent_getKeyCode, 0, key_event);
+}
+
+int32_t AKeyEvent_getScanCode(const AInputEvent* key_event) {
+    CALL(AKeyEvent_getScanCode, 0, key_event);
+}
+
+int32_t AKeyEvent_getMetaState(const AInputEvent* key_event) {
+    CALL(AKeyEvent_getMetaState, 0, key_event);
+}
+
+int32_t AKeyEvent_getRepeatCount(const AInputEvent* key_event) {
+    CALL(AKeyEvent_getRepeatCount, 0, key_event);
+}
+
+int64_t AKeyEvent_getDownTime(const AInputEvent* key_event) {
+    CALL(AKeyEvent_getDownTime, 0, key_event);
+}
+
+int64_t AKeyEvent_getEventTime(const AInputEvent* key_event) {
+    CALL(AKeyEvent_getEventTime, 0, key_event);
+}
+
+int32_t AMotionEvent_getAction(const AInputEvent* motion_event) {
+    CALL(AMotionEvent_getAction, 0, motion_event);
+}
+
+int32_t AMotionEvent_getFlags(const AInputEvent* motion_event) {
+    CALL(AMotionEvent_getFlags, 0, motion_event);
+}
+
+int32_t AMotionEvent_getMetaState(const AInputEvent* motion_event) {
+    CALL(AMotionEvent_getMetaState, 0, motion_event);
+}
+
+int32_t AMotionEvent_getButtonState(const AInputEvent* motion_event) {
+    CALL(AMotionEvent_getButtonState, 0, motion_event);
+}
+
+int32_t AMotionEvent_getEdgeFlags(const AInputEvent* motion_event) {
+    CALL(AMotionEvent_getEdgeFlags, 0, motion_event);
+}
+
+int64_t AMotionEvent_getDownTime(const AInputEvent* motion_event) {
+    CALL(AMotionEvent_getDownTime, 0, motion_event);
+}
+
+int64_t AMotionEvent_getEventTime(const AInputEvent* motion_event) {
+    CALL(AMotionEvent_getEventTime, 0, motion_event);
+}
+
+float AMotionEvent_getXOffset(const AInputEvent* motion_event) {
+    CALL(AMotionEvent_getXOffset, 0, motion_event);
+}
+
+float AMotionEvent_getYOffset(const AInputEvent* motion_event) {
+    CALL(AMotionEvent_getYOffset, 0, motion_event);
+}
+
+float AMotionEvent_getXPrecision(const AInputEvent* motion_event) {
+    CALL(AMotionEvent_getXPrecision, 0, motion_event);
+}
+
+float AMotionEvent_getYPrecision(const AInputEvent* motion_event) {
+    CALL(AMotionEvent_getYPrecision, 0, motion_event);
+}
+
+size_t AMotionEvent_getPointerCount(const AInputEvent* motion_event) {
+    CALL(AMotionEvent_getPointerCount, 0, motion_event);
+}
+
+int32_t AMotionEvent_getPointerId(const AInputEvent* motion_event, size_t pointer_index) {
+    CALL(AMotionEvent_getPointerId, 0, motion_event, pointer_index);
+}
+
+int32_t AMotionEvent_getToolType(const AInputEvent* motion_event, size_t pointer_index) {
+    CALL(AMotionEvent_getToolType, 0, motion_event, pointer_index);
+}
+
+float AMotionEvent_getRawX(const AInputEvent* motion_event, size_t pointer_index) {
+    CALL(AMotionEvent_getRawX, 0.f, motion_event, pointer_index);
+}
+
+float AMotionEvent_getRawY(const AInputEvent* motion_event, size_t pointer_index) {
+    CALL(AMotionEvent_getRawY, 0.f, motion_event, pointer_index);
+}
+
+float AMotionEvent_getX(const AInputEvent* motion_event, size_t pointer_index) {
+    CALL(AMotionEvent_getX, 0.f, motion_event, pointer_index);
+}
+
+float AMotionEvent_getY(const AInputEvent* motion_event, size_t pointer_index) {
+    CALL(AMotionEvent_getY, 0.f, motion_event, pointer_index);
+}
+
+float AMotionEvent_getPressure(const AInputEvent* motion_event, size_t pointer_index) {
+    CALL(AMotionEvent_getPressure, 0.f, motion_event, pointer_index);
+}
+
+float AMotionEvent_getSize(const AInputEvent* motion_event, size_t pointer_index) {
+    CALL(AMotionEvent_getSize, 0.f, motion_event, pointer_index);
+}
+
+float AMotionEvent_getTouchMajor(const AInputEvent* motion_event, size_t pointer_index) {
+    CALL(AMotionEvent_getTouchMajor, 0.f, motion_event, pointer_index);
+}
+
+float AMotionEvent_getTouchMinor(const AInputEvent* motion_event, size_t pointer_index) {
+    CALL(AMotionEvent_getTouchMinor, 0.f, motion_event, pointer_index);
+}
+
+float AMotionEvent_getToolMajor(const AInputEvent* motion_event, size_t pointer_index) {
+    CALL(AMotionEvent_getToolMajor, 0.f, motion_event, pointer_index);
+}
+
+float AMotionEvent_getToolMinor(const AInputEvent* motion_event, size_t pointer_index) {
+    CALL(AMotionEvent_getToolMinor, 0.f, motion_event, pointer_index);
+}
+
+float AMotionEvent_getOrientation(const AInputEvent* motion_event, size_t pointer_index) {
+    CALL(AMotionEvent_getOrientation, 0.f, motion_event, pointer_index);
+}
+
+float AMotionEvent_getAxisValue(const AInputEvent* motion_event, int32_t axis, size_t pointer_index) {
+    CALL(AMotionEvent_getAxisValue, 0.f, motion_event, axis, pointer_index);
+}
+
+size_t AMotionEvent_getHistorySize(const AInputEvent* motion_event) {
+    CALL(AMotionEvent_getHistorySize, 0, motion_event);
+}
+
+int64_t AMotionEvent_getHistoricalEventTime(const AInputEvent* motion_event, size_t history_index) {
+    CALL(AMotionEvent_getHistoricalEventTime, 0, motion_event, history_index);
+}
+
+float AMotionEvent_getHistoricalRawX(const AInputEvent* motion_event, size_t pointer_index, size_t history_index) {
+    CALL(AMotionEvent_getHistoricalRawX, 0.f, motion_event, pointer_index, history_index);
+}
+
+float AMotionEvent_getHistoricalRawY(const AInputEvent* motion_event, size_t pointer_index, size_t history_index) {
+    CALL(AMotionEvent_getHistoricalRawY, 0.f, motion_event, pointer_index, history_index);
+}
+
+float AMotionEvent_getHistoricalX(const AInputEvent* motion_event, size_t pointer_index, size_t history_index) {
+    CALL(AMotionEvent_getHistoricalX, 0.f, motion_event, pointer_index, history_index);
+}
+
+float AMotionEvent_getHistoricalY(const AInputEvent* motion_event, size_t pointer_index, size_t history_index) {
+    CALL(AMotionEvent_getHistoricalY, 0.f, motion_event, pointer_index, history_index);
+}
+
+float AMotionEvent_getHistoricalPressure(const AInputEvent* motion_event, size_t pointer_index, size_t history_index) {
+    CALL(AMotionEvent_getHistoricalPressure, 0.f, motion_event, pointer_index, history_index);
+}
+
+float AMotionEvent_getHistoricalSize(const AInputEvent* motion_event, size_t pointer_index, size_t history_index) {
+    CALL(AMotionEvent_getHistoricalSize, 0.f, motion_event, pointer_index, history_index);
+}
+
+float AMotionEvent_getHistoricalTouchMajor(const AInputEvent* motion_event, size_t pointer_index, size_t history_index) {
+    CALL(AMotionEvent_getHistoricalTouchMajor, 0.f, motion_event, pointer_index, history_index);
+}
+
+float AMotionEvent_getHistoricalTouchMinor(const AInputEvent* motion_event, size_t pointer_index, size_t history_index) {
+    CALL(AMotionEvent_getHistoricalTouchMinor, 0.f, motion_event, pointer_index, history_index);
+}
+
+float AMotionEvent_getHistoricalToolMajor(const AInputEvent* motion_event, size_t pointer_index, size_t history_index) {
+    CALL(AMotionEvent_getHistoricalToolMajor, 0.f, motion_event, pointer_index, history_index);
+}
+
+float AMotionEvent_getHistoricalToolMinor(const AInputEvent* motion_event, size_t pointer_index, size_t history_index) {
+    CALL(AMotionEvent_getHistoricalToolMinor, 0.f, motion_event, pointer_index, history_index);
+}
+
+float AMotionEvent_getHistoricalOrientation(const AInputEvent* motion_event, size_t pointer_index, size_t history_index) {
+    CALL(AMotionEvent_getHistoricalOrientation, 0.f, motion_event, pointer_index, history_index);
+}
+
+float AMotionEvent_getHistoricalAxisValue(const AInputEvent* motion_event, int32_t axis, size_t pointer_index, size_t history_index) {
+    CALL(AMotionEvent_getHistoricalAxisValue, 0.f, motion_event, axis, pointer_index, history_index);
+}
+
+void AInputQueue_attachLooper(AInputQueue* queue, ALooper* looper, int ident, ALooper_callbackFunc callback, void* data) {
+    CALL(AInputQueue_attachLooper,, queue, looper, ident, callback, data);
+}
+
+void AInputQueue_detachLooper(AInputQueue* queue) {
+    CALL(AInputQueue_detachLooper,, queue);
+}
+
+int32_t AInputQueue_hasEvents(AInputQueue* queue) {
+    CALL(AInputQueue_hasEvents, 0, queue);
+}
+
+int32_t AInputQueue_getEvent(AInputQueue* queue, AInputEvent** outEvent) {
+    CALL(AInputQueue_getEvent, 0, queue, outEvent);
+}
+
+int32_t AInputQueue_preDispatchEvent(AInputQueue* queue, AInputEvent* event) {
+    CALL(AInputQueue_preDispatchEvent, 0, queue, event);
+}
+
+void AInputQueue_finishEvent(AInputQueue* queue, AInputEvent* event, int handled) {
+    CALL(AInputQueue_finishEvent,, queue, event, handled);
+}
+
+ALooper* ALooper_forThread() {
+    CALL(ALooper_forThread, NULL);
+}
+
+ALooper* ALooper_prepare(int opts) {
+    CALL(ALooper_prepare, NULL, opts);
+}
+
+void ALooper_acquire(ALooper* looper) {
+    CALL(ALooper_acquire,, looper);
+}
+
+void ALooper_release(ALooper* looper) {
+    CALL(ALooper_release,, looper);
+}
+
+int ALooper_pollOnce(int timeoutMillis, int* outFd, int* outEvents, void** outData) {
+    CALL(ALooper_pollOnce, 0, timeoutMillis, outFd, outEvents, outData);
+}
+
+void ALooper_wake(ALooper* looper) {
+    CALL(ALooper_wake,, looper);
+}
+
+int ALooper_addFd(ALooper* looper, int fd, int ident, int events, ALooper_callbackFunc callback, void* data) {
+    CALL(ALooper_addFd, 0, looper, fd, ident, events, callback, data);
+}
+
+int ALooper_removeFd(ALooper* looper, int fd) {
+    CALL(ALooper_removeFd, 0, looper, fd);
+}
+
+void ANativeActivity_finish(ANativeActivity* activity) {
+    CALL(ANativeActivity_finish,, activity);
+}
+
+void ANativeActivity_setWindowFormat(ANativeActivity* activity, int32_t format) {
+    CALL(ANativeActivity_setWindowFormat,, activity, format);
+}
+
+void ANativeActivity_setWindowFlags(ANativeActivity* activity, uint32_t addFlags, uint32_t removeFlags) {
+    CALL(ANativeActivity_setWindowFlags,, activity, addFlags, removeFlags);
+}
+
+void ANativeActivity_showSoftInput(ANativeActivity* activity, uint32_t flags) {
+    CALL(ANativeActivity_showSoftInput,, activity, flags);
+}
+
+void ANativeActivity_hideSoftInput(ANativeActivity* activity, uint32_t flags) {
+    CALL(ANativeActivity_hideSoftInput,, activity, flags);
+}
+
+ANativeWindow* ANativeWindow_fromSurface(JNIEnv* env, jobject surface) {
+    CALL(ANativeWindow_fromSurface, NULL, env, surface);
+}
+
+jobject ANativeWindow_toSurface(JNIEnv* env, ANativeWindow* window) {
+    CALL(ANativeWindow_toSurface, NULL, env, window);
+}
+
+void ANativeWindow_acquire(ANativeWindow* window) {
+    CALL(ANativeWindow_acquire,, window);
+}
+
+void ANativeWindow_release(ANativeWindow* window) {
+    CALL(ANativeWindow_release,, window);
+}
+
+int32_t ANativeWindow_getWidth(ANativeWindow* window) {
+    CALL(ANativeWindow_getWidth, 0, window);
+}
+
+int32_t ANativeWindow_getHeight(ANativeWindow* window) {
+    CALL(ANativeWindow_getHeight, 0, window);
+}
+
+int32_t ANativeWindow_getFormat(ANativeWindow* window) {
+    CALL(ANativeWindow_getFormat, 0, window);
+}
+
+int32_t ANativeWindow_setBuffersGeometry(ANativeWindow* window, int32_t width, int32_t height, int32_t format) {
+    CALL(ANativeWindow_setBuffersGeometry, 0, window, width, height, format);
+}
+
+int32_t ANativeWindow_lock(ANativeWindow* window, ANativeWindow_Buffer* outBuffer, ARect* inOutDirtyBounds) {
+    CALL(ANativeWindow_lock, -1, window, outBuffer, inOutDirtyBounds);
+}
+
+int32_t ANativeWindow_unlockAndPost(ANativeWindow* window) {
+    CALL(ANativeWindow_unlockAndPost, 0, window);
+}
+
+int32_t ANativeWindow_setBuffersTransform(ANativeWindow* window, int32_t transform) {
+    CALL(ANativeWindow_setBuffersTransform, 0, window, transform);
+}
+
+int32_t ANativeWindow_setBuffersDataSpace(ANativeWindow* window, int32_t dataSpace) {
+    CALL(ANativeWindow_setBuffersDataSpace, 0, window, dataSpace);
+}
+
+int32_t ANativeWindow_getBuffersDataSpace(ANativeWindow* window) {
+    CALL(ANativeWindow_getBuffersDataSpace, 0, window);
+}
+
+AObbInfo* AObbScanner_getObbInfo(const char* filename) {
+    CALL(AObbScanner_getObbInfo, NULL, filename);
+}
+
+void AObbInfo_delete(AObbInfo* obbInfo) {
+    CALL(AObbInfo_delete,, obbInfo);
+}
+
+const char* AObbInfo_getPackageName(AObbInfo* obbInfo) {
+    CALL(AObbInfo_getPackageName, NULL, obbInfo);
+}
+
+int32_t AObbInfo_getVersion(AObbInfo* obbInfo) {
+    CALL(AObbInfo_getVersion, 0, obbInfo);
+}
+
+int32_t AObbInfo_getFlags(AObbInfo* obbInfo) {
+    CALL(AObbInfo_getFlags, 0, obbInfo);
+}
+
+ASensorManager* ASensorManager_getInstance() {
+    CALL(ASensorManager_getInstance, NULL);
+}
+
+ASensorManager* ASensorManager_getInstanceForPackage(const char* packageName) {
+    CALL(ASensorManager_getInstanceForPackage, NULL, packageName);
+}
+
+int ASensorManager_getSensorList(ASensorManager* manager, ASensorList* list) {
+    CALL(ASensorManager_getSensorList, 0, manager, list);
+}
+
+ASensor const* ASensorManager_getDefaultSensor(ASensorManager* manager, int type) {
+    CALL(ASensorManager_getDefaultSensor, NULL, manager, type);
+}
+
+ASensor const* ASensorManager_getDefaultSensorEx(ASensorManager* manager, int type, bool wakeUp) {
+    CALL(ASensorManager_getDefaultSensorEx, NULL, manager, type, wakeUp);
+}
+
+ASensorEventQueue* ASensorManager_createEventQueue(ASensorManager* manager, ALooper* looper, int ident, ALooper_callbackFunc callback, void* data) {
+    CALL(ASensorManager_createEventQueue, NULL, manager, looper, ident, callback, data);
+}
+
+int ASensorManager_destroyEventQueue(ASensorManager* manager, ASensorEventQueue* queue) {
+    CALL(ASensorManager_destroyEventQueue, 0, manager, queue);
+}
+
+int ASensorManager_createSharedMemoryDirectChannel(ASensorManager* manager, int fd, size_t size) {
+    CALL(ASensorManager_createSharedMemoryDirectChannel, 0, manager, fd, size);
+}
+
+int ASensorManager_createHardwareBufferDirectChannel(ASensorManager* manager, AHardwareBuffer const * buffer, size_t size) {
+    CALL(ASensorManager_createHardwareBufferDirectChannel, 0, manager, buffer, size);
+}
+
+void ASensorManager_destroyDirectChannel(ASensorManager* manager, int channelId) {
+    CALL(ASensorManager_destroyDirectChannel,, manager, channelId);
+}
+
+int ASensorManager_configureDirectReport(ASensorManager* manager, ASensor const* sensor, int channelId, int rate) {
+    CALL(ASensorManager_configureDirectReport, 0, manager, sensor, channelId, rate);
+}
+
+int ASensorEventQueue_registerSensor(ASensorEventQueue* queue, ASensor const* sensor, int32_t samplingPeriodUs, int64_t maxBatchReportLatencyUs) {
+    CALL(ASensorEventQueue_registerSensor, 0, queue, sensor, samplingPeriodUs, maxBatchReportLatencyUs);
+}
+
+int ASensorEventQueue_enableSensor(ASensorEventQueue* queue, ASensor const* sensor) {
+    CALL(ASensorEventQueue_enableSensor, 0, queue, sensor);
+}
+
+int ASensorEventQueue_disableSensor(ASensorEventQueue* queue, ASensor const* sensor) {
+    CALL(ASensorEventQueue_disableSensor, 0, queue, sensor);
+}
+
+int ASensorEventQueue_setEventRate(ASensorEventQueue* queue, ASensor const* sensor, int32_t usec) {
+    CALL(ASensorEventQueue_setEventRate, 0, queue, sensor, usec);
+}
+
+int ASensorEventQueue_hasEvents(ASensorEventQueue* queue) {
+    CALL(ASensorEventQueue_hasEvents, 0, queue);
+}
+
+ssize_t ASensorEventQueue_getEvents(ASensorEventQueue* queue, ASensorEvent* events, size_t count) {
+    CALL(ASensorEventQueue_getEvents, 0, queue, events, count);
+}
+
+const char* ASensor_getName(ASensor const* sensor) {
+    CALL(ASensor_getName, NULL, sensor);
+}
+
+const char* ASensor_getVendor(ASensor const* sensor) {
+    CALL(ASensor_getVendor, NULL, sensor);
+}
+
+int ASensor_getType(ASensor const* sensor) {
+    CALL(ASensor_getType, 0, sensor);
+}
+
+float ASensor_getResolution(ASensor const* sensor) {
+    CALL(ASensor_getResolution, 0.f, sensor);
+}
+
+int ASensor_getMinDelay(ASensor const* sensor) {
+    CALL(ASensor_getMinDelay, 0, sensor);
+}
+
+int ASensor_getFifoMaxEventCount(ASensor const* sensor) {
+    CALL(ASensor_getFifoMaxEventCount, 0, sensor);
+}
+
+int ASensor_getFifoReservedEventCount(ASensor const* sensor) {
+    CALL(ASensor_getFifoReservedEventCount, 0, sensor);
+}
+
+const char* ASensor_getStringType(ASensor const* sensor) {
+    CALL(ASensor_getStringType, NULL, sensor);
+}
+
+int ASensor_getReportingMode(ASensor const* sensor) {
+    CALL(ASensor_getReportingMode, 0, sensor);
+}
+
+bool ASensor_isWakeUpSensor(ASensor const* sensor) {
+    CALL(ASensor_isWakeUpSensor, false, sensor);
+}
+
+bool ASensor_isDirectChannelTypeSupported(ASensor const* sensor, int channelType) {
+    CALL(ASensor_isDirectChannelTypeSupported, false, sensor, channelType);
+}
+
+int ASensor_getHighestDirectReportRateLevel(ASensor const* sensor) {
+    CALL(ASensor_getHighestDirectReportRateLevel, 0, sensor);
+}
+
+int ASharedMemory_dupFromJava(JNIEnv* env, jobject sharedMemory) {
+    CALL(ASharedMemory_dupFromJava, 0, env, sharedMemory);
+}
+
+int ASharedMemory_create(const char *name, size_t size) {
+    CALL(ASharedMemory_create, -1, name, size);
+}
+
+size_t ASharedMemory_getSize(int fd) {
+    CALL(ASharedMemory_getSize, 0, fd);
+}
+
+int ASharedMemory_setProt(int fd, int prot) {
+    CALL(ASharedMemory_setProt, 0, fd, prot);
+}
+
+AStorageManager* AStorageManager_new() {
+    CALL(AStorageManager_new, NULL);
+}
+
+void AStorageManager_delete(AStorageManager* mgr) {
+    CALL(AStorageManager_delete,, mgr);
+}
+
+void AStorageManager_mountObb(AStorageManager* mgr, const char* filename, const char* key, AStorageManager_obbCallbackFunc cb, void* data) {
+    CALL(AStorageManager_mountObb,, mgr, filename, key, cb, data);
+}
+
+void AStorageManager_unmountObb(AStorageManager* mgr, const char* filename, const int force, AStorageManager_obbCallbackFunc cb, void* data) {
+    CALL(AStorageManager_unmountObb,, mgr, filename, force, cb, data);
+}
+
+int AStorageManager_isObbMounted(AStorageManager* mgr, const char* filename) {
+    CALL(AStorageManager_isObbMounted, 0, mgr, filename);
+}
+
+const char* AStorageManager_getMountedObbPath(AStorageManager* mgr, const char* filename) {
+    CALL(AStorageManager_getMountedObbPath, NULL, mgr, filename);
+}
+
+ASurfaceTexture* ASurfaceTexture_fromSurfaceTexture(JNIEnv* env, jobject surfacetexture) {
+    CALL(ASurfaceTexture_fromSurfaceTexture, NULL, env, surfacetexture);
+}
+
+void ASurfaceTexture_release(ASurfaceTexture* st) {
+    CALL(ASurfaceTexture_release,, st);
+}
+
+ANativeWindow* ASurfaceTexture_acquireANativeWindow(ASurfaceTexture* st) {
+    CALL(ASurfaceTexture_acquireANativeWindow, NULL, st);
+}
+
+int ASurfaceTexture_attachToGLContext(ASurfaceTexture* st, uint32_t texName) {
+    CALL(ASurfaceTexture_attachToGLContext, 0, st, texName);
+}
+
+int ASurfaceTexture_detachFromGLContext(ASurfaceTexture* st) {
+    CALL(ASurfaceTexture_detachFromGLContext, 0, st);
+}
+
+int ASurfaceTexture_updateTexImage(ASurfaceTexture* st) {
+    CALL(ASurfaceTexture_updateTexImage, 0, st);
+}
+
+void ASurfaceTexture_getTransformMatrix(ASurfaceTexture* st, float mtx[16]) {
+    CALL(ASurfaceTexture_getTransformMatrix,, st, mtx);
+}
+
+int64_t ASurfaceTexture_getTimestamp(ASurfaceTexture* st) {
+    CALL(ASurfaceTexture_getTimestamp, 0, st);
+}
+
+bool ATrace_isEnabled() {
+    CALL(ATrace_isEnabled, false);
+}
+
+void ATrace_beginSection(const char* sectionName) {
+    CALL(ATrace_beginSection,, sectionName);
+}
+
+void ATrace_endSection() {
+    CALL(ATrace_endSection,);
+}
+
+int android_setsocknetwork(net_handle_t network, int fd) {
+    CALL(android_setsocknetwork, 0, network, fd);
+}
+
+int android_setprocnetwork(net_handle_t network) {
+    CALL(android_setprocnetwork, 0, network);
+}
+
+int android_getaddrinfofornetwork(net_handle_t network, const char *node, const char *service, const struct addrinfo *hints, struct addrinfo **res) {
+    CALL(android_getaddrinfofornetwork, 0, network, node, service, hints, res);
+}

--- a/packages/libandroid-stub/libmediandk-wrapper.c
+++ b/packages/libandroid-stub/libmediandk-wrapper.c
@@ -1,0 +1,779 @@
+#include <dlfcn.h>
+#include <media/NdkImage.h>
+#include <media/NdkImageReader.h>
+#include <media/NdkMediaCodec.h>
+#include <media/NdkMediaCrypto.h>
+#include <media/NdkMediaDataSource.h>
+#include <media/NdkMediaDrm.h>
+#include <media/NdkMediaExtractor.h>
+#include <media/NdkMediaFormat.h>
+#include <media/NdkMediaMuxer.h>
+
+#ifdef __LP64__
+#define LIB "/system/lib64/libmediandk.so"
+#else
+#define LIB "/system/lib/libmediandk.so"
+#endif
+
+#define FUNCTIONS(f) \
+    f(AImage_delete) \
+    f(AImage_getWidth) \
+    f(AImage_getHeight) \
+    f(AImage_getFormat) \
+    f(AImage_getCropRect) \
+    f(AImage_getTimestamp) \
+    f(AImage_getNumberOfPlanes) \
+    f(AImage_getPlanePixelStride) \
+    f(AImage_getPlaneRowStride) \
+    f(AImage_getPlaneData) \
+    f(AImage_deleteAsync) \
+    f(AImage_getHardwareBuffer) \
+    f(AImageReader_new) \
+    f(AImageReader_delete) \
+    f(AImageReader_getWindow) \
+    f(AImageReader_getWidth) \
+    f(AImageReader_getHeight) \
+    f(AImageReader_getFormat) \
+    f(AImageReader_getMaxImages) \
+    f(AImageReader_acquireNextImage) \
+    f(AImageReader_acquireLatestImage) \
+    f(AImageReader_setImageListener) \
+    f(AImageReader_newWithUsage) \
+    f(AImageReader_acquireNextImageAsync) \
+    f(AImageReader_acquireLatestImageAsync) \
+    f(AImageReader_setBufferRemovedListener) \
+    f(AMediaCodec_createCodecByName) \
+    f(AMediaCodec_createDecoderByType) \
+    f(AMediaCodec_createEncoderByType) \
+    f(AMediaCodec_delete) \
+    f(AMediaCodec_configure) \
+    f(AMediaCodec_start) \
+    f(AMediaCodec_stop) \
+    f(AMediaCodec_flush) \
+    f(AMediaCodec_getInputBuffer) \
+    f(AMediaCodec_getOutputBuffer) \
+    f(AMediaCodec_dequeueInputBuffer) \
+    f(AMediaCodec_queueInputBuffer) \
+    f(AMediaCodec_queueSecureInputBuffer) \
+    f(AMediaCodec_dequeueOutputBuffer) \
+    f(AMediaCodec_getOutputFormat) \
+    f(AMediaCodec_releaseOutputBuffer) \
+    f(AMediaCodec_setOutputSurface) \
+    f(AMediaCodec_releaseOutputBufferAtTime) \
+    f(AMediaCodec_createInputSurface) \
+    f(AMediaCodec_createPersistentInputSurface) \
+    f(AMediaCodec_setInputSurface) \
+    f(AMediaCodec_setParameters) \
+    f(AMediaCodec_signalEndOfInputStream) \
+    f(AMediaCodec_getBufferFormat) \
+    f(AMediaCodec_getName) \
+    f(AMediaCodec_releaseName) \
+    f(AMediaCodec_setAsyncNotifyCallback) \
+    f(AMediaCodec_releaseCrypto) \
+    f(AMediaCodec_getInputFormat) \
+    f(AMediaCodecActionCode_isRecoverable) \
+    f(AMediaCodecActionCode_isTransient) \
+    f(AMediaCodecCryptoInfo_new) \
+    f(AMediaCodecCryptoInfo_delete) \
+    f(AMediaCodecCryptoInfo_setPattern) \
+    f(AMediaCodecCryptoInfo_getNumSubSamples) \
+    f(AMediaCodecCryptoInfo_getKey) \
+    f(AMediaCodecCryptoInfo_getIV) \
+    f(AMediaCodecCryptoInfo_getMode) \
+    f(AMediaCodecCryptoInfo_getClearBytes) \
+    f(AMediaCodecCryptoInfo_getEncryptedBytes) \
+    f(AMediaCrypto_isCryptoSchemeSupported) \
+    f(AMediaCrypto_requiresSecureDecoderComponent) \
+    f(AMediaCrypto_new) \
+    f(AMediaCrypto_delete) \
+    f(AMediaDataSource_new) \
+    f(AMediaDataSource_delete) \
+    f(AMediaDataSource_setUserdata) \
+    f(AMediaDataSource_setReadAt) \
+    f(AMediaDataSource_setGetSize) \
+    f(AMediaDataSource_setClose) \
+    f(AMediaDrm_isCryptoSchemeSupported) \
+    f(AMediaDrm_createByUUID) \
+    f(AMediaDrm_release) \
+    f(AMediaDrm_setOnEventListener) \
+    f(AMediaDrm_openSession) \
+    f(AMediaDrm_closeSession) \
+    f(AMediaDrm_getKeyRequest) \
+    f(AMediaDrm_provideKeyResponse) \
+    f(AMediaDrm_restoreKeys) \
+    f(AMediaDrm_removeKeys) \
+    f(AMediaDrm_queryKeyStatus) \
+    f(AMediaDrm_getProvisionRequest) \
+    f(AMediaDrm_provideProvisionResponse) \
+    f(AMediaDrm_getSecureStops) \
+    f(AMediaDrm_releaseSecureStops) \
+    f(AMediaDrm_getPropertyString) \
+    f(AMediaDrm_getPropertyByteArray) \
+    f(AMediaDrm_setPropertyString) \
+    f(AMediaDrm_setPropertyByteArray) \
+    f(AMediaDrm_encrypt) \
+    f(AMediaDrm_decrypt) \
+    f(AMediaDrm_sign) \
+    f(AMediaDrm_verify) \
+    f(AMediaExtractor_new) \
+    f(AMediaExtractor_delete) \
+    f(AMediaExtractor_setDataSourceFd) \
+    f(AMediaExtractor_setDataSource) \
+    f(AMediaExtractor_setDataSourceCustom) \
+    f(AMediaExtractor_getTrackCount) \
+    f(AMediaExtractor_getTrackFormat) \
+    f(AMediaExtractor_selectTrack) \
+    f(AMediaExtractor_unselectTrack) \
+    f(AMediaExtractor_readSampleData) \
+    f(AMediaExtractor_getSampleFlags) \
+    f(AMediaExtractor_getSampleTrackIndex) \
+    f(AMediaExtractor_getSampleTime) \
+    f(AMediaExtractor_advance) \
+    f(AMediaExtractor_seekTo) \
+    f(AMediaExtractor_getPsshInfo) \
+    f(AMediaExtractor_getSampleCryptoInfo) \
+    f(AMediaExtractor_getFileFormat) \
+    f(AMediaExtractor_getSampleSize) \
+    f(AMediaExtractor_getCachedDuration) \
+    f(AMediaExtractor_getSampleFormat) \
+    f(AMediaFormat_new) \
+    f(AMediaFormat_delete) \
+    f(AMediaFormat_toString) \
+    f(AMediaFormat_getInt32) \
+    f(AMediaFormat_getInt64) \
+    f(AMediaFormat_getFloat) \
+    f(AMediaFormat_getSize) \
+    f(AMediaFormat_getBuffer) \
+    f(AMediaFormat_getString) \
+    f(AMediaFormat_setInt32) \
+    f(AMediaFormat_setInt64) \
+    f(AMediaFormat_setFloat) \
+    f(AMediaFormat_setString) \
+    f(AMediaFormat_setBuffer) \
+    f(AMediaFormat_getDouble) \
+    f(AMediaFormat_getRect) \
+    f(AMediaFormat_setDouble) \
+    f(AMediaFormat_setSize) \
+    f(AMediaFormat_setRect) \
+    f(AMediaMuxer_new) \
+    f(AMediaMuxer_delete) \
+    f(AMediaMuxer_setLocation) \
+    f(AMediaMuxer_setOrientationHint) \
+    f(AMediaMuxer_addTrack) \
+    f(AMediaMuxer_start) \
+    f(AMediaMuxer_stop) \
+    f(AMediaMuxer_writeSampleData)
+
+#define STUB(s) __typeof__(s)* s;
+static struct {
+    FUNCTIONS(STUB)
+} stubs;
+#undef STUB
+
+__attribute__((constructor)) static void init() {
+    void* handle = dlopen(LIB, RTLD_LOCAL);
+    // Nothing bad happened, normal case for termux-docker.
+    if (!handle)
+        return;
+#define LOAD(s) stubs.s = dlsym(handle, #s);
+    FUNCTIONS(LOAD)
+#undef LOAD
+}
+
+#define CALL(f, def, ...) if (!stubs.f) return def; else return (stubs.f)(__VA_ARGS__)
+
+void AImage_delete(AImage* image) {
+    CALL(AImage_delete,, image);
+}
+
+media_status_t AImage_getWidth(const AImage* image, /*out*/int32_t* width) {
+    CALL(AImage_getWidth, 0, image, width);
+}
+
+media_status_t AImage_getHeight(const AImage* image, /*out*/int32_t* height) {
+    CALL(AImage_getHeight, 0, image, height);
+}
+
+media_status_t AImage_getFormat(const AImage* image, /*out*/int32_t* format) {
+    CALL(AImage_getFormat, 0, image, format);
+}
+
+media_status_t AImage_getCropRect(const AImage* image, /*out*/AImageCropRect* rect) {
+    CALL(AImage_getCropRect, 0, image, rect);
+}
+
+media_status_t AImage_getTimestamp(const AImage* image, /*out*/int64_t* timestampNs) {
+    CALL(AImage_getTimestamp, 0, image, timestampNs);
+}
+
+media_status_t AImage_getNumberOfPlanes(const AImage* image, /*out*/int32_t* numPlanes) {
+    CALL(AImage_getNumberOfPlanes, 0, image, numPlanes);
+}
+
+media_status_t AImage_getPlanePixelStride(const AImage* image, int planeIdx, /*out*/int32_t* pixelStride) {
+    CALL(AImage_getPlanePixelStride, 0, image, planeIdx, pixelStride);
+}
+
+media_status_t AImage_getPlaneRowStride(const AImage* image, int planeIdx, /*out*/int32_t* rowStride) {
+    CALL(AImage_getPlaneRowStride, 0, image, planeIdx, rowStride);
+}
+
+media_status_t AImage_getPlaneData(const AImage* image, int planeIdx, /*out*/uint8_t** data, /*out*/int* dataLength) {
+    CALL(AImage_getPlaneData, 0, image, planeIdx, data, dataLength);
+}
+
+void AImage_deleteAsync(AImage* image, int releaseFenceFd) {
+    CALL(AImage_deleteAsync,, image, releaseFenceFd);
+}
+
+media_status_t AImage_getHardwareBuffer(const AImage* image, /*out*/AHardwareBuffer** buffer) {
+    CALL(AImage_getHardwareBuffer, 0, image, buffer);
+}
+
+media_status_t AImageReader_new(int32_t width, int32_t height, int32_t format, int32_t maxImages, /*out*/AImageReader** reader) {
+    CALL(AImageReader_new, 0, width, height, format, maxImages, reader);
+}
+
+void AImageReader_delete(AImageReader* reader) {
+    CALL(AImageReader_delete,, reader);
+}
+
+media_status_t AImageReader_getWindow(AImageReader* reader, /*out*/ANativeWindow** window) {
+    CALL(AImageReader_getWindow, 0, reader, window);
+}
+
+media_status_t AImageReader_getWidth(const AImageReader* reader, /*out*/int32_t* width) {
+    CALL(AImageReader_getWidth, 0, reader, width);
+}
+
+media_status_t AImageReader_getHeight(const AImageReader* reader, /*out*/int32_t* height) {
+    CALL(AImageReader_getHeight, 0, reader, height);
+}
+
+media_status_t AImageReader_getFormat(const AImageReader* reader, /*out*/int32_t* format) {
+    CALL(AImageReader_getFormat, 0, reader, format);
+}
+
+media_status_t AImageReader_getMaxImages(const AImageReader* reader, /*out*/int32_t* maxImages) {
+    CALL(AImageReader_getMaxImages, 0, reader, maxImages);
+}
+
+media_status_t AImageReader_acquireNextImage(AImageReader* reader, /*out*/AImage** image) {
+    CALL(AImageReader_acquireNextImage, 0, reader, image);
+}
+
+media_status_t AImageReader_acquireLatestImage(AImageReader* reader, /*out*/AImage** image) {
+    CALL(AImageReader_acquireLatestImage, 0, reader, image);
+}
+
+media_status_t AImageReader_setImageListener(AImageReader* reader, AImageReader_ImageListener* listener) {
+    CALL(AImageReader_setImageListener, 0, reader, listener);
+}
+
+media_status_t AImageReader_newWithUsage(int32_t width, int32_t height, int32_t format, uint64_t usage, int32_t maxImages, /*out*/ AImageReader** reader) {
+    CALL(AImageReader_newWithUsage, 0, width, height, format, usage, maxImages, reader);
+}
+
+media_status_t AImageReader_acquireNextImageAsync(AImageReader* reader, /*out*/AImage** image, /*out*/int* acquireFenceFd) {
+    CALL(AImageReader_acquireNextImageAsync, 0, reader, image, acquireFenceFd);
+}
+
+media_status_t AImageReader_acquireLatestImageAsync(AImageReader* reader, /*out*/AImage** image, /*out*/int* acquireFenceFd) {
+    CALL(AImageReader_acquireLatestImageAsync, 0, reader, image, acquireFenceFd);
+}
+
+media_status_t AImageReader_setBufferRemovedListener(AImageReader* reader, AImageReader_BufferRemovedListener* listener) {
+    CALL(AImageReader_setBufferRemovedListener, 0, reader, listener);
+}
+
+AMediaCodec* AMediaCodec_createCodecByName(const char *name) {
+    CALL(AMediaCodec_createCodecByName, NULL, name);
+}
+
+AMediaCodec* AMediaCodec_createDecoderByType(const char *mime_type) {
+    CALL(AMediaCodec_createDecoderByType, NULL, mime_type);
+}
+
+AMediaCodec* AMediaCodec_createEncoderByType(const char *mime_type) {
+    CALL(AMediaCodec_createEncoderByType, NULL, mime_type);
+}
+
+media_status_t AMediaCodec_delete(AMediaCodec* mData) {
+    CALL(AMediaCodec_delete, 0, mData);
+}
+
+media_status_t AMediaCodec_configure(AMediaCodec* mData, const AMediaFormat* format, ANativeWindow* surface, AMediaCrypto *crypto, uint32_t flags) {
+    CALL(AMediaCodec_configure, 0, mData, format, surface, crypto, flags);
+}
+
+media_status_t AMediaCodec_start(AMediaCodec* mData) {
+    CALL(AMediaCodec_start, 0, mData);
+}
+
+media_status_t AMediaCodec_stop(AMediaCodec* mData) {
+    CALL(AMediaCodec_stop, 0, mData);
+}
+
+media_status_t AMediaCodec_flush(AMediaCodec* mData) {
+    CALL(AMediaCodec_flush, 0, mData);
+}
+
+uint8_t* AMediaCodec_getInputBuffer(AMediaCodec* mData, size_t idx, size_t *out_size) {
+    CALL(AMediaCodec_getInputBuffer, NULL, mData, idx, out_size);
+}
+
+uint8_t* AMediaCodec_getOutputBuffer(AMediaCodec* mData, size_t idx, size_t *out_size) {
+    CALL(AMediaCodec_getOutputBuffer, NULL, mData, idx, out_size);
+}
+
+ssize_t AMediaCodec_dequeueInputBuffer(AMediaCodec* mData, int64_t timeoutUs) {
+    CALL(AMediaCodec_dequeueInputBuffer, 0, mData, timeoutUs);
+}
+
+#if defined(__USE_FILE_OFFSET64) && !defined(__LP64__)
+#define _off_t_compat int32_t
+#else
+#define _off_t_compat off_t
+#endif  /* defined(__USE_FILE_OFFSET64) && !defined(__LP64__) */
+
+media_status_t AMediaCodec_queueInputBuffer(AMediaCodec* mData, size_t idx, _off_t_compat offset, size_t size, uint64_t time, uint32_t flags) {
+    CALL(AMediaCodec_queueInputBuffer, 0, mData, idx, offset, size, time, flags);
+}
+
+media_status_t AMediaCodec_queueSecureInputBuffer(AMediaCodec* mData, size_t idx, _off_t_compat offset, AMediaCodecCryptoInfo* crypto, uint64_t time, uint32_t flags) {
+    CALL(AMediaCodec_queueSecureInputBuffer, 0, mData, idx, offset, crypto, time, flags);
+}
+
+#undef _off_t_compat
+
+ssize_t AMediaCodec_dequeueOutputBuffer(AMediaCodec* mData, AMediaCodecBufferInfo *info, int64_t timeoutUs) {
+    CALL(AMediaCodec_dequeueOutputBuffer, 0, mData, info, timeoutUs);
+}
+
+AMediaFormat* AMediaCodec_getOutputFormat(AMediaCodec* mData) {
+    CALL(AMediaCodec_getOutputFormat, NULL, mData);
+}
+
+media_status_t AMediaCodec_releaseOutputBuffer(AMediaCodec* mData, size_t idx, bool render) {
+    CALL(AMediaCodec_releaseOutputBuffer, 0, mData, idx, render);
+}
+
+media_status_t AMediaCodec_setOutputSurface(AMediaCodec* mData, ANativeWindow* surface) {
+    CALL(AMediaCodec_setOutputSurface, 0, mData, surface);
+}
+
+media_status_t AMediaCodec_releaseOutputBufferAtTime(AMediaCodec *mData, size_t idx, int64_t timestampNs) {
+    CALL(AMediaCodec_releaseOutputBufferAtTime, 0, mData, idx, timestampNs);
+}
+
+media_status_t AMediaCodec_createInputSurface(AMediaCodec *mData, ANativeWindow **surface) {
+    CALL(AMediaCodec_createInputSurface, 0, mData, surface);
+}
+
+media_status_t AMediaCodec_createPersistentInputSurface(ANativeWindow **surface) {
+    CALL(AMediaCodec_createPersistentInputSurface, 0, surface);
+}
+
+media_status_t AMediaCodec_setInputSurface(AMediaCodec *mData, ANativeWindow *surface) {
+    CALL(AMediaCodec_setInputSurface, 0, mData, surface);
+}
+
+media_status_t AMediaCodec_setParameters(AMediaCodec *mData, const AMediaFormat* params) {
+    CALL(AMediaCodec_setParameters, 0, mData, params);
+}
+
+media_status_t AMediaCodec_signalEndOfInputStream(AMediaCodec *mData) {
+    CALL(AMediaCodec_signalEndOfInputStream, 0, mData);
+}
+
+AMediaFormat* AMediaCodec_getBufferFormat(AMediaCodec* mData, size_t index) {
+    CALL(AMediaCodec_getBufferFormat, 0, mData, index);
+}
+
+media_status_t AMediaCodec_getName(AMediaCodec* mData, char** out_name) {
+    CALL(AMediaCodec_getName, 0, mData, out_name);
+}
+
+void AMediaCodec_releaseName(AMediaCodec* mData, char* name) {
+    CALL(AMediaCodec_releaseName,, mData, name);
+}
+
+media_status_t AMediaCodec_setAsyncNotifyCallback(AMediaCodec* mData, AMediaCodecOnAsyncNotifyCallback callback, void *userdata) {
+    CALL(AMediaCodec_setAsyncNotifyCallback, 0, mData, callback, userdata);
+}
+
+media_status_t AMediaCodec_releaseCrypto(AMediaCodec* mData) {
+    CALL(AMediaCodec_releaseCrypto, 0, mData);
+}
+
+AMediaFormat* AMediaCodec_getInputFormat(AMediaCodec* mData) {
+    CALL(AMediaCodec_getInputFormat, NULL, mData);
+}
+
+bool AMediaCodecActionCode_isRecoverable(int32_t actionCode) {
+    CALL(AMediaCodecActionCode_isRecoverable, false, actionCode);
+}
+
+bool AMediaCodecActionCode_isTransient(int32_t actionCode) {
+    CALL(AMediaCodecActionCode_isTransient, false, actionCode);
+}
+
+AMediaCodecCryptoInfo *AMediaCodecCryptoInfo_new(int numsubsamples, uint8_t key[16], uint8_t iv[16], cryptoinfo_mode_t mode, size_t *clearbytes, size_t *encryptedbytes) {
+    CALL(AMediaCodecCryptoInfo_new, NULL, numsubsamples, key, iv, mode, clearbytes, encryptedbytes);
+}
+
+media_status_t AMediaCodecCryptoInfo_delete(AMediaCodecCryptoInfo* crypto) {
+    CALL(AMediaCodecCryptoInfo_delete, 0, crypto);
+}
+
+void AMediaCodecCryptoInfo_setPattern(AMediaCodecCryptoInfo *info, cryptoinfo_pattern_t *pattern) {
+    CALL(AMediaCodecCryptoInfo_setPattern,, info, pattern);
+}
+
+size_t AMediaCodecCryptoInfo_getNumSubSamples(AMediaCodecCryptoInfo* crypto) {
+    CALL(AMediaCodecCryptoInfo_getNumSubSamples, 0, crypto);
+}
+
+media_status_t AMediaCodecCryptoInfo_getKey(AMediaCodecCryptoInfo* crypto, uint8_t *dst) {
+    CALL(AMediaCodecCryptoInfo_getKey, 0, crypto, dst);
+}
+
+media_status_t AMediaCodecCryptoInfo_getIV(AMediaCodecCryptoInfo* crypto, uint8_t *dst) {
+    CALL(AMediaCodecCryptoInfo_getIV, 0, crypto, dst);
+}
+
+cryptoinfo_mode_t AMediaCodecCryptoInfo_getMode(AMediaCodecCryptoInfo* crypto) {
+    CALL(AMediaCodecCryptoInfo_getMode, 0, crypto);
+}
+
+media_status_t AMediaCodecCryptoInfo_getClearBytes(AMediaCodecCryptoInfo* crypto, size_t *dst) {
+    CALL(AMediaCodecCryptoInfo_getClearBytes, 0, crypto, dst);
+}
+
+media_status_t AMediaCodecCryptoInfo_getEncryptedBytes(AMediaCodecCryptoInfo* crypto, size_t *dst) {
+    CALL(AMediaCodecCryptoInfo_getEncryptedBytes, 0, crypto, dst);
+}
+
+bool AMediaCrypto_isCryptoSchemeSupported(const AMediaUUID uuid) {
+    CALL(AMediaCrypto_isCryptoSchemeSupported, false, uuid);
+}
+
+bool AMediaCrypto_requiresSecureDecoderComponent(const char *mime) {
+    CALL(AMediaCrypto_requiresSecureDecoderComponent, false, mime);
+}
+
+AMediaCrypto* AMediaCrypto_new(const AMediaUUID uuid, const void *initData, size_t initDataSize) {
+    CALL(AMediaCrypto_new, NULL, uuid, initData, initDataSize);
+}
+
+void AMediaCrypto_delete(AMediaCrypto* crypto) {
+    CALL(AMediaCrypto_delete,, crypto);
+}
+
+AMediaDataSource* AMediaDataSource_new() {
+    CALL(AMediaDataSource_new, NULL);
+}
+
+void AMediaDataSource_delete(AMediaDataSource* source) {
+    CALL(AMediaDataSource_delete,, source);
+}
+
+void AMediaDataSource_setUserdata(AMediaDataSource* source, void *userdata) {
+    CALL(AMediaDataSource_setUserdata,, source, userdata);
+}
+
+void AMediaDataSource_setReadAt(AMediaDataSource* source, AMediaDataSourceReadAt cb) {
+    CALL(AMediaDataSource_setReadAt,, source, cb);
+}
+
+void AMediaDataSource_setGetSize(AMediaDataSource* source, AMediaDataSourceGetSize cb) {
+    CALL(AMediaDataSource_setGetSize,, source, cb);
+}
+
+void AMediaDataSource_setClose(AMediaDataSource* source, AMediaDataSourceClose cb) {
+    CALL(AMediaDataSource_setClose,, source, cb);
+}
+
+bool AMediaDrm_isCryptoSchemeSupported(const uint8_t *uuid, const char *mimeType) {
+    CALL(AMediaDrm_isCryptoSchemeSupported, false, uuid, mimeType);
+}
+
+AMediaDrm* AMediaDrm_createByUUID(const uint8_t *uuid) {
+    CALL(AMediaDrm_createByUUID, NULL, uuid);
+}
+
+void AMediaDrm_release(AMediaDrm *mData) {
+    CALL(AMediaDrm_release,, mData);
+}
+
+media_status_t AMediaDrm_setOnEventListener(AMediaDrm *mData, AMediaDrmEventListener listener) {
+    CALL(AMediaDrm_setOnEventListener, 0, mData, listener);
+}
+
+media_status_t AMediaDrm_openSession(AMediaDrm *mData, AMediaDrmSessionId *sessionId) {
+    CALL(AMediaDrm_openSession, 0, mData, sessionId);
+}
+
+media_status_t AMediaDrm_closeSession(AMediaDrm * mData, const AMediaDrmSessionId *sessionId) {
+    CALL(AMediaDrm_closeSession, 0, mData, sessionId);
+}
+
+media_status_t AMediaDrm_getKeyRequest(AMediaDrm * mData, const AMediaDrmScope *scope, const uint8_t *init, size_t initSize, const char *mimeType, AMediaDrmKeyType keyType, const AMediaDrmKeyValue *optionalParameters, size_t numOptionalParameters, const uint8_t **keyRequest, size_t *keyRequestSize) {
+    CALL(AMediaDrm_getKeyRequest, 0, mData, scope, init, initSize, mimeType, keyType, optionalParameters, numOptionalParameters, keyRequest, keyRequestSize);
+}
+
+media_status_t AMediaDrm_provideKeyResponse(AMediaDrm *mData, const AMediaDrmScope *scope, const uint8_t *response, size_t responseSize, AMediaDrmKeySetId *keySetId) {
+    CALL(AMediaDrm_provideKeyResponse, 0, mData, scope, response, responseSize, keySetId);
+}
+
+media_status_t AMediaDrm_restoreKeys(AMediaDrm *mData, const AMediaDrmSessionId *sessionId, const AMediaDrmKeySetId *keySetId) {
+    CALL(AMediaDrm_restoreKeys, 0, mData, sessionId, keySetId);
+}
+
+media_status_t AMediaDrm_removeKeys(AMediaDrm *mData, const AMediaDrmSessionId *keySetId) {
+    CALL(AMediaDrm_removeKeys, 0, mData, keySetId);
+}
+
+media_status_t AMediaDrm_queryKeyStatus(AMediaDrm *mData, const AMediaDrmSessionId *sessionId, AMediaDrmKeyValue *keyValuePairs, size_t *numPairs) {
+    CALL(AMediaDrm_queryKeyStatus, 0, mData, sessionId, keyValuePairs, numPairs);
+}
+
+media_status_t AMediaDrm_getProvisionRequest(AMediaDrm *mData, const uint8_t **provisionRequest, size_t *provisionRequestSize, const char **serverUrl) {
+    CALL(AMediaDrm_getProvisionRequest, 0, mData, provisionRequest, provisionRequestSize, serverUrl);
+}
+
+media_status_t AMediaDrm_provideProvisionResponse(AMediaDrm *mData, const uint8_t *response, size_t responseSize) {
+    CALL(AMediaDrm_provideProvisionResponse, 0, mData, response, responseSize);
+}
+
+media_status_t AMediaDrm_getSecureStops(AMediaDrm *mData, AMediaDrmSecureStop *secureStops, size_t *numSecureStops) {
+    CALL(AMediaDrm_getSecureStops, 0, mData, secureStops, numSecureStops);
+}
+
+media_status_t AMediaDrm_releaseSecureStops(AMediaDrm *mData, const AMediaDrmSecureStop *ssRelease) {
+    CALL(AMediaDrm_releaseSecureStops, 0, mData, ssRelease);
+}
+
+media_status_t AMediaDrm_getPropertyString(AMediaDrm *mData, const char *propertyName, const char **propertyValue) {
+    CALL(AMediaDrm_getPropertyString, 0, mData, propertyName, propertyValue);
+}
+
+media_status_t AMediaDrm_getPropertyByteArray(AMediaDrm *mData, const char *propertyName, AMediaDrmByteArray *propertyValue) {
+    CALL(AMediaDrm_getPropertyByteArray, 0, mData, propertyName, propertyValue);
+}
+
+media_status_t AMediaDrm_setPropertyString(AMediaDrm *mData, const char *propertyName, const char *value) {
+    CALL(AMediaDrm_setPropertyString, 0, mData, propertyName, value);
+}
+
+media_status_t AMediaDrm_setPropertyByteArray(AMediaDrm *mData, const char *propertyName, const uint8_t *value, size_t valueSize) {
+    CALL(AMediaDrm_setPropertyByteArray, 0, mData, propertyName, value, valueSize);
+}
+
+media_status_t AMediaDrm_encrypt(AMediaDrm *mData, const AMediaDrmSessionId *sessionId, const char *cipherAlgorithm, uint8_t *keyId, uint8_t *iv, const uint8_t *input, uint8_t *output, size_t dataSize) {
+    CALL(AMediaDrm_encrypt, 0, mData, sessionId, cipherAlgorithm, keyId, iv, input, output, dataSize);
+}
+
+media_status_t AMediaDrm_decrypt(AMediaDrm *mData, const AMediaDrmSessionId *sessionId, const char *cipherAlgorithm, uint8_t *keyId, uint8_t *iv, const uint8_t *input, uint8_t *output, size_t dataSize) {
+    CALL(AMediaDrm_decrypt, 0, mData, sessionId, cipherAlgorithm, keyId, iv, input, output, dataSize);
+}
+
+media_status_t AMediaDrm_sign(AMediaDrm *mData, const AMediaDrmSessionId *sessionId, const char *macAlgorithm, uint8_t *keyId, uint8_t *message, size_t messageSize, uint8_t *signature, size_t *signatureSize) {
+    CALL(AMediaDrm_sign, 0, mData, sessionId, macAlgorithm, keyId, message, messageSize, signature, signatureSize);
+}
+
+media_status_t AMediaDrm_verify(AMediaDrm *mData, const AMediaDrmSessionId *sessionId, const char *macAlgorithm, uint8_t *keyId, const uint8_t *message, size_t messageSize, const uint8_t *signature, size_t signatureSize) {
+    CALL(AMediaDrm_verify, 0, mData, sessionId, macAlgorithm, keyId, message, messageSize, signature, signatureSize);
+}
+
+AMediaExtractor* AMediaExtractor_new() {
+    CALL(AMediaExtractor_new, NULL);
+}
+
+media_status_t AMediaExtractor_delete(AMediaExtractor* ex) {
+    CALL(AMediaExtractor_delete, 0, ex);
+}
+
+media_status_t AMediaExtractor_setDataSourceFd(AMediaExtractor* ex, int fd, off64_t offset, off64_t length) {
+    CALL(AMediaExtractor_setDataSourceFd, 0, ex, fd, offset, length);
+}
+
+media_status_t AMediaExtractor_setDataSource(AMediaExtractor* ex, const char *location) {
+    CALL(AMediaExtractor_setDataSource, 0, ex, location);
+}
+
+media_status_t AMediaExtractor_setDataSourceCustom(AMediaExtractor* ex, AMediaDataSource *src) {
+    CALL(AMediaExtractor_setDataSourceCustom, 0, ex, src);
+}
+
+size_t AMediaExtractor_getTrackCount(AMediaExtractor* ex) {
+    CALL(AMediaExtractor_getTrackCount, 0, ex);
+}
+
+AMediaFormat* AMediaExtractor_getTrackFormat(AMediaExtractor* ex, size_t idx) {
+    CALL(AMediaExtractor_getTrackFormat, NULL, ex, idx);
+}
+
+media_status_t AMediaExtractor_selectTrack(AMediaExtractor* ex, size_t idx) {
+    CALL(AMediaExtractor_selectTrack, 0, ex, idx);
+}
+
+media_status_t AMediaExtractor_unselectTrack(AMediaExtractor* ex, size_t idx) {
+    CALL(AMediaExtractor_unselectTrack, 0, ex, idx);
+}
+
+ssize_t AMediaExtractor_readSampleData(AMediaExtractor* ex, uint8_t *buffer, size_t capacity) {
+    CALL(AMediaExtractor_readSampleData, 0, ex, buffer, capacity);
+}
+
+uint32_t AMediaExtractor_getSampleFlags(AMediaExtractor* ex) {
+    CALL(AMediaExtractor_getSampleFlags, 0, ex);
+}
+
+int AMediaExtractor_getSampleTrackIndex(AMediaExtractor* ex) {
+    CALL(AMediaExtractor_getSampleTrackIndex, 0, ex);
+}
+
+int64_t AMediaExtractor_getSampleTime(AMediaExtractor* ex) {
+    CALL(AMediaExtractor_getSampleTime, 0, ex);
+}
+
+bool AMediaExtractor_advance(AMediaExtractor* ex) {
+    CALL(AMediaExtractor_advance, false, ex);
+}
+
+media_status_t AMediaExtractor_seekTo(AMediaExtractor* ex, int64_t seekPosUs, SeekMode mode) {
+    CALL(AMediaExtractor_seekTo, 0, ex, seekPosUs, mode);
+}
+
+PsshInfo* AMediaExtractor_getPsshInfo(AMediaExtractor* ex) {
+    CALL(AMediaExtractor_getPsshInfo, NULL, ex);
+}
+
+AMediaCodecCryptoInfo *AMediaExtractor_getSampleCryptoInfo(AMediaExtractor *ex) {
+    CALL(AMediaExtractor_getSampleCryptoInfo, NULL, ex);
+}
+
+AMediaFormat* AMediaExtractor_getFileFormat(AMediaExtractor* ex) {
+    CALL(AMediaExtractor_getFileFormat, NULL, ex);
+}
+
+ssize_t AMediaExtractor_getSampleSize(AMediaExtractor* ex) {
+    CALL(AMediaExtractor_getSampleSize, 0, ex);
+}
+
+int64_t AMediaExtractor_getCachedDuration(AMediaExtractor* ex) {
+    CALL(AMediaExtractor_getCachedDuration, 0, ex);
+}
+
+media_status_t AMediaExtractor_getSampleFormat(AMediaExtractor *ex, AMediaFormat *fmt) {
+    CALL(AMediaExtractor_getSampleFormat, 0, ex, fmt);
+}
+
+AMediaFormat *AMediaFormat_new() {
+    CALL(AMediaFormat_new, NULL);
+}
+
+media_status_t AMediaFormat_delete(AMediaFormat* mData) {
+    CALL(AMediaFormat_delete, 0, mData);
+}
+
+const char* AMediaFormat_toString(AMediaFormat* mData) {
+    CALL(AMediaFormat_toString, NULL, mData);
+}
+
+bool AMediaFormat_getInt32(AMediaFormat* mData, const char *name, int32_t *out) {
+    CALL(AMediaFormat_getInt32, false, mData, name, out);
+}
+
+bool AMediaFormat_getInt64(AMediaFormat* mData, const char *name, int64_t *out) {
+    CALL(AMediaFormat_getInt64, false, mData, name, out);
+}
+
+bool AMediaFormat_getFloat(AMediaFormat* mData, const char *name, float *out) {
+    CALL(AMediaFormat_getFloat, false, mData, name, out);
+}
+
+bool AMediaFormat_getSize(AMediaFormat* mData, const char *name, size_t *out) {
+    CALL(AMediaFormat_getSize, false, mData, name, out);
+}
+
+bool AMediaFormat_getBuffer(AMediaFormat* mData, const char *name, void** data, size_t *size) {
+    CALL(AMediaFormat_getBuffer, false, mData, name, data, size);
+}
+
+bool AMediaFormat_getString(AMediaFormat* mData, const char *name, const char **out) {
+    CALL(AMediaFormat_getString, false, mData, name, out);
+}
+
+void AMediaFormat_setInt32(AMediaFormat* mData, const char* name, int32_t value) {
+    CALL(AMediaFormat_setInt32,, mData, name, value);
+}
+
+void AMediaFormat_setInt64(AMediaFormat* mData, const char* name, int64_t value) {
+    CALL(AMediaFormat_setInt64,, mData, name, value);
+}
+
+void AMediaFormat_setFloat(AMediaFormat* mData, const char* name, float value) {
+    CALL(AMediaFormat_setFloat,, mData, name, value);
+}
+
+void AMediaFormat_setString(AMediaFormat* mData, const char* name, const char* value) {
+    CALL(AMediaFormat_setString,, mData, name, value);
+}
+
+void AMediaFormat_setBuffer(AMediaFormat* mData, const char* name, const void* data, size_t size) {
+    CALL(AMediaFormat_setBuffer,, mData, name, data, size);
+}
+
+bool AMediaFormat_getDouble(AMediaFormat* mData, const char *name, double *out) {
+    CALL(AMediaFormat_getDouble, false, mData, name, out);
+}
+
+bool AMediaFormat_getRect(AMediaFormat* mData, const char *name, int32_t *left, int32_t *top, int32_t *right, int32_t *bottom) {
+    CALL(AMediaFormat_getRect, false, mData, name, left, top, right, bottom);
+}
+
+void AMediaFormat_setDouble(AMediaFormat* mData, const char* name, double value) {
+    CALL(AMediaFormat_setDouble,, mData, name, value);
+}
+
+void AMediaFormat_setSize(AMediaFormat* mData, const char* name, size_t value) {
+    CALL(AMediaFormat_setSize,, mData, name, value);
+}
+
+void AMediaFormat_setRect(AMediaFormat* mData, const char* name, int32_t left, int32_t top, int32_t right, int32_t bottom) {
+    CALL(AMediaFormat_setRect,, mData, name, left, top, right, bottom);
+}
+
+AMediaMuxer* AMediaMuxer_new(int fd, OutputFormat format) {
+    CALL(AMediaMuxer_new, NULL, fd, format);
+}
+
+media_status_t AMediaMuxer_delete(AMediaMuxer* muxer) {
+    CALL(AMediaMuxer_delete, 0, muxer);
+}
+
+media_status_t AMediaMuxer_setLocation(AMediaMuxer* muxer, float latitude, float longitude) {
+    CALL(AMediaMuxer_setLocation, 0, muxer, latitude, longitude);
+}
+
+media_status_t AMediaMuxer_setOrientationHint(AMediaMuxer* muxer, int degrees) {
+    CALL(AMediaMuxer_setOrientationHint, 0, muxer, degrees);
+}
+
+ssize_t AMediaMuxer_addTrack(AMediaMuxer* muxer, const AMediaFormat* format) {
+    CALL(AMediaMuxer_addTrack, 0, muxer, format);
+}
+
+media_status_t AMediaMuxer_start(AMediaMuxer* muxer) {
+    CALL(AMediaMuxer_start, 0, muxer);
+}
+
+media_status_t AMediaMuxer_stop(AMediaMuxer* muxer) {
+    CALL(AMediaMuxer_stop, 0, muxer);
+}
+
+media_status_t AMediaMuxer_writeSampleData(AMediaMuxer *muxer, size_t trackIdx, const uint8_t *data, const AMediaCodecBufferInfo *info) {
+    CALL(AMediaMuxer_writeSampleData, 0, muxer, trackIdx, data, info);
+}


### PR DESCRIPTION
Fixes #23695, fixes #21660, fixes #19623, fixes #21881

Unfortunately I can not reproduce ffmpeg crash on my device, but spek works fine.
It should be tested with other system-lib-pulling projects to make sure it does not break anything else.

Also I removed a comment about the package not-to-be-dependent on because it does not ship NDK libraries anymore and fallbacks to functions in system libraries.

I am not intending to merge this until it is well tested. 

CC @licy183 @truboxl because you commited changes to this package.