### PR TITLE
bump(main/sbcl): 2.5.4

### DIFF
--- a/packages/sbcl/build.sh
+++ b/packages/sbcl/build.sh
@@ -3,9 +3,16 @@ TERMUX_PKG_DESCRIPTION="A high performance Common Lisp compiler"
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="2.5.3"
-TERMUX_PKG_SRCURL="https://github.com/sbcl/sbcl/archive/refs/tags/sbcl-${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256=f3b923778f7d1f151f2bdc08a0e92ec4f5a3db5efca5f46ea2ac439dda06cc35
+TERMUX_PKG_VERSION="2.5.4"
+# sourceforge archive is a precompiled SBCL release for GNU/Linux to use as host Lisp for bootstrapping
+TERMUX_PKG_SRCURL=(
+	https://github.com/sbcl/sbcl/archive/refs/tags/sbcl-${TERMUX_PKG_VERSION}.tar.gz
+	https://sourceforge.net/projects/sbcl/files/sbcl/${TERMUX_PKG_VERSION}/sbcl-${TERMUX_PKG_VERSION}-x86-64-linux-binary.tar.bz2
+)
+TERMUX_PKG_SHA256=(
+	fa6120bd438387636d928b0306b189d142214010e2dacf5f67136c481ce84111
+	d71adcaf3e8db6702a3b04e310513294db898e8c11e20ae0ac6bccbb97b3e955
+)
 TERMUX_PKG_DEPENDS="zstd"
 # TERMUX_ON_DEVICE_BUILD=true  build dependencies: ecl, strace
 # TERMUX_ON_DEVICE_BUILD=false build dependencies: aosp-libs, bash, coreutils, strace
@@ -27,16 +34,8 @@ termux_step_host_build() {
 		return
 	fi
 
-	# precompiled SBCL release for GNU/Linux to use as host Lisp for bootstrapping
-	SBCL_BINURL="https://sourceforge.net/projects/sbcl/files/sbcl/${TERMUX_PKG_VERSION}/sbcl-${TERMUX_PKG_VERSION}-x86-64-linux-binary.tar.bz2"
-	SBCL_BINARCHIVE="${TERMUX_PKG_CACHEDIR}/sbcl-${TERMUX_PKG_VERSION}-x86-64-linux-binary.tar.bz2"
-	SBCL_BINSHA256=e207fa6e851631dee0a467cea4f15276d31d4192c949a2b1d3d0daadbf70d443
-	SBCL_WORKDIR="${TERMUX_PKG_TMPDIR}/sbcl"
-	mkdir -p "$SBCL_WORKDIR"
-	termux_download "$SBCL_BINURL" "$SBCL_BINARCHIVE" "$SBCL_BINSHA256"
-	tar -xf "$SBCL_BINARCHIVE" --strip-components=1 -C "$SBCL_WORKDIR"
+	cd "${TERMUX_PKG_SRCDIR}/sbcl-${TERMUX_PKG_VERSION}-x86-64-linux"
 	export INSTALL_ROOT="$TERMUX_PKG_HOSTBUILD_DIR"
-	cd "$SBCL_WORKDIR"
 	sh install.sh
 }
 

--- a/packages/sbcl/disable-failing-tests-that-were-only-enabled-on-x86.patch
+++ b/packages/sbcl/disable-failing-tests-that-were-only-enabled-on-x86.patch
@@ -1,5 +1,7 @@
-elfcore.test.sh/elf-sans-immobile.test.sh is not passing on Android-x86,
-so it is disabled by this. These tests also fail on ARM, but are
+elfcore.test.sh is not passing on Android-x86,
+so it is disabled by this. Upstream also currently has 
+elf-sans-immobile.test.sh disabled.
+These tests also fail on ARM, but were
 not enabled by upstream on any targets except 64-bit x86.
 The exact reason why the test fails, or what steps might be necessary
 to fix it, are not known, but one way of describing the probable
@@ -12,11 +14,11 @@ effects that this test failing implies would be:
  . ./subr.sh
  
  run_sbcl <<EOF
--  #+(and linux x86-64 sb-thread)
-+  #+(and linux x86-64 sb-thread (not android))
-   (unless (member :immobile-space sb-impl:+internal-features+)
-     (exit :code 0)) ; proceed with test
-  (exit :code 2) ; otherwise skip the test
+-;#+(and linux x86-64 sb-thread)
++;#+(and linux x86-64 sb-thread (not android))
+ ;(unless (member :immobile-space sb-impl:+internal-features+)
+ ;  (exit :code 0)) ; proceed with test
+ (exit :code 2) ; otherwise skip the test
 --- a/tests/elfcore.test.sh
 +++ b/tests/elfcore.test.sh
 @@ -16,7 +16,7 @@

--- a/packages/sbcl/pass-testsuite-on-device.patch
+++ b/packages/sbcl/pass-testsuite-on-device.patch
@@ -74,11 +74,11 @@ contains some code from https://bugs.launchpad.net/sbcl/+bug/1956852
  ;;; race conditions and (at least on Linux) does not make use of any shell environment variables
  ;;; to determine a directory - in fact it doesn't make a directory entry at all.
  (defun sb-unix:unix-tmpfile ()
--  (make-stdio-file (alien-funcall (extern-alien "tmpfile" (function system-area-pointer)))))
-+  (make-stdio-file (alien-funcall (extern-alien "termux_tmpfile" (function system-area-pointer)))))
- 
- (defun sb-unix:unix-fclose (file)
-   (alien-funcall (extern-alien "fclose" (function int system-area-pointer))
+-  (let ((sap (alien-funcall (extern-alien "tmpfile" (function system-area-pointer)))))
++  (let ((sap (alien-funcall (extern-alien "termux_tmpfile" (function system-area-pointer)))))
+     (if (zerop (sap-int sap))
+         (error "Error calling tmpfile(): ~a" (strerror))
+         (make-stdio-file sap))))
 --- a/src/runtime/linux-os.c
 +++ b/src/runtime/linux-os.c
 @@ -416,3 +416,8 @@ char *os_get_runtime_executable_path()


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/24526

- The auto update failed to proceed because I put the host SBCL download in `termux_download` instead of `TERMUX_PKG_SRCURL` and I forgot I did that,

- However, there are some changes near areas patched by patch files, so the patches have to be rebased anyway

- `disable-failing-tests-that-were-only-enabled-on-x86.patch`: In https://github.com/sbcl/sbcl/commit/b219fb32f534cb29eba74e3e1bb1195d1556b917, upstream disabled the failing x86-only test by commenting it out, but in rebasing, I have preserved the hunk to disable it on Android should it ever be enabled again upstream, as a reminder for the future that this test was failing on Android-x86 and might need to remain disabled even if upstream enables it again in the future.

- `pass-testsuite-on-device.patch`: Upstream decided to add a null return check to the implementation of `sb-unix:unix-tmpfile()` as a result of discussion that was, in fact, related to its test failing on Termux shortly prior to the addition of `sbcl` to termux-packages, and that is OK and should not have any major effect on the tests we run here, because of our `termux_tmpfile()` implementation preventing it from returning null in most situations.