### PR TITLE
fix(main/mc): update project links

### DIFF
--- a/packages/mc/build.sh
+++ b/packages/mc/build.sh
@@ -1,9 +1,9 @@
-TERMUX_PKG_HOMEPAGE=https://www.midnight-commander.org/
+TERMUX_PKG_HOMEPAGE=https://midnight-commander.org
 TERMUX_PKG_DESCRIPTION="Midnight Commander - a powerful file manager"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="4.8.33"
-TERMUX_PKG_SRCURL=http://ftp.midnight-commander.org/mc-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SRCURL=https://ftp.osuosl.org/pub/midnightcommander/mc-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=cae149d42f844e5185d8c81d7db3913a8fa214c65f852200a9d896b468af164c
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="glib, libandroid-support, libssh2, ncurses, which"


### PR DESCRIPTION
Hello,

I'm preparing the migration to a new website. As part of this, we will be dropping the `www` prefix. Also, I have updated the package source to use HTTPS with our official OSU OSL mirror.

Thank you!