### PR TITLE
fix(x11/kitty): prepend $TERMUX_PREFIX to some absolute paths that were not previously patched

### DIFF
--- a/x11-packages/kitty/build.sh
+++ b/x11-packages/kitty/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Cross-platform, fast, feature-rich, GPU based terminal"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.40.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/kovidgoyal/kitty/releases/download/v${TERMUX_PKG_VERSION}/kitty-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=f79222090c9468fef9084bef989cc9bf1c9ec37d3980688bdacf0ddca90d4e74
 # fontconfig is dlopen(3)ed:

--- a/x11-packages/kitty/prepend-prefix-to-etc-and-share-paths.patch
+++ b/x11-packages/kitty/prepend-prefix-to-etc-and-share-paths.patch
@@ -1,0 +1,40 @@
+--- a/kitty/cli.py
++++ b/kitty/cli.py
+@@ -1063,7 +1063,7 @@ def parse_args(
+     return ans, parse_cmdline(oc, disabled, ans, args=args)
+ 
+ 
+-SYSTEM_CONF = f'/etc/xdg/{appname}/{appname}.conf'
++SYSTEM_CONF = f'@TERMUX_PREFIX@/etc/xdg/{appname}/{appname}.conf'
+ 
+ 
+ def default_config_paths(conf_paths: Sequence[str]) -> tuple[str, ...]:
+--- a/shell-integration/bash/kitty.bash
++++ b/shell-integration/bash/kitty.bash
+@@ -10,13 +10,13 @@ if [[ -n "$KITTY_BASH_INJECT" ]]; then
+     builtin unset KITTY_SHELL_INTEGRATION  # ensure manual sourcing of this file in bashrc does not have any effect
+     builtin unset KITTY_BASH_INJECT ENV
+     if [[ -z "$HOME" ]]; then HOME=~; fi
+-    if [[ -z "$KITTY_BASH_ETC_LOCATION" ]]; then KITTY_BASH_ETC_LOCATION="/etc"; fi
++    if [[ -z "$KITTY_BASH_ETC_LOCATION" ]]; then KITTY_BASH_ETC_LOCATION="@TERMUX_PREFIX@/etc"; fi
+ 
+     _ksi_sourceable() {
+         [[ -f "$1" && -r "$1" ]] && builtin return 0; builtin return 1;
+     }
+ 
+-    if [[ -n "$ksi_val" && "$ksi_val" != *no-sudo* && -n "$TERMINFO" && ! ( -r "/usr/share/terminfo/x/xterm-kitty" || -r "/usr/share/terminfo/78/xterm-kitty" ) ]]; then
++    if [[ -n "$ksi_val" && "$ksi_val" != *no-sudo* && -n "$TERMINFO" && ! ( -r "@TERMUX_PREFIX@/share/terminfo/x/xterm-kitty" || -r "@TERMUX_PREFIX@/share/terminfo/78/xterm-kitty" ) ]]; then
+         # this must be done before sourcing user bashrc otherwise aliasing of sudo does not work
+         sudo() {
+             # Ensure terminfo is available in sudo
+--- a/tools/config/api.go
++++ b/tools/config/api.go
+@@ -289,7 +289,7 @@ func (self *ConfigParser) ParseFiles(paths ...string) error {
+ }
+ 
+ func (self *ConfigParser) LoadConfig(name string, paths []string, overrides []string) (err error) {
+-	const SYSTEM_CONF = "/etc/xdg/kitty"
++	const SYSTEM_CONF = "@TERMUX_PREFIX@/etc/xdg/kitty"
+ 	system_conf := filepath.Join(SYSTEM_CONF, name)
+ 	add_if_exists := func(q string) {
+ 		err = self.ParseFiles(q)


### PR DESCRIPTION
- Fixes #23745