### PR TITLE
bump(x11/xkeyboard-config): 2.46

### DIFF
--- a/x11-packages/xkeyboard-config/build.sh
+++ b/x11-packages/xkeyboard-config/build.sh
@@ -2,16 +2,14 @@ TERMUX_PKG_HOMEPAGE=https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-co
 TERMUX_PKG_DESCRIPTION="X keyboard configuration files"
 TERMUX_PKG_LICENSE="HPND, MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="2.45"
+TERMUX_PKG_VERSION="2.46"
 TERMUX_PKG_SRCURL=https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/archive/xkeyboard-config-${TERMUX_PKG_VERSION}/xkeyboard-config-xkeyboard-config-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=9ab49abdae20545c8f215472d8537e0228635b7947d63e02592db24a5025ed6a
+TERMUX_PKG_SHA256=81107e12f71087b3f1d7dea43c186805d46abaffead0cafca9bdd24b94c2007e
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_BUILD_DEPENDS="python"
 TERMUX_PKG_PYTHON_COMMON_DEPS="StrEnum"
-
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--Dxkb-base=${TERMUX_PREFIX}/share/X11/xkb
 -Dcompat-rules=true
 -Dxorg-rules-symlinks=true
 "


### PR DESCRIPTION
Remove the build option `xkb-base`, which was ineffectual since the migration from autotools to meson in xkeyboard-config 2.35, published 3 years ago. https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/issues/532

See https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/blob/xkeyboard-config-2.46/ChangeLog.md

* Fixes #26746 