### PR TITLE
keep build state when running command again

### DIFF
--- a/scripts/build/configure/termux_step_configure.sh
+++ b/scripts/build/configure/termux_step_configure.sh
@@ -1,5 +1,6 @@
 termux_step_configure() {
 	[ "$TERMUX_PKG_METAPACKAGE" = "true" ] && return
+	[ -f "$TERMUX_PKG_CONFIGURE_MARKER" ] && ! $TERMUX_FORCE_BUILD && echo packet already configured run with -f to reconfigure && return
 
 	# This check should be above autotools check as haskell package too makes use of configure scripts which
 	# should be executed by its own build system.
@@ -31,4 +32,5 @@ termux_step_configure() {
 		fi
 		termux_step_configure_meson
 	fi
+	touch $TERMUX_PKG_CONFIGURE_MARKER
 }

--- a/scripts/build/get_source/termux_git_clone_src.sh
+++ b/scripts/build/get_source/termux_git_clone_src.sh
@@ -38,8 +38,7 @@ termux_git_clone_src() {
 		popd
 
 		echo "$TERMUX_PKG_VERSION" > $TMP_CHECKOUT_VERSION
-	fi
-
 	rm -rf $TERMUX_PKG_SRCDIR
 	cp -Rf $TMP_CHECKOUT $TERMUX_PKG_SRCDIR
+	fi
 }

--- a/scripts/build/get_source/termux_step_get_source.sh
+++ b/scripts/build/get_source/termux_step_get_source.sh
@@ -4,6 +4,7 @@ termux_step_get_source() {
 	if [ "${TERMUX_PKG_SRCURL:0:4}" == "git+" ]; then
 		termux_git_clone_src
 	else
+		[ -d "$TERMUX_PKG_SRCDIR" ] && echo source folder already exists use -f to delete  && return
 		if [ -z "${TERMUX_PKG_SRCURL}" ] || [ "${TERMUX_PKG_SKIP_SRC_EXTRACT-false}" = "true" ] || [ "$TERMUX_PKG_METAPACKAGE" = "true" ]; then
 			mkdir -p "$TERMUX_PKG_SRCDIR"
 			return

--- a/scripts/build/termux_step_make.sh
+++ b/scripts/build/termux_step_make.sh
@@ -7,7 +7,7 @@ termux_step_make() {
 	fi
 
 	if test -f build.ninja; then
-		ninja -j $TERMUX_PKG_MAKE_PROCESSES
+		ninja -j $TERMUX_PKG_MAKE_PROCESSES $TERMUX_PKG_EXTRA_MAKE_ARGS
 	elif ls ./*.cabal &>/dev/null; then
 		cabal build
 	elif ls ./*akefile &>/dev/null || [ ! -z "$TERMUX_PKG_EXTRA_MAKE_ARGS" ]; then

--- a/scripts/build/termux_step_patch_package.sh
+++ b/scripts/build/termux_step_patch_package.sh
@@ -26,7 +26,7 @@ termux_step_patch_package() {
 			-e "s%\@TERMUX_HOME\@%${TERMUX_ANDROID_HOME}%g" \
 			-e "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" \
 			-e "s%\@TERMUX_PREFIX_CLASSICAL\@%${TERMUX_PREFIX_CLASSICAL}%g" \
-			"$patch" | patch --silent -p1
+			"$patch" | patch -f --silent -p1 || [ -f "$TERMUX_PKG_CONFIGURE_MARKER" ]
 	done
 	shopt -u nullglob
 }

--- a/scripts/build/termux_step_setup_build_folders.sh
+++ b/scripts/build/termux_step_setup_build_folders.sh
@@ -1,4 +1,5 @@
 termux_step_setup_build_folders() {
+	[ -f "$TERMUX_PKG_CONFIGURE_MARKER" ] && ! $TERMUX_FORCE_BUILD && echo previous build detected use -f start over && return
 	# Following directories may contain files with read-only
 	# permissions which makes them undeletable. We need to fix
 	# that.

--- a/scripts/build/termux_step_setup_variables.sh
+++ b/scripts/build/termux_step_setup_variables.sh
@@ -136,6 +136,7 @@ termux_step_setup_variables() {
 	TERMUX_PKG_BUILD_DEPENDS=""
 	TERMUX_PKG_BUILD_IN_SRC=false
 	TERMUX_PKG_CONFFILES=""
+	TERMUX_PKG_CONFIGURE_MARKER=$TERMUX_TOPDIR/$TERMUX_PKG_NAME/.configured
 	TERMUX_PKG_CONFLICTS="" # https://www.debian.org/doc/debian-policy/ch-relationships.html#s-conflicts
 	TERMUX_PKG_DEPENDS=""
 	TERMUX_PKG_DESCRIPTION="FIXME:Add description"


### PR DESCRIPTION
flag -f will rerun configure but the source and build folders are never
deleted. it is necessary for testing that it behaves like a manual build .
usually many runs are required before everything succeed

@fornwall can you intervene here. I also speak Swedish and is also a
theoretical physicist PhD currently hiking the mountains of Tasmania.
@thunder-coding is not as experienced as us but is closing good commits
left and right without any understand of how anything works
