### PR TITLE
addpkg(x11/icewm): 3.8.1

### DIFF
--- a/x11-packages/icewm/build.sh
+++ b/x11-packages/icewm/build.sh
@@ -1,0 +1,22 @@
+TERMUX_PKG_HOMEPAGE=https://ice-wm.org/
+TERMUX_PKG_DESCRIPTION="Window manager with goals of speed, simplicity, and usability"
+TERMUX_PKG_LICENSE="LGPL-2.0-only"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="3.8.1"
+TERMUX_PKG_SRCURL="https://github.com/ice-wm/icewm/releases/download/$TERMUX_PKG_VERSION/icewm-$TERMUX_PKG_VERSION.tar.lz"
+TERMUX_PKG_SHA256=3c525512b1e4f4cf7999a4687f1b82311d7448d8c174780b5efd3b8aafbfb4a2
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="alsa-lib, imlib2, libandroid-glob, libandroid-wordexp, librsvg, libsndfile, libxcomposite, libxdamage, libxinerama, libxpm, libxrandr, libxres"
+TERMUX_PKG_BUILD_DEPENDS="aosp-libs"
+TERMUX_PKG_SUGGESTS="xdg-menu"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		termux_setup_proot
+		patch="$TERMUX_PKG_BUILDER_DIR/genpref.diff"
+		echo "Applying patch: $(basename "$patch")"
+		patch --silent -p1 < "$patch"
+	fi
+
+	LDFLAGS+=" -landroid-glob -landroid-wordexp"
+}

