### PR TITLE
fix(main/shaderc): do not conflict with `glslang`

### DIFF
--- a/packages/shaderc/build.sh
+++ b/packages/shaderc/build.sh
@@ -3,17 +3,33 @@ TERMUX_PKG_DESCRIPTION="Collection of tools, libraries, and tests for Vulkan sha
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2025.4"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/google/shaderc/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=8a89fb6612ace8954470aae004623374a8fc8b7a34a4277bee5527173b064faf
-TERMUX_PKG_DEPENDS="libc++"
-TERMUX_PKG_CONFLICTS="glslang, spirv-tools"
+TERMUX_PKG_DEPENDS="glslang, spirv-tools, libc++"
+TERMUX_PKG_BUILD_DEPENDS="spirv-headers"
 TERMUX_PKG_NO_STATICSPLIT=true
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DSHADERC_SKIP_TESTS=ON
+-Dglslang_SOURCE_DIR=$TERMUX_PREFIX/include/glslang
 "
 
-termux_step_post_get_source() {
-	./utils/git-sync-deps
+termux_step_pre_configure() {
+	# based on Arch Linux:
+	# https://gitlab.archlinux.org/archlinux/packaging/packages/shaderc/-/blob/3ed2bcb6358e964d75044f075a04cb0cd8bd4fa8/README.md
+	# de-vendor libs and disable git versioning
+	local _SPIRV_TOOLS_BUILD_SH="$TERMUX_SCRIPTDIR/packages/spirv-tools/build.sh"
+	local _GLSLANG_BUILD_SH="$TERMUX_SCRIPTDIR/packages/glslang/build.sh"
+	local _SPIRV_TOOLS_VERSION=$(bash -c ". $_SPIRV_TOOLS_BUILD_SH; echo \${TERMUX_PKG_VERSION#*:}")
+	local _GLSLANG_VERSION=$(bash -c ". $_GLSLANG_BUILD_SH; echo \${TERMUX_PKG_VERSION#*:}")
+
+	sed '/examples/d;/third_party/d' -i "$TERMUX_PKG_SRCDIR/CMakeLists.txt"
+	sed '/build-version/d' -i "$TERMUX_PKG_SRCDIR/glslc/CMakeLists.txt"
+	cat <<- EOF > "$TERMUX_PKG_SRCDIR/glslc/src/build-version.inc"
+		"${TERMUX_PKG_VERSION}\\n"
+		"${_SPIRV_TOOLS_VERSION}\\n"
+		"${_GLSLANG_VERSION}\\n"
+	EOF
 }


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/26901

- Based on Arch Linux: https://gitlab.archlinux.org/archlinux/packaging/packages/shaderc/-/blob/3ed2bcb6358e964d75044f075a04cb0cd8bd4fa8/README.md

- Unvendor dependencies `spirv-tools` and `glslang`, forcing `shaderc` to depend on the termux-packages `spirv-tools` and `glslang` instead of its vendored ones and not conflict with them.

- Desired for the creation of an improved Blender package that could then be installed simultaneously with and also depend on other packages that depend on `glslang` without conflicting with them (that is how Arch Linux's Blender package works). The current situation (before this PR) is that `shaderc` cannot be installed in Termux while anything that depends on `glslang` or `spirv-tools` is installed, which unfortunately makes it difficult to develop an improved Blender package without changing Termux's `shaderc` package to not do that.

> [!WARNING]
> **Possible downside**: after this, `shaderc` might stop working suddenly if `spirv-tools` is bumped past unknown future versions without `shaderc` being recompiled. I have not disabled auto updating of `spirv-tools` with this, but I am prepared to watch out for the potential of that happening and try to fix it myself if it does happen.

Changeset of the provided files of `shaderc` (removed files are provided instead by the `glslang` and `spriv-tools` packages):

```diff
--- shaderc-old.txt	2025-10-15 06:22:43.186510341 -0500
+++ shaderc-new.txt	2025-10-15 06:23:12.066510330 -0500
@@ -7,88 +7,17 @@
 /data/data/com.termux/files/usr/bin
 /data/data/com.termux/files/usr/bin/glslc
 /data/data/com.termux/files/usr/include
-/data/data/com.termux/files/usr/include/glslang
-/data/data/com.termux/files/usr/include/glslang/Include
-/data/data/com.termux/files/usr/include/glslang/Include/ResourceLimits.h
-/data/data/com.termux/files/usr/include/glslang/Include/glslang_c_interface.h
-/data/data/com.termux/files/usr/include/glslang/Include/glslang_c_shader_types.h
-/data/data/com.termux/files/usr/include/glslang/Include/visibility.h
-/data/data/com.termux/files/usr/include/glslang/MachineIndependent
-/data/data/com.termux/files/usr/include/glslang/MachineIndependent/Versions.h
-/data/data/com.termux/files/usr/include/glslang/Public
-/data/data/com.termux/files/usr/include/glslang/Public/ResourceLimits.h
-/data/data/com.termux/files/usr/include/glslang/Public/ShaderLang.h
-/data/data/com.termux/files/usr/include/glslang/Public/resource_limits_c.h
-/data/data/com.termux/files/usr/include/glslang/SPIRV
-/data/data/com.termux/files/usr/include/glslang/SPIRV/GlslangToSpv.h
-/data/data/com.termux/files/usr/include/glslang/SPIRV/Logger.h
-/data/data/com.termux/files/usr/include/glslang/SPIRV/SPVRemapper.h
-/data/data/com.termux/files/usr/include/glslang/SPIRV/SpvTools.h
-/data/data/com.termux/files/usr/include/glslang/SPIRV/disassemble.h
-/data/data/com.termux/files/usr/include/glslang/SPIRV/spirv.hpp11
-/data/data/com.termux/files/usr/include/glslang/build_info.h
 /data/data/com.termux/files/usr/include/shaderc
 /data/data/com.termux/files/usr/include/shaderc/env.h
 /data/data/com.termux/files/usr/include/shaderc/shaderc.h
 /data/data/com.termux/files/usr/include/shaderc/shaderc.hpp
 /data/data/com.termux/files/usr/include/shaderc/status.h
 /data/data/com.termux/files/usr/include/shaderc/visibility.h
-/data/data/com.termux/files/usr/include/spirv-tools
-/data/data/com.termux/files/usr/include/spirv-tools/libspirv.h
-/data/data/com.termux/files/usr/include/spirv-tools/libspirv.hpp
-/data/data/com.termux/files/usr/include/spirv-tools/linker.hpp
-/data/data/com.termux/files/usr/include/spirv-tools/optimizer.hpp
 /data/data/com.termux/files/usr/lib
-/data/data/com.termux/files/usr/lib/cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools/SPIRV-ToolsConfig.cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools/SPIRV-ToolsTarget-release.cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools/SPIRV-ToolsTarget.cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-diff
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-diff/SPIRV-Tools-diffConfig.cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-diff/SPIRV-Tools-diffTargets-release.cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-diff/SPIRV-Tools-diffTargets.cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-link
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-link/SPIRV-Tools-linkConfig.cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-link/SPIRV-Tools-linkTargets-release.cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-link/SPIRV-Tools-linkTargets.cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-lint
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-lint/SPIRV-Tools-lintConfig.cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-lint/SPIRV-Tools-lintTargets-release.cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-lint/SPIRV-Tools-lintTargets.cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-opt
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-opt/SPIRV-Tools-optConfig.cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-opt/SPIRV-Tools-optTargets-release.cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-opt/SPIRV-Tools-optTargets.cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-reduce
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-reduce/SPIRV-Tools-reduceConfig.cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-reduce/SPIRV-Tools-reduceTarget-release.cmake
-/data/data/com.termux/files/usr/lib/cmake/SPIRV-Tools-reduce/SPIRV-Tools-reduceTarget.cmake
-/data/data/com.termux/files/usr/lib/cmake/glslang
-/data/data/com.termux/files/usr/lib/cmake/glslang/glslang-config-version.cmake
-/data/data/com.termux/files/usr/lib/cmake/glslang/glslang-config.cmake
-/data/data/com.termux/files/usr/lib/cmake/glslang/glslang-targets-release.cmake
-/data/data/com.termux/files/usr/lib/cmake/glslang/glslang-targets.cmake
-/data/data/com.termux/files/usr/lib/libGenericCodeGen.a
-/data/data/com.termux/files/usr/lib/libMachineIndependent.a
-/data/data/com.termux/files/usr/lib/libOSDependent.a
-/data/data/com.termux/files/usr/lib/libSPIRV-Tools-diff.a
-/data/data/com.termux/files/usr/lib/libSPIRV-Tools-link.a
-/data/data/com.termux/files/usr/lib/libSPIRV-Tools-lint.a
-/data/data/com.termux/files/usr/lib/libSPIRV-Tools-opt.a
-/data/data/com.termux/files/usr/lib/libSPIRV-Tools-reduce.a
-/data/data/com.termux/files/usr/lib/libSPIRV-Tools-shared.so
-/data/data/com.termux/files/usr/lib/libSPIRV-Tools.a
-/data/data/com.termux/files/usr/lib/libSPIRV.a
-/data/data/com.termux/files/usr/lib/libSPVRemapper.a
-/data/data/com.termux/files/usr/lib/libglslang-default-resource-limits.a
-/data/data/com.termux/files/usr/lib/libglslang.a
 /data/data/com.termux/files/usr/lib/libshaderc.a
 /data/data/com.termux/files/usr/lib/libshaderc_combined.a
 /data/data/com.termux/files/usr/lib/libshaderc_shared.so
 /data/data/com.termux/files/usr/lib/pkgconfig
-/data/data/com.termux/files/usr/lib/pkgconfig/SPIRV-Tools-shared.pc
-/data/data/com.termux/files/usr/lib/pkgconfig/SPIRV-Tools.pc
 /data/data/com.termux/files/usr/lib/pkgconfig/shaderc.pc
 /data/data/com.termux/files/usr/lib/pkgconfig/shaderc_combined.pc
 /data/data/com.termux/files/usr/lib/pkgconfig/shaderc_static.pc
```