### PR TITLE
bump(x11/libime): 1.1.11

### DIFF
--- a/x11-packages/libime/build.sh
+++ b/x11-packages/libime/build.sh
@@ -2,8 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://github.com/fcitx/libime
 TERMUX_PKG_DESCRIPTION="A library to support generic input method implementation"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.1.10"
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_VERSION="1.1.11"
 TERMUX_PKG_SRCURL=git+https://github.com/fcitx/libime
 TERMUX_PKG_GIT_BRANCH="${TERMUX_PKG_VERSION}"
 TERMUX_PKG_DEPENDS="boost, fcitx5, libc++, libime-data, zstd"
@@ -30,13 +29,13 @@ termux_step_post_make_install() {
 	# from add_custom_commands in data/CMakeLists.txt
 	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
 		pushd data
-		termux-proot-run ../tools/libime_slm_build_binary -s -a 22 -q 8 trie lm_sc.arpa sc.lm
-		termux-proot-run ../tools/libime_prediction sc.lm lm_sc.arpa sc.lm.predict
-		termux-proot-run ../tools/libime_pinyindict dict_sc.txt sc.dict
-		termux-proot-run ../tools/libime_pinyindict dict_extb.txt extb.dict
+		termux-proot-run ../bin/libime_slm_build_binary -s -a 22 -q 8 trie lm_sc.arpa sc.lm
+		termux-proot-run ../bin/libime_prediction sc.lm lm_sc.arpa sc.lm.predict
+		termux-proot-run ../bin/libime_pinyindict dict_sc.txt sc.dict
+		termux-proot-run ../bin/libime_pinyindict dict_extb.txt extb.dict
 		declare -a files=(db.txt erbi.txt qxm.txt wanfeng.txt wbpy.txt wbx.txt zrm.txt cj.txt)
 		for file in "${files[@]}"; do
-			termux-proot-run ../tools/libime_tabledict "$file" "${file/.txt/.main.dict}"
+			termux-proot-run ../bin/libime_tabledict "$file" "${file/.txt/.main.dict}"
 		done
 		popd
 	fi


### PR DESCRIPTION
libime tools are built in bin directory after this upstream commit. https://github.com/fcitx/libime/commit/535d2dc551244010b72b1cec1fc569e5e6e82a63

* Fixes #25069 