### PR TITLE
addpkg(main/jellyfin): 10.10.7

### DIFF
--- a/packages/jellyfin-server/build.sh
+++ b/packages/jellyfin-server/build.sh
@@ -1,0 +1,258 @@
+TERMUX_PKG_HOMEPAGE="https://jellyfin.org"
+TERMUX_PKG_DESCRIPTION="A free media system for organizing and streaming media (server)"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=(
+	10.10.7
+	7.0.2.9
+)
+TERMUX_PKG_SRCURL=(
+	"https://github.com/jellyfin/jellyfin/archive/refs/tags/v${TERMUX_PKG_VERSION[0]}.tar.gz"
+	"https://github.com/jellyfin/jellyfin-ffmpeg/archive/refs/tags/v${TERMUX_PKG_VERSION[1]%.*}-${TERMUX_PKG_VERSION[1]##*.}.tar.gz"
+)
+TERMUX_PKG_SHA256=(
+	797db59e50e33ecf85562f6c49651963bd5f00dd9cb74bf89dd905513c8207ec
+	ae4ea57516e606a73fd2745b21284c65d41d3851d05a2ac17c425d7488192ba0
+)
+TERMUX_PKG_SUGGESTS="jellyfin-ffmpeg"
+TERMUX_PKG_BUILD_DEPENDS="aspnetcore-targeting-pack-8.0, dotnet-targeting-pack-8.0, libcairo, pango, libjpeg-turbo, giflib, librsvg"
+TERMUX_PKG_DEPENDS="libc++, fontconfig, aspnetcore-runtime-8.0, dotnet-host, dotnet-runtime-8.0, sqlite, libexpat, libpng, libwebp, freetype, ffmpeg"
+TERMUX_PKG_SERVICE_SCRIPT=(
+	"jellyfin"
+	"exec ${TERMUX_PREFIX}/bin/jellyfin 2>&1"
+)
+TERMUX_PKG_EXCLUDED_ARCHES="arm"
+TERMUX_PKG_RM_AFTER_INSTALL="
+opt/jellyfin/include
+opt/jellyfin/lib/pkgconfig
+opt/jellyfin/share
+"
+termux_step_post_get_source() {
+	# this array is for the update-git-checksums.sh script, order should be same keys of _GIT_SHA256
+	local _project=(libe_sqlite SQLitePCL.raw skiasharp jellyfin-web)
+	local -A _GIT_URL=(
+		[libe_sqlite]="git+https://github.com/ericsink/cb"
+		[SQLitePCL.raw]="git+https://github.com/ericsink/SQLitePCL.raw"
+		[skiasharp]="git+https://github.com/mono/skia"
+		[jellyfin-web]="git+https://github.com/jellyfin/jellyfin-web"
+	)
+	local -A _GIT_COMMIT=(
+		[libe_sqlite]=cd2922b8867e4360f0976601414bd24a3ad613d8
+		[SQLitePCL.raw]=7521c274efb2b49855b192f17862e87964460bac
+		[skiasharp]=4bed689c9c9eb77a120c6a9d54af6a572c85d1c2
+		[jellyfin-web]=f4b8aa0ed4c5b571a3a6cc3bb027bb8ecebe5b68
+	)
+	local -A _GIT_SHA256=(
+		[libe_sqlite]=1107df127ead66ace2baf92467fa10a8215371741e0b0b6a0580496ff1ae0bcf
+		[SQLitePCL.raw]=8cd1b773026da818c47c693cf7a4bb81ab927b869a0ce2c6abcdbbe38d79922b
+		[skiasharp]=46c733f05df257e4bec13c09b53e7ef39bb80f21acb435d206dce609f4175ab1
+		[jellyfin-web]=2b8b180bdba21acc574858e50eded5fa1f7575f2571a8f17a9da7e2d9a79bb66
+	)
+	# this portion is required until TERMUX_PKG_SRCURL adds support for multiple git repos and duplicate filenames
+	local _proj _sha256sum;
+	(( ${#_GIT_URL[@]} == ${#_GIT_COMMIT[@]} && ${#_GIT_URL[@]} == ${#_GIT_SHA256[@]} )) || termux_error_exit '_GIT_URL, _GIT_COMMIT and _GIT_SHA256 must be arrays of the same length'
+	for _proj in "${!_GIT_URL[@]}"; do
+		# the commands until the next comment can be replaced with git clone --revision "${_GIT_COMMIT["$_proj"]}" --depth 1 in git 2.49
+		mkdir "$( printf "%s" "${_GIT_URL["${_proj}"]}" | sed -E 's|^.*/(.*)$|\1|' )"
+		pushd "$( printf "%s" "${_GIT_URL["${_proj}"]}" | sed -E 's|^.*/(.*)$|\1|' )"
+		git init -q
+		git remote add origin "${_GIT_URL["${_proj}"]:4}"
+		git fetch --depth 1 origin "${_GIT_COMMIT["${_proj}"]}"
+		git -c advice.detachedHead=false checkout "${_GIT_COMMIT["${_proj}"]}"
+		# we need a deterministic checksum, logs get in the way
+		rm -rf .git/logs
+		_sha256sum="$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum | awk '{print $1}')"
+		popd
+		! [ "${_sha256sum}" = "${_GIT_SHA256["${_proj}"]}" ] && termux_error_exit "Error: checksums for sources do not match. To update checksums, run $(cd -- "$(dirname "$0")"; pwd)/update-git-checksums.sh"
+	done
+
+	pushd jellyfin-ffmpeg-"${TERMUX_PKG_VERSION[1]%.*}-${TERMUX_PKG_VERSION[1]##*.}"
+	# If quilt is added to termux-build-helper:
+	# if [[ -f "debian/patches/series" ]]; then
+	# quilt push -a
+	# fi
+	local _patch;
+	for _patch in $(<debian/patches/series); do
+		git apply --whitespace=nowarn "debian/patches/${_patch}";
+	done
+	popd
+}
+termux_step_pre_configure() {
+	termux_setup_dotnet; termux_setup_gn; termux_setup_nodejs
+	pushd jellyfin-web
+	npm install
+	npm run build:production
+	cp -R ./dist "$TERMUX_PKG_BUILDDIR/jellyfin-web"
+	popd
+	local _target_cpu=""
+	case "$TERMUX_ARCH" in
+		aarch64) _target_cpu="arm64" ;;
+		arm) _target_cpu="arm" ;;
+		x86_64) _target_cpu="x64" ;;
+		i686) _target_cpu="x86" ;;
+		*) termux_error_exit  "Unsupported arch: $TERMUX_ARCH"
+	esac
+
+	pushd skia
+	# we must use version 62 of libjpeg-turbo
+	# https://github.com/libjpeg-turbo/libjpeg-turbo/issues/795#issuecomment-2484148592
+	local _flag _GN_CFLAGS _GN_LDFLAGS _GN_CPPFLAGS;
+	for _flag in CFLAGS LDFLAGS CPPFLAGS; do
+		declare _GN_"$_flag"="$(eval printf '%s' "\"\$$_flag\"" | awk '{for (i=1;i<NF;i++) { printf "\"%s\", ",$i}; printf "\"%s\"",$i}' )"
+	done
+	local _args_pre=""
+	local _args=""
+	_args_pre="target_os='android' \
+	target_cpu='${_target_cpu}' \
+	skia_use_icu=false \
+	skia_use_harfbuzz=false \
+	skia_use_piex=true \
+	skia_use_sfntly=false \
+	skia_enable_gpu=false \
+	skia_enable_tools=false \
+	skia_use_dng_sdk=false \
+	skia_use_gl=false \
+	skia_use_vulkan=false \
+	skia_use_system_expat=true \
+	skia_use_system_libjpeg_turbo=false \
+	skia_use_system_freetype2=true \
+	skia_use_system_libpng=true \
+	skia_use_system_libwebp=true \
+	skia_use_system_zlib=true \
+	skia_enable_skottie=true \
+	third_party_isystem=false \
+	cc='$CC' \
+	cxx='$CXX' \
+	ar='$AR' \
+	ndk='${TERMUX_STANDALONE_TOOLCHAIN}' \
+	ndk_api=${TERMUX_PKG_API_LEVEL} \
+	extra_asmflags=[] \
+	extra_cflags=[ '-DSKIA_C_DLL', '-DHAVE_SYSCALL_GETRANDOM', '-DXML_DEV_URANDOM' ] \
+	extra_ldflags=[ '-static-libstdc++', '-Wl,--no-undefined', '-Wl,-z,max-page-size=16384' ] \
+	is_official_build=true \
+	extra_asmflags+=[ '-no-integrated-as', '-I${TERMUX_PREFIX}/include' ] \
+	extra_cflags+=[ '-Wno-macro-redefined', ${_GN_CPPFLAGS}, ${_GN_CFLAGS}, $(pkg-config --cflags freetype2 libpng libwebp expat | awk '{for (i=1;i<NF;i++) { printf "\"%s\", ",$i}; printf "\"%s\"",$i}') ] \
+	extra_ldflags+=[ ${_GN_LDFLAGS}, $(pkg-config --libs freetype2 libpng libwebp expat | awk '{for (i=1;i<NF;i++) { printf "\"%s\", ",$i}; printf "\"%s\"",$i}') ]"
+	_args="$(printf "%s\n" "${_args_pre}" | sed "s/'/\"/g" | sed 's/\t//g')"
+
+	./tools/git-sync-deps
+	gn gen 'out' --args="${_args}"
+	ninja -C out SkiaSharp
+
+	_args_pre="target_os='android' \
+	target_cpu='${_target_cpu}' \
+	visibility_hidden=false \
+	cc='$CC' \
+	cxx='$CXX' \
+	ar='$AR' \
+	ndk='${TERMUX_STANDALONE_TOOLCHAIN}' \
+	ndk_api=${TERMUX_PKG_API_LEVEL} \
+	extra_asmflags=[] \
+	extra_cflags=[] \
+	extra_ldflags=[ '-static-libstdc++', '-Wl,--no-undefined', '-Wl,-z,max-page-size=16384' ] \
+	is_official_build=true \
+	extra_asmflags+=[ '-no-integrated-as', '-I${TERMUX_PREFIX}/include' ] \
+	extra_cflags+=[ '-Wno-macro-redefined', ${_GN_CPPFLAGS}, ${_GN_CFLAGS} ] \
+	extra_ldflags+=[ ${_GN_LDFLAGS} ]"
+	_args="$(printf "%s\n" "${_args_pre}" | sed "s/'/\"/g" | sed 's/\t//g')"
+
+	gn gen 'out' --args="${_args}"
+	ninja -C out HarfBuzzSharp
+
+	cp out/libSkiaSharp.so out/libHarfBuzzSharp.so "$TERMUX_PKG_BUILDDIR"
+	popd
+
+#	if [ "$TERMUX_ARCH" = "arm" ]; then
+#		_target_cpu="armhf"
+#	fi
+	local _tmpdir="$(mktemp -d "${TMPDIR-/tmp}/termux.src.dotnetproj.XXXXXXXX")"
+	[ -d "${_tmpdir}" ] || termux_error_exit "mktemp failed"
+	# dotnet traverses up to find a project root, which is bad for us
+	# SQLitePCL.raw needs it at "../cb"
+	mv "cb" "${_tmpdir}/cb"
+	mv "SQLitePCL.raw" "${_tmpdir}/SQLitePCL.raw"
+	pushd "${_tmpdir}/SQLitePCL.raw"
+	dotnet tool install --global dotnet-t4
+	( cd gen_providers; dotnet run )
+	cd src/SQLitePCLRaw.lib.e_sqlite3 && dotnet pack -c Release
+	cd ../SQLitePCLRaw.bundle_e_sqlite3 && dotnet build -p:TargetFrameworks=net8.0
+	cd "${_tmpdir}"
+	pushd "cb/bld" && dotnet run && "$CC" @linux_e_sqlite3_"${_target_cpu}".gccargs -lm -ldl; popd
+	cp "cb/bld/bin/e_sqlite3/linux/${_target_cpu}/libe_sqlite3.so" SQLitePCL.raw/src/SQLitePCLRaw.bundle_e_sqlite3/bin/Debug/net8.0/*dll "$TERMUX_PKG_BUILDDIR"
+	popd # $TERMUX_PKG_SRCDIR
+	rm -rf "$_tmpdir"
+
+	pushd jellyfin-ffmpeg-"${TERMUX_PKG_VERSION[1]%.*}-${TERMUX_PKG_VERSION[1]##*.}"
+	local _ARCH=""
+	local _FFMPEG_PREFIX="${TERMUX_PREFIX}/opt/jellyfin"
+	LDFLAGS="-Wl,-rpath=${_FFMPEG_PREFIX}/lib ${LDFLAGS}"
+	local _EXTRA_CONFIGURE_FLAGS=""
+	if [ "$TERMUX_ARCH" = "i686" ]; then
+		_ARCH="x86"
+		# Specify --disable-asm to prevent text relocations on i686,
+		# see https://trac.ffmpeg.org/ticket/4928
+		_EXTRA_CONFIGURE_FLAGS="--disable-asm"
+#	elif [ "$TERMUX_ARCH" = "arm" ]; then
+#		_ARCH="armeabi-v7a"
+#		_EXTRA_CONFIGURE_FLAGS="--enable-neon"
+	elif [ "$TERMUX_ARCH" = "x86_64" ]; then
+		_ARCH="x86_64"
+	elif [ "$TERMUX_ARCH" = "aarch64" ]; then
+		_ARCH="$TERMUX_ARCH"
+		_EXTRA_CONFIGURE_FLAGS="--enable-neon"
+	else
+		termux_error_exit  "Unsupported arch: $TERMUX_ARCH"
+	fi
+	# generated using ffmpeg-configureopts.sh
+	./configure --prefix="${_FFMPEG_PREFIX}" \
+	--arch="${_ARCH}" \
+	--as="$AS" \
+	--cc="$CC" \
+	--cxx="$CXX" \
+	--nm="$NM" \
+	--ar="$AR" \
+	--ranlib=llvm-ranlib \
+	--pkg-config="$PKG_CONFIG" \
+	--strip="$STRIP" \
+	--enable-cross-compile \
+	--extra-version="Jellyfin" \
+	--extra-cflags="" \
+	--extra-cxxflags="" \
+	--extra-ldflags="" \
+	--extra-ldexeflags="-pie" \
+	--extra-libs="-ldl -landroid-glob" \
+	--target-os=android \
+	--disable-static \
+	--enable-shared \
+	--enable-gpl --enable-version3 --disable-ffplay --disable-debug --disable-doc --disable-ptx-compression --disable-sdl2 --disable-libxcb --disable-xlib --enable-lto=auto --enable-iconv --enable-zlib --enable-libfreetype --enable-libfribidi --enable-gmp --enable-libxml2 --enable-openssl --enable-lzma --enable-fontconfig --enable-libharfbuzz --enable-libvorbis --enable-opencl --enable-chromaprint --enable-libdav1d --enable-libass --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvpx --enable-libwebp --enable-libopenmpt --enable-libsrt --enable-libsvtav1 --enable-libdrm --enable-libx264 --enable-libx265 --enable-libzimg \
+	${_EXTRA_CONFIGURE_FLAGS} \
+	--disable-vulkan
+
+	make -j"$TERMUX_PKG_MAKE_PROCESSES"
+	make install
+	popd
+}
+
+termux_step_make() {
+	dotnet publish "$TERMUX_PKG_SRCDIR"/Jellyfin.Server --configuration Release --runtime "$DOTNET_TARGET_NAME" --output "$TERMUX_PKG_BUILDDIR"/build --no-self-contained -p:DebugType=None
+}
+
+termux_step_make_install() {
+	chmod 0700 "${TERMUX_PKG_BUILDDIR}/build"
+	find "${TERMUX_PKG_BUILDDIR}/build" -name '*.xml' -type f -exec rm '{}' +
+	find "$TERMUX_PKG_BUILDDIR" -maxdepth 1 \( -type f -o -name 'jellyfin-web' \) -exec mv -t "${TERMUX_PKG_BUILDDIR}/build" '{}' +
+	find "${TERMUX_PKG_BUILDDIR}/build" ! \( -name '*.so' -o -name 'jellyfin' -o -type d \) -exec chmod 0600 '{}' \;
+	find "${TERMUX_PKG_BUILDDIR}/build" \( -name 'jellyfin' -o -name '*.so' -o -type d \) -exec chmod 0700 '{}' \;
+	mv "${TERMUX_PKG_BUILDDIR}/build" "${TERMUX_PREFIX}/lib/jellyfin"
+	ln -s "${TERMUX_PREFIX}/lib/jellyfin/jellyfin" "${TERMUX_PREFIX}/bin/jellyfin"
+}
+# References
+# - SkiaSharp
+# https://cgit.freebsd.org/ports/tree/graphics/libskiasharp
+# https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=282704
+# https://github.com/mono/SkiaSharp/blob/release/2.88.9/native/android/build.cake
+# https://gn.googlesource.com/gn/+/main/docs/reference.md
+# - Jellyfin-FFMPEG
+# https://github.com/jellyfin/jellyfin-ffmpeg/blob/jellyfin/builder/build.sh
+# https://github.com/termux/termux-packages/tree/master/packages/ffmpeg
+# Note: All patches for Jellyfin-FFMPEG should be based off the patched version, see termux_step_post_get_source

--- a/packages/jellyfin-server/ffmpeg-configure.patch
+++ b/packages/jellyfin-server/ffmpeg-configure.patch
@@ -1,0 +1,16 @@
+--- a/jellyfin-ffmpeg-7.0.2-9/configure
++++ b/jellyfin-ffmpeg-7.0.2-9/configure
+@@ -5336,13 +5336,9 @@
+         striptype=""
+         ;;
+     android)
+-        disable symver
+         enable section_data_rel_ro
+         add_cflags -fPIE
+         add_ldexeflags -fPIE -pie
+-        SLIB_INSTALL_NAME='$(SLIBNAME)'
+-        SLIB_INSTALL_LINKS=
+-        SHFLAGS='-shared -Wl,-soname,$(SLIBNAME)'
+         ;;
+     haiku)
+         prefix_default="/boot/common"

--- a/packages/jellyfin-server/ffmpeg-configureopts.sh
+++ b/packages/jellyfin-server/ffmpeg-configureopts.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+cd -- "$(dirname -- "$0")" 
+_FFMPEG_VERSION="$(awk -F'=' '$0 ~ /^_FFMPEG_VERSION=/ {print gensub(/"/,"","g",$2)}' ./build.sh)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"; trap '' EXIT; exit' INT EXIT TERM
+cd "$tmp"
+
+git -c advice.detachedHead=false clone --quiet --depth 1 https://github.com/jellyfin/jellyfin-ffmpeg -b v${_FFMPEG_VERSION}
+cd jellyfin-ffmpeg/builder
+<build.sh awk '{print} $0 ~ /^FF_LIBS/ {exit}' > configure.sh
+sed -i 's/set -xe/set -e/' configure.sh
+sed -i 's/docker/:/' configure.sh
+
+cat <<'EOF' >>configure.sh
+printf '%s\n' "./configure --prefix='\${_FFMPEG_PREFIX}'
+--arch='\${_ARCH}'
+--as='\$AS'
+--cc='\$CC'
+--cxx='\$CXX'
+--nm='\$NM'
+--ar='\$AR'
+--ranlib=llvm-ranlib
+--pkg-config='\$PKG_CONFIG'
+--strip='\$STRIP'
+--enable-cross-compile
+--extra-version='Jellyfin'
+--extra-cflags='$FF_CFLAGS'
+--extra-cxxflags='$FF_CXXFLAGS'
+--extra-ldflags='$FF_LDFLAGS'
+--extra-ldexeflags='$FF_LDEXEFLAGS'
+--extra-libs='$FF_LIBS -landroid-glob'
+--target-os=android
+--disable-static
+--enable-shared
+$FF_CONFIGURE
+\${_EXTRA_CONFIGURE_FLAGS}
+--disable-vulkan" | sed "s/'/\"/g;$ ! s/$/ \\\\/"
+EOF
+# disable unused and unneeded options
+rm -rf scripts.d/*{rkrga,vulkan,rkmpp,fdk-aac,zvbi,amf,vaapi,ffnvcodec,libvpl,shaderc}*
+# acceptable inputs:
+# ./ffmpeg-configureopts.sh linux64 gpl
+# ./ffmpeg-configureopts.sh linuxarm64 gpl
+[ -z "$1" ] && set -- linuxarm64 gpl
+bash ./configure.sh "$@"

--- a/packages/jellyfin-server/ffmpeg-fix_build_with_svt-av1-3.0.patch
+++ b/packages/jellyfin-server/ffmpeg-fix_build_with_svt-av1-3.0.patch
@@ -1,0 +1,35 @@
+https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff/d1ed5c06e3edc5f2b5f3664c80121fa55b0baa95
+
+From d1ed5c06e3edc5f2b5f3664c80121fa55b0baa95 Mon Sep 17 00:00:00 2001
+From: Gyan Doshi <ffmpeg@gyani.pro>
+Date: Sat, 22 Feb 2025 10:38:53 +0530
+Subject: [PATCH] avcodec/libsvtav1: unbreak build with latest svtav1
+
+SVT-AV1 made a change in their public API in 988e930c but without a
+version bump or any other accessible marker, thus breaking ffmpeg build
+with current versions of SVT-AV1.
+
+They have finally bumped versions a month later, so check added.
+---
+ libavcodec/libsvtav1.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/libavcodec/libsvtav1.c b/libavcodec/libsvtav1.c
+index 79b28eb4df..43fe531fde 100644
+--- a/jellyfin-ffmpeg-7.0.2-9/libavcodec/libsvtav1.c
++++ b/jellyfin-ffmpeg-7.0.2-9/libavcodec/libsvtav1.c
+@@ -435,7 +435,11 @@ static av_cold int eb_enc_init(AVCodecContext *avctx)
+ 
+     svt_enc->eos_flag = EOS_NOT_REACHED;
+ 
++#if SVT_AV1_CHECK_VERSION(3, 0, 0)
++    svt_ret = svt_av1_enc_init_handle(&svt_enc->svt_handle, &svt_enc->enc_params);
++#else
+     svt_ret = svt_av1_enc_init_handle(&svt_enc->svt_handle, svt_enc, &svt_enc->enc_params);
++#endif
+     if (svt_ret != EB_ErrorNone) {
+         return svt_print_error(avctx, svt_ret, "Error initializing encoder handle");
+     }
+-- 
+2.25.1
+

--- a/packages/jellyfin-server/ffmpeg-libavcodec-allcodecs.c.patch
+++ b/packages/jellyfin-server/ffmpeg-libavcodec-allcodecs.c.patch
@@ -1,0 +1,18 @@
+--- a/jellyfin-ffmpeg-7.0.2-9/libavcodec/allcodecs.c
++++ b/jellyfin-ffmpeg-7.0.2-9/libavcodec/allcodecs.c
+@@ -151,7 +151,6 @@ extern const FFCodec ff_h263_rkmpp_decoder;
+ extern const FFCodec ff_h264_decoder;
+ extern const FFCodec ff_h264_v4l2m2m_decoder;
+ extern const FFCodec ff_h264_mediacodec_decoder;
+-extern const FFCodec ff_h264_mediacodec_encoder;
+ extern const FFCodec ff_h264_mmal_decoder;
+ extern const FFCodec ff_h264_qsv_decoder;
+ extern const FFCodec ff_h264_rkmpp_decoder;
+@@ -862,6 +861,7 @@ extern const FFCodec ff_h264_videotoolbox_encoder;
+ extern const FFCodec ff_h264_rkmpp_encoder;
+ extern const FFCodec ff_hevc_amf_encoder;
+ extern const FFCodec ff_hevc_cuvid_decoder;
++extern const FFCodec ff_h264_mediacodec_encoder;
+ extern const FFCodec ff_hevc_mediacodec_decoder;
+ extern const FFCodec ff_hevc_mediacodec_encoder;
+ extern const FFCodec ff_hevc_mf_encoder;

--- a/packages/jellyfin-server/ffmpeg-libavutil-file_open.c.patch
+++ b/packages/jellyfin-server/ffmpeg-libavutil-file_open.c.patch
@@ -1,0 +1,20 @@
+--- a/jellyfin-ffmpeg-7.0.2-9/libavutil/file_open.c
++++ b/jellyfin-ffmpeg-7.0.2-9/libavutil/file_open.c
+@@ -120,7 +120,7 @@ int avpriv_tempfile(const char *prefix, char **filename, int log_offset, void *l
+ #undef free
+     free(ptr);
+ #else
+-    size_t len = strlen(prefix) + 12; /* room for "/tmp/" and "XXXXXX\0" */
++    size_t len = strlen(prefix) + strlen("@TERMUX_PREFIX@/tmp/") + 7; /* room for "@TERMUX_PREFIX@/tmp/" and "XXXXXX\0" */
+     *filename  = av_malloc(len);
+ #endif
+     /* -----common section-----*/
+@@ -137,7 +137,7 @@ int avpriv_tempfile(const char *prefix, char **filename, int log_offset, void *l
+ #   endif
+     fd = open(*filename, O_RDWR | O_BINARY | O_CREAT | O_EXCL, 0600);
+ #else
+-    snprintf(*filename, len, "/tmp/%sXXXXXX", prefix);
++    snprintf(*filename, len, "@TERMUX_PREFIX@/tmp/%sXXXXXX", prefix);
+     fd = mkstemp(*filename);
+ #if defined(_WIN32) || defined (__ANDROID__) || defined(__DJGPP__)
+     if (fd < 0) {

--- a/packages/jellyfin-server/jellyfin-defaults.patch
+++ b/packages/jellyfin-server/jellyfin-defaults.patch
@@ -1,0 +1,60 @@
+nonetchange is pretty much mandatory on Android, so we enable it by default
+We also make Jellyfin try to use jellyfin-ffmpeg by default, if available
+
+--- a/Emby.Server.Implementations/ConfigurationOptions.cs
++++ b/Emby.Server.Implementations/ConfigurationOptions.cs
+@@ -24 +24 @@ namespace Emby.Server.Implementations
+-            { DetectNetworkChangeKey, bool.TrueString }
++            { DetectNetworkChangeKey, bool.FalseString }
+--- a/Jellyfin.Server/StartupOptions.cs
++++ b/Jellyfin.Server/StartupOptions.cs
+@@ -71 +71 @@ namespace Jellyfin.Server
+-        /// Gets or sets a value indicating whether the server should not detect network status change.
++        /// Gets or sets a value indicating whether the server should detect network status change.
+@@ -73,2 +73,2 @@ namespace Jellyfin.Server
+-        [Option("nonetchange", Required = false, HelpText = "Indicates that the server should not detect network status change.")]
+-        public bool NoDetectNetworkChange { get; set; }
++        [Option("netchange", Required = false, HelpText = "Indicates that the server should detect network status change.")]
++        public bool DetectNetworkChange { get; set; }
+@@ -99 +99 @@ namespace Jellyfin.Server
+-            if (NoDetectNetworkChange)
++            if (DetectNetworkChange)
+@@ -101 +101 @@ namespace Jellyfin.Server
+-                config.Add(DetectNetworkChangeKey, bool.FalseString);
++                config.Add(DetectNetworkChangeKey, bool.TrueString);
+--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
++++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+@@ -205 +205 @@ namespace MediaBrowser.MediaEncoding.Encoder
+-        public bool ValidateVersion()
++        public bool ValidateVersion(bool noerr = false)
+@@ -214 +214,3 @@ namespace MediaBrowser.MediaEncoding.Encoder
+-                _logger.LogError(ex, "Error validating encoder");
++                if (!noerr) {
++                        _logger.LogError(ex, "Error validating encoder");
++                }
+@@ -220 +222,3 @@ namespace MediaBrowser.MediaEncoding.Encoder
+-                _logger.LogError("FFmpeg validation: The process returned no result");
++                if (!noerr) {
++                        _logger.LogError("FFmpeg validation: The process returned no result");
++                }
+--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
++++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+@@ -196 +196,4 @@ namespace MediaBrowser.MediaEncoding.Encoder
+-            if (!ValidatePath(ffmpegPath))
++            if (ffmpegPathSetMethodText == "system $PATH" && !ValidatePath("@TERMUX_PREFIX@/opt/jellyfin/bin/ffmpeg", true)) {
++                _ffmpegPath = null;
++            }
++            if (string.IsNullOrEmpty(_ffmpegPath) && !ValidatePath(ffmpegPath))
+@@ -274,0 +278 @@ namespace MediaBrowser.MediaEncoding.Encoder
++        /// <param name="noerr">If set to true, logger is not used</param>
+@@ -276 +280 @@ namespace MediaBrowser.MediaEncoding.Encoder
+-        private bool ValidatePath(string path)
++        private bool ValidatePath(string path, bool noerr = false)
+@@ -283 +287 @@ namespace MediaBrowser.MediaEncoding.Encoder
+-            bool rc = new EncoderValidator(_logger, path).ValidateVersion();
++            bool rc = new EncoderValidator(_logger, path).ValidateVersion(noerr);
+@@ -286 +290,3 @@ namespace MediaBrowser.MediaEncoding.Encoder
+-                _logger.LogError("FFmpeg: Failed version check: {Path}", path);
++                if (!noerr) {
++                        _logger.LogError("FFmpeg: Failed version check: {Path}", path);
++                }

--- a/packages/jellyfin-server/jellyfin-ffmpeg.subpackage.sh
+++ b/packages/jellyfin-server/jellyfin-ffmpeg.subpackage.sh
@@ -1,0 +1,4 @@
+TERMUX_SUBPKG_DESCRIPTION="FFmpeg for Jellyfin with custom extensions and enhancements"
+TERMUX_SUBPKG_DEPENDS="chromaprint, libdrm, zstd"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=false
+TERMUX_SUBPKG_INCLUDE="opt/jellyfin"

--- a/packages/jellyfin-server/libe_sqlite-fixtmpdir.patch
+++ b/packages/jellyfin-server/libe_sqlite-fixtmpdir.patch
@@ -1,0 +1,14 @@
+index 37b534a..274c07b 100644
+--- a/cb/sqlite3/sqlite3.c
++++ b/cb/sqlite3/sqlite3.c
+@@ -44558,9 +44558,7 @@ static int fillInUnixFile(
+ static const char *azTempDirs[] = {
+   0,
+   0,
+-  "/var/tmp",
+-  "/usr/tmp",
+-  "/tmp",
++  "@TERMUX_PREFIX@/tmp",
+   "."
+ };
+ 

--- a/packages/jellyfin-server/skia-DEPS.patch
+++ b/packages/jellyfin-server/skia-DEPS.patch
@@ -1,0 +1,45 @@
+--- a/skia/DEPS
++++ b/skia/DEPS
+@@ -7,42 +7,8 @@ vars = {
+ deps = {
+   "buildtools"                            : "https://chromium.googlesource.com/chromium/buildtools.git@505de88083136eefd056e5ee4ca0f01fe9b33de8",
+   "common"                                : "https://skia.googlesource.com/common.git@9737551d7a52c3db3262db5856e6bcd62c462b92",
+-  "third_party/externals/angle2"          : "https://chromium.googlesource.com/angle/angle.git@47b3db22be33213eea4ad58f2453ee1088324ceb",
+-  "third_party/externals/brotli"          : "https://skia.googlesource.com/external/github.com/google/brotli.git@e61745a6b7add50d380cfd7d3883dd6c62fc2c71",
+-  "third_party/externals/d3d12allocator"  : "https://skia.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator.git@169895d529dfce00390a20e69c2f516066fe7a3b",
+-  # Dawn requires jinja2 and markupsafe for the code generator, and glslang and shaderc for SPIRV compilation.
+-  # When the Dawn revision is updated these should be updated from the Dawn DEPS as well.
+-  "third_party/externals/dawn"            : "https://dawn.googlesource.com/dawn.git@f3c829047220ec1305c6a3202ee3e067e10512c9",
+-  "third_party/externals/glslang"         : "https://chromium.googlesource.com/external/github.com/KhronosGroup/glslang@4dcc12d1a441b29d5901bc708bb1343d29d6459f",
+-  "third_party/externals/jinja2"          : "https://chromium.googlesource.com/chromium/src/third_party/jinja2@a82a4944a7f2496639f34a89c9923be5908b80aa",
+-  "third_party/externals/markupsafe"      : "https://chromium.googlesource.com/chromium/src/third_party/markupsafe@0944e71f4b2cb9a871bcbe353f95e889b64a611a",
+-  "third_party/externals/shaderc"         : "https://chromium.googlesource.com/external/github.com/google/shaderc@011139094ec790ff7f32ea2d80286255fc9ed18b",
+-  "third_party/externals/dng_sdk"         : "https://android.googlesource.com/platform/external/dng_sdk.git@c8d0c9b1d16bfda56f15165d39e0ffa360a11123",
+-  "third_party/externals/egl-registry"    : "https://skia.googlesource.com/external/github.com/KhronosGroup/EGL-Registry@a0bca08de07c7d7651047bedc0b653cfaaa4f2ae",
+-  "third_party/externals/expat"           : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@624da0f593bb8d7e146b9f42b06d8e6c80d032a3",
+-  "third_party/externals/freetype"        : "https://skia.googlesource.com/third_party/freetype2.git@40c5681ab92e7db1298273ccf3c816e6a1498260",
+   "third_party/externals/harfbuzz"        : "https://github.com/harfbuzz/harfbuzz.git@4584bcdc326564829d3cee3572386c90e4fd1974",
+-  "third_party/externals/icu"             : "https://chromium.googlesource.com/chromium/deps/icu.git@dbd3825b31041d782c5b504c59dcfb5ac7dda08c",
+-  "third_party/externals/imgui"           : "https://skia.googlesource.com/external/github.com/ocornut/imgui.git@9418dcb69355558f70de260483424412c5ca2fce",
+-  "third_party/externals/libgifcodec"     : "https://skia.googlesource.com/libgifcodec@d06d2a6d42baf6c0c91cacc28df2542a911d05fe",
+   "third_party/externals/libjpeg-turbo"   : "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git@9b894306ec3b28cea46e84c32b56773a98c483da",
+-  "third_party/externals/libpng"          : "https://skia.googlesource.com/third_party/libpng.git@f135775ad4e5d4408d2e12ffcc71bb36e6b48551",
+-  "third_party/externals/libwebp"         : "https://github.com/webmproject/libwebp.git@ca332209cb5567c9b249c86788cb2dbf8847e760",
+-  "third_party/externals/lua"             : "https://skia.googlesource.com/external/github.com/lua/lua.git@e354c6355e7f48e087678ec49e340ca0696725b1",
+-  "third_party/externals/microhttpd"      : "https://android.googlesource.com/platform/external/libmicrohttpd@748945ec6f1c67b7efc934ab0808e1d32f2fb98d",
+-  "third_party/externals/oboe"            : "https://chromium.googlesource.com/external/github.com/google/oboe.git@b02a12d1dd821118763debec6b83d00a8a0ee419",
+-  "third_party/externals/opencl-lib"      : "https://skia.googlesource.com/external/github.com/GPUOpen-Tools/common-lib-amd-APPSDK-3.0@4e6d30e406d2e5a65e1d65e404fe6df5f772a32b",
+-  "third_party/externals/opencl-registry" : "https://skia.googlesource.com/external/github.com/KhronosGroup/OpenCL-Registry@932ed55c85f887041291cef8019e54280c033c35",
+-  "third_party/externals/opengl-registry" : "https://skia.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry@14b80ebeab022b2c78f84a573f01028c96075553",
+-  "third_party/externals/piex"            : "https://android.googlesource.com/platform/external/piex.git@bb217acdca1cc0c16b704669dd6f91a1b509c406",
+-  "third_party/externals/sdl"             : "https://skia.googlesource.com/third_party/sdl@5d7cfcca344034aff9327f77fc181ae3754e7a90",
+-  "third_party/externals/sfntly"          : "https://chromium.googlesource.com/external/github.com/googlei18n/sfntly.git@b55ff303ea2f9e26702b514cf6a3196a2e3e2974",
+-  "third_party/externals/spirv-cross"     : "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross@bdbef7b1f3982fe99a62d076043036abe6dd6d80",
+-  "third_party/externals/spirv-headers"   : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers.git@c0df742ec0b8178ad58c68cff3437ad4b6a06e26",
+-  "third_party/externals/spirv-tools"     : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools.git@e95fbfb1f509ad7a7fdfb72ac35fe412d72fc4a4",
+-  "third_party/externals/swiftshader"     : "https://swiftshader.googlesource.com/SwiftShader@019feda602ec90e99c448256e1ce11f6fdb622e8",
+-  #"third_party/externals/v8"              : "https://chromium.googlesource.com/v8/v8.git@5f1ae66d5634e43563b2d25ea652dfb94c31a3b4",
+-  "third_party/externals/wuffs"           : "https://skia.googlesource.com/external/github.com/google/wuffs.git@00cc8a50aa0c86b6bcb37e9ece8fb100047cc17b",
+   "third_party/externals/zlib"            : "https://chromium.googlesource.com/chromium/src/third_party/zlib@3ca9f16f02950edffa391ec19cea856090158e9e",
+ 
+   "../src": {

--- a/packages/jellyfin-server/skia-SkDebugf.patch
+++ b/packages/jellyfin-server/skia-SkDebugf.patch
@@ -1,0 +1,34 @@
+--- a/skia/src/ports/SkDebug_android.cpp
++++ b/skia/src/ports/SkDebug_android.cpp
+@@ -6,7 +6,7 @@
+  */
+ 
+ #include "include/core/SkTypes.h"
+-#if defined(SK_BUILD_FOR_ANDROID)
++#if defined(SK_BUILD_FOR_ANDROID) && !defined(__TERMUX__)
+ 
+ #include <stdio.h>
+ 
+@@ -32,4 +32,4 @@ void SkDebugf(const char format[], ...) {
+     va_end(args1);
+ }
+ 
+-#endif//defined(SK_BUILD_FOR_ANDROID)
++#endif//defined(SK_BUILD_FOR_ANDROID) && !defined(__TERMUX__)
+--- a/skia/src/ports/SkDebug_stdio.cpp
++++ b/skia/src/ports/SkDebug_stdio.cpp
+@@ -6,7 +6,7 @@
+  */
+ 
+ #include "include/core/SkTypes.h"
+-#if !defined(SK_BUILD_FOR_WIN) && !defined(SK_BUILD_FOR_ANDROID)
++#if (!defined(SK_BUILD_FOR_WIN) && !defined(SK_BUILD_FOR_ANDROID)) || defined(__TERMUX__)
+ 
+ #include <stdarg.h>
+ #include <stdio.h>
+@@ -17,4 +17,4 @@ void SkDebugf(const char format[], ...) {
+     vfprintf(stderr, format, args);
+     va_end(args);
+ }
+-#endif//!defined(SK_BUILD_FOR_WIN) && !defined(SK_BUILD_FOR_ANDROID)
++#endif//(!defined(SK_BUILD_FOR_WIN) && !defined(SK_BUILD_FOR_ANDROID)) || defined(__TERMUX__)

--- a/packages/jellyfin-server/skia-gn-build.patch
+++ b/packages/jellyfin-server/skia-gn-build.patch
@@ -1,0 +1,103 @@
+Modifies the gn build to use correct NDK paths and compiler options
+Forces libjpeg and libskia to avoid system libjpeg
+--- a/skia/BUILD.gn
++++ b/skia/BUILD.gn
+@@ -1261,15 +1261,7 @@ component("skia") {
+ 
+   if (is_android) {
+     deps += [ "//third_party/expat" ]
+-    if (defined(ndk) && ndk != "") {
+-      deps += [ "//third_party/cpu-features" ]
+-    }
+-    sources += [ "src/ports/SkDebug_android.cpp" ]
+-    libs += [
+-      "EGL",
+-      "GLESv2",
+-      "log",
+-    ]
++    sources += [ "src/ports/SkDebug_stdio.cpp" ]
+   }
+ 
+   if (is_linux || target_cpu == "wasm") {
+--- a/skia/gn/BUILD.gn
++++ b/skia/gn/BUILD.gn
+@@ -197,28 +197,19 @@ config("default") {
+   }
+ 
+   if (is_android) {
+-    asmflags += [ "--target=$ndk_target" ]
++    asmflags += [ "--target=$ndk_target$ndk_api" ]
+     cflags += [
+       "--sysroot=$ndk/sysroot",
+       "-isystem$ndk/sysroot/usr/include/$ndk_target",
+       "-D__ANDROID_API__=$ndk_api",
+-      "--target=$ndk_target",
+-    ]
+-    cflags_cc += [
+-      "-isystem$ndk/sources/cxx-stl/llvm-libc++/include",
+-      "-isystem$ndk/sources/cxx-stl/llvm-libc++abi/include",
+-      "-isystem$ndk/sources/android/support/include",
++      "--target=$ndk_target$ndk_api",
+     ]
+     ldflags += [
+-      "--sysroot=$ndk/platforms/$ndk_platform",
+-      "--target=$ndk_target",
+-      "-B$ndk/toolchains/$ndk_gccdir-4.9/prebuilt/$ndk_host/$ndk_target/bin",
++      "--sysroot=$ndk/sysroot",
++      "--target=$ndk_target$ndk_api",
+       "-static-libstdc++",
+     ]
+     lib_dirs = [
+-      "$ndk/sources/cxx-stl/llvm-libc++/libs/$ndk_stdlib",
+-      "$ndk/toolchains/$ndk_gccdir-4.9/prebuilt/$ndk_host/lib/gcc/$ndk_target/4.9.x",
+-      "$ndk/toolchains/llvm/prebuilt/$ndk_host/sysroot/usr/lib/$ndk_target/$ndk_api",
+     ]
+ 
+     libs += [
+--- a/skia/gn/toolchain/BUILD.gn
++++ b/skia/gn/toolchain/BUILD.gn
+@@ -13,9 +13,9 @@ declare_args() {
+       target_cc = "$ndk/toolchains/llvm/prebuilt/$ndk_host/bin/clang.exe"
+       target_cxx = "$ndk/toolchains/llvm/prebuilt/$ndk_host/bin/clang++.exe"
+     } else {
+-      target_ar = "$ndk/toolchains/$ndk_gccdir-4.9/prebuilt/$ndk_host/$ndk_target/bin/ar"
+-      target_cc = "$ndk/toolchains/llvm/prebuilt/$ndk_host/bin/clang"
+-      target_cxx = "$ndk/toolchains/llvm/prebuilt/$ndk_host/bin/clang++"
++      target_ar = ar
++      target_cc = cc
++      target_cxx = cxx
+     }
+   } else if (is_tizen) {
+     if (host_os == "win") {
+--- a/skia/third_party/libjpeg-turbo/BUILD.gn
++++ b/skia/third_party/libjpeg-turbo/BUILD.gn
+@@ -15,6 +15,9 @@ if (skia_use_system_libjpeg_turbo) {
+   }
+ } else {
+   third_party("libjpeg") {
++    include_dirs = [
++      "../externals/libjpeg-turbo",
++    ]
+     public_include_dirs = [
+       ".",
+       "../externals/libjpeg-turbo",
+@@ -100,7 +103,7 @@ if (skia_use_system_libjpeg_turbo) {
+         "../externals/libjpeg-turbo/simd/arm/jidctred-neon.c",
+         "../externals/libjpeg-turbo/simd/arm/jquanti-neon.c",
+       ]
+-      include_dirs = [ "../externals/libjpeg-turbo/simd/arm" ]
++      include_dirs += [ "../externals/libjpeg-turbo/simd/arm" ]
+       if (current_cpu == "arm") {
+         sources += [
+           "../externals/libjpeg-turbo/simd/arm/aarch32/jchuff-neon.c",
+--- a/skia/third_party/third_party.gni
++++ b/skia/third_party/third_party.gni
+@@ -11,7 +11,7 @@ template("third_party_config") {
+   enabled = !defined(invoker.enabled) || invoker.enabled
+   config(target_name) {
+     if (enabled) {
+-      forward_variables_from(invoker, "*", [ "include_dirs" ])
++      forward_variables_from(invoker, "*")
+       cflags = []
+       if (is_win) {
+         include_dirs = invoker.include_dirs

--- a/packages/jellyfin-server/update-git-checksums.sh
+++ b/packages/jellyfin-server/update-git-checksums.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+sha256sums=()
+scriptdir="$( cd -- "$(dirname "$0")" >/dev/null 2>&1; pwd)"
+buildsh="${scriptdir}/build.sh"
+getvar() {
+	<"${buildsh}" awk -v scope=0 '
+$0 ~ /^termux_step_post_get_source/ {scope=1}
+scope == 1 && /local[[:blank:]]*-A[[:blank:]]*'"$1"'=\(/ {var=1; print gensub(/.*=\(/,"",1); next}
+var == 1 {if ($0 ~ /\)/) { var=0; sub(/\)/,"",$0); } print}
+'
+}
+
+tmpd="$(mktemp -d "${TMPDIR-/tmp}/termux.src.dl.XXXXXXXX")"
+trap 'cd "$scriptdir"; rm -rf "$tmpd"; trap - EXIT; exit' INT EXIT TERM
+[ -d "$tmpd" ] || { printf 'Error: mktemp failed'; exit 1; }
+pushd "$tmpd" >/dev/null
+
+eval project="$(<"${buildsh}" awk '/local[[:blank:]]*_project=/ {print gensub(/.*=/,"",1)}')"
+sha256sums=($(
+	for i in SHA256 URL COMMIT; do
+		eval "declare -A GIT_$i=($(getvar _GIT_"$i"))"
+	done
+	for proj in "${project[@]}"; do
+		# the commands enclosed in braces can be replaced with git clone --revision "${GIT_COMMIT["$proj"]}" --depth 1 in git 2.49
+		{
+		mkdir "$( printf "%s" "${GIT_URL["$proj"]}" | sed -E 's|^.*/(.*)$|\1|' )"
+		pushd "$( printf "%s" "${GIT_URL["$proj"]}" | sed -E 's|^.*/(.*)$|\1|' )"
+		git init -q
+		git remote add origin "${GIT_URL["$proj"]:4}"
+		git fetch --depth 1 origin "${GIT_COMMIT["$proj"]}"
+		git -c advice.detachedHead=false checkout "${GIT_COMMIT["$proj"]}"
+		} >/dev/null
+		# we need a deterministic checksum, logs get in the way
+		rm -rf .git/logs
+		printf '[%s]=' "$proj"
+		find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum | awk '{printf "%s ",$1}'
+		popd >/dev/null
+	done
+))
+sed -zi 's/\(_GIT_SHA256=(\)[^)]*)/\1\n'"$(printf '\\t\\t%s\\n' "${sha256sums[@]}")"'\t)/' "${buildsh}"


### PR DESCRIPTION
Closes https://github.com/termux/termux-packages/issues/9751
Supersedes https://github.com/termux/termux-packages/pull/23074
Had to go a bit overboard with the post_get_source step because multiple git urls in TERMUX_PKG_SRCURL don't seem to be supported. Most patches are taken from the termux packages repo except for skia-DEPS.patch, skia-gn-build.patch, and jellyfin-defaults.patch.