### PR TITLE
bump(main/nodejs): 24.4.0

### DIFF
--- a/packages/nodejs/build.sh
+++ b/packages/nodejs/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://nodejs.org/
 TERMUX_PKG_DESCRIPTION="Open Source, cross-platform JavaScript runtime environment"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Yaksh Bariya <thunder-coding@termux.dev>"
-TERMUX_PKG_VERSION=24.3.0
+TERMUX_PKG_VERSION=24.4.0
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=eb688ef8a63fda9ebc0b5f907609a46e26db6d9aceefc0832009a98371e992ed
+TERMUX_PKG_SHA256=42fa8079da25a926013cd89b9d3467d09110e4fbb0c439342ebe4dd6ecc26bbb
 # thunder-coding: don't try to autoupdate nodejs, that thing takes 2 whole hours to build for a single arch, and requires a lot of patch updates everytime. Also I run tests everytime I update it to ensure least bugs
 TERMUX_PKG_AUTO_UPDATE=false
 # Note that we do not use a shared libuv to avoid an issue with the Android


### PR DESCRIPTION
Needs testing before merge. The last release didn't have any regressions. Let's hope for the same once again 