### PR TITLE
bump(main/git): 2.49.0

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -185,6 +185,7 @@
 /packages/borgbackup/ @TomJo2000
 /packages/coreutils/ @TomJo2000
 /packages/eza/ @TomJo2000
+/packages/git/ @TomJo2000
 /packages/git-delta/ @TomJo2000
 /packages/gopass/ @TomJo2000
 /packages/gopls/ @TomJo2000

--- a/packages/git/build.sh
+++ b/packages/git/build.sh
@@ -1,10 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://git-scm.com/
 TERMUX_PKG_DESCRIPTION="Fast, scalable, distributed revision control system"
 TERMUX_PKG_LICENSE="GPL-2.0"
-TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="2.48.1"
+TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
+TERMUX_PKG_VERSION="2.49.0"
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/pub/software/scm/git/git-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=1c5d545f5dc1eb51e95d2c50d98fdf88b1a36ba1fa30e9ae5d5385c6024f82ad
+TERMUX_PKG_SHA256=618190cf590b7e9f6c11f91f23b1d267cd98c3ab33b850416d8758f8b5a85628
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libcurl, libexpat, libiconv, less, openssl, pcre2, zlib"
 TERMUX_PKG_RECOMMENDS="openssh"

--- a/packages/git/disable-fdsan.patch
+++ b/packages/git/disable-fdsan.patch
@@ -1,9 +1,10 @@
-diff -uNr git-2.36.1/common-main.c git-2.36.1.mod/common-main.c
---- git-2.36.1/common-main.c      2022-06-24 14:42:50.227057300 +0800
-+++ git-2.36.1.mod/common-main.c  2022-06-24 14:37:29.198791200 +0800
-@@ -2,6 +2,9 @@
- #include "exec-cmd.h"
- #include "attr.h"
+diff --git a/common-init.c b/common-init.c
+index 5cc73f058c..778837a0bb 100644
+--- a/common-init.c
++++ b/common-init.c
+@@ -10,6 +10,9 @@
+ #include "strbuf.h"
+ #include "trace2.h"
  
 +#include <android/fdsan.h>
 +#include <dlfcn.h>
@@ -11,7 +12,7 @@ diff -uNr git-2.36.1/common-main.c git-2.36.1.mod/common-main.c
  /*
   * Many parts of Git have subprograms communicate via pipe, expect the
   * upstream of a pipe to die with SIGPIPE when the downstream of a
-@@ -23,11 +26,25 @@
+@@ -31,10 +34,24 @@ static void restore_sigpipe_to_default(void)
  	signal(SIGPIPE, SIG_DFL);
  }
  
@@ -27,9 +28,8 @@ diff -uNr git-2.36.1/common-main.c git-2.36.1.mod/common-main.c
 +	}
 +}
 +
- int main(int argc, const char **argv)
+ void init_git(const char **argv)
  {
- 	int result;
  	struct strbuf tmp = STRBUF_INIT;
  
 +	termux_disable_fdsan();


### PR DESCRIPTION
closes #23791
- Update Git to 2.49
- Update `disable-fdsan.patch`, `common-main.c` has been split into `common-init.c` and `common-exit.c`.
Upstream commit: https://web.git.kernel.org/pub/scm/git/git.git/commit/?h=main&id=3f8f2abe05c0aeb0ea60768d44a99261ed456d44
- Set a maintainer (and update the CODEOWNERS file)