### PR TITLE
bump(main/bitcoin): 30.0

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -84,6 +84,10 @@ source "$TERMUX_SCRIPTDIR/scripts/build/setup/termux_setup_bpc.sh"
 # shellcheck source=scripts/build/termux_step_setup_cgct_environment.sh
 source "$TERMUX_SCRIPTDIR/scripts/build/termux_step_setup_cgct_environment.sh"
 
+# Utility function to setup capnproto (may be used by bitcoin).
+# shellcheck source=scripts/build/setup/termux_setup_capnp.sh.
+source "$TERMUX_SCRIPTDIR/scripts/build/setup/termux_setup_capnp.sh"
+
 # Utility function for setting up Cargo C-ABI helpers.
 # shellcheck source=scripts/build/setup/termux_setup_cargo_c.sh
 source "$TERMUX_SCRIPTDIR/scripts/build/setup/termux_setup_cargo_c.sh"

--- a/packages/bitcoin/build.sh
+++ b/packages/bitcoin/build.sh
@@ -2,13 +2,14 @@ TERMUX_PKG_HOMEPAGE=https://bitcoincore.org/
 TERMUX_PKG_DESCRIPTION="Bitcoin Core"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="29.1"
+TERMUX_PKG_VERSION="30.0"
 TERMUX_PKG_SRCURL=https://github.com/bitcoin/bitcoin/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=75072253405b43c47aae4431945ae0c1a7959d709faf3a205dd25304e7fb7e9b
+TERMUX_PKG_SHA256=6efa1947043783f7ea2f3e9bec602ff5a9740f7f61d5f93c8d421f5fc67548f7
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="libc++, libevent"
+TERMUX_PKG_DEPENDS="capnproto, libc++, libevent"
 TERMUX_PKG_BUILD_DEPENDS="boost-headers"
 TERMUX_PKG_SERVICE_SCRIPT=("bitcoind" 'exec bitcoind 2>&1')
+TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DBUILD_DAEMON=ON
 -DBUILD_FUZZ_BINARY=OFF
@@ -18,3 +19,33 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DBUILD_UTIL=ON
 -DBUILD_WALLET_TOOL=ON
 "
+
+termux_step_host_build() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "true" ]]; then
+		return
+	fi
+
+	termux_setup_cmake
+	termux_setup_ninja
+	termux_setup_capnp
+
+	cmake "$TERMUX_PKG_SRCDIR/src/ipc/libmultiprocess" -GNinja
+	ninja -j "$TERMUX_PKG_MAKE_PROCESSES"
+}
+
+_setup_mpgen() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "true" ]]; then
+		return
+	fi
+
+	export PATH="$TERMUX_PKG_HOSTBUILD_DIR:$PATH"
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DMPGEN_EXECUTABLE=$(command -v mpgen)"
+}
+
+termux_step_pre_configure() {
+	termux_setup_capnp
+	_setup_mpgen
+
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DCAPNP_EXECUTABLE=$(command -v capnp)"
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DCAPNPC_CXX_EXECUTABLE=$(command -v capnpc-c++)"
+}

--- a/scripts/build/setup/termux_setup_capnp.sh
+++ b/scripts/build/setup/termux_setup_capnp.sh
@@ -1,0 +1,59 @@
+termux_setup_capnp() {
+	local _CAPNP_BUILD_SH="$TERMUX_SCRIPTDIR/packages/capnproto/build.sh"
+	local _CAPNP_VERSION=$(bash -c ". $_CAPNP_BUILD_SH; echo \${TERMUX_PKG_VERSION#*:}")
+	local _CAPNP_SRCURL=$(bash -c ". $_CAPNP_BUILD_SH; echo \${TERMUX_PKG_SRCURL}")
+	local _CAPNP_SHA256=$(bash -c ". $_CAPNP_BUILD_SH; echo \${TERMUX_PKG_SHA256}")
+	local _CAPNP_SRCARCHIVE="${TERMUX_PKG_TMPDIR}/capnp-${_CAPNP_VERSION}.tar.gz"
+	local _CAPNP_SRCDIR="${TERMUX_PKG_TMPDIR}/capnp-${_CAPNP_VERSION}"
+	local _CAPNP_FOLDER
+
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "true" ]]; then
+		if ([ ! -e "$TERMUX_BUILT_PACKAGES_DIRECTORY/capnproto" ] ||
+			[ "$(cat "$TERMUX_BUILT_PACKAGES_DIRECTORY/capnproto")" != "$_CAPNP_VERSION" ]) &&
+			([[ "$TERMUX_APP_PACKAGE_MANAGER" = "apt" && "$(dpkg-query -W -f '${db:Status-Status}\n' capnproto 2>/dev/null)" != "installed" ]] ||
+			[[ "$TERMUX_APP_PACKAGE_MANAGER" = "pacman" && ! "$(pacman -Q capnproto 2>/dev/null)" ]]); then
+			echo "Package 'capnproto' is not installed."
+			echo "You can install it with"
+			echo
+			echo "  pkg install capnproto"
+			echo
+			echo "  pacman -S capnproto"
+			echo
+			echo "or build it from source with"
+			echo
+			echo "  ./build-package.sh capnproto"
+			echo
+			exit 1
+		fi
+		return
+	fi
+
+	if [ "${TERMUX_PACKAGES_OFFLINE-false}" = "true" ]; then
+		_CAPNP_FOLDER="${TERMUX_SCRIPTDIR}/build-tools/capnp-${_CAPNP_VERSION}"
+	else
+		_CAPNP_FOLDER="${TERMUX_COMMON_CACHEDIR}/capnp-${_CAPNP_VERSION}"
+	fi
+
+	if [ ! -d "$_CAPNP_FOLDER" ]; then
+	(
+		termux_download "$_CAPNP_SRCURL" "$_CAPNP_SRCARCHIVE" "$_CAPNP_SHA256"
+
+		rm -Rf "$_CAPNP_SRCDIR"
+		mkdir -p "$_CAPNP_SRCDIR/build"
+		tar -xf "$_CAPNP_SRCARCHIVE" --strip-components=1 -C "$_CAPNP_SRCDIR"
+		termux_setup_cmake
+		termux_setup_ninja
+		unset AR CC CFLAGS CPPFLAGS CXX CXXFLAGS LD LDFLAGS PKG_CONFIG PKG_CONFIG_LIBDIR PKGCONFIG STRIP
+		cmake \
+			-S "$_CAPNP_SRCDIR" \
+			-B "$_CAPNP_SRCDIR/build" \
+			-GNinja \
+			-DPKG_CONFIG_EXECUTABLE=/usr/bin/pkg-config \
+			-DCMAKE_INSTALL_PREFIX="$_CAPNP_FOLDER"
+		ninja -C "$_CAPNP_SRCDIR/build" -j "$TERMUX_PKG_MAKE_PROCESSES"
+		ninja -C "$_CAPNP_SRCDIR/build" install
+	)
+	fi
+
+	export PATH="$_CAPNP_FOLDER/bin:$PATH"
+}


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/26875

- Implement hostbuild-step to compile an `mpgen` executable for use during cross-compiling

- Implement `termux_setup_capnp()` in order to cross-compile `bitcoin` 30.0  without disabling the multiprocessing feature