### PR TITLE
bump(main/git): 2.50.0

### DIFF
--- a/packages/git/compat-posix.h.patch
+++ b/packages/git/compat-posix.h.patch
@@ -1,12 +1,13 @@
 Fix ST_CTIME_NSEC and ST_MTIME_NSEC macros on Android.
 
-diff -u -r ../git-1.8.5.3/git-compat-util.h ./git-compat-util.h
---- ../git-1.8.5.3/git-compat-util.h    2014-01-14 18:10:09.000000000 +0100
-+++ ./git-compat-util.h 2014-01-22 13:07:19.000000000 +0100
-@@ -657,6 +657,10 @@
- # define FORCE_DIR_SET_GID 0
- #endif
-
+diff --git a/compat/posix.h b/compat/posix.h
+index 067a00f33b..c839d9ca25 100644
+--- a/compat/posix.h
++++ b/compat/posix.h
+@@ -476,6 +476,10 @@ int git_qsort_s(void *base, size_t nmemb, size_t size,
+ 		BUG("qsort_s() failed");			\
+ } while (0)
+ 
 +#ifdef __ANDROID__
 +#define ST_CTIME_NSEC(st) ((unsigned int)((st).st_ctime_nsec))
 +#define ST_MTIME_NSEC(st) ((unsigned int)((st).st_mtime_nsec))
@@ -14,12 +15,11 @@ diff -u -r ../git-1.8.5.3/git-compat-util.h ./git-compat-util.h
  #ifdef NO_NSEC
  #undef USE_NSEC
  #define ST_CTIME_NSEC(st) 0
-@@ -670,6 +674,7 @@
+@@ -489,6 +493,7 @@ int git_qsort_s(void *base, size_t nmemb, size_t size,
  #define ST_MTIME_NSEC(st) ((unsigned int)((st).st_mtim.tv_nsec))
  #endif
  #endif
 +#endif
-
- #ifdef UNRELIABLE_FSTAT
- #define fstat_is_reliable() 0
-
+ 
+ #ifndef va_copy
+ /*

--- a/packages/git/config.mak.uname.patch
+++ b/packages/git/config.mak.uname.patch
@@ -1,9 +1,10 @@
 Set uname_S to Linux instead of detecting build machine.
 Android before API 26 does not support sync_file_range.
 
-diff -uNr ../git-2.36.0/config.mak.uname ./config.mak.uname
---- ../git-2.36.0/config.mak.uname	2022-04-18 02:52:38.000000000 -0300
-+++ ./config.mak.uname	2022-05-03 21:26:12.831013435 -0300
+diff --git a/config.mak.uname b/config.mak.uname
+index 3e26bb074a..8135d42963 100644
+--- a/config.mak.uname
++++ b/config.mak.uname
 @@ -4,7 +4,7 @@
  # Microsoft's Safe Exception Handling in libraries (such as zlib).
  # Typically required for VS2013+/32-bit compilation on Vista+ versions.
@@ -13,11 +14,11 @@ diff -uNr ../git-2.36.0/config.mak.uname ./config.mak.uname
  uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
  uname_O := $(shell sh -c 'uname -o 2>/dev/null || echo not')
  uname_R := $(shell sh -c 'uname -r 2>/dev/null || echo not')
-@@ -57,7 +57,6 @@
+@@ -56,7 +56,6 @@ ifeq ($(uname_S),Linux)
+ 	HAVE_DEV_TTY = YesPlease
+ 	HAVE_CLOCK_GETTIME = YesPlease
  	HAVE_CLOCK_MONOTONIC = YesPlease
- 	# -lrt is needed for clock_gettime on glibc <= 2.16
- 	NEEDS_LIBRT = YesPlease
 -	HAVE_SYNC_FILE_RANGE = YesPlease
  	HAVE_GETDELIM = YesPlease
  	FREAD_READS_DIRECTORIES = UnfortunatelyYes
- 	BASIC_CFLAGS += -DHAVE_SYSINFO
+ 	HAVE_SYSINFO = YesPlease


### PR DESCRIPTION
This PR:
- closes #25075
- Moves the old `git.patch` from `git-compat-util.h` to the newly split out `compat/posix.h`,
and renames the patch accordingly.
- Regenerates `config.mak.uname.patch`, which had stopped applying properly.
- Specifies that `openssl` should be used for Git's pRNG function,
it now defaults to trying to use `getrandom()`, which causes a build error.
Git *probably* fell back to its `/dev/urandom` pRNG function before 2.50.0 on Termux.
But I don't know of a way to easily test this.
OpenSSL's pRNG should work just fine without introducing changes noticeable to the user.
- Cleans up some slop in the build script.