### PR TITLE
bump(x11/epiphany): 49.1

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -76,6 +76,10 @@ source "$TERMUX_SCRIPTDIR/scripts/build/termux_download.sh"
 # shellcheck source=scripts/build/setup/termux_setup_proot.sh
 source "$TERMUX_SCRIPTDIR/scripts/build/setup/termux_setup_proot.sh"
 
+# Utility function to setup blueprint-compiler (may be used by gnome-calculator and epiphany).
+# shellcheck source=scripts/build/setup/termux_setup_bpc.sh.
+source "$TERMUX_SCRIPTDIR/scripts/build/setup/termux_setup_bpc.sh"
+
 # Installing packages if necessary for the full operation of CGCT.
 # shellcheck source=scripts/build/termux_step_setup_cgct_environment.sh
 source "$TERMUX_SCRIPTDIR/scripts/build/termux_step_setup_cgct_environment.sh"

--- a/scripts/build/setup/termux_setup_bpc.sh
+++ b/scripts/build/setup/termux_setup_bpc.sh
@@ -1,0 +1,56 @@
+termux_setup_bpc() {
+	local _BPC_BUILD_SH="$TERMUX_SCRIPTDIR/packages/blueprint-compiler/build.sh"
+	local _BPC_VERSION=$(bash -c ". $_BPC_BUILD_SH; echo \${TERMUX_PKG_VERSION#*:}")
+	local _BPC_SRCURL=$(bash -c ". $_BPC_BUILD_SH; echo \${TERMUX_PKG_SRCURL}")
+	local _BPC_SHA256=$(bash -c ". $_BPC_BUILD_SH; echo \${TERMUX_PKG_SHA256}")
+	local _BPC_SRCARCHIVE="${TERMUX_PKG_TMPDIR}/bpc-${_BPC_VERSION}.tar.gz"
+	local _BPC_SRCDIR="${TERMUX_PKG_TMPDIR}/bpc-${_BPC_VERSION}"
+	local _BPC_FOLDER
+
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "true" ]]; then
+		if ([ ! -e "$TERMUX_BUILT_PACKAGES_DIRECTORY/blueprint-compiler" ] ||
+			[ "$(cat "$TERMUX_BUILT_PACKAGES_DIRECTORY/blueprint-compiler")" != "$_BPC_VERSION" ]) &&
+			([[ "$TERMUX_APP_PACKAGE_MANAGER" = "apt" && "$(dpkg-query -W -f '${db:Status-Status}\n' blueprint-compiler 2>/dev/null)" != "installed" ]] ||
+			[[ "$TERMUX_APP_PACKAGE_MANAGER" = "pacman" && ! "$(pacman -Q blueprint-compiler 2>/dev/null)" ]]); then
+			echo "Package 'blueprint-compiler' is not installed."
+			echo "You can install it with"
+			echo
+			echo "  pkg install blueprint-compiler"
+			echo
+			echo "  pacman -S blueprint-compiler"
+			echo
+			echo "or build it from source with"
+			echo
+			echo "  ./build-package.sh blueprint-compiler"
+			echo
+			exit 1
+		fi
+		return
+	fi
+
+	if [ "${TERMUX_PACKAGES_OFFLINE-false}" = "true" ]; then
+		_BPC_FOLDER="${TERMUX_SCRIPTDIR}/build-tools/bpc-${_BPC_VERSION}"
+	else
+		_BPC_FOLDER="${TERMUX_COMMON_CACHEDIR}/bpc-${_BPC_VERSION}"
+	fi
+
+	if [ ! -d "$_BPC_FOLDER" ]; then
+	(
+		termux_download "$_BPC_SRCURL" "$_BPC_SRCARCHIVE" "$_BPC_SHA256"
+
+		rm -Rf "$_BPC_SRCDIR"
+		mkdir -p "$_BPC_SRCDIR/build"
+		tar -xf "$_BPC_SRCARCHIVE" --strip-components=1 -C "$_BPC_SRCDIR"
+		# termux_setup_meson for hostbuilds copied from glib package
+		AR=;CC=;CFLAGS=;CPPFLAGS=;CXX=;CXXFLAGS=;LD=;LDFLAGS=;PKG_CONFIG=;STRIP=
+		termux_setup_meson
+		unset AR CC CFLAGS CPPFLAGS CXX CXXFLAGS LD LDFLAGS PKG_CONFIG STRIP
+		${TERMUX_MESON} setup "$_BPC_SRCDIR" "$_BPC_SRCDIR/build" --prefix "$_BPC_FOLDER"
+		ninja -C "$_BPC_SRCDIR/build" -j "$TERMUX_PKG_MAKE_PROCESSES"
+		ninja -C "$_BPC_SRCDIR/build" install
+	)
+	fi
+
+	export PATH="$_BPC_FOLDER/bin:$PATH"
+	export GI_TYPELIB_PATH="$TERMUX_PREFIX/lib/girepository-1.0"
+}

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -208,7 +208,6 @@ PACKAGES+=" libunistring-dev"
 
 # Needed by packages in X11 repository.
 PACKAGES+=" alex"
