### PR TITLE
fix(main/emacs): make touch scroll work

### DIFF
--- a/packages/emacs/build.sh
+++ b/packages/emacs/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # Update both emacs and emacs-x to the same version in one PR.
 TERMUX_PKG_VERSION=30.1
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=https://ftp.gnu.org/gnu/emacs/emacs-${TERMUX_PKG_VERSION}.tar.xz
 if [[ $TERMUX_PKG_VERSION == *-rc* ]]; then
 	TERMUX_PKG_SRCURL=https://alpha.gnu.org/gnu/emacs/pretest/emacs-${TERMUX_PKG_VERSION#*:}.tar.xz

--- a/packages/emacs/site-start.el
+++ b/packages/emacs/site-start.el
@@ -1,7 +1,7 @@
 ;; Enable terminal mouse events:
 (xterm-mouse-mode 1)
-(global-set-key [mouse-4] 'scroll-down-line)
-(global-set-key [mouse-5] 'scroll-up-line)
+(global-set-key [wheel-up] 'scroll-down-line)
+(global-set-key [wheel-down] 'scroll-up-line)
 
 ;; Assume UTF-8 keyboard input for emacsclient:
 (add-hook 'server-visit-hook


### PR DESCRIPTION
Scrolling on the touch screen is now registered as wheel-up and wheel-down instead of mouse-4 and mouse-5. Adjust our site-start.el to fix it.