### PR TITLE
tree-wide: migrate system-`clang` hostbuilds to `clang-19`

### DIFF
--- a/packages/nodejs-lts/build.sh
+++ b/packages/nodejs-lts/build.sh
@@ -34,9 +34,9 @@ termux_step_host_build() {
 	local ICU_VERSION=76.1
 	local ICU_TAR=icu4c-${ICU_VERSION//./_}-src.tgz
 	local ICU_DOWNLOAD=https://github.com/unicode-org/icu/releases/download/release-${ICU_VERSION//./-}/$ICU_TAR
-	export CC=/usr/bin/clang-18
-	export CXX=/usr/bin/clang++-18
-	export LD=/usr/bin/clang++-18
+	export CC="$TERMUX_HOST_LLVM_BASE_DIR/bin/clang"
+	export CXX="$TERMUX_HOST_LLVM_BASE_DIR/bin/clang++"
+	export LD="$TERMUX_HOST_LLVM_BASE_DIR/bin/clang++"
 	termux_download \
 		$ICU_DOWNLOAD\
 		$TERMUX_PKG_CACHEDIR/$ICU_TAR \

--- a/packages/nodejs/build.sh
+++ b/packages/nodejs/build.sh
@@ -37,9 +37,9 @@ termux_step_host_build() {
 		dfacb46bfe4747410472ce3e1144bf28a102feeaa4e3875bac9b4c6cf30f4f3e
 	tar xf $TERMUX_PKG_CACHEDIR/$ICU_TAR
 	cd icu/source
-	export CC=/usr/bin/clang-18
-	export CXX=/usr/bin/clang++-18
-	export LD=/usr/bin/clang++-18
+	export CC="$TERMUX_HOST_LLVM_BASE_DIR/bin/clang"
+	export CXX="$TERMUX_HOST_LLVM_BASE_DIR/bin/clang++"
+	export LD="$TERMUX_HOST_LLVM_BASE_DIR/bin/clang++"
 	if [ "$TERMUX_ARCH_BITS" = 32 ]; then
 		./configure --prefix $TERMUX_PKG_HOSTBUILD_DIR/icu-installed \
 			--disable-samples \

--- a/packages/openjdk-17/build.sh
+++ b/packages/openjdk-17/build.sh
@@ -90,12 +90,12 @@ termux_step_configure() {
 		OBJDUMP="$OBJDUMP" \
 		STRIP="$STRIP" \
 		CXXFILT="llvm-cxxfilt" \
-		BUILD_CC="/usr/bin/clang-18" \
-		BUILD_CXX="/usr/bin/clang++-18" \
-		BUILD_NM="/usr/bin/llvm-nm-18" \
-		BUILD_AR="/usr/bin/llvm-ar-18" \
-		BUILD_OBJCOPY="/usr/bin/llvm-objcopy-18" \
-		BUILD_STRIP="/usr/bin/llvm-strip-18" \
+		BUILD_CC="$TERMUX_HOST_LLVM_BASE_DIR/bin/clang" \
+		BUILD_CXX="$TERMUX_HOST_LLVM_BASE_DIR/bin/clang++" \
+		BUILD_NM="$TERMUX_HOST_LLVM_BASE_DIR/bin/llvm-nm" \
+		BUILD_AR="$TERMUX_HOST_LLVM_BASE_DIR/bin/llvm-ar" \
+		BUILD_OBJCOPY="$TERMUX_HOST_LLVM_BASE_DIR/bin/llvm-objcopy" \
+		BUILD_STRIP="$TERMUX_HOST_LLVM_BASE_DIR/bin/llvm-strip" \
 		--with-jobs=$TERMUX_PKG_MAKE_PROCESSES
 }
 

--- a/packages/openjdk-21/build.sh
+++ b/packages/openjdk-21/build.sh
@@ -92,12 +92,12 @@ termux_step_configure() {
 		OBJDUMP="$OBJDUMP" \
 		STRIP="$STRIP" \
 		CXXFILT="llvm-cxxfilt" \
-		BUILD_CC="/usr/bin/clang-18" \
-		BUILD_CXX="/usr/bin/clang++-18" \
-		BUILD_NM="/usr/bin/llvm-nm-18" \
-		BUILD_AR="/usr/bin/llvm-ar-18" \
-		BUILD_OBJCOPY="/usr/bin/llvm-objcopy-18" \
-		BUILD_STRIP="/usr/bin/llvm-strip-18" \
+		BUILD_CC="$TERMUX_HOST_LLVM_BASE_DIR/bin/clang" \
+		BUILD_CXX="$TERMUX_HOST_LLVM_BASE_DIR/bin/clang++" \
+		BUILD_NM="$TERMUX_HOST_LLVM_BASE_DIR/bin/llvm-nm" \
+		BUILD_AR="$TERMUX_HOST_LLVM_BASE_DIR/bin/llvm-ar" \
+		BUILD_OBJCOPY="$TERMUX_HOST_LLVM_BASE_DIR/bin/llvm-objcopy" \
+		BUILD_STRIP="$TERMUX_HOST_LLVM_BASE_DIR/bin/llvm-strip" \
 		--with-jobs=$TERMUX_PKG_MAKE_PROCESSES
 }
 

--- a/packages/rust/build.sh
+++ b/packages/rust/build.sh
@@ -148,6 +148,7 @@ termux_step_configure() {
 	sed \
 		-e "s|@TERMUX_PREFIX@|${TERMUX_PREFIX}|g" \
 		-e "s|@TERMUX_STANDALONE_TOOLCHAIN@|${TERMUX_STANDALONE_TOOLCHAIN}|g" \
+		-e "s|@TERMUX_HOST_LLVM_BASE_DIR@|${TERMUX_HOST_LLVM_BASE_DIR}|g" \
 		-e "s|@CARGO_TARGET_NAME@|${CARGO_TARGET_NAME}|g" \
 		-e "s|@RUSTC@|${RUSTC}|g" \
 		-e "s|@CARGO@|${CARGO}|g" \

--- a/packages/rust/config.toml
+++ b/packages/rust/config.toml
@@ -48,7 +48,7 @@ rpath = false
 lld = false
 
 [target.x86_64-unknown-linux-gnu]
-llvm-config = "/usr/bin/llvm-config-19"
+llvm-config = "@TERMUX_HOST_LLVM_BASE_DIR@/bin/llvm-config"
 rpath = true
 
 [target.aarch64-linux-android]

--- a/packages/swift/build.sh
+++ b/packages/swift/build.sh
@@ -118,10 +118,10 @@ termux_step_host_build() {
 
 		# The Ubuntu Docker image (sometimes used by CI but sometimes not)
 		# might not have clang/clang++ in its path, so explicitly set it
-		# to clang-18 if necessary.
+		# to the versioned system clang if necessary.
 		if [ -z "$CLANG" ]; then
-			CLANG=$(command -v clang-18)
-			CLANGXX=$(command -v clang++-18)
+			CLANG="$TERMUX_HOST_LLVM_BASE_DIR/bin/clang"
+			CLANGXX="$TERMUX_HOST_LLVM_BASE_DIR/bin/clang++"
 		fi
 
 		# Natively compile llvm-tblgen and some other files needed later.

--- a/scripts/properties.sh
+++ b/scripts/properties.sh
@@ -314,6 +314,9 @@ TERMUX_NDK_VERSION="${TERMUX_NDK_VERSION_NUM}${TERMUX_NDK_REVISION}"
 # and update SHA256 sums in scripts/setup-android-sdk.sh
 # check all packages build and run correctly and bump if needed
 
+: "${TERMUX_HOST_LLVM_MAJOR_VERSION:="19"}"
+: "${TERMUX_HOST_LLVM_BASE_DIR:="/usr/lib/llvm-${TERMUX_HOST_LLVM_MAJOR_VERSION}"}"
+
 : "${TERMUX_JAVA_HOME:=/usr/lib/jvm/java-17-openjdk-amd64}"
 export JAVA_HOME="${TERMUX_JAVA_HOME}"
 

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -144,10 +144,7 @@ PACKAGES+=" php-xml"
 PACKAGES+=" composer"
 
 # Needed by package rust.
-PACKAGES+=" libssl-dev" # Needed to build Rust
-PACKAGES+=" llvm-19-dev"
-PACKAGES+=" llvm-19-tools"
-PACKAGES+=" clang-19"
+PACKAGES+=" libssl-dev"
 
 # Needed by librusty-v8
 PACKAGES+=" libclang-rt-17-dev"
@@ -331,22 +328,35 @@ fi
 # Allow 32-bit packages.
 $SUDO dpkg --add-architecture i386
 
+$SUDO apt-get -yq update
+
+# Install jq first, then source properties.sh
+$SUDO env DEBIAN_FRONTEND=noninteractive \
+	apt-get install -yq --no-install-recommends $PACKAGES
+
+. $(dirname "$(realpath "$0")")/properties.sh
+
+LLVM_PACKAGES=""
+
+# Needed by rust and other packages.
+LLVM_PACKAGES+=" llvm-${TERMUX_HOST_LLVM_MAJOR_VERSION}-dev"
+LLVM_PACKAGES+=" llvm-${TERMUX_HOST_LLVM_MAJOR_VERSION}-tools"
+LLVM_PACKAGES+=" clang-${TERMUX_HOST_LLVM_MAJOR_VERSION}"
+
 # Add apt.llvm.org repo to get newer LLVM than Ubuntu provided
 $SUDO cp $(dirname "$(realpath "$0")")/llvm-snapshot.gpg.key /etc/apt/trusted.gpg.d/apt.llvm.org.asc
 $SUDO chmod a+r /etc/apt/trusted.gpg.d/apt.llvm.org.asc
 {
-	echo "deb [arch=amd64] http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main"
+	echo "deb [arch=amd64] http://apt.llvm.org/noble/ llvm-toolchain-noble-${TERMUX_HOST_LLVM_MAJOR_VERSION} main"
 } | $SUDO tee /etc/apt/sources.list.d/apt-llvm-org.list > /dev/null
 
 $SUDO apt-get -yq update
 
 $SUDO env DEBIAN_FRONTEND=noninteractive \
-	apt-get install -yq --no-install-recommends $PACKAGES
+	apt-get install -yq --no-install-recommends $LLVM_PACKAGES
 
 $SUDO locale-gen --purge en_US.UTF-8
 echo -e 'LANG="en_US.UTF-8"\nLANGUAGE="en_US:en"\n' | $SUDO tee -a /etc/default/locale
-
-. $(dirname "$(realpath "$0")")/properties.sh
 
 # Ownership of `TERMUX__PREFIX` must be fixed before `TERMUX_APP__DATA_DIR`
 # if its under it, otherwise `TERMUX__ROOTFS` will not have its ownership fixed.

--- a/x11-packages/qt5-qtwebengine/build.sh
+++ b/x11-packages/qt5-qtwebengine/build.sh
@@ -15,8 +15,8 @@ TERMUX_PKG_HOSTBUILD=true
 termux_step_host_build() {
 	# Generate ffmpeg headers for i686
 	mkdir -p fake-bin
-	ln -s $(command -v clang-18) fake-bin/clang
-	ln -s $(command -v clang++-18) fake-bin/clang++
+	ln -s "$TERMUX_HOST_LLVM_BASE_DIR/bin/clang" fake-bin/clang
+	ln -s "$TERMUX_HOST_LLVM_BASE_DIR/bin/clang++" fake-bin/clang++
 
 	# Remove python3 compatibility file preventing using newer python3 versions:
 	rm $TERMUX_PKG_SRCDIR/src/3rdparty/chromium/third_party/ffmpeg/chromium/scripts/enum.py


### PR DESCRIPTION
- After https://github.com/termux/termux-packages/pull/25197, the termux-package-builder docker container will now contain `clang-19`, not `clang-18`, so all instances of `clang-18` and accompanying `-18` program names need to be renamed to `-19` instead.

- It should be noted that there is another kind of `clang`-hostbuild that can be found in termux-packages that uses NDK-`clang` to hostbuild rather than system-`clang`. Those do not have a number appended to their invocations of `clang`, so they are unaffected here and do not need to be modified.

- Introduce new variables `TERMUX_HOST_LLVM_MAJOR_VERSION` and `TERMUX_HOST_LLVM_BASE_DIR` in `scripts/properties.sh` to reduce the number of places where the llvm.org-provided LLVM installation version number needs to be updated to just 1