### PR TITLE
fix(scripts/build/termux_step_setup_variables): update for termux-exec 2+

### DIFF
--- a/scripts/build/termux_step_setup_variables.sh
+++ b/scripts/build/termux_step_setup_variables.sh
@@ -54,7 +54,7 @@ termux_step_setup_variables() {
 
 		if [ "$TERMUX_PACKAGE_LIBRARY" = "bionic" ]; then
 			# On-device builds without termux-exec are unsupported.
-			if ! grep -q "${TERMUX_PREFIX}/lib/libtermux-exec.so" <<< "${LD_PRELOAD-x}"; then
+			if [[ ":${LD_PRELOAD:-}:" != ":${TERMUX_PREFIX}/lib/libtermux-exec"*".so:" ]]; then
 				termux_error_exit "On-device builds without termux-exec are not supported."
 			fi
 		fi


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/23951

After `termux-exec` 2+ https://github.com/termux/termux-packages/commit/eaf26b3,

`LD_PRELOAD` might not end with exactly "`libtermux-exec.so`". It might end with something else like for example, "`libtermux-exec-ld-preload.so`". Therefore, the `grep` check should be replaced with a check that allows a wider range of filenames in `LD_PRELOAD`.

Relevant changes within `termux-exec`:

- https://github.com/termux/termux-exec-package/commit/1fac1073
- https://github.com/termux/termux-exec-package/commit/db738a11