### PR TITLE
fix(main/pypy3): fix build with NDK r28c

### DIFF
--- a/packages/pypy3/0012-do-not-use-wno-discarded-qualifiers.patch
+++ b/packages/pypy3/0012-do-not-use-wno-discarded-qualifiers.patch
@@ -1,0 +1,14 @@
+Prevents the repetitive warning
+warning: unknown warning option '-Wno-discarded-qualifiers'
+from filling the build log and impacting readability.
+
+--- a/rpython/translator/platform/linux.py
++++ b/rpython/translator/platform/linux.py
+@@ -15,7 +15,6 @@ class Linux(BasePosix):
+     cflags = tuple(
+              ['-O3', '-pthread', '-fomit-frame-pointer',
+               '-Wall', '-Wno-unused', '-Wno-address',
+-              '-Wno-discarded-qualifiers',  # RPyField does not know about const
+               # The parser turns 'const char *const *includes' into 'const const char **includes'
+               '-Wno-duplicate-decl-specifier',
+               # These make older gcc  behave like gcc-14

--- a/packages/pypy3/build.sh
+++ b/packages/pypy3/build.sh
@@ -318,6 +318,17 @@ termux_step_make_install() {
 }
 
 termux_step_create_debscripts() {
+	# postinst script to clean up runtime-generated files of previous pypy3 versions that
+	# do not match the current $_MAJOR_VERSION
+	# (this one needs to have bash in the shebang, not sh, because of the use of a
+	# wildcard feature that does not work if the shebang is sh)
+	cat <<- POSTINST_EOF > ./postinst
+	#!$TERMUX_PREFIX/bin/bash
+	echo "Deleting files from other versions of $TERMUX_PKG_NAME..."
+	rm -Rf $TERMUX_PREFIX/opt/$TERMUX_PKG_NAME/lib/pypy*[^$_MAJOR_VERSION]
+	exit 0
+	POSTINST_EOF
+
 	# Pre-rm script to cleanup runtime-generated files.
 	cat <<- PRERM_EOF > ./prerm
 	#!$TERMUX_PREFIX/bin/sh
@@ -335,5 +346,5 @@ termux_step_create_debscripts() {
 	exit 0
 	PRERM_EOF
 
-	chmod 0755 prerm
+	chmod 0755 postinst prerm
 }

--- a/packages/pypy3/build.sh
+++ b/packages/pypy3/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@licy183"
 _MAJOR_VERSION=3.11
 TERMUX_PKG_VERSION=7.3.19
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://downloads.python.org/pypy/pypy$_MAJOR_VERSION-v$TERMUX_PKG_VERSION-src.tar.bz2
 TERMUX_PKG_SHA256=4817c044bb469a3274e60aa3645770f81eb4f9166ea7fdc4e6c351345554c8d8
 TERMUX_PKG_DEPENDS="gdbm, libandroid-posix-semaphore, libandroid-support, libbz2, libcrypt, libexpat, libffi, liblzma, libsqlite, ncurses, ncurses-ui-libs, openssl, zlib"
@@ -38,6 +39,7 @@ termux_step_post_get_source() {
 		| patch --silent -p1
 
 	sed -e "s|@TERMUX_PREFIX@|${TERMUX_PREFIX}|g" \
+		-e "s|@TERMUX_PKG_API_LEVEL@|${TERMUX_PKG_API_LEVEL}|g" \
 		"$TERMUX_PKG_BUILDER_DIR"/termux.py.in > \
 		"$TERMUX_PKG_SRCDIR"/rpython/translator/platform/termux.py
 }

--- a/packages/pypy3/pypy3-tests.subpackage.sh
+++ b/packages/pypy3/pypy3-tests.subpackage.sh
@@ -10,7 +10,7 @@ termux_step_create_subpkg_debscripts() {
 	cat <<- PRERM_EOF > ./prerm
 	#!$TERMUX_PREFIX/bin/sh
 
-	if [ "$TERMUX_PACKAGE_FORMAT" != "pacman" ] && [ "\$1" != "remove" ]; then
+	if [ "$TERMUX_PACKAGE_FORMAT" = "debian" ] && [ "\$1" != "remove" ]; then
 	    exit 0
 	fi
 

--- a/packages/pypy3/pypy3-tkinter.subpackage.sh
+++ b/packages/pypy3/pypy3-tkinter.subpackage.sh
@@ -9,7 +9,7 @@ termux_step_create_subpkg_debscripts() {
 	cat <<- PRERM_EOF > ./prerm
 	#!$TERMUX_PREFIX/bin/sh
 
-	if [ "$TERMUX_PACKAGE_FORMAT" != "pacman" ] && [ "\$1" != "remove" ]; then
+	if [ "$TERMUX_PACKAGE_FORMAT" = "debian" ] && [ "\$1" != "remove" ]; then
 	    exit 0
 	fi
 

--- a/packages/pypy3/termux.py.in
+++ b/packages/pypy3/termux.py.in
@@ -95,8 +95,11 @@ class BaseTermux(Linux):
     def get_multiarch(self):
         raise NotImplementedError("Needs to be overwritten")
 
+    def get_api_level(self):
+        return "@TERMUX_PKG_API_LEVEL@"
+
     def _get_cross_compiler(self):
-        return "clang" if self._is_same_platform_type() else ("clang --target=" + self.get_multiarch())
+        return "clang" if self._is_same_platform_type() else ("clang --target=" + self.get_multiarch() + self.get_api_level())
 
     def _get_build_platform_type(self):
         return "x86"


### PR DESCRIPTION
- After https://github.com/termux/termux-packages/pull/25487, which was built with NDK r27c

- This is like https://github.com/termux/termux-packages/pull/25627, but for the package `pypy3` instead of the package `libllvm`

- Also prevent the repetitive warning `warning: unknown warning option '-Wno-discarded-qualifiers'`
- Also refactor the `$TERMUX_PACKAGE_FORMAT` check
- Also add `postinst` script to clean up runtime-generated files of previous `pypy3` versions that do not match the current `$_MAJOR_VERSION`