### PR TITLE
fix(subpackages): Fix check for if subpackage should depend on parent

### DIFF
--- a/scripts/build/termux_create_debian_subpackages.sh
+++ b/scripts/build/termux_create_debian_subpackages.sh
@@ -103,7 +103,7 @@ termux_create_debian_subpackages() {
 
 		# If the subpackage is not in the $TERMUX_PKG_DEPENDS for the parent package,
 		# and TERMUX_SUBPKG_DEPEND_ON_PARENT doesn't have a value, the subpackage should depend on its parent
-		[[ " ${TERMUX_PKG_DEPENDS//,/ } " == *" $SUB_PKG_NAME "* ]] && : "${TERMUX_SUBPKG_DEPEND_ON_PARENT:=true}"
+		[[ " ${TERMUX_PKG_DEPENDS//,/ } " != *" $SUB_PKG_NAME "* ]] && : "${TERMUX_SUBPKG_DEPEND_ON_PARENT:=true}"
 
 		case "$TERMUX_SUBPKG_DEPEND_ON_PARENT" in
 			'unversioned') TERMUX_SUBPKG_DEPENDS+=", $TERMUX_PKG_NAME";;


### PR DESCRIPTION
Fixes a regression in 97a63bdb78dcd042750708253ed4fcdf09fac3f2.

One quick-building test case is the `dpkg` package with the `dpkg-perl` subpackage: `dpkg-perl` should depend on `dpkg`, its parent package (since `dpkg` does not depend on `dpkg-perl`).