### PR TITLE
bump(main/helix): 25.07

### DIFF
--- a/packages/helix/build.sh
+++ b/packages/helix/build.sh
@@ -2,10 +2,9 @@ TERMUX_PKG_HOMEPAGE="https://helix-editor.com/"
 TERMUX_PKG_DESCRIPTION="A post-modern modal text editor written in rust"
 TERMUX_PKG_LICENSE="MPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="25.01.1"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION="25.07"
 TERMUX_PKG_SRCURL="https://github.com/helix-editor/helix/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256=3f2364463e2e58b0e78ea16fd37a23a93ec2b086323b9ca1e6e310d86a9b3663
+TERMUX_PKG_SHA256=ebeaefc984aea45b0ebcc3e2e7399edf3a156ace06f80c8837a0675aabeef643
 TERMUX_PKG_SUGGESTS="helix-grammars, bash-completion, clang, delve, elvish, gopls, lldb, nodejs | nodejs-lts"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
@@ -26,6 +25,7 @@ termux_step_make() {
 
 termux_step_make_install() {
 	local datadir="${TERMUX_PREFIX}/opt/${TERMUX_PKG_NAME}"
+	rm -rf "${datadir}"
 	mkdir -p "${datadir}"
 
 	cat >"${TERMUX_PREFIX}/bin/hx" <<-EOF

--- a/packages/helix/helix.alternatives
+++ b/packages/helix/helix.alternatives
@@ -1,0 +1,6 @@
+Name: editor
+Link: bin/editor
+Alternative: bin/hx
+Priority: 35
+
+# vim: ft=raml

--- a/packages/helix/libc++_shared-not-found.patch
+++ b/packages/helix/libc++_shared-not-found.patch
@@ -1,12 +1,12 @@
---- a/helix-loader/src/grammar.rs	2022-03-31 12:52:29.105571523 +0530
-+++ b/helix-loader/src/grammar.rs	2022-03-31 13:06:19.215571207 +0530
-@@ -319,6 +319,9 @@
-     } else {
+--- a/helix-loader/src/grammar.rs
++++ b/helix-loader/src/grammar.rs
+@@ -492,6 +492,9 @@ fn build_tree_sitter_library(
+ 
          command
              .arg("-shared")
 +            .arg("-L@TERMUX_PREFIX@/lib")
 +            .arg("-Wl,-rpath=@TERMUX_PREFIX@/lib")
 +            .arg("-Wno-error=implicit-int")
-             .arg("-fPIC")
              .arg("-fno-exceptions")
-             .arg("-g")
+             .arg("-I")
+             .arg(header_path)


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/25363

- Add `.alternatives` file for `editor` for `helix`

- Remove `$TERMUX_PREFIX/opt/helix` at the start of `termux_step_make_install()` in order to prevent errors during repeated builds