### PR TITLE
addpkg(main/hledger-cli): 1.43.2

### DIFF
--- a/packages/hledger/build.sh
+++ b/packages/hledger/build.sh
@@ -1,0 +1,47 @@
+TERMUX_PKG_HOMEPAGE=https://hledger.org/
+TERMUX_PKG_DESCRIPTION="Robust, friendly, fast plain text accounting software. (CLI only)"
+TERMUX_PKG_LICENSE="GPL-3.0-or-later"
+TERMUX_PKG_MAINTAINER="@erplsf"
+TERMUX_PKG_VERSION=1.43.2
+TERMUX_PKG_SRCURL=https://hackage.haskell.org/package/hledger-${TERMUX_PKG_VERSION}/hledger-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=211e424568acd3a68299958a3284212516be4eaa84f94fbb5c2e0956d5e06f10
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_BUILD_DEPENDS="aosp-libs"
+TERMUX_PKG_DEPENDS="libffi, libiconv, libgmp, zlib, ncurses, asciinema"
+TERMUX_PKG_EXCLUDED_ARCHES="arm, i686" # upstream doesn't support 32bit
+
+termux_step_post_configure() {
+	cabal get splitmix-0.1.3.1
+	mv splitmix{-*,}
+
+	for f in "$TERMUX_PKG_BUILDER_DIR"/splitmix-patches/*.patch; do
+		patch --silent -p1 -d splitmix < "$f"
+	done
+
+	cabal get entropy-0.4.1.11
+	mv entropy{-*,}
+	sed -i -E 's|(build-type:\s*)Custom|\1Simple|' entropy/entropy.cabal
+
+	cat <<-EOF >>cabal.project.local
+		packages: splitmix entropy
+
+		package splitmix
+			benchmarks: False
+			tests: False
+
+		package entropy
+			flags: +donotgetentropy
+	EOF
+
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == false ]]; then # We do not need iserv for on device builds.
+		termux_setup_ghc_iserv
+		cat <<-EOF >>cabal.project.local
+			package *
+			    ghc-options: -fexternal-interpreter -pgmi=$(command -v termux-ghc-iserv)
+		EOF
+	fi
+}
+
+termux_step_make() {
+	cabal --config="$TERMUX_CABAL_CONFIG" build exe:hledger
+}

--- a/packages/hledger/splitmix-patches/0001-add-conditionals-to-support-Android.patch
+++ b/packages/hledger/splitmix-patches/0001-add-conditionals-to-support-Android.patch
@@ -1,0 +1,27 @@
+From b97a93ed42bed73330237bd563c0e3c45aa50afd Mon Sep 17 00:00:00 2001
+From: Andriy Mykhaylyk <erp.lsf@gmail.com>
+Date: Sun, 15 Jun 2025 16:10:09 +0200
+Subject: [PATCH] add conditionals to support Android
+
+---
+ cbits-unix/init.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/cbits-unix/init.c b/cbits-unix/init.c
+index 255b667..25a6ce7 100644
+--- a/cbits-unix/init.c
++++ b/cbits-unix/init.c
+@@ -8,6 +8,10 @@
+ 
+ uint64_t splitmix_init() {
+ 	uint64_t result;
++#if (!defined(__ANDROID__) || __ANDROID_API__ >= 28)
+ 	int r = getentropy(&result, sizeof(uint64_t));
++#else
++	int r = -1;
++#endif
+ 	return r == 0 ? result : 0xfeed1000;
+ }
+-- 
+2.49.0
+

--- a/scripts/build/configure/termux_step_configure.sh
+++ b/scripts/build/configure/termux_step_configure.sh
@@ -3,7 +3,7 @@ termux_step_configure() {
 
 	# This check should be above autotools check as haskell package too makes use of configure scripts which
 	# should be executed by its own build system.
-	if ls "${TERMUX_PKG_SRCDIR}"/*.cabal &>/dev/null; then
+	if ls "${TERMUX_PKG_SRCDIR}"/*.cabal &>/dev/null || ls "${TERMUX_PKG_SRCDIR}"/cabal.project &>/dev/null; then
 		[ "$TERMUX_CONTINUE_BUILD" == "true" ] && return
 		termux_step_configure_cabal
 	elif [ "$TERMUX_PKG_FORCE_CMAKE" = "false" ] && [ -f "$TERMUX_PKG_SRCDIR/configure" ]; then

--- a/scripts/build/termux_step_make.sh
+++ b/scripts/build/termux_step_make.sh
@@ -8,7 +8,7 @@ termux_step_make() {
 
 	if test -f build.ninja; then
 		ninja -j $TERMUX_PKG_MAKE_PROCESSES
-	elif ls ./*.cabal &>/dev/null; then
+	elif ls ./*.cabal &>/dev/null || ls ./cabal.project &>/dev/null; then
 		cabal --config="$TERMUX_CABAL_CONFIG" build
 	elif ls ./*akefile &>/dev/null || [ ! -z "$TERMUX_PKG_EXTRA_MAKE_ARGS" ]; then
 		if [ -z "$TERMUX_PKG_EXTRA_MAKE_ARGS" ]; then

--- a/scripts/build/termux_step_make_install.sh
+++ b/scripts/build/termux_step_make_install.sh
@@ -6,7 +6,7 @@ termux_step_make_install() {
 		ninja -j $TERMUX_PKG_MAKE_PROCESSES install
 	elif test -f setup.py || test -f pyproject.toml || test -f setup.cfg; then
 		pip install --no-deps . --prefix $TERMUX_PREFIX
-	elif ls ./*.cabal &>/dev/null; then
+	elif ls ./*.cabal &>/dev/null || ls ./cabal.project &>/dev/null; then
 		# Workaround until `cabal install` is fixed.
 		while read -r bin; do
 			[[ -f "$bin" ]] || termux_error_exit "'$bin', no such file. Has build completed?"


### PR DESCRIPTION
Greetings,

This is a PR in an attempt to package [`hledger`](https://github.com/simonmichael/hledger) for Termux. I'm not very accustomed with the way that Haskell programs are built, and even less so with Termux-specific process. I've tried to follow the general steps where I could - added dependencies and other small tweaks.

I've decided to adjust common build steps `make` and `make_install` to also detect other naming convention for Cabal projects.

But the build fails now on compiling `exe:alex` and I'm out of luck. Any help or pointers are very welcome.

Here I also attach the full build log when running `./scripts/run-docker.sh ./build-package.sh -f -I hledger`.

Ideally this closes https://github.com/termux/termux-packages/issues/3803 and https://github.com/simonmichael/hledger/issues/398.

[build.log](https://github.com/user-attachments/files/21075401/build.log)