### PR TITLE
bump(main/gst-plugins-base): 1.26.4

### DIFF
--- a/packages/gst-plugins-base/build.sh
+++ b/packages/gst-plugins-base/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://gstreamer.freedesktop.org/
 TERMUX_PKG_DESCRIPTION="GStreamer base plug-ins"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.26.3"
+TERMUX_PKG_VERSION="1.26.4"
 TERMUX_PKG_SRCURL=https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=4ef9f9ef09025308ce220e2dd22a89e4c992d8ca71b968e3c70af0634ec27933
+TERMUX_PKG_SHA256=d6fcca7be4253e5d8541c6e3e07729120a16e1dc356f9a14a4a83a901120742f
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="glib, graphene, gstreamer, libandroid-shmem, libjpeg-turbo, libogg, libopus, libpng, libtheora, libvorbis, libx11, libxcb, libxext, libxi, libxv, zlib"
 TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, opengl"
@@ -13,16 +13,14 @@ TERMUX_PKG_BREAKS="gst-plugins-base-dev"
 TERMUX_PKG_REPLACES="gst-plugins-base-dev"
 TERMUX_PKG_VERSIONED_GIR=false
 TERMUX_PKG_DISABLE_GIR=false
+
+# wrap-mode=nodownload prevents downloading gl-headers which conflicts with libglvnd-dev
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dintrospection=enabled
 -Dtests=disabled
 -Dexamples=disabled
 -Dpango=disabled
-"
-# This file is only relevant to Windows
-# and is not found in any gst-plugins package of other Linux distributions
-TERMUX_PKG_RM_AFTER_INSTALL="
-include/GL/wglext.h
+--wrap-mode=nodownload
 "
 
 termux_step_pre_configure() {


### PR DESCRIPTION
Use wrap-mode=nodownload to prevent installing files from gl-headers subproject because those conflict with libglvnd-dev headers.

* Fixes #25374 