### PR TITLE
fix(main/tsduck-tools): rename `tsp` to `tsp-tsduck` to avoid conflict with `task-spooler`

### DIFF
--- a/packages/libtsduck/build.sh
+++ b/packages/libtsduck/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="An extensible toolkit for MPEG transport streams"
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.40.4165"
+TERMUX_PKG_REVISION=1
 _VERSION=$(echo "${TERMUX_PKG_VERSION}" | sed 's/\./-/2')
 TERMUX_PKG_SRCURL=https://github.com/tsduck/tsduck/archive/refs/tags/v${_VERSION}.tar.gz
 TERMUX_PKG_SHA256=d499fd4571e3ebb6660de70b0ca3217423bf8d66b929e7bc0b92cfb6f01c9d04

--- a/packages/libtsduck/rename-tsp-to-tsp-tsduck.patch.beforehostbuild
+++ b/packages/libtsduck/rename-tsp-to-tsp-tsduck.patch.beforehostbuild
@@ -1,0 +1,4 @@
+diff --git a/src/tstools/tsp.cpp b/src/tstools/tsp-tsduck.cpp
+similarity index 100%
+rename from src/tstools/tsp.cpp
+rename to src/tstools/tsp-tsduck.cpp


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/25848

- The build system of `libtsduck` automatically calculates the executable name from the name of the source code file, so renaming the file seems to entirely rename the executable.