### PR TITLE
bump(main/plantuml): 1.2025.3

### DIFF
--- a/packages/plantuml/build.sh
+++ b/packages/plantuml/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://plantuml.com/
 TERMUX_PKG_DESCRIPTION="Draws UML diagrams, using a simple and human readable text description"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.2025.2"
+TERMUX_PKG_VERSION="1.2025.3"
 TERMUX_PKG_SRCURL=https://github.com/plantuml/plantuml/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=5c7a06e91aad9eb46c0b370621ff7f4e482815f9efb6f0a233130968815a1162
+TERMUX_PKG_SHA256=81679a8dda219873c8a307dc96233246ace1dc2ab9294f53a87de9cb1c520d8b
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="openjdk-17"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
@@ -12,7 +12,10 @@ TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+\.\d+"
 
 termux_step_make() {
-	$TERMUX_PKG_SRCDIR/gradlew --no-daemon --parallel --stacktrace assemble
+	# increase gradle memory to avoid 'JVM garbage collector thrashing':
+	# https://stackoverflow.com/a/74143183/11708026
+	# https://github.com/termux/termux-packages/issues/24917
+	$TERMUX_PKG_SRCDIR/gradlew --no-daemon --parallel --stacktrace assemble -Dorg.gradle.jvmargs=-Xmx4096M
 }
 
 termux_step_make_install() {


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/24917

- Increase gradle JVM memory to avoid `the JVM garbage collector is thrashing`