### PR TITLE
enhance(main/task-spooler): Rename to tsp to avoid conflict with moreutils

### DIFF
--- a/packages/task-spooler/build.sh
+++ b/packages/task-spooler/build.sh
@@ -3,12 +3,13 @@ TERMUX_PKG_DESCRIPTION="Task spooler is a Unix batch system where the tasks spoo
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1:1.0.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://vicerveza.homeunix.net/~viric/soft/ts/ts-${TERMUX_PKG_VERSION:2}.tar.gz
 TERMUX_PKG_SHA256=fa833311543dc535b60cb7ab83c64ab5ee31128dbaaaa13dde341984e542b428
 TERMUX_PKG_AUTO_UPDATE=false
-TERMUX_PKG_CONFLICTS="moreutils"
 
 termux_step_post_make_install() {
-	install -Dm600 -t $TERMUX_PREFIX/share/man/man1 \
-		$TERMUX_PKG_SRCDIR/ts.1
+	install -Dm600  \
+		$TERMUX_PKG_SRCDIR/ts.1 \
+		$TERMUX_PREFIX/share/man/man1/tsp.1
 }

--- a/packages/task-spooler/tsp.patch
+++ b/packages/task-spooler/tsp.patch
@@ -1,0 +1,178 @@
+diff --git a/meson.build b/meson.build
+index 81db455..891698e 100644
+--- a/meson.build
++++ b/meson.build
+@@ -2,7 +2,7 @@ project('ts', 'c',
+   version : '1.0.1',
+   default_options : ['warning_level=3'])
+ 
+-executable('ts',
++executable('tsp',
+            'client.c',
+            'env.c',
+            'error.c',
+diff --git a/ts.1 b/ts.1
+index 0d4a53c..d4fcf2d 100644
+--- a/ts.1
++++ b/ts.1
+@@ -5,11 +5,11 @@
+ .\" that should have been distributed together with this file.
+ .\" 
+ .\" Note: I took the gnu 'ls' man page as an example.
+-.TH TS 1 2020-12 "Task Spooler 1.0.3"
++.TH TSP 1 2020-12 "Task Spooler 1.0.3"
+ .SH NAME
+-ts \- task spooler. A simple unix batch system
++tsp \- task spooler. A simple unix batch system
+ .SH SYNOPSIS
+-.BI "ts [" actions "] [" options "] [" command... ]
++.BI "tsp [" actions "] [" options "] [" command... ]
+ .sp
+ Actions:
+ .BI "[\-KClhV]
+@@ -32,13 +32,13 @@ Options:
+ .BI "[\-D <"id >]
+ 
+ .SH DESCRIPTION
+-.B ts
++.B tsp
+ will run by default a per user unix task queue. The user can add commands to
+ the queue, watch that queue at any moment, and look at the task results
+ (actually, standard output and exit error).
+ .SH SIMPLE USE
+ Calling
+-.B ts
++.B tsp
+ with a command will add that command to the queue, and calling it without
+ commands or parameters will show the task list.
+ .SH COMMAND OPTIONS
+@@ -93,12 +93,12 @@ as if the job failed.
+ .TP
+ .B "\-B"
+ In the case the queue is full (due to \fBTS_MAXCONN\fR or system limits),
+-by default ts will block the enqueuing command. Using \fB\-B\fR,
++by default tsp will block the enqueuing command. Using \fB\-B\fR,
+ if the queue is full it will exit returning the value 2 instead of blocking.
+ .TP
+ .B "\-E"
+ Keep two different output files for the command stdout and stderr. stdout goes to
+-the file announced by ts (look at \fB\-o\fR), and stderr goes to the stdout file
++the file announced by tsp (look at \fB\-o\fR), and stderr goes to the stdout file
+ with an additional ".e". For example, /tmp/ts-out.SKsDw8 and /tmp/ts-out.SKsDw8.e.
+ Only the stdout file gets created with \fBmkstemp\fR, ensuring it does not overwrite
+ any other; the ".e" will be overwritten if it existed.
+@@ -107,21 +107,21 @@ any other; the ".e" will be overwritten if it existed.
+ Run the command only if there are \fbnum\fB slots free in the queue. Without it,
+ the job will run if there is one slot free. For example, if you use the
+ queue to feed cpu cores, and you know that a job will take two cores, with \fB\-N\fB
+-you can let ts know that.
++you can let tsp know that.
+ .SH ACTIONS
+ Instead of giving a new command, we can use the parameters for other purposes:
+ .TP
+ .B "\-K"
+ Kill the
+-.B ts
++.B tsp
+ server for the calling client. This will remove the unix socket and
+ all the
+-.B ts
++.B tsp
+ processes related to the queue. This will not kill the command being
+ run at that time.
+ 
+ It is not reliable to think that
+-.B ts -K
++.B tsp -K
+ will finish when the server is really killed. By now it is a race condition.
+ .TP
+ .B "\-C"
+@@ -130,7 +130,7 @@ Clear the results of finished jobs from the queue.
+ .B "\-l"
+ Show the list of jobs - to be run, running and finished - for the current queue.
+ This is the default behaviour if
+-.B ts
++.B tsp
+ is called without options.
+ .TP
+ .B "\-t [id]"
+@@ -165,7 +165,7 @@ Wait for the named job, or for the last in the queue.
+ Kill the process group of the named job (SIGTERM),
+ or the last running/run job if not specified.
+ Equivalent to
+-.B kill -- -`ts -p`
++.B kill -- -`tsp -p`
+ .TP
+ .B "\-u [id]"
+ Make the named job (or the last in the queue) urgent - this means that it goes
+@@ -186,7 +186,7 @@ Show help on standard output.
+ .B "\-V"
+ Show the program version.
+ .SH MULTI-SLOT
+-.B ts
++.B tsp
+ by default offers a queue where each job runs only after the previous finished.
+ Nevertheless, you can change the maximum number of jobs running at once with
+ the
+@@ -215,7 +215,7 @@ option if you are tired of
+ .B \-C.
+ .TP
+ .B "TS_MAXCONN"
+-The maximum number of ts server connections to clients. This will make the ts clients
++The maximum number of tsp server connections to clients. This will make the tsp clients
+ block until connections are freed. This helps, for example, on systems with a limited
+ number of processes, because each job waiting in the queue remains as a process. This
+ variable has to be set at server start, and cannot be modified later.
+@@ -244,7 +244,7 @@ otherwise.
+ Each queue has a related unix socket. You can specify the socket path with this
+ environment variable. This way, you can have a queue for your heavy disk
+ operations, another for heavy use of ram., and have a simple script/alias
+-wrapper over ts for those special queues. If it is not specified, it will be
++wrapper over tsp for those special queues. If it is not specified, it will be
+ .B $TMPDIR/socket-ts.[uid].
+ .TP
+ .B "TS_SLOTS"
+@@ -252,7 +252,7 @@ Set the number of slots at the start of the server, similar to
+ .B \-S,
+ but the contents of the variable are read only when running
+ the first instance of
+-.B ts.
++.B tsp.
+ .TP
+ .B "TS_MAILTO"
+ Send the letters with job results to the address specified in this variable.
+@@ -275,7 +275,7 @@ is not specified.
+ .TP
+ .B "TS_SAVELIST"
+ If it is defined when starting the queue server (probably the first
+-.B ts
++.B tsp
+ command run), on SIGTERM the queue status will be saved to the file pointed
+ by this environment variable - for example, at system shutdown.
+ .TP
+@@ -288,12 +288,12 @@ For example, you may use \fBTS_ENV='pwd;set;mount'\fR.
+ .TP
+ .B /tmp/ts.error
+ if
+-.B ts
++.B tsp
+ finds any internal problem, you should find an error report there.
+ Please send this to the author as part of the bug report.
+ 
+ .SH BUGS
+-.B ts
++.B tsp
+ expects a simple command line. It does not start a shell parser.
+ If you want to run complex shell commands, you may want to run them through
+ .B sh -c 'commands...'
+@@ -313,8 +313,8 @@ is created, which you can submit to the developer in order to fix the bug.
+ Lluis Batlle i Rossell
+ .SH NOTES
+ This page describes
+-.B ts
++.B tsp
+ as in version 1.0. Other versions may differ. The file
+ .B TRICKS
+ found in the distribution package can show some ideas on special uses of
+-.B ts.
++.B tsp.


### PR DESCRIPTION
This is an addendum to an earlier fix for #5662. Task-spooler provides `ts` and `ts.1`, which is already provided by moreutils, but is an entirely different tool (for prefixing input with a timestamp). Since moreutils is a very common utility package and task-spooler is much less commonly used, it should be renamed. This PR addresses this by renaming `ts` to `tsp` and patching the man page accordingly. This way both moreutils and task-spooler can be installed simultaneously.

This actually brings the package in line with Debian which has long since done the same.

https://sources.debian.org/patches/task-spooler/1.0.3%2Bdfsg1-1/tsp.patch/

The same is true in Ubuntu:
https://manpages.ubuntu.com/manpages/jammy/man1/tsp.1.html

And ArchLinux:
https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=task-spooler#n18
And probably more.