### PR TITLE
fix(x11/icewm): set `$TERMUX_PREFIX` throughout the software

### DIFF
--- a/x11-packages/icewm/build.sh
+++ b/x11-packages/icewm/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Window manager with goals of speed, simplicity, and usab
 TERMUX_PKG_LICENSE="LGPL-2.0-only"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.8.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/ice-wm/icewm/releases/download/$TERMUX_PKG_VERSION/icewm-$TERMUX_PKG_VERSION.tar.lz"
 TERMUX_PKG_SHA256=3c525512b1e4f4cf7999a4687f1b82311d7448d8c174780b5efd3b8aafbfb4a2
 TERMUX_PKG_AUTO_UPDATE=true
@@ -19,4 +20,10 @@ termux_step_pre_configure() {
 	fi
 
 	LDFLAGS+=" -landroid-glob -landroid-wordexp"
+
+	# Every instance of '/usr' in the code is replaceable with '$TERMUX_PREFIX'.
+	find "$TERMUX_PKG_SRCDIR" -type f | \
+		xargs -n 1 sed -i \
+		-e "s|/usr|$TERMUX_PREFIX|g" \
+		-e "s|/etc|$TERMUX_PREFIX/etc|g"
 }


### PR DESCRIPTION
- `termux-exec` should handle the path replacement for most of these, but patch all of them just in case

- I checked, and there is no string `/usr` or `/etc` in the code of IceWM that is not representing a UNIX-like system resources folder path or et cetera path respectively that can be safely and correctly replaced with `$TERMUX_PREFIX`, therefore this global replacement is safe
  - (**Note: this software does attempt to use some features/files that do not exist in Termux/Android, like `(PREFIX)/etc/shells` and `(PREFIX)/etc/passwd`**. I tried for a little while to implement those features over `termux-tools` [shells implementation] / `termux-auth` [passwd implementation], but I wasn't able to do that yet. As far as I can tell, if these features are not available, they just don't do anything and everything else in IceWM works normally)

- This is a rewrite of the patch that was lost in https://github.com/termux-user-repository/tur/pull/1876, because unfortunately, I did not realize until too late that an older version of IceWM was already present in the TUR. I don't want to cause the loss of any fixes that correctly replacing `/usr` with `$TERMUX_PREFIX` globally in IceWM might have had.