### PR TITLE
tree-wide: migrate all reverse dependencies of `protobuf-static` to `libprotobuf`

### DIFF
--- a/packages/ffmpeg/build.sh
+++ b/packages/ffmpeg/build.sh
@@ -4,10 +4,10 @@ TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # Please align version with `ffplay` package.
 TERMUX_PKG_VERSION="7.1.1"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://www.ffmpeg.org/releases/ffmpeg-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=733984395e0dbbe5c046abda2dc49a5544e7e0e1e2366bba849222ae9e3a03b1
-TERMUX_PKG_DEPENDS="fontconfig, freetype, fribidi, game-music-emu, harfbuzz, libaom, libandroid-glob, libass, libbluray, libbz2, libdav1d, libgnutls, libiconv, liblzma, libmp3lame, libopencore-amr, libopenmpt, libopus, librav1e, libsoxr, libsrt, libssh, libtheora, libv4l, libvidstab, libvmaf, libvo-amrwbenc, libvorbis, libvpx, libwebp, libx264, libx265, libxml2, libzimg, libzmq, littlecms, ocl-icd, rubberband, svt-av1, xvidcore, zlib"
+TERMUX_PKG_DEPENDS="fontconfig, freetype, fribidi, game-music-emu, harfbuzz, libaom, libandroid-glob, libandroid-stub, libass, libbluray, libbz2, libdav1d, libgnutls, libiconv, liblzma, libmp3lame, libopencore-amr, libopenmpt, libopus, librav1e, libsoxr, libsrt, libssh, libtheora, libv4l, libvidstab, libvmaf, libvo-amrwbenc, libvorbis, libvpx, libwebp, libx264, libx265, libxml2, libzimg, libzmq, littlecms, ocl-icd, rubberband, svt-av1, xvidcore, zlib"
 TERMUX_PKG_BUILD_DEPENDS="opencl-headers"
 TERMUX_PKG_CONFLICTS="libav"
 TERMUX_PKG_BREAKS="ffmpeg-dev"

--- a/packages/ffmpeg/postinst.sh.in
+++ b/packages/ffmpeg/postinst.sh.in
@@ -13,14 +13,14 @@ check_command() {
 			*"CANNOT LINK EXECUTABLE"*)
 				printf '%s\n' \
 					"To fix the '$command' command, manually upgrade all packages by running: \`pkg upgrade\`" \
-					"If upgrading packages does not fix it, then you may be able to fix the error by running: \`pkg install libandroid-stub\`" \
+					"If upgrading packages does not fix it, then please open an issue at https://github.com/termux/termux-packages/issues" \
 					"See also: https://github.com/termux/termux-packages/wiki/Termux-execution-environment#dynamic-library-linking-errors"
 			;;
 			# - https://github.com/termux/termux-packages/issues/23189#issuecomment-2663464359
 			# - https://cs.android.com/android/platform/superproject/+/android15-qpr1-release:external/boringssl/src/crypto/fipsmodule/bcm.c;l=141
 			*"FIPS module doesn't span expected symbol"*)
 				printf '%s\n' \
-					"You should be able to fix the error by running: \`pkg install libandroid-stub\`" \
+					"If you see this error, then please open an issue at https://github.com/termux/termux-packages/issues" \
 					"See also: https://github.com/termux/termux-packages/wiki/Termux-execution-environment#dynamic-library-linking-errors"
 			;;
 		esac

--- a/packages/libncnn/use-cross-protoc.patch
+++ b/packages/libncnn/use-cross-protoc.patch
@@ -1,0 +1,31 @@
+For some reason, this by itself makes libncnn select
+/home/builder/.termux-build/_cache/protobuf-30.0/bin/protoc
+instead of
+/data/data/com.termux/files/usr/bin/protoc-30.0.0
+
+--- a/tools/caffe/CMakeLists.txt
++++ b/tools/caffe/CMakeLists.txt
+@@ -1,5 +1,4 @@
+ 
+-find_package(protobuf CONFIG)
+ 
+ if(protobuf_FOUND)
+     set(PROTOBUF_FOUND ${protobuf_FOUND})
+--- a/tools/onnx/CMakeLists.txt
++++ b/tools/onnx/CMakeLists.txt
+@@ -1,5 +1,4 @@
+ 
+-find_package(protobuf CONFIG)
+ 
+ if(protobuf_FOUND)
+     set(PROTOBUF_FOUND ${protobuf_FOUND})
+--- a/tools/pnnx/CMakeLists.txt
++++ b/tools/pnnx/CMakeLists.txt
+@@ -95,7 +95,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+ endif()
+ 
+ if((PNNX_TORCH_USE_CXX11_ABI AND PNNX_COMPILER_USE_CXX11_ABI) OR (NOT PNNX_TORCH_USE_CXX11_ABI AND NOT PNNX_COMPILER_USE_CXX11_ABI))
+-    find_package(protobuf CONFIG)
+ 
+     if(protobuf_FOUND)
+         set(PROTOBUF_FOUND ${protobuf_FOUND})

