### PR TITLE
enhance(main/rust): Suppress hard linking failed warning.

### DIFF
--- a/packages/rust/0006-suppress-hard-linking-failed-warning.patch
+++ b/packages/rust/0006-suppress-hard-linking-failed-warning.patch
@@ -1,0 +1,32 @@
+--- a/compiler/rustc_incremental/src/persist/fs.rs
++++ b/compiler/rustc_incremental/src/persist/fs.rs
+@@ -272,13 +272,9 @@
+         debug!("attempting to copy data from source: {}", source_directory.display());
+ 
+         // Try copying over all files from the source directory
+-        if let Ok(allows_links) = copy_files(sess, &session_dir, &source_directory) {
++        if let Ok(_allows_links) = copy_files(sess, &session_dir, &source_directory) {
+             debug!("successfully copied data from: {}", source_directory.display());
+ 
+-            if !allows_links {
+-                sess.dcx().emit_warn(errors::HardLinkFailed { path: &session_dir });
+-            }
+-
+             sess.init_incr_comp_session(session_dir, directory_lock);
+             return;
+         } else {
+--- a/compiler/rustc_incremental/src/errors.rs
++++ b/compiler/rustc_incremental/src/errors.rs
+@@ -201,12 +201,6 @@
+ }
+ 
+ #[derive(Diagnostic)]
+-#[diag(incremental_hard_link_failed)]
+-pub(crate) struct HardLinkFailed<'a> {
+-    pub path: &'a Path,
+-}
+-
+-#[derive(Diagnostic)]
+ #[diag(incremental_delete_partial)]
+ pub(crate) struct DeletePartial<'a> {
+     pub path: &'a Path,

--- a/packages/rust/build.sh
+++ b/packages/rust/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_DESCRIPTION="Systems programming language focused on safety, speed an
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.87.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/rustc-${TERMUX_PKG_VERSION}-src.tar.xz
 TERMUX_PKG_SHA256=8623b8651893e8c6aebfa45b6a90645a4f652f7b18189a0992a90d11ac2631f4
 _LLVM_MAJOR_VERSION=$(. $TERMUX_SCRIPTDIR/packages/libllvm/build.sh; echo $LLVM_MAJOR_VERSION)


### PR DESCRIPTION
Well Android does not support hard linking. but rust does not know that and keeps filling the terminal with this useless warning.
This pr patches only one line from the upstream to suppress it.
Please refer to https://github.com/termux/termux-packages/issues/4921.
See this image ![hard-linking](https://github.com/user-attachments/assets/4d7f0aca-4d41-4831-8656-185fa0a638cc)

Note: this issue was reported to the upstream for almost 5 years. But unfortunately it seems that no one really cares about it. https://github.com/rust-lang/rust/issues/75997

@TomJo2000 I followed the commit message guidelines this time ;)