### PR TITLE
bump(x11/godot): 4.5

### DIFF
--- a/x11-packages/godot/build.sh
+++ b/x11-packages/godot/build.sh
@@ -2,11 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://godotengine.org
 TERMUX_PKG_DESCRIPTION="Advanced cross-platform 2D and 3D game engine"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="4.4.1"
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_VERSION="4.5"
 TERMUX_PKG_SRCURL=https://github.com/godotengine/godot/archive/$TERMUX_PKG_VERSION-stable.tar.gz
-TERMUX_PKG_SHA256=a486c523494e155b6912a607b5813577f8f39285f8ad43ac76cb9141edad9888
-TERMUX_PKG_DEPENDS="ca-certificates, glu, libandroid-execinfo, libc++, libenet, libogg, libtheora, libvorbis, libvpx, libwebp, libwslay, libxcursor, libxi, libxinerama, libxkbcommon, libxrandr, mbedtls, miniupnpc, opengl, opusfile, pcre2, speechd, zstd, fontconfig"
+TERMUX_PKG_SHA256=0b2c942c79f756da5c94990e06678feaa582ae533b5e126f992a29d1ea8a816c
+TERMUX_PKG_DEPENDS="brotli, ca-certificates, fontconfig, freetype, glu, libandroid-execinfo, libc++, libenet, libgraphite, libjpeg-turbo, libogg, libtheora, libvorbis, libvpx, libwebp, libwslay, libxcursor, libxi, libxinerama, libxkbcommon, libxrandr, mbedtls, miniupnpc, opengl, opusfile, pcre2, sdl3, speechd, zlib, zstd"
 TERMUX_PKG_BUILD_DEPENDS="pulseaudio, yasm"
 TERMUX_PKG_PYTHON_COMMON_DEPS="scons"
 TERMUX_PKG_AUTO_UPDATE=true
@@ -14,12 +13,33 @@ TERMUX_PKG_UPDATE_VERSION_REGEXP='\d+\.\d+(\.\d+)?'
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_make() {
-	local to_unbundle="libogg libtheora libvorbis libvpx libwebp mbedtls miniupnpc opus pcre2 wslay zstd enet"
-	local system_libs=""
+	local to_unbundle="" system_libs=""
+
+	to_unbundle+="brotli "
+	to_unbundle+="enet "
+	to_unbundle+="freetype "
+	to_unbundle+="graphite "
+	to_unbundle+="libjpeg-turbo "
+	to_unbundle+="libogg "
+	to_unbundle+="libtheora "
+	to_unbundle+="libvorbis "
+	to_unbundle+="libvpx "
+	to_unbundle+="libwebp "
+	to_unbundle+="mbedtls "
+	to_unbundle+="miniupnpc "
+	to_unbundle+="opus "
+	to_unbundle+="pcre2 "
+	to_unbundle+="sdl "
+	to_unbundle+="wslay "
+	to_unbundle+="zlib "
+	to_unbundle+="zstd "
+
 	for _lib in $to_unbundle; do
 		rm -fr thirdparty/$_lib
-		system_libs+="builtin_"$_lib"=no "
+		system_libs+="builtin_${_lib//-/_}=no "
 	done
+
+	echo "$system_libs"
 
 	local _ARCH
 	case $TERMUX_ARCH in
@@ -28,6 +48,16 @@ termux_step_make() {
 		x86_64) _ARCH=x86_64;;
 		i686) _ARCH=x86_32;;
 	esac
+
+	local debug=""
+	if [[ "$TERMUX_DEBUG_BUILD" == "true" ]]; then
+		# godot has a lot of possible weird debug settings,
+		# so if TERMUX_DEBUG_BUILD=true, enable a sane set
+		# of two that seem appropriate and compatible with
+		# the typical termux package debugging workflow
+		debug+="debug_symbols=yes "
+		debug+="optimize=debug "
+	fi
 
 	export BUILD_NAME=termux
 	scons -j$TERMUX_PKG_MAKE_PROCESSES \
