### PR TITLE
chore(build-package.sh,scripts): add error stacktrace printing

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -18,7 +18,7 @@ else
 	export TERMUX_BUILD_PACKAGE_CALL_DEPTH=$((TERMUX_BUILD_PACKAGE_CALL_DEPTH+1))
 fi
 
-set -e -o pipefail -u
+set -e -E -o pipefail -u
 
 cd "$(realpath "$(dirname "$0")")"
 TERMUX_SCRIPTDIR=$(pwd)
@@ -63,6 +63,10 @@ export TERMUX_REPO_PKG_FORMAT=$(jq --raw-output '.pkg_format // "debian"' ${TERM
 # Special variable for internal use. It forces script to ignore
 # lock file.
 : "${TERMUX_BUILD_IGNORE_LOCK:=false}"
+
+# Utility code to track errors in buildsystem.
+# shellcheck source=scripts/build/termux_setup_self_debug.shh
+source "$TERMUX_SCRIPTDIR/scripts/build/termux_setup_self_debug.sh"
 
 # Utility function to log an error message and exit with an error code.
 # shellcheck source=scripts/build/termux_error_exit.sh

--- a/scripts/build/termux_setup_self_debug.sh
+++ b/scripts/build/termux_setup_self_debug.sh
@@ -1,0 +1,15 @@
+termux_print_stacktrace() {
+	local func src lineno
+	echo "💥 Error occurred at line $1 in script ${BASH_SOURCE[1]}"
+	echo "🔍 Stack trace:"
+	for i in "${!FUNCNAME[@]}"; do
+		func="${FUNCNAME[$i]}"
+		src="${BASH_SOURCE[$i]}"
+		lineno="${BASH_LINENO[$((i - 1))]}"
+		# skip print_stacktrace itself
+		(( $i )) && echo "  at $func() in $src:$lineno"
+	done
+	[[ -n "${TERMUX_PKG_NAME:-}" ]] && echo "  while trying to build package ${TERMUX_PKG_NAME:-}"
+}
+
+trap 'termux_print_stacktrace $LINENO' ERR


### PR DESCRIPTION
In the case if CI exits with error in most cases we can not check where exactly error happened. We can not explicitly check if error happened during host-building, configuring package, building or installing it, or maybe during massaging or even in other buildsystem scripts. CI even does not specify what package was being built.

This PR prints nice stacktrace like this:
```
...regular log...
   ...
💥 Error occurred at line 117 in script /home/builder/termux-packages/scripts/build/configure/termux_step_configure_autotools.sh
🔍 Stack trace:
  at termux_step_configure_autotools() in /home/builder/termux-packages/scripts/build/configure/termux_step_configure_autotools.sh:117
  at termux_step_configure() in /home/builder/termux-packages/scripts/build/configure/termux_step_configure.sh:13
  at main() in ./build-package.sh:689
  while trying to build package codeblocks
💥 Error occurred at line 726 in script ./build-package.sh
🔍 Stack trace:
  at main() in ./build-package.sh:726
```
(Yes, emojis are coming from ChatGPT, I know it is childish but I decided to keep them if nobody minds).