### PR TITLE
fix(root/fio): add http engine

### DIFF
--- a/root-packages/fio/build.sh
+++ b/root-packages/fio/build.sh
@@ -3,11 +3,11 @@ TERMUX_PKG_DESCRIPTION="Flexible I/O Tester"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.40"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/axboe/fio/archive/refs/tags/fio-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=9fc81e3a490a53fe821d76dd759d64f229d0ac6b4d2c711837bcad158242e3b2
-TERMUX_PKG_DEPENDS="openssl, libandroid-shmem, libaio"
+TERMUX_PKG_DEPENDS="openssl, libandroid-shmem, libaio, libcurl"
 TERMUX_PKG_SUGGESTS="python"
-TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+"
 
@@ -22,4 +22,5 @@ termux_pkg_auto_update() {
 
 termux_step_pre_configure() {
 	sed -i "s/@VERSION@/${TERMUX_PKG_VERSION}/g" $TERMUX_PKG_SRCDIR/Makefile
+	LDFLAGS+=" -I/data/data/com.termux/files/usr/include"
 }


### PR DESCRIPTION
libcurl is required (at configure time) to make it enable http engine

`./configure` wont accept `includedir` option as usual. add it to `LDFLAGS` so that `curl/curl.h` can be found