### PR TITLE
fix(main/coreutils): fix undefined behavior in coreutils built with selinux enabled and xattrs disabled

### DIFF
--- a/packages/coreutils/backport-d89387b.patch
+++ b/packages/coreutils/backport-d89387b.patch
@@ -1,0 +1,34 @@
+From d89387b293068773c74f37ebf8fb692ad962b43a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?P=C3=A1draig=20Brady?= <P@draigBrady.com>
+Date: Thu, 20 Mar 2025 18:40:01 +0000
+Subject: [PATCH] ls: fix crash on systems with SELinux but without xattr
+ support
+
+This was seen on termux with ./configure --disable-xattr
+where listxattr() and getxattr() returned ENOTSUP.
+Then the valid security context obtained by file_has_aclinfo()
+was discounted, and problematically then freed multiple times.
+Reported at https://github.com/termux/termux-packages/issues/23752
+
+* src/ls.c (file_has_aclinfo_cache): Only discount the returned
+acl info when all components are defaulted due to being unsupported.
+---
+ NEWS     | 3 ++-
+ src/ls.c | 3 ++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+--- a/src/ls.c
++++ b/src/ls.c
+@@ -3327,7 +3327,8 @@ file_has_aclinfo_cache (char const *file, struct fileinfo *f,
+   errno = 0;
+   int n = file_has_aclinfo (file, ai, flags);
+   int err = errno;
+-  if (f->stat_ok && n <= 0 && !acl_errno_valid (err))
++  if (f->stat_ok && n <= 0 && !acl_errno_valid (err)
++      && (!(flags & ACL_GET_SCONTEXT) || !acl_errno_valid (ai->scontext_err)))
+     {
+       unsupported_return = n;
+       unsupported_scontext = ai->scontext;
+-- 
+2.48.1
+

--- a/packages/coreutils/build.sh
+++ b/packages/coreutils/build.sh
@@ -3,12 +3,16 @@ TERMUX_PKG_DESCRIPTION="Basic file, shell and text manipulation utilities from t
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION=9.6
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/coreutils/coreutils-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=7a0124327b398fd9eb1a6abde583389821422c744ffa10734b24f557610d3283
 TERMUX_PKG_DEPENDS="libandroid-selinux, libandroid-support, libgmp, libiconv"
 TERMUX_PKG_BREAKS="chroot, busybox (<< 1.30.1-4)"
 TERMUX_PKG_REPLACES="chroot, busybox (<< 1.30.1-4)"
 TERMUX_PKG_ESSENTIAL=true
+# On device build is unsupported as it removes utility 'ln' (and maybe
+# something else) in the installation process.
+TERMUX_PKG_ON_DEVICE_BUILD_NOT_SUPPORTED=true
 
 # pinky has no usage on Android.
 # df does not work either, let system binary prevail.
@@ -32,10 +36,4 @@ termux_step_pre_configure() {
 
 	CPPFLAGS+=" -D__USE_FORTIFY_LEVEL=0"
 	LDFLAGS+=" -landroid-selinux"
-
-	# On device build is unsupported as it removes utility 'ln' (and maybe
-	# something else) in the installation process.
-	if $TERMUX_ON_DEVICE_BUILD; then
-		termux_error_exit "Package '$TERMUX_PKG_NAME' is not safe for on-device builds."
-	fi
 }


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/23752

Patch created and shared by pixelb

This restores the `ls -Z` command to its pre-coreutils-9.6 behavior,

and passes these test cases on Samsung Galaxy A70 SM-A705FN with Android 13:

(should not crash)
```bash
cd && ls -Z ..
```

(should not crash)
```bash
cd && ls -Z . > out
```

(should not crash)
```bash
ls -Z /storage/emulated/0/
```

(should show correct output, like `u:object_r:fuse:s0`)
```bash
cd /storage/emulated/0 && ls -Z $(pwd)
```

(should print both directories without crashing)
```bash
ls -l /storage/emulated/0 /storage/emulated/0/Download
```

(should print both directories without crashing)
```bash
ls -Z /storage/emulated/0 /storage/emulated/0/Download
```

(should print both directories without crashing)
```bash
ls -lZ /storage/emulated/0 /storage/emulated/0/Download
```

More information here:

https://github.com/termux/termux-packages/pull/23691#discussion_r1986260242
https://github.com/termux/termux-packages/pull/23756#discussion_r1993138524