### PR TITLE
chore(main/xmlsec): replace unreliable source URL

### DIFF
--- a/packages/xmlsec/build.sh
+++ b/packages/xmlsec/build.sh
@@ -4,9 +4,9 @@ TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="Copyright"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.3.7"
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://www.aleksey.com/xmlsec/download/xmlsec1-$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_SHA256=d82e93b69b8aa205a616b62917a269322bf63a3eaafb3775014e61752b2013ea
+TERMUX_PKG_REVISION=2
+TERMUX_PKG_SRCURL=https://github.com/lsh123/xmlsec/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=b6308903cab7214b4f0c35982afbe5f38b3bf0c59aaddaacbde4ea56a96f9a28
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libgcrypt, libxml2, libnspr, libnss, libxslt, openssl"
 TERMUX_PKG_BREAKS="xmlsec-dev"
@@ -19,4 +19,8 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 
 termux_step_post_get_source() {
 	echo >> src/openssl/symkeys.c
+}
+
+termux_step_pre_configure() {
+	autoreconf -fi
 }


### PR DESCRIPTION
Forgot to change this before merging #24211 but we should switch `xmlsec`'s source url over to the github repo since the upstream website has been unreliable.
See: https://github.com/termux/termux-packages/actions/runs/14434349180/job/40473123158