### PR TITLE
fix(main/xls2csv): rename to `libxls2csv`

### DIFF
--- a/packages/libxls/build.sh
+++ b/packages/libxls/build.sh
@@ -3,9 +3,11 @@ TERMUX_PKG_DESCRIPTION="A C library for reading Excel files in the nasty old bin
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.6.3"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/libxls/libxls/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=587c9f0ebb5647eb68ec1e0ed8c3f7f6102622d6dd83473a21d3a36dee04eed7
 TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--program-prefix=lib"
 
 termux_step_pre_configure() {
 	autoreconf -fi

--- a/packages/libxls/libxls2csv.subpackage.sh
+++ b/packages/libxls/libxls2csv.subpackage.sh
@@ -1,2 +1,4 @@
 TERMUX_SUBPKG_INCLUDE="bin/ share/man/man1/"
 TERMUX_SUBPKG_DESCRIPTION="A command-line tool for converting XLS to CSV"
+TERMUX_SUBPKG_BREAKS="xls2csv"
+TERMUX_SUBPKG_REPLACES="xls2csv"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/26046

- Just like Arch Linux AUR package `libxls`, except that Arch Linux does not subpackage `libxls2csv`, so it seems appropriate to rename the subpackage https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=libxls#n29