### PR TITLE
phpMyAdmin: Adjust and fix the settings

### DIFF
--- a/packages/phpmyadmin/build.sh
+++ b/packages/phpmyadmin/build.sh
@@ -1,8 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://www.phpmyadmin.net
 TERMUX_PKG_DESCRIPTION="A PHP tool for administering MySQL and MariaDB databases"
 TERMUX_PKG_LICENSE="GPL-2.0"
-TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_MAINTAINER="@williamdes"
 TERMUX_PKG_VERSION=5.2.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://files.phpmyadmin.net/phpMyAdmin/$TERMUX_PKG_VERSION/phpMyAdmin-$TERMUX_PKG_VERSION-all-languages.tar.xz
 TERMUX_PKG_SHA256=57881348297c4412f86c410547cf76b4d8a236574dd2c6b7d6a2beebe7fc44e3
 TERMUX_PKG_DEPENDS="apache2, php, php-apache"
@@ -19,4 +20,17 @@ termux_step_make_install() {
 	mkdir -p $TERMUX_PREFIX/etc/apache2/conf.d
 	sed -e "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" $TERMUX_PKG_BUILDER_DIR/phpmyadmin.conf \
 		> $TERMUX_PREFIX/etc/apache2/conf.d/phpmyadmin.conf
+	# Variable data folder
+	mkdir -p $TERMUX_PREFIX/var/lib/phpmyadmin/sessions
+	touch "$TERMUX_PREFIX/var/lib/phpmyadmin/sessions/.placeholder"
+	mkdir -p $TERMUX_PREFIX/var/lib/phpmyadmin/tmp
+	touch "$TERMUX_PREFIX/var/lib/phpmyadmin/tmp/.placeholder"
+	mkdir -p $TERMUX_PREFIX/var/lib/phpmyadmin/uploads
+	touch "$TERMUX_PREFIX/var/lib/phpmyadmin/uploads/.placeholder"
+	# Custom settings
+	sed -i "s,\$cfg\['UploadDir'\] = '';,\$cfg\['UploadDir'\] = '$TERMUX_PREFIX/var/lib/phpmyadmin/uploads';," $TERMUX_PREFIX/etc/phpmyadmin/config.inc.php
+	sed -i "s,\$cfg\['SaveDir'\] = '';,\$cfg\['SaveDir'\] = '$TERMUX_PREFIX/var/lib/phpmyadmin/uploads';," $TERMUX_PREFIX/etc/phpmyadmin/config.inc.php
+	echo "\$cfg['TempDir'] = '$TERMUX_PREFIX/var/lib/phpmyadmin/tmp';" >> $TERMUX_PREFIX/etc/phpmyadmin/config.inc.php
+	# Check for syntax errors
+	php -l $TERMUX_PREFIX/etc/phpmyadmin/config.inc.php
 }

--- a/packages/phpmyadmin/phpmyadmin.conf
+++ b/packages/phpmyadmin/phpmyadmin.conf
@@ -9,7 +9,9 @@ Alias /phpmyadmin @TERMUX_PREFIX@/share/phpmyadmin
     <IfModule mod_php.c>
         php_value error_reporting "E_ALL & ~E_DEPRECATED"
         php_value include_path .
-        php_admin_value open_basedir @TERMUX_PREFIX@/share/phpmyadmin:@TERMUX_PREFIX@/etc/phpmyadmin/
+        php_admin_value open_basedir @TERMUX_PREFIX@/share/phpmyadmin:@TERMUX_PREFIX@/etc/phpmyadmin:@TERMUX_PREFIX@/var/lib/phpmyadmin
+        php_admin_value upload_tmp_dir @TERMUX_PREFIX@/var/lib/phpmyadmin/tmp
+        php_admin_value session.save_path @TERMUX_PREFIX@/var/lib/phpmyadmin/sessions
     </IfModule>
 
 </Directory>
@@ -17,9 +19,10 @@ Alias /phpmyadmin @TERMUX_PREFIX@/share/phpmyadmin
 # Authorize for setup
 <Directory @TERMUX_PREFIX@/share/phpmyadmin/setup>
     <IfModule mod_authn_file.c>
-    AuthType Basic
-    AuthName "phpMyAdmin Setup"
-    AuthUserFile etc/phpmyadmin/htpasswd.setup
+        AuthType Basic
+        AuthName "phpMyAdmin Setup"
+        # To create it, run htpasswd -c @TERMUX_PREFIX@/etc/phpmyadmin/htpasswd.setup my-username
+        AuthUserFile @TERMUX_PREFIX@/etc/phpmyadmin/htpasswd.setup
     </IfModule>
     Require valid-user
 </Directory>


### PR DESCRIPTION
Fixing https://github.com/termux/termux-packages/pull/26809

- The temp folder for sessions was missing in the open base dir path
- Adjusted and tested the /setup folder, even if it does not work if you keep your config file around. Else use the demo mode to test it.

The config is more like https://salsa.debian.org/phpmyadmin-team/phpmyadmin/-/blob/debian/latest/debian/conf/apache.conf?ref_type=heads now

Should we not use `debian/dirs` to create empty folders ? (not yet implemented in the custom packaging)
See: https://www.debian.org/doc/manuals/maint-guide/dother.en.html#dirs
Near
https://github.com/termux/termux-packages/blob/d100c313016543a8377ddfa65306f0369503f553/scripts/build/termux_step_create_debian_package.sh#L47C33-L47C95