### PR TITLE
addpkg(x11/code-oss-extension-codelldb): 1.11.5

### DIFF
--- a/x11-packages/vsix-package-codelldb/CMakeLists.txt.patch
+++ b/x11-packages/vsix-package-codelldb/CMakeLists.txt.patch
@@ -1,0 +1,47 @@
+AllowedDependencies is only used for the testsuite
+LLDB_PACKAGE is replaced with the absolute path to $TERMUX_PREFIX in lldb-paths.patch
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -19,8 +19,6 @@ message("Version ${VERSION}")
+ set(LLDB_PACKAGE $ENV{LLDB_PACKAGE} CACHE PATH "Zip archive containing LLDB files")
+ if (LLDB_PACKAGE)
+     message("Using LLDB_PACKAGE=${LLDB_PACKAGE}")
+-else()
+-    message(FATAL_ERROR "LLDB_PACKAGE not set." )
+ endif()
+ 
+ if (CMAKE_SYSROOT)
+@@ -34,7 +34,17 @@ set(WithEnv ${CMAKE_COMMAND} -E env)
+ set(UpdateFile ${CMAKE_COMMAND} -E copy_if_different)
+ 
+ # General OS-specific definitions
+-if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
++if (${CMAKE_SYSTEM_NAME} STREQUAL "Android")
++    set(Python python3)
++    set(LibPrefix lib)
++    set(LibSuffix .a)
++    set(DylibSuffix .so)
++    set(NPM npm)
++    set(PathSep ":")
++    set(DefaultTarget "${CARGO_TARGET_NAME}")
++    set(DefaultPlatformId "${VSIX_PLATFORM}")
++    set(AllowedDependencies "N/A")
++elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+     set(Python python3)
+     set(LibPrefix lib)
+     set(LibSuffix .a)
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -98,10 +108,9 @@ endif()
+ # Adapter
+ 
+ add_subdirectory(adapter)
+-add_subdirectory(lldb)
+ add_subdirectory(lang_support)
+ 
+-add_dependencies(adapter lldb lang_support)
++add_dependencies(adapter lang_support)
+ 
+ if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+     configure_file(cargo_config.windows.toml ${CMAKE_BINARY_DIR}/.cargo/config.toml)

