### PR TITLE
ci(packages.yml): ban merge commits in PRs to avoid wasting CI time

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -74,6 +74,12 @@ jobs:
         mkdir -p ./artifacts ./debs
         touch ./debs/.placeholder
 
+        if [[ "${{ github.event_name }}" == "pull_request" && -n "$(git rev-list --merges "$(git fetch origin master >&2; git merge-base origin/master $HEAD_COMMIT)..$HEAD_COMMIT")" ]]; then
+          # Github does not allow multiline errors, but it will interpret the escape sequence %0A as a line break.
+          echo "::error ::Merge commits are not allowed in pull requests.%0AYou should rebase your commits or squash them.%0Ahttps://docs.github.com/en/get-started/using-git/using-git-rebase-on-the-command-line"
+          exit 1
+        fi
+
         OLD_COMMIT="$OLD_COMMIT" HEAD_COMMIT="$HEAD_COMMIT" GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" scripts/utils/termux_reuse_pr_build_artifacts.sh "${{ github.event_name }}" "${{ matrix.target_arch }}" || true
 
         if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then


### PR DESCRIPTION
First time contributors often sync their branches with master using merge commits.
Even though these PRs can not be merged due to our merging policy it still triggers CI rebuilding recently changed packages and wastes a lot of CI time.
I am going to merge this in 12 hours if nobody minds.