### PR TITLE
enhance(main/libsqlite): Enable rtree extension for gdal

### DIFF
--- a/packages/gdal/build.sh
+++ b/packages/gdal/build.sh
@@ -3,10 +3,9 @@ TERMUX_PKG_DESCRIPTION="A translator library for raster and vector geospatial da
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="LICENSE.TXT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="3.10.2"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="3.10.3"
 TERMUX_PKG_SRCURL=https://download.osgeo.org/gdal/${TERMUX_PKG_VERSION}/gdal-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=67b4e08acd1cc4b6bd67b97d580be5a8118b586ad6a426b09d5853898deeada5
+TERMUX_PKG_SHA256=335a8d2c7567d783563d3fed37e8b58d72d9c1723f6fd1d8c299fe4c0d936781
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="giflib, json-c, libc++, libcurl, libexpat, libfreexl, libgeos, libiconv, libjpeg-turbo, libjxl, liblzma, libpng, libspatialite, libsqlite, libwebp, libxml2, netcdf-c (>= 4.9.3), openjpeg, openssl, proj, postgresql, zlib, zstd"
 TERMUX_PKG_BUILD_DEPENDS="json-c-static"

--- a/packages/libsqlite/build.sh
+++ b/packages/libsqlite/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Library implementing a self-contained and transactional 
 TERMUX_PKG_LICENSE="Public Domain"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.49.1"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 _SQLITE_YEAR=2025
 TERMUX_PKG_SRCURL=https://www.sqlite.org/${_SQLITE_YEAR}/sqlite-autoconf-$(sed 's/\./''/; s/\./0/' <<< "$TERMUX_PKG_VERSION")00.tar.gz
 TERMUX_PKG_SHA256=106642d8ccb36c5f7323b64e4152e9b719f7c0215acf5bfeac3d5e7f97b59254
@@ -17,6 +17,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --enable-fts4
 --enable-fts5
 --enable-readline
+--enable-rtree
 --enable-session
 "
 


### PR DESCRIPTION

    This fixes the following error with gdal build.
    
    CMake Error at cmake/helpers/CheckDependentLibraries.cmake:276 (message):
    /data/data/com.termux/files/usr/lib/libsqlite3.so lacks the RTree
    extension! Spatialite will not behave properly.  Define the
    ACCEPT_MISSING_SQLITE3_RTREE:BOOL=ON CMake variable if you want to build
    despite this limitation.

* Fixes #24187 