### PR TITLE
Update get_hash_from_file.py

### DIFF
--- a/scripts/get_hash_from_file.py
+++ b/scripts/get_hash_from_file.py
@@ -1,47 +1,65 @@
 #!/usr/bin/env python3
 
-import sys, os
+import sys
+import os
 
 def get_pkg_hash_from_Packages(Packages_file, package, version, hash_type="SHA256"):
     with open(Packages_file, 'r') as Packages:
         package_list = Packages.read().split('\n\n')
+    
     for pkg in package_list:
-        if pkg.split('\n')[0] == "Package: "+package:
-            for line in pkg.split('\n'):
-                # Assuming Filename: comes before Version:
+        lines = pkg.split('\n')
+        if lines[0].strip() == "Package: " + package:
+            for line in lines:
+                line = line.strip()
                 if line.startswith('Filename:'):
-                    print(line.split(" ")[1] + " ")
+                    # Print the filename
+                    print(line.split(None, 1)[1], end=" ")
                 elif line.startswith('Version:'):
-                    if os.getenv('TERMUX_WITHOUT_DEPVERSION_BINDING') != 'true' and line != 'Version: '+version:
-                        # Seems the repo contains the wrong version, or several versions
-                        # We can't use this one so continue looking
+                    if os.getenv('TERMUX_WITHOUT_DEPVERSION_BINDING') != 'true' and line.strip() != 'Version: ' + version:
+                        # Wrong version, skip this package
                         break
                 elif line.startswith(hash_type):
-                    print(line.split(" ")[1])
-                    package_list.clear()
+                    # Print the hash
+                    print(line.split(None, 1)[1])
+                    return  # Found the package, stop searching
 
 def get_Packages_hash_from_Release(Release_file, arch, component, hash_type="SHA256"):
-    string_to_find = component+'/binary-'+arch+'/Packages'
+    string_to_find = f"{component}/binary-{arch}/Packages"
+    
     with open(Release_file, 'r') as Release:
         hash_list = Release.readlines()
-    for i in range(len(hash_list)):
-        if hash_list[i].startswith(hash_type+':'):
+    
+    # Find the start of the hash section
+    start_index = 0
+    for i, line in enumerate(hash_list):
+        if line.startswith(hash_type + ':'):
+            start_index = i
             break
-    for j in range(i, len(hash_list)):
-        if string_to_find in hash_list[j].strip(' ') and string_to_find+"." not in hash_list[j].strip(' '):
-            hash_entry = list(filter(lambda s: s != '', hash_list[j].strip('').split(' ')))
-            if hash_entry[2].startswith(".work_"):
+    
+    # Search for the line matching our Packages file
+    for j in range(start_index, len(hash_list)):
+        line = hash_list[j].strip()
+        if string_to_find in line and string_to_find + "." not in line:
+            hash_entry = list(filter(None, line.split()))
+            if len(hash_entry) >= 3 and hash_entry[2].startswith(".work_"):
                 continue
             print(hash_entry[0])
-            break
+            return  # Found the hash, stop searching
 
 if __name__ == '__main__':
     if len(sys.argv) < 4:
-        sys.exit('Too few arguments, I need the path to a Packages file, a package name and a version, or an InRelease file, an architecture and a component name. Exiting')
+        sys.exit(
+            'Too few arguments. Provide either:\n'
+            '1) Packages file path, package name, version\n'
+            '2) Release/InRelease file path, architecture, component name'
+        )
 
-    if sys.argv[1].endswith('Packages'):
-        get_pkg_hash_from_Packages(sys.argv[1], sys.argv[2], sys.argv[3])
-    elif sys.argv[1].endswith(('InRelease', 'Release')):
-        get_Packages_hash_from_Release(sys.argv[1], sys.argv[2], sys.argv[3])
+    input_file = sys.argv[1]
+
+    if input_file.endswith('Packages'):
+        get_pkg_hash_from_Packages(input_file, sys.argv[2], sys.argv[3])
+    elif input_file.endswith(('InRelease', 'Release')):
+        get_Packages_hash_from_Release(input_file, sys.argv[2], sys.argv[3])
     else:
-        sys.exit(sys.argv[1]+' does not seem to be a path to a Packages or InRelease/Release file')
+        sys.exit(f"{input_file} does not seem to be a Packages or InRelease/Release file")


### PR DESCRIPTION
* Fixed `strip('')` → `strip()`.
* Safer splitting for hash lines.
* Checked list length before accessing indices.
* Used `.strip()` for comparisons.
* Removed unnecessary `package_list.clear()`.
* Added `return` after printing hash/filename to avoid unnecessary looping.


**Key improvements:**

1. Safe splitting for hash and filename lines using `split(None, 1)`.
2. Stripping whitespace before comparisons.
3. Avoids crashes when `hash_entry` has fewer than 3 elements.
4. Stops searching after printing hash/filename.
5. Cleaner error messages.
