### PR TITLE
bump(main/ncftp): 3.3.0

### DIFF
--- a/packages/ncftp/build.sh
+++ b/packages/ncftp/build.sh
@@ -4,16 +4,14 @@ TERMUX_PKG_DESCRIPTION="A free set of programs that use the File Transfer Protoc
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="doc/LICENSE.txt"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="3.2.8"
-TERMUX_PKG_SRCURL=https://www.ncftp.com/downloads/ncftp/ncftp-${TERMUX_PKG_VERSION}-src.tar.gz
-TERMUX_PKG_SHA256=db7da662458a1643209d6869465c38ec811f8975a6ac54fd20c63a3349f7dbf4
+TERMUX_PKG_VERSION="3.3.0"
+TERMUX_PKG_SRCURL=https://www.ncftp.com/public_ftp/ncftp/ncftp-${TERMUX_PKG_VERSION}-src.tar.gz
+TERMUX_PKG_SHA256=7920f884c2adafc82c8e41c46d6f3d22698785c7b3f56f5677a8d5c866396386
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="ncurses, resolv-conf"
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_pre_configure() {
-	autoreconf -fi -Iautoconf_local
-
 	CFLAGS+=" -fcommon"
 
 	export ac_cv_path_TAR=$TERMUX_PREFIX/bin/tar


### PR DESCRIPTION
autoreconf was added in d3fbf84d472a183c8fd1e8c20109f073886247ec commit it is no longer required after e850aab8fd517ac4f93c7de2b89839eab30c0e95

* Fixes #23963 