### PR TITLE
fix(x11/qt6-qtbase): Don't remove files needed for PySide6 build

### DIFF
--- a/x11-packages/qt6-qtbase/build.sh
+++ b/x11-packages/qt6-qtbase/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="GPL-3.0-only"
 TERMUX_PKG_LICENSE_FILE="LICENSES/GPL-3.0-only.txt"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="6.9.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://download.qt.io/official_releases/qt/${TERMUX_PKG_VERSION%.*}/${TERMUX_PKG_VERSION}/submodules/qtbase-everywhere-src-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=c1800c2ea835801af04a05d4a32321d79a93954ee3ae2172bbeacf13d1f0598c
 TERMUX_PKG_DEPENDS="brotli, double-conversion, freetype, glib, harfbuzz, libandroid-posix-semaphore, libandroid-shmem, libc++, libdrm, libice, libicu, libjpeg-turbo, libpng, libsm, libsqlite, libuuid, libx11, libxcb, libxi, libxkbcommon, libwayland, opengl, openssl, pcre2, vulkan-loader, xcb-util-cursor, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm, zlib, zstd"
@@ -63,10 +64,6 @@ opt/qt6/cross/lib/qt6/qt-internal-configure-examples
 opt/qt6/cross/lib/qt6/qt-internal-configure-tests
 opt/qt6/cross/lib/qt6/qt-testrunner.py
 opt/qt6/cross/lib/qt6/sanitizer-testrunner.py
-"
-TERMUX_PKG_RM_AFTER_INSTALL="
-lib/objects-*
-opt/qt6/cross/lib/objects-*
 "
 
 termux_step_host_build() {


### PR DESCRIPTION
```shell
CMake Error at /data/data/com.termux/files/usr/lib/cmake/Qt6ExampleIconsPrivate/Qt6ExampleIconsPrivateTargets.cmake:110 (message):
  The imported target "Qt6::ExampleIconsPrivate_resources_1" references the
  file

     "/data/data/com.termux/files/usr/lib/objects-Release/ExampleIconsPrivate_resources_1/.qt/rcc/qrc_example_icons_init.cpp.o"

  but this file does not exist.  Possible reasons include:

  * The file was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and contained

     "/data/data/com.termux/files/usr/lib/cmake/Qt6ExampleIconsPrivate/Qt6ExampleIconsPrivateTargets.cmake"

  but not all the files it references.

Call Stack (most recent call first):
  /data/data/com.termux/files/usr/lib/cmake/Qt6ExampleIconsPrivate/Qt6ExampleIconsPrivateConfig.cmake:55 (include)
  /data/data/com.termux/files/usr/lib/cmake/Qt6/Qt6Config.cmake:212 (find_package)
  sources/pyside6/qtexampleicons/CMakeLists.txt:15 (find_package)


-- Configuring incomplete, errors occurred!
```

I'm able to successfully compile and install PySide6 from source right on my phone with this change

![Screenshot_20250531-041053_Termux_X11](https://github.com/user-attachments/assets/90e6a09c-07c5-475d-aa6d-a5054eb0c6f9)

this file also seems to be included by archlinux

```shell
❯ pacman -Qo /usr/lib/objects-RelWithDebInfo/ExampleIconsPrivate_resources_1/.qt/rcc/qrc_example_icons_init.cpp.o
/usr/lib/objects-RelWithDebInfo/ExampleIconsPrivate_resources_1/.qt/rcc/qrc_example_icons_init.cpp.o は qt6-base 6.9.0-1 によって所有されています
```