### PR TITLE
addpkg(x11/screengrab): 3.0.0

### DIFF
--- a/x11-packages/libqtxdg/build.sh
+++ b/x11-packages/libqtxdg/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Qt implementation of freedesktop.org XDG specifications"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="4.2.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/lxqt/libqtxdg/releases/download/${TERMUX_PKG_VERSION}/libqtxdg-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=a5d430218550d66fa806debce7c418db41268286b17bdab46b8ce3a58f0fe82a
 TERMUX_PKG_DEPENDS="libc++, qt6-qtbase, qt6-qtsvg, glib"

--- a/x11-packages/screengrab/build.sh
+++ b/x11-packages/screengrab/build.sh
@@ -1,0 +1,16 @@
+TERMUX_PKG_HOMEPAGE=https://lxqt.github.io
+TERMUX_PKG_DESCRIPTION="Cross-platform tool for creating screenshots"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="3.0.0"
+TERMUX_PKG_SRCURL="https://github.com/lxqt/screengrab/releases/download/${TERMUX_PKG_VERSION}/screengrab-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256=30ad0428688595eb09ca684133c1bb1b02c4affae302791c4d2eb7990f6ccee7
+TERMUX_PKG_DEPENDS="kf6-kwindowsystem, layer-shell-qt, libc++, libx11, libxcb, libqtxdg, qt6-qtbase"
+TERMUX_PKG_BUILD_DEPENDS="lxqt-build-tools, qt6-qttools"
+TERMUX_PKG_AUTO_UPDATE=true
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=${TERMUX_PREFIX}/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+}


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/25650

- It's very similar to `flameshot`, but it has some features that `flameshot` does not, like **timed screenshots**, **cursor capture**, **zoom on cursor** and **instant edit in GIMP**.

<img width="2400" height="1080" alt="Screenshot_20250812-160541_Termux_X11" src="https://github.com/user-attachments/assets/f276c9c1-a356-4fb2-af32-9fdda41e8f23" />
<img width="2400" height="1080" alt="Screenshot_20250812-161806_Termux_X11" src="https://github.com/user-attachments/assets/2273fef1-fe1b-4b7b-9d1a-06e1debfd3b8" />
