### PR TITLE
bump(main/libtorrent): 0.16.0

### DIFF
--- a/packages/libtorrent/build.sh
+++ b/packages/libtorrent/build.sh
@@ -2,12 +2,12 @@ TERMUX_PKG_HOMEPAGE=https://github.com/rakshasa/rtorrent/wiki
 TERMUX_PKG_DESCRIPTION="Libtorrent BitTorrent library"
 TERMUX_PKG_MAINTAINER="Krishna Kanhaiya @kcubeterm"
 TERMUX_PKG_LICENSE="GPL-2.0"
-TERMUX_PKG_VERSION="0.15.6"
+TERMUX_PKG_VERSION="0.16.0"
 TERMUX_PKG_SRCURL=https://github.com/rakshasa/libtorrent/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=e96ec8d0ef07e0ce32bc6e9a280ef3511a3781b9f5a9a3fe34e6c4935c16b646
+TERMUX_PKG_SHA256=ca3b96bc478db2cd282ccb87b91b169662d7c9298dbca9934f8556c2935cab73
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
-TERMUX_PKG_DEPENDS="libc++, openssl, zlib"
+TERMUX_PKG_DEPENDS="libc++, libcurl, openssl, zlib"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --enable-aligned=true
 --without-fastcgi


### PR DESCRIPTION
curl dependency was added in the following upstream commit https://github.com/rakshasa/libtorrent/commit/20b923309774e108243270fd13324ca174a91db1

* Fixes #25972 