### PR TITLE
addpkg(main/trunk): 0.21.14

### DIFF
--- a/packages/trunk/build.sh
+++ b/packages/trunk/build.sh
@@ -1,0 +1,14 @@
+TERMUX_PKG_HOMEPAGE=https://trunkrs.dev/
+TERMUX_PKG_DESCRIPTION="Build, bundle & ship your Rust WASM application to the web"
+TERMUX_PKG_LICENSE="Apache-2.0, MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.21.14"
+TERMUX_PKG_SRCURL=https://github.com/trunk-rs/trunk/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=8687bcf96bdc4decee88458745bbb760ad31dfd109e955cf455c2b64caeeae2f
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="openssl, bzip2"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--no-default-features
+--features native-tls
+"


### PR DESCRIPTION
Build, bundle & ship your Rust WASM application to the web with [trunk](https://trunkrs.dev/).

_NOTE_: I can't just build `trunk` on my device via `cargo install trunk` because got out of memory error at final executable linking step.

_NOTE_: I was use `build.sh` from `cargo-c` as template.