### PR TITLE
bump(main/mailutils): 3.20

### DIFF
--- a/packages/mailutils/build.sh
+++ b/packages/mailutils/build.sh
@@ -2,18 +2,18 @@ TERMUX_PKG_HOMEPAGE=https://mailutils.org/
 TERMUX_PKG_DESCRIPTION="Mailutils is a swiss army knife of electronic mail handling. "
 TERMUX_PKG_LICENSE="LGPL-3.0, GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="3.19"
+TERMUX_PKG_VERSION="3.20"
 TERMUX_PKG_SRCURL=https://ftp.gnu.org/gnu/mailutils/mailutils-$TERMUX_PKG_VERSION.tar.xz
-TERMUX_PKG_SHA256=50230d20036c5b8ad8c96b0d996177f1f133fba4c7c7e3b462d39eeb30849f45
+TERMUX_PKG_SHA256=a8f3faab1edda5188bb5ca3e4e9c0c5bc72cd0dadf4e1f4799d27fa75c6ae829
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="libandroid-glob, libcrypt, libiconv, libltdl, libunistring, ncurses, readline"
+TERMUX_PKG_DEPENDS="gdbm, libandroid-glob, libcrypt, libiconv, libltdl, libunistring, ncurses, readline"
 # Most of these configure arguments are for avoiding automagic dependencies.
 # You may instead add dependencies properly and enable them.
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-python
+--disable-static
 --without-gssapi
 --without-gnutls
---without-gdbm
 --without-berkeley-db
 --without-fribidi
 --without-ldap


### PR DESCRIPTION
Enable gdbm option for libmu_dbm and uidnew binaries. See changelog https://cgit.git.savannah.gnu.org/cgit/mailutils.git/tree/NEWS?h=v3.20

* Fixes #25551 