### PR TITLE
bump(main/swi-prolog): 9.3.32

### DIFF
--- a/packages/swi-prolog/build.sh
+++ b/packages/swi-prolog/build.sh
@@ -2,36 +2,114 @@ TERMUX_PKG_HOMEPAGE=https://swi-prolog.org/
 TERMUX_PKG_DESCRIPTION="Most popular and complete prolog implementation"
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="9.3.22"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="9.3.32"
 TERMUX_PKG_SRCURL=https://www.swi-prolog.org/download/devel/src/swipl-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=1b1bfee1ed6026c1eedfa9b03494ed1f03a02578d630b430e59742e196edd048
-TERMUX_PKG_DEPENDS="libandroid-execinfo, libarchive, libcrypt, libgmp, libyaml, ncurses, openssl, ossp-uuid, readline, zlib, pcre2"
+TERMUX_PKG_SHA256=e10dfa5814f7b01c123f7dc2b360873cd588ba93816ae1106e05f2bc93bdac4f
+TERMUX_PKG_DEPENDS="libandroid-execinfo, libarchive, libcrypt, libdb, libedit, libgmp, libyaml, ncurses, openssl, ossp-uuid, pcre2, python, unixodbc, zlib"
 TERMUX_PKG_FORCE_CMAKE=true
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_AUTO_UPDATE=true
+
+# configure arguments that should only be applied to the target build, and never the hostbuild
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DHAVE_WEAK_ATTRIBUTE_EXITCODE=0
--DHAVE_WEAK_ATTRIBUTE_EXITCODE__TRYRUN_OUTPUT=
--DINSTALL_DOCUMENTATION=OFF
--DUSE_GMP=ON
 -DSWIPL_NATIVE_FRIEND=${TERMUX_PKG_HOSTBUILD_DIR}
 -DPOSIX_SHELL=${TERMUX_PREFIX}/bin/sh
 -DSWIPL_TMP_DIR=${TERMUX_PREFIX}/tmp
+-DSYSTEM_CACERT_FILENAME=${TERMUX_PREFIX}/etc/tls/cert.pem
+-DODBC_CONFIG=
+"
+
+# configure arguments that can/should be kept the same for both the hostbuild and the target build
+# (if some of these are not the same, then errors can happen)
+_SHARED_EXTRA_CONFIGURE_ARGS="
+-DUSE_GMP=ON
+-DSWIPL_SHARED_LIB=ON
 -DSWIPL_INSTALL_IN_LIB=ON
--DSWIPL_PACKAGES_BDB=OFF
--DSWIPL_PACKAGES_ODBC=OFF
--DSWIPL_PACKAGES_QT=OFF
--DSWIPL_PACKAGES_X=OFF
--DINSTALL_TESTS=OFF
+-DSWIPL_PACKAGES=ON
+-DSWIPL_PACKAGES_BASIC=ON
+-DSWIPL_PACKAGES_BDB=ON
+-DSWIPL_PACKAGES_ODBC=ON
+-DSWIPL_PACKAGES_PYTHON=ON
+-DSWIPL_PACKAGES_JAVA=OFF
+-DSWIPL_PACKAGES_GUI=OFF
+-DINSTALL_QLF=ON
 -DBUILD_TESTING=OFF
