### PR TITLE
Updated packages->await->build.sh to fix dead homepage

### DIFF
--- a/packages/await/build.sh
+++ b/packages/await/build.sh
@@ -1,4 +1,4 @@
-TERMUX_PKG_HOMEPAGE=https://await-cli.app/
+TERMUX_PKG_HOMEPAGE=https://web.archive.org/web/20240308152556/https://await-cli.app/#expand
 TERMUX_PKG_DESCRIPTION="Runs list of commands in parallel and waits for their termination"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"


### PR DESCRIPTION
I modified the homepage for await to fix the homepage that quite getting updates after March 23, 2024. This homepage utilizes the wayback machine to grab a capture of the way the homepage looked at the time and date the capture was taken.