### PR TITLE
fix(main/erlang): enable building manpages and HTML docs

### DIFF
--- a/packages/erlang/auto-download-ex_doc-noninteractively.patch.beforehostbuild
+++ b/packages/erlang/auto-download-ex_doc-noninteractively.patch.beforehostbuild
@@ -1,0 +1,29 @@
+Autoaccepts the interactive prompt:
+"Could not find ex_doc! Do you want to download latest ex_doc from github? (y/n)?"
+when building docs.
+
+--- a/make/ex_doc_wrapper.in
++++ b/make/ex_doc_wrapper.in
+@@ -10,21 +10,12 @@ if [ ! -f "${EX_DOC}" ]; then
+ fi
+ 
+ if [ -z "${EX_DOC}" ]; then
+-    echo -n "Could not find ex_doc! "
+-    read -p "Do you want to download latest ex_doc from github? (y/n)? " -n 1 -r
+-    echo
+-    if [[ $REPLY =~ ^[Yy]$ ]]
+-    then
++    echo -n "Could not find ex_doc! Downloading the latest ex_doc from github..."
+         if $ERL_TOP/otp_build download_ex_doc; then
+-            read -p "Press any key to continue..." -n 1 -r
+-            echo "continuing"
+             EX_DOC=$(command -v ex_doc || true)
+         else
+             exit 1
+         fi
+-    else
+-        exit 1
+-    fi
+ fi
+ 
+ ## The below bash magic captures the output of stderr into OUTPUT while still printing

--- a/packages/erlang/build.sh
+++ b/packages/erlang/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="General-purpose concurrent functional programming langua
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="27.3.4"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/erlang/otp/archive/refs/tags/OTP-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=a05fa5c952fdf1718121d4ca3fd0c96fcb8b54ed61e37862417478d7b6c89232
 TERMUX_PKG_AUTO_UPDATE=true
@@ -16,6 +17,11 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --with-ssl=${TERMUX_PREFIX}
 --with-termcap
 erl_xcomp_sysroot=${TERMUX_PREFIX}
+"
+# for some reason, these do not work properly, and are duplicates
+# of ones patched to work which are installed into $TERMUX_PREFIX/share/man/man1
+TERMUX_PKG_RM_AFTER_INSTALL="
+lib/erlang/man
 "
 
 termux_pkg_auto_update() {
@@ -39,8 +45,11 @@ termux_step_host_build() {
 	cd $TERMUX_PKG_BUILDDIR
 	# Erlang cross compile reference: https://github.com/erlang/otp/blob/master/HOWTO/INSTALL-CROSS.md#building-a-bootstrap-system
 	# Build erlang bootstrap system.
-	./configure --enable-bootstrap-only --without-javac --without-ssl --without-termcap
+	# the prefix must be set to $TERMUX_PREFIX here to install the documentation where desired
+	# without making a mess.
+	./configure --prefix="$TERMUX_PREFIX" --without-javac --with-termcap
 	make -j $TERMUX_PKG_MAKE_PROCESSES
+	make RELSYS_MANDIR="$TERMUX_PREFIX/share/man" install-docs
 }
 
 termux_step_pre_configure() {

--- a/packages/erlang/disable-docs-of-disabled-features.patch.beforehostbuild
+++ b/packages/erlang/disable-docs-of-disabled-features.patch.beforehostbuild
@@ -1,0 +1,24 @@
+erlang for Termux does not currently seem to support the odbc or jinterface
+features, so to avoid errors when building docs, they must be disabled
+from the docs Makefile. If the enabled features change in the future, this
+patch should be changed to match.
+
+Configure log summary report of these features being disabled
+(both in hostbuild and main build):
+jinterface     : Java compiler disabled by user
+odbc           : ODBC library - link check failed
+
+--- a/system/doc/top/Makefile
++++ b/system/doc/top/Makefile
+@@ -32,9 +32,9 @@ HTMLDIR=../../../doc
+ RELSYS_HTMLDIR=$(RELEASE_PATH)/doc
+ 
+ CORE=compiler erts kernel sasl stdlib
+-DATABASE=mnesia odbc
++DATABASE=mnesia
+ OAM=os_mon snmp
+-INTERFACES=asn1 crypto diameter eldap erl_interface ftp inets jinterface megaco \
++INTERFACES=asn1 crypto diameter eldap erl_interface ftp inets megaco \
+ 	public_key ssh ssl tftp wx xmerl
+ TOOLS=debugger dialyzer et observer parsetools reltool runtime_tools syntax_tools tools
+ TESTING=common_test eunit

--- a/packages/erlang/do-not-set-manpath.patch
+++ b/packages/erlang/do-not-set-manpath.patch
@@ -1,0 +1,17 @@
+For some reason, if this line is enabled while the command "erl -man erl"
+is run, then MANPATH is set to $TERMUX_PREFIX/lib/erlang/man/
+and erl searches a whole bunch of paths under that path for man pages,
+but somehow none of the paths it searches are the actual correct path,
+$TERMUX_PREFIX/lib/erlang/man/cat1/erl.1.
+If this line is deleted, then the command "erl -man erl" works.
+
+--- a/erts/etc/common/erlexec.c
++++ b/erts/etc/common/erlexec.c
+@@ -759,7 +759,6 @@ int main(int argc, char **argv)
+                             }
+                         }
+ 			erts_snprintf(tmpStr, sizeof(tmpStr), "%s/man", rootdir);
+-			set_env("MANPATH", tmpStr);
+ 			execvp("man", argv+i);
+ 			error("Could not execute the 'man' command.");
+ #endif

--- a/packages/erlang/erlang-doc.subpackage.sh
+++ b/packages/erlang/erlang-doc.subpackage.sh
@@ -1,0 +1,7 @@
+TERMUX_SUBPKG_DESCRIPTION="Erlang HTML documentation"
+TERMUX_SUBPKG_PLATFORM_INDEPENDENT=true
+TERMUX_SUBPKG_INCLUDE="
+lib/erlang/doc
+lib/erlang/*/doc
+lib/erlang/*/*/doc
+"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/24624

- This is able to make the commands `man erl` and `erl -man erl` both work, and also, several others
  like `man run_erl`, `erl -man run_erl`, and more. Unfortunately,
  it is **not** possible to get the `erl -man io` to fully work, but the erlang command
  `h(io).` inside the interactive `erl` shell already provides a help page for `io`,
  and also, **both Arch Linux and Debian also cannot currently run the command `erl -man io`**
  **successfully, even while all their erlang packages are installed**.
  The reason this happened is because Erlang version 27 upstream no
  longer supports the `erl -man io` command, so all implementations of
  it will be at best stuck at the manpage content from Erlang version
  26.

- building docs requires using the hostbuilt `erlang`, and that hostbuilt
  `erlang` must be a full build with ssl and termcap enabled to avoid errors
  and build all docs matching the featureset of the Android build.
  The `Makefile` automatically detects and uses this hostbuilt `erlang`
  to build the docs if it was the last `erlang` built.

- Unlike the `-DCMAKE_INSTALL_PREFIX` argument that CMake users might be familiar with,
  the `--prefix` argument of autotools `configure` does not seem to typically cause the configure step to
  attempt to find and import dependencies in that prefix, only sets the installation destination,
  so unlike the configure step of CMake projects, it is safe to use with `$TERMUX_PREFIX` during
  `termux_step_host_build()`. This message is written so that this example is not accidentally
  used as a reference to attempt a similar technique for any CMake-based package.