### PR TITLE
enhance(main/nushell): replace OSC 52 paste with termux-clipboard-get

### DIFF
--- a/packages/nushell/build.sh
+++ b/packages/nushell/build.sh
@@ -3,11 +3,12 @@ TERMUX_PKG_DESCRIPTION="A new type of shell operating on structured data"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.106.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/nushell/nushell/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=3e24044c354d050a850b69dc77c99cc503542c3d9d75fed0aef1c12fefdf380b
-TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="openssl"
 TERMUX_PKG_RECOMMENDS="command-not-found"
+TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_pre_configure() {

--- a/packages/nushell/replace-osc-52-with-termux-clipboard-get.patch
+++ b/packages/nushell/replace-osc-52-with-termux-clipboard-get.patch
@@ -1,0 +1,24 @@
+diff --git a/crates/nu-std/std/clip/mod.nu b/crates/nu-std/std/clip/mod.nu
+index ef2da0bfd..eb7065916 100644
+--- a/crates/nu-std/std/clip/mod.nu
++++ b/crates/nu-std/std/clip/mod.nu
+@@ -30,16 +30,13 @@ export def copy [
+ } --result "Hello"
+ export def paste []: [nothing -> string] {
+   try {
+-    term query $'(ansi osc)52;c;?(ansi st)' -p $'(ansi osc)52;c;' -t (ansi st)
++    ^@TERMUX_PREFIX@/bin/termux-clipboard-get
+   } catch {
+     error make -u {
+-      msg: "Terminal did not responds to OSC 52 paste request."
+-      help: $"Check if your terminal supports OSC 52."
++      msg: "termux-clipboard-get failed to paste."
++      help: $"Make sure you have Termux:API app and termux-api package installed."
+     }
+   }
+-  | decode
+-  | decode base64
+-  | decode
+ }
+ 
+ # Add a prefix to each line of the content to be copied


### PR DESCRIPTION
I don't know why OSC 52 copy works in termux but OSC 52 paste doesn't. So I replaced it with `termux-clipboard-get`