### PR TITLE
bump(x11/xfce4-timer-plugin): 1.8.0

### DIFF
--- a/x11-packages/xfce4-timer-plugin/build.sh
+++ b/x11-packages/xfce4-timer-plugin/build.sh
@@ -2,13 +2,8 @@ TERMUX_PKG_HOMEPAGE=https://docs.xfce.org/panel-plugins/xfce4-timer-plugin/start
 TERMUX_PKG_DESCRIPTION="alarm and timer module for Xfce panel"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@Yisus7u7"
-TERMUX_PKG_VERSION="1.7.3"
-TERMUX_PKG_SRCURL=https://archive.xfce.org/src/panel-plugins/xfce4-timer-plugin/${TERMUX_PKG_VERSION%.*}/xfce4-timer-plugin-${TERMUX_PKG_VERSION}.tar.bz2
-TERMUX_PKG_SHA256=acf4c861af88608b9e802a76a4b05846bd30189e0085e826680cc179b6df4cd3
+TERMUX_PKG_VERSION="1.8.0"
+TERMUX_PKG_SRCURL=https://archive.xfce.org/src/panel-plugins/xfce4-timer-plugin/${TERMUX_PKG_VERSION%.*}/xfce4-timer-plugin-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=1d3ac3aa2c4345400c025642778e7643aab41047622baf9cdc00bbac78e89f99
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="atk, gdk-pixbuf, glib, gtk3, harfbuzz, libcairo, libxfce4ui, libxfce4util, pango, xfce4-panel, zlib"
-TERMUX_PKG_BUILD_IN_SRC=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
---disable-debug
---disable-static
-"
+TERMUX_PKG_DEPENDS="glib, gtk3, libxfce4ui, libxfce4util, xfce4-panel"


### PR DESCRIPTION
Replace autotools with meson.

* Fixes #24775 