### PR TITLE
fix(x11/firefox): prepend `$TERMUX_PREFIX` to some absolute paths found in `nsXREDirProvider.cpp`

### DIFF
--- a/x11-packages/firefox/0029-prepend-prefix-to-nsXREDirProvider-absolute-paths.patch
+++ b/x11-packages/firefox/0029-prepend-prefix-to-nsXREDirProvider-absolute-paths.patch
@@ -1,0 +1,29 @@
+--- a/toolkit/xre/nsXREDirProvider.cpp
++++ b/toolkit/xre/nsXREDirProvider.cpp
+@@ -294,7 +294,7 @@ static nsresult GetSystemParentDirectory(nsIFile** aFile) {
+ #    elif defined(__OpenBSD__) || defined(__FreeBSD__)
+       "/usr/local/lib/mozilla"_ns
+ #    else
+-      "/usr/lib/mozilla"_ns
++      "@TERMUX_PREFIX@/lib/mozilla"_ns
+ #    endif
+       ;
+   rv = NS_NewNativeLocalFile(dirname, getter_AddRefs(localDir));
+@@ -400,7 +400,7 @@ nsXREDirProvider::GetFile(const char* aProperty, bool* aPersistent,
+ #    if defined(__OpenBSD__) || defined(__FreeBSD__)
+     static const char* const sysLExtDir = "/usr/local/share/mozilla/extensions";
+ #    else
+-    static const char* const sysLExtDir = "/usr/share/mozilla/extensions";
++    static const char* const sysLExtDir = "@TERMUX_PREFIX@/share/mozilla/extensions";
+ #    endif
+     rv = NS_NewNativeLocalFile(nsDependentCString(sysLExtDir),
+                                getter_AddRefs(file));
+@@ -413,7 +413,7 @@ nsXREDirProvider::GetFile(const char* aProperty, bool* aPersistent,
+ #endif
+   } else if (!strcmp(aProperty, XRE_USER_RUNTIME_DIR)) {
+ #if defined(XP_UNIX)
+-    nsPrintfCString path("/run/user/%d/%s/", getuid(), GetAppName());
++    nsPrintfCString path("@TERMUX_PREFIX@/var/run/user/%d/%s/", getuid(), GetAppName());
+     ToLowerCase(path);
+     rv = NS_NewNativeLocalFile(path, getter_AddRefs(file));
+ #endif

--- a/x11-packages/firefox/build.sh
+++ b/x11-packages/firefox/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Mozilla Firefox web browser"
 TERMUX_PKG_LICENSE="MPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="138.0.3"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://archive.mozilla.org/pub/firefox/releases/${TERMUX_PKG_VERSION}/source/firefox-${TERMUX_PKG_VERSION}.source.tar.xz
 TERMUX_PKG_SHA256=a27f3ab41d635b2a1d8418289d1dedcd6cb532148c7d63d3f8b97c66445513e4
 # ffmpeg and pulseaudio are dependencies through dlopen(3):


### PR DESCRIPTION
- This is a dependency of https://github.com/termux/termux-packages/pull/24708