### PR TITLE
bump(x11/libmateweather): 1.28.1

### DIFF
--- a/x11-packages/libmateweather/build.sh
+++ b/x11-packages/libmateweather/build.sh
@@ -2,9 +2,12 @@ TERMUX_PKG_HOMEPAGE=https://libmateweather.mate-desktop.dev/
 TERMUX_PKG_DESCRIPTION="libmateweather is a libgnomeweather fork."
 TERMUX_PKG_LICENSE="LGPL-2.1, GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.28.0"
-TERMUX_PKG_REVISION=3
-TERMUX_PKG_SRCURL=https://github.com/mate-desktop/libmateweather/releases/download/v$TERMUX_PKG_VERSION/libmateweather-$TERMUX_PKG_VERSION.tar.xz
-TERMUX_PKG_SHA256=2094a4ba78da7a4b75536ea8e45ccdc00691adfe1c13a557c8a77dcd76450a8b
+TERMUX_PKG_VERSION="1.28.1"
+TERMUX_PKG_SRCURL=https://github.com/mate-desktop/libmateweather/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=dfd0de546afda06e2a4d6837748910fa2074ab6fd76361fa67f642f456e184c1
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="atk, gdk-pixbuf, glib, gtk3, harfbuzz, libcairo, libsoup, libxml2, pango, zlib"
+
+termux_step_pre_configure() {
+	autoreconf -fiv
+}


### PR DESCRIPTION
Use GitHub generated tarball instead of release artifact which is not provided with this release.

* Fixes #27031 