### PR TITLE
scripts(build): Fix cabal configuration

### DIFF
--- a/scripts/build/configure/termux_step_configure_cabal.sh
+++ b/scripts/build/configure/termux_step_configure_cabal.sh
@@ -2,14 +2,6 @@ termux_step_configure_cabal() {
 	termux_setup_ghc
 	termux_setup_cabal
 
-	local target="$TERMUX_HOST_PLATFORM"
-	[[ "$TERMUX_ARCH" == "arm" ]] && target="armv7a-linux-androideabi"
-
-	TARGET_FLAG="--target=$target"
-	if [[ ${TERMUX_PKG_EXTRA_CONFIGURE_ARGS} != "${TERMUX_PKG_EXTRA_CONFIGURE_ARGS/--target=/}" ]]; then
-		TARGET_FLAG=""
-	fi
-
 	QUIET_BUILD=
 	if [[ ${TERMUX_QUIET_BUILD} == true ]]; then
 		QUIET_BUILD="-v0"
@@ -73,21 +65,8 @@ termux_step_configure_cabal() {
 
 	# NOTE: We do not want to quote AVOID_GNULIB as we want word expansion.
 	# shellcheck disable=SC2086
-	# shellcheck disable=SC2250,SC2154,SC2248,SC2312
-	env $AVOID_GNULIB cabal configure \
+	env $AVOID_GNULIB cabal --config="$TERMUX_CABAL_CONFIG" configure \
 		$TERMUX_GHC_OPTIMISATION \
-		--prefix="$TERMUX_PREFIX" \
-		--configure-option="$TARGET_FLAG" \
-		--with-compiler="$(command -v ghc)" \
-		--with-ghc-pkg="$(command -v ghc-pkg)" \
-		--with-hsc2hs="$(command -v hsc2hs)" \
-		"$([[ "$TERMUX_ON_DEVICE_BUILD" == false ]] && echo -n "--hsc2hs-option=--cross-compile")" \
-		--with-ld="$(command -v "$LD")" \
-		--with-ar="$(command -v "$AR")" \
-		--with-pkg-config="$(command -v "$PKG_CONFIG")" \
-		--with-happy="$(command -v happy)" \
-		--with-alex="$(command -v alex)" \
-		--disable-tests \
 		$QUIET_BUILD \
 		$TERMUX_PKG_EXTRA_CONFIGURE_ARGS
 }

--- a/scripts/build/setup/termux_setup_cabal.sh
+++ b/scripts/build/setup/termux_setup_cabal.sh
@@ -13,6 +13,7 @@ termux_setup_cabal() {
 		fi
 
 		export PATH="${TERMUX_CABAL_RUNTIME_FOLDER}:${PATH}"
+		export TERMUX_CABAL_CONFIG="$TERMUX_CABAL_RUNTIME_FOLDER/cabal.config"
 
 		[[ -d "${TERMUX_CABAL_RUNTIME_FOLDER}" ]] && return
 
@@ -26,6 +27,28 @@ termux_setup_cabal() {
 
 		cabal update
 
+		# Configuration:
+
+		local repo="hackage.haskell.org"
+
+		cat <<-EOF >"$TERMUX_CABAL_CONFIG"
+			repository hackage.haskell.org
+			 url: https://$repo/
+
+			remote-repo-cache: $HOME/.cache/cabal/packages
+			executable-stripping: True
+			configure-option: --host=$TERMUX_HOST_PLATFORM
+			tests: False
+			build-summary: $HOME/.cache/cabal/logs/build.log
+			remote-build-reporting: none
+			jobs: $TERMUX_PKG_MAKE_PROCESSES
+
+			program-locations
+			 strip-location: $(command -v "$STRIP")
+
+			program-default-options
+			 $([[ "$TERMUX_ON_DEVICE_BUILD" == false ]] && printf "%s" "hsc2hs-options: --cross-compile")
+		EOF
 	else
 		if [[ "${TERMUX_APP_PACKAGE_MANAGER}" == "apt" ]] && "$(dpkg-query -W -f '${db:Status-Status}\n' cabal-install 2>/dev/null)" != "installed" ||
 			[[ "${TERMUX_APP_PACKAGE_MANAGER}" == "pacman" ]] && ! "$(pacman -Q cabal-install 2>/dev/null)"; then

--- a/scripts/build/termux_step_make.sh
+++ b/scripts/build/termux_step_make.sh
@@ -9,7 +9,7 @@ termux_step_make() {
 	if test -f build.ninja; then
 		ninja -j $TERMUX_PKG_MAKE_PROCESSES
 	elif ls ./*.cabal &>/dev/null; then
-		cabal build
+		cabal --config="$TERMUX_CABAL_CONFIG" build
 	elif ls ./*akefile &>/dev/null || [ ! -z "$TERMUX_PKG_EXTRA_MAKE_ARGS" ]; then
 		if [ -z "$TERMUX_PKG_EXTRA_MAKE_ARGS" ]; then
 			make -j $TERMUX_PKG_MAKE_PROCESSES $QUIET_BUILD


### PR DESCRIPTION
- Moved project level configuration to global. They are applied to
  dependencies too (which wasn't the case with former).
  See: https://github.com/termux/termux-packages/issues/24930

Signed-off-by: Aditya Alok <alok@termux.dev>
