### PR TITLE
fix(main/dpkg): fixes for the `update-alternatives` -> `mandoc` hook

### DIFF
--- a/packages/dpkg/build.sh
+++ b/packages/dpkg/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Debian package management system"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.22.6"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 # old tarball are removed in https://mirrors.kernel.org/debian/pool/main/d/dpkg/dpkg_${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SRCURL=git+https://salsa.debian.org/dpkg-team/dpkg.git
 TERMUX_PKG_GIT_BRANCH="${TERMUX_PKG_VERSION}"

--- a/packages/dpkg/mandoc_hook.patch
+++ b/packages/dpkg/mandoc_hook.patch
@@ -9,6 +9,24 @@
  
  /* Global variables: */
  
+@@ -108,6 +108,8 @@ static FILE *fh_log = NULL;
+ static int opt_skip_auto = 0;
+ static int opt_verbose = OUTPUT_NORMAL;
+ static int opt_force = 0;
++/* for mandoc hook */
++static bool should_update_mandoc = false;
+ 
+ /*
+  * Functions.
+@@ -2089,6 +2091,8 @@ alternative_prepare_install(struct alternative *a, const char *choice)
+ 		alternative_add_commit_op(a, OPCODE_RM, fn, NULL);
+ 		free(fn);
+ 	}
++
++	should_update_mandoc = true;
+ }
+ 
+ static void
 @@ -2552,6 +2552,31 @@ alternative_install(struct alternative **aptr, struct alternative *inst_alt,
  	return new_choice;
  }
@@ -16,7 +34,7 @@
 +/* Update mandoc database after creating symbolic links */
 +/* command launching logic copied from the extracthalf() function in src/deb/extract.c */
 +static void
-+alternative_update_mandoc(void) {
++update_mandoc(void) {
 +	const char *cmd_string = "makewhatis";
 +
 +	if (!command_in_path(cmd_string)) {
@@ -41,20 +59,15 @@
  static void
  alternative_update(struct alternative *a,
                     const char *current_choice, const char *new_choice)
-@@ -3215,8 +3215,12 @@ main(int argc, char **argv)
- 	if (modifies_alt)
- 		alternative_update(a, current_choice, new_choice);
- 
--	if (a)
-+	if (a) {
-+		if (a->modified) {
-+			alternative_update_mandoc();
-+		}
- 		alternative_free(a);
-+	}
- 	free(new_choice);
+@@ -3221,5 +3225,8 @@ main(int argc, char **argv)
  	free(log_file);
  	free(admdir);
+ 
++	if (should_update_mandoc)
++		update_mandoc();
++
+ 	return 0;
+ }
 --- a/utils/Makefile.am
 +++ b/utils/Makefile.am
 @@ -34,6 +34,7 @@ update_alternatives_SOURCES = \


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/25217

- Moves the call to `update_mandoc()` to a codepath that is simultaneously:
  - more likely to run when necessary (such as during `--config` subcommands)
  - and less likely to run when unnecessary (such as during `--install` and `--remove` subcommands)

- I would be interested in test results from others' devices if possible, because unfortunately, when I tested the original version of this patch it initially worked, but then stopped working after a few days.