### PR TITLE
fix(x11/qt6-qtbase): only send the `opt/qt6/cross` `QT_HOST_PATH` to cross-compilations of revdeps, not on-device builds

### DIFF
--- a/x11-packages/libfm-qt/build.sh
+++ b/x11-packages/libfm-qt/build.sh
@@ -3,11 +3,15 @@ TERMUX_PKG_DESCRIPTION="Library providing components to build desktop file manag
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.2.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/lxqt/libfm-qt/releases/download/${TERMUX_PKG_VERSION}/libfm-qt-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=4d8aa86fcfcf424f7f41c4a931e8d804dd12bedc8428931b5bc955345c4313a9
 TERMUX_PKG_DEPENDS="libc++, qt6-qtbase, glib, libxcb, libexif, lxqt-menu-data, menu-cache"
 TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt6-qttools"
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools
-"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+}

--- a/x11-packages/lximage-qt/build.sh
+++ b/x11-packages/lximage-qt/build.sh
@@ -3,11 +3,15 @@ TERMUX_PKG_DESCRIPTION="LXQt Image Viewer"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.2.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/lxqt/lximage-qt/releases/download/${TERMUX_PKG_VERSION}/lximage-qt-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=cc2ebfef3a7e2901114e71c2e15a9d1a382fe2d8a2b1468bade67fe0b68f99ea
 TERMUX_PKG_DEPENDS="glib, libc++, libexif, libfm-qt, libx11, libxfixes, qt6-qtbase, qt6-qtsvg"
 TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt6-qttools"
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools
-"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+}

--- a/x11-packages/lxqt-about/build.sh
+++ b/x11-packages/lxqt-about/build.sh
@@ -3,11 +3,15 @@ TERMUX_PKG_DESCRIPTION="LXQt dialog showing information about LXQt and the syste
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.2.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/lxqt/lxqt-about/releases/download/${TERMUX_PKG_VERSION}/lxqt-about-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=c5cb4eaa1c05be347a920dcc97c7892499d483e7e776b4633e390b67c16cd76f
 TERMUX_PKG_DEPENDS="libc++, liblxqt, libqtxdg, qt6-qtbase"
 TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt6-qttools"
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools
-"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+}

--- a/x11-packages/lxqt-archiver/build.sh
+++ b/x11-packages/lxqt-archiver/build.sh
@@ -3,11 +3,15 @@ TERMUX_PKG_DESCRIPTION="A simple & lightweight Qt file archiver"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.2.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/lxqt/lxqt-archiver/releases/download/${TERMUX_PKG_VERSION}/lxqt-archiver-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=53e4121369e3dc72c74e3ae2323ff277072550c83622486b94ad77b26a993ac6
 TERMUX_PKG_DEPENDS="glib, json-glib, libc++, libfm-qt, qt6-qtbase"
 TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt6-qttools"
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools
-"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+}

--- a/x11-packages/lxqt-config/build.sh
+++ b/x11-packages/lxqt-config/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Tools to configure LXQt and the underlying operating sys
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.2.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/lxqt/lxqt-config/releases/download/${TERMUX_PKG_VERSION}/lxqt-config-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=527b0b39e8156450f8f69bd6e516d10193b07e492a8945761036de46990f331e
 TERMUX_PKG_DEPENDS="libc++, liblxqt, libqtxdg, libxcb, libxcursor, libxfixes, lxqt-menu-data, qt6-qtbase, shared-mime-info, zlib"
@@ -12,12 +13,15 @@ TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt6-qttools"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DWITH_INPUT=OFF
 -DWITH_MONITOR=OFF
--DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools
 "
 
 TERMUX_PKG_AUTO_UPDATE=true
 
 termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+
 	# This is required because of the private lib used by lxqt-config-appearance
 	LDFLAGS+=" -Wl,-rpath=${TERMUX_PREFIX}/lib/lxqt-config"
 	export LDFLAGS

--- a/x11-packages/lxqt-globalkeys/build.sh
+++ b/x11-packages/lxqt-globalkeys/build.sh
@@ -3,11 +3,15 @@ TERMUX_PKG_DESCRIPTION="Tools to set global keyboard shortcuts in LXQt sessions"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.2.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/lxqt/lxqt-globalkeys/releases/download/${TERMUX_PKG_VERSION}/lxqt-globalkeys-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=66cfdfeed4c0b968f4635847ccc32bec8136bb74cfbd9a5b31e0475339f9979a
 TERMUX_PKG_DEPENDS="libc++, liblxqt, libx11, qt6-qtbase"
 TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt6-qttools"
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools
-"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+}

