### PR TITLE
fix(main/bitlbee): Fix building due to conflict with host library path

### DIFF
--- a/packages/bitlbee/build.sh
+++ b/packages/bitlbee/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="An IRC to other chat networks gateway"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.6-1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/bitlbee/bitlbee/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=81c6357fe08a8941221472e3790e2b351e3a8a41f9af0cf35395fdadbc8ac6cb
 TERMUX_PKG_DEPENDS="ca-certificates, glib, libgcrypt, libgnutls"

--- a/packages/bitlbee/configure.patch
+++ b/packages/bitlbee/configure.patch
@@ -1,3 +1,6 @@
+# Use TERMUX_PREFIX to prevent searching libraries from host x86_64 system.
+# libgcrypt-config is replaced with PKG_CONFIG for same reason.
+
 --- a/configure
 +++ b/configure
 @@ -7,22 +7,22 @@
@@ -29,3 +32,45 @@
  sysroot=''
  
  configure_args="$@"
+@@ -402,8 +402,8 @@ detect_gnutls()
+ {
+ 	if $PKG_CONFIG --exists gnutls; then
+ 		cat <<EOF >>Makefile.settings
+-EFLAGS+=$($PKG_CONFIG --libs gnutls) $(libgcrypt-config --libs)
+-CFLAGS+=$($PKG_CONFIG --cflags gnutls) $(libgcrypt-config --cflags)
++EFLAGS+=$($PKG_CONFIG --libs gnutls) $($PKG_CONFIG --libs libgcrypt)
++CFLAGS+=$($PKG_CONFIG --cflags gnutls) $($PKG_CONFIG --cflags libgcrypt)
+ EOF
+ 		ssl=gnutls
+ 		if ! $PKG_CONFIG gnutls --atleast-version=2.8; then
+@@ -413,8 +413,8 @@ EOF
+ 		ret=1
+ 	elif libgnutls-config --version > /dev/null 2> /dev/null; then
+ 		cat <<EOF >>Makefile.settings
+-EFLAGS+=$(libgnutls-config --libs) $(libgcrypt-config --libs)
+-CFLAGS+=$(libgnutls-config --cflags) $(libgcrypt-config --cflags)
++EFLAGS+=$(libgnutls-config --libs) $($PKG_CONFIG --libs libgcrypt)
++CFLAGS+=$(libgnutls-config --cflags) $($PKG_CONFIG --cflags libgcrypt)
+ EOF
+ 		
+ 		ssl=gnutls
+@@ -762,15 +762,15 @@ fi
+ if [ "$otr" = 1 ]; then
+ 	# BI == built-in
+ 	echo '#define OTR_BI' >> config.h
+-	echo "EFLAGS+=$($PKG_CONFIG --libs libotr) $(libgcrypt-config --libs)" >> Makefile.settings
+-	echo "CFLAGS+=$($PKG_CONFIG --cflags libotr) $(libgcrypt-config --cflags)" >> Makefile.settings
++	echo "EFLAGS+=$($PKG_CONFIG --libs libotr) $($PKG_CONFIG --libs libgcrypt)" >> Makefile.settings
++	echo "CFLAGS+=$($PKG_CONFIG --cflags libotr) $($PKG_CONFIG --cflags libgcrypt)" >> Makefile.settings
+ 	echo 'OTR_BI=otr.o' >> Makefile.settings
+ elif [ "$otr" = "plugin" ]; then
+ 	# for some mysterious reason beyond the comprehension of my mortal mind,
+ 	# the libgcrypt flags aren't needed when building as plugin. add them anyway.
+ 	echo '#define OTR_PI' >> config.h
+-	echo "OTRFLAGS=$($PKG_CONFIG --libs libotr) $(libgcrypt-config --libs)" >> Makefile.settings
+-	echo "CFLAGS+=$($PKG_CONFIG --cflags libotr) $(libgcrypt-config --cflags)" >> Makefile.settings
++	echo "OTRFLAGS=$($PKG_CONFIG --libs libotr) $($PKG_CONFIG --libs libgcrypt)" >> Makefile.settings
++	echo "CFLAGS+=$($PKG_CONFIG --cflags libotr) $($PKG_CONFIG --cflags libgcrypt)" >> Makefile.settings
+ 	echo 'OTR_PI=otr.so' >> Makefile.settings
+ fi
+ 


### PR DESCRIPTION
This fixes the following compiler error.
ld.lld: error: --fix-cortex-a53-843419 is only supported on AArch64 targets

The configure.patch is modified to replace libgcrypt-config with equivalent pkg-config command. Otherwise, libgcrypt-config is picked up from host system and -L/usr/lib/x86_64-linux-gnu is added to LDFLAGS.

* Fixes #24870 