### PR TITLE
fix(main/tinysparql): temporary workaround for conflict with `asciidoc`

### DIFF
--- a/packages/tinysparql/build.sh
+++ b/packages/tinysparql/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Desktop-neutral metadata-based search framework"
 TERMUX_PKG_LICENSE="LGPL-2.1-or-later"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.9.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/GNOME/tinysparql/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=387fc277889f64e2beea7ac5be2532e937c803e216fcf949ab4e4d96f9726d62
 TERMUX_PKG_DEPENDS="libicu, dbus, pygobject, python, json-glib, libxml2, sqlite"
@@ -17,6 +18,8 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dtests=false
 -Doverride_sqlite_version_check=true
 "
+# Temporary - remove after the merge of https://github.com/termux/termux-packages/pull/23652
+TERMUX_PKG_RM_AFTER_INSTALL="lib/python$TERMUX_PYTHON_VERSION/site-packages/asciidoc/__pycache__"
 
 termux_step_post_get_source() {
 	rm -f subprojects/*.wrap


### PR DESCRIPTION
- Temporary workaround for https://github.com/termux/termux-packages/issues/25921

- Remove after the merge of https://github.com/termux/termux-packages/pull/23652