### PR TITLE
enhance(libgit2): Remove termux_step_pre_configure as it's not needed anymore.

### DIFF
--- a/packages/libgit2/build.sh
+++ b/packages/libgit2/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.9.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/libgit2/libgit2/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=14cab3014b2b7ad75970ff4548e83615f74d719afe00aa479b4a889c1e13fc00
 TERMUX_PKG_AUTO_UPDATE=true
@@ -27,9 +28,4 @@ termux_step_post_get_source() {
 	if [ "${v}" != "${_SOVERSION}" ]; then
 		termux_error_exit "SOVERSION guard check failed."
 	fi
-}
-
-termux_step_pre_configure() {
-	find "$TERMUX_PKG_SRCDIR" -name CMakeLists.txt | xargs -n 1 \
-		sed -i 's/\( PROPERTIES C_STANDARD\) 90/\1 99/g'
 }


### PR DESCRIPTION
Now libgit2 does automatically use c99 on Android.
See https://github.com/libgit2/libgit2/blob/58d9363f02f1fa39e46d49b604f27008e75b72f2/CMakeLists.txt#L60-L64