--DSYSTEM_CACERT_FILENAME=${TERMUX_PREFIX}/etc/tls/cert.pem"
+-DINSTALL_TESTS=OFF
+-DINSTALL_DOCUMENTATION=OFF
+"
 
 termux_pkg_auto_update() {
 	# upstream website recommendes this to get the latest devel version
 	local latest_devel='https://www.swi-prolog.org/download/devel/src/swipl-latest.tar.gz'
 	local version="$(curl -s "$latest_devel" | grep location | sed -n 's/.*swipl-\([0-9\.]*\).tar.gz.*/\1/p')"
 	termux_pkg_upgrade_version "$version"
+}
+
+# Function to obtain the .deb URL
+obtain_deb_url() {
+	local url attempt retries wait PAGE deb_url
+	url="https://packages.ubuntu.com/noble/amd64/$1/download"
+	retries=50
+	wait=50
+
+	>&2 echo "url: $url"
+
+	for ((attempt=1; attempt<=retries; attempt++)); do
+		PAGE="$(curl -s "$url")"
+		deb_url="$(grep -oE 'https?://.*\.deb' <<< "$PAGE" | head -n1)"
+		if [[ -n "$deb_url" ]]; then
+				echo "$deb_url"
+				return 0
+		else
+			>&2 echo "Attempt $attempt: Failed to obtain deb URL. Retrying in $wait seconds..."
+		fi
+		sleep "$wait"
+	done
+
+	termux_error_exit "Failed to obtain URL after $retries attempts."
+}
+
+_install_ubuntu_packages() {
+	# install Ubuntu packages, like in the aosp-libs build.sh
+	export HOSTBUILD_ROOTFS="${TERMUX_PKG_HOSTBUILD_DIR}/ubuntu_packages"
+	mkdir -p "${HOSTBUILD_ROOTFS}"
+	local URL DEB_NAME DEB_LIST
+
+	DEB_LIST="$@"
+
+	for i in $DEB_LIST; do
+		echo "deb: $i"
+		URL="$(obtain_deb_url "$i")"
+		DEB_NAME="${URL##*/}"
+		termux_download "$URL" "${TERMUX_PKG_CACHEDIR}/${DEB_NAME}" SKIP_CHECKSUM
+		mkdir -p "${TERMUX_PKG_TMPDIR}/${DEB_NAME}"
+		ar x "${TERMUX_PKG_CACHEDIR}/${DEB_NAME}" --output="${TERMUX_PKG_TMPDIR}/${DEB_NAME}"
+		tar xf "${TERMUX_PKG_TMPDIR}/${DEB_NAME}/data.tar.zst" \
+			-C "${HOSTBUILD_ROOTFS}"
+	done
+
+	find "${HOSTBUILD_ROOTFS}" -type f -name '*.pc' | \
+		xargs -n 1 sed -i -e "s|/usr|${HOSTBUILD_ROOTFS}/usr|g"
+
+	# delete python static libraries to prevent error:
+	# relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
+	find "${HOSTBUILD_ROOTFS}" -type f -name '*python*.a' -delete
+
+	find "${HOSTBUILD_ROOTFS}/usr/lib/x86_64-linux-gnu" -xtype l \
+		-exec sh -c "ln -snvf /usr/lib/x86_64-linux-gnu/\$(readlink \$1) \$1" sh {} \;
+
+	export LD_LIBRARY_PATH="${HOSTBUILD_ROOTFS}/usr/lib/x86_64-linux-gnu"
+	LD_LIBRARY_PATH+=":${HOSTBUILD_ROOTFS}/usr/lib"
+
+	# fixes: fatal error: uuid.h: No such file or directory
+	export CFLAGS+=" -I${HOSTBUILD_ROOTFS}/usr/include/ossp"
+
+	# fixes: fatal error: unixodbc.h: No such file or directory
+	CFLAGS+=" -I${HOSTBUILD_ROOTFS}/usr/include/x86_64-linux-gnu"
+
+	# fixes: fatal error: x86_64-linux-gnu/python3.12/pyconfig.h: No such file or directory
+	CFLAGS+=" -I${HOSTBUILD_ROOTFS}/usr/include"
 }
 
 # We do this to produce:
