### PR TITLE
scripts(termux_step_get_dependencies): refactor and consistency

### DIFF
--- a/scripts/build/termux_extract_dep_info.sh
+++ b/scripts/build/termux_extract_dep_info.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/bash
 
 termux_extract_dep_info() {
-	( # Do everything in a subshell do avoid variable hell outside the function
-	PKG=$1
-	PKG_DIR=$2
+	( # Do everything in a subshell to avoid variable hell outside the function
+	PKG="$1"
+	PKG_DIR="$2"
 
 	# set TERMUX_SUBPKG_PLATFORM_INDEPENDENT to
 	# parent package's value and override if
 	# needed
-	TERMUX_PKG_PLATFORM_INDEPENDENT=false
+	TERMUX_PKG_ON_DEVICE_BUILD_NOT_SUPPORTED="false"
+	TERMUX_PKG_PLATFORM_INDEPENDENT="false"
 	TERMUX_PKG_REVISION="0"
-	source ${PKG_DIR}/build.sh
+	source "${PKG_DIR}/build.sh"
 
 	# debian version
 	VER_DEBIAN="$TERMUX_PKG_VERSION"
@@ -27,12 +28,13 @@ termux_extract_dep_info() {
 
 	if [[ "$PKG" != "${PKG_DIR##*/}" && "${PKG/-glibc/}" != "${PKG_DIR##*/}" ]]; then
 		if [[ "$TERMUX_INSTALL_DEPS" == "false" || \
-			   "$TERMUX_PKG_NO_STATICSPLIT" = "true" || \
-			   "${PKG/-static/}-static" != "${PKG}" ]]; then
+				"$TERMUX_PKG_NO_STATICSPLIT" = "true" || \
+				"${PKG/-static/}-static" != "${PKG}" ]]; then
+			# shellcheck source=/dev/null
 			if [[ -f "${PKG_DIR}/${PKG}.subpackage.sh" ]]; then
-				source ${PKG_DIR}/${PKG}.subpackage.sh
+				source "${PKG_DIR}/${PKG}.subpackage.sh"
 			else
-				source ${PKG_DIR}/${PKG/-glibc/}.subpackage.sh
+				source "${PKG_DIR}/${PKG/-glibc/}.subpackage.sh"
 			fi
 		fi
 	fi
@@ -40,7 +42,7 @@ termux_extract_dep_info() {
 		TERMUX_ARCH=all
 	fi
 
-	echo "${TERMUX_ARCH} ${VER_DEBIAN} ${VER_PACMAN}-${TERMUX_PKG_REVISION}"
+	echo "${TERMUX_ARCH} ${VER_DEBIAN} ${VER_PACMAN}-${TERMUX_PKG_REVISION} ${TERMUX_PKG_ON_DEVICE_BUILD_NOT_SUPPORTED}"
 	)
 }
 

--- a/scripts/build/termux_step_get_dependencies.sh
+++ b/scripts/build/termux_step_get_dependencies.sh
@@ -1,79 +1,60 @@
 termux_step_get_dependencies() {
-	if [[ "$TERMUX_SKIP_DEPCHECK" == "true" || "$TERMUX_PKG_METAPACKAGE" == "true" ]]; then
-		return 0
-	fi
+	[[ "$TERMUX_SKIP_DEPCHECK" == "true" || "$TERMUX_PKG_METAPACKAGE" == "true" ]] && return 0
+	[[ "$TERMUX_INSTALL_DEPS" == "true" ]] && termux_download_repo_file # Download repo files
 
-	if [[ "$TERMUX_INSTALL_DEPS" == "true" ]]; then
-		# Download repo files
-		termux_download_repo_file
-	fi
-
-	while read PKG PKG_DIR; do
+	while read -r PKG PKG_DIR; do
 		# Checking for duplicate dependencies
 		local cyclic_dependence="false"
 		if termux_check_package_in_building_packages_list "$PKG_DIR"; then
 			echo "A circular dependency was found on '$PKG', the old version of the package will be installed to resolve the conflict"
 			cyclic_dependence="true"
-			if [[ "$TERMUX_INSTALL_DEPS" == "false" ]]; then
-				termux_download_repo_file
-			fi
+			[[ "$TERMUX_INSTALL_DEPS" == "false" ]] && termux_download_repo_file
 		fi
 
+		[[ -z "$PKG" ]] && continue
+		[[ "$PKG" == "ERROR" ]] && termux_error_exit "Obtaining buildorder failed"
+
 		if [[ "$TERMUX_INSTALL_DEPS" == "true" || "$cyclic_dependence" = "true" ]]; then
-			if [[ -z "$PKG" ]]; then
-				continue
-			elif [[ "$PKG" == "ERROR" ]]; then
-				termux_error_exit "Obtaining buildorder failed"
-			fi
-			# llvm doesn't build if ndk-sysroot is installed:
-			if [[ "$PKG" == "ndk-sysroot" ]]; then continue; fi
-			read DEP_ARCH DEP_VERSION DEP_VERSION_PAC <<< $(termux_extract_dep_info $PKG "${PKG_DIR}")
-			local pkg_versioned="$PKG"
+			[[ "$PKG" == "ndk-sysroot" ]] && continue # llvm doesn't build if ndk-sysroot is installed:
+			read -r DEP_ARCH DEP_VERSION DEP_VERSION_PAC DEP_ON_DEVICE_NOT_SUPPORTED < <(termux_extract_dep_info "${PKG}" "${PKG_DIR}")
+			local pkg_versioned="$PKG" build_dependency="false" force_build_dependency="$TERMUX_FORCE_BUILD_DEPENDENCIES"
 			[[ "${TERMUX_WITHOUT_DEPVERSION_BINDING}" == "false" ]] && pkg_versioned+="@$DEP_VERSION"
 			if [[ "$cyclic_dependence" == "false" ]]; then
 				[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo "Downloading dependency $pkg_versioned if necessary..."
-				local force_build_dependency="$TERMUX_FORCE_BUILD_DEPENDENCIES"
-				if [[ "$TERMUX_FORCE_BUILD_DEPENDENCIES" == "true" && "$TERMUX_ON_DEVICE_BUILD" == "true" ]] && ! termux_package__is_package_on_device_build_supported "$PKG_DIR"; then
+				if [[ "$TERMUX_FORCE_BUILD_DEPENDENCIES" == "true" && "$TERMUX_ON_DEVICE_BUILD" == "true" && "$DEP_ON_DEVICE_NOT_SUPPORTED" == "true" ]]; then
 					echo "Building dependency $PKG on device is not supported. It will be downloaded..."
 					force_build_dependency="false"
 				fi
 			else
-				local force_build_dependency="false"
+				force_build_dependency="false"
 			fi
-			local build_dependency="false"
 			if [[ "$force_build_dependency" = "true" ]]; then
+				termux_force_check_package_dependency && continue || :
 				[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo "Force building dependency $PKG instead of downloading due to -I flag..."
-				termux_force_check_package_dependency && continue
-				build_dependency=true
+				build_dependency="true"
 			else
 				if termux_package__is_package_version_built "$PKG" "$DEP_VERSION"; then
 					[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo "Skipping already built dependency $pkg_versioned"
 					continue
 				fi
 				if ! TERMUX_WITHOUT_DEPVERSION_BINDING="$([[ "${cyclic_dependence}" == "true" ]] && echo "true" || echo "${TERMUX_WITHOUT_DEPVERSION_BINDING}")" termux_download_deb_pac $PKG $DEP_ARCH $DEP_VERSION $DEP_VERSION_PAC; then
-					if [[ "$cyclic_dependence" == "true" || ( "$TERMUX_FORCE_BUILD_DEPENDENCIES" == "true" && "$TERMUX_ON_DEVICE_BUILD" == "true" ) ]]; then
-						echo "Download of $PKG$([[ "${TERMUX_WITHOUT_DEPVERSION_BINDING}" == "false" && "${cyclic_dependence}" == "false" ]] && echo "@$DEP_VERSION") from $TERMUX_REPO_URL failed"
-						return 1
-					else
-						echo "Download of $pkg_versioned from $TERMUX_REPO_URL failed, building instead"
-						build_dependency=true
-					fi
+					[[ "$cyclic_dependence" == "true" || ( "$TERMUX_FORCE_BUILD_DEPENDENCIES" == "true" && "$TERMUX_ON_DEVICE_BUILD" == "true" ) ]] \
+						&& termux_error_exit "Download of $PKG$([[ "${TERMUX_WITHOUT_DEPVERSION_BINDING}" == "false" && "${cyclic_dependence}" == "false" ]] && echo "@$DEP_VERSION") from $TERMUX_REPO_URL failed"
+					echo "Download of $pkg_versioned from $TERMUX_REPO_URL failed, building instead"
+					build_dependency="true"
 				fi
 			fi
 			if [[ "$cyclic_dependence" == "false" ]]; then
-				if $build_dependency; then
-					termux_run_build-package
-					continue
-				fi
+				[[ "$build_dependency" == "true" ]] && termux_run_build-package && continue
 				termux_add_package_to_built_packages_list "$PKG"
 			fi
 			if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
 				[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo "extracting $PKG to $TERMUX_COMMON_CACHEDIR-$DEP_ARCH..."
 				(
-					cd $TERMUX_COMMON_CACHEDIR-$DEP_ARCH
+					cd "$TERMUX_COMMON_CACHEDIR-$DEP_ARCH"
 					if [[ "$TERMUX_REPO_PKG_FORMAT" == "debian" ]]; then
 						# Ignore topdir `.`, to avoid possible  permission errors from tar
-						ar p ${PKG}_${DEP_VERSION}_${DEP_ARCH}.deb data.tar.xz | \
+						ar p "${PKG}_${DEP_VERSION}_${DEP_ARCH}.deb data.tar.xz" | \
 							tar xJ --no-overwrite-dir --transform='s#^.$#data#' -C /
 					elif [[ "$TERMUX_REPO_PKG_FORMAT" == "pacman" ]]; then
 						tar -xJf "${PKG}-${DEP_VERSION_PAC}-${DEP_ARCH}.pkg.tar.xz" \
@@ -82,28 +63,20 @@ termux_step_get_dependencies() {
 					fi
 				)
 			fi
-			mkdir -p $TERMUX_BUILT_PACKAGES_DIRECTORY
+			mkdir -p "$TERMUX_BUILT_PACKAGES_DIRECTORY"
 			if [[ "$cyclic_dependence" == "false" && ( "$TERMUX_WITHOUT_DEPVERSION_BINDING" == "false" || "$TERMUX_ON_DEVICE_BUILD" == "false" ) ]]; then
 				echo "$DEP_VERSION" > "$TERMUX_BUILT_PACKAGES_DIRECTORY/$PKG"
 			fi
-		else
-		# Build dependencies
-			if [[ -z "$PKG" ]]; then
-				continue
-			elif [[ "$PKG" == "ERROR" ]]; then
-				termux_error_exit "Obtaining buildorder failed"
-			fi
+		else # Build dependencies
 			# Built dependencies are put in the default TERMUX_OUTPUT_DIR instead of the specified one
 			if [[ "$TERMUX_FORCE_BUILD_DEPENDENCIES" == "true" ]]; then
-				[[ "$TERMUX_QUIET_BUILD" != true ]] && echo "Force building dependency $PKG..."
-				if [[ "$TERMUX_ON_DEVICE_BUILD" == "true" ]] && ! termux_package__is_package_on_device_build_supported "$PKG_DIR"; then
-					echo "Building $PKG on device is not supported. Consider passing -I flag to download it instead"
-					return 1
-				fi
-				read DEP_ARCH DEP_VERSION DEP_VERSION_PAC < <(termux_extract_dep_info $PKG "${PKG_DIR}")
+				[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo "Force building dependency $PKG..."
+				read -r DEP_ARCH DEP_VERSION DEP_VERSION_PAC DEP_ON_DEVICE_NOT_SUPPORTED < <(termux_extract_dep_info $PKG "${PKG_DIR}")
+				[[ "$TERMUX_ON_DEVICE_BUILD" == "true" && "$DEP_ON_DEVICE_NOT_SUPPORTED" == "true" ]] \
+					&& termux_error_exit "Building $PKG on device is not supported. Consider passing -I flag to download it instead"
 				termux_force_check_package_dependency && continue
 			else
-				[[ "$TERMUX_QUIET_BUILD" != true ]] && echo "Building dependency $PKG if necessary..."
+				[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo "Building dependency $PKG if necessary..."
 			fi
 			termux_run_build-package
 		fi
@@ -120,7 +93,7 @@ termux_force_check_package_dependency() {
 
 termux_run_build-package() {
 	local set_library
-	if [ "$TERMUX_GLOBAL_LIBRARY" = "true" ]; then
+	if [[ "$TERMUX_GLOBAL_LIBRARY" = "true" ]]; then
 		set_library="$TERMUX_PACKAGE_LIBRARY -L"
 	else
 		set_library="bionic"
@@ -129,18 +102,18 @@ termux_run_build-package() {
 		fi
 	fi
 	TERMUX_BUILD_IGNORE_LOCK=true ./build-package.sh \
- 		$([[ "${TERMUX_INSTALL_DEPS}" == "true" ]] && echo "-I" || echo "-s") \
- 		$([[ "${TERMUX_FORCE_BUILD}" == "true" && "${TERMUX_FORCE_BUILD_DEPENDENCIES}" == "true" ]] && echo "-F") \
- 		$([[ "${TERMUX_PKGS__BUILD__RM_ALL_PKG_BUILD_DEPENDENT_DIRS}" == "true" ]] && echo "-r") \
-   		$([[ "${TERMUX_WITHOUT_DEPVERSION_BINDING}" = "true" ]] && echo "-w") \
-     		--format $TERMUX_PACKAGE_FORMAT --library $set_library "${PKG_DIR}"
+		$([[ "${TERMUX_INSTALL_DEPS}" == "true" ]] && echo "-I" || echo "-s") \
+		$([[ "${TERMUX_FORCE_BUILD}" == "true" && "${TERMUX_FORCE_BUILD_DEPENDENCIES}" == "true" ]] && echo "-F") \
+		$([[ "${TERMUX_PKGS__BUILD__RM_ALL_PKG_BUILD_DEPENDENT_DIRS}" == "true" ]] && echo "-r") \
+		$([[ "${TERMUX_WITHOUT_DEPVERSION_BINDING}" = "true" ]] && echo "-w") \
+			--format $TERMUX_PACKAGE_FORMAT --library $set_library "${PKG_DIR}"
 }
 
 termux_download_repo_file() {
 	termux_get_repo_files
 
 	# When doing build on device, ensure that apt lists are up-to-date.
-	if [ "$TERMUX_ON_DEVICE_BUILD" = "true" ]; then
+	if [[ "$TERMUX_ON_DEVICE_BUILD" = "true" ]]; then
 		case "$TERMUX_APP_PACKAGE_MANAGER" in
 			"apt") apt update;;
 			"pacman") pacman -Sy;;

--- a/scripts/build/termux_step_setup_cgct_environment.sh
+++ b/scripts/build/termux_step_setup_cgct_environment.sh
@@ -33,7 +33,7 @@ termux_step_setup_cgct_environment() {
 			termux_error_exit "Could not find '${PKG_DIR_SPLIT[-3]}' repo"
 		fi
 
-		read DEP_ARCH DEP_VERSION DEP_VERSION_PAC <<< $(termux_extract_dep_info $PKG "${PKG_DIR/'/build.sh'/}")
+		read -r DEP_ARCH DEP_VERSION DEP_VERSION_PAC _ < <(termux_extract_dep_info $PKG "${PKG_DIR/'/build.sh'/}")
 
 		if ! termux_package__is_package_version_built "$PKG" "$DEP_VERSION" && [ ! -f "$TERMUX_BUILT_PACKAGES_DIRECTORY/$PKG-for-cgct" ]; then
 			[ ! "$TERMUX_QUIET_BUILD" = "true" ] && echo "Installing '${PKG}' for the CGCT tool environment."


### PR DESCRIPTION
Deduplicated some code.
Reduced one sourcing bash script per package for speed by extracting `TERMUX_PKG_ON_DEVICE_BUILD_NOT_SUPPORTED` during `termux_extract_dep_info`.
Enquotted previously not quotted strings for consistency with other similar places in scripts.
Removed treating variable as a command, replaced with explicit comparing with `true` literal.
Condensed/compacted some conditional blocks by applying short-circuit evaluation to reduce excessive code verbosity.

That is the last change before implementing parallel dependency download (to make CI build packages faster).