### PR TITLE
bump(main/pass-otp): 1.2.0-p20221228

### DIFF
--- a/packages/pass-otp/build.sh
+++ b/packages/pass-otp/build.sh
@@ -1,19 +1,21 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/tadfisher/pass-otp
-TERMUX_PKG_DESCRIPTION="A pass extension for managing one-time-password (OTP) tokens"
+TERMUX_PKG_DESCRIPTION="A pass/passage extension for managing one-time-password (OTP) tokens"
 TERMUX_PKG_LICENSE="GPL-3.0-or-later"
+_COMMIT=a364d2a71ad24158a009c266102ce0d91149de67
+_COMMIT_DATE=20221228
 TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
-TERMUX_PKG_VERSION=1.2.0
-TERMUX_PKG_REVISION=4
-TERMUX_PKG_SRCURL=https://github.com/tadfisher/pass-otp/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=5720a649267a240a4f7ba5a6445193481070049c1d08ba38b00d20fc551c3a67
-TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="oathtool, pass"
-TERMUX_PKG_SUGGESTS="libqrencode"
+TERMUX_PKG_VERSION=1.2.0-p${_COMMIT_DATE}
+TERMUX_PKG_SRCURL=https://github.com/tadfisher/pass-otp/archive/$_COMMIT.tar.gz
+TERMUX_PKG_SHA256=02c6fa59b30ee009c62807b763c41df44cc9e4da3e137f1b5774e995ee18e2f6
+TERMUX_PKG_DEPENDS="oathtool"
+TERMUX_PKG_SUGGESTS="pass | passage, libqrencode"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 
 termux_step_pre_configure() {
-	export BASHCOMPDIR=$TERMUX_PREFIX/etc/bash_completion.d
+	export PREFIX=$TERMUX_PREFIX
+	export BASHCOMPDIR=$TERMUX_PREFIX/share/bash-completion/completions
+	export MANDIR=$TERMUX_PREFIX/share/man
 }
 
 termux_step_post_configure() {
@@ -21,4 +23,10 @@ termux_step_post_configure() {
 	# to avoid variable name conflicts with Termux's $PREFIX
 	# See: https://github.com/termux/termux-packages/issues/23569
 	sed -i "s|PREFIX|PASS_PREFIX|g" otp.bash
+}
+
+termux_step_post_make_install() {
+	# Symlink for passage
+	mkdir -p "$TERMUX_PREFIX/lib/passage/extensions"
+	ln -sf $TERMUX_PREFIX/lib/password-store/extensions/otp.bash "$TERMUX_PREFIX/lib/passage/extensions/"
 }

--- a/packages/pass-otp/otp.bash.patch
+++ b/packages/pass-otp/otp.bash.patch
@@ -1,11 +1,15 @@
---- ./otp.bash~	2018-11-15 21:17:12.000000000 +0100
-+++ ./otp.bash	2021-11-25 13:13:08.973741663 +0100
-@@ -17,7 +17,7 @@
+diff --git a/otp.bash b/otp.bash
+index a0688d2..c859404 100755
+--- a/otp.bash
++++ b/otp.bash
+@@ -17,8 +17,8 @@
  # []
  
- VERSION="1.1.1"
+ VERSION="1.1.2"
 -OATH=$(which oathtool)
+-OTPTOOL=$(which otptool)
 +OATH=$(command -v oathtool)
++OTPTOOL=$(command -v otptool)
  
  ## source:  https://gist.github.com/cdown/1163649
  urlencode() {

--- a/packages/pass-otp/support-passage.patch
+++ b/packages/pass-otp/support-passage.patch
@@ -1,0 +1,113 @@
+Patch-Source: https://github.com/tadfisher/pass-otp/pull/178.patch
+From 3735077495f709000d08bd1f4cd08227ef06cb53 Mon Sep 17 00:00:00 2001
+From: Remko Tronçon <remko@el-tramo.be>
+Date: Wed, 28 Dec 2022 20:27:53 +0100
+Subject: [PATCH] Support passage as backend
+
+---
+ otp.bash | 43 +++++++++++++++++++++++++++++++++----------
+ 1 file changed, 33 insertions(+), 10 deletions(-)
+
+diff --git a/otp.bash b/otp.bash
+index a0688d2..eb209b8 100755
+--- a/otp.bash
++++ b/otp.bash
+@@ -20,6 +20,12 @@ VERSION="1.1.2"
+ OATH=$(which oathtool)
+ OTPTOOL=$(which otptool)
+ 
++if [[ $PASSAGE == 1 ]]; then
++  EXT="age"
++else
++  EXT="gpg"
++fi
++
+ ## source:  https://gist.github.com/cdown/1163649
+ urlencode() {
+   local l=${#1}
+@@ -137,9 +143,13 @@ otp_insert() {
+   set_git "$passfile"
+ 
+   mkdir -p -v "$PREFIX/$(dirname "$path")"
+-  set_gpg_recipients "$(dirname "$path")"
+-
+-  echo "$contents" | $GPG -e "${GPG_RECIPIENT_ARGS[@]}" -o "$passfile" "${GPG_OPTS[@]}" || die "OTP secret encryption aborted."
++  if [[ $PASSAGE == 1 ]]; then
++    set_age_recipients "$(dirname "$path")"
++    echo "$contents" | $AGE -e "${AGE_RECIPIENT_ARGS[@]}" -o "$passfile" || die "OTP secret encryption aborted"
++  else
++    set_gpg_recipients "$(dirname "$path")"
++    echo "$contents" | $GPG -e "${GPG_RECIPIENT_ARGS[@]}" -o "$passfile" "${GPG_OPTS[@]}" || die "OTP secret encryption aborted."
++  fi
+ 
+   if [[ "$quiet" -eq 1 ]]; then
+     git_add_file "$passfile" "$message" 1>/dev/null
+@@ -243,7 +253,7 @@ cmd_otp_insert() {
+     yesno "Insert into $path?"
+   fi
+ 
+-  local passfile="$PREFIX/$path.gpg"
++  local passfile="$PREFIX/$path.$EXT"
+   [[ $force -eq 0 && -e $passfile ]] && yesno "An entry already exists for $path. Overwrite it?"
+ 
+   otp_insert "$path" "$passfile" "$otp_uri" "Add OTP secret for $path to store."
+@@ -268,16 +278,21 @@ cmd_otp_append() {
+   local uri
+   local path="${1%/}"
+   local prompt="$path"
+-  local passfile="$PREFIX/$path.gpg"
++  local passfile="$PREFIX/$path.$EXT"
+ 
+   [[ -f $passfile ]] || die "Passfile not found"
++  if [[ $PASSAGE == 1 ]]; then
++    old_contents=$($AGE -d -i "$IDENTITIES_FILE" "$passfile")
++  else
++    old_contents=$($GPG -d "${GPG_OPTS[@]}" "$passfile")
++  fi
+ 
+   local existing contents=""
+   while IFS= read -r line || [ -n "$line" ]; do
+     [[ -z "$existing" && "$line" == otpauth://* ]] && existing="$line"
+     [[ -n "$contents" ]] && contents+=$'\n'
+     contents+="$line"
+-  done < <($GPG -d "${GPG_OPTS[@]}" "$passfile")
++  done < <(echo "$old_contents")
+ 
+   [[ -n "$existing" ]] && yesno "An OTP secret already exists for $path. Overwrite it?"
+ 
+@@ -329,11 +344,15 @@ cmd_otp_code() {
+   [[ $err -ne 0 || $# -ne 1 ]] && die "Usage: $PROGRAM $COMMAND [--clip,-c] [--quiet,-q] pass-name"
+ 
+   local path="${1%/}"
+-  local passfile="$PREFIX/$path.gpg"
++  local passfile="$PREFIX/$path.$EXT"
+   check_sneaky_paths "$path"
+   [[ ! -f $passfile ]] && die "$path: passfile not found."
+ 
+-  contents=$($GPG -d "${GPG_OPTS[@]}" "$passfile")
++  if [[ $PASSAGE == 1 ]]; then
++    contents=$($AGE -d -i "$IDENTITIES_FILE" "$passfile")
++  else
++    contents=$($GPG -d "${GPG_OPTS[@]}" "$passfile")
++  fi
+   while read -r line; do
+     if [[ "$line" == otpauth://* ]]; then
+       local uri="$line"
+@@ -401,11 +420,15 @@ cmd_otp_uri() {
+   [[ $err -ne 0 || $# -ne 1 ]] && die "Usage: $PROGRAM $COMMAND uri [--clip,-c | --qrcode,-q] pass-name"
+ 
+   local path="$1"
+-  local passfile="$PREFIX/$path.gpg"
++  local passfile="$PREFIX/$path.$EXT"
+   check_sneaky_paths "$path"
+   [[ ! -f $passfile ]] && die "Passfile not found"
++  if [[ $PASSAGE == 1 ]]; then
++    contents=$($AGE -d -i "$IDENTITIES_FILE" "$passfile")
++  else
++    contents=$($GPG -d "${GPG_OPTS[@]}" "$passfile")
++  fi
+ 
+-  contents=$($GPG -d "${GPG_OPTS[@]}" "$passfile")
+   while read -r line; do
+     if [[ "$line" == otpauth://* ]]; then
+       otp_parse_uri "$line"

--- a/packages/passage/build.sh
+++ b/packages/passage/build.sh
@@ -3,18 +3,19 @@ TERMUX_PKG_DESCRIPTION="A fork of password-store that uses age as backend"
 TERMUX_PKG_LICENSE="GPL-2.0-or-later"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.7.4a2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/FiloSottile/passage/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=d4bd97be2eda4249b31c2042707ef70ba50385f6fb7791598f51be794168ee2c
 TERMUX_PKG_DEPENDS="bash, age, tree"
 TERMUX_PKG_RECOMMENDS="git"
-# TERMUX_PKG_SUGGESTS="pass-otp" # todo
+TERMUX_PKG_SUGGESTS="pass-otp"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_EXTRA_MAKE_ARGS="WITH_ALLCOMP=yes"
 
 termux_step_post_configure() {
-	# Replace $PREFIX with $PASSAGE_PREFIX
+	# Replace $PREFIX with $PASS_PREFIX
 	# to avoid variable name conflicts with Termux's $PREFIX
 	# See: https://github.com/termux/termux-packages/issues/23569
-	sed -i "s|PREFIX|PASSAGE_PREFIX|g" src/password-store.sh
+	sed -i "s|PREFIX|PASS_PREFIX|g" src/password-store.sh
 }


### PR DESCRIPTION
Add patch with passage support.
This also removes pass from dependencies.

There is also a second commit that fixes passage so it works with pass-otp.