### PR TITLE
ffmpeg add VVC/266 Versatile video coder

### DIFF
--- a/packages/ffmpeg/build.sh
+++ b/packages/ffmpeg/build.sh
@@ -6,8 +6,8 @@ TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="7.1.1"
 TERMUX_PKG_SRCURL=https://www.ffmpeg.org/releases/ffmpeg-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=733984395e0dbbe5c046abda2dc49a5544e7e0e1e2366bba849222ae9e3a03b1
-TERMUX_PKG_DEPENDS="fontconfig, freetype, fribidi, game-music-emu, harfbuzz, libaom, libandroid-glob, libass, libbluray, libbz2, libdav1d, libgnutls, libiconv, liblzma, libmp3lame, libopencore-amr, libopenmpt, libopus, librav1e, libsoxr, libsrt, libssh, libtheora, libv4l, libvidstab, libvmaf, libvo-amrwbenc, libvorbis, libvpx, libwebp, libx264, libx265, libxml2, libzimg, littlecms, ocl-icd, rubberband, svt-av1, xvidcore, zlib"
-TERMUX_PKG_BUILD_DEPENDS="opencl-headers"
+TERMUX_PKG_DEPENDS="fontconfig, freetype, fribidi, game-music-emu, harfbuzz, libaom, libandroid-glob, libass, libbluray, libbz2, libdav1d, libgnutls, libiconv, liblzma, libmp3lame, libopencore-amr, libopenmpt, libopus, librav1e, libsoxr, libsrt, libssh, libtheora, libv4l, libvidstab, libvmaf, libvo-amrwbenc, libvorbis, libvpx, libvvenc, libwebp, libx264, libx265, libxml2, libzimg, littlecms, ocl-icd, rubberband, svt-av1, xvidcore, zlib"
+TERMUX_PKG_BUILD_DEPENDS="gnutls, gobject-introspection, libicu, opencl-headers"
 TERMUX_PKG_CONFLICTS="libav"
 TERMUX_PKG_BREAKS="ffmpeg-dev"
 TERMUX_PKG_REPLACES="ffmpeg-dev"
@@ -100,6 +100,7 @@ termux_step_configure() {
 		--enable-libvo-amrwbenc \
 		--enable-libvorbis \
 		--enable-libvpx \
+		--enable-libvvenc \
 		--enable-libwebp \
 		--enable-libx264 \
 		--enable-libx265 \

--- a/packages/libvvenc/build.sh
+++ b/packages/libvvenc/build.sh
@@ -1,0 +1,20 @@
+TERMUX_PKG_DESCRIPTION="H.266/VVC video stream encoder library"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0"
+TERMUX_PKG_SRCURL=git+https://github.com/fraunhoferhhi/vvenc
+TERMUX_PKG_GIT_BRANCH=master
+TERMUX_PKG_DEPENDS="libandroid-posix-semaphore, libc++"
+# TERMUX_PKG_BUILD_DEPENDS="llvmgold"
+TERMUX_PKG_MAKE_PROCESSES=4
+# this was because the build kept resetting I didn't realise there was a -c flag to avoid that
+TERMUX_PKG_EXTRA_MAKE_ARGS="-d explain"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DBUILD_SHARED_LIBS=ON"
+
+termux_step_post_configure() {
+	# exit
+	sed -i s,fuse-ld=gold,fuse-ld=lld,g $TERMUX_PKG_BUILDDIR/build.ninja
+	! grep -r -l fuse-ld=gold $TERMUX_PKG_BUILDDIR
+	# test $? -ne 0 && echo error! try again &
+}
+


### PR DESCRIPTION
it is very slow I don't know what they have fixed here. I guess it is up
to date with the latest Pearlman and Sayood edition . mostly for
academic interests. I still can't use media coder for 264 ...no hardware
acceleration
