### PR TITLE
addpkg(main/cargo-leptos): 0.2.44

### DIFF
--- a/packages/cargo-leptos/01_target_os_android.patch
+++ b/packages/cargo-leptos/01_target_os_android.patch
@@ -1,0 +1,11 @@
+--- src.orig/src/ext/util.rs	2025-09-17 13:13:26.000000000 +0000
++++ src/src/ext/util.rs	2025-10-02 20:05:14.447708864 +0000
+@@ -10,6 +10,8 @@
+         "macos"
+     } else if cfg!(target_os = "linux") {
+         "linux"
++    } else if cfg!(target_os = "android") {
++        "android"
+     } else {
+         bail!("unsupported OS")
+     };

--- a/packages/cargo-leptos/build.sh
+++ b/packages/cargo-leptos/build.sh
@@ -1,0 +1,15 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/leptos-rs/cargo-leptos
+TERMUX_PKG_DESCRIPTION="Build tool for the Rust framework Leptos"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.2.44"
+TERMUX_PKG_SRCURL=https://github.com/leptos-rs/cargo-leptos/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=3c68c56ca57e1e4ef5a04956ea300f7730a38950e632c3c29c2429a152cc271a
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="openssl"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+	termux_setup_rust
+	export OPENSSL_NO_VENDOR=1
+}


### PR DESCRIPTION
[Build tool](https://github.com/leptos-rs/cargo-leptos) for the Rust framework [Leptos](https://leptos.dev/).