### PR TITLE
enhance(main/just): set a default `JUST_CEILING`

### DIFF
--- a/packages/just/build.sh
+++ b/packages/just/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A handy way to save and run project-specific commands"
 TERMUX_PKG_LICENSE="CC0-1.0"
 TERMUX_PKG_MAINTAINER="@flipee"
 TERMUX_PKG_VERSION="1.43.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/casey/just/archive/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=03904d6380344dbe10e25f04cd1677b441b439940257d3cc9d8c5f09d91e3065
 TERMUX_PKG_AUTO_UPDATE=true
@@ -25,4 +26,16 @@ termux_step_post_make_install() {
 	cargo run -- --completions   bash > "${TERMUX_PREFIX}/share/bash-completion/completions/just"
 	cargo run -- --completions   fish > "${TERMUX_PREFIX}/share/fish/vendor_completions.d/just.fish"
 	cargo run -- --completions elvish > "${TERMUX_PREFIX}/share/elvish/lib/just.elv"
+
+	# Move the `just` binary to $PREFIX/libexec
+	# and replace it with our --ceiling shim.
+	# See: packages/just/just-shim.sh for details.
+	mkdir -p "$TERMUX_PREFIX/libexec/just"
+	mv "${TERMUX_PREFIX}"/bin/just "${TERMUX_PREFIX}"/libexec/just
+	sed \
+		-e "s|@TERMUX_PREFIX@|${TERMUX_PREFIX}|g" \
+		-e "s|@TERMUX_HOME@|${TERMUX_ANDROID_HOME}|g" \
+		"$TERMUX_PKG_BUILDER_DIR/just-shim.sh" \
+		> "${TERMUX_PREFIX}/bin/just"
+	chmod 700 "${TERMUX_PREFIX}/bin/just"
 }

--- a/packages/just/just-shim.sh
+++ b/packages/just/just-shim.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+# For further details see:
+# https://github.com/casey/just/issues/1492#issuecomment-3231502973
+# https://github.com/casey/just/pull/2870
+JUST_CEILING="${JUST_CEILING:-@TERMUX_HOME@}" exec "@TERMUX_PREFIX@/libexec/just/just" "$@"


### PR DESCRIPTION
- This PR is a follow-up to https://github.com/casey/just/issues/1492#issuecomment-3239135217

`just` 1.43.0 introduces the concept of a "ceiling" to `just` which is the top directory that will not be searched past when looking for `justfile`s.
In Termux's case it makes sense to set a global default of `$HOME` for this, while allowing it to be overwritten via the `$JUST_CEILING` environment variable or `--ceiling` flag.

Since there is not currently a way to compile in a default ceiling the most straightforward way to achieve this is to turn `$PREFIX/bin/just` into a shim, akin to what we're doing for `nvim`.
https://github.com/termux/termux-packages/blob/2860bc8eba9c24ed1c064f5c591e621deed09670/packages/neovim/nvim-shim.sh#L12-L13