### PR TITLE
bump(main/lesspipe): 2.19

### DIFF
--- a/packages/lesspipe/build.sh
+++ b/packages/lesspipe/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=http://www-zeuthen.desy.de/~friebel/unix/lesspipe.html
 TERMUX_PKG_DESCRIPTION="An input filter for the pager less"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
-TERMUX_PKG_VERSION="2.18"
+TERMUX_PKG_VERSION="2.19"
 TERMUX_PKG_SRCURL=https://github.com/wofr06/lesspipe/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=a78c5c2841771adb5cdc7eb918ca8e4865be88cb9f7a53622ca3fa064d5ec5bc
+TERMUX_PKG_SHA256=32a56f2db7a9b45daf10cec6445afc8b600a6e88793b9d0cee6abe6b30ad1d47
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="less"
 TERMUX_PKG_BUILD_DEPENDS="bash-completion"
@@ -14,8 +14,7 @@ TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_configure() {
 	./configure \
-		--prefix="$TERMUX_PREFIX" \
-		--all-completions
+		--prefix="$TERMUX_PREFIX"
 }
 
 termux_step_post_make_install() {

--- a/packages/lesspipe/configure.patch
+++ b/packages/lesspipe/configure.patch
@@ -1,19 +1,15 @@
---- ./configure.orig	2025-01-22 07:22:22.309483203 +0000
-+++ ./configure	2025-01-22 07:24:11.825224432 +0000
-@@ -48,12 +48,12 @@
+Install both bash and zsh shell completions.
+
+--- a/configure
++++ b/configure
+@@ -44,8 +44,8 @@
+ # gererate Makefile
  my @bad = ();
  my $shell = check_shell_vers();
- if ( ! $opt_nomake ) {
--	my $no_bash = (grep {/bash/} @bad and ! $opt_all_completions);
--	my $no_zsh = (grep {/zsh/} @bad and ! $opt_all_completions);
-+	my $no_bash = ($opt_all_completions or ! grep {/bash/} @bad);
-+	my $no_zsh = ($opt_all_completions or ! grep {/zsh/} @bad);
- 	open OUT, ">Makefile";
- 	while (<DATA>) {
--		next if /bash_complete_dir/ and $no_bash;
--		next if /zsh\/site-functions/ and $no_zsh;
-+		next if $no_bash and /bash_complete_dir/;
-+		next if $no_zsh and /zsh\/site-functions/;
- 		s/opt_prefix/$prefix/;
- 		if ($bash_complete_dir and ! $opt_prefix) {
- 			s/mkdir.*bash-completion.*/mkdir -p $bash_complete_dir/;
+-my $no_bash = (grep {/bash/} @bad);
+-my $no_zsh = (grep {/zsh/} @bad);
++my $no_bash = 0;
++my $no_zsh = 0;
+ my $bash_complete_dir = "$prefix/share/bash-completion";
+ # override prefix and use the system defined directory if known
+ if (`pkg-config --version 2>/dev/null`) {


### PR DESCRIPTION
The option to install both bash and zsh completions was removed in https://github.com/wofr06/lesspipe/commit/612b3116efd1eaac68bff567178842864400c0fe

* Fixes #25390 