### PR TITLE
bump(main/sbcl): 2.5.5

### DIFF
--- a/packages/sbcl/build.sh
+++ b/packages/sbcl/build.sh
@@ -3,15 +3,15 @@ TERMUX_PKG_DESCRIPTION="A high performance Common Lisp compiler"
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="2.5.4"
+TERMUX_PKG_VERSION="2.5.5"
 # sourceforge archive is a precompiled SBCL release for GNU/Linux to use as host Lisp for bootstrapping
 TERMUX_PKG_SRCURL=(
 	https://github.com/sbcl/sbcl/archive/refs/tags/sbcl-${TERMUX_PKG_VERSION}.tar.gz
 	https://sourceforge.net/projects/sbcl/files/sbcl/${TERMUX_PKG_VERSION}/sbcl-${TERMUX_PKG_VERSION}-x86-64-linux-binary.tar.bz2
 )
 TERMUX_PKG_SHA256=(
-	fa6120bd438387636d928b0306b189d142214010e2dacf5f67136c481ce84111
-	d71adcaf3e8db6702a3b04e310513294db898e8c11e20ae0ac6bccbb97b3e955
+	39373eaf44f3a33c11652a93b960f549a3425526fcbd6098efc8de7d051c9807
+	3c77e7d674c6720d56e6dd16ab61890c52b123bde9babace71b2a6cbfce0a0cd
 )
 TERMUX_PKG_DEPENDS="zstd"
 # TERMUX_ON_DEVICE_BUILD=true  build dependencies: ecl, strace

--- a/packages/sbcl/disable-failing-tests-that-were-only-enabled-on-x86.patch
+++ b/packages/sbcl/disable-failing-tests-that-were-only-enabled-on-x86.patch
@@ -1,7 +1,5 @@
-elfcore.test.sh is not passing on Android-x86,
-so it is disabled by this. Upstream also currently has 
-elf-sans-immobile.test.sh disabled.
-These tests also fail on ARM, but were
+elfcore.test.sh/elf-sans-immobile.test.sh is not passing on Android-x86,
+so it is disabled by this. These tests also fail on ARM, but are
 not enabled by upstream on any targets except 64-bit x86.
 The exact reason why the test fails, or what steps might be necessary
 to fix it, are not known, but one way of describing the probable
@@ -14,10 +12,10 @@ effects that this test failing implies would be:
  . ./subr.sh
  
  run_sbcl <<EOF
--;#+(and linux x86-64 sb-thread)
-+;#+(and linux x86-64 sb-thread (not android))
- ;(unless (member :immobile-space sb-impl:+internal-features+)
- ;  (exit :code 0)) ; proceed with test
+-#+(and linux x86-64 sb-thread)
++#+(and linux x86-64 sb-thread (not android))
+ (unless (member :immobile-space sb-impl:+internal-features+)
+   (exit :code 0)) ; proceed with test
  (exit :code 2) ; otherwise skip the test
 --- a/tests/elfcore.test.sh
 +++ b/tests/elfcore.test.sh


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/24907

- Rebase `disable-failing-tests-that-were-only-enabled-on-x86.patch` - upstream re-enabled this test, but it is still failing on Android-x86, just like with SBCL 2.5.3