### PR TITLE
fix(main/sbcl): add correct `TERMUX_PKG_UPDATE_VERSION_REGEXP`

### DIFF
--- a/packages/sbcl/build.sh
+++ b/packages/sbcl/build.sh
@@ -18,6 +18,7 @@ TERMUX_PKG_BUILD_DEPENDS="aosp-libs, bash, coreutils, strace"
 # incompatibilties, like the lack of support for a fully position-independent runtime executable.
 TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"
 TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+.\d+.\d+"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_HOSTBUILD=true
 


### PR DESCRIPTION
Unfortunately, I didn't understand how to make the auto update work correctly for this type of `TERMUX_PKG_SRCURL`, I need to find a package that has an exactly matching `TERMUX_PKG_SRCURL` format that has already been auto updated successfully, and copy the logic that it uses.

`sbcl` has this `TERMUX_PKG_SRCURL` format:

`https://github.com/(account name)/(package name)/archive/refs/tags/(package name)-${TERMUX_PKG_VERSION}.tar.gz`

I noticed that `jql` has exactly that format, and that it also has `TERMUX_PKG_AUTO_UPDATE=true`, and that the only addtional difference it has from `sbcl` is that it has `TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+.\d+.\d+"`, so I hope that this change makes the auto updater run correctly on `sbcl`.

https://github.com/termux/termux-packages/commit/1055def368cc4ca5bded8800fd40a9a5894e4c69

https://github.com/termux/termux-packages/blob/d32ab22d36e0f71fd1624f4303d28e883f5fa3ba/packages/jql/build.sh#L6-L10

- Fixes #24494