### PR TITLE
bump(main/libusbmuxd): 2.1.1

### DIFF
--- a/packages/libusbmuxd/build.sh
+++ b/packages/libusbmuxd/build.sh
@@ -2,12 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://libimobiledevice.org
 TERMUX_PKG_DESCRIPTION="A client library for applications to handle usbmux protocol connections with iOS devices"
 TERMUX_PKG_LICENSE="LGPL-2.1, GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-_COMMIT=19d6bec393c9f9b31ccb090059f59268da32e281
-_COMMIT_DATE=20250216
-TERMUX_PKG_VERSION=2.1.0-p${_COMMIT_DATE}
-TERMUX_PKG_SRCURL=git+https://github.com/libimobiledevice/libusbmuxd
-TERMUX_PKG_SHA256=93a2995dfc0b7d690bbf2da62f9e523f7505086baf64fd8d338911114c931686
-TERMUX_PKG_GIT_BRANCH=master
+TERMUX_PKG_VERSION="2.1.1"
+TERMUX_PKG_SRCURL=https://github.com/libimobiledevice/libusbmuxd/releases/download/${TERMUX_PKG_VERSION}/libusbmuxd-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_SHA256=5546f1aba1c3d1812c2b47d976312d00547d1044b84b6a461323c621f396efce
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libimobiledevice-glue, libplist"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
@@ -16,22 +13,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 "
 
 termux_step_post_get_source() {
-	git fetch --unshallow
-	git checkout $_COMMIT
-
-	local pdate="p$(git log -1 --format=%cs | sed 's/-//g')"
-	if [[ "$TERMUX_PKG_VERSION" != *"${pdate}" ]]; then
-		echo -n "ERROR: The version string \"$TERMUX_PKG_VERSION\" is"
-		echo -n " different from what is expected to be; should end"
-		echo " with \"${pdate}\"."
-		return 1
-	fi
-
-	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
-	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
-		termux_error_exit "Checksum mismatch for source files."
-	fi
-
 	# Do not forget to bump revision of reverse dependencies and rebuild them
 	# after SOVERSION is changed.
 	local _SOVERSION=7


### PR DESCRIPTION
Revert to tagged release from git commits which was added in fdfec333a311212389e948d28c32e6a2796baca4

* Fixes #24957 