### PR TITLE
bump(main/fish): 4.0.6

### DIFF
--- a/packages/fish/build.sh
+++ b/packages/fish/build.sh
@@ -2,10 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://fishshell.com/
 TERMUX_PKG_DESCRIPTION="The user-friendly command line shell"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="4.0.2"
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_VERSION="4.0.6"
 TERMUX_PKG_SRCURL=https://github.com/fish-shell/fish-shell/releases/download/$TERMUX_PKG_VERSION/fish-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=6e1ecdb164285fc057b2f35acbdc20815c1623099e7bb47bbfc011120adf7e83
+TERMUX_PKG_SHA256=125d9ce0dd8a3704dc0782925df34f0208bffc42af5f34914449d14c34b5dae1
 TERMUX_PKG_AUTO_UPDATE=true
 # fish calls 'tput' from ncurses-utils, at least when cancelling (Ctrl+C) a command line.
 # man is needed since fish calls apropos during command completion.

--- a/packages/fish/partial-revert-d68f8bd.patch
+++ b/packages/fish/partial-revert-d68f8bd.patch
@@ -1,0 +1,21 @@
+Partially reverts https://github.com/fish-shell/fish-shell/commit/d68f8bdd3b60a4a4cee0c938b5b3e2ff23c1ed86
+(https://github.com/fish-shell/fish-shell/commit/7228cb15bfacfc88f97a1733a8e55b0ae78ec53c)
+In order to work around "error: call to undeclared function 'UNUSED'"
+
+This topic is closely related to this other commit,
+https://github.com/fish-shell/fish-shell/commit/70bd49f61265c3a50c98d439fc77e13ef4409231
+which is not yet present in stable fish (4.0.6 at time of writing),
+but which will probably also break the build of fish for Android in the future and need to be
+reverted or partially reverted.
+
+--- a/src/libc.c
++++ b/src/libc.c
+@@ -9,6 +9,8 @@
+ #include <sys/statvfs.h>  // ST_LOCAL
+ #include <unistd.h>       // _CS_PATH, _PC_CASE_SENSITIVE
+ 
++#define UNUSED(x) (void)(x)
++
+ size_t C_MB_CUR_MAX() { return MB_CUR_MAX; }
+ 
+ uint64_t C_ST_LOCAL() {

--- a/packages/fish/revert-6644cc9.patch
+++ b/packages/fish/revert-6644cc9.patch
@@ -1,0 +1,84 @@
+Reverts https://github.com/fish-shell/fish-shell/commit/6644cc9b0e29841e3d0a85fbc672a95c4a2fd000,
+a NetBSD-related commit,
+because it causes this compilation failure on Android:
+
+error[E0308]: mismatched types
+   --> src/path.rs:749:13
+    |
+748 |         let remoteness = remoteness_via_statfs(
+    |                          --------------------- arguments to this function are incorrect
+749 |             libc::statfs,
+    |             ^^^^^^^^^^^^ expected fn pointer, found fn item
+    |
+    = note: expected fn pointer `unsafe extern "C" fn(*const i8, _) -> _`
+                  found fn item `unsafe extern "C" fn(*const u8, _) -> _ {libc::statfs}`
+
+--- a/src/path.rs
++++ b/src/path.rs
+@@ -6,6 +6,8 @@ use crate::common::{wcs2osstring, wcs2zstring};
+ use crate::env::{EnvMode, EnvStack, Environment};
+ use crate::expand::{expand_tilde, HOME_DIRECTORY};
+ use crate::flog::{FLOG, FLOGF};
++#[cfg(not(target_os = "linux"))]
++use crate::libc::{MNT_LOCAL, ST_LOCAL};
+ use crate::wchar::prelude::*;
+ use crate::wutil::{normalize_path, path_normalize_for_cd, waccess, wdirname, wstat};
+ use errno::{errno, set_errno, Errno};
+@@ -709,49 +711,25 @@ fn path_remoteness(path: &wstr) -> DirRemoteness {
+     }
+     #[cfg(not(target_os = "linux"))]
+     {
+-        fn remoteness_via_statfs<StatFS, Flags>(
+-            statfn: unsafe extern "C" fn(*const i8, *mut StatFS) -> libc::c_int,
+-            flagsfn: fn(&StatFS) -> Flags,
+-            is_local_flag: u64,
+-            path: &std::ffi::CStr,
+-        ) -> DirRemoteness
+-        where
+-            u64: From<Flags>,
+-        {
+-            if is_local_flag == 0 {
+-                return DirRemoteness::unknown;
+-            }
++        // ST_LOCAL is a flag to statvfs, which is itself standardized.
++        // In practice the only system to define it is NetBSD.
++        let local_flag = ST_LOCAL() | MNT_LOCAL();
++        if local_flag != 0 {
+             let mut buf = MaybeUninit::uninit();
+-            if unsafe { (statfn)(path.as_ptr(), buf.as_mut_ptr()) } < 0 {
++            if unsafe { libc::statfs(narrow.as_ptr(), buf.as_mut_ptr()) } < 0 {
+                 return DirRemoteness::unknown;
+             }
+             let buf = unsafe { buf.assume_init() };
+             // statfs::f_flag is hard-coded as 64-bits on 32/64-bit FreeBSD but it's a (4-byte)
+             // long on 32-bit NetBSD.. and always 4-bytes on macOS (even on 64-bit builds).
+             #[allow(clippy::useless_conversion)]
+-            if u64::from((flagsfn)(&buf)) & is_local_flag != 0 {
++            return if u64::from(buf.f_flags) & local_flag != 0 {
+                 DirRemoteness::local
+             } else {
+                 DirRemoteness::remote
+-            }
++            };
+         }
+-        // ST_LOCAL is a flag to statvfs, which is itself standardized.
+-        // In practice the only system to define it is NetBSD.
+-        #[cfg(target_os = "netbsd")]
+-        let remoteness = remoteness_via_statfs(
+-            libc::statvfs,
+-            |stat: &libc::statvfs| stat.f_flag,
+-            crate::libc::ST_LOCAL(),
+-            &narrow,
+-        );
+-        #[cfg(not(target_os = "netbsd"))]
+-        let remoteness = remoteness_via_statfs(
+-            libc::statfs,
+-            |stat: &libc::statfs| stat.f_flags,
+-            crate::libc::MNT_LOCAL(),
+-            &narrow,
+-        );
+-        remoteness
++        DirRemoteness::unknown
+     }
+ }
+ 


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/26325

- Upstream fish, it appears through the heavy patching we increasingly need to do, does not officially support Android. This means that it is completely understandable that they continue to make changes that break the Android build, and these are not necessarily bugs on their end because they don't build or test for Android, and already work a lot to support all non-Android platforms. Therefore, sometimes the only viable option we might have is to revert or partially revert some commits which are problematic for Android support, in the downstream.

Commits being reverted in this PR:
  - https://github.com/fish-shell/fish-shell/commit/d68f8bdd3b60a4a4cee0c938b5b3e2ff23c1ed86 - partially reverted to avoid error `error: call to undeclared function 'UNUSED'`
  - https://github.com/fish-shell/fish-shell/commit/6644cc9b0e29841e3d0a85fbc672a95c4a2fd000 - reverted to avoid error `expected fn pointer`...`*const i8`...`found fn item`...`*const u8`

Commits that I am aware are in the development branch of fish that are not yet present in this fish stable release, but which I believe are highly likely to cause errors in a future release and will most likely also need to be reverted in order to build that future release for Android:
  - https://github.com/fish-shell/fish-shell/commit/70bd49f61265c3a50c98d439fc77e13ef4409231