### PR TITLE
fix(main/apr): do not apply upstream's cross-compiling changes to `apr-config`'s includes path when cross-compiling reverse dependencies of `apr`

### DIFF
--- a/packages/apr/apr-config-do-not-use-upstream-cross-compiler-detection.patch
+++ b/packages/apr/apr-config-do-not-use-upstream-cross-compiler-detection.patch
@@ -1,0 +1,18 @@
+Causes
+/home/builder/.termux-build/subversion/tmp/config-scripts/apr-1-config --includes
+to print
+ -I/data/data/com.termux/files/usr/include/apr-1
+instead of
+ -I/home/builder/.termux-build/subversion/tmp/config-scripts/apr-1-config//data/data/com.termux/files/usr/include/apr-1
+
+--- a/apr-config.in
++++ b/apr-config.in
+@@ -50,7 +50,7 @@ location=@APR_CONFIG_LOCATION@
+ 
+ cross_compiling=@APR_CROSS_COMPILING@
+ 
+-if test "$cross_compiling" != "no"; then
++if false; then
+ 
+     # Normalize $0 and bindir by removing consecutive '/' as the comparison
+     # and the suffix removal below might fail for semantic equal pathes.

--- a/packages/apr/build.sh
+++ b/packages/apr/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Apache Portable Runtime Library"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.7.6"
+TERMUX_PKG_REVISION=1
 # old tarballs are removed in https://dlcdn.apache.org/apr/apr-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SRCURL=https://archive.apache.org/dist/apr/apr-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=49030d92d2575da735791b496dc322f3ce5cff9494779ba8cc28c7f46c5deb32


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/25495

