### PR TITLE
fix(main/util-linux): Fix building with NDK r28

### DIFF
--- a/packages/util-linux/build.sh
+++ b/packages/util-linux/build.sh
@@ -11,7 +11,7 @@ TERMUX_PKG_LICENSE_FILE="
 "
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.40.2"
-TERMUX_PKG_REVISION=4
+TERMUX_PKG_REVISION=5
 TERMUX_PKG_SRCURL=https://www.kernel.org/pub/linux/utils/util-linux/v${TERMUX_PKG_VERSION:0:4}/util-linux-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=d78b37a66f5922d70edf3bdfb01a6b33d34ed3c3cafd6628203b2a2b67c8e8b3
 # libcrypt is required for only newgrp and sulogin, which are not built anyways

--- a/packages/util-linux/schedutils-sched_attr.h.patch
+++ b/packages/util-linux/schedutils-sched_attr.h.patch
@@ -1,0 +1,33 @@
+diff -u -r ../cache/util-linux-2.40.2/schedutils/sched_attr.h ./schedutils/sched_attr.h
+--- ../cache/util-linux-2.40.2/schedutils/sched_attr.h	2024-01-31 10:02:15.742809948 +0000
++++ ./schedutils/sched_attr.h	2025-08-07 22:32:31.062558966 +0000
+@@ -84,6 +84,7 @@
+ #if defined (__linux__) && !defined(HAVE_SCHED_SETATTR) && defined(SYS_sched_setattr)
+ # define HAVE_SCHED_SETATTR
+ 
++#ifndef __ANDROID__
+ struct sched_attr {
+ 	uint32_t size;
+ 	uint32_t sched_policy;
+@@ -104,16 +105,19 @@
+ 	uint32_t sched_util_min;
+ 	uint32_t sched_util_max;
+ };
++#endif
+ 
+-static int sched_setattr(pid_t pid, const struct sched_attr *attr, unsigned int flags)
++static int sched_setattr_compat(pid_t pid, const struct sched_attr *attr, unsigned int flags)
+ {
+ 	return syscall(SYS_sched_setattr, pid, attr, flags);
+ }
+ 
+-static int sched_getattr(pid_t pid, struct sched_attr *attr, unsigned int size, unsigned int flags)
++static int sched_getattr_compat(pid_t pid, struct sched_attr *attr, unsigned int size, unsigned int flags)
+ {
+ 	return syscall(SYS_sched_getattr, pid, attr, size, flags);
+ }
++#define sched_setattr sched_setattr_compat
++#define sched_getattr sched_getattr_compat
+ #endif
+ 
+ /* the SCHED_DEADLINE is supported since Linux 3.14


### PR DESCRIPTION
Alternative approach to https://github.com/termux/termux-packages/pull/25606, see information and discussion there.

This change currently makes a `#ifndef __ANDROID__` to avoid redefining `struct sched_attr` - a more proper approach (before e.g. considering upstreaming) is to check for the existence of the struct instead.
