### PR TITLE
bump(scripts/build/setup/termux_setup_python_pip): setuptools 78.1.0, wheel 0.46.1

### DIFF
--- a/packages/python-pillow/build.sh
+++ b/packages/python-pillow/build.sh
@@ -3,12 +3,13 @@ TERMUX_PKG_DESCRIPTION="Python Imaging Library"
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="11.1.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/python-pillow/Pillow/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=1e63499468dc069a31ea0226b531be1c1c31b185b80616f8707066aba599db12
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="freetype, libimagequant, libjpeg-turbo, libraqm, libtiff, libwebp, libxcb, littlecms, openjpeg, python, zlib"
 TERMUX_PKG_LICENSE_FILE="LICENSE"
-TERMUX_PKG_PYTHON_COMMON_DEPS="wheel, 'setuptools==67.8'"
+TERMUX_PKG_SETUP_PYTHON=true
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_post_make_install() {

--- a/packages/python-pip/build.sh
+++ b/packages/python-pip/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="The PyPA recommended tool for installing Python packages
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="25.0.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/pypa/pip/archive/$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=334371888f0c679c04e819ddc234562feaea81331658a76842b62dc9dc83a832
 TERMUX_PKG_AUTO_UPDATE=true
@@ -13,7 +14,7 @@ TERMUX_PKG_ANTI_BUILD_DEPENDS="clang"
 TERMUX_PKG_BREAKS="python (<< 3.11.1-1)"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_BUILD_IN_SRC=true
-TERMUX_PKG_PYTHON_COMMON_DEPS="wheel, setuptools==69.5.1, docutils, myst_parser, sphinx_copybutton, sphinx_inline_tabs, sphinxcontrib.towncrier, completion"
+TERMUX_PKG_PYTHON_COMMON_DEPS="docutils, myst_parser, sphinx_copybutton, sphinx_inline_tabs, sphinxcontrib.towncrier, completion"
 
 termux_pkg_auto_update() {
 	local tag

--- a/packages/python-torchvision/build.sh
+++ b/packages/python-torchvision/build.sh
@@ -3,14 +3,15 @@ TERMUX_PKG_DESCRIPTION="Datasets, Transforms and Models specific to Computer Vis
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.21.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/pytorch/vision/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=0a4a967bbb7f9810f792cd0289a07fb98c8fb5d1303fae8b63e3a6b05d720058
 TERMUX_PKG_DEPENDS="libc++, ffmpeg, python, python-numpy, python-pillow, python-pip, python-torch, libjpeg-turbo, libpng, libwebp, zlib"
-TERMUX_PKG_PYTHON_COMMON_DEPS="wheel, setuptools"
+TERMUX_PKG_SETUP_PYTHON=true
 
 termux_step_pre_configure() {
-	CFLAGS+=" -I${TERMUX_PYTHON_HOME}/site-packages/torch/include"
-	CFLAGS+=" -I${TERMUX_PYTHON_HOME}/site-packages/torch/include/torch/csrc/api/include"
+	CXXFLAGS+=" -I${TERMUX_PYTHON_HOME}/site-packages/torch/include"
+	CXXFLAGS+=" -I${TERMUX_PYTHON_HOME}/site-packages/torch/include/torch/csrc/api/include"
 	CXXFLAGS+=" -DUSE_PYTHON"
 	LDFLAGS+=" -ltorch_cpu -ltorch_python -lc10"
 

--- a/scripts/build/setup/termux_setup_python_pip.sh
+++ b/scripts/build/setup/termux_setup_python_pip.sh
@@ -19,7 +19,8 @@ termux_setup_python_pip() {
 		mkdir -p "$_VENV_DIR"
 		python${TERMUX_PYTHON_VERSION} -m venv --system-site-packages "$_VENV_DIR"
 		. "$_VENV_DIR/bin/activate"
-		return
+		
+		pip install 'setuptools==78.1.0' 'wheel==0.46.1'
 	else
 		local _CROSSENV_VERSION=1.4.0
 		local _CROSSENV_TAR=crossenv-$_CROSSENV_VERSION.tar.gz
@@ -60,11 +61,9 @@ termux_setup_python_pip() {
 		. "${TERMUX_PYTHON_CROSSENV_PREFIX}/bin/activate"
 
 		# Since 3.12, distutils is removed from python, but setuptools>=60 provides it
-		build-pip install 'setuptools==67.6.1' wheel
-		cross-pip install 'setuptools==67.6.1' wheel
-		if [ "${TERMUX_PYTHON_VERSION#*.}" -lt "12" ]; then
-			export SETUPTOOLS_USE_DISTUTILS=stdlib
-		fi
+		# Since wheel 0.46, setuptools>=70 is required to provide bdist_wheel
+		build-pip install 'setuptools==78.1.0' 'wheel==0.46.1'
+		cross-pip install 'setuptools==78.1.0' 'wheel==0.46.1'
 
 		export PATH="${TERMUX_PYTHON_CROSSENV_PREFIX}/build/bin:${PATH}"
 		local _CROSS_PATH="${TERMUX_PYTHON_CROSSENV_PREFIX}/cross/bin"


### PR DESCRIPTION
- `wheel` version 0.46+ now requires `setuptools` version 70 or newer
  - discussed upstream here: https://github.com/pypa/wheel/issues/660
  - discovered in termux-packages here: https://github.com/termux/termux-packages/pull/24062#issuecomment-2788106897

- Lock `wheel` version at 0.46.1 so that if a future `wheel` update causes a similar problem in the future, it doesn't immediately propagate into termux-packages without us explicitly bumping it. Recommended by Tomjo2000 here: https://github.com/termux/termux-packages/pull/24062#issuecomment-2798403944

- I have confirmed that this change works to fix the build of `python-lxml` **both**
  - **in `TERMUX_ON_DEVICE_BUILD=false` mode (temporarily broken for 1 week)**,
    - fixes `error: invalid command 'bdist_wheel'`
  - **and also in `TERMUX_ON_DEVICE_BUILD=true` mode (broken for 6 months)**.
    - fixes `ModuleNotFoundError: No module named 'setuptools'`

- It seems appropriate to remove the `if [ "${TERMUX_PYTHON_VERSION#*.}" -lt "12" ]` block because there is no longer any `python3.11` so it does not seem like that code is reachable anymore.

- `python-torchvision` needed ajustment of its custom `CFLAGS` to be `CXXFLAGS` instead, because the newer `setuptools` is now compiling it using `aarch64-linux-android-clang++` instead of `aarch64-linux-android-clang`.

- `python-pip` and `python-pillow` both had locked `setuptools` in their `TERMUX_PKG_PYTHON_COMMON_DEPS` at versions slightly newer than the old global version, now that the global version is newer than either of those, they do not seem to need that anymore.