### PR TITLE
fix(ndk): fix on-device building and remove custom `__ANDROID_API__`  header patches

### DIFF
--- a/packages/libc++/build.sh
+++ b/packages/libc++/build.sh
@@ -5,8 +5,9 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Version should be equal to TERMUX_NDK_{VERSION_NUM,REVISION} in
 # scripts/properties.sh
 TERMUX_PKG_VERSION=28c
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://dl.google.com/android/repository/android-ndk-r${TERMUX_PKG_VERSION}-linux.zip
-TERMUX_PKG_SHA256=59c2f6dc96743b5daf5d1626684640b20a6bd2b1d85b13156b90333741bad5cc
+TERMUX_PKG_SHA256=dfb20d396df28ca02a8c708314b814a4d961dc9074f9a161932746f815aa552f
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_ESSENTIAL=true
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -17,6 +18,7 @@ termux_step_get_source() {
 		termux_download_src_archive
 		cd $TERMUX_PKG_TMPDIR
 		termux_extract_src_archive
+		mv "$TERMUX_PKG_SRCDIR/android-ndk-r$TERMUX_PKG_VERSION"/* "$TERMUX_PKG_SRCDIR"
 	else
 		local lib_path="toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/${TERMUX_HOST_PLATFORM}"
 		mkdir -p "$TERMUX_PKG_SRCDIR"/"$lib_path"

--- a/packages/ndk-multilib/build.sh
+++ b/packages/ndk-multilib/build.sh
@@ -5,9 +5,9 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Version should be equal to TERMUX_NDK_{VERSION_NUM,REVISION} in
 # scripts/properties.sh
 TERMUX_PKG_VERSION=28c
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://dl.google.com/android/repository/android-ndk-r${TERMUX_PKG_VERSION}-linux.zip
-TERMUX_PKG_SHA256=59c2f6dc96743b5daf5d1626684640b20a6bd2b1d85b13156b90333741bad5cc
+TERMUX_PKG_SHA256=dfb20d396df28ca02a8c708314b814a4d961dc9074f9a161932746f815aa552f
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_NO_STATICSPLIT=true
@@ -19,6 +19,7 @@ termux_step_get_source() {
 		termux_download_src_archive
 		cd $TERMUX_PKG_TMPDIR
 		termux_extract_src_archive
+		mv "$TERMUX_PKG_SRCDIR/android-ndk-r$TERMUX_PKG_VERSION"/* "$TERMUX_PKG_SRCDIR"
 	else
 		local lib_path="toolchains/llvm/prebuilt/linux-x86_64/sysroot"
 		mkdir -p "$TERMUX_PKG_SRCDIR"/"$lib_path"

--- a/packages/ndk-sysroot/build.sh
+++ b/packages/ndk-sysroot/build.sh
@@ -5,8 +5,9 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Version should be equal to TERMUX_NDK_{VERSION_NUM,REVISION} in
 # scripts/properties.sh
 TERMUX_PKG_VERSION=28c
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://dl.google.com/android/repository/android-ndk-r${TERMUX_PKG_VERSION}-linux.zip
-TERMUX_PKG_SHA256=59c2f6dc96743b5daf5d1626684640b20a6bd2b1d85b13156b90333741bad5cc
+TERMUX_PKG_SHA256=dfb20d396df28ca02a8c708314b814a4d961dc9074f9a161932746f815aa552f
 TERMUX_PKG_AUTO_UPDATE=false
 # This package has taken over <pty.h> from the previous libutil-dev
 # and iconv.h from libandroid-support-dev:
@@ -40,6 +41,7 @@ termux_step_get_source() {
 		termux_download_src_archive
 		cd $TERMUX_PKG_TMPDIR
 		termux_extract_src_archive
+		mv "$TERMUX_PKG_SRCDIR/android-ndk-r$TERMUX_PKG_VERSION"/* "$TERMUX_PKG_SRCDIR"
 	else
 		local lib_path="toolchains/llvm/prebuilt/linux-x86_64/sysroot"
 		mkdir -p "$TERMUX_PKG_SRCDIR"/"$lib_path"
@@ -62,8 +64,6 @@ termux_step_post_get_source() {
 			-e "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" \
 			"$patch" | patch --silent -p1
 	done
-	sed -i "s/define __ANDROID_API__ __ANDROID_API_FUTURE__/define __ANDROID_API__ $TERMUX_PKG_API_LEVEL/" \
-		usr/include/android/api-level.h
 	grep -lrw usr/include/c++/v1 -e '<version>' | xargs -n 1 sed -i 's/<version>/\"version\"/g'
 	popd
 }

--- a/packages/vulkan-loader-android/build.sh
+++ b/packages/vulkan-loader-android/build.sh
@@ -5,9 +5,9 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Version should be equal to TERMUX_NDK_{VERSION_NUM,REVISION} in
 # scripts/properties.sh
 TERMUX_PKG_VERSION=28c
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://dl.google.com/android/repository/android-ndk-r${TERMUX_PKG_VERSION}-linux.zip
-TERMUX_PKG_SHA256=59c2f6dc96743b5daf5d1626684640b20a6bd2b1d85b13156b90333741bad5cc
+TERMUX_PKG_SHA256=dfb20d396df28ca02a8c708314b814a4d961dc9074f9a161932746f815aa552f
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -26,6 +26,7 @@ termux_step_get_source() {
 		termux_download_src_archive
 		cd $TERMUX_PKG_TMPDIR
 		termux_extract_src_archive
+		mv "$TERMUX_PKG_SRCDIR/android-ndk-r$TERMUX_PKG_VERSION"/* "$TERMUX_PKG_SRCDIR"
 	else
 		local lib_path="toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr"
 		mkdir -p "$TERMUX_PKG_SRCDIR"/"$lib_path"

--- a/scripts/build/termux_step_setup_toolchain.sh
+++ b/scripts/build/termux_step_setup_toolchain.sh
@@ -7,10 +7,10 @@ termux_step_setup_toolchain() {
 		# toolchain setup to ensure that everyone gets an updated
 		# toolchain
 		if [ "${TERMUX_NDK_VERSION}" = "28c" ]; then
-			TERMUX_STANDALONE_TOOLCHAIN+="-v1"
+			TERMUX_STANDALONE_TOOLCHAIN+="-v2"
 			termux_setup_toolchain_28c
 		elif [ "${TERMUX_NDK_VERSION}" = 23c ]; then
-			TERMUX_STANDALONE_TOOLCHAIN+="-v8"
+			TERMUX_STANDALONE_TOOLCHAIN+="-v9"
 			termux_setup_toolchain_23c
 		else
 			termux_error_exit "We do not have a setup_toolchain function for NDK version $TERMUX_NDK_VERSION"

--- a/scripts/build/toolchain/termux_setup_toolchain_23c.sh
+++ b/scripts/build/toolchain/termux_setup_toolchain_23c.sh
@@ -216,9 +216,6 @@ termux_setup_toolchain_23c() {
 	rm -Rf usr/include/vulkan
 	rm -Rf usr/include/{EGL,GLES{,2,3}}
 
-	sed -i "s/define __ANDROID_API__ __ANDROID_API_FUTURE__/define __ANDROID_API__ $TERMUX_PKG_API_LEVEL/" \
-		usr/include/android/api-level.h
-
 	$TERMUX_ELF_CLEANER --api-level=$TERMUX_PKG_API_LEVEL usr/lib/*/*/*.so | { [[ "${CI-}" == "true" ]] && sed -e '1i\::group::Applying `termux-elf-cleaner`' -e '$a\::endgroup::' || cat; }
 	for dir in usr/lib/*; do
 		# This seem to be needed when building rust

--- a/scripts/build/toolchain/termux_setup_toolchain_28c.sh
+++ b/scripts/build/toolchain/termux_setup_toolchain_28c.sh
@@ -219,9 +219,6 @@ termux_setup_toolchain_28c() {
 	rm -Rf usr/include/vulkan
 	rm -Rf usr/include/{EGL,GLES{,2,3}}
 
-	sed -i "s/define __ANDROID_API__ __ANDROID_API_FUTURE__/define __ANDROID_API__ $TERMUX_PKG_API_LEVEL/" \
-		usr/include/android/api-level.h
-
 	$TERMUX_ELF_CLEANER --api-level=$TERMUX_PKG_API_LEVEL usr/lib/*/*/*.so | { [[ "${CI-}" == "true" ]] && sed -e '1i\::group::Applying `termux-elf-cleaner`' -e '$a\::endgroup::' || cat; }
 	for dir in usr/lib/*; do
 		# This seem to be needed when building rust


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/26838

- Fixes partly https://github.com/termux/termux-packages/issues/23401

- After https://github.com/termux/termux-packages/pull/25627, it is believed that the custom definition of `__ANDROID_API__` is no longer needed, because:
  - There is no longer a way to reproduce any of the errors that it fixed before
  - Even if there were a way to, it would no longer be able to fix those errors by itself because of the update to NDK r28c (see https://github.com/termux/termux-packages/issues/25622 for more details)
  - It is replaced with https://github.com/termux/termux-packages/pull/25627, which does what it used to a different way that also fixes other errors and seems more reliable