### PR TITLE
bump(main/poke): 4.3

### DIFF
--- a/packages/poke/build.sh
+++ b/packages/poke/build.sh
@@ -2,14 +2,15 @@ TERMUX_PKG_HOMEPAGE=http://www.jemarch.net/poke.html
 TERMUX_PKG_DESCRIPTION="Interactive, extensible editor for binary data."
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="4.2"
+TERMUX_PKG_VERSION="4.3"
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/poke/poke-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=8aaf36e61e367a53140ea40e2559e9ec512e779c42bee34e7ac24b34ba119bde
+TERMUX_PKG_SHA256=a84cb9175d50d45a411f2481fd0662b83cb32ce517316b889cfb570819579373
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="gettext, libgc, ncurses, readline"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 ac_cv_header_glob_h=no
+gl_cv_func_strcasecmp_works=yes
 --disable-hserver
 --disable-threads
 --with-sysroot=$TERMUX_BASE_DIR


### PR DESCRIPTION
    
    Enable strcasecmp explicitly to fix the following configure error.
    
    checking for strcasecmp... yes
    checking whether strcasecmp works...
    configure: error: in '/home/builder/.termux-build/poke/src/jitter':
    configure: error: cannot run test program while cross compiling

* Fixes #23740 