### PR TITLE
fix(scripts/setup_toolchain_28c): cp source.properties after setting up toolchain tmpdir

### DIFF
--- a/scripts/build/toolchain/termux_setup_toolchain_28c.sh
+++ b/scripts/build/toolchain/termux_setup_toolchain_28c.sh
@@ -143,8 +143,8 @@ termux_setup_toolchain_28c() {
 	elif [ "$TERMUX_ARCH" = "i686" ]; then
 		_NDK_ARCHNAME=x86
 	fi
-	cp $NDK/source.properties $_TERMUX_TOOLCHAIN_TMPDIR
 	cp $NDK/toolchains/llvm/prebuilt/linux-x86_64 $_TERMUX_TOOLCHAIN_TMPDIR -r
+	cp $NDK/source.properties $_TERMUX_TOOLCHAIN_TMPDIR
 
 	# Remove android-support header wrapping not needed on android-21:
 	rm -Rf $_TERMUX_TOOLCHAIN_TMPDIR/sysroot/usr/local


### PR DESCRIPTION
Currently source.properties is renamed to $_TERMUX_TOOLHAIN_TMPDIR instead of being copying into the directory $_TERMUX_TOOLCAIN_TMPDIR. The directory $_TERMUX_TOOLCAIN_TMPDIR is created from the directory linux-x86_64, move the copying of source.properties to after the folder has been created.