### PR TITLE
fix(main/aspell): apply patch from NetBSD that avoids use of GNU regex extensions

### DIFF
--- a/packages/aspell/android-14-support.patch
+++ b/packages/aspell/android-14-support.patch
@@ -1,0 +1,23 @@
+NetBSD uses this patch in its present-day releases,
+https://github.com/NetBSD/pkgsrc/commit/72ca05d074a5d4a271f71fd92a6370965674007d
+
+and it is necessary for Android 14+ because part of Android 14's source code
+is copied and pasted from NetBSD.
+https://android-review.googlesource.com/c/platform/bionic/+/2290937
+
+$NetBSD: patch-modules_filter_modes_perl.amf,v 1.1 2021/05/11 01:26:25 rin Exp $
+
+Fix for regex(3) update for NetBSD 9.99;
+Stop using GNU regex(3) extension \w.
+
+--- a/modules/filter/modes/perl.amf.orig	2021-05-11 10:16:54.496163627 +0900
++++ b/modules/filter/modes/perl.amf	2021-05-11 10:17:11.072694968 +0900
+@@ -2,7 +2,7 @@
+ 
+ ASPELL >=0.60.1
+ 
+-MAGIC /0:256:^[ \t]*\#!((\/\w*)+)\/perl/pl/pm
++MAGIC /0:256:^[ \t]*\#!((\/[[:alnum:]_]*)+)\/perl/pl/pm
+ MAGIC /<noregex>/pl/pm
+ 
+ DESCRIPTION mode for checking Perl comments and string literals

--- a/packages/aspell/build.sh
+++ b/packages/aspell/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A free and open source spell checker designed to replace
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.60.8.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://ftp.gnu.org/gnu/aspell/aspell-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=d6da12b34d42d457fa604e435ad484a74b2effcd120ff40acd6bb3fb2887d21b
 TERMUX_PKG_AUTO_UPDATE=true


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/25825 (The command `aspell dump modes` on Android 14+)

- NetBSD uses this patch in its present-day releases, https://github.com/NetBSD/pkgsrc/commit/72ca05d074a5d4a271f71fd92a6370965674007d

- and it is necessary for Android 14+ because part of Android 14's source code is copied and pasted from that newer NetBSD. https://android-review.googlesource.com/c/platform/bionic/+/2290937