### PR TITLE
bump(x11/marco): 1.29.0

### DIFF
--- a/x11-packages/marco/build.sh
+++ b/x11-packages/marco/build.sh
@@ -2,12 +2,15 @@ TERMUX_PKG_HOMEPAGE=https://marco.mate-desktop.dev/
 TERMUX_PKG_DESCRIPTION="MATE default window manager"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.28.1"
+TERMUX_PKG_VERSION="1.29.0"
 TERMUX_PKG_SRCURL=https://github.com/mate-desktop/marco/releases/download/v$TERMUX_PKG_VERSION/marco-$TERMUX_PKG_VERSION.tar.xz
-TERMUX_PKG_SHA256=2496e5e40ee980cd6849493ac3e0f8fd0dec8b81c674da8d9ba19a577f0ac2e1
+TERMUX_PKG_SHA256=54aa87fe49b904b6911d7b81081eaea524eeb75b158b2558b84e33ef0315fc54
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="atk, gdk-pixbuf, glib, gtk3, harfbuzz, libcairo, libcanberra, libice, libsm, libx11, libxcomposite, libxcursor, libxdamage, libxext, libxfixes, libxinerama, libxrandr, libxrender, libxres, mate-desktop, pango, startup-notification, zenity, zlib"
+TERMUX_PKG_DEPENDS="atk, gdk-pixbuf, glib, gtk3, libcairo, libcanberra, libice, libsm, libx11, libxcomposite, libxcursor, libxdamage, libxext, libxfixes, libxinerama, libxpresent, libxrandr, libxrender, libxres, mate-desktop, pango, startup-notification, zenity"
 
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
-ZENITY=${TERMUX_PREFIX}/bin/zenity
-"
+termux_step_pre_configure() {
+	# Workaround: make compiler warning non-fatal
+	sed -i "s/-Werror=/-Wno-error=/g" meson.build
+
+	termux_setup_glib_cross_pkg_config_wrapper
+}

--- a/x11-packages/marco/meson.build.patch
+++ b/x11-packages/marco/meson.build.patch
@@ -1,0 +1,13 @@
+# Workaround: meson tries to find zenity in host system but it is already in dependency
+
+--- a/meson.build
++++ b/meson.build
+@@ -294,7 +294,7 @@
+ endif
+ 
+ gdk_pixbuf_csource = find_program('gdk-pixbuf-csource')
+-zenity = find_program('zenity')
++zenity = find_program('zenity', required: false)
+ 
+ libxext = cc.find_library('Xext', required: false)
+ if build_xsync


### PR DESCRIPTION
Build system was changed from autotools to meson.

* Fixes #26271 