### PR TITLE
addpkg(main/farbfeld): Conversion tools for farbfeld image format

### DIFF
--- a/packages/farbfeld/build.sh
+++ b/packages/farbfeld/build.sh
@@ -1,0 +1,24 @@
+
+TERMUX_PKG_HOMEPAGE=https://tools.suckless.org/farbfeld/
+TERMUX_PKG_DESCRIPTION="conversion tools for farbfelt, like netpbm without the complexity"
+TERMUX_PKG_LICENSE="ISC"
+
+TERMUX_PKG_MAINTAINER="@termux"
+
+TERMUX_PKG_VERSION=4
+TERMUX_PKG_SRCURL=https://dl.suckless.org/farbfeld/farbfeld-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=c7df5921edd121ca5d5b1cf6fb01e430aff9b31242262e4f690d3af72ccbe72a
+
+TERMUX_PKG_DEPENDS=libjpeg-turbo,libpng
+# The 2ff(1) script just uses convert(1) to convert to png and then png2ff(1) to convert to farbfeld.
+# Without convert(1), we can't even convert PNM to farbfeld!
+TERMUX_PKG_RECOMMENDS=imagemagick
+
+# plain Makefile; doesn't seem to support out-of-tree builds?
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_configure() {
+	# Need to pass these on command line to override settings in config.mk,
+	# but they aren't available before configure
+	TERMUX_PKG_EXTRA_MAKE_ARGS="PREFIX=${TERMUX_PREFIX} CC=${CC} LD=${LD}"
+}


### PR DESCRIPTION
The farbfeldt format is designed to be trivial to parse, so that custom tools can easily parse it without needing a special library.

Unlike netpbm's PNM family, which has 7(?) different formats with tricky-to-parse textual headers, farbfelt is a single format with a binary header, and always stores a 16-bit-per-channel RGBA (non-premultiplied) image, in no specified color space, with 32-bit unsigned width and height.

So it's trivial to parse, and there's no need to worry about what readers will do with color management information because there is no such information.