### PR TITLE
 -c flag errors after make + various odds and ends

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/env bash
 # shellcheck disable=SC1117
 
 # Setting the TMPDIR variable
@@ -370,6 +370,10 @@ source "$TERMUX_SCRIPTDIR/scripts/build/termux_step_create_pacman_package.sh"
 # shellcheck source=scripts/build/termux_step_finish_build.sh
 source "$TERMUX_SCRIPTDIR/scripts/build/termux_step_finish_build.sh"
 
+termux_step_post_finish_build() {
+	return
+}
+
 ################################################################################
 
 # shellcheck source=scripts/properties.sh
@@ -663,9 +667,11 @@ for ((i=0; i<${#PACKAGE_LIST[@]}; i++)); do
 			termux_step_get_dependencies_python
 			termux_step_patch_package
 			termux_step_replace_guess_scripts
+		fi
+
+			$TERMUX_CONTINUE_BUILD && echo try to not reset the build just set the version variables without touching any build files
 			cd "$TERMUX_PKG_SRCDIR"
 			termux_step_pre_configure
-		fi
 
 		# Even on continued build we might need to setup paths
 		# to tools so need to run part of configure step
@@ -708,6 +714,7 @@ for ((i=0; i<${#PACKAGE_LIST[@]}; i++)); do
 		termux_add_package_to_built_packages_list "$TERMUX_PKG_NAME"
 		termux_step_finish_build
 	) 5< "$TERMUX_BUILD_LOCK_FILE"
+		termux_step_post_finish_build
 done
 
 # Removing a file to store a list of compiled packages

--- a/packages/test/build.sh
+++ b/packages/test/build.sh
@@ -1,0 +1,45 @@
+TERMUX_PKG_DESCRIPTION="empty test packet for build system "
+TERMUX_PKG_VERSION=0
+TERMUX_PKG_LICENSE="WTFPL"
+TERMUX_PKG_NO_ELF_CLEANER=true
+
+termux_step_pre_configure() {
+# echo $TERMUX_PREFIX
+# echo $TERMUX_PREFIX_CLASSICAL
+echo TERMUX_TOPDIR=$TERMUX_TOPDIR
+# exit
+# $TERMUX_ON_DEVICE_BUILD && test TERMUX_PREFIX = TERMUX_PREFIX_CLASSICAL && echo unsafe prefix detected && exit
+echo pwd=
+pwd
+# touch a
+# touch configure.in
+# exit
+test=123
+$TERMUX_CONTINUE_BUILD || termux_error_exit I failed redo with -c 
+}
+
+termux_step_post_make_install() {
+	test $test = 123 || echo test != 123
+	pwd
+	mkdir -p $TERMUX_PREFIX
+	# cp $TERMUX_PKG_SRCDIR/* $TERMUX_PREFIX/
+# install -Dm700 -t $TERMUX_PREFIX/ $TERMUX_PKG_SRCDIR/a
+# cat $TERMUX_PKG_SRCDIR/configure.in
+mkdir -p $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/usr
+touch $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/usr/a
+}
+
+termux_step_extract_into_massagedir() {
+$TERMUX_ON_DEVICE_BUILD && echo skip prefix folder scan on device to save the memory chip 
+}
+
+# termux_step_post_massage() {
+termux_step_post_finish_build() {
+	echo
+echo -e '\e[1m post massage  \e[0m'
+	echo TERMUX_PKG_PACKAGEDIR=$TERMUX_PKG_PACKAGEDIR
+	ls $TERMUX_PKG_PACKAGEDIR
+	tar tf $TERMUX_PKG_PACKAGEDIR/data.*
+	dpkg -c $TERMUX_OUTPUT_DIR/test* | grep /DEBIAN/control && termux_error_exit 
+	echo done
+}

--- a/scripts/build/termux_step_create_debian_package.sh
+++ b/scripts/build/termux_step_create_debian_package.sh
@@ -3,6 +3,7 @@ termux_step_create_debian_package() {
 		# Metapackage doesn't have data inside.
 		rm -rf data
 	fi
+	$TERMUX_CONTINUE_BUILD && rm -rf DEBIAN
 	tar --sort=name \
 		--mtime="@${SOURCE_DATE_EPOCH}" \
 		--owner=0 --group=0 --numeric-owner \

--- a/scripts/build/termux_step_massage.sh
+++ b/scripts/build/termux_step_massage.sh
@@ -107,7 +107,7 @@ termux_step_massage() {
 		find ./${ADDING_PREFIX}share/man -mindepth 1 -maxdepth 1 -type d ! -name man\* | xargs -r rm -rf
 
 		# Compress man pages with gzip:
-		find ./${ADDING_PREFIX}share/man -type f ! -iname \*.gz -print0 | xargs -r -0 gzip -9 -n
+		find ./${ADDING_PREFIX}share/man -type f ! -iname \*.gz -print0 | xargs -r -0 gzip -9 -n || $TERMUX_CONTINUE_BUILD
 
 		# Update man page symlinks, e.g. unzstd.1 -> zstd.1:
 		while IFS= read -r -d '' file; do
@@ -179,7 +179,7 @@ termux_step_massage() {
 	# Check so that package is not affected by
 	# https://github.com/android/ndk/issues/1614, or
 	# https://github.com/termux/termux-packages/issues/9944
-	if [[ "${TERMUX_PACKAGE_LIBRARY}" == "bionic" ]]; then
+	if [[ "${TERMUX_PACKAGE_LIBRARY}" == "bionic" ]] && ! $TERMUX_ON_DEVICE_BUILD; then
 		echo "INFO: READELF=${READELF} ... $(command -v ${READELF})"
 		export pattern_file_undef=$(mktemp)
 		echo "INFO: Generating undefined symbols regex to ${pattern_file_undef}"

--- a/scripts/build/termux_step_setup_variables.sh
+++ b/scripts/build/termux_step_setup_variables.sh
@@ -51,10 +51,11 @@ termux_step_setup_variables() {
 		TERMUX_BUILT_PACKAGES_DIRECTORY="$TERMUX_TOPDIR/.built-packages"
 		TERMUX_NO_CLEAN="true"
 
-		if [ "$TERMUX_PACKAGE_LIBRARY" = "bionic" ]; then
+		# this imbecile message needs to be sileneced
+		if [ "$TERMUX_PACKAGE_LIBRARY" = "bionic" ] && ! $TERMUX_FORCE_BUILD; then
 			# On-device builds without termux-exec are unsupported.
 			if ! grep -q "${TERMUX_PREFIX}/lib/libtermux-exec.so" <<< "${LD_PRELOAD-x}"; then
-				termux_error_exit "On-device builds without termux-exec are not supported."
+				termux_error_exit "On-device builds without termux-exec are not supported. use -f to ignore "
 			fi
 		fi
 	else

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -88,7 +88,7 @@ termux_step_start_build() {
 		termux_error_exit "Package '$TERMUX_PKG_NAME' is not available for on-device builds."
 	fi
 
-	if [ "$TERMUX_PACKAGE_LIBRARY" = "bionic" ]; then
+	if [ "$TERMUX_PACKAGE_LIBRARY" = "bionic" ] && ! $TERMUX_PKG_NO_ELF_CLEANER; then
 		if [ "$TERMUX_ON_DEVICE_BUILD" = "true" ]; then
 			case "$TERMUX_APP_PACKAGE_MANAGER" in
 				"apt") apt install -y termux-elf-cleaner;;

--- a/scripts/build/toolchain/termux_setup_toolchain_27c.sh
+++ b/scripts/build/toolchain/termux_setup_toolchain_27c.sh
@@ -215,7 +215,7 @@ termux_setup_toolchain_27c() {
 	sed -i "s/define __ANDROID_API__ __ANDROID_API_FUTURE__/define __ANDROID_API__ $TERMUX_PKG_API_LEVEL/" \
 		usr/include/android/api-level.h
 
-	$TERMUX_ELF_CLEANER --api-level=$TERMUX_PKG_API_LEVEL usr/lib/*/*/*.so
+	$TERMUX_PKG_NO_ELF_CLEANER || $TERMUX_ELF_CLEANER --api-level=$TERMUX_PKG_API_LEVEL usr/lib/*/*/*.so
 	for dir in usr/lib/*; do
 		# This seem to be needed when building rust
 		# packages


### PR DESCRIPTION
annoying since it requires rebuild from scratch especially on device .
~~there is is still an error where control files are included at the end.~~ fixed now
I just gave up and reset. I still think this should be automatic I will
try to fix my fix for this . it should be easy to keep a marker instead
of asking the builder to remember to switch a flag on and off

these errors remain to be solved these files should not be there in the
final packet. somehow the control files ended up in the data tar ball at
the end of ffmpeg build -- update fixed!

20 09:10 ./
drwxr-xr-x 0/0               0 2025-0
3-20 09:10 ./DEBIAN/
-rw-r--r-- 0/0             199 2025-0
3-20 09:10 ./DEBIAN/control
drwxr-xr-x 0/0               0 20

 # skip Generating undefined symbols regex on device

 it seems to work anyway I don't remember exactly what it did seemed
 pointless on device that is already burdened enough with scanning the
 entire prefix folder because builds are not sanitized in a sand box
 instead of dumping all kinds of garbage directly onto the system folder
 including broken files like libtool is dumped prefix on device and then
 searched to find the files. I am just strongly against applying
 everything from off device on device it is a completely different
 situation than off device. I ask everyone to look at my :ondev (#ondev
 is there no tag for linking my branches??) branch
 again and consider the sand boxing idea

  lastly the elf cleaner kept nagging me over and over my default Debian
  gcloud has insufficient glibc++ version for it and there is a flag
  that supposed to disable it
