### PR TITLE
scripts(run-docker): let docker image detect CI and fold some long logs

### DIFF
--- a/scripts/bin/update-packages
+++ b/scripts/bin/update-packages
@@ -231,11 +231,11 @@ _fetch_and_cache_tags() {
 		termux_pkg_auto_update
 	}
 
-	echo "${CI:+"::group::"}INFO: Fetching GitHub packages via GraphQL API"
+	echo "$([[ "${CI-false}" == "true" ]] && echo "::group::")INFO: Fetching GitHub packages via GraphQL API"
 	LATEST_TAGS_GITHUB="$(
 		termux_github_graphql "${GITHUB_GRAPHQL_QUERIES[@]}"
 	)"
-	[[ -n "$CI" ]] && echo "::endgroup::"
+	[[ "${CI-false}" == "true" ]] && echo "::endgroup::"
 
 	echo "INFO: Fetching non-GitHub packages"
 	local LATEST_TAGS=''
@@ -247,7 +247,7 @@ _fetch_and_cache_tags() {
 	unset -f __main__
 
 	declare -A __GITHUB_CURRENT_TAGS=()
-	[[ -n "$CI" ]] && echo "::group::INFO: Skipping the following up-to-date packages"
+	[[ "${CI-false}" == "true" ]] && echo "::group::INFO: Skipping the following up-to-date packages"
 	while IFS='|' read -r type pkg version; do
 		if [[ "${type}" == "LOCAL" ]]; then # Current git-originated package version
 			__GITHUB_CURRENT_TAGS["${pkg:-_}"]="$version"
@@ -259,7 +259,7 @@ _fetch_and_cache_tags() {
 			_ALREADY_SEEN+=("${pkg}")
 		fi
 	done < <(printf '%s\n' "$LATEST_TAGS" "$LATEST_TAGS_GITHUB")
-	[[ -n "$CI" ]] && echo "::endgroup::"
+	[[ "${CI-false}" == "true" ]] && echo "::endgroup::"
 	unset __GITHUB_CURRENT_TAGS
 }
 

--- a/scripts/build/termux_get_repo_files.sh
+++ b/scripts/build/termux_get_repo_files.sh
@@ -7,6 +7,8 @@ termux_get_repo_files() {
 		return
 	fi
 
+	[[ "${CI-false}" == "true" ]] && echo "::group::INFO: Fetching repo metadata"
+
 	for idx in "${!TERMUX_REPO_URL[@]}"; do
 		local TERMUX_REPO_NAME="${TERMUX_REPO_URL[$idx]#https://}"
 		TERMUX_REPO_NAME="${TERMUX_REPO_NAME#http://}"
@@ -79,4 +81,5 @@ termux_get_repo_files() {
 			exit 1
 		fi
 	done
+	[[ "${CI-false}" == "true" ]] && echo "::endgroup::"
 }

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -14,6 +14,12 @@ else
 	SEC_OPT=" --security-opt seccomp=$REPOROOT/scripts/profile.json"
 fi
 
+if [ "${CI:-}" = "true" ]; then
+	CI_OPT="--env CI=true"
+else
+	CI_OPT=""
+fi
+
 # Required for Linux with SELinux and btrfs to avoid permission issues, eg: Fedora
 # To reset, use "restorecon -Fr ."
 # To check, use "ls -Z ."
@@ -71,4 +77,4 @@ if [ "$#" -eq "0" ]; then
 	set -- bash
 fi
 
-$SUDO docker exec --env "DOCKER_EXEC_PID_FILE_PATH=$DOCKER_EXEC_PID_FILE_PATH" --interactive $DOCKER_TTY $CONTAINER_NAME "$@"
+$SUDO docker exec $CI_OPT --env "DOCKER_EXEC_PID_FILE_PATH=$DOCKER_EXEC_PID_FILE_PATH" --interactive $DOCKER_TTY $CONTAINER_NAME "$@"

--- a/scripts/updates/utils/termux_pkg_is_update_needed.sh
+++ b/scripts/updates/utils/termux_pkg_is_update_needed.sh
@@ -11,7 +11,7 @@ termux_pkg_is_update_needed() {
 
 	# Compare versions.
 	# shellcheck disable=SC2091
-	dpkg --compare-versions "${CURRENT_VERSION}" lt "${LATEST_VERSION}" 2> >(sed -e "s/^/${CI:+"::warning::${TERMUX_PKG_NAME:-}: "}/" >&2)
+	dpkg --compare-versions "${CURRENT_VERSION}" lt "${LATEST_VERSION}" 2> >(sed -e "s/^/$([[ "${CI-false}" == "true" ]] && echo "::warning::${TERMUX_PKG_NAME:-}: ")/" >&2)
 	DPKG_EXIT_CODE=$?
 	if [ "$DPKG_EXIT_CODE" = 0 ]; then
 		return 0 # true. Update needed.

--- a/scripts/utils/termux_reuse_pr_build_artifacts.sh
+++ b/scripts/utils/termux_reuse_pr_build_artifacts.sh
@@ -10,7 +10,7 @@ unset PR WORKFLOW_ID
 
 infoexit() {
 	echo "$@"
-	[[ -n "${PR}" && -n "${CI}" ]] && echo "::error ::Failed to reuse PR #${PR} ${WORKFLOW_ID:+"(workflow run ${WORKFLOW_ID})"} build artifacts, see \`Gathering build summary\` step logs."
+	[[ -n "${PR}" && "${CI-false}" == "true" ]] && echo "::error ::Failed to reuse PR #${PR} ${WORKFLOW_ID:+"(workflow run ${WORKFLOW_ID})"} build artifacts, see \`Gathering build summary\` step logs."
 	exit 1
 } >&2
 


### PR DESCRIPTION
Small change to let image detect CI and perform folding of some long and usually not so important listings, like log of `termux_step_get_dependencies` which becomes irrelevant immediately after the step is finished.