### PR TITLE
bump(x11/xfce4-session): 4.20.2

### DIFF
--- a/x11-packages/xfce4-session/build.sh
+++ b/x11-packages/xfce4-session/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://docs.xfce.org/xfce/xfce4-session/start
 TERMUX_PKG_DESCRIPTION="A session manager for XFCE environment"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="4.20.0"
+TERMUX_PKG_VERSION="4.20.2"
 TERMUX_PKG_SRCURL=https://archive.xfce.org/src/xfce/xfce4-session/${TERMUX_PKG_VERSION%.*}/xfce4-session-${TERMUX_PKG_VERSION}.tar.bz2
-TERMUX_PKG_SHA256=5229233fe6ee692361cc28724886c5b08e0216d89f09c42d273191d38fd64f85
+TERMUX_PKG_SHA256=a0b80b7136515bc3c0c54fa859ad420365e29b715b6da0b58a2d2781bfbe73c3
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="atk, gdk-pixbuf, glib, gtk3, gtk-layer-shell, libcairo, libice, libsm, libwnck, libx11, libxfce4ui, libxfce4util, libxfce4windowing, pango, xfconf, xorg-iceauth, xorg-xrdb"
 TERMUX_PKG_BUILD_DEPENDS="xfce4-dev-tools"
@@ -18,6 +18,10 @@ ac_cv_path_ICEAUTH=${TERMUX_PREFIX}/bin/iceauth
 --with-wayland-session-prefix=${TERMUX_PREFIX}
 --with-xsession-prefix=${TERMUX_PREFIX}
 "
+
+termux_step_pre_configure() {
+	termux_setup_glib_cross_pkg_config_wrapper
+}
 
 termux_step_create_debscripts() {
 	cat <<- EOF > ./postinst


### PR DESCRIPTION
Fix the following error for cross-compiling.
/bin/bash: line 1: /data/data/com.termux/files/usr/bin/glib-compile-resources:
cannot execute binary file: Exec format error

* Fixes #23948 