### PR TITLE
bump(main/restic): 0.18.0

### DIFF
--- a/packages/restic/build.sh
+++ b/packages/restic/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://restic.net/
 TERMUX_PKG_DESCRIPTION="Fast, secure, efficient backup program"
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.17.3"
-TERMUX_PKG_SRCURL=https://github.com/restic/restic/archive/v$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_SHA256=bf0dd73edfae531c24070e2e7833938613f7b179ed165e6b681098edfdf286c8
+TERMUX_PKG_VERSION="0.18.0"
+TERMUX_PKG_SRCURL=https://github.com/restic/restic/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=fc068d7fdd80dd6a968b57128d736b8c6147aa23bcba584c925eb73832f6523e
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_SUGGESTS="openssh, rclone, restic-server"
 

--- a/packages/restic/failsafe-chmod.patch
+++ b/packages/restic/failsafe-chmod.patch
@@ -3,8 +3,8 @@ diff -uNr restic/internal/fs/file_unix.go restic.mod/internal/fs/file_unix.go
 +++ restic.mod/internal/fs/file_unix.go	2020-01-01 17:54:08.797875856 +0200
 @@ -47,12 +47,6 @@
  
- // Chmod changes the mode of the named file to mode.
- func Chmod(name string, mode os.FileMode) error {
+ // chmod changes the mode of the named file to mode.
+ func chmod(name string, mode os.FileMode) error {
 -	err := os.Chmod(fixpath(name), mode)
 -
 -	// ignore the error if the FS does not support setting this mode (e.g. CIFS with gvfs on Linux)


### PR DESCRIPTION
* Fixes #24007 

Rebase patch file after https://github.com/restic/restic/commit/6d3a5260d358cd89e8727fd279a94dd8d553ff35 commit.