### PR TITLE
fix(scripts/build/termux_get_repo_files): increase maximum number of GPG verification attempts back to 6 and delay back to 30s

### DIFF
--- a/scripts/build/termux_get_repo_files.sh
+++ b/scripts/build/termux_get_repo_files.sh
@@ -32,12 +32,16 @@ termux_get_repo_files() {
 		esac
 
 		(
-			for retry in {1..3}; do
+			local attempt delay=5
+			if [[ "${CI-false}" == "true" ]]; then
+				delay=30
+			fi
+			for attempt in {1..6}; do
 				if termux_download "${RELEASE_FILE_URL}" "${RELEASE_FILE}" SKIP_CHECKSUM \
 						&& termux_download "${RELEASE_FILE_SIG_URL}" "${RELEASE_FILE}.gpg" SKIP_CHECKSUM; then
 					if ! gpg --verify "${RELEASE_FILE}.gpg" "${RELEASE_FILE}"; then
-						echo "GPG verification failed, probably we downloaded corrupted metadata. Retrying in 5 seconds."
-						sleep 5
+						echo "GPG verification failed, probably we downloaded corrupted metadata. Retrying in $delay seconds."
+						sleep "$delay"
 						continue
 					fi
 


### PR DESCRIPTION
- Is likely to make https://github.com/termux/termux-packages/issues/25050 statistically more difficult to reproduce, not completely fixing it but making it less severe

- Rename variable `retry` to more accurate name `attempt`