### PR TITLE
scripts(termux_extract_dep_info): optimize by using bash builtins

### DIFF
--- a/scripts/build/termux_extract_dep_info.sh
+++ b/scripts/build/termux_extract_dep_info.sh
@@ -25,7 +25,7 @@ termux_extract_dep_info() {
 		VER_PACMAN=${VER_PACMAN//"$p"/"${p:0:1}.${p:1:1}"}
 	fi
 
-	if [ "$PKG" != "$(basename ${PKG_DIR})" ] && [ "${PKG/-glibc/}" != "$(basename ${PKG_DIR})" ]; then
+	if [[ "$PKG" != "${PKG_DIR##*/}" && "${PKG/-glibc/}" != "${PKG_DIR##*/}" ]]; then
 		if [[ "$TERMUX_INSTALL_DEPS" == "false" || \
 			   "$TERMUX_PKG_NO_STATICSPLIT" = "true" || \
 			   "${PKG/-static/}-static" != "${PKG}" ]]; then


### PR DESCRIPTION
Near zero-cost optimization which slightly reduces `termux_step_get_dependencies` execution by second (drop from ~7s to ~6s for `kf6-breeze-icons`) which is good when you debug some package's configure step and re-run `./build-package.sh` after each small change.