### PR TITLE
fix(scripts/build/termux_create_pacman_subpackages): Fix check for if pacman subpackage should depend on parent

### DIFF
--- a/scripts/build/termux_create_pacman_subpackages.sh
+++ b/scripts/build/termux_create_pacman_subpackages.sh
@@ -84,7 +84,7 @@ termux_create_pacman_subpackages() {
 
 		# If the subpackage is not in the $TERMUX_PKG_DEPENDS for the parent package,
 		# and TERMUX_SUBPKG_DEPEND_ON_PARENT doesn't have a value, the subpackage should depend on its parent
-		[[ " ${TERMUX_PKG_DEPENDS//,/ } " == *" $SUB_PKG_NAME "* ]] && : "${TERMUX_SUBPKG_DEPEND_ON_PARENT:=true}"
+		[[ " ${TERMUX_PKG_DEPENDS//,/ } " != *" $SUB_PKG_NAME "* ]] && : "${TERMUX_SUBPKG_DEPEND_ON_PARENT:=true}"
 
 		case "$TERMUX_SUBPKG_DEPEND_ON_PARENT" in
 			'unversioned') TERMUX_SUBPKG_DEPENDS+=", $TERMUX_PKG_NAME";;


### PR DESCRIPTION
- This is https://github.com/termux/termux-packages/pull/24227, but for `termux_create_pacman_subpackages()` instead of `termux_create_debian_subpackages()`

- Fixes https://github.com/termux/termux-packages/issues/24825

- Fixes a regression in https://github.com/termux/termux-packages/commit/97a63bdb78dcd042750708253ed4fcdf09fac3f2