-PACKAGES+=" blueprint-compiler"
 PACKAGES+=" docbook-xsl-ns"
 PACKAGES+=" gnome-common"
 PACKAGES+=" gobject-introspection"

--- a/x11-packages/epiphany/build.sh
+++ b/x11-packages/epiphany/build.sh
@@ -2,17 +2,17 @@ TERMUX_PKG_HOMEPAGE=https://wiki.gnome.org/Apps/Web
 TERMUX_PKG_DESCRIPTION="A GNOME web browser based on the WebKit rendering engine"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="48.5"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="49.1"
 TERMUX_PKG_SRCURL=https://download.gnome.org/sources/epiphany/${TERMUX_PKG_VERSION%%.*}/epiphany-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=0f66552ad6593c7952a3ddee5bf515656c8c434871076d9f1a91a7af9346b1b4
+TERMUX_PKG_SHA256=d767c5cbb9e2566bc9903d411b6896161e343f712aa33305365739d8dedac521
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="adwaita-icon-theme, gcr4, gdk-pixbuf, glib, graphene, gsettings-desktop-schemas, gstreamer, gtk4, iso-codes, json-glib, libadwaita, libarchive, libcairo, libgmp, libnettle, libportal-gtk4, libsecret, libsoup3, libsqlite, libxml2, pango, webkitgtk-6.0"
-TERMUX_PKG_BUILD_DEPENDS="glib-cross"
+TERMUX_PKG_BUILD_DEPENDS="blueprint-compiler, glib-cross"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dunit_tests=disabled
 "
 
 termux_step_pre_configure() {
 	termux_setup_glib_cross_pkg_config_wrapper
+	termux_setup_bpc
 }

--- a/x11-packages/gnome-calculator/build.sh
+++ b/x11-packages/gnome-calculator/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="GNOME Scientific calculator"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="49.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://download.gnome.org/sources/gnome-calculator/${TERMUX_PKG_VERSION%%.*}/gnome-calculator-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=5da02b87d913c3d72cb606afbbfb308479cde48dc4e1a1d54c049a1e86ca607e
 TERMUX_PKG_DISABLE_GIR=false
@@ -14,7 +15,5 @@ TERMUX_PKG_RECOMMENDS="gnome-calculator-help"
 termux_step_pre_configure() {
 	termux_setup_gir
 	termux_setup_glib_cross_pkg_config_wrapper
-
-	# for blueprint-compiler
-	export GI_TYPELIB_PATH="$TERMUX_PREFIX"/lib/girepository-1.0
+	termux_setup_bpc
 }


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/26272

- Partially reverts https://github.com/termux/termux-packages/pull/26493

- Implement `termux_setup_bpc` and share it between `gnome-caluclator` and `epiphany`. In https://github.com/termux/termux-packages/pull/26493, I suggested similar code, but unfortunately, at that time Biswa96 didn't like it and decided to edit `setup-ubuntu.sh`. However, unfortunately, that method did not work sufficiently for `epiphany`, so it is necessary to ensure that the `blueprint-compiler` version while cross-compiling matches the version while non-cross-compiling.