### PR TITLE
fix(main/guile): revert commit which causes crashes on 32-bit devices and environments

### DIFF
--- a/packages/guile/build.sh
+++ b/packages/guile/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Portable, embeddable Scheme implementation written in C"
 TERMUX_PKG_LICENSE="LGPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.0.10
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/guile/guile-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=2dbdbc97598b2faf31013564efb48e4fed44131d28e996c26abe8a5b23b56c2a
 TERMUX_PKG_DEPENDS="libandroid-spawn, libandroid-support, libffi, libgc, libgmp, libiconv, libunistring, ncurses, readline"

--- a/packages/guile/revert-d579848c.patch.beforehostbuild
+++ b/packages/guile/revert-d579848c.patch.beforehostbuild
@@ -1,0 +1,80 @@
+Reverts https://cgit.git.savannah.gnu.org/cgit/guile.git/commit/?id=d579848cb5d65440af5afd9c8968628665554c22
+Fixes https://github.com/termux/termux-packages/issues/26976
+Also allows using this guile to build gnucash for 32-bit devices while running the 32-bit Termux guile inside termux-proot-run
+
+--- a/module/language/cps/specialize-numbers.scm
++++ b/module/language/cps/specialize-numbers.scm
+@@ -284,23 +284,18 @@
+ 
+ (define significant-bits-handlers (make-hash-table))
+ (define-syntax-rule (define-significant-bits-handler
+-                      ((primop label types out def ...) param arg ...)
++                      ((primop label types out def ...) arg ...)
+                       body ...)
+   (hashq-set! significant-bits-handlers 'primop
+               (lambda (label types out param args defs)
+                 (match args ((arg ...) (match defs ((def ...) body ...)))))))
+ 
+-(define-significant-bits-handler ((logand label types out res) param a b)
++(define-significant-bits-handler ((logand label types out res) a b)
+   (let ((sigbits (sigbits-intersect3 (inferred-sigbits types label a)
+                                      (inferred-sigbits types label b)
+                                      (intmap-ref out res (lambda (_) 0)))))
+     (intmap-add (intmap-add out a sigbits sigbits-union)
+                 b sigbits sigbits-union)))
+-(define-significant-bits-handler ((logand/immediate label types out res) param a)
+-  (let ((sigbits (sigbits-intersect3 (inferred-sigbits types label a)
+-                                     param
+-                                     (intmap-ref out res (lambda (_) 0)))))
+-    (intmap-add out a sigbits sigbits-union)))
+ 
+ (define (significant-bits-handler primop)
+   (hashq-ref significant-bits-handlers primop))
+@@ -561,11 +556,11 @@
+               (specialize-unop cps k src op param a
+                                (unbox-u64 a) (box-u64 result))))
+ 
+-           (('logand/immediate (? u64-result? ) param (? u64-operand? a))
++           (('logand/immediate (? u64-result? ) param a)
+             (specialize-unop cps k src 'ulogand/immediate
+                              (logand param (1- (ash 1 64)))
+                              a
+-                             (unbox-u64 a) (box-u64 result)))
++                             (unbox-u64/truncate a) (box-u64 result)))
+ 
+            (((or 'add/immediate 'sub/immediate 'mul/immediate)
+              (? s64-result?) (? s64-parameter?) (? s64-operand? a))
+--- a/module/language/cps/type-fold.scm
++++ b/module/language/cps/type-fold.scm
+@@ -692,9 +692,13 @@
+    ((and (eqv? type1 &fixnum) (eqv? min1 max1) (power-of-two? min1)
+          (<= 0 min0))
+     (with-cps cps
+-      (build-term
++      (letv mask)
++      (letk kmask
++            ($kargs ('mask) (mask)
+         ($continue k src
+-          ($primcall 'logand/immediate (1- min1) (arg0))))))
++                ($primcall 'logand #f (arg0 mask)))))
++      (build-term
++        ($continue kmask src ($const (1- min1))))))
+    (else
+     (with-cps cps #f))))
+ 
+@@ -706,9 +710,13 @@
+     (with-cps cps #f))
+    ((and (eqv? type1 &fixnum) (eqv? min1 max1) (power-of-two? min1))
+     (with-cps cps
+-      (build-term
++      (letv mask)
++      (letk kmask
++            ($kargs ('mask) (mask)
+         ($continue k src
+-          ($primcall 'logand/immediate (1- min1) (arg0))))))
++                ($primcall 'logand #f (arg0 mask)))))
++      (build-term
++        ($continue kmask src ($const (1- min1))))))
+    (else
+     (with-cps cps #f))))
+ 


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/26976

- Reverts https://cgit.git.savannah.gnu.org/cgit/guile.git/commit/?id=d579848cb5d65440af5afd9c8968628665554c22

- **Must be named `.patch.beforehostbuild`**. If it's not, the problematic commit can **actually propagate its undesired behavior into the target `guile`** that the hostbuild `guile` builds, and the error is not prevented.