### PR TITLE
chore(main/gawk): remove `gawkbug`

### DIFF
--- a/packages/gawk/build.sh
+++ b/packages/gawk/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Programming language designed for text processing"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="5.3.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/gawk/gawk-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=694db764812a6236423d4ff40ceb7b6c4c441301b72ad502bb5c27e00cd56f78
 TERMUX_PKG_AUTO_UPDATE=false
@@ -10,7 +11,11 @@ TERMUX_PKG_DEPENDS="libandroid-support, libgmp, libmpfr, readline"
 TERMUX_PKG_BREAKS="gawk-dev"
 TERMUX_PKG_REPLACES="gawk-dev"
 TERMUX_PKG_ESSENTIAL=true
-TERMUX_PKG_RM_AFTER_INSTALL="bin/gawk-* bin/igawk share/man/man1/igawk.1"
+TERMUX_PKG_RM_AFTER_INSTALL="
+bin/gawkbug
+bin/gawk-${TERMUX_PKG_VERSION}
+share/man/man1/gawkbug.1
+"
 TERMUX_PKG_GROUPS="base-devel"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-pma


### PR DESCRIPTION
- For consistency with `bash`: https://github.com/termux/termux-packages/pull/25113#issuecomment-2993204795

https://github.com/termux/termux-packages/blob/6d9084fcd742271e7c3eab852f0a34a6ed167d7e/packages/bash/build.sh#L37

- This kind of command prompts to autosend bug reports to gnu.org.
  - This is not desirable because the gnu.org bug tracker should not be overwhelmed by bugs from an esoteric platform that might not be convenient for upstream developers.
  - It is more efficient for bugs in Termux packages to be reported here, then forwarded to upstream issue trackers if reproducible on a mainstream desktop platform familiar to desktop developers.
  - It is assumed that is why the choice was made for `bash`, and that the same removal should be applied to `gawkbug`.

```
Send bug report to bug-gawk@gnu.org? [y/n]
```

- Remove references to `igawk`, which no longer seems to exist

- Specify removal of `gawk-${TERMUX_PKG_VERSION}` explicitly instead of `gawk-*`