--- a/packages/libprotobuf/build.sh
+++ b/packages/libprotobuf/build.sh
@@ -2,28 +2,32 @@ TERMUX_PKG_HOMEPAGE=https://github.com/protocolbuffers/protobuf
 TERMUX_PKG_DESCRIPTION="Protocol buffers C++ library"
 # utf8_range is licensed under MIT
 TERMUX_PKG_LICENSE="BSD 3-Clause, MIT"
-TERMUX_PKG_LICENSE_FILE="LICENSE"
+TERMUX_PKG_LICENSE_FILE="
+LICENSE
+third_party/utf8_range/LICENSE
+"
 TERMUX_PKG_MAINTAINER="@termux"
 # When bumping version:
 # - update SHA256 checksum for $_PROTOBUF_ZIP in
 #     $TERMUX_SCRIPTDIR/scripts/build/setup/termux_setup_protobuf.sh
 # - ALWAYS bump revision of reverse dependencies and rebuild them.
 TERMUX_PKG_VERSION="2:30.0"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/protocolbuffers/protobuf/archive/v${TERMUX_PKG_VERSION#*:}.tar.gz
 TERMUX_PKG_SHA256=9df0e9e8ebe39f4fbbb9cf7db3d811287fe3616b2f191eb2bf5eaa12539c881f
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_DEPENDS="abseil-cpp, libc++, zlib"
-TERMUX_PKG_BREAKS="libprotobuf-dev, protobuf-static (<< ${TERMUX_PKG_VERSION#*:}), libutf8-range"
-TERMUX_PKG_REPLACES="libprotobuf-dev, libutf8-range"
+TERMUX_PKG_BREAKS="libprotobuf-dev, protobuf-static, libutf8-range"
+TERMUX_PKG_REPLACES="libprotobuf-dev, protobuf-static, libutf8-range"
+TERMUX_PKG_CONFLICTS="protobuf-static"
 TERMUX_PKG_FORCE_CMAKE=true
+TERMUX_PKG_NO_STATICSPLIT=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dprotobuf_ABSL_PROVIDER=package
 -Dprotobuf_BUILD_TESTS=OFF
 -DBUILD_SHARED_LIBS=ON
 -DCMAKE_INSTALL_LIBDIR=lib
 "
-TERMUX_PKG_NO_STATICSPLIT=true
 
 termux_step_post_get_source() {
 	# Version guard
@@ -35,9 +39,6 @@ termux_step_post_get_source() {
 }
 
 termux_step_post_make_install() {
-	install -Dm600 -t $TERMUX_PREFIX/share/doc/libutf8-range \
-		$TERMUX_PKG_SRCDIR/third_party/utf8_range/LICENSE
-
 	# Copy lib/*.cmake to opt/protobuf-cmake/shared for future use
 	mkdir -p $TERMUX_PREFIX/opt/protobuf-cmake/shared
 	cp $TERMUX_PREFIX/lib/cmake/protobuf/protobuf-targets{,-release}.cmake \

--- a/packages/libprotobuf/protobuf.subpackage.sh
+++ b/packages/libprotobuf/protobuf.subpackage.sh
@@ -5,4 +5,3 @@ lib/libprotoc.so*
 lib/pkgconfig/protobuf-lite.pc
 "
 TERMUX_SUBPKG_DESCRIPTION="Compiler for protocol buffer definition files"
-

--- a/packages/protobuf-static/build.sh
+++ b/packages/protobuf-static/build.sh
@@ -1,23 +1,22 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/protocolbuffers/protobuf
 TERMUX_PKG_DESCRIPTION="Protocol buffers C++ library (static)"
-TERMUX_PKG_LICENSE="BSD 3-Clause"
+# utf8_range is licensed under MIT
+TERMUX_PKG_LICENSE="BSD 3-Clause, MIT"
+TERMUX_PKG_LICENSE_FILE="
+LICENSE
+third_party/utf8_range/LICENSE
+"
 TERMUX_PKG_MAINTAINER="@termux"
-# Please align the version with `libprotobuf` package.
+# Please align the version and revision with `libprotobuf` package.
 TERMUX_PKG_VERSION=30.0
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/protocolbuffers/protobuf/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=9df0e9e8ebe39f4fbbb9cf7db3d811287fe3616b2f191eb2bf5eaa12539c881f
-v_proto_version_shared=$(. $TERMUX_SCRIPTDIR/packages/libprotobuf/build.sh; echo ${TERMUX_PKG_VERSION})
-v_proto_version_revision=$(TERMUX_PKG_REVISION=0; . $TERMUX_SCRIPTDIR/packages/libprotobuf/build.sh; echo ${TERMUX_PKG_REVISION})
-v_proto_extract_version="${v_proto_version_shared}-${v_proto_version_revision}"
-if [ "$v_proto_version_revision" = 0 ]; then
-	v_proto_extract_version="${v_proto_version_shared}"
-fi
-TERMUX_PKG_DEPENDS="abseil-cpp, protobuf (= ${v_proto_extract_version})"
-unset v_proto_version_shared v_proto_version_revision v_proto_extract_version
-TERMUX_PKG_BUILD_DEPENDS="libc++, zlib"
-TERMUX_PKG_BREAKS="libprotobuf (<< 2:21.12)"
-TERMUX_PKG_REPLACES="libprotobuf (<< 2:21.12)"
-TERMUX_PKG_CONFLICTS="protobuf-dev"
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="abseil-cpp, libc++, zlib"
+TERMUX_PKG_BREAKS="libprotobuf"
+TERMUX_PKG_REPLACES="libprotobuf"
+TERMUX_PKG_CONFLICTS="libprotobuf, protobuf-dev"
 TERMUX_PKG_NO_STATICSPLIT=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dprotobuf_ABSL_PROVIDER=package
@@ -35,33 +34,9 @@ termux_step_post_get_source() {
 	fi
 }
 
-termux_step_pre_configure() {
-	# Version guard
-	local ver_shared=$(. $TERMUX_SCRIPTDIR/packages/libprotobuf/build.sh; echo ${TERMUX_PKG_VERSION#*:})
-	local ver_static=${TERMUX_PKG_VERSION#*:}
-	if [ "${ver_shared}" != "${ver_static}" ]; then
-		termux_error_exit "Version mismatch between libprotobuf and protobuf-static."
-	fi
-}
-
 termux_step_post_make_install() {
 	# Copy lib/*.cmake to opt/protobuf-cmake/static for future use
 	mkdir -p $TERMUX_PREFIX/opt/protobuf-cmake/static
 	cp $TERMUX_PREFIX/lib/cmake/protobuf/protobuf-targets{,-release}.cmake \
 		$TERMUX_PREFIX/opt/protobuf-cmake/static/
-}
-
-termux_step_post_massage() {
-	find . ! -type d \
-		! -wholename "./lib/*.a" \
-		! -wholename "./lib/cmake/protobuf/protobuf-targets-release.cmake" \
-		! -wholename "./lib/cmake/protobuf/protobuf-targets.cmake" \
-		! -wholename "./opt/protobuf-cmake/static/protobuf-targets-release.cmake" \
-		! -wholename "./opt/protobuf-cmake/static/protobuf-targets.cmake" \
-		! -wholename "./share/doc/$TERMUX_PKG_NAME/*" \
-		-exec rm -f '{}' \;
-	find . ! -type d \
-		-wholename "./lib/libutf8_*" \
-		-exec rm -f '{}' \;
-	find . -type d -empty -delete
 }

--- a/packages/termux-gui-c/build.sh
+++ b/packages/termux-gui-c/build.sh
@@ -3,9 +3,8 @@ TERMUX_PKG_DESCRIPTION="A C library for the Termux:GUI plugin"
 TERMUX_PKG_LICENSE="MPL-2.0"
 TERMUX_PKG_MAINTAINER="@tareksander"
 TERMUX_PKG_VERSION="0.1.3"
-TERMUX_PKG_REVISION=2
-TERMUX_PKG_DEPENDS="abseil-cpp, libc++"
-TERMUX_PKG_BUILD_DEPENDS="protobuf-static"
+TERMUX_PKG_REVISION=3
+TERMUX_PKG_DEPENDS="abseil-cpp, libc++, libandroid-stub, libprotobuf"
 TERMUX_PKG_SRCURL="https://github.com/tareksander/termux-gui-c-bindings/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=7781fdbd37ca1376b4c2339440976b0aa00cc2188592ea51438e473589db466f
 TERMUX_PKG_AUTO_UPDATE=true
@@ -13,4 +12,5 @@ TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
 
 termux_step_pre_configure() {
 	termux_setup_protobuf
+	export SHARED_BUILD=1
 }

--- a/x11-packages/opencv/fix-build-with-qt-6.9.patch
+++ b/x11-packages/opencv/fix-build-with-qt-6.9.patch
@@ -1,0 +1,15 @@
+Patch by badshah400 in https://github.com/opencv/opencv/issues/27223
+to fix:
+ninja: error: build.ninja:13215: bad $-escape (literal $ must be written as $$)
+
+--- a/modules/highgui/CMakeLists.txt
++++ b/modules/highgui/CMakeLists.txt
+@@ -125,7 +125,7 @@ elseif(HAVE_QT)
+     endif()
+ 
+     foreach(dt_dep ${qt_deps})
+-      add_definitions(${Qt${QT_VERSION_MAJOR}${dt_dep}_DEFINITIONS})
++      link_libraries(${Qt${QT_VERSION_MAJOR}${dt_dep}})
+       include_directories(${Qt${QT_VERSION_MAJOR}${dt_dep}_INCLUDE_DIRS})
+       list(APPEND HIGHGUI_LIBRARIES ${Qt${QT_VERSION_MAJOR}${dt_dep}_LIBRARIES})
+     endforeach()

--- a/x11-packages/spek/build.sh
+++ b/x11-packages/spek/build.sh
@@ -3,11 +3,10 @@ TERMUX_PKG_DESCRIPTION="An acoustic spectrum analyser"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.8.5
-TERMUX_PKG_REVISION=4
+TERMUX_PKG_REVISION=5
 TERMUX_PKG_SRCURL=https://github.com/alexkay/spek/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=9053d2dec452dcde421daa0f5f59a9dee47927540f41d9c0c66800cb6dbf6996
 TERMUX_PKG_DEPENDS="ffmpeg, libc++, wxwidgets"
-TERMUX_PKG_SUGGESTS="libandroid-stub"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="ac_cv_path_WX_CONFIG_PATH=$TERMUX_PREFIX/bin/wx-config"
 
 termux_step_pre_configure() {
@@ -19,7 +18,6 @@ termux_step_pre_configure() {
 termux_step_create_subpkg_debscripts() {
 	cat <<- EOF > ./postinst
 	#!$TERMUX_PREFIX/bin/sh
-	echo "Note: If you encounter Segmentation Fault, execute the following command:"
-	echo "pkg install libandroid-stub"
+	echo "Note: If you encounter Segmentation Fault, then please open an issue at https://github.com/termux/termux-packages/issues"
 	EOF
 }

--- a/x11-packages/telegram-desktop/build.sh
+++ b/x11-packages/telegram-desktop/build.sh
@@ -5,10 +5,11 @@ TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="LICENSE, LEGAL"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=5.13.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/telegramdesktop/tdesktop/releases/download/v$TERMUX_PKG_VERSION/tdesktop-$TERMUX_PKG_VERSION-full.tar.gz
 TERMUX_PKG_SHA256=caa37bbf7d9fcdfecdb5f596f02a44becbe468ea5c6af7f3c670b61952744a80
-TERMUX_PKG_DEPENDS="abseil-cpp, boost, ffmpeg, glib, hicolor-icon-theme, hunspell, kf6-kcoreaddons, libandroid-shmem, libdispatch, libdrm, liblz4, libminizip, libprotobuf, librnnoise, libsigc++-3.0, libx11, libxcomposite, libxdamage, libxrandr, libxtst, openal-soft, opengl, openh264, openssl, pipewire, pulseaudio, qt6-qtbase, qt6-qtimageformats, qt6-qtsvg, xxhash"
-TERMUX_PKG_BUILD_DEPENDS="ada, boost-headers, glib-cross, protobuf-static, qt6-qtbase-cross-tools"
+TERMUX_PKG_DEPENDS="abseil-cpp, boost, ffmpeg, glib, hicolor-icon-theme, hunspell, kf6-kcoreaddons, libandroid-shmem, libdispatch, libdrm, liblz4, libminizip, protobuf, librnnoise, libsigc++-3.0, libx11, libxcomposite, libxdamage, libxrandr, libxtst, openal-soft, opengl, openh264, openssl, pipewire, pulseaudio, qt6-qtbase, qt6-qtimageformats, qt6-qtsvg, xxhash"
+TERMUX_PKG_BUILD_DEPENDS="ada, boost-headers, glib-cross, qt6-qtbase-cross-tools"
 TERMUX_PKG_VERSIONED_GIR=false
 TERMUX_PKG_AUTO_UPDATE=true
 
@@ -191,18 +192,12 @@ termux_step_configure() {
 		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DPROTOBUF_PROTOC_EXECUTABLE=$(command -v protoc)"
 
 		mkdir -p "$TERMUX_PKG_TMPDIR/bin"
-		cat <<- EOF > "$TERMUX_PKG_TMPDIR/bin/$(basename ${CC})"
-			#!/bin/bash
-			set -- "\${@/-lprotobuf/-l:libprotobuf.a}"
-			exec $TERMUX_STANDALONE_TOOLCHAIN/bin/$(basename ${CC}) "\$@"
-		EOF
 		local _type
 		for _type in emoji lang style; do
 			ln -sf \
 				"$TERMUX_PKG_HOSTBUILD_DIR/codegen-host-build/out/Telegram/codegen/codegen/$_type/Release/codegen_$_type" \
 				"$TERMUX_PKG_TMPDIR/bin/codegen_$_type"
 		done
-		chmod +x "$TERMUX_PKG_TMPDIR/bin/$(basename ${CC})"
 		export PATH="$TERMUX_PKG_TMPDIR/bin:$PATH"
 	else
 		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DCMAKE_CROSSCOMPILING=FALSE"


### PR DESCRIPTION
- This is fixing multiple problems with:
  - `libprotobuf`
  - `protobuf-static`
  - `glslang`
  - `libncnn`
  - `opencv`
  - `termux-gui-c`
  - `ffmpeg`
  - `spek`
  - `telegram-desktop`

- reverts https://github.com/termux/termux-packages/commit/335b1c1bd185d9be65b1aa62f28d8df1de456238

- partially reverts https://github.com/termux/termux-packages/commit/27db768920497a230bc68e52b3c5cc5e83a61c63

- partially reverts https://github.com/termux/termux-packages/commit/aff43fd305b6c88d390502077c922ae8262239c9

- important related code: https://github.com/termux/termux-packages/commit/f8feaa907b0bee27dd4151431f52a226c0a448aa

- important related code: https://github.com/Kitware/CMake/blob/a2530fd9559023afdbbeaa26748f1edbfa7e22dd/Modules/FindProtobuf.cmake#L821

- `ffmpeg`: depend on new `libandroid-stub`

- `spek`: `libandroid-stub` now pulled in by `ffmpeg` dependency

- `libprotobuf`:
  - conflict with `protobuf-static` (because of `libupb.a`)
  - add license file for `libutf8-range`

- `protobuf-static`:
  - align `TERMUX_PKG_REVISION` with `libprotobuf`
  - conflict with `libprotobuf` (because of `libupb.a`)
  - provide its own `libutf8-range` and `protoc` (because of conflict with `libprotobuf` preventing it from depending on `protobuf` [which is `protoc`])
  - add license file for `libutf8-range`

- `libncnn`:
  - bump to 20241226
  - migrate to `libprotobuf`
  - depend on new `libandroid-stub`: https://github.com/termux/termux-packages/pull/23712

- `opencv`:
  - fix build with Qt 6.9, issue tracked upstream here: https://github.com/opencv/opencv/issues/27223
  - migrate to `libprotobuf`

- `termux-gui-c`:
  - migrate to `libprotobuf`
  - depend on new `libandroid-stub`

- `telegram-desktop`:
  - migrate to `libprotobuf`
  - depend explicitly on `protobuf` at runtime, to fix `CANNOT LINK EXECUTABLE "telegram-desktop": library "libprotobuf-lite.so" not found: needed by main executable`


This change **orphans `protobuf-static`**, which can now eventually be **completely removed some time in the future** if it does not end up being needed anymore by anyone.