### PR TITLE
cmake -DBUILD_SHARED_LIBS=ON for all packets no static libs

### DIFF
--- a/scripts/build/configure/termux_step_configure_cmake.sh
+++ b/scripts/build/configure/termux_step_configure_cmake.sh
@@ -52,6 +52,7 @@ termux_step_configure_cmake() {
 		-DCMAKE_USE_SYSTEM_LIBRARIES=True \
 		-DDOXYGEN_EXECUTABLE= \
 		-DBUILD_TESTING=OFF \
+		-DBUILD_SHARED_LIBS=ON \
 		"${CMAKE_ADDITIONAL_ARGS[@]}" \
 		$TERMUX_PKG_EXTRA_CONFIGURE_ARGS \
 		|| (termux_step_configure_cmake_failure_hook && false)


### PR DESCRIPTION
s is better because builds failed without this. ffmpeg contains this
check that doesn't accept static libs

check_func_headers "$headers" "$funcs" $pkg_cflags $pkg_libs "$@" &&

besides static libs are absolutely insanity . I have on my to-do list to
create share libs from netsurf for elinks libdom libcss should be broken
out and build sharedas separate packets . -- UPDATE  this is fixed and pending elinks including JavaScript is now down to one meg without debug symbols from over six meg---I really want to make more
progress with elinks JavaScript . good old memories

 # possible bionic dlopen bug in Quick JS

 in quickjs@shared in my account a possible bug is explained in dlopen.
 unless there is something wrong with the build the linked JS
 interpreter fails to use dlopen from libquickjs.so . the exact same
 static program works and glibc shared with exact same build recipe.
 DL_DEBUG is also disabled in bionic but it would not say anything about
 dlopen only the initial linking . bionic is relatively small and it
 should be possible to test this on device it is only a few thousand
 files with a custom libc.so with logging for dlopen