--- a/x11-packages/lxqt-notificationd/build.sh
+++ b/x11-packages/lxqt-notificationd/build.sh
@@ -3,11 +3,15 @@ TERMUX_PKG_DESCRIPTION="The LXQt notification daemon"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.2.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/lxqt/lxqt-notificationd/releases/download/${TERMUX_PKG_VERSION}/lxqt-notificationd-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=4223bf6ce1c2e5f67020320c70f221c13c94b17b5e33fd00fd6f8e2983a779c4
 TERMUX_PKG_DEPENDS="kf6-kwindowsystem, layer-shell-qt, libc++, liblxqt, libqtxdg, qt6-qtbase"
 TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt6-qttools"
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools
-"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+}

--- a/x11-packages/lxqt-panel/build.sh
+++ b/x11-packages/lxqt-panel/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="The LXQt desktop panel"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.2.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/lxqt/lxqt-panel/releases/download/${TERMUX_PKG_VERSION}/lxqt-panel-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=63d7f8af2e85b1a2580441943230fb4ab6edaaf52fd29fe0e616f6d57fd05d16
 TERMUX_PKG_DEPENDS="kf6-kwindowsystem, layer-shell-qt, libc++, libdbusmenu-lxqt, liblxqt, libqtxdg, libsysstat, libxcb, libxkbcommon, libxtst, libx11, lxqt-globalkeys, lxqt-menu-data, pulseaudio, qt6-qtbase, xcb-util, xcb-util-image"
@@ -17,11 +18,14 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DMOUNT_PLUGIN=OFF
 -DSENSORS_PLUGIN=OFF
 -DVOLUME_USE_ALSA=OFF
--DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools
 "
 TERMUX_PKG_AUTO_UPDATE=true
 
 termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+
 	# Add RUNPATH to the private libraries used by lxqt-panel's plugins
 	LDFLAGS+=" -Wl,-rpath=${TERMUX_PREFIX}/lib/lxqt-panel"
 	export LDFLAGS

--- a/x11-packages/lxqt-runner/build.sh
+++ b/x11-packages/lxqt-runner/build.sh
@@ -3,11 +3,15 @@ TERMUX_PKG_DESCRIPTION="LXQt application launcher"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.2.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/lxqt/lxqt-runner/releases/download/${TERMUX_PKG_VERSION}/lxqt-runner-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=e15caab4c9bc4e95b147095310ec4ed85553a906e1d4381067460b63a286e890
 TERMUX_PKG_DEPENDS="kf6-kwindowsystem, layer-shell-qt, libc++, liblxqt, libmuparser, lxqt-globalkeys, libqtxdg, qt6-qtbase"
 TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt6-qttools"
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools
-"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+}

--- a/x11-packages/lxqt-session/build.sh
+++ b/x11-packages/lxqt-session/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="The LXQt session manager"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.2.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/lxqt/lxqt-session/releases/download/${TERMUX_PKG_VERSION}/lxqt-session-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=27bc2613b516af503511f15f38216ef9650bc8f65ae6154990b76b1a20d3898a
 TERMUX_PKG_AUTO_UPDATE=true
@@ -10,9 +11,12 @@ TERMUX_PKG_DEPENDS="kf6-kwindowsystem, layer-shell-qt, libandroid-wordexp, libc+
 TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt6-qttools"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DWITH_LIBUDEV=OFF
--DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools
 "
 
 termux_step_pre_configure(){
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+
 	LDFLAGS+=" -landroid-wordexp"
 }

--- a/x11-packages/obconf-qt/build.sh
+++ b/x11-packages/obconf-qt/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="OpenBox window manager configuration tool"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.16.5"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL="https://github.com/lxqt/obconf-qt/releases/download/${TERMUX_PKG_VERSION}/obconf-qt-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=034883680912f7ea24dbd4c28b8ee4cf096774aa588e39431d319d56a924160c
 TERMUX_PKG_REPLACES="obconf"
@@ -11,11 +11,13 @@ TERMUX_PKG_BREAKS="obconf"
 TERMUX_PKG_DEPENDS="libc++, qt6-qtbase, glib, openbox, liblxqt, hicolor-icon-theme, libxml2"
 TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt6-qtbase-cross-tools, qt6-qttools-cross-tools"
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools
-"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+}
 
 termux_step_post_make_install() {
-	cd "$TERMUX_PREFIX"/bin
-	ln -s obconf-qt obconf
+	ln -sf obconf-qt "$TERMUX_PREFIX"/bin/obconf
 }

