### PR TITLE
bump(x11/xfce4-genmon-plugin): 4.3.0

### DIFF
--- a/x11-packages/xfce4-genmon-plugin/build.sh
+++ b/x11-packages/xfce4-genmon-plugin/build.sh
@@ -2,13 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://docs.xfce.org/panel-plugins/xfce4-genmon-plugin
 TERMUX_PKG_DESCRIPTION="Display cyclically run script or program output onto the panel"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="4.2.1"
-TERMUX_PKG_SRCURL=https://archive.xfce.org/src/panel-plugins/xfce4-genmon-plugin/${TERMUX_PKG_VERSION%.*}/xfce4-genmon-plugin-${TERMUX_PKG_VERSION}.tar.bz2
-TERMUX_PKG_SHA256=de540562e1ea58f35a9c815e20736d26af541a0a9372011148cb75b5f0b65951
+TERMUX_PKG_VERSION="4.3.0"
+TERMUX_PKG_SRCURL=https://archive.xfce.org/src/panel-plugins/xfce4-genmon-plugin/${TERMUX_PKG_VERSION%.*}/xfce4-genmon-plugin-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=077197911d84e5ba22e7bb895ce6c038dbbd8e8e0067ed6f4e48502b7167a282
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="atk, gdk-pixbuf, glib, gtk3, harfbuzz, libcairo, libxfce4ui, libxfce4util, pango, xfce4-panel, xfconf, zlib"
+TERMUX_PKG_DEPENDS="glib, gtk3, pango, libxfce4ui, libxfce4util, xfce4-panel, xfconf"
 TERMUX_PKG_RECOMMENDS="hicolor-icon-theme"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
---disable-debug
---disable-static
-"


### PR DESCRIPTION
Replace autotools with meson.

* Fixes #24774 