### PR TITLE
bump(main/openjdk-21): 21.0.8

### DIFF
--- a/packages/openjdk-17/build.sh
+++ b/packages/openjdk-17/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Java development kit and runtime"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="17.0.16"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/openjdk/jdk17u/archive/refs/tags/jdk-${TERMUX_PKG_VERSION}-ga.tar.gz
 TERMUX_PKG_SHA256=bc339edfa44646fa3c80971237ba4681e43a28877912cda2839aa42a15f0c7e7
 TERMUX_PKG_AUTO_UPDATE=true
@@ -13,7 +14,8 @@ TERMUX_PKG_RECOMMENDS="ca-certificates-java, openjdk-17-x, resolv-conf"
 TERMUX_PKG_SUGGESTS="cups"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_HAS_DEBUG=false
-# enable lto
+# enable lto, but do not explicitly enable zgc or shenandoahgc because they
+# are automatically enabled for x86, but are not supported for arm.
 __jvm_features="link-time-opt"
 
 termux_pkg_auto_update() {
@@ -69,7 +71,7 @@ termux_step_configure() {
 		--with-toolchain-type=clang \
 		--with-extra-cflags="$CFLAGS $CPPFLAGS -DLE_STANDALONE -D__ANDROID__=1 -D__TERMUX__=1" \
 		--with-extra-cxxflags="$CXXFLAGS $CPPFLAGS -DLE_STANDALONE -D__ANDROID__=1 -D__TERMUX__=1" \
-		--with-extra-ldflags="${jdk_ldflags} -Wl,--as-needed -landroid-shmem -landroid-spawn" \
+		--with-extra-ldflags="${jdk_ldflags} -Wl,--as-needed -landroid-shmem -landroid-spawn -liconv" \
 		--with-cups-include="$TERMUX_PREFIX/include" \
 		--with-fontconfig-include="$TERMUX_PREFIX/include" \
 		--with-freetype-include="$TERMUX_PREFIX/include/freetype2" \
@@ -209,6 +211,7 @@ termux_step_create_debscripts() {
 		rmiregistry.1.gz
 		serialver.1.gz
 	)
+	# For older versions
 	echo 'if [ "$#" = "3" ] && dpkg --compare-versions "$2" le "17.0.15-1"; then' > ./preinst
 	echo '  echo "Removing older alternatives for openjdk-21 and openjdk-17"' >> ./preinst
 	echo '  echo "This may take a while if mandoc package is installed, please wait..."' >> ./preinst

--- a/packages/openjdk-21/0012-Add-CXXFLAGS_JDKLIB-to-CXXFLAGS.patch
+++ b/packages/openjdk-21/0012-Add-CXXFLAGS_JDKLIB-to-CXXFLAGS.patch
@@ -25,10 +25,10 @@ diff --git a/make/modules/jdk.jdwp.agent/Lib.gmk b/make/modules/jdk.jdwp.agent/L
 index 9631bf239..ae889b6f5 100644
 --- a/make/modules/jdk.jdwp.agent/Lib.gmk
 +++ b/make/modules/jdk.jdwp.agent/Lib.gmk
-@@ -58,6 +58,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJDWP, \
-     DISABLED_WARNINGS_clang_EventRequestImpl.c := self-assign, \
+@@ -59,6 +59,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJDWP, \
      DISABLED_WARNINGS_clang_inStream.c := sometimes-uninitialized, \
      DISABLED_WARNINGS_clang_log_messages.c := format-nonliteral, \
+     DISABLED_WARNINGS_microsoft_debugInit.c := 5287, \
 +    CXXFLAGS := $(CXXFLAGS_JDKLIB), \
      EXTRA_HEADER_DIRS := \
        include \


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/25364

- Fixes https://github.com/termux/termux-packages/issues/25368

- Realigns the contents of `packages/openjdk-17/build.sh` and `packages/openjdk-21/build.sh`, which had started to drift apart again, using this command: `diff -u packages/openjdk-17/build.sh  packages/openjdk-21/build.sh`