### PR TITLE
script(properties.sh): Fix unbound variable `TERMUX_SCRIPTDIR`

### DIFF
--- a/scripts/properties.sh
+++ b/scripts/properties.sh
@@ -3,6 +3,8 @@
 # coreutils and are clearly not a default part of most Linux installations,
 # or sourcing any other script in our build directories.
 
+: "${TERMUX_SCRIPTDIR:=$(dirname "$(realpath "$0")")/../}"
+
 TERMUX_SDK_REVISION=9123335
 TERMUX_ANDROID_BUILD_TOOLS_VERSION=33.0.1
 # when changing the above:


### PR DESCRIPTION
- This happens while being sourced from setup-ubuntu.sh script

See: https://github.com/termux/termux-packages/actions/runs/13993202074/job/39181694224?pr=23875#step:6:3227

Signed-off-by: Aditya Alok <alok@termux.dev>
