### PR TITLE
bump(x11/cairo-dock-core): 3.6.0

### DIFF
--- a/x11-packages/cairo-dock-core/CMakeLists.txt.patch
+++ b/x11-packages/cairo-dock-core/CMakeLists.txt.patch
@@ -1,0 +1,13 @@
+# Fix include directory with $PREFIX/$PREFIX paths
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -83,7 +83,7 @@
+ 	set (libdir "${prefix}/${CMAKE_INSTALL_LIBDIR}")  # (...)/lib or (...)/lib64 or custom ## GNU Install dir
+ endif()
+ 
+-set (includedir "${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")  # (...)/include
++set (includedir "${CMAKE_INSTALL_INCLUDEDIR}")  # (...)/include
+ set (bindir "${prefix}/${CMAKE_INSTALL_BINDIR}")  # (...)/bin
+ 
+ if (NOT DEFINED plugins-prefix)

--- a/x11-packages/cairo-dock-core/build.sh
+++ b/x11-packages/cairo-dock-core/build.sh
@@ -1,11 +1,10 @@
-TERMUX_PKG_HOMEPAGE=http://glx-dock.org/
+TERMUX_PKG_HOMEPAGE=https://github.com/Cairo-Dock/cairo-dock-core
 TERMUX_PKG_DESCRIPTION="Cairo-Dock is a simple and avanzed dock for linux desktop."
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="3.5.2"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="3.6.0"
 TERMUX_PKG_SRCURL=https://github.com/Cairo-Dock/cairo-dock-core/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=9a08efe15e257f18e33161b17c4bbab7c6889854a9fab96a69d6568f0e91475f
+TERMUX_PKG_SHA256=8b7c5d08dbd61d4f18c463a0eba4b8a0ff5c2830225c56b7cffe9e84d01af2e3
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="dbus-glib, gdk-pixbuf, glib, glu, gtk3, libcairo, libcurl, librsvg, libx11, libxcomposite, libxinerama, libxml2, libxrandr, libxrender, libxtst, opengl, pango, which"
 TERMUX_PKG_BUILD_DEPENDS="valac"
@@ -13,4 +12,3 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DFORCE_NOT_LIB64=yes
 -DCMAKE_INSTALL_LIBDIR=lib
 "
-TERMUX_CMAKE_BUILD="Unix Makefiles"


### PR DESCRIPTION
* Fix include directory with $PREFIX/$PREFIX paths.
* Remove old url in homepage variable. It will be discontinued. https://github.com/Cairo-Dock/cairo-dock-core/releases/tag/3.6.0
* Fixes #26731 