### PR TITLE
screen: enable truecolor display by default

### DIFF
--- a/packages/screen/build.sh
+++ b/packages/screen/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Terminal multiplexer with VT100/ANSI terminal emulation"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="5.0.0"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/screen/screen-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=f04a39d00a0e5c7c86a55338808903082ad5df4d73df1a2fd3425976aed94971
 # libandroid-support is necessary as screen uses `wcwidth`, see #22688
@@ -28,4 +28,5 @@ termux_step_pre_configure() {
 termux_step_post_configure() {
 	echo '#define HAVE_SVR4_PTYS 1' >> "$TERMUX_PKG_BUILDDIR/config.h"
 	echo 'mousetrack on' > "$TERMUX_PREFIX/etc/screenrc"
+	echo 'truecolor on' >> "$TERMUX_PREFIX/etc/screenrc"
 }


### PR DESCRIPTION
This commit makes screen's output consistent with tmux, allowing for more colors to be displayed.