### PR TITLE
fix(main/vitetris): remove `.desktop` file from package as intended

### DIFF
--- a/packages/vitetris/build.sh
+++ b/packages/vitetris/build.sh
@@ -4,12 +4,12 @@ TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_LICENSE_FILE="licence.txt"
 TERMUX_PKG_VERSION=0.59.1
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://github.com/vicgeralds/vitetris/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=699443df03c8d4bf2051838c1015da72039bbbdd0ab0eede891c59c840bdf58d
 TERMUX_PKG_DEPENDS="ncurses"
 TERMUX_PKG_BUILD_IN_SRC=true
-TERMUX_PKG_REMOVE_AFTER_INSTALL="share/applications/vitetris.desktop"
+TERMUX_PKG_RM_AFTER_INSTALL="share/applications/vitetris.desktop share/pixmaps"
 TERMUX_PKG_GROUPS="games"
 
 termux_step_configure() {


### PR DESCRIPTION
- `TERMUX_PKG_REMOVE_AFTER_INSTALL` -> `TERMUX_PKG_RM_AFTER_INSTALL`

- CLI packages dating to the same time period usually also remove the `share/pixmaps` folder because it is only used by the `.desktop` file. Example:

https://github.com/termux/termux-packages/blob/55445555fffdd0ab801eeb2f95eb410b9a97e31a/packages/mathomatic/build.sh#L12