### PR TITLE
enhance(main/git): ship `git-shell` and `git-cvsserver`

### DIFF
--- a/packages/git/build.sh
+++ b/packages/git/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Fast, scalable, distributed revision control system"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION="2.50.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/pub/software/scm/git/git-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=7e3e6c36decbd8f1eedd14d42db6674be03671c2204864befa2a41756c5c8fc4
 TERMUX_PKG_AUTO_UPDATE=true
@@ -34,18 +35,6 @@ DEFAULT_PAGER=pager
 DEFAULT_EDITOR=editor
 "
 TERMUX_PKG_BUILD_IN_SRC=true
-
-# Things to remove to save space:
-#  bin/git-cvsserver - server emulating CVS
-#  bin/git-shell - restricted login shell for Git-only SSH access
-TERMUX_PKG_RM_AFTER_INSTALL="
-bin/git-cvsserver
-bin/git-shell
-libexec/git-core/git-shell
-libexec/git-core/git-cvsserver
-share/man/man1/git-cvsserver.1
-share/man/man1/git-shell.1
-"
 
 termux_step_pre_configure() {
 	# Certain packages are not safe to build on device because their


### PR DESCRIPTION
Requested in: https://www.reddit.com/r/termux/comments/1mdxqgz/git_package_does_not_include_gitshell/

`git-shell` can be utilized via the `~/.ssh/authorized_keys` file.
Example courtesy of @sylirre:
```yml
no-port-forwarding,no-agent-forwarding,command="git-shell -c \"$SSH_ORIGINAL_COMMAND\"" ssh-rsa <authorized-pubkey-data>
```

`git-cvsserver` should just work through the same mechanism.

These two add up to about 300KiB in the final package size, which I don't think is worth fretting about.
`4.1 MiB -> 4.4MiB` (`21.7 MiB -> 25.6 MiB` installed).