### PR TITLE
fix(scripts/termux_pkg_upgrade_version): handle -suffix versions

### DIFF
--- a/packages/asciinema/build.sh
+++ b/packages/asciinema/build.sh
@@ -2,8 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://asciinema.org/
 TERMUX_PKG_DESCRIPTION="Record and share your terminal sessions, the right way"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="3.0.0-rc.5"
-TERMUX_PKG_SRCURL=https://github.com/asciinema/asciinema/archive/v${TERMUX_PKG_VERSION//\~/-}.tar.gz
+TERMUX_PKG_VERSION="1:3.0.0~rc.5"
+: "${TERMUX_PKG_VERSION:2}" # We need to remove both the epoch and the '~' from the version
+TERMUX_PKG_SRCURL=https://github.com/asciinema/asciinema/archive/v${_//\~/-}.tar.gz
 TERMUX_PKG_SHA256=31b56c062309316a961eb4fa86b73b7a478ac0a8c89ab44d978958e81a420dd0
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true

--- a/scripts/updates/utils/termux_pkg_upgrade_version.sh
+++ b/scripts/updates/utils/termux_pkg_upgrade_version.sh
@@ -61,9 +61,15 @@ termux_pkg_upgrade_version() {
 		unset OLD_LATEST_VERSION
 	fi
 
-	# Translate "_" into ".": some packages use underscores to seperate
+	# Translate "_" into ".": some packages use underscores to separate
 	# version numbers, but we require them to be separated by dots.
 	LATEST_VERSION="${LATEST_VERSION//_/.}"
+
+	# Translate "-suffix" into "~suffix": "X.Y.Z-suffix" is considered later
+	# than X.Y.Z. for it to be considered earlier use "X.Y.Z~suffix".
+	LATEST_VERSION="${LATEST_VERSION//-rc/~rc}"
+	LATEST_VERSION="${LATEST_VERSION//-alpha/~alpha}"
+	LATEST_VERSION="${LATEST_VERSION//-beta/~beta}"
 
 	if [[ "${SKIP_VERSION_CHECK}" != "--skip-version-check" ]]; then
 		if ! termux_pkg_is_update_needed \


### PR DESCRIPTION
- Forgot to add a `TERMUX_PKG_UPDATE_VERSION_SED_REGEXP` in #25894.

I'll look into making this a general fix in `scripts/updates/utils/termux_pkg_upgrade_version.sh`.
Should be able to do something similar to the `//_/.` substitution we have already.
https://github.com/termux/termux-packages/blob/e39ee5b950e154eeeb97f6e55a8089e4549be240/scripts/updates/utils/termux_pkg_upgrade_version.sh#L64-L66