### PR TITLE
addpkg(main/vapoursynth): 72

### DIFF
--- a/packages/vapoursynth/build.sh
+++ b/packages/vapoursynth/build.sh
@@ -1,0 +1,49 @@
+TERMUX_PKG_HOMEPAGE=https://www.vapoursynth.com/
+TERMUX_PKG_DESCRIPTION="Video processing framework with simplicity in mind"
+TERMUX_PKG_LICENSE="LGPL-2.1-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="72"
+TERMUX_PKG_SRCURL=https://github.com/vapoursynth/vapoursynth/archive/refs/tags/R${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=650f77feebfd08842b521273f59e0c88f7ba9d7cb5f151d89b79b8dfdd4ce633
+TERMUX_PKG_DEPENDS="libzimg, python"
+TERMUX_PKG_PYTHON_COMMON_DEPS="Cython"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" --disable-x86-asm"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_VERSION_REGEXP='\d{2}'
+
+termux_pkg_auto_update() {
+	local latest_release
+	latest_release="$(git ls-remote --tags https://github.com/vapoursynth/vapoursynth.git \
+	| grep -oP "refs/tags/R\K${TERMUX_PKG_UPDATE_VERSION_REGEXP}$" \
+	| sort -V \
+	| tail -n1)"
+
+	if [[ "${latest_release}" == "${TERMUX_PKG_VERSION}" ]]; then
+		echo "INFO: No update needed. Already at version '${TERMUX_PKG_VERSION}'."
+		return
+	fi
+
+	termux_pkg_upgrade_version "${latest_release}"
+}
+
+
+termux_step_pre_configure() {
+	rm -f "$TERMUX_PKG_SRCDIR/setup.py"
+
+	if [[ "$TERMUX_ARCH" == 'aarch64' ]]; then
+		export CFLAGS+=" -march=armv8.1-a"
+		export CXXFLAGS+=" -march=armv8.1-a"
+	fi
+
+	# Workaround borrowed from https://github.com/termux/termux-packages/pull/22212/files
+	local _libgcc_file _libgcc_path _libgcc_name
+	_libgcc_file="$($CC -print-libgcc-file-name)"
+	_libgcc_path="$(dirname "$_libgcc_file")"
+	_libgcc_name="$(basename "$_libgcc_file")"
+
+	LDFLAGS+=" -L$_libgcc_path -l:$_libgcc_name"
+	LDFLAGS+=" -Wl,-rpath=$TERMUX_PREFIX/lib/vapoursynth"
+
+	./autogen.sh
+}


### PR DESCRIPTION
- closes #24826

I've got it building, but I haven't confirmed if the `vapoursynth` package is complete and/or working yet.

I'd appreciate some help in that regard.

<h1><em></em></h1> <!-- thin separator --> 

<sup>(This is a pre-written, saved reply.)</sup>
If you want to test this PR please download the appropriate DEB package(s)
from the build artifacts of the [associated PR's latest CI run](https://github.com/termux/termux-packages/actions/runs/15556056585).
![Screenshot_20240619_232413](https://github.com/user-attachments/assets/998a145b-5f1d-4f58-a7d9-f034ea0b9668)


After downloading the build artifact, make sure to `unzip` and un-`tar` it.
<details><summary>Detailed instructions, if needed.</summary>
<p>

```bash
# finding out what architecture you need
# architecture is just below the TERMUX_VERSION
termux-info

# e.g.
# [...]
# TERMUX_MAIN_PACKAGE_FORMAT=debian
# TERMUX_VERSION=0.118.0
# TERMUX__USER_ID=0
# Packages CPU architecture:
# aarch64
# [...]

# =======================

# make sure `unzip` and `tar` are installed using
pkg install unzip tar

# unzip the artifact (if you have a different architecture this might be arm, i686 or x86_64 instead)
unzip debs-aarch64-*.zip

# untar the artifact
tar xf debs-aarch64-*.tar

# You should now have a debs/ directory in your current working directory
# Install the packages from the local source using
pkg install -- ./debs/*.deb

# to clean up, you can remove the debs/ directory, .tar file and .zip file
rm -rfi debs debs-aarch64-*.zip debs-aarch64-*.tar
```

</p>
</details> 