### PR TITLE
fix(main/libwebp): add regex to filter rc releases for auto update

### DIFF
--- a/packages/libwebp/build.sh
+++ b/packages/libwebp/build.sh
@@ -6,6 +6,7 @@ TERMUX_PKG_VERSION="1.6.0"
 TERMUX_PKG_SRCURL=https://github.com/webmproject/libwebp/archive/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=93a852c2b3efafee3723efd4636de855b46f9fe1efddd607e1f42f60fc8f2136
 TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_VERSION_REGEXP='^\d+\.\d+\.\d+$'
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
 TERMUX_PKG_DEPENDS="giflib, libjpeg-turbo, libpng, libtiff, zlib"
 TERMUX_PKG_BREAKS="libwebp-dev"


### PR DESCRIPTION
Earlier the package was updated to 1.6.0-rc1. Hopefully,
https://github.com/webmproject/libwebp/compare/v1.6.0-rc1...v1.6.0 shows
that there is no change at all in the builds of both the versions.
Avoiding adding +really hack to change the version as it will break
upcoming auto updates. And adding a epoch is unnecessary, we need to
ensure that we don't use epochs unnecessarily.

This should automatically resolve the issue when the next auto-update
happens. I'll ignore the errors for libwebp in repository health checks
for the time being

%ci:no-build