### PR TITLE
fix(main/libtool): Correct more absolute paths to some binaries for `termux-exec`-less fallback support

### DIFF
--- a/packages/libtool/build.sh
+++ b/packages/libtool/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Generic library support script hiding the complexity of 
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.5.4"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/libtool/libtool-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=da8ebb2ce4dcf46b90098daf962cffa68f4b4f62ea60f798d0ef12929ede6adf
 TERMUX_PKG_AUTO_UPDATE=true
@@ -13,5 +14,7 @@ TERMUX_PKG_NO_STATICSPLIT=true
 TERMUX_PKG_GROUPS="base-devel"
 
 termux_step_post_make_install() {
-	perl -p -i -e "s|\"/bin/|\"$TERMUX_PREFIX/bin/|" $TERMUX_PREFIX/bin/{libtool,libtoolize}
+	perl -p -i -e \
+		"s|\"/usr/bin/|\"$TERMUX_PREFIX/bin/|;s|\"/bin/|\"$TERMUX_PREFIX/bin/|" \
+		$TERMUX_PREFIX/bin/{libtool,libtoolize}
 }


### PR DESCRIPTION
**robertkirkman commit message**:

- Fixes https://github.com/termux/termux-packages/issues/24165

- https://github.com/termux/termux-packages/commit/3a19b11880a7734a414f6c4f572426fedbc5d591, but applied to `/usr/bin` as well instead of only `/bin`.

**john-peterson original message**:

a recent update that used more local host files from /usr turned into a pancake
$SED was hard coded into host path /usr/bin/sed etc in the resulting
files libtool and libtoolize

/data/.../bin/libtoolize
${EGREP="/usr/bin/grep -E"}
: ${FGREP="/usr/bin/grep -F"}
: ${GREP="/usr/bin/grep"}
: ${LN_S="ln -s"}
: ${SED="/usr/bin/sed"}
