### PR TITLE
fix(main/protobuf-static): for termux-pacman, remove `TERMUX_PKG_REPLACES="libprotobuf"` to prevent unintended prompt during every upgrade

### DIFF
--- a/packages/libprotobuf/build.sh
+++ b/packages/libprotobuf/build.sh
@@ -12,7 +12,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 #     $TERMUX_SCRIPTDIR/scripts/build/setup/termux_setup_protobuf.sh
 # - ALWAYS bump revision of reverse dependencies and rebuild them.
 TERMUX_PKG_VERSION="2:30.0"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://github.com/protocolbuffers/protobuf/archive/v${TERMUX_PKG_VERSION#*:}.tar.gz
 TERMUX_PKG_SHA256=9df0e9e8ebe39f4fbbb9cf7db3d811287fe3616b2f191eb2bf5eaa12539c881f
 TERMUX_PKG_AUTO_UPDATE=false

--- a/packages/protobuf-static/build.sh
+++ b/packages/protobuf-static/build.sh
@@ -9,13 +9,12 @@ third_party/utf8_range/LICENSE
 TERMUX_PKG_MAINTAINER="@termux"
 # Please align the version and revision with `libprotobuf` package.
 TERMUX_PKG_VERSION=30.0
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://github.com/protocolbuffers/protobuf/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=9df0e9e8ebe39f4fbbb9cf7db3d811287fe3616b2f191eb2bf5eaa12539c881f
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_DEPENDS="abseil-cpp, libc++, zlib"
 TERMUX_PKG_BREAKS="libprotobuf"
-TERMUX_PKG_REPLACES="libprotobuf"
 TERMUX_PKG_CONFLICTS="libprotobuf, protobuf-dev"
 TERMUX_PKG_NO_STATICSPLIT=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/24598

- This should have **no observable effect on termux-apt**, only on termux-pacman