@@ -41,30 +119,50 @@ termux_pkg_auto_update() {
 # this build for the artifacts needed to build the
 # Android version
 termux_step_host_build() {
+	# make build dependencies of hostbuild exactly match build dependencies of target build
+	# prevents possible errors that can otherwise occur
+	_install_ubuntu_packages libacl1-dev \
+							libarchive-dev \
+							libattr1-dev \
+							libext2fs-dev \
+							liblz4-dev \
+							nettle-dev \
+							libpython3-dev \
+							libpython3.12-dev \
+							python3-dev \
+							python3.12-dev \
+							libbsd-dev \
+							libedit-dev \
+							libmd-dev \
+							libossp-uuid-dev \
+							libossp-uuid16 \
+							libdb-dev \
+							libdb5.3-dev \
+							libodbccr2 \
+							libodbcinst2 \
+							unixodbc-common \
+							unixodbc-dev
+
+	local HOSTBUILD_EXTRA_CONFIGURE_ARGS_32=""
+	if [[ "$TERMUX_ARCH_BITS" == "32" ]]; then
+		export LDFLAGS+=" -m32"
+		export CFLAGS+=" -m32"
+		export CXXFLAGS+=" -m32 -funwind-tables"
+		HOSTBUILD_EXTRA_CONFIGURE_ARGS_32+=" -DCMAKE_LIBRARY_PATH=/usr/lib/i386-linux-gnu"
+		# problem: difficult to enable these during hostbuild for 32-bit targets without errors
+		HOSTBUILD_EXTRA_CONFIGURE_ARGS_32+=" -DSWIPL_PACKAGES_ODBC=OFF"
+		HOSTBUILD_EXTRA_CONFIGURE_ARGS_32+=" -DSWIPL_PACKAGES_PYTHON=OFF"
+	fi
+
 	termux_setup_cmake
 	termux_setup_ninja
 
-	if [ $TERMUX_ARCH_BITS = 32 ]; then
-		export LDFLAGS=-m32
-		export CFLAGS=-m32
-		export CXXFLAGS='-m32 -funwind-tables'
-		CMAKE_EXTRA_DEFS="-DCMAKE_LIBRARY_PATH=/usr/lib/i386-linux-gnu"
-	else
-		CMAKE_EXTRA_DEFS=""
-	fi
+	cmake "$TERMUX_PKG_SRCDIR"                        \
+		-G "Ninja"                                    \
+		-DCMAKE_PREFIX_PATH="${HOSTBUILD_ROOTFS}/usr" \
+		$_SHARED_EXTRA_CONFIGURE_ARGS                 \
+		$HOSTBUILD_EXTRA_CONFIGURE_ARGS_32
 
-	cmake "$TERMUX_PKG_SRCDIR"          \
-		-G "Ninja"                      \
-		$CMAKE_EXTRA_DEFS               \
-		-DINSTALL_DOCUMENTATION=OFF     \
-		-DSWIPL_PACKAGES=ON             \
-		-DUSE_GMP=OFF                   \
-		-DBUILD_TESTING=ON              \
-		-DSWIPL_SHARED_LIB=OFF          \
-		-DSWIPL_PACKAGES_BDB=OFF        \
-		-DSWIPL_PACKAGES_ODBC=OFF       \
-		-DSWIPL_PACKAGES_QT=OFF         \
-		-DSWIPL_PACKAGES_X=OFF
 	ninja
 
 	unset LDFLAGS
@@ -73,7 +171,14 @@ termux_step_host_build() {
 }
 
 termux_step_pre_configure() {
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" $_SHARED_EXTRA_CONFIGURE_ARGS"
+
 	LDFLAGS+=" -landroid-execinfo $($CC -print-libgcc-file-name)"
+
+	local HOSTBUILD_ROOTFS="${TERMUX_PKG_HOSTBUILD_DIR}/ubuntu_packages"
+
+	export LD_LIBRARY_PATH="${HOSTBUILD_ROOTFS}/usr/lib/x86_64-linux-gnu"
+	LD_LIBRARY_PATH+=":${HOSTBUILD_ROOTFS}/usr/lib"
 }
 
 termux_step_post_make_install() {

--- a/packages/swi-prolog/continue-on-abi-check-failure.patch
+++ b/packages/swi-prolog/continue-on-abi-check-failure.patch
@@ -14,7 +14,7 @@ https://github.com/termux/termux-packages/issues/22737
 -      return match_abi_version(abi_version(), abi_string);
 +    if ( build_time_abi_string )
 +    { remove_trailing_whitespace(build_time_abi_string);
-+      char *run_time_abi_string = abi_version();
++      const char *run_time_abi_string = abi_version();
 +      if (match_abi_version(run_time_abi_string, build_time_abi_string) == 1)
 +      { return true;
 +      } else

--- a/packages/swi-prolog/disable-installation-of-some-qlfs.patch
+++ b/packages/swi-prolog/disable-installation-of-some-qlfs.patch
@@ -1,0 +1,18 @@
+For some unknown reason, these files are not having .qlf files generated for them during cross-compilation,
+so they need to be excluded here otherwise errors like "chr.qlf: No such file or directory" will happen.
+
+--- a/cmake/InstallSource.cmake
++++ b/cmake/InstallSource.cmake
+@@ -185,6 +185,12 @@ set(noqlf_pattern
+     "home/library/ext/ltx2htm/sty_.*[.]pl")
+ 
+ set(noqlf_file
++    packages/chr//chr.pl
++    packages/chr//chr_translate.pl
++    packages/chr//chr_translate_bootstrap1.pl
++    packages/chr//chr_translate_bootstrap2.pl
++    packages/chr//guard_entailment.pl
++    packages/http/jquery.pl
+     home/library/tabling.pl
+     home/library/prolog_qlfmake.pl
+     home/library/win_menu.pl


### PR DESCRIPTION
- Fixes https://github.com/SWI-Prolog/swipl-devel/issues/1365

- Fixes https://github.com/termux/termux-packages/issues/24399

- Fixes or works around all observable errors during the build until they all disappeared

- Enables most of the `.qlf` files except for the ones that are supposed to be in the `packages/chr` and `packages/http` folders

- Enables more dependencies until `check_installation.` reports no failures except for an X11-related one and a Java-related one:

```
?- check_installation.
% Checking your SWI-Prolog kit for common issues ...
%
% Version: ............. 9.3.30
% Address bits: ........ 64
% Architecture: ........ arm64-android
% Installed at: ........ /data/data/com.termux/files/usr/lib/swipl
% Cores: ............... 8
%
% Checking gmp ................................. ok
% Loading library(archive) ..................... ok
%   Supported filters: bzip2, compress, gzip, grzip, lrzip, lzip, lzma, lzop, none, rpm, uu, xz
%   Supported formats: 7zip, ar, cab, cpio, empty, gnutar, iso9660, lha, mtree, rar, raw, tar, xar, zip
% Loading library(cgi) ......................... ok
% Loading library(crypt) ....................... ok
% Loading library(bdb) ......................... ok
% Loading library(double_metaphone) ............ ok
% Loading library(editline) .................... ok
% Loading library(filesex) ..................... ok
% Loading library(http/http_stream) ............ ok
% Loading library(http/json) ................... ok
% Loading library(http/jquery) ................. ok
%   jQuery from /data/data/com.termux/files/usr/lib/swipl/library/http/web/js/jquery-3.6.0.min.js
% Loading library(isub) ........................ ok
% Loading library(janus) ....................... ok
% Interactive session; added `.` to Python `sys.path`
%   Python version 3.12.11 (main, Aug 27 2025, 21:27:47) [Clang 19.0.1 (https://android.googlesource.com/toolchain/llvm-project 97a699bf4
Warning: library(jpl) .......................... NOT FOUND
Warning: See http://www.swi-prolog.org/build/issues/jpl.html
% Loading library(memfile) ..................... ok
% Loading library(odbc) ........................ ok
Warning: library(pce) .......................... NOT FOUND
Warning: See http://www.swi-prolog.org/build/issues/xpce.html
% Loading library(pcre) ........................ ok
% Loading library(pdt_console) ................. ok
% Loading library(porter_stem) ................. ok
% Loading library(process) ..................... ok
% Loading library(protobufs) ................... ok
% Loading library(readutil) .................... ok
% Loading library(rlimit) ...................... ok
% Loading library(semweb/rdf_db) ............... ok
% Loading library(semweb/rdf_ntriples) ......... ok
% Loading library(semweb/turtle) ............... ok
% Loading library(sgml) ........................ ok
% Loading library(sha) ......................... ok
% Loading library(snowball) .................... ok
% Loading library(socket) ...................... ok
% Loading library(ssl) ......................... ok
% Loading library(sweep_link) .................. ok
%   GNU-Emacs plugin loads
%     L /data/data/com.termux/files/usr/lib/libswipl.so
%     M /data/data/com.termux/files/usr/lib/swipl/lib/arm64-android/sweep-module.so
% Loading library(crypto) ...................... ok
% Loading library(syslog) ...................... ok
% Loading library(table) ....................... ok
% Loading library(time) ........................ ok
% Loading library(unicode) ..................... ok
% Loading library(uri) ......................... ok
% Loading library(uuid) ........................ ok
% Loading library(yaml) ........................ ok
% Loading library(zlib) ........................ ok
Warning: Found 2 issues.
```