### PR TITLE
enhance(ndk-multilib): Adding more libraries. closes #25201

### DIFF
--- a/packages/ndk-multilib/build.sh
+++ b/packages/ndk-multilib/build.sh
@@ -48,8 +48,14 @@ prepare_libs() {
 	cp $BASEDIR/lib{c++_static,c++abi}.a $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib
 	echo 'INPUT(-lc++_static -lc++abi)' > $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib/libc++_shared.a
 
+	local libs="lib{android,c,dl,log,m}.so"
+	libs+=" lib{c,dl,m}.a"
+	# Those are all the *other* libs that are supported by android api 24.
+	libs+=" lib{camera2ndk,mediandk,jnigraphics}.so"
+	libs+=" lib{EGL,GLESv1_CM,GLESv2,GLESv3,vulkan}.so"
+	libs+=" lib{OpenMAXAL,OpenSLES}.so"
 	local f
-	for f in lib{android,c,dl,log,m}.so lib{c,dl,m}.a; do
+	for f in $libs; do
 		ln -sfT $TERMUX_PREFIX/opt/ndk-multilib/$SUFFIX/lib/${f} \
 			$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib/${f}
 	done

--- a/packages/ndk-multilib/build.sh
+++ b/packages/ndk-multilib/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Version should be equal to TERMUX_NDK_{VERSION_NUM,REVISION} in
 # scripts/properties.sh
 TERMUX_PKG_VERSION=27c
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://dl.google.com/android/repository/android-ndk-r${TERMUX_PKG_VERSION}-linux.zip
 TERMUX_PKG_SHA256=59c2f6dc96743b5daf5d1626684640b20a6bd2b1d85b13156b90333741bad5cc
 TERMUX_PKG_AUTO_UPDATE=false
@@ -41,14 +42,14 @@ prepare_libs() {
 	mkdir -p $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/opt/ndk-multilib/$SUFFIX/lib
 	local BASEDIR=toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/$SUFFIX/
 	cp $BASEDIR/${TERMUX_PKG_API_LEVEL}/*.o $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib
-	cp $BASEDIR/${TERMUX_PKG_API_LEVEL}/lib{c,dl,log,m}.so $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/opt/ndk-multilib/$SUFFIX/lib
+	cp $BASEDIR/${TERMUX_PKG_API_LEVEL}/lib{android,c,dl,log,m}.so $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/opt/ndk-multilib/$SUFFIX/lib
 	cp $BASEDIR/libc++_shared.so $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib
 	cp $BASEDIR/lib{c,dl,m}.a $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/opt/ndk-multilib/$SUFFIX/lib
 	cp $BASEDIR/lib{c++_static,c++abi}.a $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib
 	echo 'INPUT(-lc++_static -lc++abi)' > $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib/libc++_shared.a
 
 	local f
-	for f in lib{c,dl,log,m}.so lib{c,dl,m}.a; do
+	for f in lib{android,c,dl,log,m}.so lib{c,dl,m}.a; do
 		ln -sfT $TERMUX_PREFIX/opt/ndk-multilib/$SUFFIX/lib/${f} \
 			$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib/${f}
 	done
@@ -84,7 +85,7 @@ termux_step_make_install() {
 termux_step_post_massage() {
 	local triple f
 	for triple in aarch64-linux-android arm-linux-androideabi i686-linux-android x86_64-linux-android; do
-		for f in lib{c,dl,log,m}.so lib{c,dl,m}.a; do
+		for f in lib{android,c,dl,log,m}.so lib{c,dl,m}.a; do
 			rm -f ${triple}/lib/${f}
 		done
 	done

--- a/packages/ndk-multilib/ndk-multilib-native-stubs.subpackage.sh
+++ b/packages/ndk-multilib/ndk-multilib-native-stubs.subpackage.sh
@@ -5,6 +5,7 @@ TERMUX_SUBPKG_INCLUDE=
 case "$TERMUX_ARCH" in
 	aarch64 )
 		TERMUX_SUBPKG_INCLUDE+="
+			aarch64-linux-android/lib/libandroid.so
 			aarch64-linux-android/lib/libc.so
 			aarch64-linux-android/lib/libdl.so
 			aarch64-linux-android/lib/liblog.so
@@ -13,6 +14,7 @@ case "$TERMUX_ARCH" in
 		;& # fallthrough
 	arm )
 		TERMUX_SUBPKG_INCLUDE+="
+			arm-linux-android/lib/libandroid.so
 			arm-linux-androideabi/lib/libc.so
 			arm-linux-androideabi/lib/libdl.so
 			arm-linux-androideabi/lib/liblog.so
@@ -21,6 +23,7 @@ case "$TERMUX_ARCH" in
 		;;
 	x86_64 )
 		TERMUX_SUBPKG_INCLUDE+="
+			x86_64-linux-android/lib/libandroid.so
 			x86_64-linux-android/lib/libc.so
 			x86_64-linux-android/lib/libdl.so
 			x86_64-linux-android/lib/liblog.so
@@ -29,6 +32,7 @@ case "$TERMUX_ARCH" in
 		;& # fallthrough
 	i686 )
 		TERMUX_SUBPKG_INCLUDE+="
+			i686-linux-android/lib/libandroid.so
 			i686-linux-android/lib/libc.so
 			i686-linux-android/lib/libdl.so
 			i686-linux-android/lib/liblog.so

--- a/packages/ndk-multilib/ndk-multilib-native-stubs.subpackage.sh
+++ b/packages/ndk-multilib/ndk-multilib-native-stubs.subpackage.sh
@@ -1,42 +1,31 @@
 TERMUX_SUBPKG_DESCRIPTION="Install native stubs for shared libs from NDK"
 TERMUX_SUBPKG_PLATFORM_INDEPENDENT=false
+NDK_MULTILIB_LIBS="libandroid.so libc.so libdl.so liblog.so libm.so"
+NDK_MULTILIB_LIBS+=" libc.a ibdl.a libm.a"
+# Those are all the *other* libs that are supported by android api 24.
+NDK_MULTILIB_LIBS+=" libEGL.so libGLESv1_CM.so libGLESv2.so libGLESv3.so libvulkan.so"
+NDK_MULTILIB_LIBS+=" liOpenMAXAL.so libOpenSLES.so"
 TERMUX_SUBPKG_INCLUDE=
 
 case "$TERMUX_ARCH" in
 	aarch64 )
-		TERMUX_SUBPKG_INCLUDE+="
-			aarch64-linux-android/lib/libandroid.so
-			aarch64-linux-android/lib/libc.so
-			aarch64-linux-android/lib/libdl.so
-			aarch64-linux-android/lib/liblog.so
-			aarch64-linux-android/lib/libm.so
-		"
+		for lib in $NDK_MULTILIB_LIBS; do
+			TERMUX_SUBPKG_INCLUDE+=" aarch64-linux-android/lib/$lib"
+		done
 		;& # fallthrough
 	arm )
-		TERMUX_SUBPKG_INCLUDE+="
-			arm-linux-android/lib/libandroid.so
-			arm-linux-androideabi/lib/libc.so
-			arm-linux-androideabi/lib/libdl.so
-			arm-linux-androideabi/lib/liblog.so
-			arm-linux-androideabi/lib/libm.so
-		"
+		for lib in $NDK_MULTILIB_LIBS; do
+			TERMUX_SUBPKG_INCLUDE+=" arm-linux-androideabi/$lib"
+		done
 		;;
 	x86_64 )
-		TERMUX_SUBPKG_INCLUDE+="
-			x86_64-linux-android/lib/libandroid.so
-			x86_64-linux-android/lib/libc.so
-			x86_64-linux-android/lib/libdl.so
-			x86_64-linux-android/lib/liblog.so
-			x86_64-linux-android/lib/libm.so
-		"
+		for lib in $NDK_MULTILIB_LIBS; do
+			TERMUX_SUBPKG_INCLUDE+=" x86_64-linux-android/$lib"
+		done
 		;& # fallthrough
 	i686 )
-		TERMUX_SUBPKG_INCLUDE+="
-			i686-linux-android/lib/libandroid.so
-			i686-linux-android/lib/libc.so
-			i686-linux-android/lib/libdl.so
-			i686-linux-android/lib/liblog.so
-			i686-linux-android/lib/libm.so
-		"
+		for lib in $NDK_MULTILIB_LIBS; do
+			TERMUX_SUBPKG_INCLUDE+=" i686-linux-android/$lib"
+		done
 		;;
 esac

--- a/packages/ndk-multilib/postinst-alien.in
+++ b/packages/ndk-multilib/postinst-alien.in
@@ -5,7 +5,7 @@ for triple in aarch64-linux-android arm-linux-androideabi i686-linux-android x86
 	   { [ x"$native_triple" = x"x86_64-linux-android" ] && [ "$triple" = "i686-linux-android" ]; }; then
 		continue
 	fi
-	for so in libc.so libdl.so liblog.so libm.so libc.a libdl.a libm.a; do
+	for so in libandroid.so libc.so libdl.so liblog.so libm.so libc.a libdl.a libm.a; do
 		@COMMAND@
 	done
 done

--- a/packages/ndk-multilib/postinst-alien.in
+++ b/packages/ndk-multilib/postinst-alien.in
@@ -5,7 +5,13 @@ for triple in aarch64-linux-android arm-linux-androideabi i686-linux-android x86
 	   { [ x"$native_triple" = x"x86_64-linux-android" ] && [ "$triple" = "i686-linux-android" ]; }; then
 		continue
 	fi
-	for so in libandroid.so libc.so libdl.so liblog.so libm.so libc.a libdl.a libm.a; do
+
+	libs="libandroid.so libc.so libdl.so liblog.so libm.so"
+	libs+=" libc.a ibdl.a libm.a"
+	# Those are all the *other* libs that are supported by android api 24.
+	libs+=" libEGL.so libGLESv1_CM.so libGLESv2.so libGLESv3.so libvulkan.so"
+	libs+=" liOpenMAXAL.so libOpenSLES.so"
+	for so in $libs; do
 		@COMMAND@
 	done
 done


### PR DESCRIPTION
Adding libraries that are supported by Android 7.
EGL, GLES(v1,v2,v3), vulkan, camera2ndk, mediandk, jnigraphics, OpenMAXAL OpenSLES.
See https://developer.android.com/ndk/guides/stable_apis
This libraries are needed when cross compiling some stuff.

Closes: #25202