### PR TITLE
fix(main/manpages): Replace array in package version with separate variable

### DIFF
--- a/packages/manpages/build.sh
+++ b/packages/manpages/build.sh
@@ -3,20 +3,22 @@ TERMUX_PKG_DESCRIPTION="Man pages for linux kernel and C library interfaces"
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="LICENSES/Linux-man-pages-copyleft.txt, _man-pages-posix/POSIX-COPYRIGHT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=(6.16
-                    2017)
+TERMUX_PKG_VERSION="6.16"
+_POSIX_MANPAGE_VERSION="2017"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=(
 	8e247abd75cd80809cfe08696c81b8c70690583b045749484b242fb43631d7a3
 	ce67bb25b5048b20dad772e405a83f4bc70faf051afa289361c81f9660318bc3
 )
-TERMUX_PKG_SRCURL=(https://www.kernel.org/pub/linux/docs/man-pages/man-pages-${TERMUX_PKG_VERSION[0]}.tar.xz
-                   https://www.kernel.org/pub/linux/docs/man-pages/man-pages-posix/man-pages-posix-${TERMUX_PKG_VERSION[1]}-a.tar.xz)
+TERMUX_PKG_SRCURL=(https://www.kernel.org/pub/linux/docs/man-pages/man-pages-${TERMUX_PKG_VERSION}.tar.xz
+                   https://www.kernel.org/pub/linux/docs/man-pages/man-pages-posix/man-pages-posix-${_POSIX_MANPAGE_VERSION}-a.tar.xz)
 TERMUX_PKG_DEPENDS="mandoc"
 TERMUX_PKG_CONFLICTS="linux-man-pages"
 TERMUX_PKG_REPLACES="linux-man-pages"
 TERMUX_PKG_PROVIDES="linux-man-pages"
 TERMUX_PKG_EXTRA_MAKE_ARGS="-R prefix=$TERMUX_PREFIX VERSION=$TERMUX_PKG_VERSION"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
 
 # Do not remove an entire section; intro should always be included.
@@ -42,7 +44,7 @@ share/man/man7/mdoc.7
 "
 
 termux_step_post_get_source() {
-	mv man-pages-posix-${TERMUX_PKG_VERSION[1]} _man-pages-posix
+	mv man-pages-posix-${_POSIX_MANPAGE_VERSION} _man-pages-posix
 }
 
 termux_step_make() {


### PR DESCRIPTION
This removes any quirks with linting build script and helps to enable auto update.

The linting issue was caught in this CI run https://github.com/termux/termux-packages/actions/runs/19025073645