### PR TITLE
new package: vulkan-icd

### DIFF
--- a/packages/vulkan-icd/build.sh
+++ b/packages/vulkan-icd/build.sh
@@ -1,0 +1,16 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/termux/termux-packages
+TERMUX_PKG_DESCRIPTION="A metapackage that provides Vulkan ICDs"
+TERMUX_PKG_LICENSE="Public Domain"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=0.1
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_SKIP_SRC_EXTRACT=true
+TERMUX_PKG_METAPACKAGE=true
+
+# XXX: Make buildorder.py happy
+if [ true = true ]; then
+	TERMUX_PKG_DEPENDS="mesa-vulkan-icd-swrast"
+	TERMUX_PKG_DEPENDS+=" | mesa-vulkan-icd-freedreno"
+	TERMUX_PKG_DEPENDS+=" | swiftshader"
+fi

--- a/packages/vulkan-loader-generic/build.sh
+++ b/packages/vulkan-loader-generic/build.sh
@@ -3,11 +3,13 @@ TERMUX_PKG_DESCRIPTION="Vulkan Loader"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.4.311"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/KhronosGroup/Vulkan-Loader/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=bcebd281753384a2b019a633e6a81dca0e75414f0c8ec49f56edfcda8020ec20
 TERMUX_PKG_BUILD_DEPENDS="vulkan-headers (=${TERMUX_PKG_VERSION}), libx11, libxcb, libxrandr"
 TERMUX_PKG_CONFLICTS="vulkan-loader-android"
 TERMUX_PKG_PROVIDES="vulkan-loader-android"
+TERMUX_PKG_RECOMMENDS="vulkan-icd"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+.\d+.\d+"


### PR DESCRIPTION
Add a metapackage to provide Vulkan ICDs, ane make `vulkan-loader-generic` recommend `vulkan-icd`.

This PR makes it technically difficult to have no available ICD on device, thus avoiding things like #23969

Closes #23969