### PR TITLE
scripts(build-packages.sh,build): Add support to run target binaries

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -72,6 +72,10 @@ source "$TERMUX_SCRIPTDIR/scripts/build/termux_error_exit.sh"
 # shellcheck source=scripts/build/termux_download.sh
 source "$TERMUX_SCRIPTDIR/scripts/build/termux_download.sh"
 
+# Utility function to run binaries under termux environment via proot.
+# shellcheck source=scripts/build/setup/termux_setup_proot.sh
+source "$TERMUX_SCRIPTDIR/scripts/build/setup/termux_setup_proot.sh"
+
 # Installing packages if necessary for the full operation of CGCT.
 # shellcheck source=scripts/build/termux_step_setup_cgct_environment.sh
 source "$TERMUX_SCRIPTDIR/scripts/build/termux_step_setup_cgct_environment.sh"

--- a/scripts/build/setup/termux_setup_proot.sh
+++ b/scripts/build/setup/termux_setup_proot.sh
@@ -1,0 +1,54 @@
+# shellcheck shell=bash
+# This provides an utility to run binaries under termux environment via proot.
+termux_setup_proot() {
+	local TERMUX_PROOT_VERSION=5.3.0
+	local TERMUX_QEMU_VERSION=7.2.0-1
+	local TERMUX_PROOT_BIN="$TERMUX_COMMON_CACHEDIR/proot-bin-$TERMUX_ARCH"
+	local TERMUX_PROOT_QEMU=""
+	local TERMUX_PROOT_BIN_NAME="termux-proot-run"
+
+	export PATH="$TERMUX_PROOT_BIN:$PATH"
+
+	[[ -d "$TERMUX_PROOT_BIN" ]] && return
+
+	if ! [[ -d "$TERMUX_PREFIX/opt/aosp" ]]; then
+		echo "ERROR: Add 'aosp-libs' to TERMUX_PKG_BUILD_DEPENDS. 'proot' cannot run without it."
+		exit 1
+	fi
+
+	mkdir -p "$TERMUX_PROOT_BIN"
+
+	termux_download https://github.com/proot-me/proot/releases/download/v"$TERMUX_PROOT_VERSION"/proot-v"$TERMUX_PROOT_VERSION"-x86_64-static \
+		"$TERMUX_PROOT_BIN/proot" \
+		d1eb20cb201e6df08d707023efb000623ff7c10d6574839d7bb42d0adba6b4da
+	chmod +x "$TERMUX_PROOT_BIN"/proot
+
+	declare -A checksums=(
+		["aarch64"]="dce64b2dc6b005485c7aa735a7ea39cb0006bf7e5badc28b324b2cd0c73d883f"
+		["arm"]="9f07762a3cd0f8a199cb5471a92402a4765f8e2fcb7fe91a87ee75da9616a806"
+	)
+	if [[ "$TERMUX_ARCH" == "aarch64" ]] || [[ "$TERMUX_ARCH" == "arm" ]]; then
+		termux_download https://github.com/multiarch/qemu-user-static/releases/download/v"$TERMUX_QEMU_VERSION"/qemu-"${TERMUX_ARCH/i686/i386}"-static \
+			"$TERMUX_PROOT_BIN"/qemu-"$TERMUX_ARCH" \
+			"${checksums[$TERMUX_ARCH]}"
+		chmod +x "$TERMUX_PROOT_BIN"/qemu-"$TERMUX_ARCH"
+		TERMUX_PROOT_QEMU="-q $TERMUX_PROOT_BIN/qemu-$TERMUX_ARCH"
+	fi
+
+	# NOTE: We include current PATH too so that host binaries also become available under proot.
+	cat <<-EOF >"$TERMUX_PROOT_BIN/$TERMUX_PROOT_BIN_NAME"
+		#!/bin/bash
+		env -i \
+			PATH=$TERMUX_PREFIX/bin:$PATH \
+			ANDROID_DATA=/data \
+			ANDROID_ROOT=/system \
+			HOME=$TERMUX_ANDROID_HOME \
+			LANG=en_US.UTF-8 \
+			PREFIX=$TERMUX_PREFIX \
+			TERM=$TERM \
+			TZ=UTC \
+			$TERMUX_PROOT_EXTRA_ENV_VARS \
+			$TERMUX_PROOT_BIN/proot $TERMUX_PROOT_QEMU -R "\$@"
+	EOF
+	chmod +x "$TERMUX_PROOT_BIN/$TERMUX_PROOT_BIN_NAME"
+}

--- a/scripts/build/termux_step_setup_variables.sh
+++ b/scripts/build/termux_step_setup_variables.sh
@@ -189,6 +189,7 @@ termux_step_setup_variables() {
 	TERMUX_PYTHON_HOME=$TERMUX_PREFIX/lib/python${TERMUX_PYTHON_VERSION} # location of python libraries
 	TERMUX_PKG_MESON_NATIVE=false
 	TERMUX_PKG_CMAKE_CROSSCOMPILING=true
+	TERMUX_PROOT_EXTRA_ENV_VARS="" # Extra environvent variables for proot command in termux_setup_proot
 
 	unset CFLAGS CPPFLAGS LDFLAGS CXXFLAGS
 	unset TERMUX_MESON_ENABLE_SOVERSION # setenv to enable SOVERSION suffix for shared libs built with Meson


### PR DESCRIPTION
- Inspired by @licy183 implementation in https://github.com/termux/termux-packages/commit/5278c839dbded789e0b6992c90024f6e4a4d412c#diff-96e86e41ad7faf61d20b787ee4808183614387e8d49810c78d579259e89fe3ffR37 
- Will we used to run `ghc-iserv` to cross compile haskell template.

Signed-off-by: Aditya Alok <alok@termux.dev>
