### PR TITLE
chore(CODEOWNERS): add myself as codeowner for build system, github

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,19 @@
 # Default assignment: frequent contributors from @termux.
 * @Grimler91 @TomJo2000
 
+# GitHub Actions & other stuff
+/.github @thunder-coding
+
+# Documentation for contributors
+/CONTRIBUTING.md @thunder-coding
+/README.md @thunder-coding
+
 # Build system.
 /build-all.sh @Grimler91
-/build-package.sh @Grimler91
-/clean.sh @Grimler91
-/scripts/ @Grimler91
+/build-package.sh @Grimler91 @thunder-coding
+/clean.sh @Grimler91 @thunder-coding
+/scripts/ @Grimler91 @thunder-coding
+/repo.json @Grimler91 @thunder-coding
 
 # GN setup script
 /scripts/build/setup/termux_setup_gn.sh @thunder-coding


### PR DESCRIPTION
actions and documentation

It seems like I am currently one of the people who is more active and in the position to review changes for the build system in PRs, in case there is anyone else who too is interested in stepping up for being added as codeowners, feel free to comment in the PR.