### PR TITLE
fix(main/openssh): re-add ssh-agent wrapper scripts

### DIFF
--- a/packages/openssh/build.sh
+++ b/packages/openssh/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Secure shell for logging into a remote machine"
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION="10.0p2"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/openssh/openssh-portable/archive/refs/tags/V_$(sed 's/\./_/g; s/p/_P/g' <<< $TERMUX_PKG_VERSION).tar.gz
 TERMUX_PKG_SHA256=a25b32645dc6b474064b9deb07afc9d8e37b127d026a1170b54feb929145140c
 TERMUX_PKG_AUTO_UPDATE=true
@@ -78,6 +78,11 @@ termux_step_post_configure() {
 }
 
 termux_step_post_make_install() {
+	install -Dm700 "$TERMUX_PKG_BUILDER_DIR/source-ssh-agent.sh" "$TERMUX_PREFIX/bin/source-ssh-agent"
+	install -Dm700 "$TERMUX_PKG_BUILDER_DIR/ssh-with-agent.sh"   "$TERMUX_PREFIX/bin/ssha"
+	install -Dm700 "$TERMUX_PKG_BUILDER_DIR/sftp-with-agent.sh"  "$TERMUX_PREFIX/bin/sftpa"
+	install -Dm700 "$TERMUX_PKG_BUILDER_DIR/scp-with-agent.sh"   "$TERMUX_PREFIX/bin/scpa"
+
 	mkdir -p "$TERMUX_PREFIX/var/run"
 	echo "OpenSSH needs this directory to put sshd.pid in" > "$TERMUX_PREFIX/var/run/README.openssh"
 	# Install ssh-copy-id:

--- a/packages/openssh/scp-with-agent.sh
+++ b/packages/openssh/scp-with-agent.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+. source-ssh-agent
+scp "$@"

--- a/packages/openssh/sftp-with-agent.sh
+++ b/packages/openssh/sftp-with-agent.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+. source-ssh-agent
+sftp "$@"

--- a/packages/openssh/source-ssh-agent.sh
+++ b/packages/openssh/source-ssh-agent.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# source-ssh-agent: Script to source for ssh-agent to work.
+
+start_agent() {
+	ssh-agent -a "$1" > /dev/null
+	ssh-add
+}
+
+# Allow overriding the start_agent function easily.
+if [ -r "${PREFIX}/etc/ssh/start_agent.sh" ]; then
+	. "${PREFIX}/etc/ssh/start_agent.sh"
+fi
+
+export SSH_AUTH_SOCK="${PREFIX}/var/run/ssh-agent"
+
+MESSAGE=$(ssh-add -L 2>&1)
+if [ "$MESSAGE" = 'Could not open a connection to your authentication agent.' -o \
+     "$MESSAGE" = 'Error connecting to agent: Connection refused' -o \
+     "$MESSAGE" = 'Error connecting to agent: No such file or directory' ]; then
+	rm -f "${SSH_AUTH_SOCK}"
+	start_agent "${SSH_AUTH_SOCK}"
+elif [ "$MESSAGE" = "The agent has no identities." ]; then
+	ssh-add
+fi

--- a/packages/openssh/ssh-with-agent.sh
+++ b/packages/openssh/ssh-with-agent.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+. source-ssh-agent
+ssh "$@"


### PR DESCRIPTION
- This reverts their removal in https://github.com/termux/termux-packages/commit/7b5bd568c27b1d2d08d349e6431c95b1e6195e28

We shouldn't revisit this until we've put in place a seamless replacement with the `ssh-agent` `sv` service and have properly discussed and documented the deprecation of the non-standard wrappers.