### PR TITLE
bump(x11/xfce4-panel): 4.20.4

### DIFF
--- a/x11-packages/xfce4-panel/0001-workaround-xfce-dev-tools.patch
+++ b/x11-packages/xfce4-panel/0001-workaround-xfce-dev-tools.patch
@@ -1,0 +1,17 @@
+# XDT_GEN_VISIBILITY has termux python in shebang. This patch overrides that to use host python.
+
+--- a/libxfce4panel/Makefile.am
++++ b/libxfce4panel/Makefile.am
+@@ -85,10 +85,10 @@
+ 	&& glib-genmarshal --prefix=_libxfce4panel_marshal --body $< >> $@
+ 
+ libxfce4panel-visibility.h: libxfce4panel.symbols Makefile
+-	$(AM_V_GEN) $(XDT_GEN_VISIBILITY) --kind=header $< $@
++	$(AM_V_GEN) python $(XDT_GEN_VISIBILITY) --kind=header $< $@
+ 
+ libxfce4panel-visibility.c: libxfce4panel.symbols Makefile
+-	$(AM_V_GEN) $(XDT_GEN_VISIBILITY) --kind=source $< $@
++	$(AM_V_GEN) python $(XDT_GEN_VISIBILITY) --kind=source $< $@
+ 
+ libxfce4panel-enum-types.h: $(libxfce4panel_headers) Makefile
+ 	$(AM_V_GEN) ( cd $(srcdir) && glib-mkenums \

--- a/x11-packages/xfce4-panel/build.sh
+++ b/x11-packages/xfce4-panel/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://docs.xfce.org/xfce/xfce4-panel/start
 TERMUX_PKG_DESCRIPTION="Panel for the XFCE environment"
 TERMUX_PKG_LICENSE="GPL-2.0, LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="4.20.3"
+TERMUX_PKG_VERSION="4.20.4"
 TERMUX_PKG_SRCURL=https://archive.xfce.org/src/xfce/xfce4-panel/${TERMUX_PKG_VERSION%.*}/xfce4-panel-${TERMUX_PKG_VERSION}.tar.bz2
-TERMUX_PKG_SHA256=4006dddf465a4ae02e14355941458c718f6da0896eae68435c9fd24fcd89b6b8
+TERMUX_PKG_SHA256=695b23af490719e734c8659394821b43cc94d3bee69994bafdc42ef40daa0d2c
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="atk, exo, garcon, gdk-pixbuf, glib, gtk3, gtk-layer-shell, harfbuzz, libcairo, libdisplay-info, libice, libsm, libwayland, libwnck, libx11, libxext, libxrandr, libxfce4ui, libxfce4util, libxfce4windowing, pango, xfconf, zlib"
 TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, xfce4-dev-tools"
@@ -21,9 +21,12 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --enable-wayland
 --enable-x11
 --disable-dbusmenu-gtk3
+XDT_GEN_VISIBILITY=${TERMUX_PREFIX}/bin/xdt-gen-visibility
 "
 
 termux_step_pre_configure() {
 	termux_setup_gir
 	termux_setup_glib_cross_pkg_config_wrapper
+
+	autoreconf -fiv
 }

--- a/x11-packages/xfce4-panel/gir/Libxfce4panel-2.0.xml
+++ b/x11-packages/xfce4-panel/gir/Libxfce4panel-2.0.xml
@@ -62,6 +62,9 @@
     </signal>
     <signal name="free-data" return="void" when="last">
     </signal>
+    <signal name="hidden-event" return="void" when="last">
+      <param type="gboolean"/>
+    </signal>
     <signal name="orientation-changed" return="void" when="last">
       <param type="GtkOrientation"/>
     </signal>


### PR DESCRIPTION
Add workaround for the following autotools error.
configure: error: Could not find xdt-gen-visibility in PATH, please install xfce4-dev-tools

* Fixes #23947 