### PR TITLE
bump(main/libxml2): 2.15.0

### DIFF
--- a/packages/libxml2/backport-dc307e3-mandir-fix.patch
+++ b/packages/libxml2/backport-dc307e3-mandir-fix.patch
@@ -1,0 +1,28 @@
+From dc307e31fd1343934a66fabe3ba4b42f34ac63c0 Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Wed, 17 Sep 2025 11:10:51 +0200
+Subject: [PATCH] meson: Fix install dir of man pages
+
+Regressed when reworking documentation in 2.15.
+
+Fixes #985.
+---
+ doc/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/doc/meson.build b/doc/meson.build
+index 018b7d037..8cde254a9 100644
+--- a/doc/meson.build
++++ b/doc/meson.build
+@@ -31,7 +31,7 @@ if want_docs
+ 
+     xsltproc = find_program('xsltproc')
+     types = [
+-        [ 'manpages', '.1',    dir_man ],
++        [ 'manpages', '.1',    dir_man / 'man1' ],
+         [ 'html',     '.html', dir_doc ],
+     ]
+     programs = [ 'xmllint' ]
+-- 
+GitLab
+

--- a/packages/libxml2/libxml2-python-static.subpackage.sh
+++ b/packages/libxml2/libxml2-python-static.subpackage.sh
@@ -1,6 +1,0 @@
-TERMUX_SUBPKG_INCLUDE="
-lib/python*/**/*.a
-lib/python*/**/*.la
-"
-TERMUX_SUBPKG_DESCRIPTION="Static libraries for libxml2-python"
-TERMUX_SUBPKG_DEPENDS="libxml2-python"

--- a/packages/libxml2/libxml2-python.subpackage.sh
+++ b/packages/libxml2/libxml2-python.subpackage.sh
@@ -1,6 +1,5 @@
 TERMUX_SUBPKG_INCLUDE="
 lib/python*
-share/doc/libxml2/python/
 "
 TERMUX_SUBPKG_DESCRIPTION="Python bindings for libxml2"
 TERMUX_SUBPKG_DEPENDS="python"

--- a/packages/libxml2/libxml2-utils.subpackage.sh
+++ b/packages/libxml2/libxml2-utils.subpackage.sh
@@ -1,3 +1,9 @@
-TERMUX_SUBPKG_INCLUDE="bin/xmllint bin/xmlcatalog share/man/man1/xmllint.1.gz share/man/man1/xmlcatalog.1.gz"
+TERMUX_SUBPKG_INCLUDE="
+bin/xmllint
+bin/xmlcatalog
+share/man/man1/xmllint.1.gz
+share/man/man1/xmlcatalog.1.gz
+"
 TERMUX_SUBPKG_DESCRIPTION="XML utilities"
+TERMUX_SUBPKG_DEPENDS="readline"
 TERMUX_SUBPKG_PROVIDES="xmllint"

--- a/packages/libxml2/no-doxygen.patch
+++ b/packages/libxml2/no-doxygen.patch
@@ -1,0 +1,21 @@
+diff --git a/doc/meson.build b/doc/meson.build
+index 018b7d03..327aab3e 100644
+--- a/doc/meson.build
++++ b/doc/meson.build
+@@ -1,6 +1,6 @@
+ # Doxygen
+ 
+-doxygen = find_program('doxygen')
++doxygen = find_program('true')
+ 
+ # TODO: To make the xml directory work as dependency of the
+ # Python target, we must make sure that its timestamp changes
+@@ -18,7 +18,7 @@ doxygen_docs = custom_target(
+         'SOURCE_ROOT': meson.project_source_root() + '/',
+         'BUILD_ROOT':  meson.project_build_root()  + '/',
+     },
+-    install: true,
++    install: false,
+     install_dir: [ want_docs ? dir_doc : false, false ],
+ )
+ 


### PR DESCRIPTION
This took me the better part of a day since it just turned into one thing after the other.
To quickly summarize the things I ran into without inducing madness in the reader:

