### PR TITLE
Do not remove docker while cleaning space for `package_updates` workflow 

### DIFF
--- a/.github/workflows/package_updates.yml
+++ b/.github/workflows/package_updates.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Set process id limit for 32-bit builds depending on aosp-libs
         run: echo 65535 | sudo tee /proc/sys/kernel/pid_max
       - name: Free additional disk space
-        run: ./scripts/free-space.sh
+        run: CLEAN_DOCKER_IMAGES=false ./scripts/free-space.sh
       - name: Process package updates
         env:
           GITHUB_TOKEN: ${{ secrets.TERMUXBOT2_TOKEN }}

--- a/scripts/free-space.sh
+++ b/scripts/free-space.sh
@@ -1,11 +1,19 @@
 #!/bin/sh
 
-# This script clears about ~22G of space.
+# This script clears about ~22G of space. It also sets up a swapfile to account
+# for packages requiring large memory.
 
 # Test:
 # echo "Listing 100 largest packages after"
 # dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
 # exit 0
+
+create_swapfile() {
+	sudo fallocate -l 4G /swapfile
+	sudo chmod 600 /swapfile
+	sudo mkswap /swapfile
+	sudo swapon /swapfile
+}
 
 if [ "${CI-false}" != "true" ]; then
 	echo "ERROR: not running on CI, not deleting system files to free space!"
@@ -59,4 +67,6 @@ else
 
 	sudo apt autoremove -yq
 	sudo apt clean
+
+	create_swapfile
 fi

--- a/scripts/free-space.sh
+++ b/scripts/free-space.sh
@@ -20,7 +20,6 @@ else
 	)
 
 	sudo apt purge -yq \
-		containerd.io \
 		snapd \
 		kubectl \
 		podman \
@@ -51,8 +50,12 @@ else
 	sudo rm -rf "/usr/local/share/boost"
 	sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
-	sudo docker image prune --all --force
-	sudo docker builder prune -a
+	# We shouldn't remove docker & it's images when running from `package_updates` workflow.
+	if [ "${CLEAN_DOCKER_IMAGES-true}" = "true" ]; then
+		sudo docker image prune --all --force
+		sudo docker builder prune -a
+		sudo apt purge -yq containerd.io
+	fi
 
 	sudo apt autoremove -yq
 	sudo apt clean


### PR DESCRIPTION
- **scripts(free-space): Add switch to disable docker cleaning**
- **ci(package_updates): Do not remove docker and it's images**

Closes: #24086
Closes: #24085
Closes: #24084
Closes: #24083
Closes: #24082
Closes: #24080
Closes: #24079
Closes: #24078
Closes: #24077
Closes: #24074
Closes: #24073
Closes: #24072
Closes: #24071
Closes: #24132 
Closes: #24133 
Closes: #24134 
Closes: #24135 
Closes: #24136
Closes: #24137 
Closes: #24138 
Closes: #24139 
Closes: #24140