--- a/x11-packages/pcmanfm-qt/build.sh
+++ b/x11-packages/pcmanfm-qt/build.sh
@@ -3,11 +3,15 @@ TERMUX_PKG_DESCRIPTION="PCManFM-Qt is the file manager of LXQt"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.2.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/lxqt/pcmanfm-qt/releases/download/${TERMUX_PKG_VERSION}/pcmanfm-qt-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=a5eeeafa8d02c9ada1b4660c238f95fde08fa13278c9ea5e191ea3bdfba1be8f
 TERMUX_PKG_DEPENDS="desktop-file-utils, glib, layer-shell-qt, libc++, libfm-qt, libxcb, qt6-qtbase"
 TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt6-qttools"
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools
-"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+}

--- a/x11-packages/qt6-qtbase/build.sh
+++ b/x11-packages/qt6-qtbase/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="GPL-3.0-only"
 TERMUX_PKG_LICENSE_FILE="LICENSES/GPL-3.0-only.txt"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="6.9.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://download.qt.io/official_releases/qt/${TERMUX_PKG_VERSION%.*}/${TERMUX_PKG_VERSION}/submodules/qtbase-everywhere-src-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=40caedbf83cc9a1959610830563565889878bc95f115868bbf545d1914acf28e
 TERMUX_PKG_DEPENDS="brotli, double-conversion, freetype, glib, harfbuzz, libandroid-posix-semaphore, libandroid-shmem, libc++, libdrm, libice, libicu, libjpeg-turbo, libpng, libsm, libsqlite, libuuid, libx11, libxcb, libxi, libxkbcommon, libwayland, opengl, openssl, pcre2, vulkan-loader, xcb-util-cursor, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm, zlib, zstd"

--- a/x11-packages/qt6-qtbase/do-not-use-cross-tools-paths-ondevice-for-reverse-deps.patch
+++ b/x11-packages/qt6-qtbase/do-not-use-cross-tools-paths-ondevice-for-reverse-deps.patch
@@ -1,0 +1,31 @@
+Fixes the build in TERMUX_ON_DEVICE_BUILD=true mode of reverse dependencies of qt6 like tageditor,
+where CMAKE_HOST_SYSTEM_NAME is "Android" and the path $TERMUX_PREFIX/opt/qt6/cross should never be
+used because it contains GNU/Linux binaries that are sent there by the automatic installation
+of qt6-*-cross-tools packages during termux_step_get_dependencies() by scripts/buildorder.py
+installing the qt6-*-cross-tools subpackages of qt6-* packages during the builds of reverse dependencies
+of qt6,
+https://github.com/termux/termux-packages/blob/da3717f43930c480bd8dfcf1c002430e43e49013/scripts/buildorder.py#L159
+
+without breaking the builds of anything in TERMUX_ON_DEVICE_BUILD=false mode,
+where CMAKE_HOST_SYSTEM_NAME is "Linux" so the paths set by
+"-DQT_HOST_PATH=${TERMUX_PREFIX}/opt/qt6/cross" in TERMUX_PKG_EXTRA_CONFIGURE_ARGS of qt6-qtbase
+are used here instead.
+
+--- a/cmake/QtConfigDependencies.cmake.in
++++ b/cmake/QtConfigDependencies.cmake.in
+@@ -10,8 +10,13 @@ elseif(DEFINED ENV{QT_REQUIRE_HOST_PATH_CHECK})
+ else()
+     set(__qt_platform_requires_host_info_package "@platform_requires_host_info_package@")
+ endif()
+-set(__qt_platform_initial_qt_host_path "@qt_host_path_absolute@")
+-set(__qt_platform_initial_qt_host_path_cmake_dir "@qt_host_path_cmake_dir_absolute@")
++if (${CMAKE_HOST_SYSTEM_NAME} STREQUAL Android)
++    set(__qt_platform_initial_qt_host_path "@TERMUX_PREFIX@")
++    set(__qt_platform_initial_qt_host_path_cmake_dir "@TERMUX_PREFIX@/lib/cmake")
++else()
++    set(__qt_platform_initial_qt_host_path "@qt_host_path_absolute@")
++    set(__qt_platform_initial_qt_host_path_cmake_dir "@qt_host_path_cmake_dir_absolute@")
++endif()
+ 
+ _qt_internal_setup_qt_host_path(
+     "${__qt_platform_requires_host_info_package}"

--- a/x11-packages/qterminal/build.sh
+++ b/x11-packages/qterminal/build.sh
@@ -3,11 +3,15 @@ TERMUX_PKG_DESCRIPTION="A lightweight Qt terminal emulator"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.2.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/lxqt/qterminal/releases/download/${TERMUX_PKG_VERSION}/qterminal-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=0cd38c3408bbaf4737a0276cf3d64b4c987716f0ef1f1eb8e9c1485e0c08f5d2
 TERMUX_PKG_DEPENDS="layer-shell-qt, libc++, libx11, qt6-qtbase, qtermwidget"
 TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt6-qttools-cross-tools"
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools
-"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+}

--- a/x11-packages/qtermwidget/build.sh
+++ b/x11-packages/qtermwidget/build.sh
@@ -3,11 +3,15 @@ TERMUX_PKG_DESCRIPTION="A terminal emulator widget for Qt 5"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.2.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/lxqt/qtermwidget/releases/download/${TERMUX_PKG_VERSION}/qtermwidget-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=ba4ffbba79cf55aff76243564936f9337beeebdf8c4a8bfa365b9fc88f261ce9
 TERMUX_PKG_DEPENDS="libc++, libx11, qt6-qtbase"
 TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt6-qttools-cross-tools"
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools
-"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+}

--- a/x11-packages/qtutilities/build.sh
+++ b/x11-packages/qtutilities/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Common Qt related C++ classes and routines used by my ap
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="6.15.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/Martchus/qtutilities/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=9826fef8a4e87d7d529fd1173802a7a5fcdd26f3ef0cb50ff0b68d308ef06184
 TERMUX_PKG_AUTO_UPDATE=true
@@ -11,5 +12,10 @@ TERMUX_PKG_BUILD_DEPENDS="qt6-qtbase-cross-tools, qt6-qttools-cross-tools"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DBUILD_SHARED_LIBS=ON
 -DQT_PACKAGE_PREFIX=Qt6
--DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools
 "
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+}

