### PR TITLE
fix(scripts/lint-packages): do not print diff during version check

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,6 +15,9 @@
 /scripts/ @Grimler91 @thunder-coding
 /repo.json @Grimler91 @thunder-coding
 
+# Build script linter
+/scripts/lint-packages.sh @TomJo2000
+
 # Repository Health Check
 /scripts/check-repository-health.js @thunder-coding
 /scripts/generate-apt-packages-list.sh @thunder-coding

--- a/scripts/lint-packages.sh
+++ b/scripts/lint-packages.sh
@@ -148,14 +148,14 @@ check_version() {
 		(( i++ ))
 
 		# Is this version valid?
-		dpkg --validate-version "${version}" &>/dev/null || {
+		dpkg --validate-version "${version}" &> /dev/null || {
 			printf 'INVALID %s\n' "$(dpkg --validate-version "${version}" 2>&1)"
 			(( error++ ))
 			continue
 		}
 
 		# Was the package modified in this branch?
-		git diff --exit-code "${base_commit}" -- "${package_dir}" 2> /dev/null && {
+		git diff --exit-code "${base_commit}" -- "${package_dir}" &> /dev/null && {
 			printf '%s\n' "PASS - ${version} (not modified in this branch)"
 			continue
 		}
@@ -175,7 +175,7 @@ check_version() {
 
 		# Is ${version_old} valid?
 		local version_old_is_bad=""
-		dpkg --validate-version "${version_old}" &>/dev/null || version_old_is_bad="0~invalid"
+		dpkg --validate-version "${version_old}" &> /dev/null || version_old_is_bad="0~invalid"
 
 		# If ${version_new} isn't greater than "$version_old" that's an issue.
 		# If ${version_old} isn't valid this check is a no-op.


### PR DESCRIPTION
- Missed this during #26786.

I'm also setting myself as a point of contact for the build script linter since I've written about 60% of the current iteration if `git blame` is to be trusted.