### PR TITLE
fix(main/yosys): enable `abc`

### DIFF
--- a/packages/yosys/Makefile.patch
+++ b/packages/yosys/Makefile.patch
@@ -1,14 +1,5 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -10,7 +10,7 @@
- 
- # features (the more the better)
- ENABLE_TCL := 1
--ENABLE_ABC := 1
-+ENABLE_ABC := 0
- ENABLE_GLOB := 1
- ENABLE_PLUGINS := 1
- ENABLE_READLINE := 1
 @@ -222,7 +222,7 @@
  
  ifeq ($(CONFIG),clang)
@@ -18,3 +9,25 @@
  ifeq ($(ENABLE_LTO),1)
  LINKFLAGS += -fuse-ld=lld
  endif
+--- a/abc/Makefile
++++ b/abc/Makefile
+@@ -57,7 +57,7 @@ ARCHFLAGS := $(ARCHFLAGS)
+ 
+ OPTFLAGS  ?= -g -O
+ 
+-CFLAGS    += -Wall -Wno-unused-function -Wno-write-strings -Wno-sign-compare $(ARCHFLAGS)
++CFLAGS    += -Wall -Wno-unused-function -Wno-write-strings -Wno-sign-compare -Wno-c++11-narrowing $(ARCHFLAGS)
+ ifneq ($(findstring arm,$(shell uname -m)),)
+ 	CFLAGS += -DABC_MEMALIGN=4
+ endif
+@@ -76,8 +76,8 @@ ifndef ABC_USE_NO_CUDD
+   $(info $(MSG_PREFIX)Compiling with CUDD)
+ endif
+ 
+-ABC_READLINE_INCLUDES ?=
+-ABC_READLINE_LIBRARIES ?= -lreadline
++ABC_READLINE_INCLUDES ?= -I@TERMUX_PREFIX@/include -DNCURSES_WIDECHAR
++ABC_READLINE_LIBRARIES ?= -L@TERMUX_PREFIX@/lib -lreadline
+ 
+ # whether to use libreadline
+ ifndef ABC_USE_NO_READLINE

--- a/packages/yosys/build.sh
+++ b/packages/yosys/build.sh
@@ -3,11 +3,12 @@ TERMUX_PKG_DESCRIPTION="A framework for RTL synthesis tools"
 TERMUX_PKG_LICENSE="ISC"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.55"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/YosysHQ/yosys
 TERMUX_PKG_GIT_BRANCH="v$TERMUX_PKG_VERSION"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+"
-TERMUX_PKG_DEPENDS="boost, graphviz, libandroid-glob, libandroid-spawn, libc++, libffi, readline, tcl, zlib, python"
+TERMUX_PKG_DEPENDS="boost, graphviz, libandroid-glob, libandroid-spawn, libc++, libffi, ncurses, readline, tcl, zlib, python"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_MAKE_ARGS="PREFIX=$TERMUX_PREFIX"
 


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/25349

- Adds `ncurses` to `TERMUX_PKG_DEPENDS`, because `yosys` is linked to `libncursesw.so.6`.