### PR TITLE
chore(main/rust): temporary pin to 1.89.0

### DIFF
--- a/packages/rust/build.sh
+++ b/packages/rust/build.sh
@@ -3,9 +3,9 @@ TERMUX_PKG_HOMEPAGE=https://www.rust-lang.org/
 TERMUX_PKG_DESCRIPTION="Systems programming language focused on safety, speed and concurrency"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.90.0"
-TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/rustc-${TERMUX_PKG_VERSION}-src.tar.xz
-TERMUX_PKG_SHA256=6bfeaddd90ffda2f063492b092bfed925c4b8c701579baf4b1316e021470daac
+TERMUX_PKG_VERSION="1.90.0+really1.89.0"
+TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/rustc-${TERMUX_PKG_VERSION##*y}-src.tar.xz
+TERMUX_PKG_SHA256=0b9d55610d8270e06c44f459d1e2b7918a5e673809c592abed9b9c600e33d95a
 _LLVM_MAJOR_VERSION=$(. $TERMUX_SCRIPTDIR/packages/libllvm/build.sh; echo $LLVM_MAJOR_VERSION)
 _LLVM_MAJOR_VERSION_NEXT=$((_LLVM_MAJOR_VERSION + 1))
 _LZMA_VERSION=$(. $TERMUX_SCRIPTDIR/packages/liblzma/build.sh; echo $TERMUX_PKG_VERSION)
@@ -14,7 +14,7 @@ TERMUX_PKG_BUILD_DEPENDS="wasi-libc"
 TERMUX_PKG_SUGGESTS="rust-analyzer"
 TERMUX_PKG_NO_REPLACE_GUESS_SCRIPTS=true
 TERMUX_PKG_NO_STATICSPLIT=true
-TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_RM_AFTER_INSTALL="
 bin/llc
 bin/llvm-*
@@ -215,6 +215,7 @@ termux_step_make_install() {
 
 	# remove version suffix: beta, nightly
 	local VERSION=${TERMUX_PKG_VERSION//~*}
+	VERSION="${VERSION##*y}"
 
 	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "true" ]]; then
 		echo "WARN: Replacing on device rust! Caveat emptor!"

--- a/scripts/build/setup/termux_setup_rust.sh
+++ b/scripts/build/setup/termux_setup_rust.sh
@@ -29,6 +29,7 @@ termux_setup_rust() {
 	if [[ "${TERMUX_RUST_VERSION}" == *"~beta"* ]]; then
 		TERMUX_RUST_VERSION="beta"
 	fi
+	TERMUX_RUST_VERSION="${TERMUX_RUST_VERSION##*y}"
 
 	curl https://sh.rustup.rs -sSfo "${TERMUX_PKG_TMPDIR}"/rustup.sh
 	sh "${TERMUX_PKG_TMPDIR}"/rustup.sh -y --default-toolchain "${TERMUX_RUST_VERSION}"


### PR DESCRIPTION
Until a fix for rust 1.90.0 runtime issue

Refer #26682 