### PR TITLE
fix(main/libwebp): migrate to CMake to provide `WebPConfig.cmake`

### DIFF
--- a/packages/libwebp/build.sh
+++ b/packages/libwebp/build.sh
@@ -3,26 +3,26 @@ TERMUX_PKG_DESCRIPTION="Library to encode and decode images in WebP format"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.5.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/webmproject/libwebp/archive/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=668c9aba45565e24c27e17f7aaf7060a399f7f31dba6c97a044e1feacb930f37
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
-TERMUX_PKG_DEPENDS="giflib, libjpeg-turbo, libpng, libtiff"
+TERMUX_PKG_DEPENDS="giflib, libjpeg-turbo, libpng, libtiff, zlib"
 TERMUX_PKG_BREAKS="libwebp-dev"
 TERMUX_PKG_REPLACES="libwebp-dev"
+TERMUX_PKG_FORCE_CMAKE=true
+# "vwebp" is an X11 program and triggers a dependency on GLUT, which is in x11-packages
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
---enable-libwebpmux
---enable-libwebpdemux
---enable-libwebpdecoder
---enable-libwebpextras
---enable-swap-16bit-csp
---enable-gif
---enable-jpeg
---enable-png
---enable-tiff
---disable-wic
+-DBUILD_SHARED_LIBS=ON
+-DWEBP_BUILD_VWEBP=OFF
+-DWEBP_BUILD_CWEBP=ON
+-DWEBP_BUILD_DWEBP=ON
+-DWEBP_BUILD_GIF2WEBP=ON
+-DWEBP_BUILD_IMG2WEBP=ON
+-DWEBP_BUILD_EXTRAS=ON
+-DWEBP_ENABLE_SWAP_16BIT_CSP=ON
 "
-TERMUX_PKG_RM_AFTER_INSTALL="share/man/man1"
 
 termux_step_post_get_source() {
 	# Do not forget to bump revision of reverse dependencies and rebuild them
@@ -34,8 +34,4 @@ termux_step_post_get_source() {
 	if [ ! "${e}" ] || [ "${_SOVERSION}" != "$(( "${e}" ))" ]; then
 		termux_error_exit "SOVERSION guard check failed."
 	fi
-}
-
-termux_step_pre_configure() {
-	./autogen.sh
 }

--- a/packages/libwebp/disable-check-cpufeatures.patch
+++ b/packages/libwebp/disable-check-cpufeatures.patch
@@ -1,0 +1,17 @@
+libcpufeatures in only used in libwebp for NEON,
+and all Termux's supported ARM devices support NEON
+(Android 5.0+ requires NEON: https://developer.android.com/ndk/guides/cpu-arm-neon)
+and the NEON support is already successfully detected at configure-time separately from this:
+-- Performing Test WEBP_HAVE_FLAG_NEON - Success
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -181,7 +181,7 @@ endif()
+ 
+ # ##############################################################################
+ # Android only.
+-if(ANDROID)
++if(FALSE)
+   include_directories(${ANDROID_NDK}/sources/android/cpufeatures)
+   add_library(cpufeatures-webp STATIC
+               ${ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c)


### PR DESCRIPTION
- Context: similar to https://github.com/termux/termux-packages/pull/24956. This is needed as a deeply-nested dependency of a potential improved Blender package.

- Enable manpages

- New files provided after this change:

```diff
 /data/data/com.termux/files/usr/lib/pkgconfig/libwebpdemux.pc
 /data/data/com.termux/files/usr/lib/pkgconfig/libwebpmux.pc
 /data/data/com.termux/files/usr/share
+/data/data/com.termux/files/usr/share/WebP
+/data/data/com.termux/files/usr/share/WebP/cmake
+/data/data/com.termux/files/usr/share/WebP/cmake/WebPConfig.cmake
+/data/data/com.termux/files/usr/share/WebP/cmake/WebPConfigVersion.cmake
+/data/data/com.termux/files/usr/share/WebP/cmake/WebPTargets-release.cmake
+/data/data/com.termux/files/usr/share/WebP/cmake/WebPTargets.cmake
 /data/data/com.termux/files/usr/share/doc
 /data/data/com.termux/files/usr/share/doc/libwebp
 /data/data/com.termux/files/usr/share/doc/libwebp/copyright
+/data/data/com.termux/files/usr/share/man
+/data/data/com.termux/files/usr/share/man/man1
+/data/data/com.termux/files/usr/share/man/man1/cwebp.1.gz
+/data/data/com.termux/files/usr/share/man/man1/dwebp.1.gz
+/data/data/com.termux/files/usr/share/man/man1/gif2webp.1.gz
+/data/data/com.termux/files/usr/share/man/man1/img2webp.1.gz
+/data/data/com.termux/files/usr/share/man/man1/webpinfo.1.gz
+/data/data/com.termux/files/usr/share/man/man1/webpmux.1.gz
```

- Compare Arch Linux: https://gitlab.archlinux.org/archlinux/packaging/packages/libwebp/-/blob/8aad1cd0f1748a36ffaaa1211d4b5e77463964b7/PKGBUILD