### PR TITLE
scripts(termux_get_repo_files): parallelize fetching files and refactor

### DIFF
--- a/scripts/build/termux_get_repo_files.sh
+++ b/scripts/build/termux_get_repo_files.sh
@@ -1,64 +1,82 @@
 termux_get_repo_files() {
+	local PACKAGES_HASH RELEASE_FILE repo_base dl_prefix RELEASE_FILE_URL RELEASE_FILE_SIG_URL
+	local -a pids=()
 	# Not needed for on-device builds or when building
 	# dependencies.
-	if [ "$TERMUX_ON_DEVICE_BUILD" = "true" ] || [ "$TERMUX_INSTALL_DEPS" = "false" ]; then
+	if [[ "$TERMUX_ON_DEVICE_BUILD" = "true" || "$TERMUX_INSTALL_DEPS" = "false" ]]; then
 		return
 	fi
 
-	for idx in $(seq ${#TERMUX_REPO_URL[@]}); do
-		local TERMUX_REPO_NAME=$(echo ${TERMUX_REPO_URL[$idx-1]} | sed -e 's%https://%%g' -e 's%http://%%g' -e 's%/%-%g')
-		if [ "$TERMUX_REPO_PKG_FORMAT" = "debian" ]; then
-			local RELEASE_FILE=${TERMUX_COMMON_CACHEDIR}/${TERMUX_REPO_NAME}-${TERMUX_REPO_DISTRIBUTION[$idx-1]}-Release
-			local repo_base="${TERMUX_REPO_URL[$idx-1]}/dists/${TERMUX_REPO_DISTRIBUTION[$idx-1]}"
-			local dl_prefix="${TERMUX_REPO_NAME}-${TERMUX_REPO_DISTRIBUTION[$idx-1]}-${TERMUX_REPO_COMPONENT[$idx-1]}"
-		elif [ "$TERMUX_REPO_PKG_FORMAT" = "pacman" ]; then
-			local JSON_FILE="${TERMUX_COMMON_CACHEDIR}-${TERMUX_ARCH}/${TERMUX_REPO_NAME}-json"
-			local repo_base="${TERMUX_REPO_URL[$idx-1]}/${TERMUX_ARCH}"
-		fi
+	for idx in "${!TERMUX_REPO_URL[@]}"; do
+		local TERMUX_REPO_NAME="${TERMUX_REPO_URL[$idx]#https://}"
+		TERMUX_REPO_NAME="${TERMUX_REPO_NAME#http://}"
+		TERMUX_REPO_NAME="${TERMUX_REPO_NAME//\//-}"
+		case "$TERMUX_REPO_PKG_FORMAT" in
+		"debian")
+			RELEASE_FILE="${TERMUX_COMMON_CACHEDIR}/${TERMUX_REPO_NAME}-${TERMUX_REPO_DISTRIBUTION[$idx]}-Release"
+			repo_base="${TERMUX_REPO_URL[$idx]}/dists/${TERMUX_REPO_DISTRIBUTION[$idx]}"
+			dl_prefix="${TERMUX_REPO_NAME}-${TERMUX_REPO_DISTRIBUTION[$idx]}-${TERMUX_REPO_COMPONENT[$idx]}"
+			RELEASE_FILE_URL="${repo_base}/Release"
+			RELEASE_FILE_SIG_URL="${RELEASE_FILE_URL}.gpg"
+			;;
+		"pacman")
+			RELEASE_FILE="${TERMUX_COMMON_CACHEDIR}-${TERMUX_ARCH}/${TERMUX_REPO_NAME}-json"
+			repo_base="${TERMUX_REPO_URL[$idx]}/${TERMUX_ARCH}"
+			RELEASE_FILE_URL="${repo_base}/${TERMUX_REPO_DISTRIBUTION[$idx]}.json"
+			RELEASE_FILE_SIG_URL="${RELEASE_FILE_URL}.sig"
+			;;
+		*) termux_error_exit "Invalid package format: $TERMUX_REPO_PKG_FORMAT"
+			;;
+		esac
 
