### PR TITLE
fix(x11/mint-themes): Fix build by creating directory

### DIFF
--- a/x11-packages/mint-themes/build.sh
+++ b/x11-packages/mint-themes/build.sh
@@ -25,5 +25,6 @@ termux_step_make() {
 }
 
 termux_step_make_install() {
+	mkdir -p $TERMUX_PREFIX/share/themes/
 	cp -r $TERMUX_PKG_SRCDIR/usr/share/themes/* $TERMUX_PREFIX/share/themes/
 }


### PR DESCRIPTION
Create $TERMUX_PREFIX/share/themes/ if necessary.

The original CI build only worked because other packages, which created the directory, where built before this package.

%ci:no-build