### PR TITLE
addpkg(main/sendme): 0.27.0

### DIFF
--- a/packages/sendme/build.sh
+++ b/packages/sendme/build.sh
@@ -1,0 +1,12 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/n0-computer/sendme
+TERMUX_PKG_DESCRIPTION="A tool to send files and directories, based on iroh"
+TERMUX_PKG_LICENSE="Apache-2.0, MIT"
+TERMUX_PKG_LICENSE_FILE="
+LICENSE-APACHE
+LICENSE-MIT
+"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.27.0"
+TERMUX_PKG_SRCURL="https://github.com/n0-computer/sendme/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=1afbc67d504ba595f5b1af42ced07dc64ba3db28addc00ff118a695b4619caf5
+TERMUX_PKG_BUILD_IN_SRC=true


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/25293

- It is true that the package is very easy to compile, however, the problem explained in the issue is that it takes an extremely long time to compile on a slow device.