### PR TITLE
ci(packages): cancel outdated PR workflow runs via concurrency

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -23,6 +23,12 @@ on:
 
 permissions: {} # none
 
+concurrency:
+  # if this is a PR event, group = "pr-<number>", otherwise group = run_id so it never collides with other runs
+  group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_id }}
+  # only cancel in-progress when it’s a PR
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     permissions:


### PR DESCRIPTION
When new commits are pushed to a pull request, previous CI workflow runs for that PR continue consuming runner time even though their results are no longer relevant. This change uses GitHub Actions’ built-in concurrency feature with a conditional group name so that:

- For pull_request events, group is set to `pr-<PR number>` and cancel-in-progress is true, ensuring only the latest run for a PR completes; earlier in-progress runs are automatically cancelled.
- For all other events (push/workflow_dispatch/schedule), group falls back to the unique run_id and cancel-in-progress is false, so non-PR builds do not interfere with each other.

This reduces wasted runner time and keeps the CI queue clean without affecting non-PR workflows.