### PR TITLE
scripts: make download or build of dependencies less verbose

### DIFF
--- a/scripts/build/termux_download_deb_pac.sh
+++ b/scripts/build/termux_download_deb_pac.sh
@@ -25,6 +25,7 @@ termux_download_deb_pac() {
 	fi
 
 	if [ "$TERMUX_ON_DEVICE_BUILD" = "true" ]; then
+		echo ""
 		case "$TERMUX_APP_PACKAGE_MANAGER" in
 			"apt") apt install -y "${PACKAGE}$(test ${TERMUX_WITHOUT_DEPVERSION_BINDING} != true && echo "=${VERSION}")";;
 			"pacman") pacman -S "${PACKAGE}$(test ${TERMUX_WITHOUT_DEPVERSION_BINDING} != true && echo "=${VERSION_PACMAN}")" --needed --noconfirm;;
@@ -54,9 +55,9 @@ termux_download_deb_pac() {
 					if [ -n "$PKG_HASH" ] && [ "$PKG_HASH" != "null" ]; then
 						if [ ! "$TERMUX_QUIET_BUILD" = true ]; then
 							if [ "$TERMUX_REPO_PKG_FORMAT" = "debian" ]; then
-								echo "Found $PACKAGE in ${TERMUX_REPO_URL[$idx-1]}/dists/${TERMUX_REPO_DISTRIBUTION[$idx-1]}"
+								echo "found $PACKAGE in ${TERMUX_REPO_URL[$idx-1]}/dists/${TERMUX_REPO_DISTRIBUTION[$idx-1]}"
 							elif [ "$TERMUX_REPO_PKG_FORMAT" = "pacman" ]; then
-								echo "Found $PACKAGE in ${TERMUX_REPO_URL[$idx-1]}"
+								echo "found $PACKAGE in ${TERMUX_REPO_URL[$idx-1]}"
 							fi
 						fi
 						break 2
@@ -82,9 +83,9 @@ termux_download_deb_pac() {
 			if [ -n "$PKG_HASH" ] && [ "$PKG_HASH" != "null" ]; then
 				if [ ! "$TERMUX_QUIET_BUILD" = true ]; then
 					if [ "$TERMUX_REPO_PKG_FORMAT" = "debian" ]; then
-						echo "Found $PACKAGE in ${TERMUX_REPO_URL[$idx-1]}/dists/${TERMUX_REPO_DISTRIBUTION[$idx-1]}"
+						echo "found $PACKAGE in ${TERMUX_REPO_URL[$idx-1]}/dists/${TERMUX_REPO_DISTRIBUTION[$idx-1]}"
 					elif [ "$TERMUX_REPO_PKG_FORMAT" = "pacman" ]; then
-						echo "Found $PACKAGE in ${TERMUX_REPO_URL[$idx-1]}"
+						echo "found $PACKAGE in ${TERMUX_REPO_URL[$idx-1]}"
 					fi
 				fi
 				break
@@ -102,9 +103,9 @@ termux_download_deb_pac() {
 			if [ -n "$PKG_HASH" ] && [ "$PKG_HASH" != "null" ]; then
 				if [ ! "$TERMUX_QUIET_BUILD" = true ]; then
 					if [ "$TERMUX_REPO_PKG_FORMAT" = "debian" ]; then
-						echo "Found $PACKAGE in ${TERMUX_REPO_URL[$idx-1]}/dists/${TERMUX_REPO_DISTRIBUTION[$idx-1]}"
+						echo "found $PACKAGE in ${TERMUX_REPO_URL[$idx-1]}/dists/${TERMUX_REPO_DISTRIBUTION[$idx-1]}"
 					elif [ "$TERMUX_REPO_PKG_FORMAT" = "pacman" ]; then
-						echo "Found $PACKAGE in ${TERMUX_REPO_URL[$idx-1]}"
+						echo "found $PACKAGE in ${TERMUX_REPO_URL[$idx-1]}"
 					fi
 				fi
 				break

--- a/scripts/build/termux_step_get_dependencies.sh
+++ b/scripts/build/termux_step_get_dependencies.sh
@@ -20,9 +20,9 @@ termux_step_get_dependencies() {
 			local pkg_versioned="$PKG" build_dependency="false" force_build_dependency="$TERMUX_FORCE_BUILD_DEPENDENCIES"
 			[[ "${TERMUX_WITHOUT_DEPVERSION_BINDING}" == "false" ]] && pkg_versioned+="@$DEP_VERSION"
 			if [[ "$cyclic_dependence" == "false" ]]; then
-				[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo "Downloading dependency $pkg_versioned if necessary..."
+				[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo -n "Downloading dependency $pkg_versioned if necessary... "
 				if [[ "$TERMUX_FORCE_BUILD_DEPENDENCIES" == "true" && "$TERMUX_ON_DEVICE_BUILD" == "true" && "$DEP_ON_DEVICE_NOT_SUPPORTED" == "true" ]]; then
-					echo "Building dependency $PKG on device is not supported. It will be downloaded..."
+					echo -n "building dependency $PKG on device is not supported. It will be downloaded... "
 					force_build_dependency="false"
 				fi
 			else
@@ -30,17 +30,17 @@ termux_step_get_dependencies() {
 			fi
 			if [[ "$force_build_dependency" = "true" ]]; then
 				termux_force_check_package_dependency && continue || :
-				[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo "Force building dependency $PKG instead of downloading due to -I flag..."
+				[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo -n "force building dependency $PKG instead of downloading due to -I flag... "
 				build_dependency="true"
 			else
 				if termux_package__is_package_version_built "$PKG" "$DEP_VERSION"; then
-					[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo "Skipping already built dependency $pkg_versioned"
+					[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo "have already built dependency $pkg_versioned"
 					continue
 				fi
 				if ! TERMUX_WITHOUT_DEPVERSION_BINDING="$([[ "${cyclic_dependence}" == "true" ]] && echo "true" || echo "${TERMUX_WITHOUT_DEPVERSION_BINDING}")" termux_download_deb_pac $PKG $DEP_ARCH $DEP_VERSION $DEP_VERSION_PAC; then
 					[[ "$cyclic_dependence" == "true" || ( "$TERMUX_FORCE_BUILD_DEPENDENCIES" == "true" && "$TERMUX_ON_DEVICE_BUILD" == "true" ) ]] \
 						&& termux_error_exit "Download of $PKG$([[ "${TERMUX_WITHOUT_DEPVERSION_BINDING}" == "false" && "${cyclic_dependence}" == "false" ]] && echo "@$DEP_VERSION") from $TERMUX_REPO_URL failed"
-					echo "Download of $pkg_versioned from $TERMUX_REPO_URL failed, building instead"
+					echo "Download from $TERMUX_REPO_URL failed, building instead"
 					build_dependency="true"
 				fi
 			fi
@@ -49,7 +49,6 @@ termux_step_get_dependencies() {
 				termux_add_package_to_built_packages_list "$PKG"
 			fi
 			if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
-				[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo "extracting $PKG to $TERMUX_COMMON_CACHEDIR-$DEP_ARCH..."
 				(
 					cd "$TERMUX_COMMON_CACHEDIR-$DEP_ARCH"
 					if [[ "$TERMUX_REPO_PKG_FORMAT" == "debian" ]]; then
@@ -70,13 +69,13 @@ termux_step_get_dependencies() {
 		else # Build dependencies
 			# Built dependencies are put in the default TERMUX_OUTPUT_DIR instead of the specified one
 			if [[ "$TERMUX_FORCE_BUILD_DEPENDENCIES" == "true" ]]; then
-				[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo "Force building dependency $PKG..."
+				[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo -n "force building dependency $PKG... "
 				read -r DEP_ARCH DEP_VERSION DEP_VERSION_PAC DEP_ON_DEVICE_NOT_SUPPORTED < <(termux_extract_dep_info $PKG "${PKG_DIR}")
 				[[ "$TERMUX_ON_DEVICE_BUILD" == "true" && "$DEP_ON_DEVICE_NOT_SUPPORTED" == "true" ]] \
 					&& termux_error_exit "Building $PKG on device is not supported. Consider passing -I flag to download it instead"
 				termux_force_check_package_dependency && continue
 			else
-				[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo "Building dependency $PKG if necessary..."
+				[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo -n "building dependency $PKG if necessary... "
 			fi
 			termux_run_build-package
 		fi
@@ -85,7 +84,7 @@ termux_step_get_dependencies() {
 
 termux_force_check_package_dependency() {
 	if termux_check_package_in_built_packages_list "$PKG" && termux_package__is_package_version_built "$PKG" "$DEP_VERSION"; then
-		[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo "Skipping already built dependency $PKG$([[ "${TERMUX_WITHOUT_DEPVERSION_BINDING}" == "false" ]] && echo "@$DEP_VERSION")"
+		[[ "$TERMUX_QUIET_BUILD" != "true" ]] && echo "skipping already built dependency $PKG$([[ "${TERMUX_WITHOUT_DEPVERSION_BINDING}" == "false" ]] && echo "@$DEP_VERSION")"
 		return 0
 	fi
 	return 1

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -11,7 +11,7 @@ termux_step_start_build() {
 	fi
 
 	if [ -n "${TERMUX_PKG_EXCLUDED_ARCHES:=""}" ] && [ "$TERMUX_PKG_EXCLUDED_ARCHES" != "${TERMUX_PKG_EXCLUDED_ARCHES/$TERMUX_ARCH/}" ]; then
-		echo "Skipping building $TERMUX_PKG_NAME for arch $TERMUX_ARCH"
+		echo "skipping build $TERMUX_PKG_NAME for $TERMUX_ARCH"
 		exit 0
 	fi
 
@@ -42,7 +42,7 @@ termux_step_start_build() {
 		if [ "$TERMUX_PKG_HAS_DEBUG" = "true" ]; then
 			DEBUG="-dbg"
 		else
-			echo "Skipping building debug build for $TERMUX_PKG_NAME"
+			echo "skipping debug build of $TERMUX_PKG_NAME"
 			exit 0
 		fi
 	else
@@ -52,12 +52,12 @@ termux_step_start_build() {
 	if [ "$TERMUX_DEBUG_BUILD" = "false" ] && [ "$TERMUX_FORCE_BUILD" = "false" ]; then
 		if [ -e "$TERMUX_BUILT_PACKAGES_DIRECTORY/$TERMUX_PKG_NAME" ] &&
 			[ "$(cat "$TERMUX_BUILT_PACKAGES_DIRECTORY/$TERMUX_PKG_NAME")" = "$TERMUX_PKG_FULLVERSION" ]; then
-			echo "$TERMUX_PKG_NAME@$TERMUX_PKG_FULLVERSION built - skipping (rm $TERMUX_BUILT_PACKAGES_DIRECTORY/$TERMUX_PKG_NAME to force rebuild)"
+			echo "$TERMUX_PKG_NAME@$TERMUX_PKG_VERSION already built - skipping (rm $TERMUX_BUILT_PACKAGES_DIRECTORY/$TERMUX_PKG_NAME to force rebuild)"
 			exit 0
 		elif [ "$TERMUX_ON_DEVICE_BUILD" = "true" ] &&
 			([[ "$TERMUX_APP_PACKAGE_MANAGER" = "apt" && "$(dpkg-query -W -f '${db:Status-Status} ${Version}\n' "$TERMUX_PKG_NAME" 2>/dev/null)" = "installed $TERMUX_PKG_FULLVERSION" ]] ||
 			 [[ "$TERMUX_APP_PACKAGE_MANAGER" = "pacman" && "$(pacman -Q $TERMUX_PKG_NAME 2>/dev/null)" = "$TERMUX_PKG_NAME $TERMUX_PKG_FULLVERSION_FOR_PACMAN" ]]); then
-			echo "$TERMUX_PKG_NAME@$TERMUX_PKG_FULLVERSION installed - skipping"
+			echo "$TERMUX_PKG_NAME@$TERMUX_PKG_VERSION already installed - skipping"
 			exit 0
 		fi
 	fi
@@ -69,7 +69,7 @@ termux_step_start_build() {
 		TERMUX_PKG_BUILD_ONLY_MULTILIB=true
 	fi
 
-	echo "termux - building $TERMUX_PKG_NAME for arch $TERMUX_ARCH..."
+	echo "Building $TERMUX_PKG_NAME for $TERMUX_ARCH..."
 	test -t 1 && printf "\033]0;%s...\007" "$TERMUX_PKG_NAME"
 
 	# Avoid exporting PKG_CONFIG_LIBDIR until after termux_step_host_build.


### PR DESCRIPTION
No need to print info over several lines, stick to one per package unless something goes wrong.

We now get something like:

```
Downloading dependency grep@3.12 if necessary... found grep in https://packages-cf.termux.dev/apt/termux-main/dists/stable
Downloading dependency gzip@1.14 if necessary... found gzip in https://packages-cf.termux.dev/apt/termux-main/dists/stable
Downloading dependency less@668 if necessary... found less in https://packages-cf.termux.dev/apt/termux-main/dists/stable
Downloading dependency procps@3.3.17-5 if necessary... found procps in https://packages-cf.termux.dev/apt/termux-main/dists/stable
Downloading dependency psmisc@23.7 if necessary... found psmisc in https://packages-cf.termux.dev/apt/termux-main/dists/stable
Downloading dependency sed@4.9-1 if necessary... found sed in https://packages-cf.termux.dev/apt/termux-main/dists/stable
Downloading dependency libandroid-glob@0.6-2 if necessary... found libandroid-glob in https://packages-cf.termux.dev/apt/termux-main/dists/stable
Downloading https://packages-cf.termux.dev/apt/termux-main/pool/main/liba/libandroid-glob/libandroid-glob_0.6-2_aarch64.deb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  6802  100  6802    0     0    862      0  0:00:07  0:00:07 --:--:--  1652
Downloading dependency tar@1.35 if necessary... found tar in https://packages-cf.termux.dev/apt/termux-main/dists/stable
Downloading dependency termux-am@0.8.0-1 if necessary... found termux-am in https://packages-cf.termux.dev/apt/termux-main/dists/stable
Downloading dependency termux-am-socket@1.5.0 if necessary... found termux-am-socket in https://packages-cf.termux.dev/apt/termux-main/dists/stable
Downloading dependency termux-core@0.4.0 if necessary... found termux-core in https://packages-cf.termux.dev/apt/termux-main/dists/stable
Downloading dependency termux-core-static@0.4.0 if necessary... found termux-core-static in https://packages-cf.termux.dev/apt/termux-main/dists/stable
```

Or, for build case:

```
Building dependency libgmp if necessary... libgmp@6.3.0 already built - skipping (rm /data/data/.built-packages/libgmp to force rebuild)
Building dependency libiconv if necessary... libiconv@1.18 already built - skipping (rm /data/data/.built-packages/libiconv to force rebuild)
Building dependency coreutils if necessary... coreutils@9.6 already built - skipping (rm /data/data/.built-packages/coreutils to force rebuild)
Building dependency libnghttp2 if necessary... libnghttp2@1.65.0 already built - skipping (rm /data/data/.built-packages/libnghttp2 to force rebuild)
Building dependency libnghttp3 if necessary... libnghttp3@1.9.0 already built - skipping (rm /data/data/.built-packages/libnghttp3 to force rebuild)
Building dependency ca-certificates if necessary... ca-certificates@1:2025.02.25 already built - skipping (rm /data/data/.built-packages/ca-certificates to force rebuild)
Building dependency zlib if necessary... zlib@1.3.1 already built - skipping (rm /data/data/.built-packages/zlib to force rebuild)
Building dependency openssl if necessary... openssl@1:3.4.1 already built - skipping (rm /data/data/.built-packages/openssl to force rebuild)
Building dependency libssh2 if necessary... libssh2@1.11.1 already built - skipping (rm /data/data/.built-packages/libssh2 to force rebuild)
Building dependency libcurl if necessary... libcurl@8.13.0 already built - skipping (rm /data/data/.built-packages/libcurl to force rebuild)
Building dependency dash if necessary... dash@0.5.12 already built - skipping (rm /data/data/.built-packages/dash to force rebuild)

```