### PR TITLE
enhance(scripts): use `dpkg --validate-version` to check version numbers

### DIFF
--- a/scripts/lint-packages.sh
+++ b/scripts/lint-packages.sh
@@ -56,13 +56,15 @@ check_package_license() {
 check_package_name() {
 	local pkg_name="$1"
 	echo -n "Package name '${pkg_name}': "
+	# 1 character package names are technically permitted by `dpkg`
+	# but we do not want to allow single letter packages.
 	if (( ${#pkg_name} < 2 )); then
 		echo "INVALID (less than two characters long)"
 		return 1
 	fi
 
-	if ! grep -qP '^[0-9a-z][0-9a-z+\-\.]+$' <<< "${pkg_name}"; then
-		echo "INVALID (contains characters that are not allowed)"
+	if ! dpkg --validate-pkgname "${pkg_name}" &> /dev/null; then
+		echo "INVALID ($(dpkg --validate-pkgname "${pkg_name}"))"
 		return 1
 	fi
 
@@ -331,7 +333,7 @@ lint_package() {
 
 		echo -n "TERMUX_PKG_VERSION: "
 		if (( ${#TERMUX_PKG_VERSION} )); then
-			if grep -qiP '^([0-9]+\:)?[0-9][0-9a-z+\-\.\~]*$' <<< "${TERMUX_PKG_VERSION}"; then
+			if dpkg --validate-version "${TERMUX_PKG_VERSION}"; then
 				echo "PASS"
 			else
 				echo "INVALID (contains characters that are not allowed)"

--- a/scripts/updates/utils/termux_pkg_is_update_needed.sh
+++ b/scripts/updates/utils/termux_pkg_is_update_needed.sh
@@ -9,20 +9,19 @@ termux_pkg_is_update_needed() {
 	local CURRENT_VERSION="$1"
 	local LATEST_VERSION="$2"
 
+	# Is this even a validly formatted version number?
+	if ! dpkg --validate-version "${LATEST_VERSION}" &> /dev/null; then
+		termux_error_exit "::warning::${TERMUX_PKG_NAME:-}: $(dpkg --validate-version "${LATEST_VERSION}" &> /dev/stdout)"
+	fi
+
 	# Compare versions.
-	# shellcheck disable=SC2091
-	dpkg --compare-versions "${CURRENT_VERSION}" lt "${LATEST_VERSION}" 2> >(sed -e "s/^/$([[ "${CI-false}" == "true" ]] && echo "::warning::${TERMUX_PKG_NAME:-}: ")/" >&2)
+	dpkg --compare-versions "${CURRENT_VERSION}" lt "${LATEST_VERSION}"
 	DPKG_EXIT_CODE=$?
 	case "$DPKG_EXIT_CODE" in
-	0) ;;          # true.  Update needed but we need to do additional checking.
-	1) return 1 ;; # false. Update not needed.
-	*) termux_error_exit "Bad 'dpkg --compare-versions' exit code: $DPKG_EXIT_CODE - bad version numbers?" ;;
+		0) ;;          # true.  Update needed.
+		1) return 1 ;; # false. Update not needed.
+		*) termux_error_exit "Bad 'dpkg --compare-versions' exit code: $DPKG_EXIT_CODE - bad version numbers?" ;;
 	esac
-
-	# Additional checking dpkg warns but not errors
-	if ! grep -E "^[0-9]" <<< "${LATEST_VERSION}"; then
-		termux_error_exit "${TERMUX_PKG_NAME} latest version '${LATEST_VERSION}' does not start with digit"
-	fi
 }
 
 # Make it also usable as command line tool. `scripts/bin/apt-compare-versions` is symlinked to this file.


### PR DESCRIPTION
Follow up to #25950.

This should catch situations like https://github.com/termux/termux-packages/commit/2798b0f8c59bd2c54c87bb5f696fbb6e33a59069 going forward.

In this case despite being invalid the version did compare as greater than the previous version and produce exit code 0.
```console
dpkg --compare-versions "2025.09.05" lt "2025.09.05a(2)"; echo $?
dpkg: warning: version '2025.09.05a(2)' has bad syntax: invalid character in version number
0
```

To avoid false negatives like this in the future we should use `dpkg --validate-version` in both the auto-updater and the package linter.