### PR TITLE
bump(main/salty-chat): 0.0.22-p20251006

### DIFF
--- a/packages/salty-chat/build.sh
+++ b/packages/salty-chat/build.sh
@@ -2,12 +2,32 @@ TERMUX_PKG_HOMEPAGE=https://salty.im/
 TERMUX_PKG_DESCRIPTION="A secure, easy, self-hosted messaging"
 TERMUX_PKG_LICENSE="MIT, WTFPL"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=0.0.22
-TERMUX_PKG_REVISION=4
-TERMUX_PKG_SRCURL=https://git.mills.io/saltyim/saltyim/archive/${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=fdc4dd8c0547f87f3c04022eb4558420eb07b136cc4de8b0d75b8b8cf47a0040
+_COMMIT=5a5510e8869fa878381deb30fedc1d2c92c33311
+_COMMIT_DATE=20251006
+TERMUX_PKG_VERSION="0.0.22-p${_COMMIT_DATE}"
+TERMUX_PKG_SRCURL=git+https://git.mills.io/saltyim/saltyim
+TERMUX_PKG_GIT_BRANCH=master
+TERMUX_PKG_SHA256=ab1d28e52e449ee41379f724b5aea9d50a9e82f31a5f00fb92fe3f062254d71e
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_MAKE_ARGS="VERSION=${TERMUX_PKG_VERSION}"
+
+termux_step_post_get_source() {
+	git fetch --unshallow
+	git checkout "$_COMMIT"
+
+	local pdate="p$(git log -1 --format=%cs | sed 's/-//g')"
+	if [[ "$TERMUX_PKG_VERSION" != *"${pdate}" ]]; then
+		echo -n "ERROR: The version string \"$TERMUX_PKG_VERSION\" is"
+		echo -n " different from what is expected to be; should end"
+		echo " with \"${pdate}\"."
+		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
+	fi
+}
 
 termux_step_pre_configure() {
 	termux_setup_golang

--- a/packages/salty-chat/makefile.patch
+++ b/packages/salty-chat/makefile.patch
@@ -1,19 +1,17 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -1,14 +1,14 @@
+@@ -1,7 +1,7 @@
  -include environ.inc
  .PHONY: help deps dev build install image release test clean clean-all
  
 -export CGO_ENABLED=0
--VERSION=$(shell git describe --abbrev=0 --tags 2>/dev/null || echo "0.0.0")
--COMMIT=$(shell git rev-parse --short HEAD || echo "HEAD")
--BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 +export CGO_ENABLED=1
-+VERSION=$(echo "0.0.0")
-+COMMIT=$(echo "HEAD")
-+BRANCH="master"
+ VERSION=$(shell git describe --abbrev=0 --tags 2>/dev/null || echo "$VERSION")
+ COMMIT=$(shell git rev-parse --short HEAD || echo "$COMMIT")
+ BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+@@ -9,7 +9,7 @@ BUILD=$(shell git show -s --pretty=format:%cI)
  GOCMD=go
- GOVER=$(shell go version | grep -o -E 'go1\.17\.[0-9]+')
+ GOCMD=go
  
 -DESTDIR=/usr/local/bin
 +DESTDIR=@TERMUX_PREFIX@/bin


### PR DESCRIPTION
- For some reason, the release archive URL does not work anymore, but downloading the release tag using the git protocol does work.

- However, for some reason the current release fails to build in termux-packages GitHub Actions with error ` ../../_cache/go1.25.0-r1/src/os/user/lookup.go:22:41: undefined: current`, but not locally, but the current master branch is not affected by that error, so bump to the newest commit.