### PR TITLE
chore: copy dpkg --compare-version warnings to job annotation

### DIFF
--- a/scripts/updates/utils/termux_pkg_is_update_needed.sh
+++ b/scripts/updates/utils/termux_pkg_is_update_needed.sh
@@ -11,7 +11,7 @@ termux_pkg_is_update_needed() {
 
 	# Compare versions.
 	# shellcheck disable=SC2091
-	dpkg --compare-versions "${CURRENT_VERSION}" lt "${LATEST_VERSION}"
+	dpkg --compare-versions "${CURRENT_VERSION}" lt "${LATEST_VERSION}" 2> >(sed -e "s/^/${CI:+"::warning::"}/" >&2)
 	DPKG_EXIT_CODE=$?
 	if [ "$DPKG_EXIT_CODE" = 0 ]; then
 		return 0 # true. Update needed.


### PR DESCRIPTION
It is needed to explicitly catch situations where auto-update is not possible due to wrong regexp.

Related to #24496.