### PR TITLE
bump(main/leptonica): 1.86.0

### DIFF
--- a/packages/leptonica/build.sh
+++ b/packages/leptonica/build.sh
@@ -3,10 +3,9 @@ TERMUX_PKG_DESCRIPTION="Library for image processing and image analysis"
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_LICENSE_FILE="leptonica-license.txt"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.85.0"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="1.86.0"
 TERMUX_PKG_SRCURL=https://github.com/DanBloomberg/leptonica/archive/${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=c01376bce0379d4ea4bc2ec5d5cbddaa49e2f06f88242619ab8c059e21adf233
+TERMUX_PKG_SHA256=b4447faf61a8786a9b211d58d4103d85d47fd3a5dd418d5a6bc525d41db54ccc
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="giflib, libjpeg-turbo, libpng, libtiff, libwebp, openjpeg, zlib"
 TERMUX_PKG_BREAKS="leptonica-dev"
@@ -17,8 +16,7 @@ termux_step_post_get_source() {
 	# after SOVERSION is changed.
 	local _SOVERSION=6
 
-	local v=$(sed -En 's/^.*set_target_properties\s*\(leptonica PROPERTIES SOVERSION ([0-9]+).*$/\1/p' \
-			src/CMakeLists.txt)
+	local v=$(sed -En 's/^.*SOVERSION ([0-9]+).*$/\1/p' src/CMakeLists.txt)
 	if [ "${_SOVERSION}" != "${v}" ]; then
 		termux_error_exit "SOVERSION guard check failed."
 	fi


### PR DESCRIPTION
SOVERSION was not changed in the leptonica 1.86.0 but the `set_target_properties()` format was changed in https://github.com/DanBloomberg/leptonica/commit/5dae0e5f9d63c7213004cadd4987869058b85c4d

* Fixes #26662 