### PR TITLE
fix(main/dbus): disable pidfd_open syscall

### DIFF
--- a/packages/dbus/build.sh
+++ b/packages/dbus/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Freedesktop.org message bus system"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.16.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://dbus.freedesktop.org/releases/dbus/dbus-$TERMUX_PKG_VERSION.tar.xz"
 TERMUX_PKG_SHA256=0ba2a1a4b16afe7bceb2c07e9ce99a8c2c3508e5dec290dbb643384bd6beb7e2
 TERMUX_PKG_DEPENDS="libexpat, libx11"

--- a/packages/dbus/disable-pidfd-open.patch
+++ b/packages/dbus/disable-pidfd-open.patch
@@ -1,0 +1,22 @@
+A way of reverting this upstream change:
+https://gitlab.freedesktop.org/dbus/dbus/-/merge_requests/398
+
+Fixes https://github.com/termux/termux-packages/issues/23981
+
+--- a/meson.build
++++ b/meson.build
+@@ -810,13 +810,7 @@ config.set('HAVE_FSTATFS',
+     )
+ )
+ 
+-config.set10('HAVE_DECL_SYS_PIDFD_OPEN',
+-    cc.has_header_symbol(
+-        'sys/syscall.h',
+-        'SYS_pidfd_open',
+-        args: compile_args_c,
+-    )
+-)
++config.set10('HAVE_DECL_SYS_PIDFD_OPEN', false)
+ 
+ ###############################################################################
+ # Project options


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/23981

- In a way, reverts https://gitlab.freedesktop.org/dbus/dbus/-/merge_requests/398 (introduced in dbus version 1.15.8)