### PR TITLE
termux_create_{debian,pacman}_subpackages.sh: fix the checking scheme for excluded archs

### DIFF
--- a/scripts/build/termux_create_debian_subpackages.sh
+++ b/scripts/build/termux_create_debian_subpackages.sh
@@ -45,6 +45,13 @@ termux_create_debian_subpackages() {
 		# shellcheck source=/dev/null
 		source "$subpackage"
 
+		# Do not create subpackage for specific arches.
+		# Using TERMUX_ARCH instead of SUB_PKG_ARCH (defined below) is intentional.
+		if [[ " ${TERMUX_SUBPKG_EXCLUDED_ARCHES//,/ } " == *" ${TERMUX_ARCH} "* ]]; then
+			echo "Skipping creating subpackage '$SUB_PKG_NAME' for arch $TERMUX_ARCH"
+			continue
+		fi
+
 		# Allow globstar (i.e. './**/') patterns.
 		shopt -s globstar
 		# Allow negation patterns.
@@ -63,13 +70,6 @@ termux_create_debian_subpackages() {
 			fi
 		done
 		shopt -u globstar extglob
-
-		# Do not create subpackage for specific arches.
-		# Using TERMUX_ARCH instead of SUB_PKG_ARCH (defined below) is intentional.
-		if [[ " ${TERMUX_SUBPKG_EXCLUDED_ARCHES//,/ } " == *" ${TERMUX_ARCH} "* ]]; then
-			echo "Skipping creating subpackage '$SUB_PKG_NAME' for arch $TERMUX_ARCH"
-			continue
-		fi
 
 		local SUB_PKG_ARCH=$TERMUX_ARCH
 		[[ "$TERMUX_SUBPKG_PLATFORM_INDEPENDENT" == "true" ]] && SUB_PKG_ARCH=all

--- a/scripts/build/termux_create_pacman_subpackages.sh
+++ b/scripts/build/termux_create_pacman_subpackages.sh
@@ -46,6 +46,13 @@ termux_create_pacman_subpackages() {
 		# shellcheck source=/dev/null
 		source "$subpackage"
 
+		# Do not create subpackage for specific arches.
+		# Using TERMUX_ARCH instead of SUB_PKG_ARCH (defined below) is intentional.
+		if [[ " ${TERMUX_SUBPKG_EXCLUDED_ARCHES//,/ } " == *" ${TERMUX_ARCH} "* ]]; then
+			echo "Skipping creating subpackage '$SUB_PKG_NAME' for arch $TERMUX_ARCH"
+			continue
+		fi
+
 		# Allow globstar (i.e. './**/') patterns.
 		shopt -s globstar
 		for includeset in $TERMUX_SUBPKG_INCLUDE; do
@@ -60,13 +67,6 @@ termux_create_pacman_subpackages() {
 			fi
 		done
 		shopt -u globstar
-
-		# Do not create subpackage for specific arches.
-		# Using TERMUX_ARCH instead of SUB_PKG_ARCH (defined below) is intentional.
-		if [[ " ${TERMUX_SUBPKG_EXCLUDED_ARCHES//,/ } " == *" ${TERMUX_ARCH} "* ]]; then
-			echo "Skipping creating subpackage '$SUB_PKG_NAME' for arch $TERMUX_ARCH"
-			continue
-		fi
 
 		local SUB_PKG_ARCH=$TERMUX_ARCH
 		[[ "$TERMUX_SUBPKG_PLATFORM_INDEPENDENT" == "true" ]] && SUB_PKG_ARCH=any


### PR DESCRIPTION
The checking algorithm is under the algorithm where subpackage files are included. That is, the algorithm for including subpackage files is not regulated by the algorithm of the supported architecture, which in turn can create unplanned inclusions of subpackage files that should be in the main package according to the plan.