### PR TITLE
bump(x11/gspell): 1.14.1

### DIFF
--- a/x11-packages/gspell/build.sh
+++ b/x11-packages/gspell/build.sh
@@ -2,10 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://gitlab.gnome.org/GNOME/gspell
 TERMUX_PKG_DESCRIPTION="Spell-checking for GTK applications"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.14.0"
-TERMUX_PKG_REVISION=3
-TERMUX_PKG_SRCURL=https://download.gnome.org/sources/gspell/${TERMUX_PKG_VERSION%.*}/gspell-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=64ea1d8e9edc1c25b45a920e80daf67559d1866ffcd7f8432fecfea6d0fe8897
+TERMUX_PKG_VERSION="1.14.1"
+# https://download.gnome.org/sources/gspell/${TERMUX_PKG_VERSION%.*}/gspell-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SRCURL=https://gitlab.gnome.org/GNOME/gspell/-/archive/${TERMUX_PKG_VERSION}/gspell-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=1ecdc789e4f798e63cf49fc1718541e7974e5f67034ce152ae052a2b8f337e8e
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="enchant, glib, gtk3, libicu, pango"
 TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, glib-cross, valac"


### PR DESCRIPTION
Since October 2025, only a git tag is created for releasing gspell, and tarballs are no longer uploaded to `download.gnome.org`.
https://gitlab.gnome.org/GNOME/gspell/-/commit/de7091cf01ad6b8a7c55cb6c3eaa6bd2eda5403f

* Fixes #26743 