### PR TITLE
fix(main/mplayer): explicitly disable some video playback dependencies

### DIFF
--- a/packages/mplayer/build.sh
+++ b/packages/mplayer/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="The Movie Player"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.5
-TERMUX_PKG_REVISION=8
+TERMUX_PKG_REVISION=9
 TERMUX_PKG_SRCURL=https://mplayerhq.hu/MPlayer/releases/MPlayer-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=650cd55bb3cb44c9b39ce36dac488428559799c5f18d16d98edb2b7256cbbf85
 TERMUX_PKG_DEPENDS="ffmpeg, fontconfig, freetype, fribidi, liba52, libass, libbluray, libdvdnav, libdvdread, libiconv, libjpeg-turbo, liblzo, libmad, libmp3lame, libogg, libpng, libtheora, libtwolame, libvorbis, libx11, libx264, libxext, libxss, libxv, mpg123, ncurses, openal-soft, pulseaudio, xvidcore, zlib"
@@ -16,6 +16,9 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-dga2
 --disable-dga1
 --disable-xinerama
+--disable-caca
+--disable-libmpeg2
+--disable-aa
 "
 TERMUX_PKG_EXTRA_MAKE_ARGS="INSTALLSTRIP="
 TERMUX_PKG_EXCLUDED_ARCHES="i686"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/25137

- Prevents `scripts/run-docker.sh ./build-package.sh -I -f libmpeg2 aalib libcaca mplayer` from creating a malformed `mplayer` package

- Confirmed to prevent that with testing and this command: `ldd $(which mplayer) | grep -e caca -e mpeg2 -e aa`