### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,8 @@
 name: "CodeQL analysis of GitHub action jobs"
 
+permissions:
+  models: none
+
 on:
   push:
     branches: [ "master", "android-5" ]

--- a/.github/workflows/golang_validation.yml
+++ b/.github/workflows/golang_validation.yml
@@ -1,5 +1,9 @@
 name: Golang validation
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/termux/termux-packages/security/code-scanning/1](https://github.com/termux/termux-packages/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow. Based on the provided workflow, it primarily performs repository cloning, environment setup, and artifact uploading. These tasks only require `contents: read` and `actions: write` permissions. Adding this block ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
