### PR TITLE
bump(main/libxml2): 2.14.1

### DIFF
--- a/packages/libxml2/build.sh
+++ b/packages/libxml2/build.sh
@@ -2,12 +2,13 @@ TERMUX_PKG_HOMEPAGE=http://www.xmlsoft.org
 TERMUX_PKG_DESCRIPTION="Library for parsing XML documents"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="2.13.7"
+TERMUX_PKG_VERSION="2.14.1"
 TERMUX_PKG_SRCURL=https://download.gnome.org/sources/libxml2/${TERMUX_PKG_VERSION%.*}/libxml2-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=14796d24402108e99d8de4e974d539bed62e23af8c4233317274ce073ceff93b
+TERMUX_PKG_SHA256=310df85878b65fa717e5e28e0d9e8f6205fd29d883929303a70a4f2fc4f6f1f2
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_SETUP_PYTHON=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--with-http
 --with-legacy
 --with-python
 "
@@ -29,8 +30,10 @@ termux_step_post_massage() {
 		termux_error_exit "SONAME for libxml2.so is not properly set."
 	fi
 
-	local _GUARD_FILE="lib/libxml2.so.2"
-	if [ ! -e "${_GUARD_FILE}" ]; then
-		termux_error_exit "Error: file ${_GUARD_FILE} not found."
+	local _SOVERSION=16
+	if [[ ! -e "lib/libxml2.so.${_SOVERSION}" ]]; then
+		echo "ERROR - Expected: lib/libxml2.so.${_SOVERSION}" >&2
+		echo "ERROR - Found   : $(find lib/libxml2* -regex '.*so\.[0-9]+')" >&2
+		termux_error_exit "Not proceeding with update."
 	fi
 }


### PR DESCRIPTION
Will follow up with rebuilds in separate PRs shortly.
Libxml 2.14.0 raised the SOVERSION from 2 to 16 (`2 + 14`)
<sup>Upstream commit: https://gitlab.gnome.org/GNOME/libxml2/-/commit/137466aeb7d51472f418ef61dd53a27e54a4a39b</sup>

I've adjusted the SOVERSION guard to make the mismatch clearer accordingly.

Here's the full revdep list for rebuilds.
I'll split these into ~5 to 7 batches.
```console
packages/appstream
packages/aria2
packages/at-spi2-core
packages/cfengine
packages/clamav
packages/codon
packages/crystal
packages/ctags
packages/dcmtk
packages/dnsutils
packages/dvdauthor
packages/ebook-tools
packages/emacs
packages/ffmpeg
packages/finch
packages/gdal
packages/gettext
packages/gnucobol
packages/graphicsmagick
packages/gst-plugins-bad
packages/gst-plugins-good
packages/icecast
packages/imagemagick
packages/lastpass-cli
packages/libarchive
packages/libbluray
packages/libcroco
packages/libgnt
packages/libgnustep-base
packages/libgsf
packages/libraptor2
packages/librasqal
packages/librsvg
packages/libshout
packages/libsoup
packages/libspatialite
packages/libwayland
packages/libwv
packages/libxml2
packages/libxslt
packages/lv2
packages/mapserver
packages/monetdb
packages/netpbm
packages/newsboat
packages/nzbget
packages/oathtool
packages/openbabel
packages/openscad
packages/php
packages/postgis
packages/postgresql
packages/python-lxml
packages/qalc
packages/rdrview
packages/recoll
packages/sc-im
packages/spatialite-tools
packages/squid
packages/stoken
packages/swift
packages/texlive-bin
packages/totem-pl-parser
packages/uwsgi
packages/vlc
packages/xmlsec
packages/xmlstarlet
packages/yuma123
root-packages/nfs-utils
root-packages/tshark
x11-packages/abiword
x11-packages/ardour
x11-packages/atril
x11-packages/audacious-plugins
x11-packages/bluefish
x11-packages/cairo-dock-core
x11-packages/caja
x11-packages/cherrytree
x11-packages/emacs-x
x11-packages/epiphany
x11-packages/evince
x11-packages/far2l
x11-packages/florence
x11-packages/fontforge-gtk
x11-packages/glade
x11-packages/gnome-calculator
x11-packages/gnumeric
x11-packages/goffice
x11-packages/gtksourceview3
x11-packages/gtksourceview4
x11-packages/gtksourceview5
x11-packages/gvfs
x11-packages/handbrake
x11-packages/inkscape
x11-packages/labwc
x11-packages/libgedit-gtksourceview
x11-packages/libmateweather
x11-packages/libxkbcommon
x11-packages/libxklavier
x11-packages/libxml++-2.6
x11-packages/mlt
x11-packages/openbox
x11-packages/pidgin
x11-packages/rhythmbox
x11-packages/shared-mime-info
x11-packages/vlc-qt
x11-packages/webkit2gtk-4.1
x11-packages/webkitgtk-6.0
x11-packages/wireshark-qt
x11-packages/xournalpp
```
A handful of the "very large" packages on that list will probably need their own PRs. 