### PR TITLE
scripts(auto-update): allow update termux_setup_* scripts, termux_setup_cmake 4.1.1

### DIFF
--- a/packages/cmake/build.sh
+++ b/packages/cmake/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_LICENSE_FILE="LICENSE.rst"
 TERMUX_PKG_MAINTAINER="@termux"
 # When updating version here, please update termux_setup_cmake.sh as well.
 TERMUX_PKG_VERSION="4.1.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.cmake.org/files/v${TERMUX_PKG_VERSION:0:3}/cmake-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=b29f6f19733aa224b7763507a108a427ed48c688e1faf22b29c44e1c30549282
 TERMUX_PKG_AUTO_UPDATE=true
@@ -27,7 +28,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 
 termux_pkg_auto_update() {
 	local TERMUX_SETUP_CMAKE="${TERMUX_SCRIPTDIR}/scripts/build/setup/termux_setup_cmake.sh"
-	local TERMUX_CMAKE_VERSION=$(grep "local TERMUX_CMAKE_VERSION=" "${TERMUX_SETUP_CMAKE}" | cut -d"=" -f2)
 	local TERMUX_REPOLOGY_DATA_FILE=$(mktemp)
 	python3 "${TERMUX_SCRIPTDIR}"/scripts/updates/api/dump-repology-data \
 		"${TERMUX_REPOLOGY_DATA_FILE}" "${TERMUX_PKG_NAME}" >/dev/null || \
@@ -36,8 +36,7 @@ termux_pkg_auto_update() {
 	if [[ "${latest_version}" == "null" ]]; then
 		latest_version="${TERMUX_PKG_VERSION}"
 	fi
-	if [[ "${latest_version}" == "${TERMUX_PKG_VERSION}" ]] && \
-		[[ "${latest_version}" == "${TERMUX_CMAKE_VERSION}" ]]; then
+	if [[ "${latest_version}" == "${TERMUX_PKG_VERSION}" ]]; then
 		echo "INFO: No update needed. Already at version '${TERMUX_PKG_VERSION}'."
 		rm -f "${TERMUX_REPOLOGY_DATA_FILE}"
 		return

--- a/scripts/build/setup/termux_setup_cmake.sh
+++ b/scripts/build/setup/termux_setup_cmake.sh
@@ -1,6 +1,6 @@
 termux_setup_cmake() {
-	local TERMUX_CMAKE_VERSION=4.0.3
-	local TERMUX_CMAKE_SHA256=585ae9e013107bc8e7c7c9ce872cbdcbdff569e675b07ef57aacfb88c886faac
+	local TERMUX_CMAKE_VERSION=4.1.1
+	local TERMUX_CMAKE_SHA256=5a6c61cb62b38e153148a2c8d4af7b3d387f0c8c32b6dbceb5eb4af113efd65a
 	local TERMUX_CMAKE_MAJORVERSION="${TERMUX_CMAKE_VERSION%.*}"
 	local TERMUX_CMAKE_TARNAME="cmake-${TERMUX_CMAKE_VERSION}-linux-x86_64.tar.gz"
 	local TERMUX_CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v${TERMUX_CMAKE_VERSION}/${TERMUX_CMAKE_TARNAME}"

--- a/scripts/updates/utils/termux_pkg_upgrade_version.sh
+++ b/scripts/updates/utils/termux_pkg_upgrade_version.sh
@@ -141,9 +141,14 @@ termux_pkg_upgrade_version() {
 	if [[ "${GIT_COMMIT_PACKAGES}" == "true" ]]; then
 		echo "INFO: Committing package."
 		stderr="$(
-			git add "${TERMUX_PKG_BUILDER_DIR}" 2>&1 >/dev/null
-			git commit -m "bump(${repo}/${TERMUX_PKG_NAME}): ${LATEST_VERSION}" \
-				-m "This commit has been automatically submitted by Github Actions." 2>&1 >/dev/null
+			git add \
+				"${TERMUX_PKG_BUILDER_DIR}" \
+				"${TERMUX_SCRIPTDIR}/scripts/build/setup/" \
+				2>&1 >/dev/null
+			git commit \
+				-m "bump(${repo}/${TERMUX_PKG_NAME}): ${LATEST_VERSION}" \
+				-m "This commit has been automatically submitted by Github Actions." \
+				2>&1 >/dev/null
 		)" || {
 			git reset HEAD --hard
 			termux_error_exit <<-EndOfError


### PR DESCRIPTION
We keep forgetting update `termux_setup_*` scripts. This should finally allow custom auto update to do the job.