### PR TITLE
fix(scripts/lint-packages): don't fail if branch name is `master`

### DIFF
--- a/scripts/lint-packages.sh
+++ b/scripts/lint-packages.sh
@@ -126,7 +126,7 @@ check_indentation() {
 # - Or specify one of the CI skip tags
 check_version_change() {
 	local base_commit commit_diff package="$1"
-	base_commit="$(git merge-base --fork-point origin/master)"
+	base_commit="$(git merge-base 'master@{upstream}' 'HEAD')"
 	commit_diff="$(git log --patch "${base_commit}.." -- "$package")"
 
 	# If the diff is empty there's no commit modifying that package on this branch, which is a PASS.


### PR DESCRIPTION
- Found while reviewing #25042

This fixes an edgecase where `git merge-base` is unable to find a base commit with `origin/master` if the PR is opened from the `master` branch of the fork.