### PR TITLE
bump(x11/xfce4-clipman-plugin): 1.7.0

### DIFF
--- a/x11-packages/xfce4-clipman-plugin/build.sh
+++ b/x11-packages/xfce4-clipman-plugin/build.sh
@@ -2,17 +2,21 @@ TERMUX_PKG_HOMEPAGE=https://docs.xfce.org/panel-plugins/xfce4-clipman-plugin/sta
 TERMUX_PKG_DESCRIPTION="Clipman is a clipboard manager for Xfce"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.6.7"
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://archive.xfce.org/src/panel-plugins/xfce4-clipman-plugin/${TERMUX_PKG_VERSION%.*}/xfce4-clipman-plugin-$TERMUX_PKG_VERSION.tar.bz2
-TERMUX_PKG_SHA256=9bae27808a50e959e0912b7202ea5d651ed7401a6fc227f811d9bdaf2e44178c
+TERMUX_PKG_VERSION="1.7.0"
+TERMUX_PKG_SRCURL=https://archive.xfce.org/src/panel-plugins/xfce4-clipman-plugin/${TERMUX_PKG_VERSION%.*}/xfce4-clipman-plugin-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=903302c3070a951d44ee17a84fa3cf21d36c6787678af8fbfc79e469fd00cb46
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="atk, gdk-pixbuf, glib, gtk3, harfbuzz, libcairo, libice, libqrencode, libwayland, libx11, libxfce4ui, libxfce4util, libxtst, pango, xfce4-panel, xfconf, zlib"
+TERMUX_PKG_DEPENDS="glib, gdk-pixbuf, gtk3, libcairo, libqrencode, libwayland, libx11, libxfce4ui, libxfce4util, libxtst, xfce4-panel, xfconf"
+TERMUX_PKG_BUILD_DEPENDS="glib-cross, libwayland-protocols, libwayland-cross-scanner"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
---disable-debug
---disable-static
---enable-libqrencode
---enable-libxtst
---enable-wayland
---enable-x11
+-Dqrencode=enabled
+-Dtests=false
+-Dwayland=enabled
+-Dx11=enabled
+-Dxtst=enabled
 "
+
+termux_step_pre_configure() {
+	termux_setup_pkg_config_wrapper \
+	"${TERMUX_PREFIX}/opt/glib/cross/lib/x86_64-linux-gnu/pkgconfig:${TERMUX_PREFIX}/opt/libwayland/cross/lib/x86_64-linux-gnu/pkgconfig"
+}


### PR DESCRIPTION
Replace autotools with meson.

* Fixes #24773 