### PR TITLE
bump(main/nodejs): 24.1.0

### DIFF
--- a/packages/nodejs/build.sh
+++ b/packages/nodejs/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://nodejs.org/
 TERMUX_PKG_DESCRIPTION="Open Source, cross-platform JavaScript runtime environment"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Yaksh Bariya <thunder-coding@termux.dev>"
-TERMUX_PKG_VERSION=24.0.2
+TERMUX_PKG_VERSION=24.1.0
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=1597075afc06e5c6145d0bfbd77e2072c2ec0ab71ac4950cf008b2641374cd71
+TERMUX_PKG_SHA256=c8171b2aeccb28c8c5347f273a25adae172fb2a65bc8c975bc22ec58949d0eaf
 # thunder-coding: don't try to autoupdate nodejs, that thing takes 2 whole hours to build for a single arch, and requires a lot of patch updates everytime. Also I run tests everytime I update it to ensure least bugs
 TERMUX_PKG_AUTO_UPDATE=false
 # Note that we do not use a shared libuv to avoid an issue with the Android

--- a/packages/nodejs/build.sh
+++ b/packages/nodejs/build.sh
@@ -135,9 +135,15 @@ termux_step_configure() {
 	fi
 
 	export GYP_DEFINES="host_os=linux"
-	export CC_host="$TERMUX_PKG_HOSTBUILD_DIR/llvm-project/build/bin/clang"
-	export CXX_host="$TERMUX_PKG_HOSTBUILD_DIR/llvm-project/build/bin/clang++"
-	export LINK_host="$TERMUX_PKG_HOSTBUILD_DIR/llvm-project/build/bin/clang++"
+	if [ "$TERMUX_ARCH_BITS" = "64" ]; then
+		export CC_host="$TERMUX_PKG_HOSTBUILD_DIR/llvm-project/build/bin/clang"
+		export CXX_host="$TERMUX_PKG_HOSTBUILD_DIR/llvm-project/build/bin/clang++"
+		export LINK_host="$TERMUX_PKG_HOSTBUILD_DIR/llvm-project/build/bin/clang++"
+	else
+		export CC_host="$TERMUX_PKG_HOSTBUILD_DIR/llvm-project/build/bin/clang -m32"
+		export CXX_host="$TERMUX_PKG_HOSTBUILD_DIR/llvm-project/build/bin/clang++ -m32"
+		export LINK_host="$TERMUX_PKG_HOSTBUILD_DIR/llvm-project/build/bin/clang++ -m32"
+	fi
 	LDFLAGS+=" -ldl"
 	# See note above TERMUX_PKG_DEPENDS why we do not use a shared libuv.
 	# When building with ninja, build.ninja is generated for both Debug and Release builds.

--- a/packages/nodejs/build.sh
+++ b/packages/nodejs/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://nodejs.org/
 TERMUX_PKG_DESCRIPTION="Open Source, cross-platform JavaScript runtime environment"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Yaksh Bariya <thunder-coding@termux.dev>"
-TERMUX_PKG_VERSION=23.11.1
+TERMUX_PKG_VERSION=24.0.2
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=aef6c67395c328376b665bceefc9d17a06a2961f9a92b93019dff39854d5b2ef
+TERMUX_PKG_SHA256=1597075afc06e5c6145d0bfbd77e2072c2ec0ab71ac4950cf008b2641374cd71
 # thunder-coding: don't try to autoupdate nodejs, that thing takes 2 whole hours to build for a single arch, and requires a lot of patch updates everytime. Also I run tests everytime I update it to ensure least bugs
 TERMUX_PKG_AUTO_UPDATE=false
 # Note that we do not use a shared libuv to avoid an issue with the Android

--- a/packages/nodejs/common.gypi.patch
+++ b/packages/nodejs/common.gypi.patch
@@ -11,17 +11,3 @@
            ['clang==1', {
              'msbuild_toolset': 'ClangCL',
            }],
-@@ -520,11 +516,11 @@
-           }],
-           ['_toolset=="host"', {
-             'conditions': [
--              [ 'host_arch=="ia32"', {
-+              [ 'host_arch=="ia32" or (target_arch=="ia32" or target_arch=="arm")', {
-                 'cflags': [ '-m32' ],
-                 'ldflags': [ '-m32' ],
-               }],
--              [ 'host_arch=="x64"', {
-+              [ 'host_arch=="x64" and (target_arch=="x64" or target_arch=="arm64")', {
-                 'cflags': [ '-m64' ],
-                 'ldflags': [ '-m64' ],
-               }],

--- a/packages/nodejs/deps-v8-src-trap-handler-trap-handler.h.patch
+++ b/packages/nodejs/deps-v8-src-trap-handler-trap-handler.h.patch
@@ -1,18 +1,17 @@
-diff -u -r ../node-v22.2.0/deps/v8/src/trap-handler/trap-handler.h ./deps/v8/src/trap-handler/trap-handler.h
---- ../node-v22.2.0/deps/v8/src/trap-handler/trap-handler.h	2024-05-15 12:35:03.000000000 +0000
-+++ ./deps/v8/src/trap-handler/trap-handler.h	2024-05-30 20:41:54.491637576 +0000
-@@ -17,45 +17,7 @@
- namespace internal {
- namespace trap_handler {
+--- ./deps/v8/src/trap-handler/trap-handler.h.orig	2025-05-08 13:56:19.000000000 +0530
++++ ./deps/v8/src/trap-handler/trap-handler.h	2025-05-09 19:48:23.129472068 +0530
+@@ -15,45 +15,7 @@
+ 
+ namespace v8::internal::trap_handler {
  
 -// X64 on Linux, Windows, MacOS, FreeBSD.
 -#if V8_HOST_ARCH_X64 && V8_TARGET_ARCH_X64 &&                        \
 -    ((V8_OS_LINUX && !V8_OS_ANDROID) || V8_OS_WIN || V8_OS_DARWIN || \
 -     V8_OS_FREEBSD)
 -#define V8_TRAP_HANDLER_SUPPORTED true
--// Arm64 (non-simulator) on Mac and Linux.
+-// Arm64 (non-simulator) on Linux, Windows, MacOS.
 -#elif V8_TARGET_ARCH_ARM64 && V8_HOST_ARCH_ARM64 && \
--    (V8_OS_DARWIN || (V8_OS_LINUX && !V8_OS_ANDROID))
+-    ((V8_OS_LINUX && !V8_OS_ANDROID) || V8_OS_WIN || V8_OS_DARWIN)
 -#define V8_TRAP_HANDLER_SUPPORTED true
 -// Arm64 simulator on x64 on Linux, Mac, or Windows.
 -//
@@ -33,7 +32,8 @@ diff -u -r ../node-v22.2.0/deps/v8/src/trap-handler/trap-handler.h ./deps/v8/src
 -#define V8_TRAP_HANDLER_VIA_SIMULATOR
 -#define V8_TRAP_HANDLER_SUPPORTED true
 -// RISCV64 (non-simulator) on Linux.
--#elif V8_TARGET_ARCH_RISCV64 && V8_HOST_ARCH_RISCV64 && V8_OS_LINUX
+-#elif V8_TARGET_ARCH_RISCV64 && V8_HOST_ARCH_RISCV64 && V8_OS_LINUX && \
+-    !V8_OS_ANDROID
 -#define V8_TRAP_HANDLER_SUPPORTED true
 -// RISCV64 simulator on x64 on Linux
 -#elif V8_TARGET_ARCH_RISCV64 && V8_HOST_ARCH_X64 && V8_OS_LINUX
@@ -43,7 +43,6 @@ diff -u -r ../node-v22.2.0/deps/v8/src/trap-handler/trap-handler.h ./deps/v8/src
 -#else
  #define V8_TRAP_HANDLER_SUPPORTED false
 -#endif
--
+ 
  #if V8_OS_ANDROID && V8_TRAP_HANDLER_SUPPORTED
  // It would require some careful security review before the trap handler
- // can be enabled on Android.  Android may do unexpected things with signal

--- a/packages/nodejs/node.gyp.patch
+++ b/packages/nodejs/node.gyp.patch
@@ -1,6 +1,6 @@
---- ./node.gyp.orig	2025-02-13 17:23:54.000000000 +0530
-+++ ./node.gyp	2025-02-26 15:30:38.507113531 +0530
-@@ -532,7 +532,8 @@
+--- ./node.gyp.orig	2025-05-08 13:56:21.000000000 +0530
++++ ./node.gyp	2025-05-09 19:47:04.157493775 +0530
+@@ -534,7 +534,8 @@
        ],
  
        'sources': [
@@ -10,7 +10,7 @@
        ],
  
        'dependencies': [
-@@ -1012,302 +1013,7 @@
+@@ -1019,303 +1020,6 @@
          },
        ],
      }, # node_lib_target_name
@@ -155,6 +155,7 @@
 -        'deps/googletest/googletest.gyp:gtest_main',
 -        'deps/histogram/histogram.gyp:histogram',
 -        'deps/nbytes/nbytes.gyp:nbytes',
+-        'tools/v8_gypfiles/abseil.gyp:abseil',
 -      ],
 -
 -      'includes': [
@@ -236,7 +237,7 @@
 -    {
 -      'target_name': 'embedtest',
 -      'type': 'executable',
- 
+-
 -      'dependencies': [
 -        '<(node_lib_target_name)',
 -        'deps/histogram/histogram.gyp:histogram',
@@ -313,7 +314,7 @@
      {
        'target_name': 'node_js2c',
        'type': 'executable',
-@@ -1344,76 +1050,6 @@
+@@ -1352,76 +1056,6 @@
          }],
        ]
      },

--- a/packages/nodejs/tools-v8_gypfiles-v8.gyp.patch
+++ b/packages/nodejs/tools-v8_gypfiles-v8.gyp.patch
@@ -1,15 +1,15 @@
---- ./tools/v8_gypfiles/v8.gyp.orig	2025-02-13 17:23:55.000000000 +0530
-+++ ./tools/v8_gypfiles/v8.gyp	2025-03-01 22:23:08.640009780 +0530
-@@ -1351,7 +1351,7 @@
-         }],
+--- ./tools/v8_gypfiles/v8.gyp.orig	2025-05-08 13:56:23.000000000 +0530
++++ ./tools/v8_gypfiles/v8.gyp	2025-05-09 19:46:24.096599118 +0530
+@@ -1309,7 +1309,7 @@
          # Platforms that don't have Compare-And-Swap (CAS) support need to link atomic library
-         # to implement atomic memory access
--        ['v8_current_cpu in ["mips64", "mips64el", "ppc", "arm", "riscv64", "loong64"]', {
-+        ['((OS=="linux" or OS=="android") and clang==1) or (v8_current_cpu in ["mips64", "mips64el", "ppc", "arm", "riscv64", "loong64"])', {
+         # to implement atomic memory access.
+         # Clang needs it for some atomic operations (https://clang.llvm.org/docs/Toolchain.html#atomics-library).
+-        ['(OS=="linux" and clang==1) or (v8_current_cpu in ["mips64", "mips64el", "arm", "riscv64", "loong64"])', {
++        ['((OS=="linux" or OS=="android") and clang==1) or (v8_current_cpu in ["mips64", "mips64el", "arm", "riscv64", "loong64"])', {
            'link_settings': {
              'libraries': ['-latomic', ],
            },
-@@ -1495,6 +1495,7 @@
+@@ -1448,6 +1448,7 @@
              '<(V8_ROOT)/src/base/platform/platform-posix.h',
              '<(V8_ROOT)/src/base/platform/platform-posix-time.cc',
              '<(V8_ROOT)/src/base/platform/platform-posix-time.h',
@@ -17,7 +17,7 @@
            ],
            'link_settings': {
              'target_conditions': [
-@@ -2017,12 +2018,12 @@
+@@ -1973,12 +1974,12 @@
              ],
            }, { # 'OS!="win"'
              'conditions': [

--- a/packages/nodejs/tools-v8_gypfiles-v8.gyp.patch
+++ b/packages/nodejs/tools-v8_gypfiles-v8.gyp.patch
@@ -17,18 +17,3 @@
            ],
            'link_settings': {
              'target_conditions': [
-@@ -1973,12 +1974,12 @@
-             ],
-           }, { # 'OS!="win"'
-             'conditions': [
--              ['_toolset == "host" and host_arch == "x64" or _toolset == "target" and target_arch=="x64"', {
-+              ['_toolset == "host" and host_arch == "x64" and (target_arch == "x64" or target_arch == "arm64") or (_toolset == "target" and target_arch == "x64")', {
-                 'sources': [
-                   '<(V8_ROOT)/src/heap/base/asm/x64/push_registers_asm.cc',
-                 ],
-               }],
--              ['_toolset == "host" and host_arch == "ia32" or _toolset == "target" and target_arch=="ia32"', {
-+              ['_toolset == "host" and host_arch == "x64" and (target_arch == "arm" or target_arch == "ia32") or (_toolset == "target" and target_arch == "ia32")', {
-                 'sources': [
-                   '<(V8_ROOT)/src/heap/base/asm/ia32/push_registers_asm.cc',
-                 ],


### PR DESCRIPTION
A lot of tests are failing in comparision to v23.x releases. In v23.x I had managed to squash down the number of tests failing to less than 20, with most of them being due to permissions, and would pass on rooted devices. Let's hope to do the same once again. And since this is the latest release, I don't plan to fix all the tests in one go, may go ahead with keeping the tests broke for time and incrementally fix them. Users who want stable and highly test version of node are requested to use the LTS package (nodejs-lts) instead to install the latest LTS release

List of failing tests:

~~TODO, the tests are still running on my device, so it's going to take some time to list them :)~~ The tests were failing because I was running v24.0.1 tests with v22 nodejs binary, there are no significant regression as pointed out by test failures. There is some regression in sqlite module, but it is experimental, so I am ignoring it