--- a/x11-packages/icewm/cross-compiling.patch
+++ b/x11-packages/icewm/cross-compiling.patch
@@ -1,0 +1,40 @@
+--- a/configure
++++ b/configure
+@@ -22677,10 +22677,8 @@ rm -f conftest*
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for strlcpy" >&5
+ $as_echo_n "checking for strlcpy... " >&6; }
+ if test "$cross_compiling" = yes; then :
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run test program while cross compiling
+-See \`config.log' for more details" "$LINENO" 5; }
++  $as_echo "yes"
++  $as_echo "#define HAVE_STRLCPY 1" >>confdefs.h
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+@@ -22719,10 +22716,8 @@ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for strlcat" >&5
+ $as_echo_n "checking for strlcat... " >&6; }
+ if test "$cross_compiling" = yes; then :
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run test program while cross compiling
+-See \`config.log' for more details" "$LINENO" 5; }
++  $as_echo "yes"
++  $as_echo "#define HAVE_STRLCAT 1" >>confdefs.h
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+@@ -22755,10 +22755,7 @@ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for C++11 by default" >&5
+ $as_echo_n "checking for C++11 by default... " >&6; }
+ if test "$cross_compiling" = yes; then :
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run test program while cross compiling
+-See \`config.log' for more details" "$LINENO" 5; }
++  $as_echo "yes"
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */

--- a/x11-packages/icewm/fix-mailbox-port-datatype.patch
+++ b/x11-packages/icewm/fix-mailbox-port-datatype.patch
@@ -1,0 +1,21 @@
+Fixes this error:
+
+src/amailbox.cc:121:9: error: no matching function for call to 'inrange'
+  121 |     if (inrange(fPort, 1, USHRT_MAX)) {
+      |         ^~~~~~~
+src/base.h:50:13: note: candidate template ignored: deduced conflicting types for parameter 'T' ('int' vs. 'unsigned int')
+   50 | inline bool inrange(T value, T lower, T upper) {
+      |             ^
+1 error generated.
+
+--- a/src/amailbox.cc
++++ b/src/amailbox.cc
+@@ -118,7 +118,7 @@ void MailCheck::resolve() {
+     setState(IDLE);
+ 
+     fPort = portNumber();
+-    if (inrange(fPort, 1, USHRT_MAX)) {
++    if (inrange(fPort, 1, (int)USHRT_MAX)) {
+         if (ssl()) return; // fAddr is unnecessary for SSL
+ 
+         addrinfo hints = {};

--- a/x11-packages/icewm/genpref.diff
+++ b/x11-packages/icewm/genpref.diff
@@ -1,0 +1,11 @@
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -2197,7 +2197,7 @@ uninstall-am: uninstall-binPROGRAMS uninstall-nodist_pkgdataDATA
+ 
+ 
+ preferences: genpref$(EXEEXT)
+-	$(AM_V_GEN)./genpref$(EXEEXT) -o $@ -s
++	$(AM_V_GEN)termux-proot-run ./genpref$(EXEEXT) -o $@ -s
+ 
+ # Tell versions [3.59,3.63) of GNU make to not export all variables.
+ # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/x11-packages/icewm/mblen.patch
+++ b/x11-packages/icewm/mblen.patch
@@ -1,0 +1,34 @@
+The `android_mblen()` implementation copied from the `imlib2` Termux package
+
+--- a/src/ypaint.cc
++++ b/src/ypaint.cc
+@@ -18,6 +18,11 @@
+ 
+ #ifdef CONFIG_I18N
+ #include <wctype.h>
++
++static int android_mblen(const char *s, size_t n)
++{
++    return mbtowc(0, s, n);
++}
+ #endif
+ 
+ static inline Display* display()  { return xapp->display(); }
+@@ -310,7 +315,7 @@ void Graphics::drawCharUnderline(int x, int y, const char *str, int charPos) {
+     int c = 0, cp = 0;
+ 
+ #ifdef CONFIG_I18N
+-    if (multiByte) mblen(nullptr, 0);
++    if (multiByte) android_mblen(nullptr, 0);
+ #endif
+     while (c <= len && cp <= charPos + 1) {
+         if (charPos == cp) {
+@@ -325,7 +330,7 @@ void Graphics::drawCharUnderline(int x, int y, const char *str, int charPos) {
+             break;
+ #ifdef CONFIG_I18N
+         if (multiByte) {
+-            int nc = mblen(str + c, size_t(len - c));
++            int nc = android_mblen(str + c, size_t(len - c));
+             if (nc < 1) { // bad things
+                 c++;
+                 cp++;

--- a/x11-packages/icewm/suppress-network-permission-warning.patch
+++ b/x11-packages/icewm/suppress-network-permission-warning.patch
@@ -1,0 +1,25 @@
+Most Android 11+ devices do not have permission
+to access /proc/net/dev without root, with
+some exceptions, so suppress this warning with
+the assumption that users of Android 11+ are
+probably familiar with this limitation and would rather
+not be annoyed by this warning spamming.
+The other observable effect when this warning occurs is
+the network status monitor not working,
+and if the user sees that happening, trying the commands
+'pkg install iproute2' and 'ip a' on the same device without
+using root will show the user the same 'permission denied'
+message, informing them that they are using a device
+that does not permit network adapter metadata permission
+without root.
+--- a/src/apppstatus.cc
++++ b/src/apppstatus.cc
+@@ -761,7 +761,7 @@ bool NetStatusControl::readNetDev(char* data, size_t size) {
+     if (fNetDev < 0) {
+         fNetDev = open(path, O_RDONLY | O_CLOEXEC);
+         if (fNetDev < 0) {
+-            fail("open %s", path);
++            //fail("open %s", path);
+             return false;
+         }
+     }

--- a/x11-packages/xdg-menu/build.sh
+++ b/x11-packages/xdg-menu/build.sh
@@ -1,0 +1,46 @@
+TERMUX_PKG_HOMEPAGE=https://wiki.archlinux.org/title/Xdg-menu
+TERMUX_PKG_DESCRIPTION="Tool that generates XDG Desktop Menus for icewm and other window managers"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.7.6.6"
+TERMUX_PKG_SRCURL="https://arch.p5n.pp.ru/~sergej/dl/2023/arch-xdg-menu-$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=01cbd3749939c180fed33783f0f7c4f47ac9563af2d1c4b39e23cb6cba792b40
+TERMUX_PKG_DEPENDS="perl"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_CONFFILES="
+etc/update-menus.conf
+etc/xdg/menus/termux-applications.menu
+"
+
+# The original "termux_extract_src_archive" always strips the first components
+# but the source of xdg-menu is directly under the root directory of the tar file
+termux_extract_src_archive() {
+	local file="$TERMUX_PKG_CACHEDIR/$(basename "$TERMUX_PKG_SRCURL")"
+	mkdir -p "$TERMUX_PKG_SRCDIR"
+	tar -xf "$file" -C "$TERMUX_PKG_SRCDIR"
+}
+
+termux_step_make_install() {
+	install -D -m 0755 xdg_menu "$TERMUX_PREFIX"/bin/xdg_menu
+	install -D -m 0755 xdg_menu_su "$TERMUX_PREFIX"/bin/xdg_menu_su
+	install -D -m 0755 update-menus "$TERMUX_PREFIX"/bin/update-menus
+	install -D -m 0644 update-menus.conf "$TERMUX_PREFIX"/etc/update-menus.conf
+	mkdir -p "$TERMUX_PREFIX"/share/desktop-directories/
+	cp termux-desktop-directories/* "$TERMUX_PREFIX"/share/desktop-directories/
+	mkdir -p "$TERMUX_PREFIX"/etc/xdg/menus/
+	cp termux-xdg-menu/* "$TERMUX_PREFIX"/etc/xdg/menus/
+}
+
+termux_step_create_debscripts()  {
+	cat <<- POSTINST_EOF > ./postinst
+	#!$TERMUX_PREFIX/bin/bash
+	set -e
+
+	echo "Sideloading Perl XML::Parser..."
+	cpan install XML::Parser
+
+	exit 0
+	POSTINST_EOF
+	chmod +x ./postinst
+}

--- a/x11-packages/xdg-menu/termux.patch
+++ b/x11-packages/xdg-menu/termux.patch
@@ -1,0 +1,344 @@
+diff --git a/arch-desktop-directories/Arch-Accessibility.directory b/termux-desktop-directories/Termux-Accessibility.directory
+similarity index 100%
+rename from arch-desktop-directories/Arch-Accessibility.directory
+rename to termux-desktop-directories/Termux-Accessibility.directory
+diff --git a/arch-desktop-directories/Arch-Accessories.directory b/termux-desktop-directories/Termux-Accessories.directory
+similarity index 100%
+rename from arch-desktop-directories/Arch-Accessories.directory
+rename to termux-desktop-directories/Termux-Accessories.directory
+diff --git a/arch-desktop-directories/Arch-Applications.directory b/termux-desktop-directories/Termux-Applications.directory
+similarity index 100%
+rename from arch-desktop-directories/Arch-Applications.directory
+rename to termux-desktop-directories/Termux-Applications.directory
+diff --git a/arch-desktop-directories/Arch-Development.directory b/termux-desktop-directories/Termux-Development.directory
+similarity index 100%
+rename from arch-desktop-directories/Arch-Development.directory
+rename to termux-desktop-directories/Termux-Development.directory
+diff --git a/arch-desktop-directories/Arch-Education.directory b/termux-desktop-directories/Termux-Education.directory
+similarity index 100%
+rename from arch-desktop-directories/Arch-Education.directory
+rename to termux-desktop-directories/Termux-Education.directory
+diff --git a/arch-desktop-directories/Arch-Games.directory b/termux-desktop-directories/Termux-Games.directory
+similarity index 100%
+rename from arch-desktop-directories/Arch-Games.directory
+rename to termux-desktop-directories/Termux-Games.directory
+diff --git a/arch-desktop-directories/Arch-Graphics.directory b/termux-desktop-directories/Termux-Graphics.directory
+similarity index 100%
+rename from arch-desktop-directories/Arch-Graphics.directory
+rename to termux-desktop-directories/Termux-Graphics.directory
+diff --git a/arch-desktop-directories/Arch-Internet.directory b/termux-desktop-directories/Termux-Internet.directory
+similarity index 100%
+rename from arch-desktop-directories/Arch-Internet.directory
+rename to termux-desktop-directories/Termux-Internet.directory
+diff --git a/arch-desktop-directories/Arch-Multimedia.directory b/termux-desktop-directories/Termux-Multimedia.directory
+similarity index 100%
+rename from arch-desktop-directories/Arch-Multimedia.directory
+rename to termux-desktop-directories/Termux-Multimedia.directory
+diff --git a/arch-desktop-directories/Arch-Office.directory b/termux-desktop-directories/Termux-Office.directory
+similarity index 100%
+rename from arch-desktop-directories/Arch-Office.directory
+rename to termux-desktop-directories/Termux-Office.directory
+diff --git a/arch-desktop-directories/Arch-Other.directory b/termux-desktop-directories/Termux-Other.directory
+similarity index 100%
+rename from arch-desktop-directories/Arch-Other.directory
+rename to termux-desktop-directories/Termux-Other.directory
+diff --git a/arch-desktop-directories/Arch-Science.directory b/termux-desktop-directories/Termux-Science.directory
+similarity index 100%
+rename from arch-desktop-directories/Arch-Science.directory
+rename to termux-desktop-directories/Termux-Science.directory
+diff --git a/arch-desktop-directories/Arch-System-Tools.directory b/termux-desktop-directories/Termux-System-Tools.directory
+similarity index 100%
+rename from arch-desktop-directories/Arch-System-Tools.directory
+rename to termux-desktop-directories/Termux-System-Tools.directory
+diff --git a/arch-xdg-menu/arch-applications.menu b/termux-xdg-menu/termux-applications.menu
+similarity index 76%
+rename from arch-xdg-menu/arch-applications.menu
+rename to termux-xdg-menu/termux-applications.menu
+index 41b9c64..e44f6eb 100644
+--- a/arch-xdg-menu/arch-applications.menu
++++ b/termux-xdg-menu/termux-applications.menu
+@@ -3,22 +3,22 @@
+ <Menu>
+ 
+   <Name>Applications</Name>
+-  <Directory>Arch-Applications.directory</Directory>
++  <Directory>Termux-Applications.directory</Directory>
+   <DefaultAppDirs/>
+   <DefaultDirectoryDirs/>
+   <DefaultMergeDirs/>
+ 
+   <Menu>
+-    <Name>Archlinux</Name>
+-    <Directory>Archlinux.directory</Directory>
++    <Name>Termux</Name>
++    <Directory>Termux.directory</Directory>
+     <Include>
+-      <Category>Archlinux</Category>
++      <Category>Termux</Category>
+     </Include>
+   </Menu>
+ 
+   <Menu>
+     <Name>Accessories</Name>
+-    <Directory>Arch-Accessories.directory</Directory>
++    <Directory>Termux-Accessories.directory</Directory>
+     <Include>
+       <And>
+         <Category>Utility</Category>
+@@ -31,7 +31,7 @@
+ 
+   <Menu>
+     <Name>Accessibility</Name>
+-    <Directory>Arch-Accessibility.directory</Directory>
++    <Directory>Termux-Accessibility.directory</Directory>
+     <Include>
+       <And>
+         <Category>Accessibility</Category>
+@@ -44,7 +44,7 @@
+ 
+   <Menu>
+     <Name>Development</Name>
+-    <Directory>Arch-Development.directory</Directory>
++    <Directory>Termux-Development.directory</Directory>
+     <Include>
+       <And>
+         <Category>Development</Category>
+@@ -55,7 +55,7 @@
+ 
+   <Menu>
+     <Name>Education</Name>
+-    <Directory>Arch-Education.directory</Directory>
++    <Directory>Termux-Education.directory</Directory>
+     <Include>
+       <And>
+         <Category>Education</Category>
+@@ -65,7 +65,7 @@
+ 
+   <Menu>
+     <Name>Games</Name>
+-    <Directory>Arch-Games.directory</Directory>
++    <Directory>Termux-Games.directory</Directory>
+     <Include>
+       <And>
+         <Category>Game</Category>
+@@ -75,7 +75,7 @@
+ 
+   <Menu>
+     <Name>Graphics</Name>
+-    <Directory>Arch-Graphics.directory</Directory>
++    <Directory>Termux-Graphics.directory</Directory>
+     <Include>
+       <And>
+         <Category>Graphics</Category>
+@@ -85,7 +85,7 @@
+ 
+   <Menu>
+     <Name>Internet</Name>
+-    <Directory>Arch-Internet.directory</Directory>
++    <Directory>Termux-Internet.directory</Directory>
+     <Include>
+       <And>
+         <Category>Network</Category>
+@@ -95,7 +95,7 @@
+ 
+   <Menu>
+     <Name>Multimedia</Name>
+-    <Directory>Arch-Multimedia.directory</Directory>
++    <Directory>Termux-Multimedia.directory</Directory>
+     <Include>
+       <And>
+         <Category>AudioVideo</Category>
+@@ -105,7 +105,7 @@
+ 
+   <Menu>
+     <Name>Office</Name>
+-    <Directory>Arch-Office.directory</Directory>
++    <Directory>Termux-Office.directory</Directory>
+     <Include>
+       <And>
+         <Category>Office</Category>
+@@ -115,7 +115,7 @@
+ 
+     <Menu>
+ 	<Name>Science</Name>
+-	<Directory>Arch-Science.directory</Directory>
++	<Directory>Termux-Science.directory</Directory>
+ 	<Include>
+ 		<And>
+ 			<Or>
+@@ -135,7 +135,7 @@
+ 
+   <Menu>
+     <Name>System</Name>
+-    <Directory>Arch-System-Tools.directory</Directory>
++    <Directory>Termux-System-Tools.directory</Directory>
+     <Include>
+       <And>
+         <Category>System</Category>
+@@ -146,7 +146,7 @@
+ 
+   <Menu>
+     <Name>Other</Name>
+-    <Directory>Arch-Other.directory</Directory>
++    <Directory>Termux-Other.directory</Directory>
+     <OnlyUnallocated/>
+     <Include>
+       <And>
+diff --git a/update-menus b/update-menus
+index 68233f7..0053640 100755
+--- a/update-menus
++++ b/update-menus
+@@ -1,10 +1,10 @@
+-#!/usr/bin/perl -w
++#!@TERMUX_PREFIX@/bin/perl -w
+ 
+ # SPDX-License-Identifier: GPL2+
+ 
+-$XDG_CFG="/etc/xdg/menus/arch-applications.menu";
+-$CACHE_DIR="/var/cache/xdg-menu";
+-$LOG_FILE="/var/log/update-menus.log";
++$XDG_CFG="@TERMUX_PREFIX@/etc/xdg/menus/termux-applications.menu";
++$CACHE_DIR="@TERMUX_PREFIX@/var/cache/xdg-menu";
++$LOG_FILE="@TERMUX_PREFIX@/var/log/update-menus.log";
+ 
+ sub get_cache_dir
+ {
+@@ -25,7 +25,7 @@ my $cachedir = get_cache_dir;
+ system("rm -rf $cachedir");
+ (system("rm -rf $CACHE_DIR/*") == 0) || die("Cannot purge cache!");
+ 
+-open(FH, "</etc/update-menus.conf") || die("No config file!");
++open(FH, "<@TERMUX_PREFIX@/etc/update-menus.conf") || die("No config file!");
+ 
+ while(<FH>)
+ {
+diff --git a/xdg_menu b/xdg_menu
+index e45ca4e..1bb5368 100755
+--- a/xdg_menu
++++ b/xdg_menu
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl -w
++#!@TERMUX_PREFIX@/bin/perl -w
+ 
+ #
+ # xdg-menu for archlinux. based on suse xdg-menu written by <nadvornik@suse.cz>
+@@ -74,7 +74,7 @@ sub findicon
+         my $iconname = shift;
+ 
+         my $home = $ENV{"HOME"};
+-        my $xdg_data_dirs = $ENV{"XDG_DATA_DIRS"} || "/usr/local/share:/usr/share:$home/.local/share";
++        my $xdg_data_dirs = $ENV{"XDG_DATA_DIRS"} || "@TERMUX_PREFIX@/local/share:@TERMUX_PREFIX@/share:$home/.local/share";
+ 
+         my (@xdg_data_dirs);
+         @xdg_data_dirs = split(":",$xdg_data_dirs);
+@@ -121,7 +121,7 @@ sub findicon
+                 }
+         }
+ 
+-        push @icon_search_path, "/usr/share/pixmaps";
++        push @icon_search_path, "@TERMUX_PREFIX@/share/pixmaps";
+ 
+         my $filename;
+ 
+@@ -1579,9 +1579,9 @@ sub output_blackbox_menu ($;$;$)
+     $output .= '[config] (Configuration)
+                 [workspaces] (Workspace)
+                 [submenu] (System Styles) {Choose a style...}
+-                        [stylesdir] (/usr/share/blackbox/styles)
+-			[stylesdir] (/usr/share/fluxbox/styles)
+-			[stylesdir] (/usr/share/openbox/styles)
++                        [stylesdir] (@TERMUX_PREFIX@/share/blackbox/styles)
++			[stylesdir] (@TERMUX_PREFIX@/share/fluxbox/styles)
++			[stylesdir] (@TERMUX_PREFIX@/share/openbox/styles)
+                 [end]
+                 [submenu] (User Styles) {Choose a style...}
+                         [stylesdir] (~/.blackbox/styles)
+@@ -1986,7 +1986,7 @@ sub output_openbox3_menu ($;$)
+ <openbox_menu xmlns="http://openbox.org/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://openbox.org/
+-                file:///usr/share/openbox/menu.xsd">';
++                file://@TERMUX_PREFIX@/share/openbox/menu.xsd">';
+     $output .= "<menu id=\"xdg\" label=\"xdg\">\n";
+     $output .= output_openbox3_inner_menu ($menu, $indent);
+     $output .= "</menu>\n";
+@@ -2200,10 +2200,10 @@ sub output_jwm_menu ($;$)
+ 
+ sub get_root_menu
+ {
+-    foreach my $dir (split(/:/, $ENV{XDG_CONFIG_DIRS}), "/etc/xdg")
++    foreach my $dir (split(/:/, $ENV{XDG_CONFIG_DIRS}), "@TERMUX_PREFIX@/etc/xdg")
+     {
+-        check_file("$dir/menus/arch-applications.menu");
+-        return "$dir/menus/arch-applications.menu" if -f "$dir/menus/arch-applications.menu";
++        check_file("$dir/menus/termux-applications.menu");
++        return "$dir/menus/termux-applications.menu" if -f "$dir/menus/termux-applications.menu";
+     }
+     return "";
+ }
+@@ -2211,13 +2211,13 @@ sub get_root_menu
+ sub get_kde_config
+ {
+     my $ret = 'true';
+-    if(-x '/usr/bin/kde4-config')
++    if(-x '@TERMUX_PREFIX@/bin/kde4-config')
+     {
+-        $ret = '/usr/bin/kde4-config';
++        $ret = '@TERMUX_PREFIX@/bin/kde4-config';
+     }
+-    elsif(-x '/opt/kde/bin/kde-config')
++    elsif(-x '@TERMUX_PREFIX@/opt/kde/bin/kde-config')
+     {
+-        $ret = '/opt/kde/bin/kde-config';
++        $ret = '@TERMUX_PREFIX@/opt/kde/bin/kde-config';
+     }
+     return $ret;
+ }
+@@ -2236,7 +2236,7 @@ sub get_app_dirs
+     };
+ 
+     my $home = $ENV{"HOME"};
+-    foreach my $d (split(/:/, $ENV{XDG_DATA_DIRS}), @kde_xdgdata, "/usr/share", "$home/.local/share", "/opt/gnome/share")
++    foreach my $d (split(/:/, $ENV{XDG_DATA_DIRS}), @kde_xdgdata, "@TERMUX_PREFIX@/share", "$home/.local/share", "@TERMUX_PREFIX@/opt/gnome/share")
+     {
+         my $dir = $d;
+         $dir =~ s/\/*$//;
+@@ -2254,7 +2254,7 @@ sub get_desktop_dirs
+     my %used;
+     my $ret = '';
+     my $home = $ENV{"HOME"};
+-    foreach my $dir (split(/:/, $ENV{XDG_DATA_DIRS}), "/usr/share", "$home/.local/share", "/opt/kde3/share", "/opt/gnome/share")
++    foreach my $dir (split(/:/, $ENV{XDG_DATA_DIRS}), "@TERMUX_PREFIX@/share", "$home/.local/share", "@TERMUX_PREFIX@/opt/kde3/share", "@TERMUX_PREFIX@/opt/gnome/share")
+     {
+         next if defined $used{$dir};
+         next if check_file("$dir/desktop-directories") ne 'D';
+@@ -2269,7 +2269,7 @@ sub get_KDE_legacy_dirs
+ {
+     my %used;
+     my @ret;
+-    foreach my $d ("/etc/opt/kde3/share/applnk", "/opt/kde3/share/applnk", reverse(split(/:/, `$kdeconfig --path apps`)))
++    foreach my $d ("@TERMUX_PREFIX@/etc/opt/kde3/share/applnk", "@TERMUX_PREFIX@/opt/kde3/share/applnk", reverse(split(/:/, `$kdeconfig --path apps`)))
+     {
+         my $dir = $d;
+         chomp $dir;
+@@ -2496,9 +2496,6 @@ my $root_menu = get_root_menu();
+ $charset = langinfo(CODESET);
+ $language = setlocale(LC_MESSAGES);
+ 
+-$root_cmd = "/usr/bin/gnomesu" if -x '/usr/bin/gnomesu';
+-$root_cmd = "/usr/bin/kdesu" if -x '/usr/bin/kdesu';
+-
+ my $help;
+ 
+ GetOptions("format=s" => \$format,
+diff --git a/xdg_menu_su b/xdg_menu_su
+index db5f23b..e6303ba 100755
+--- a/xdg_menu_su
++++ b/xdg_menu_su
+@@ -4,5 +4,5 @@
+ 
+ xterm -bg LightGoldenRod -fn 9x15 -geometry 34x4 \
+       -vb +sb -T "root permission" \
+-      -e sh -c "echo \"Run command with root privileges\"; echo \"Command: $*\"; sux -c \"/usr/bin/env LANG=${LANG} $*\""
++      -e sh -c "echo \"Run command with root privileges\"; echo \"Command: $*\"; su -c \"@TERMUX_PREFIX@/bin/env LANG=${LANG} $*\""
+ 


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/25426

<img width="2400" height="1080" alt="Screenshot_20250722-033735_Termux_X11" src="https://github.com/user-attachments/assets/f661fb07-69e4-40e0-a1fa-388198104fcc" />

### How to launch IceWM in Termux:X11

```bash
pkg upgrade
pkg install x11-repo
pkg install termux-x11-nightly icewm xdg-menu
mkdir -p ~/.icewm/
xdg_menu --format icewm \
    --fullmenu \
    --root-menu \
    $PREFIX/etc/xdg/menus/termux-applications.menu \
    > ~/.icewm/programs
export DISPLAY=:0 TERMUX_X11_XSTARTUP=icewm-session
termux-x11 &
```

I was on the fence about whether or not to add `xdg_menu` commands to `postinst` scripts of window managers that don't generate their own menus by default, but I decided not to,

because originally, the idea was that users of IceWM, Openbox, Fluxbox and others are supposed to have control over their own configuration files and choose their own way to set up their menu, and learn how to manually run a menu autogenerator,

I just personally found the Arch Linux branch of the `xdg_menu` generator to be the easiest to port to Termux and generate a good applications menu for IceWM.