### PR TITLE
bump(x11/xfce4-screensaver): 4.20.1

### DIFF
--- a/x11-packages/xfce4-screensaver/build.sh
+++ b/x11-packages/xfce4-screensaver/build.sh
@@ -2,14 +2,16 @@ TERMUX_PKG_HOMEPAGE=https://docs.xfce.org/apps/screensaver/start
 TERMUX_PKG_DESCRIPTION="Xfce Screensaver is a screen saver and locker that aims to have simple, sane, secure defaults and be well integrated with the desktop."
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@Yisus7u7"
-TERMUX_PKG_VERSION="4.20.0"
+TERMUX_PKG_VERSION="4.20.1"
 TERMUX_PKG_SRCURL=https://archive.xfce.org/src/apps/xfce4-screensaver/${TERMUX_PKG_VERSION%.*}/xfce4-screensaver-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=e370298d002848fdb2065fee254cb5b0efa0f2699b74299c234019c8d79b852e
-TERMUX_PKG_DEPENDS="dbus, dbus-glib, garcon, gdk-pixbuf, glib, gtk3, libcairo, libwnck, libx11, libxext, libxfce4ui, libxfce4util, libxklavier, libxss, opengl, pango, termux-auth, xfconf"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-locking --sysconfdir=$TERMUX_PREFIX/etc"
+TERMUX_PKG_SHA256=a94ce9ca3f56db183f1cbc60ba4accd91575b02a6d20b1876ad19131982f2243
 TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="dbus, dbus-glib, garcon, gdk-pixbuf, glib, gtk3, libcairo, libwnck, libx11, libxext, libxfce4ui, libxfce4util, libxklavier, libxss, opengl, pango, termux-auth, xfconf"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-Dauthentication-scheme=none
+-Dsession-manager=none
+"
 
 termux_step_pre_configure() {
-	autoreconf -fiv
 	termux_setup_glib_cross_pkg_config_wrapper
 }


### PR DESCRIPTION
Port to meson, autotools were removed.
https://gitlab.xfce.org/apps/xfce4-screensaver/-/tags/xfce4-screensaver-4.20.1

* Fixes #25730 