--- a/x11-packages/vsix-package-codelldb/adapter-CMakeLists.txt.patch
+++ b/x11-packages/vsix-package-codelldb/adapter-CMakeLists.txt.patch
@@ -1,0 +1,27 @@
+--- a/adapter/CMakeLists.txt
++++ b/adapter/CMakeLists.txt
+@@ -31,8 +31,13 @@ add_custom_target(adapter
+ 
+ set(CodelldbExe codelldb${ExeSuffix})
+ set(CargoOutDir ${CMAKE_BINARY_DIR}/target/${LLVM_TRIPLE}/${CargoBuildType})
+-
+-if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
++if (${CMAKE_SYSTEM_NAME} STREQUAL "Android")
++    set(RustcFlags
++        -Csplit-debuginfo=packed
++        -Clink-arg=-fuse-ld=lld
++        -Clink-arg=-lc++
++    )
++elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+     set(RustcFlags
+         -Csplit-debuginfo=packed
+         -Clink-arg=-fuse-ld=lld
+@@ -59,8 +59,6 @@ externalproject_add(cargo_build
+     INSTALL_COMMAND ""
+ )
+ 
+-add_dependencies(cargo_build lldb)
+-
+ # Exe
+ add_custom_target(codelldb_exe
+     COMMAND ${UpdateFile} ${CargoOutDir}/${CodelldbExe} ${CMAKE_CURRENT_BINARY_DIR}

--- a/x11-packages/vsix-package-codelldb/build.sh
+++ b/x11-packages/vsix-package-codelldb/build.sh
@@ -1,0 +1,62 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/vadimcn/codelldb
+TERMUX_PKG_DESCRIPTION="A native debugger extension for VSCode based on LLDB"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="1.11.5"
+TERMUX_PKG_SRCURL="https://github.com/vadimcn/codelldb/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=87ff4a444dbd0c6c9bcf1ac5527485355a400e9bee2386d7b0d33c70eeca188e
+TERMUX_PKG_AUTO_UPDATE=true
+# lldb does not support 32-bit
+TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"
+TERMUX_PKG_DEPENDS="lldb"
+TERMUX_CMAKE_BUILD="Unix Makefiles"
+TERMUX_PKG_EXTRA_MAKE_ARGS="vsix_full"
+
+termux_step_pre_configure() {
+	termux_setup_nodejs
+	termux_setup_rust
+
+	# codelldb is a project that uses CMake in a slightly nonstandard way
+	# (there is a place where the CMake build directory is hardcoded to
+	# "[source directory]/build")
+	# upstream only supports their official releases and not custom builds,
+	# so this is not planned to be fixed upstream
+	patch="$TERMUX_PKG_BUILDER_DIR/fix-tsconfig-cmake-builddir-path.diff"
+	echo "Applying patch: $(basename "$patch")"
+	test -f "$patch" && sed \
+		-e "s%\@TERMUX_PKG_BUILDDIR\@%${TERMUX_PKG_BUILDDIR}%g" \
+		"$patch" | patch --silent -p1 -d"$TERMUX_PKG_SRCDIR"
+
+	case $TERMUX_ARCH in
+		"aarch64") VSIX_ARCH="arm64";;
+		"x86_64") VSIX_ARCH="x64";;
+		*) termux_error_exit "${TERMUX_ARCH} is not a supported architecture."
+	esac
+
+	: "${CARGO_HOME:=$HOME/.cargo}"
+	export CARGO_HOME
+	rm -rf "$CARGO_HOME"/git/checkouts/weaklink-*
+
+	cargo fetch --target "${CARGO_TARGET_NAME}"
+
+	for dir in "$CARGO_HOME"/git/checkouts/weaklink-*/*; do
+		patch --silent -p1 \
+			-d "$dir" \
+			< "$TERMUX_PKG_BUILDER_DIR"/weaklink-android.diff
+	done
+
+	# goes with CMakeLists.txt.patch
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DCARGO_TARGET_NAME=$CARGO_TARGET_NAME -DVSIX_PLATFORM=linux-$VSIX_ARCH"
+
+	# avoids 'gyp: Undefined variable android_ndk_path in binding.gyp while trying to load binding.gyp'
+	export GYP_DEFINES="android_ndk_path=''"
+}
+
+termux_step_make_install() {
+	install -DTm644 "$TERMUX_PKG_BUILDDIR/codelldb-full.vsix" \
+		"$TERMUX_PREFIX/opt/vsix-packages/codelldb-$TERMUX_PKG_FULLVERSION.vsix"
+
+	# subpackage file
+	install -DTm644 "$TERMUX_PKG_SRCDIR/LICENSE" \
+		"$TERMUX_PREFIX/share/doc/code-oss-extension-codelldb/copyright"
+}

--- a/x11-packages/vsix-package-codelldb/code-oss-extension-codelldb.subpackage.sh
+++ b/x11-packages/vsix-package-codelldb/code-oss-extension-codelldb.subpackage.sh
@@ -1,0 +1,21 @@
+TERMUX_SUBPKG_DESCRIPTION="A native debugger extension for code-oss based on LLDB"
+TERMUX_SUBPKG_INCLUDE="share/doc/code-oss-extension-codelldb"
+TERMUX_SUBPKG_DEPENDS="code-oss"
+TERMUX_SUBPKG_PLATFORM_INDEPENDENT=true
+
+termux_step_create_subpkg_debscripts() {
+	cat <<-EOF >./postinst
+		#!${TERMUX_PREFIX}/bin/sh
+		code-oss --install-extension "$TERMUX_PREFIX/opt/vsix-packages/codelldb-$TERMUX_PKG_FULLVERSION.vsix"
+		exit 0
+	EOF
+	cat <<-EOF >./prerm
+		#!${TERMUX_PREFIX}/bin/sh
+		if [ "$TERMUX_PACKAGE_FORMAT" = "debian" ] && [ "\$1" != "remove" ]; then
+			exit 0
+		fi
+		code-oss --uninstall-extension vadimcn.vscode-lldb
+		exit 0
+	EOF
+	chmod +x ./postinst ./prerm
+}

--- a/x11-packages/vsix-package-codelldb/disable-sbapi.patch
+++ b/x11-packages/vsix-package-codelldb/disable-sbapi.patch
@@ -1,0 +1,58 @@
+This entire structure is used to detect whether the LLDB being used
+has SBInstruction::GetControlFlowKind(), which LLDB versions 16 and newer have.
+Termux has had LLDB version 16 or newer since 2023.
+
+
+--- a/adapter/lldb-stub/build.rs
++++ b/adapter/lldb-stub/build.rs
+@@ -32,21 +32,6 @@ fn main() -> Result<(), Error> {
+ 
+     let mut wl_config = weaklink_build::Config::new("liblldb");
+ 
+-    // Generate optional api groups via SBAPI.toml
+-    let api_groups = get_api_groups("SBAPI.toml")?;
+-    for (version, imports) in api_groups {
+-        for imp in &imports {
+-            if !common_syms.remove(&imp.name) {
+-                println!(
+-                    "cargo:warning=Symbol \"{}\" is declared in {version}, but isn't used by codelldb.",
+-                    imp.name
+-                );
+-            }
+-        }
+-        let symbols: Vec<_> = imports.iter().map(|e| SymbolStub::new(&e.name)).collect();
+-        wl_config.add_symbol_group(version.as_str(), symbols)?;
+-    }
+-
+     // Emit the rest of common symbols as base group.
+     let symbols: Vec<_> = exports
+         .into_iter()
+--- a/adapter/codelldb/src/debug_session.rs
++++ b/adapter/codelldb/src/debug_session.rs
+@@ -613,7 +613,7 @@ impl DebugSession {
+             supports_read_memory_request: Some(true),
+             supports_restart_request: Some(true),
+             supports_set_variable: Some(true),
+-            supports_step_in_targets_request: Some(lldb_stub::v16.resolve().is_ok()),
++            supports_step_in_targets_request: Some(true),
+             supports_stepping_granularity: Some(true),
+             supports_write_memory_request: Some(true),
+             ..Default::default()
+--- a/adapter/codelldb/src/debug_session/step_in.rs
++++ b/adapter/codelldb/src/debug_session/step_in.rs
+@@ -34,7 +34,6 @@ impl super::DebugSession {
+         let Some(cu) = frame.compile_uint() else {
+             bail!("No compile unit for frame.");
+         };
+-        let _token = lldb_stub::v16.resolve()?;
+ 
+         // This is the typical case we aim to handle:
+         // ```
+--- a/adapter/lldb/src/lib.rs
++++ b/adapter/lldb/src/lib.rs
+@@ -26,5 +26,4 @@ fn test_init() {
+     use std::path::Path;
+     lldb_stub::liblldb.load_from(Path::new(env!("LLDB_DYLIB"))).unwrap();
+     lldb_stub::base.resolve().unwrap().mark_permanent();
+-    lldb_stub::v16.resolve().unwrap().mark_permanent();
+ }

--- a/x11-packages/vsix-package-codelldb/fix-tsconfig-cmake-builddir-path.diff
+++ b/x11-packages/vsix-package-codelldb/fix-tsconfig-cmake-builddir-path.diff
@@ -1,0 +1,16 @@
+--- a/extension/tsconfig.json
++++ b/extension/tsconfig.json
+@@ -11,11 +11,11 @@
+ 		"sourceMap": true,
+ 		"baseUrl": ".",
+ 		"typeRoots": [
+-			"../build/node_modules/@types",
++			"@TERMUX_PKG_BUILDDIR@/node_modules/@types",
+ 		],
+ 		"paths": {
+ 			"*": [
+-				"../build/node_modules/*",
++				"@TERMUX_PKG_BUILDDIR@/node_modules/*",
+ 			]
+ 		}
+ 	}

--- a/x11-packages/vsix-package-codelldb/lldb-paths.patch
+++ b/x11-packages/vsix-package-codelldb/lldb-paths.patch
@@ -1,0 +1,25 @@
+Direct the extension to search for LLDB in $TERMUX_PREFIX/bin and $TERMUX_PREFIX/lib instead
+of in the extension's own installation folder
+
+--- a/extension/main.ts
++++ b/extension/main.ts
+@@ -374,7 +374,7 @@ class Extension implements DebugConfigurationProvider, DebugAdapterDescriptorFac
+             if (liblldb) {
+                 liblldb = await adapter.findLibLLDB(liblldb)
+             } else {
+-                liblldb = await adapter.findLibLLDB(path.join(this.context.extensionPath, 'lldb'));
++                liblldb = await adapter.findLibLLDB('@TERMUX_PREFIX@');
+             }
+             this.adapterDylibsCache = [liblldb];
+         }
+--- a/cargo_config.unix.toml
++++ b/cargo_config.unix.toml
+@@ -10,6 +10,6 @@ CXX_${LLVM_TRIPLE} = "${CMAKE_CXX_COMPILER}"
+ CFLAGS_${LLVM_TRIPLE} = "${CMAKE_C_FLAGS}"
+ CXXFLAGS_${LLVM_TRIPLE} = "${CMAKE_CXX_FLAGS}"
+ 
+-LLDB_INCLUDE = "${LLDB_INCLUDE}"
+-LLDB_DYLIB = "${CMAKE_BINARY_DIR}/lldb/lib/liblldb${DylibSuffix}"
++LLDB_INCLUDE = "@TERMUX_PREFIX@/include"
++LLDB_DYLIB = "@TERMUX_PREFIX@/lib/liblldb.so"
+ ADAPTER_SOURCE_DIR = "${CMAKE_SOURCE_DIR}/adapter"

--- a/x11-packages/vsix-package-codelldb/main.rs.patch
+++ b/x11-packages/vsix-package-codelldb/main.rs.patch
@@ -1,0 +1,11 @@
+--- a/adapter/codelldb/bin/main.rs
++++ b/adapter/codelldb/bin/main.rs
+@@ -31,7 +31,7 @@ fn main() -> Result<(), Error> {
+         #[cfg(windows)]
+         pub const DYLIB_SUBDIR: &str = "bin";
+ 
+-        #[cfg(target_os = "linux")]
++        #[cfg(any(target_os = "linux", target_os = "android"))]
+         pub const DYLIB_EXTENSION: &str = "so";
+         #[cfg(target_os = "macos")]
+         pub const DYLIB_EXTENSION: &str = "dylib";

--- a/x11-packages/vsix-package-codelldb/weaklink-android.diff
+++ b/x11-packages/vsix-package-codelldb/weaklink-android.diff
@@ -1,0 +1,20 @@
+In Android, RTLD_LOCAL is 0x0 and RTLD_GLOBAL is 0x100, just like GNU/Linux
+https://android.googlesource.com/platform/bionic/+/refs/heads/main/libc/include/dlfcn.h#181
+
+--- a/weaklink/src/loading.rs
++++ b/weaklink/src/loading.rs
+@@ -27,12 +27,12 @@ pub mod unix {
+     pub const RTLD_LAZY: c_int = 0x0001;
+     pub const RTLD_NOW: c_int = 0x0002;
+ 
+-    #[cfg(target_os = "linux")]
++    #[cfg(any(target_os = "linux", target_os = "android"))]
+     pub const RTLD_LOCAL: c_int = 0x0000;
+     #[cfg(target_os = "macos")]
+     pub const RTLD_LOCAL: c_int = 0x0004;
+ 
+-    #[cfg(target_os = "linux")]
++    #[cfg(any(target_os = "linux", target_os = "android"))]
+     pub const RTLD_GLOBAL: c_int = 0x0100;
+     #[cfg(target_os = "macos")]
+     pub const RTLD_GLOBAL: c_int = 0x0008;


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/24715
- This single build works with both `code-oss` and also with another editor that exists somewhere else, but for the time being, only `code-oss` can be found in this Termux repository, so for now this package only references `code-oss` and could be expanded to have a subpackage that depends on the other editor if it happens to come here in the future

![image](https://github.com/user-attachments/assets/0d12eea1-5eaa-41a0-ac59-2af54671805a)