@@ -38,6 +68,7 @@ termux_step_make() {
 		execinfo=yes \
 		pulseaudio=yes \
 		udev=no \
+		module_camera_enabled=no \
 		arch=$_ARCH \
 		system_certs_path=$TERMUX_PREFIX/etc/tls/cert.pem \
 		use_llvm=yes \
@@ -48,10 +79,11 @@ termux_step_make() {
 		STRIP="$(command -v $STRIP)" \
 		cflags="$CPPFLAGS $CFLAGS" \
 		cxxflags="$CPPFLAGS $CXXFLAGS" \
-		linkflags="$LDFLAGS -landroid-execinfo" \
+		linkflags="$LDFLAGS -landroid-execinfo -lturbojpeg" \
 		CPPPATH="$TERMUX_PREFIX/include" \
 		LIBPATH="$TERMUX_PREFIX/lib" \
 		$system_libs \
+		$debug \
 		verbose=1
 
 	mv $TERMUX_PKG_BUILDDIR/bin/godot.linuxbsd.editor.$_ARCH.llvm $TERMUX_PKG_BUILDDIR/bin/godot.linuxbsd.editor.llvm

--- a/x11-packages/godot/crypto_core.cpp.patch
+++ b/x11-packages/godot/crypto_core.cpp.patch
@@ -63,22 +63,22 @@
  	return ret ? FAILED : OK;
  }
  
-@@ -178,16 +178,16 @@
+@@ -236,16 +236,16 @@ Error CryptoCore::b64_decode(uint8_t *r_dst, size_t p_dst_len, size_t *r_len, co
  }
  
- Error CryptoCore::md5(const uint8_t *p_src, int p_src_len, unsigned char r_hash[16]) {
+ Error CryptoCore::md5(const uint8_t *p_src, size_t p_src_len, unsigned char r_hash[16]) {
 -	int ret = mbedtls_md5_ret(p_src, p_src_len, r_hash);
 +	int ret = mbedtls_md5(p_src, p_src_len, r_hash);
  	return ret ? FAILED : OK;
  }
  
- Error CryptoCore::sha1(const uint8_t *p_src, int p_src_len, unsigned char r_hash[20]) {
+ Error CryptoCore::sha1(const uint8_t *p_src, size_t p_src_len, unsigned char r_hash[20]) {
 -	int ret = mbedtls_sha1_ret(p_src, p_src_len, r_hash);
 +	int ret = mbedtls_sha1(p_src, p_src_len, r_hash);
  	return ret ? FAILED : OK;
  }
  
- Error CryptoCore::sha256(const uint8_t *p_src, int p_src_len, unsigned char r_hash[32]) {
+ Error CryptoCore::sha256(const uint8_t *p_src, size_t p_src_len, unsigned char r_hash[32]) {
 -	int ret = mbedtls_sha256_ret(p_src, p_src_len, r_hash, 0);
 +	int ret = mbedtls_sha256(p_src, p_src_len, r_hash, 0);
  	return ret ? FAILED : OK;

--- a/x11-packages/godot/force-system-libjpeg-turbo.patch
+++ b/x11-packages/godot/force-system-libjpeg-turbo.patch
@@ -1,0 +1,33 @@
+--- a/modules/jpg/SCsub
++++ b/modules/jpg/SCsub
+@@ -82,7 +82,6 @@ def source_paths(files):
+     return [thirdparty_dir + "/src/" + f for f in files]
+ 
+ 
+-env_jpg.Prepend(CPPEXTPATH=[thirdparty_dir + "/src"])
+ 
+ 
+ def add_bit_depth(bit_depth: int):
+@@ -90,7 +89,6 @@ def add_bit_depth(bit_depth: int):
+     env_bit_depth.disable_warnings()
+     env_bit_depth["OBJSUFFIX"] = f"_{bit_depth}{env_bit_depth['OBJSUFFIX']}"
+     env_bit_depth.Append(CPPDEFINES=[f"BITS_IN_JSAMPLE={bit_depth}"])
+-    env_bit_depth.add_source_files(thirdparty_obj, source_paths(thirdparty_sources_by_bits[bit_depth]))
+ 
+ 
+ add_bit_depth(8)
+@@ -98,8 +96,6 @@ add_bit_depth(12)
+ 
+ env_thirdparty = env_jpg.Clone()
+ env_thirdparty.disable_warnings()
+-env_thirdparty.add_source_files(thirdparty_obj, source_paths(thirdparty_sources_common))
+-env.modules_sources += thirdparty_obj
+ 
+ # Godot source files
+ 
+@@ -108,5 +104,3 @@ module_obj = []
+ env_jpg.add_source_files(module_obj, "*.cpp")
+ env.modules_sources += module_obj
+ 
+-# Needed to force rebuilding the module files when the thirdparty library is updated.
+-env.Depends(module_obj, thirdparty_obj)

--- a/x11-packages/godot/prepend-prefix-to-absolute-tmp-paths.patch
+++ b/x11-packages/godot/prepend-prefix-to-absolute-tmp-paths.patch
@@ -6,8 +6,8 @@ Fixes https://github.com/termux/termux-packages/issues/24214
  	path_src = p_path;
  	ERR_FAIL_COND_V_MSG(fd[0] >= 0 || fd[1] >= 0, ERR_ALREADY_IN_USE, "Pipe is already in use.");
  
--	path = String("/tmp/") + p_path.replace("pipe://", "").replace("/", "_");
-+	path = String("@TERMUX_PREFIX@/tmp/") + p_path.replace("pipe://", "").replace("/", "_");
+-	path = String("/tmp/") + p_path.replace("pipe://", "").replace_char('/', '_');
++	path = String("@TERMUX_PREFIX@/tmp/") + p_path.replace("pipe://", "").replace_char('/', '_');
  	const CharString path_utf8 = path.utf8();
  
  	struct stat st = {};

--- a/x11-packages/godot/set_handle_dlopen.patch
+++ b/x11-packages/godot/set_handle_dlopen.patch
@@ -50,19 +50,6 @@ index 86aacbc..2fc009e 100644
    if (!handle) {
      if (verbose) {
        fprintf(stderr, "%s\n", dlerror());
-diff --git a/platform/linuxbsd/libudev-so_wrap.c b/platform/linuxbsd/libudev-so_wrap.c
-index 5455c1a..cc4c942 100644
---- a/platform/linuxbsd/libudev-so_wrap.c
-+++ b/platform/linuxbsd/libudev-so_wrap.c
-@@ -281,7 +281,7 @@ int (*udev_util_encode_string_dylibloader_wrapper_libudev)(const char*, char*, s
- int initialize_libudev(int verbose) {
-   void *handle;
-   char *error;
--  handle = dlopen("libudev.so.1", RTLD_LAZY);
-+  handle = dlopen("libudev.so", RTLD_LAZY);
-   if (!handle) {
-     if (verbose) {
-       fprintf(stderr, "%s\n", dlerror());
 diff --git a/platform/linuxbsd/speechd-so_wrap.c b/platform/linuxbsd/speechd-so_wrap.c
 index 1dc5f08..15d878a 100644
 --- a/platform/linuxbsd/speechd-so_wrap.c


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/26487

- New dependencies in this release that are added as system dependencies because they do not build within Godot for Termux unless unvendored:
  - `sdl3`
  - `libjpeg-turbo`

- Unvendor all other dependencies that can be unvendored without causing any errors or warnings in the build process:
  - `brotli`
  - `freetype`
  - `libgraphite`
  - `zlib`

- Implement `TERMUX_DEBUG_BUILD=true` support

- Force the use of system `libjpeg-turbo`, since the Godot build system currently seems unable to officially do that without patching

- Drop `libudev.so` patch because its file no longer exists, and also `libudev.so` does not exist in Android or Termux, so if the `dlopen("libudev.so.1")` has been moved somewhere else, it should be allowed to fail as the expected behavior.

> [!IMPORTANT]
> I have discovered that this release of Godot contains **code which is capable of triggering this error on Pointer-tag-checking-enabled devices:**
> ```
> Pointer tag for 0xf was truncated, see 'https://source.android.com/devices/tech/debug/tagged-pointers'.
> ```
> I have managed to debug and successfully disable this code, because in my opinion it appears to be incompatible with Android, so I do not think attempting to fix the pointer tag problem rather than bulk-disable the code would have any benefit.

- https://github.com/godotengine/godot/pull/53666

- https://github.com/godotengine/godot/blob/6efa557e9b77a4499519b4f5585c5f8f314afdfd/modules/camera/camera_linux.cpp#L80

- The exact line of code that triggers the `Pointer tag for 0xf was truncated, see 'https://source.android.com/devices/tech/debug/tagged-pointers'.` is `free(devices);` in `CameraLinux::_update_devices()` in `camera_linux.cpp`

- Pointer-tag-checking-enabled device used to debug: Samsung Galaxy A70 SM-A705FN with LineageOS 20 Android 13

- licy183's Pointer-tag-truncated debugging guide was very helpful for this https://github.com/termux/termux-packages/pull/22911#issuecomment-2588503676