- I updated the homepage, the previous one was a redirect to the new one.
- Surprise sidequest number 1: The SOVERSION wasn't bumped despite the apparent scheme being Major + Minor since 2.14
<sup>(Put a pin in that...)</sup>
- Doxygen is now ***required*** to build any and all docs for `libxml2`
    - Suprise sidequest number 2: Can't get Autotools to recognize `doxygen`, alright... Meson it is then.
  Had to get that working by overwriting `termux_step_configure()` but that worked without issues.
- LZMA support was removed
- Enable Zlib support
- Enable ICU support
- Enable history and readline support for `xmllint`'s shell mode.
- Surprise sidequest number 3: `libxml2-python-static` is empty now.
I checked the Arch package, that's just how it is now.
  - Do a sanity check for everything that's in the build directory and what ends up in the packages.
  There is no more `gtk-doc`, but a shit ton of `html` ones.
- Surprise sidequest number 4: The `xmlcatalog.1` and `xmllint.1` manpages are ending up in `man` instead of `man/man1`
  This seems like an error in the `CMakeLists.txt`.
  <sup>(Put a pin in that...)</sup>
  https://gitlab.gnome.org/GNOME/libxml2/-/blob/2.15/CMakeLists.txt?ref_type=heads#L570-580
  
So, that pin from earlier.
@Biswa96 pointed me at this.
https://discourse.gnome.org/t/stepping-down-as-libxml2-maintainer/31398
It looks like Libxml2 is effectively without an upstream maintainer at this time, which partially explains some of the jank I encountered this update cycle.

I also had a look at the Meson summary and tried enabling
```console
-Dthread-alloc=enabled
-Dtls=enabled # (thread local storage, not transport layer security)
```

<details><summary>It <i>builds</i> with those but throws some compiler warnings.</summary>
<p>

```yml
../src/globals.c:208:13: warning: no previous extern declaration for non-static variable 'xmlFree' [-Wmissing-variable-declarations]
  208 | xmlFreeFunc xmlFree = free;
      |             ^
../src/globals.c:208:1: note: declare 'static' if the variable is not intended to be used outside of this translation unit
  208 | xmlFreeFunc xmlFree = free;
      | ^
../src/globals.c:209:15: warning: no previous extern declaration for non-static variable 'xmlMalloc' [-Wmissing-variable-declarations]
  209 | xmlMallocFunc xmlMalloc = malloc;
      |               ^
../src/globals.c:209:1: note: declare 'static' if the variable is not intended to be used outside of this translation unit
  209 | xmlMallocFunc xmlMalloc = malloc;
      | ^
../src/globals.c:210:15: warning: no previous extern declaration for non-static variable 'xmlMallocAtomic' [-Wmissing-variable-declarations]
  210 | xmlMallocFunc xmlMallocAtomic = malloc;
      |               ^
../src/globals.c:210:1: note: declare 'static' if the variable is not intended to be used outside of this translation unit
  210 | xmlMallocFunc xmlMallocAtomic = malloc;
      | ^
../src/globals.c:211:16: warning: no previous extern declaration for non-static variable 'xmlRealloc' [-Wmissing-variable-declarations]
  211 | xmlReallocFunc xmlRealloc = realloc;
      |                ^
../src/globals.c:211:1: note: declare 'static' if the variable is not intended to be used outside of this translation unit
  211 | xmlReallocFunc xmlRealloc = realloc;
      | ^
../src/globals.c:212:15: warning: no previous extern declaration for non-static variable 'xmlMemStrdup' [-Wmissing-variable-declarations]
  212 | xmlStrdupFunc xmlMemStrdup = xmlPosixStrdup;
      |               ^
../src/globals.c:212:1: note: declare 'static' if the variable is not intended to be used outside of this translation unit
  212 | xmlStrdupFunc xmlMemStrdup = xmlPosixStrdup;
      | ^
5 warnings generated.
```


</p>
</details> 
And I'm not up for a 5th sidequest today.