### PR TITLE
Termux download retry timeout

### DIFF
--- a/scripts/build/termux_download.sh
+++ b/scripts/build/termux_download.sh
@@ -18,17 +18,19 @@ termux_download() {
 
 	local TMPFILE
 	local -a CURL_OPTIONS=(
-		--fail
-		--retry 5
-		--retry-connrefused
-		--retry-delay 5
-		--speed-limit 1000
-		--speed-time 60
-		--location
+		--fail               # Consider 4xx and 5xx responses as failures
+		--retry 5            # Retry up to 5 times on transient failures
+		--retry-connrefused  # Also retry on refused connections
+		--retry-delay 5      # Wait 5 seconds between retries
+		--connect-timeout 30 # Wait at most 30 seconds for a connection to be established
+		--retry-max-time 120 # Stop retrying if it's still failing after 120 seconds
+		--speed-limit 1000   # Expect at least 1000 Bytes per second
+		--speed-time 60      # Fail if the minimum speed isn't met for at least 60 seconds
+		--location           # Follow redirects
 	)
 	TMPFILE=$(mktemp "$TERMUX_PKG_TMPDIR/download.${TERMUX_PKG_NAME-unnamed}.XXXXXXXXX")
 	if [[ "${TERMUX_QUIET_BUILD-}" == "true" ]]; then
-		CURL_OPTIONS+=( --no-progress-meter)
+		CURL_OPTIONS+=(--no-progress-meter) # Don't print out transfer statistics
 	fi
 
 	echo "Downloading ${URL}"


### PR DESCRIPTION
This PR should hopefully cut down on the time spent by `termux_download` when retrying an unresponsive URL, by putting a 300 second cumulative limit on retries.
- See: #23841
- This PR partly follows up on: #21251