### PR TITLE
addpkg(main/python-yt-dlp): 2025.02.19 - Migrate from TUR.

### DIFF
--- a/packages/python-brotli/build.sh
+++ b/packages/python-brotli/build.sh
@@ -1,0 +1,27 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/google/brotli
+TERMUX_PKG_DESCRIPTION="lossless compression algorithm and format (Python bindings)"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=1.1.0
+TERMUX_PKG_REVISION=2
+TERMUX_PKG_SRCURL=https://github.com/google/brotli/archive/v$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=e720a6ca29428b803f4ad165371771f5398faba397edf6778837a18599ea13ff
+TERMUX_PKG_DEPENDS="python, python-pip"
+TERMUX_PKG_PYTHON_COMMON_DEPS="wheel"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+
+termux_step_configure() {
+	# ERROR: ./lib/python3.12/site-packages/_brotli.cpython-312.so contains undefined symbols:
+	# 31: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND log2
+	LDFLAGS+=" -lm"
+	LDFLAGS+=" -Wl,--no-as-needed -lpython${TERMUX_PYTHON_VERSION}"
+}
+
+termux_step_make() {
+	:
+}
+
+termux_step_make_install() {
+	pip install . --prefix="$TERMUX_PREFIX" -vv --no-build-isolation --no-deps
+}

--- a/packages/python-pycryptodomex/build.sh
+++ b/packages/python-pycryptodomex/build.sh
@@ -1,0 +1,25 @@
+TERMUX_PKG_HOMEPAGE=https://www.pycryptodome.org/
+TERMUX_PKG_DESCRIPTION="A self-contained Python package of low-level cryptographic primitives"
+TERMUX_PKG_LICENSE="BSD 2-Clause, Public Domain"
+TERMUX_PKG_LICENSE_FILE="LICENSE.rst"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="3.21.0"
+TERMUX_PKG_REVISION=2
+TERMUX_PKG_SRCURL="https://github.com/Legrandin/pycryptodome/archive/refs/tags/v${TERMUX_PKG_VERSION}x.tar.gz"
+TERMUX_PKG_SHA256=7762d1b658b47e989f21ed844a8bf9a527b130fecec26f0d5076656dc38c0558
+TERMUX_PKG_DEPENDS="python, python-pip"
+TERMUX_PKG_PYTHON_COMMON_DEPS="wheel"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+
+termux_step_pre_configure() {
+	LDFLAGS+=" -Wl,--no-as-needed -lpython${TERMUX_PYTHON_VERSION}"
+}
+
+termux_step_make() {
+	:
+}
+
+termux_step_make_install() {
+	pip install . --prefix="$TERMUX_PREFIX" -vv --no-build-isolation --no-deps
+}

--- a/packages/python-yt-dlp/build.sh
+++ b/packages/python-yt-dlp/build.sh
@@ -1,0 +1,47 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/yt-dlp/yt-dlp
+TERMUX_PKG_DESCRIPTION="A youtube-dl fork with additional features and fixes"
+TERMUX_PKG_LICENSE="Unlicense"
+TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
+TERMUX_PKG_VERSION="2025.02.19"
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=https://github.com/yt-dlp/yt-dlp/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=3942d04ac56b7cbd51881653946662dc84b8628c9405f9e9bacb29d0259e0ab1
+TERMUX_PKG_DEPENDS="libc++, libexpat, openssl, python, python-brotli, python-pip, python-pycryptodomex"
+TERMUX_PKG_RECOMMENDS="ffmpeg"
+TERMUX_PKG_PYTHON_COMMON_DEPS="hatchling, wheel"
+TERMUX_PKG_PYTHON_TARGET_DEPS="mutagen, pycryptodomex, websockets, certifi, brotli, requests, urllib3"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_HOSTBUILD=true
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_PROVIDES='yt-dlp'
+
+termux_step_host_build() {
+	cp -Rf $TERMUX_PKG_SRCDIR ./
+
+	( cd src && make completions )
+}
+
+termux_step_make() {
+	:
+}
+
+termux_step_make_install() {
+	# Install library
+	pip install . --prefix=$TERMUX_PREFIX -vv --no-build-isolation --no-deps
+
+	# Install completions
+	install -Dm600 $TERMUX_PKG_HOSTBUILD_DIR/src/completions/bash/yt-dlp \
+		-t "$TERMUX_PREFIX"/share/bash-completion/completions
+	install -Dm600 $TERMUX_PKG_HOSTBUILD_DIR/src/completions/zsh/_yt-dlp \
+		-t "$TERMUX_PREFIX"/share/zsh/site-functions
+	install -Dm600 $TERMUX_PKG_HOSTBUILD_DIR/src/completions/fish/yt-dlp.fish \
+		-t "$TERMUX_PREFIX"/share/fish/completions
+}
+
+termux_step_create_debscripts() {
+	cat <<- EOF > ./postinst
+	#!$TERMUX_PREFIX/bin/sh
+	echo "Installing dependencies through pip..."
+	pip3 install ${TERMUX_PKG_PYTHON_TARGET_DEPS//, / }
+	EOF
+}


### PR DESCRIPTION
This PR migrates `python-yt-dlp` from the TUR.
Additionally:
- Sets a maintainer
- Makes it provide `yt-dlp` to aid package discoverability
- Changes `ffmpeg` from a `TERMUX_PKG_SUGGESTS`[^1] to `TERMUX_PKG_RECOMMENDS`[^2]
- Clean up a few shellcheck warnings

- Corresponding TUR PR: https://github.com/termux-user-repository/tur/pull/1593

[^1]: Comma-separated list of packages that are related to or enhance the current one.
[^2]: Comma-separated list of non-absolute dependencies - packages usually used with the current one.
https://github.com/termux/termux-packages/wiki/Creating-new-package#package-build-script-variables