### PR TITLE
revbump(main/libelf): rebuild for 16KB page size

### DIFF
--- a/packages/libelf/build.sh
+++ b/packages/libelf/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="ELF object file access library"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.193"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://sourceware.org/elfutils/ftp/${TERMUX_PKG_VERSION}/elfutils-${TERMUX_PKG_VERSION}.tar.bz2"
 TERMUX_PKG_SHA256=7857f44b624f4d8d421df851aaae7b1402cfe6bcdd2d8049f15fc07d3dde7635
 # libandroid-support for langinfo.
@@ -10,7 +11,15 @@ TERMUX_PKG_DEPENDS="libandroid-support, zlib, zstd, json-c"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="ac_cv_c99=yes --disable-symbol-versioning"
 TERMUX_PKG_CONFLICTS="libelf-dev"
 TERMUX_PKG_REPLACES="libelf-dev"
-TERMUX_PKG_BUILD_IN_SRC=true
+
+# https://github.com/llvm/llvm-project/issues/71925#issuecomment-1987141438
+#
+# In file included from ../../elfutils-0.191/src/srcfiles.cxx:50:
+# ...
+# ./stack:1:1: error: expected unqualified-id
+#
+# do not set this to true due to clang bug
+TERMUX_PKG_BUILD_IN_SRC=false
 
 termux_step_pre_configure() {
 	CXXFLAGS+=" -Wno-unused-const-variable -Wno-error=unused-function"
@@ -26,7 +35,7 @@ termux_step_pre_configure() {
 	fi
 
 	cp $TERMUX_PKG_BUILDER_DIR/stdio_ext.h .
-	cp $TERMUX_PKG_BUILDER_DIR/obstack.h .
+	cp $TERMUX_PKG_BUILDER_DIR/obstack.h src
 	cp $TERMUX_PKG_BUILDER_DIR/qsort_r.h .
 	cp $TERMUX_PKG_BUILDER_DIR/aligned_alloc.c libelf
 	cp -r $TERMUX_PKG_BUILDER_DIR/search src/


### PR DESCRIPTION
Also adjust build recipe to not build inside source folder due to clang bug

https://github.com/llvm/llvm-project/issues/71925#issuecomment-1987141438

Supersedes #26538 