### PR TITLE
bump(main/iwyu): 0.25

### DIFF
--- a/packages/iwyu/build.sh
+++ b/packages/iwyu/build.sh
@@ -3,10 +3,9 @@ TERMUX_PKG_DESCRIPTION="A tool to analyze #includes in C and C++ source files"
 TERMUX_PKG_LICENSE=NCSA
 TERMUX_PKG_MAINTAINER="@termux"
 # Update this and the clang version below when libllvm is updated:
-TERMUX_PKG_VERSION=0.24
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="0.25"
 TERMUX_PKG_SRCURL=https://github.com/include-what-you-use/include-what-you-use/archive/$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_SHA256=897b4c864a983f493c8efef4a1a9a2d429fd7ead1011f7a41743ed7b6dbe8c2e
+TERMUX_PKG_SHA256=2e8381368ec0a6ecb770834bce00fc62efa09a2b2f9710ed569acbb823ead9cc
 TERMUX_PKG_AUTO_UPDATE=false # can't be auto-updated since release correspond to clang version.
-TERMUX_PKG_DEPENDS="clang (>= 20), clang (<< 21), libc++, python"
+TERMUX_PKG_DEPENDS="clang (>= 21), clang (<< 22), libc++, python"
 TERMUX_PKG_BUILD_DEPENDS="libllvm-static"


### PR DESCRIPTION
It's working with clang 21.

```
~ $ include-what-you-use --version
include-what-you-use 0.25 based on clang version 21.1.3
~ $ clang --version
clang version 21.1.3
Target: x86_64-unknown-linux-android24
Thread model: posix
InstalledDir: /data/data/com.termux/files/usr/bin
```