--- a/x11-packages/tageditor/build.sh
+++ b/x11-packages/tageditor/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A tag editor with Qt GUI and command-line interface. Sup
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.9.5"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/Martchus/tageditor/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=2f8d80ca7da8395d5d704ae9bfc8bb9ea5a562df131ceb99ffc5318a2670b6cf
 TERMUX_PKG_AUTO_UPDATE=true
@@ -11,5 +12,10 @@ TERMUX_PKG_BUILD_DEPENDS="qt6-qtbase-cross-tools, qt6-qtdeclarative-cross-tools,
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DWEBVIEW_PROVIDER=none
 -DQT_PACKAGE_PREFIX=Qt6
--DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools
 "
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+}


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/24975

Fixes the build in `TERMUX_ON_DEVICE_BUILD=true` mode of reverse dependencies of qt6 like `tageditor`, where `CMAKE_HOST_SYSTEM_NAME` is "`Android`" and the path `$TERMUX_PREFIX/opt/qt6/cross` should never be used because it contains GNU/Linux binaries that are sent there by the automatic installation of `qt6-*-cross-tools packages` during `termux_step_get_dependencies()` by `scripts/buildorder.py` installing the `qt6-*-cross-tools` subpackages of `qt6-*` packages during the builds of reverse dependencies of qt6,
https://github.com/termux/termux-packages/blob/da3717f43930c480bd8dfcf1c002430e43e49013/scripts/buildorder.py#L159

without breaking the builds of anything in `TERMUX_ON_DEVICE_BUILD=false` mode, where `CMAKE_HOST_SYSTEM_NAME` is "`Linux`" so the paths set by "`-DQT_HOST_PATH=${TERMUX_PREFIX}/opt/qt6/cross`" in `TERMUX_PKG_EXTRA_CONFIGURE_ARGS` of `qt6-qtbase` are used here instead.

The patch `do-not-use-cross-tools-paths-ondevice-for-reverse-deps.patch` fixes only the `moc: 1: ELF: not found` part of the error message,
and the changes to the use of `-DQt6LinguistTools_DIR` fix the `lupdate: 1: Syntax error: word unexpected (expecting ")")` part of the error message.