### PR TITLE
fix(x11/schismtracker): uncomment the SONAME pattern that matches Android's traditional SONAME pattern

### DIFF
--- a/x11-packages/schismtracker/build.sh
+++ b/x11-packages/schismtracker/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A free and open-source reimplementation of Impulse Track
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="20250728"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/schismtracker/schismtracker/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=adbf92c2690e59e177868d88a823802891d47fffab496a0a726864a0363d2bb1
 TERMUX_PKG_AUTO_UPDATE=true

--- a/x11-packages/schismtracker/partially-revert-db8b7a7.patch
+++ b/x11-packages/schismtracker/partially-revert-db8b7a7.patch
@@ -1,0 +1,14 @@
+Partially reverts https://github.com/schismtracker/schismtracker/commit/db8b7a7fd41f951a1953f1f625bb1ad47fc89d6c,
+which introduces a change that doesn't work on Android.
+
+--- a/schism/loadso.c
++++ b/schism/loadso.c
+@@ -224,7 +224,7 @@ static const char *loadso_lib_fmts[] = {
+ #elif defined(SCHISM_MACOSX)
+ 	"lib%s.dylib",
+ #else
+-	//"lib%s.so",
++	"lib%s.so",
+ #endif
+ 	NULL,
+ };


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/25676
- Partially reverts https://github.com/schismtracker/schismtracker/commit/db8b7a7fd41f951a1953f1f625bb1ad47fc89d6c, because it introduces a change that is only for upstream's official GNU/Linux releases and that doesn't work on Android