### PR TITLE
bump(main/imlib2): 1.12.4

### DIFF
--- a/packages/imlib2/build.sh
+++ b/packages/imlib2/build.sh
@@ -3,10 +3,12 @@ TERMUX_PKG_DESCRIPTION="Library that does image file loading and saving as well 
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="COPYING, COPYING-PLAIN"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.12.3"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="1.12.4"
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/enlightenment/imlib2-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=96244656576a3e0a6f58b78e514ddc919622ac6806711bc231837eee62c1de34
+TERMUX_PKG_SHA256=bf07ff09255ed30f05a1c252d4b578426c2dcdbbc28e8c714adf060690395720
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="freetype, gdk-pixbuf, giflib, glib, libandroid-shmem, libbz2, libcairo, libheif, libid3tag, libjpeg-turbo, libjxl, liblzma, libpng, librsvg, libtiff, libwebp, libx11, libxcb, libxext, openjpeg, zlib"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="LIBS=-landroid-shmem"
+
+termux_step_pre_configure() {
+	LDFLAGS+=" -landroid-shmem -lm"
+}


### PR DESCRIPTION
Link with math library explicitly to fix the following error. ERROR: ./lib/imlib2/filters/colormod.so contains undefined symbols: pow

* Fixes #23838 