### PR TITLE
bump(main/pandoc): 3.7.0.2

### DIFF
--- a/packages/liblua51/build.sh
+++ b/packages/liblua51/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Shared library for the Lua interpreter (v5.1.x)"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=5.1.5
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.lua.org/ftp/lua-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333
 TERMUX_PKG_BUILD_DEPENDS="readline"
@@ -37,6 +38,8 @@ termux_step_make_install() {
 		INSTALL_MAN="$TERMUX_PREFIX/share/man/man1" \
 		install
 	install -Dm600 lua.pc "$TERMUX_PREFIX"/lib/pkgconfig/lua51.pc
+	ln -sf lua51.pc "$TERMUX_PREFIX"/lib/pkgconfig/lua5.1.pc
+	ln -sf lua51.pc "$TERMUX_PREFIX"/lib/pkgconfig/lua-5.1.pc
 
 	mv -f "$TERMUX_PREFIX"/share/man/man1/lua.1 "$TERMUX_PREFIX"/share/man/man1/lua5.1.1
 	mv -f "$TERMUX_PREFIX"/share/man/man1/luac.1 "$TERMUX_PREFIX"/share/man/man1/luac5.1.1

--- a/packages/liblua52/build.sh
+++ b/packages/liblua52/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Shared library for the Lua interpreter (v5.2.x)"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=5.2.4
-TERMUX_PKG_REVISION=8
+TERMUX_PKG_REVISION=9
 TERMUX_PKG_SRCURL=https://www.lua.org/ftp/lua-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=b9e2e4aad6789b3b63a056d442f7b39f0ecfca3ae0f1fc0ae4e9614401b69f4b
 TERMUX_PKG_BREAKS="liblua52-dev"
@@ -36,6 +36,8 @@ termux_step_make_install() {
 		INSTALL_MAN="$TERMUX_PREFIX/share/man/man1" \
 		install
 	install -Dm600 lua.pc "$TERMUX_PREFIX"/lib/pkgconfig/lua52.pc
+	ln -sf lua52.pc "$TERMUX_PREFIX"/lib/pkgconfig/lua5.2.pc
+	ln -sf lua52.pc "$TERMUX_PREFIX"/lib/pkgconfig/lua-5.2.pc
 
 	mv -f "$TERMUX_PREFIX"/share/man/man1/lua.1 "$TERMUX_PREFIX"/share/man/man1/lua5.2.1
 	mv -f "$TERMUX_PREFIX"/share/man/man1/luac.1 "$TERMUX_PREFIX"/share/man/man1/luac5.2.1

--- a/packages/liblua53/build.sh
+++ b/packages/liblua53/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Shared library for the Lua interpreter (v5.3.x)"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=5.3.6
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.lua.org/ftp/lua-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=fc5fd69bb8736323f026672b1b7235da613d7177e72558893a0bdcd320466d60
 TERMUX_PKG_EXTRA_MAKE_ARGS=linux
@@ -34,6 +35,8 @@ termux_step_make_install() {
 		INSTALL_MAN="$TERMUX_PREFIX/share/man/man1" \
 		install
 	install -Dm600 lua.pc "$TERMUX_PREFIX"/lib/pkgconfig/lua53.pc
+	ln -sf lua53.pc "$TERMUX_PREFIX"/lib/pkgconfig/lua5.3.pc
+	ln -sf lua53.pc "$TERMUX_PREFIX"/lib/pkgconfig/lua-5.3.pc
 }
 
 termux_step_post_make_install() {

--- a/packages/liblua54/build.sh
+++ b/packages/liblua54/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Shared library for the Lua interpreter"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=5.4.7
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.lua.org/ftp/lua-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=9fbf5e28ef86c69858f6d3d34eccc32e911c1a28b4120ff3e84aaa70cfbf1e30
 TERMUX_PKG_EXTRA_MAKE_ARGS=linux-readline
@@ -34,6 +35,8 @@ termux_step_make_install() {
 		INSTALL_MAN="$TERMUX_PREFIX/share/man/man1" \
 		install
 	install -Dm600 lua.pc "$TERMUX_PREFIX"/lib/pkgconfig/lua54.pc
+	ln -sf lua54.pc "$TERMUX_PREFIX"/lib/pkgconfig/lua5.4.pc
+	ln -sf lua54.pc "$TERMUX_PREFIX"/lib/pkgconfig/lua-5.4.pc
 }
 
 termux_step_post_make_install() {

--- a/packages/pandoc/build.sh
+++ b/packages/pandoc/build.sh
@@ -2,14 +2,17 @@ TERMUX_PKG_HOMEPAGE=https://pandoc.org/
 TERMUX_PKG_DESCRIPTION="Universal markup converter"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="Aditya Alok <alok@termux.dev>"
-TERMUX_PKG_VERSION=3.7.0.1
+TERMUX_PKG_VERSION=3.7.0.2
 TERMUX_PKG_SRCURL="https://hackage.haskell.org/package/pandoc-cli-$TERMUX_PKG_VERSION/pandoc-cli-$TERMUX_PKG_VERSION.tar.gz"
-TERMUX_PKG_SHA256=62cfd812ed0e980bb7da2100983bc3842856625c006c3b393f186e297d181754
-TERMUX_PKG_DEPENDS="libffi, libiconv, libgmp, zlib"
+TERMUX_PKG_SHA256=ff4dcab86cfa5291ba11a14d14fef49ddf494c549bdd01b6752ed6a8043c3d3d
+TERMUX_PKG_DEPENDS="libffi, libiconv, libgmp, liblua54, zlib"
 TERMUX_PKG_BUILD_DEPENDS="aosp-libs"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--f-lua -f+server
+-f+lua -f+server
+-c lua+system-lua
+-c lua+pkg-config
+-c lua+cross-compile
 -c pandoc+embed_data_files
 "
 


### PR DESCRIPTION
- Re-enable Lua support

- Fixes https://github.com/termux/termux-packages/issues/24900

- Depends on some more pkg-config symbolic links being provided by `liblua54`, for example, like Arch Linux does: https://gitlab.archlinux.org/archlinux/packaging/packages/lua/-/blob/e852e632500de8297229d9860229ed218de1ef4c/PKGBUILD#L62