### PR TITLE
addpkg(x11/kcalc): 25.08.0

### DIFF
--- a/x11-packages/kcalc/build.sh
+++ b/x11-packages/kcalc/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://apps.kde.org/kcalc/"
+TERMUX_PKG_DESCRIPTION="Scientific Calculator by KDE"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="25.08.0"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/kcalc-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="449a0d8827c44735f34cdddbdca9c3e038b3debcc86c60a57bca3ed42512d5f9"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kf6-kcolorscheme, kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-kcrash, kf6-kguiaddons, kf6-ki18n, kf6-knotifications, kf6-kwidgetsaddons, kf6-kxmlgui, libc++, libgmp, libmpc, libmpfr, qt6-qtbase"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}


### PR DESCRIPTION
This pull request adds the `kcalc` package to the Termux repository.  
• **KCalc is a scientific calculator from KDE.**