### PR TITLE
fix(main/valkey): do not conflict with `libhiredis`

### DIFF
--- a/packages/valkey/build.sh
+++ b/packages/valkey/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="In-memory data structure store used as a database, cache
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="8.1.4"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/valkey-io/valkey/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=32350b017fee5e1a85f7e2d8580d581a0825ceae5cb3395075012c0970694dee
 TERMUX_PKG_AUTO_UPDATE=false

--- a/packages/valkey/do-not-install-hiredis-files.patch
+++ b/packages/valkey/do-not-install-hiredis-files.patch
@@ -1,0 +1,57 @@
+diff --git a/deps/hiredis/CMakeLists.txt b/deps/hiredis/CMakeLists.txt
+index b7d6ee8..cb23a6a 100644
+--- a/deps/hiredis/CMakeLists.txt
++++ b/deps/hiredis/CMakeLists.txt
+@@ -93,35 +93,6 @@ set(CPACK_RPM_PACKAGE_AUTOREQPROV ON)
+ 
+ include(CPack)
+ 
+-INSTALL(TARGETS hiredis
+-    EXPORT hiredis-targets
+-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-
+-if (MSVC AND BUILD_SHARED_LIBS)
+-    INSTALL(FILES $<TARGET_PDB_FILE:hiredis>
+-        DESTINATION ${CMAKE_INSTALL_BINDIR}
+-        CONFIGURATIONS Debug RelWithDebInfo)
+-endif()
+-
+-# For NuGet packages
+-INSTALL(FILES hiredis.targets
+-    DESTINATION build/native)
+-
+-INSTALL(FILES hiredis.h read.h sds.h async.h alloc.h sockcompat.h
+-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hiredis)
+-
+-INSTALL(DIRECTORY adapters
+-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hiredis)
+-
+-INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/hiredis.pc
+-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+-
+-export(EXPORT hiredis-targets
+-    FILE "${CMAKE_CURRENT_BINARY_DIR}/hiredis-targets.cmake"
+-    NAMESPACE hiredis::)
+-
+ if(WIN32)
+     SET(CMAKE_CONF_INSTALL_DIR share/hiredis)
+ else()
+@@ -135,16 +106,6 @@ configure_package_config_file(hiredis-config.cmake.in ${CMAKE_CURRENT_BINARY_DIR
+                               INSTALL_DESTINATION ${CMAKE_CONF_INSTALL_DIR}
+                               PATH_VARS INCLUDE_INSTALL_DIR)
+ 
+-INSTALL(EXPORT hiredis-targets
+-        FILE hiredis-targets.cmake
+-        NAMESPACE hiredis::
+-        DESTINATION ${CMAKE_CONF_INSTALL_DIR})
+-
+-INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/hiredis-config.cmake
+-              ${CMAKE_CURRENT_BINARY_DIR}/hiredis-config-version.cmake
+-        DESTINATION ${CMAKE_CONF_INSTALL_DIR})
+-
+-
+ IF(ENABLE_SSL)
+     IF (NOT OPENSSL_ROOT_DIR)
+         IF (APPLE)


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/26864

- `libhiredis` is built into the CMake version of `valkey` and is hard to separate cleanly, but I was able to separate it by modifying the vendored `libhiredis` code to not install `libhiredis` files with `valkey`.