### PR TITLE
fix(scripts/build/get_source/termux_extract_src_archive): remove `TERMUX_PKG_SRCDIR` before replacing it with the first folder of a `.zip` archive

### DIFF
--- a/scripts/build/get_source/termux_unpack_src_archive.sh
+++ b/scripts/build/get_source/termux_unpack_src_archive.sh
@@ -9,7 +9,7 @@ termux_extract_src_archive() {
 		set +o pipefail
 		if [ "${file##*.}" = zip ]; then
 			folder=$(unzip -qql "$file" | head -n1 | tr -s ' ' | cut -d' ' -f5-)
-			rm -Rf "$folder"
+			rm -Rf "$folder" "$TERMUX_PKG_SRCDIR"
 			unzip -q "$file"
 			mv "$folder" "$TERMUX_PKG_SRCDIR"
 		else


### PR DESCRIPTION
- Fixes #24336

- After https://github.com/termux/termux-packages/commit/0e4a2580db26d3d778ded60d872c1b3b7f06e13e, `scripts/run-docker.sh ./build-package.sh -I -f proot` began failing because `TERMUX_PKG_SRCDIR` can now exist as a directory _before_ `termux_extract_src_archive()` runs, but when `TERMUX_PKG_SRCURL` ends in `.zip`, by default the first folder inside the `.zip` is intended to **become** the `TERMUX_PKG_SRCDIR`, so the previous `TERMUX_PKG_SRCDIR` must be removed in this situation in order to preserve the intended behavior.