### PR TITLE
Use a common wrapper pattern for s{sh,cp,ftp}a scripts

### DIFF
--- a/packages/openssh/build.sh
+++ b/packages/openssh/build.sh
@@ -78,11 +78,11 @@ termux_step_post_configure() {
 }
 
 termux_step_post_make_install() {
-	install -Dm700 "$TERMUX_PKG_BUILDER_DIR/source-ssh-agent.sh" "$TERMUX_PREFIX/bin/source-ssh-agent"
-	install -Dm700 "$TERMUX_PKG_BUILDER_DIR/wrap-ssh-agent.sh"   "$TERMUX_PREFIX/bin/wrap-ssh-agent.sh"
-	ln -s -f -T 'wrap-ssh-agent.sh'                              "$TERMUX_PREFIX/bin/ssha"
-	ln -s -f -T 'wrap-ssh-agent.sh'                              "$TERMUX_PREFIX/bin/sftpa"
-	ln -s -f -T 'wrap-ssh-agent.sh'                              "$TERMUX_PREFIX/bin/scpa"
+	install -Dm700 "$TERMUX_PKG_BUILDER_DIR/source-ssh-agent.sh" "$TERMUX_PREFIX/libexec/source-ssh-agent.sh"
+	install -Dm700 "$TERMUX_PKG_BUILDER_DIR/wrap-ssh-agent.sh"   "$TERMUX_PREFIX/libexec/wrap-ssh-agent.sh"
+	ln -s -f -T '../libexec/wrap-ssh-agent.sh'                   "$TERMUX_PREFIX/bin/ssha"
+	ln -s -f -T '../libexec/wrap-ssh-agent.sh'                   "$TERMUX_PREFIX/bin/sftpa"
+	ln -s -f -T '../libexec/wrap-ssh-agent.sh'                   "$TERMUX_PREFIX/bin/scpa"
 
 	mkdir -p "$TERMUX_PREFIX/var/run"
 	echo "OpenSSH needs this directory to put sshd.pid in" > "$TERMUX_PREFIX/var/run/README.openssh"

--- a/packages/openssh/build.sh
+++ b/packages/openssh/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Secure shell for logging into a remote machine"
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION="10.0p2"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://github.com/openssh/openssh-portable/archive/refs/tags/V_$(sed 's/\./_/g; s/p/_P/g' <<< $TERMUX_PKG_VERSION).tar.gz
 TERMUX_PKG_SHA256=a25b32645dc6b474064b9deb07afc9d8e37b127d026a1170b54feb929145140c
 TERMUX_PKG_AUTO_UPDATE=true
@@ -79,9 +79,10 @@ termux_step_post_configure() {
 
 termux_step_post_make_install() {
 	install -Dm700 "$TERMUX_PKG_BUILDER_DIR/source-ssh-agent.sh" "$TERMUX_PREFIX/bin/source-ssh-agent"
-	install -Dm700 "$TERMUX_PKG_BUILDER_DIR/ssh-with-agent.sh"   "$TERMUX_PREFIX/bin/ssha"
-	install -Dm700 "$TERMUX_PKG_BUILDER_DIR/sftp-with-agent.sh"  "$TERMUX_PREFIX/bin/sftpa"
-	install -Dm700 "$TERMUX_PKG_BUILDER_DIR/scp-with-agent.sh"   "$TERMUX_PREFIX/bin/scpa"
+	install -Dm700 "$TERMUX_PKG_BUILDER_DIR/wrap-ssh-agent.sh"   "$TERMUX_PREFIX/bin/wrap-ssh-agent.sh"
+	ln -s -f -T "$TERMUX_PREFIX/bin/wrap-ssh-agent.sh"           "$TERMUX_PREFIX/bin/ssha"
+	ln -s -f -T "$TERMUX_PREFIX/bin/wrap-ssh-agent.sh"           "$TERMUX_PREFIX/bin/sftpa"
+	ln -s -f -T "$TERMUX_PREFIX/bin/wrap-ssh-agent.sh"           "$TERMUX_PREFIX/bin/scpa"
 
 	mkdir -p "$TERMUX_PREFIX/var/run"
 	echo "OpenSSH needs this directory to put sshd.pid in" > "$TERMUX_PREFIX/var/run/README.openssh"

--- a/packages/openssh/build.sh
+++ b/packages/openssh/build.sh
@@ -80,9 +80,9 @@ termux_step_post_configure() {
 termux_step_post_make_install() {
 	install -Dm700 "$TERMUX_PKG_BUILDER_DIR/source-ssh-agent.sh" "$TERMUX_PREFIX/bin/source-ssh-agent"
 	install -Dm700 "$TERMUX_PKG_BUILDER_DIR/wrap-ssh-agent.sh"   "$TERMUX_PREFIX/bin/wrap-ssh-agent.sh"
-	ln -s -f -T "$TERMUX_PREFIX/bin/wrap-ssh-agent.sh"           "$TERMUX_PREFIX/bin/ssha"
-	ln -s -f -T "$TERMUX_PREFIX/bin/wrap-ssh-agent.sh"           "$TERMUX_PREFIX/bin/sftpa"
-	ln -s -f -T "$TERMUX_PREFIX/bin/wrap-ssh-agent.sh"           "$TERMUX_PREFIX/bin/scpa"
+	ln -s -f -T 'wrap-ssh-agent.sh'                              "$TERMUX_PREFIX/bin/ssha"
+	ln -s -f -T 'wrap-ssh-agent.sh'                              "$TERMUX_PREFIX/bin/sftpa"
+	ln -s -f -T 'wrap-ssh-agent.sh'                              "$TERMUX_PREFIX/bin/scpa"
 
 	mkdir -p "$TERMUX_PREFIX/var/run"
 	echo "OpenSSH needs this directory to put sshd.pid in" > "$TERMUX_PREFIX/var/run/README.openssh"

--- a/packages/openssh/sftp-with-agent.sh
+++ b/packages/openssh/sftp-with-agent.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-. source-ssh-agent
-sftp "$@"

--- a/packages/openssh/source-ssh-agent.sh
+++ b/packages/openssh/source-ssh-agent.sh
@@ -22,3 +22,10 @@ if [ "$MESSAGE" = 'Could not open a connection to your authentication agent.' -o
 elif [ "$MESSAGE" = "The agent has no identities." ]; then
 	ssh-add
 fi
+
+# may be used by wrapper scripts:
+# . source-ssh-agent
+# "${wrapped_cmd}" "$@"
+_arg_zero="${0##*/}"
+wrapped_cmd="${_arg_zero%a}"
+unset -v _arg_zero

--- a/packages/openssh/source-ssh-agent.sh
+++ b/packages/openssh/source-ssh-agent.sh
@@ -24,7 +24,7 @@ elif [ "$MESSAGE" = "The agent has no identities." ]; then
 fi
 
 # may be used by wrapper scripts:
-# . source-ssh-agent
+# . /path/to/source-ssh-agent.sh
 # "${wrapped_cmd}" "$@"
 _arg_zero="${0##*/}"
 wrapped_cmd="${_arg_zero%a}"

--- a/packages/openssh/ssh-with-agent.sh
+++ b/packages/openssh/ssh-with-agent.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-. source-ssh-agent
-ssh "$@"

--- a/packages/openssh/wrap-ssh-agent.sh
+++ b/packages/openssh/wrap-ssh-agent.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 . source-ssh-agent
-scp "$@"
+"${wrapped_cmd}" "$@"

--- a/packages/openssh/wrap-ssh-agent.sh
+++ b/packages/openssh/wrap-ssh-agent.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-. source-ssh-agent
+. "${TERMUX__PREFIX:-${PREFIX}}"/libexec/source-ssh-agent.sh
 "${wrapped_cmd}" "$@"


### PR DESCRIPTION
This makes it easy to have a single wrapper script with
symbolic links pointing at it for each wrapped command.