### PR TITLE
scripts(start_build): set `TERMUX_ELF_CLEANER` for on-device continued build

### DIFF
--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -79,6 +79,10 @@ termux_step_start_build() {
 			termux_error_exit "Cannot continue this build, hostbuilt tools are missing"
 		fi
 
+		# Set TERMUX_ELF_CLEANER for on-device continued build
+		if [ "$TERMUX_PACKAGE_LIBRARY" = "bionic" ] && [ "$TERMUX_ON_DEVICE_BUILD" = "true" ]; then
+			TERMUX_ELF_CLEANER="$(command -v termux-elf-cleaner)"
+		fi
 		# The rest in this function can be skipped when doing
 		# a continued build
 		return
@@ -102,7 +106,7 @@ termux_step_start_build() {
 				"apt") apt install -y termux-elf-cleaner;;
 				"pacman") pacman -S termux-elf-cleaner --needed --noconfirm;;
 			esac
-			ln -sf $TERMUX_ELF_CLEANER "$(command -v termux-elf-cleaner)"
+			TERMUX_ELF_CLEANER="$(command -v termux-elf-cleaner)"
 		else
 			local TERMUX_ELF_CLEANER_VERSION
 			TERMUX_ELF_CLEANER_VERSION=$(bash -c ". $TERMUX_SCRIPTDIR/packages/termux-elf-cleaner/build.sh; echo \$TERMUX_PKG_VERSION")

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -102,7 +102,7 @@ termux_step_start_build() {
 				"apt") apt install -y termux-elf-cleaner;;
 				"pacman") pacman -S termux-elf-cleaner --needed --noconfirm;;
 			esac
-			TERMUX_ELF_CLEANER="$(command -v termux-elf-cleaner)"
+			ln -sf $TERMUX_ELF_CLEANER "$(command -v termux-elf-cleaner)"
 		else
 			local TERMUX_ELF_CLEANER_VERSION
 			TERMUX_ELF_CLEANER_VERSION=$(bash -c ". $TERMUX_SCRIPTDIR/packages/termux-elf-cleaner/build.sh; echo \$TERMUX_PKG_VERSION")


### PR DESCRIPTION
In a continued build, `TERMUX_ELF_CLEANER` is set to `$PREFIX/bin/termux-elf-cleaner` after the early-return check of `TERMUX_CONTINUE_BUILD`.