### PR TITLE
fix(ncurses): connection error with package source

### DIFF
--- a/packages/ncurses/build.sh
+++ b/packages/ncurses/build.sh
@@ -20,7 +20,7 @@ TERMUX_PKG_VERSION=(6.5.20240831
 TERMUX_PKG_REVISION=2
 # shellcheck disable=SC2031
 TERMUX_PKG_SRCURL=("https://github.com/ThomasDickey/ncurses-snapshots/archive/${_SNAPSHOT_COMMIT}.tar.gz"
-                   "https://fossies.org/linux/misc/rxvt-unicode-${TERMUX_PKG_VERSION[1]}.tar.bz2"
+                   "https://dist.schmorp.de/rxvt-unicode/Attic/rxvt-unicode-${TERMUX_PKG_VERSION[1]}.tar.bz2"
                    "$(. "$TERMUX_SCRIPTDIR/x11-packages/kitty/build.sh"; echo "$TERMUX_PKG_SRCURL")"
                    "$(. "$TERMUX_SCRIPTDIR/x11-packages/alacritty/build.sh"; echo "$TERMUX_PKG_SRCURL")"
                    "$(. "$TERMUX_SCRIPTDIR/x11-packages/foot/build.sh"; echo "$TERMUX_PKG_SRCURL")")


### PR DESCRIPTION
The original `fossies.org` source now requires human verification and refuses to connect in CI. [Context](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/24944#note_2633682997).

Updated to another source that provides the same file with exact checksum.

```
$ shasum -a 256 rxvt-unicode-9.31-2.tar.bz2  # from fossies.org
aaa13fcbc149fe0f3f391f933279580f74a96fd312d6ed06b8ff03c2d46672e8  rxvt-unicode-9.31-2.tar.bz2

$ shasum -a 256 rxvt-unicode-9.31.tar.bz2    # from dist.schmorp.de
aaa13fcbc149fe0f3f391f933279580f74a96fd312d6ed06b8ff03c2d46672e8  rxvt-unicode-9.31.tar.bz2
```