### PR TITLE
bump(x11/codelldb): 1.11.7

### DIFF
--- a/x11-packages/codelldb/build.sh
+++ b/x11-packages/codelldb/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://github.com/vadimcn/codelldb
 TERMUX_PKG_DESCRIPTION="A native debugger extension for VSCode based on LLDB"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.11.6"
+TERMUX_PKG_VERSION="1.11.7"
 TERMUX_PKG_SRCURL="https://github.com/vadimcn/codelldb/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256=53081ba015f61ca47203666c3961394084c86b2474f29f77ab6bc677187cd5c3
+TERMUX_PKG_SHA256=e5625da8a09e2cfa6a5102b634544295b9d9fbf41a8c1956c5b6d792416a9e8d
 TERMUX_PKG_AUTO_UPDATE=true
 # codelldb does not work properly on 32-bit Android
 TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"

--- a/x11-packages/codelldb/move-adapter-outside-vsix.diff
+++ b/x11-packages/codelldb/move-adapter-outside-vsix.diff
@@ -80,15 +80,15 @@ package file to outside of it.
      if (options.liblldb) {
 --- a/extension/main.ts
 +++ b/extension/main.ts
-@@ -234,7 +234,7 @@ class Extension implements DebugAdapterDescriptorFactory {
- 
+@@ -263,7 +263,7 @@ class Extension implements DebugAdapterDescriptorFactory {
+     ): Promise<DebugConfiguration | undefined | null> {
          if (debugConfig.cargo) {
              let cargo = new Cargo(folder, cancellation);
--            let launcher = path.join(this.context.extensionPath, 'adapter', 'codelldb-launch');
+-            let launcher = path.join(this.context.extensionPath, 'bin', 'codelldb-launch');
 +            let launcher = '@TERMUX_PREFIX@/bin/codelldb-launch';
              debugConfig = await cargo.resolveCargoConfig(debugConfig, launcher);
          }
- 
+         if (cancellation?.isCancellationRequested)
 --- a/src/codelldb/src/terminal.rs
 +++ b/src/codelldb/src/terminal.rs
 @@ -5,6 +5,7 @@ use adapter_protocol::*;


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/26915

- It seems very similar to 1.11.6. There are not very many changes since then.

- In https://github.com/vadimcn/codelldb/commit/046f04fc40a1c53f7db95d93a847bab80f7b0412, upstream appears to have fixed the error "unable to find codelldb-launch!" that I was experiencing in 1.11.6. However, after seeing it, I had already gone ahead and moved the new `codelldb-launch` executable outside of the `.vsix` file and into `$TERMUX_PREFIX` because that worked to fix it for me and followed the pattern I set with the other Rust executable that is normally inside the `.vsix` file, and that's the way I've tested it, so I guess it is best not to move it back inside or anything like that.