### PR TITLE
bump(main/libtirpc): 1.3.7

### DIFF
--- a/packages/libtirpc/build.sh
+++ b/packages/libtirpc/build.sh
@@ -2,10 +2,9 @@ TERMUX_PKG_HOMEPAGE="http://git.linux-nfs.org/?p=steved/libtirpc.git"
 TERMUX_PKG_DESCRIPTION="Transport Independent RPC library"
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.3.6"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="1.3.7"
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/sourceforge/libtirpc/libtirpc-${TERMUX_PKG_VERSION}.tar.bz2
-TERMUX_PKG_SHA256=bbd26a8f0df5690a62a47f6aa30f797f3ef8d02560d1bc449a83066b5a1d3508
+TERMUX_PKG_SHA256=b47d3ac19d3549e54a05d0019a6c400674da716123858cfdb6d3bdd70a66c702
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-gssapi"
 
@@ -17,7 +16,5 @@ termux_step_pre_configure() {
 	# Avoid build errors such as: version script assignment of 'TIRPC_0.3.0' to symbol '_svcauth_gss' failed: symbol not defined
 	LDFLAGS+=" -Wl,-undefined-version"
 
-	aclocal
-	automake
-	autoconf
+	autoreconf -fiv
 }


### PR DESCRIPTION
Use autoreconf instead of multiple autotools command to fix the error.

Makefile.am: error: required file './INSTALL' not found
Makefile.am:   'automake --add-missing' can install 'INSTALL'

* Fixes #25819 