### PR TITLE
addpkg(root/thin-provisioning-tools): add v0.9.0

### DIFF
--- a/root-packages/thin-provisioning-tools/build.patch
+++ b/root-packages/thin-provisioning-tools/build.patch
@@ -1,0 +1,19 @@
+diff --git a/Makefile.in b/Makefile.in
+index b1fd4aa5..e5d9a1bf 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -185,13 +185,10 @@ else
+ CXXLIB+=-lstdc++
+ endif
+ 
+-ifeq ("@STATIC@", "yes")
+-LDFLAGS+=-static
+-endif
+ 
+ INSTALL:=@INSTALL@
+ PREFIX:=@prefix@
+-BINDIR:=$(DESTDIR)$(PREFIX)/sbin
++BINDIR:=$(DESTDIR)$(PREFIX)/bin
+ DATADIR:=$(DESTDIR)$(PREFIX)/share
+ MANPATH:=$(DATADIR)/man
+ 

--- a/root-packages/thin-provisioning-tools/build.sh
+++ b/root-packages/thin-provisioning-tools/build.sh
@@ -1,0 +1,18 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/jthornber/thin-provisioning-tools
+TERMUX_PKG_DESCRIPTION="A suite of tools for manipulating the metadata of the dm-thin, dm-cache and dm-era device-mapper targets."
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.9.0"
+TERMUX_PKG_SRCURL=https://github.com/jthornber/thin-provisioning-tools/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=a2508d9933ed8a3f6c8d302280d838d416668a1d914a83c4bd0fb01eaf0676e8
+TERMUX_PKG_DEPENDS="libexpat, libaio, boost"
+TERMUX_PKG_BUILD_DEPENDS="boost-headers"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-optimisation=-O3"
+TERMUX_PKG_AUTO_UPDATE=false
+
+termux_step_pre_configure() {
+	CFLAGS+=" -I$TERMUX_PREFIX/include"
+	CXXFLAGS+=" -I$TERMUX_PREFIX/include"
+	autoconf
+}

--- a/root-packages/thin-provisioning-tools/file_utils.patch
+++ b/root-packages/thin-provisioning-tools/file_utils.patch
@@ -1,0 +1,25 @@
+diff --git a/base/file_utils.cc b/base/file_utils.cc
+index e4f37228..14ae277a 100644
+--- a/base/file_utils.cc
++++ b/base/file_utils.cc
+@@ -10,6 +10,7 @@
+ #include <fcntl.h>
+ #include <unistd.h>
+ #include <string.h>
++#include <cstdlib>
+ 
+ //----------------------------------------------------------------
+ 
+@@ -150,9 +151,9 @@ file_utils::zero_superblock(std::string const &path)
+ 	unsigned const SUPERBLOCK_SIZE = 4096;
+ 	file_descriptor fd = open_block_file(path, SUPERBLOCK_SIZE, true, true);
+ 
+-	buffer = reinterpret_cast<char *>(aligned_alloc(SUPERBLOCK_SIZE, SUPERBLOCK_SIZE));
+-	if (!buffer)
+-        	throw runtime_error("out of memory");
++	if (posix_memalign(reinterpret_cast<void**>(&buffer), SUPERBLOCK_SIZE, SUPERBLOCK_SIZE) != 0) {
++		throw runtime_error("out of memory");
++	}
+ 
+ 	memset(buffer, 0, SUPERBLOCK_SIZE);
+ 	if (::write(fd.fd_, buffer, SUPERBLOCK_SIZE) != SUPERBLOCK_SIZE)


### PR DESCRIPTION
add thin-provisioning-tools to allow lvm2 use thin pools on 4.19 kernel