### PR TITLE
bump(root/below): 0.10.0

### DIFF
--- a/root-packages/below/below-config-src-lib.rs.patch
+++ b/root-packages/below/below-config-src-lib.rs.patch
@@ -1,15 +1,13 @@
 --- a/below/config/src/lib.rs
 +++ b/below/config/src/lib.rs
-@@ -22,9 +22,9 @@
+@@ -27,8 +27,8 @@
  #[cfg(test)]
  mod test;
  
 -pub const BELOW_DEFAULT_CONF: &str = "/etc/below/below.conf";
--const BELOW_DEFAULT_LOG: &str = "/var/log/below";
 -const BELOW_DEFAULT_STORE: &str = "/var/log/below/store";
 +pub const BELOW_DEFAULT_CONF: &str = "@TERMUX_PREFIX@/etc/below/below.conf";
-+const BELOW_DEFAULT_LOG: &str = "@TERMUX_PREFIX@/var/log/below";
 +const BELOW_DEFAULT_STORE: &str = "@TERMUX_PREFIX@/var/log/below/store";
  
  /// Global below config
- pub static BELOW_CONFIG: OnceCell<BelowConfig> = OnceCell::new();
+ pub static BELOW_CONFIG: OnceLock<BelowConfig> = OnceLock::new();

--- a/root-packages/below/build.sh
+++ b/root-packages/below/build.sh
@@ -2,32 +2,29 @@ TERMUX_PKG_HOMEPAGE=https://github.com/facebookincubator/below
 TERMUX_PKG_DESCRIPTION="An interactive tool to view and record historical system data"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.9.0"
+TERMUX_PKG_VERSION="0.10.0"
 TERMUX_PKG_SRCURL=https://github.com/facebookincubator/below/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=c51c202e9c15aafc1c741f053ba374c302dc0a737aef6a1120b5c7957ab013fe
+TERMUX_PKG_SHA256=04d837417acbfbbbcf58f028a4e527f4c392a459b6c1bf0fcf91a837a6cbc1dc
 TERMUX_PKG_DEPENDS="libelf, zlib"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
-
-# ```
-# error[E0308]: mismatched types
-#    --> /home/builder/.cargo/registry/src/github.com-1ecc6299db9ec823/openat-0.1.21/src/dir.rs:465:34
-#     |
-# 465 |             match stat.st_mode & libc::S_IFMT {
-#     |                                  ^^^^^^^^^^^^ expected `u32`, found `u16`
-# ```
-TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"
 
 termux_step_pre_configure() {
 	termux_setup_rust
 	: "${CARGO_HOME:=$HOME/.cargo}"
 	export CARGO_HOME
 
+	rm -rf "$CARGO_HOME"/registry/src/*/nix-*
+	rm -rf "$CARGO_HOME"/registry/src/*/libbpf-sys-*
+	rm -rf "$CARGO_HOME"/registry/src/*/openat-*
+
+	cargo update
+
 	cargo fetch --target $CARGO_TARGET_NAME
 
 	local d p
-	for d in $CARGO_HOME/registry/src/*/libbpf-sys-*; do
+	for d in "$CARGO_HOME"/registry/src/*/libbpf-sys-*; do
 		for p in libbpf-sys-0.6.0-1-libbpf-include-linux-{compiler,types}.h.diff; do
 			patch --silent -p1 -d ${d} \
 				< "$TERMUX_PKG_BUILDER_DIR/${p}" || :
@@ -38,12 +35,19 @@ termux_step_pre_configure() {
 		patch --silent -p1 -d "$d" <  "$TERMUX_PKG_BUILDER_DIR"/nix-0.20.0-src-net-if_.rs.diff || :
 	done
 
+	for d in "$CARGO_HOME"/registry/src/*/openat-*; do
+		patch --silent -p1 -d "$d" <  "$TERMUX_PKG_BUILDER_DIR"/openat-st_mode-32-bit.diff || :
+	done
+
 	local _CARGO_TARGET_LIBDIR=target/$CARGO_TARGET_NAME/release/deps
 	mkdir -p $_CARGO_TARGET_LIBDIR
 	local lib
 	for lib in lib{elf,z}.so; do
 		ln -sf $TERMUX_PREFIX/lib/${lib} $_CARGO_TARGET_LIBDIR/
 	done
+
+	# prevents "gcc: error: unrecognized command-line option '-mfpu=neon'" when targeting 32-bit
+	unset CFLAGS
 }
 
 termux_step_make() {

--- a/root-packages/below/openat-st_mode-32-bit.diff
+++ b/root-packages/below/openat-st_mode-32-bit.diff
@@ -1,0 +1,41 @@
+Fixes this error when compiling the openat crate for 32-bit Android:
+error[E0308]: mismatched types
+   --> /home/builder/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/openat-0.1.21/src/dir.rs:472:17
+    |
+471 |             match stat.st_mode & libc::S_IFMT as u32 {
+    |                   ---------------------------------- this expression has type `u32`
+472 |                 libc::S_IFDIR => Ok(Dir(fd)),
+    |                 ^^^^^^^^^^^^^ expected `u32`, found `u16`
+
+--- a/src/dir.rs
++++ b/src/dir.rs
+@@ -462,10 +462,16 @@ impl Dir {
+         if res < 0 {
+             Err(io::Error::last_os_error())
+         } else {
++            #[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
+             match stat.st_mode & libc::S_IFMT {
+                 libc::S_IFDIR => Ok(Dir(fd)),
+                 _ => Err(io::Error::from_raw_os_error(libc::ENOTDIR))
+             }
++            #[cfg(all(target_os = "android", target_pointer_width = "32"))]
++            match stat.st_mode as u16 & libc::S_IFMT {
++                libc::S_IFDIR => Ok(Dir(fd)),
++                _ => Err(io::Error::from_raw_os_error(libc::ENOTDIR))
++            }
+         }
+     }
+ 
+--- a/src/metadata.rs
++++ b/src/metadata.rs
+@@ -17,7 +17,10 @@ pub struct Metadata {
+ impl Metadata {
+     /// Returns simplified type of the directory entry
+     pub fn simple_type(&self) -> SimpleType {
++        #[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
+         let typ = self.stat.st_mode & libc::S_IFMT;
++        #[cfg(all(target_os = "android", target_pointer_width = "32"))]
++        let typ = self.stat.st_mode as u16 & libc::S_IFMT;
+         match typ {
+             libc::S_IFREG => SimpleType::File,
+             libc::S_IFDIR => SimpleType::Dir,


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/25445

- Fixes building targeting 32-bit; tested working, but keep in mind that `below` only works on devices that have a kernel with cgroupv2 support, which usually means a kernel with version 5.8 or newer.