### PR TITLE
scripts(build): Fix regressions introduced in #24952

### DIFF
--- a/scripts/build/setup/termux_setup_cabal.sh
+++ b/scripts/build/setup/termux_setup_cabal.sh
@@ -36,7 +36,6 @@ termux_setup_cabal() {
 			 url: https://$repo/
 
 			remote-repo-cache: $HOME/.cache/cabal/packages
-			executable-stripping: True
 			configure-option: --host=$TERMUX_HOST_PLATFORM
 			tests: False
 			build-summary: $HOME/.cache/cabal/logs/build.log
@@ -44,7 +43,8 @@ termux_setup_cabal() {
 			jobs: $TERMUX_PKG_MAKE_PROCESSES
 
 			program-locations
-			 strip-location: $(command -v "$STRIP")
+			 alex-location: $(command -v alex)
+			 happy-location: $(command -v happy)
 
 			program-default-options
 			 $([[ "$TERMUX_ON_DEVICE_BUILD" == false ]] && printf "%s" "hsc2hs-options: --cross-compile")


### PR DESCRIPTION
- Executable stripping does not work while cross-compiling

Signed-off-by: Aditya Alok <alok@termux.dev>
