### PR TITLE
fix(main/dpkg): Adjust the phrasing of the `update-alternatives` `mandoc` hook warning message to be clearer

### DIFF
--- a/packages/dpkg/build.sh
+++ b/packages/dpkg/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Debian package management system"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.22.6"
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 # old tarball are removed in https://mirrors.kernel.org/debian/pool/main/d/dpkg/dpkg_${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SRCURL=git+https://salsa.debian.org/dpkg-team/dpkg.git
 TERMUX_PKG_GIT_BRANCH="${TERMUX_PKG_VERSION}"

--- a/packages/dpkg/mandoc_hook.patch
+++ b/packages/dpkg/mandoc_hook.patch
@@ -38,7 +38,7 @@
 +	const char *cmd_string = "makewhatis";
 +
 +	if (!command_in_path(cmd_string)) {
-+		warning("failed to detect '%s', not updating manpage database", cmd_string);
++		warning("skipping updating manpage database as '%s' command from 'mandoc' package is not installed", cmd_string);
 +		return;
 +	}
 +


### PR DESCRIPTION
- For several users, the message was unclear and seemed to imply a serious problem occurring, which was not intended. This should improve the readability of the message.