### PR TITLE
bump(main/gnunet): 0.25.0

### DIFF
--- a/packages/gnunet/0001-workaround-incomplete-const-changes.patch
+++ b/packages/gnunet/0001-workaround-incomplete-const-changes.patch
@@ -1,0 +1,43 @@
+# Workaround for incomplete const change which only modified declaration
+# https://git.gnunet.org/gnunet.git/commit/src/include/gnunet_testing_lib.h?id=9ac6841eadc9f4b3b1e71e2ec08e75d94e851149
+
+--- a/src/lib/testing/testing_api_cmd_exec.c
++++ b/src/lib/testing/testing_api_cmd_exec.c
+@@ -183,7 +183,7 @@
+ }
+ 
+ 
+-const struct GNUNET_TESTING_Command
++struct GNUNET_TESTING_Command
+ GNUNET_TESTING_cmd_exec (
+   const char *label,
+   enum GNUNET_OS_ProcessStatusType expected_type,
+@@ -213,7 +213,7 @@
+ }
+ 
+ 
+-const struct GNUNET_TESTING_Command
++struct GNUNET_TESTING_Command
+ GNUNET_TESTING_cmd_exec_va (
+   const char *label,
+   enum GNUNET_OS_ProcessStatusType expected_type,
+--- a/src/lib/testing/testing_api_cmd_finish.c
++++ b/src/lib/testing/testing_api_cmd_finish.c
+@@ -125,7 +125,7 @@
+   struct GNUNET_TESTING_Interpreter *is)
+ {
+   struct FinishState *finish_state = cls;
+-  const struct GNUNET_TESTING_Command *async_cmd;
++  struct GNUNET_TESTING_Command *async_cmd;
+   struct GNUNET_TESTING_AsyncContext *aac;
+ 
+   async_cmd
+@@ -184,7 +184,7 @@
+ }
+ 
+ 
+-const struct GNUNET_TESTING_Command
++struct GNUNET_TESTING_Command
+ GNUNET_TESTING_cmd_finish (
+   const char *finish_label,
+   const char *cmd_ref,

--- a/packages/gnunet/build.sh
+++ b/packages/gnunet/build.sh
@@ -2,10 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://gnunet.org
 TERMUX_PKG_DESCRIPTION="A framework for secure peer-to-peer networking"
 TERMUX_PKG_LICENSE="AGPL-V3"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.24.3"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="0.25.0"
 TERMUX_PKG_SRCURL=https://ftpmirror.gnu.org/gnu/gnunet/gnunet-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=5b06897b0e84489bbb438278ec73e4362442b2e05a63e40023ec1d0cccc6c576
+TERMUX_PKG_SHA256=2dea662ee8605946852af02d2806ca64fdadedcc718eeef6b86e0b26822c36ff
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libcurl, libgcrypt, libgnutls, libgpg-error, libidn2, libjansson, libltdl, libmicrohttpd, libsodium, libsqlite, libunistring, zlib"
 


### PR DESCRIPTION
Fix compiler error based on this patch
https://github.com/Homebrew/homebrew-core/commit/6baabc2ed63e31ff2bd43108fd9cad496ed0f74d

* Fixes #26517 