### PR TITLE
fix(x11/xfce4-pulseaudio-plugin): Add pavucontrol dependency

### DIFF
--- a/x11-packages/xfce4-pulseaudio-plugin/build.sh
+++ b/x11-packages/xfce4-pulseaudio-plugin/build.sh
@@ -3,9 +3,10 @@ TERMUX_PKG_DESCRIPTION="Pulseaudio plugin for the Xfce4 panel"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.5.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://archive.xfce.org/src/panel-plugins/xfce4-pulseaudio-plugin/${TERMUX_PKG_VERSION%.*}/xfce4-pulseaudio-plugin-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=3fe69bc6f9c0dd68bd317c0a7813975cf162ba1dd64e23c2ffef372d4b4f808a
-TERMUX_PKG_DEPENDS="exo, gdk-pixbuf, glib, gtk3, libcairo, libcanberra, libnotify, libxfce4ui, libxfce4util, libxfce4windowing, pulseaudio, xfce4-panel, xfconf"
+TERMUX_PKG_DEPENDS="exo, gdk-pixbuf, glib, gtk3, libcairo, libcanberra, libnotify, libxfce4ui, libxfce4util, libxfce4windowing, pavucontrol, pulseaudio, xfce4-panel, xfconf"
 TERMUX_PKG_AUTO_UPDATE=true
 
 termux_step_pre_configure() {


### PR DESCRIPTION
It is used as default mixer command.
https://gitlab.xfce.org/panel-plugins/xfce4-pulseaudio-plugin/-/blob/xfce4-pulseaudio-plugin-0.5.0/meson_options.txt?ref_type=tags#L39

* Fixes #24434 