### PR TITLE
enhancement(github): add contact badges with links to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -7,6 +7,8 @@ body:
   - type: markdown
     attributes:
       value: |
+        [![Join the Termux Discord server](https://img.shields.io/discord/641256914684084234.svg?label=&logo=discord&logoColor=ffffff&color=5865F2)](https://discord.gg/HXpF69X) [![Join the Termux space on Matrix](https://img.shields.io/badge/Matrix-%E2%80%8B?style=plastic&logo=matrix&logoColor=white&color=green)](https://matrix.to/#/#Termux:matrix.org) [![Join the Termux server on Telegram](https://img.shields.io/badge/Telegram-%E2%80%8B?style=plastic&logo=telegram&logoColor=white&color=blue)](https://t.me/termux24x7) [![Official subreddit](https://img.shields.io/badge/Reddit-%E2%80%8B?style=plastic&logo=reddit&logoColor=white&color=red)](https://www.reddit.com/r/termux/)
+
         This is a bug tracker of the official Termux packages. Please do not report issues of third-party software there, but ask in [GitHub Discussions](https://github.com/termux/termux-packages/discussions) or [Community Social Media](https://wiki.termux.com/wiki/Community) instead. Use search to check whether your issue has been already reported and perhaps solved.
 
         Android versions 5.x and 6.x are not supported anymore. Issues happening on these operating system versions will not be resolved.


### PR DESCRIPTION
Alternative to #23713.

[Preview link.](https://github.com/termux/termux-packages/blob/links-in-bug-report-template/.github/ISSUE_TEMPLATE/01-bug-report.yml)

badges are generated with https://shields.io/badges.