### PR TITLE
fix(main/libcompiler-rt): conflict with `libllvm` older than 21

### DIFF
--- a/packages/flang/build.sh
+++ b/packages/flang/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_LICENSE_FILE="flang/LICENSE.TXT"
 TERMUX_PKG_MAINTAINER="@termux"
 LLVM_MAJOR_VERSION=21
 TERMUX_PKG_VERSION=${LLVM_MAJOR_VERSION}.1.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=(
 	https://github.com/llvm/llvm-project/releases/download/llvmorg-$TERMUX_PKG_VERSION/llvm-project-$TERMUX_PKG_VERSION.src.tar.xz
 	https://github.com/llvm/llvm-project/releases/download/llvmorg-$TERMUX_PKG_VERSION/LLVM-$TERMUX_PKG_VERSION-Linux-X64.tar.xz

--- a/packages/libllvm/build.sh
+++ b/packages/libllvm/build.sh
@@ -6,6 +6,7 @@ TERMUX_PKG_MAINTAINER="@finagolfin"
 # Keep flang version and revision in sync when updating (enforced by check in termux_step_pre_configure).
 LLVM_MAJOR_VERSION=21
 TERMUX_PKG_VERSION=${LLVM_MAJOR_VERSION}.1.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=9c9db50d8046f668156d83f6b594631b4ca79a0d96e4f19bed9dc019b022e58f
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_SRCURL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$TERMUX_PKG_VERSION/llvm-project-${TERMUX_PKG_VERSION}.src.tar.xz

--- a/packages/libllvm/libcompiler-rt.subpackage.sh
+++ b/packages/libllvm/libcompiler-rt.subpackage.sh
@@ -16,7 +16,8 @@ share/libalpm/scripts/update-libcompiler-rt
 "
 TERMUX_SUBPKG_DEPEND_ON_PARENT=false
 TERMUX_SUBPKG_DEPENDS=libc++
-TERMUX_SUBPKG_CONFLICTS="ndk-multilib (<< 23b-6)"
+# file include/fuzzer/FuzzedDataProvider.h is now in libcompiler-rt instead of libllvm
+TERMUX_SUBPKG_CONFLICTS="libllvm (<< 21.1.3), ndk-multilib (<< 23b-6)"
 
 termux_step_create_subpkg_debscripts() {
 	local RT_OPT_DIR=$TERMUX_PREFIX/opt/ndk-multilib/cross-compiler-rt


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/26879

- File `include/fuzzer/FuzzedDataProvider.h` is now in `libcompiler-rt` instead of `libllvm`