### PR TITLE
ffmpeg: configure --enable-vulkan

### DIFF
--- a/packages/ffmpeg/build.sh
+++ b/packages/ffmpeg/build.sh
@@ -7,7 +7,7 @@ TERMUX_PKG_VERSION="7.1.1"
 TERMUX_PKG_SRCURL=https://www.ffmpeg.org/releases/ffmpeg-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=733984395e0dbbe5c046abda2dc49a5544e7e0e1e2366bba849222ae9e3a03b1
 TERMUX_PKG_DEPENDS="fontconfig, freetype, fribidi, game-music-emu, harfbuzz, libaom, libandroid-glob, libass, libbluray, libbz2, libdav1d, libgnutls, libiconv, liblzma, libmp3lame, libopencore-amr, libopenmpt, libopus, librav1e, libsoxr, libsrt, libssh, libtheora, libv4l, libvidstab, libvmaf, libvo-amrwbenc, libvorbis, libvpx, libwebp, libx264, libx265, libxml2, libzimg, littlecms, ocl-icd, rubberband, svt-av1, xvidcore, zlib"
-TERMUX_PKG_BUILD_DEPENDS="opencl-headers"
+TERMUX_PKG_BUILD_DEPENDS="opencl-headers, texinfo, vulkan-headers"
 TERMUX_PKG_CONFLICTS="libav"
 TERMUX_PKG_BREAKS="ffmpeg-dev"
 TERMUX_PKG_REPLACES="ffmpeg-dev"
@@ -51,10 +51,12 @@ termux_step_configure() {
 		termux_error_exit "Unsupported arch: $TERMUX_ARCH"
 	fi
 
+		# --toolchain=clang-asan \
 	$TERMUX_PKG_SRCDIR/configure \
 		--arch="${_ARCH}" \
 		--as="$AS" \
 		--cc="$CC" \
+		--host-cc="$CC" \
 		--cxx="$CXX" \
 		--nm="$NM" \
 		--ar="$AR" \
@@ -112,7 +114,7 @@ termux_step_configure() {
 		--prefix="$TERMUX_PREFIX" \
 		--target-os=android \
 		--extra-libs="-landroid-glob" \
-		--disable-vulkan \
+		--enable-vulkan \
 		$_EXTRA_CONFIGURE_FLAGS \
 		--disable-libfdk-aac
 	# GPLed FFmpeg binaries linked against fdk-aac are not redistributable.


### PR DESCRIPTION
even if it doesn't work all angles to attack the graphics card is
useful. there are gigantic amounts of assumptions that breaks mobile for
typical desktop applications . maybe someone can get further than me I failed at VK_KHR_portability_enumeration it should be possible to get to VK_KHR_video_encode_queue. I am on unisoc 606 Mali Valhalla. it is surprising that it could not even find the device when it works fine elsewhere. if someone could post an example where ffmpeg find the mobile graphics card that would be useful in itself. it is unique in NOT immediately exiting when DISPLAY is unset which many Vulkan apps do. but seems to be too particular in finding a device I think there is another extension or command that works on mobile

ffmpeg -v  debug -init_hw_device  vulkan

[AVHWDeviceContext @ 0xb400007a8d4bf2b0] Supported layers:
[AVHWDeviceContext @ 0xb400007a8d4bf2b0] 	VK_LAYER_window_system_integration
[AVHWDeviceContext @ 0xb400007a8d4bf2b0] 	VK_LAYER_KHRONOS_synchronization2
[AVHWDeviceContext @ 0xb400007a8d4bf2b0] 	VK_LAYER_KHRONOS_timeline_semaphore
[AVHWDeviceContext @ 0xb400007a8d4bf2b0] 	VK_LAYER_KHRONOS_shader_object
[AVHWDeviceContext @ 0xb400007a8d4bf2b0] 	VK_LAYER_KHRONOS_validation
[AVHWDeviceContext @ 0xb400007a8d4bf2b0] Using instance extension VK_KHR_portability_enumeration
[AVHWDeviceContext @ 0xb400007a8d4bf2b0] No devices found: VK_ERROR_INITIALIZATION_FAILED!
Device creation failed: -19.
Failed to set value 'vulkan' for option 'init_hw_device': No such device
Error parsing global options: No such device

 on the broad well server with no graphics cards it gets further

gcc -march=native -Q --help=target|grep march
  -march=       broadwell

ffmpeg -y -init_hw_device   vulkan=vkdev:0  -filter_hw_device vkdev -i  $i -filter:v  "format=nv12,hwupload" -c:v    hevc_vulkan vk.mkv

[hevc_vulkan @ 0x5555d4da1a80] Device does not support the VK_KHR_video_encode_queue extension!

 # media encode is ALSO broken but should work I don't know what to make
 of it

 this was a distraction to get some where with my unisoc media codec.  I
 have made an incorrect setting some where it is not coding anything. i don't have another phone to compare with

c2.unisoc.avc.encoder
c2.unisoc.hevc.encoder

there are also software versions that ALSO is broken

c2.android.avc.encoder
c2.android.hevc.encoder

the -hwaccel opencl flag only applies to filters and make no difference for coding . -hwaccel mediacodec use c2.unisoc.avc.decoder that works and code a working file with software hevc but no gain in speed. trying to use any mc coder ends up with an empty file for mysterious reason I can't understand the output. nnothing is coded but there is no discernible error any where to find even with maximum debug output. it immediately terminate with a success return code = 0. the software versions return an error incomprehensible

ffmpeg -y -hwaccel opencl -i $i -c:v hevc -an out.mp4
encoded 240 frames in 2.58s (92.87 fps), 112.69 kb/s, Avg QP:32.77

ffmpeg -y -hwaccel mediacodec -i $i -c:v hevc -an out.mp4
encoded 240 frames in 2.74s (87.46 fps), 112.69 kb/s, Avg QP:32.77

ffmpeg -y -i $i -c:v hevc_mediacodec  out.mkv
[vost#0:0/hevc_mediacodec @ 0xb400006
e54cef3b0] Terminating thread with return code 0 (success)
[out#0/matroska @ 0xb400007ba63cdef0]   Output stream #0:0 (video): 1 frames encoded; 0 packets muxed (0 bytes)
;

ffmpeg -y -i $i -c:v hevc_mediacodec -codec_name c2.android.hevc.encoder out.mkv
[hevc_mediacodec @ 0xb40000745742c8b0] dequeue input buffer failed, -10000Error submitting video frame to the e
ncoder
