### PR TITLE
libvips: enable SOVERSION suffix

### DIFF
--- a/packages/libvips/build.sh
+++ b/packages/libvips/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A fast image processing library with low memory needs"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="8.16.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/libvips/libvips/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=df960c3df02da8ae16ee19e79c9428e955d178242a8f06064e07e0c417238e6e
 TERMUX_PKG_AUTO_UPDATE=true
@@ -18,4 +19,17 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 termux_step_pre_configure() {
 	termux_setup_gir
 	termux_setup_glib_cross_pkg_config_wrapper
+
+	export TERMUX_MESON_ENABLE_SOVERSION=1
+}
+
+termux_step_post_massage() {
+	# Do not forget to bump revision of reverse dependencies and rebuild them
+	# after SOVERSION is changed.
+	local _SOVERSION=42
+	if [ ! -e "lib/libvips.so.${_SOVERSION}" ]; then
+		echo "ERROR: Expected: lib/libvips.so.${_SOVERSION}" 1>&2
+		echo "ERROR: Found   : $(find lib/libvips* -regex '.*so\.[0-9]+')" 1>&2
+		termux_error_exit "Not proceeding with update."
+	fi
 }


### PR DESCRIPTION
Most FFI-based libvips bindings expect version-suffixed SONAMEs.

Context: https://github.com/libvips/php-vips/pull/260.