### PR TITLE
new package: tgpt

### DIFF
--- a/packages/tgpt/build.sh
+++ b/packages/tgpt/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/aandrew-me/tgpt
+TERMUX_PKG_DESCRIPTION="AI Chatbots in terminal without needing API keys"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="2.10.0"
+TERMUX_PKG_SRCURL=https://github.com/aandrew-me/tgpt/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=0e312176908d581eeb7f0df8fcd0524a4aa4702029d50f553f0f75d6c15bc0d9
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+	termux_setup_golang
+}
+
+termux_step_make() {
+	go build
+}
+
+termux_step_make_install() {
+	install -Dm700 tgpt "$TERMUX_PREFIX"/bin/tgpt
+}


### PR DESCRIPTION
#### Why is it worth to add this package?

Accessible AI chatbot on terminal without API keys.

### Home page URL

https://github.com/aandrew-me/tgpt

### Source code URL

https://github.com/aandrew-me/tgpt

### Packaging policy acknowledgement


- [x]  The project is actively developed.
- [x]  The project has [existing packages](https://repology.org/projects) and is "well known".
- [x]  Licensed under an [open source license](https://spdx.org/licenses/).
- [x]  Not available through a language package manager: pip, npm, cpan, cargo, etc.
- [x]  Not taking up too much disk space (< 100MiB per architecture, exceptions can be made)
- [x]  Not duplicating the functionality of existing packages.
- [x]  Not serving hacking, malware, phishing, spamming, spying, ddos functionality.
- [x]  I certify that I have read [Termux Packaging Policy](https://github.com/termux/termux-packages/blob/master/CONTRIBUTING.md#packaging-policy) and understand that my request will be denied if it is found lacking.

### Additional information
 
Just an attempt to add this package. I have read https://github.com/termux/termux-packages/issues/17614. I'm not sure if it still violates the Termux Packaging Policy.

Build steps on build.sh are copied from the [Arch Linux tgpt package](https://archlinux.org/packages/extra/x86_64/tgpt/) [PKGBUILD](https://gitlab.archlinux.org/archlinux/packaging/packages/tgpt/-/blob/main/PKGBUILD).