### PR TITLE
ci(update-packages): trigger repology metadata generation at the end

### DIFF
--- a/.github/workflows/package_updates.yml
+++ b/.github/workflows/package_updates.yml
@@ -161,3 +161,12 @@ jobs:
           else
             ./scripts/bin/update-packages "@all"
           fi
+      - name: Trigger repology metadata generation
+        if: always()
+        run: |
+          curl \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -X POST \
+            --data '{"ref":"master"}' \
+            "https://api.github.com/repos/termux/repology-metadata/actions/workflows/repology_metadata.yml/dispatches"


### PR DESCRIPTION
Currently repology metadata generation is scheduled and it runs the same time as regular update workflow. This causes repology metadata to be slightly outdated.
This change makes sure repology metadata is always up to date.

After merging this I am going to disable scheduled runs of repology metadata generation to not waste CI time.

I am going to merge this in 30 hours if nobody minds or after 2+ approves.