### PR TITLE
mpv -vo tct enable video output for the non GUI build

### DIFF
--- a/packages/mpv/mpv.conf
+++ b/packages/mpv/mpv.conf
@@ -19,4 +19,4 @@ ao=opensles
 # audio-format=s16
 
 # Disable Video Decode and Output. Termux doesn't support video output (with the exception of "tct").
-vid=no
+vo=tct


### PR DESCRIPTION
man tager vad man haver

if you have video use it I usually just need to know roughly what is inside if anything from downloading some garbage or  a failed coder. my hardware coder from Unisoc continue to elude my persuasive powers. I don't understand why there is no open hardware coder why is it tied to specific hardware all massive core count hardware is essentially the same tons of simple cores that all works the same way:

anyway this should play VVC videos at least it did in Debian Sid.
otherwise I have to fix that too maybe mpv VVC isn't added here

where is the Debian packet system BTW I just can't find it would be much
easier if I could use it as a reference