-		local download_attempts=6
-		while ((download_attempts > 0)); do
-			if [ "$TERMUX_REPO_PKG_FORMAT" = "debian" ]; then
-				if termux_download "${repo_base}/Release" "$RELEASE_FILE" SKIP_CHECKSUM && \
-					termux_download "${repo_base}/Release.gpg" "${RELEASE_FILE}.gpg" SKIP_CHECKSUM && \
-					gpg --verify "${RELEASE_FILE}.gpg" "$RELEASE_FILE"; then
+		(
+			if termux_download "${RELEASE_FILE_URL}" "${RELEASE_FILE}" SKIP_CHECKSUM && \
+				termux_download "${RELEASE_FILE_SIG_URL}" "${RELEASE_FILE}.gpg" SKIP_CHECKSUM && \
+				gpg --verify "${RELEASE_FILE}.gpg" "${RELEASE_FILE}"; then
 
-					local failed=false
-					for arch in all $TERMUX_ARCH; do
-						local PACKAGES_HASH=$(./scripts/get_hash_from_file.py ${RELEASE_FILE} $arch ${TERMUX_REPO_COMPONENT[$idx-1]})
+				if [[ "$TERMUX_REPO_PKG_FORMAT" == "debian" ]]; then
+					for arch in all "${TERMUX_ARCH}"; do
+						PACKAGES_HASH="$(./scripts/get_hash_from_file.py "${RELEASE_FILE}" "${arch}" "${TERMUX_REPO_COMPONENT[$idx]}")"
 
 						# If packages_hash = "" then the repo probably doesn't contain debs for $arch
-						if [ -n "$PACKAGES_HASH" ]; then
-							if ! termux_download "${repo_base}/${TERMUX_REPO_COMPONENT[$idx-1]}/binary-$arch/Packages" \
-								"${TERMUX_COMMON_CACHEDIR}-$arch/${dl_prefix}-Packages" \
-								$PACKAGES_HASH; then
-								failed=true
-								break
-							fi
-						fi
+						[[ -n "$PACKAGES_HASH" ]] && \
+							termux_download "${repo_base}/${TERMUX_REPO_COMPONENT[$idx]}/binary-$arch/Packages" \
+									"${TERMUX_COMMON_CACHEDIR}-$arch/${dl_prefix}-Packages" "$PACKAGES_HASH" && \
+							exit 0
 					done
-
-					if ! $failed; then
-						break
-					fi
 				fi
-			elif [ "$TERMUX_REPO_PKG_FORMAT" = "pacman" ]; then
-				if termux_download "${repo_base}/${TERMUX_REPO_DISTRIBUTION[$idx-1]}.json" "$JSON_FILE" SKIP_CHECKSUM && \
-					termux_download "${repo_base}/${TERMUX_REPO_DISTRIBUTION[$idx-1]}.json.sig" "${JSON_FILE}.sig" SKIP_CHECKSUM && \
-					gpg --verify "${JSON_FILE}.sig" "$JSON_FILE"; then
-
-					break
-				fi
+				exit 0
 			fi
+			termux_error_exit "Failed to download package repository metadata. Try to build without -i/-I option."
+		) 2>&1 | (
+			set +e
+			# curl progress meter uses carriage return instead of newlines, fixing it
+			sed -u 's/\r/\n/g' | while :; do
+				local buffer=()
+				# Half second buffer to prevent mixing lines and make output consistent.
+				sleep 0.5;
+				while :; do
+					# read with 0 timeout does not read any data so giving minimal timeout
+					IFS='' read -t 0.001 -r line; rc=$?
+					# append job name to the start for tracking multiple jobs
+					[[ $rc == 0 ]] && buffer+=( "[$TERMUX_REPO_NAME]: $line" )
+					# Probably EOF or timeout
+					[[ $rc == 1 || $rc -ge 128 ]] && break
+				done
 
-			download_attempts=$((download_attempts - 1))
-			if ((download_attempts < 1)); then
-				termux_error_exit "Failed to download package repository metadata. Try to build without -i/-I option."
-			fi
+				# prevent output garbling by using stdout as a lock file
+				[[ "${#buffer[@]}" -ge 1 ]] && flock --no-fork 1 printf "%s\n" "${buffer[@]}"
+				[[ $rc == 1 ]] && break # exit on EOF
+			done
+		) &
+		pids+=( $! )
+	done
 
-			echo "Retrying download in 30 seconds (${download_attempts} attempts left)..." >&2
-			sleep 30
-		done
-
+	for _ in "${pids[@]}"; do
+		if ! wait -n; then
+			# One of jobs exited with non-zero status, we should return error too.
+			kill "${pids[@]}" 2>/dev/null
+			exit 1
+		fi
 	done
 }


### PR DESCRIPTION
Removed duplicating code and got rid of external commands (seq and sed) invocations during the preparation phase.

This change reduces latency of `termux_get_repo_files`.
It does not matter much, but it also serves as PoC and training for parallel dependency downloading which will be implemented later.

Parallelizing is pretty much naive and here we do not track which file downloading failed, we simply bail on any downloading failure.