### PR TITLE
chore: old copy_into_massagedir compatible behaviour

### DIFF
--- a/scripts/build/termux_step_copy_into_massagedir.sh
+++ b/scripts/build/termux_step_copy_into_massagedir.sh
@@ -1,12 +1,7 @@
 termux_step_copy_into_massagedir() {
 	local DEST="$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX_CLASSICAL"
-	cd "$TERMUX_PREFIX_CLASSICAL"
 	mkdir -p "$DEST"
-	# Recreate each new directory and copy its metadata in one go
-	find . -path ./tmp -prune -o -type d -newer "$TERMUX_BUILD_TS_FILE" \
-		-exec mkdir -p "$DEST"/{} \; -exec chmod --reference="{}" "$DEST"/{} \;
-	# Copy only files modified during the build preserving original modes in order to massage them
-	# xargs is needed to avoid exceeding ARG_MAX
-	find . -path ./tmp -prune -o -newer "$TERMUX_BUILD_TS_FILE" \( -type f -o -type l \) \
-		-exec cp -P --preserve=all --parents -t "$DEST" {} +
+	# Copy files changed during the build into massagedir in order to massage them
+	tar -C "$TERMUX_PREFIX_CLASSICAL" -N "$TERMUX_BUILD_TS_FILE" --exclude='tmp' -cf - . | \
+		tar -C "$DEST" -xf -
 }


### PR DESCRIPTION
After experimenting with the massaging step, I realized that my previous changes - while avoiding tar compression - introduced extra execution overhead (due to `find|xargs` spawning) on packages with many files, and risked altering file attributes  in (unexpected) ways that could (possibly) break package behaviour. This pull request restores the original `extract_into_massagedir` logic while still eliminating any storage or compression overhead. Effectively only three binary executions and copying over pipe (without compression) are used to achieve the minimal possible overhead without changing old behaviour.