### PR TITLE
bump(x11/gnome-terminal): 3.58.0

### DIFF
--- a/x11-packages/gnome-terminal/0001-fix-paths.patch
+++ b/x11-packages/gnome-terminal/0001-fix-paths.patch
@@ -27,7 +27,7 @@ diff --git a/src/terminal-default.cc b/src/terminal-default.cc
 index 3788d54..ecdd46e 100644
 --- a/src/terminal-default.cc
 +++ b/src/terminal-default.cc
-@@ -156,7 +156,7 @@ xte_data_check(char const* name,
+@@ -162,7 +162,7 @@ xte_data_check(char const* name,
      if (xte_data_check_one(path, full))
        return true;
    }
@@ -36,7 +36,7 @@ index 3788d54..ecdd46e 100644
      gs_free auto path = g_build_filename(TERM_PREFIX,
                                           "local",
                                           "share",
-@@ -203,15 +203,15 @@ xte_data_check(char const* name,
+@@ -209,15 +209,15 @@ xte_data_check(char const* name,
      if (xte_data_check_one(path, full))
        return true;
    }
@@ -45,7 +45,7 @@ index 3788d54..ecdd46e 100644
 +  if (!g_str_equal(TERM_PREFIX, "@TERMUX_PREFIX@")) {
 +    gs_free auto path = g_build_filename("@TERMUX_PREFIX@", "share",
                                           XTE_CONFIG_DIRNAME,
-                                          name,
+                                          desktop_id,
                                           nullptr);
      if (xte_data_check_one(path, full))
        return true;
@@ -54,8 +54,8 @@ index 3788d54..ecdd46e 100644
 +    gs_free auto path2 = g_build_filename("@TERMUX_PREFIX@",
                                            "share",
                                            "applications",
-                                           name,
-@@ -432,9 +432,9 @@ xte_config_get_default(char const* native_name)
+                                           desktop_id,
+@@ -442,9 +442,9 @@ xte_config_get_default(char const* native_name)
    auto const user_dir = g_get_user_config_dir();
    if (auto term = xte_config_get_default_for_path_and_desktops(user_dir, desktops, native_name))
      return term;
@@ -66,7 +66,7 @@ index 3788d54..ecdd46e 100644
 +  if (auto term = xte_config_get_default_for_path_and_desktops("@TERMUX_PREFIX@/etc/xdg", desktops, native_name))
      return term;
  
-   return nullptr;
+   auto data_dirs = g_get_system_data_dirs();
 diff --git a/src/terminal-util.cc b/src/terminal-util.cc
 index 8ea4ef6..65d2cff 100644
 --- a/src/terminal-util.cc

--- a/x11-packages/gnome-terminal/build.sh
+++ b/x11-packages/gnome-terminal/build.sh
@@ -2,9 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://wiki.gnome.org/Apps/Terminal
 TERMUX_PKG_DESCRIPTION="Terminal emulator for GNOME"
 TERMUX_PKG_LICENSE="GPL-3.0-or-later"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="3.56.2"
-TERMUX_PKG_SRCURL="https://download.gnome.org/sources/gnome-terminal/${TERMUX_PKG_VERSION%.*}/gnome-terminal-${TERMUX_PKG_VERSION}.tar.xz"
-TERMUX_PKG_SHA256=235bc09dfa34cc5f1e95122e9bf60203a84daf861cfacf7e4496c5f548239978
+TERMUX_PKG_VERSION="3.58.0"
+# "https://download.gnome.org/sources/gnome-terminal/${TERMUX_PKG_VERSION%.*}/gnome-terminal-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SRCURL="https://gitlab.gnome.org/GNOME/gnome-terminal/-/archive/${TERMUX_PKG_VERSION}/gnome-terminal-${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=098ebd149b17e77218fd66f69d1c613dc644d27b6b7239b18ac72ac85db7b742
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="glib, gtk3, libx11, dbus, gsettings-desktop-schemas, libhandy, libvte "
 TERMUX_PKG_BUILD_DEPENDS="glib-cross, dconf, pcre2, gettext, libxslt"


### PR DESCRIPTION
Switch source link to GitLab generated tarball because it was not uploaded in download.gnome.org.

* Fixes #26602 