### PR TITLE
addpkg(main/btop): 1.4.5

### DIFF
--- a/root-packages/btop/CMakeLists.txt.patch
+++ b/root-packages/btop/CMakeLists.txt.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bca0f39..1e00db6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -76,7 +76,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+   target_sources(btop PRIVATE src/openbsd/btop_collect.cpp src/openbsd/sysctlbyname.cpp)
+ elseif(CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
+   target_sources(btop PRIVATE src/netbsd/btop_collect.cpp)
+-elseif(LINUX)
++elseif((LINUX) OR (CMAKE_SYSTEM_NAME STREQUAL "Android"))
+   target_sources(btop PRIVATE src/linux/btop_collect.cpp)
+   if(BTOP_GPU)
+     add_subdirectory(src/linux/intel_gpu_top)

--- a/root-packages/btop/build.sh
+++ b/root-packages/btop/build.sh
@@ -1,0 +1,31 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/aristocratos/btop
+TERMUX_PKG_DESCRIPTION="Resource monitor that shows usage and stats for processor, memory, disks, network and processes."
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="1.4.5"
+TERMUX_PKG_SRCURL=https://github.com/aristocratos/btop/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=0ffe03d3e26a3e9bbfd5375adf34934137757994f297d6b699a46edd43c3fc02
+TERMUX_PKG_BUILD_DEPENDS="aosp-libs, lowdown"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+	-DBTOP_LTO=OFF
+	-DBTOP_GPU=OFF
+	-DLOWDOWN_EXECUTABLE="${TERMUX_PKG_TMPDIR}/bin/lowdown"
+"
+TERMUX_PKG_AUTO_UPDATE=true
+
+termux_step_pre_configure() {
+	[[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]] && termux_setup_proot
+	mkdir "${TERMUX_PKG_TMPDIR}/bin"
+	printf '%s\ntermux-proot-run %s "$@"\n' \
+		"#!/bin/sh" \
+		"${TERMUX_PREFIX}/bin/lowdown" \
+	> "${TERMUX_PKG_TMPDIR}/bin/lowdown"
+	chmod +x "${TERMUX_PKG_TMPDIR}/bin/lowdown"
+
+	PATH="${TERMUX_PKG_TMPDIR}/bin:$PATH"
+}
+
+termux_step_post_make_install() {
+	mkdir -p "$TERMUX_PREFIX/var/btop"
+	cp -L "$TERMUX_PKG_BUILDER_DIR/procstat" "$TERMUX_PREFIX/var/btop/stat"
+}

--- a/root-packages/btop/disable-pthread.patch
+++ b/root-packages/btop/disable-pthread.patch
@@ -1,0 +1,31 @@
+diff --git a/src/btop.cpp b/src/btop.cpp
+index ffd5ee6..21568d6 100644
+--- a/src/btop.cpp
++++ b/src/btop.cpp
+@@ -202,12 +202,6 @@ void clean_quit(int sig) {
+ 			Logger::warning("Failed to join _runner thread on exit!");
+ 			pthread_cancel(Runner::runner_id);
+ 		}
+-	#else
+-		constexpr struct timespec ts { .tv_sec = 5, .tv_nsec = 0 };
+-		if (pthread_timedjoin_np(Runner::runner_id, nullptr, &ts) != 0) {
+-			Logger::warning("Failed to join _runner thread on exit!");
+-			pthread_cancel(Runner::runner_id);
+-		}
+ 	#endif
+ 	}
+ 
+@@ -719,12 +713,7 @@ namespace Runner {
+ 		if (active) {
+ 			Logger::error("Stall in Runner thread, restarting!");
+ 			active = false;
+-			// exit(1);
+-			pthread_cancel(Runner::runner_id);
+-			if (pthread_create(&Runner::runner_id, nullptr, &Runner::_runner, nullptr) != 0) {
+-				Global::exit_error_msg = "Failed to re-create _runner thread!";
+-				clean_quit(1);
+-			}
++			exit(1);
+ 		}
+ 		if (stopping or Global::resized) return;
+ 

--- a/root-packages/btop/getloadavg.patch
+++ b/root-packages/btop/getloadavg.patch
@@ -1,0 +1,53 @@
+diff --git a/src/linux/btop_collect.cpp b/src/linux/btop_collect.cpp
+index 8b538bd..763860a 100644
+--- a/src/linux/btop_collect.cpp
++++ b/src/linux/btop_collect.cpp
+@@ -54,6 +54,48 @@ extern "C" {
+ 	#undef class
+ #endif
+ 
++#ifdef __ANDROID__
++/*
++ * Copyright (C) 2018 The Android Open Source Project
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *  * Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ *  * Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in
++ *    the documentation and/or other materials provided with the
++ *    distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
++ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
++ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
++ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
++ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
++ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
++ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
++ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
++ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++#include <stdlib.h>
++#include <sys/sysinfo.h>
++int getloadavg(double averages[], int n) {
++  if (n < 0) return -1;
++  if (n > 3) n = 3;
++  struct sysinfo si;
++  if (sysinfo(&si) == -1) return -1;
++  for (int i = 0; i < n; ++i) {
++    averages[i] = static_cast<double>(si.loads[i]) / static_cast<double>(1 << SI_LOAD_SHIFT);
++  }
++  return n;
++}
++#endif
++
+ using std::abs;
+ using std::clamp;
+ using std::cmp_greater;

--- a/root-packages/btop/proc-stat.patch
+++ b/root-packages/btop/proc-stat.patch
@@ -1,0 +1,13 @@
+diff --git a/src/linux/btop_collect.cpp b/src/linux/btop_collect.cpp
+index 8b538bd..c56610f 100644
+--- a/src/linux/btop_collect.cpp
++++ b/src/linux/btop_collect.cpp
+@@ -943,7 +943,7 @@ namespace Cpu {
+ 		try {
+ 			//? Get cpu total times for all cores from /proc/stat
+ 			string cpu_name;
+-			cread.open(Shared::procPath / "stat");
++			cread.open("@TERMUX_PREFIX@/var/btop/stat");
+ 			int i = 0;
+ 			int target = Shared::coreCount;
+ 			for (; i <= target or (cread.good() and cread.peek() == 'c'); i++) {

--- a/root-packages/btop/procstat
+++ b/root-packages/btop/procstat
@@ -1,0 +1,1 @@
+../../packages/htop/procstat


### PR DESCRIPTION
It's *almost* building.
<details><summary>Can't quite figure out the pthread errors.</summary>
<p>

```console
[2/12] Building CXX object CMakeFiles/btop.dir/src/btop.cpp.o
FAILED: CMakeFiles/btop.dir/src/btop.cpp.o
/home/builder/.termux-build/_cache/android-r28c-api-24-v2/bin/clang++ --target=aarch64-none-linux-android --gcc-toolchain=/home/builder/.termux-build/_cache/android-r28c-api-24-v2 --sysroot=/home/builder/.termux-build/_cache/android-r28c-api-24-v2/sysroot -DFMT_HEADER_ONLY -D_FILE_OFFSET_BITS=64 -I/home/builder/.termux-build/btop/build -I/home/builder/.termux-build/btop/src -isystem /home/builder/.termux-build/btop/src/include -fstack-protector-strong -Oz --target=aarch64-linux-android24  -isystem/data/data/com.termux/files/usr/include/c++/v1 -isystem/data/data/com.termux/files/usr/include -O3 -DNDEBUG -std=c++20 -fPIE -fcolor-diagnostics -Wall -Wextra -Wpedantic -fstack-clash-protection -fstack-protector -pthread -MD -MT CMakeFiles/btop.dir/src/btop.cpp.o -MF CMakeFiles/btop.dir/src/btop.cpp.o.d -o CMakeFiles/btop.dir/src/btop.cpp.o -c /home/builder/.termux-build/btop/src/src/btop.cpp
/home/builder/.termux-build/btop/src/src/btop.cpp:207:7: error: use of undeclared identifier 'pthread_timedjoin_np'
  207 |                 if (pthread_timedjoin_np(Runner::runner_id, nullptr, &ts) != 0) {
      |                     ^
/home/builder/.termux-build/btop/src/src/btop.cpp:209:4: error: use of undeclared identifier 'pthread_cancel'
  209 |                         pthread_cancel(Runner::runner_id);
      |                         ^
/home/builder/.termux-build/btop/src/src/btop.cpp:723:4: error: use of undeclared identifier 'pthread_cancel'
  723 |                         pthread_cancel(Runner::runner_id);
      |                         ^
3 errors generated.
[3/12] Building CXX object CMakeFiles/btop.dir/src/linux/btop_collect.cpp.o
FAILED: CMakeFiles/btop.dir/src/linux/btop_collect.cpp.o
/home/builder/.termux-build/_cache/android-r28c-api-24-v2/bin/clang++ --target=aarch64-none-linux-android --gcc-toolchain=/home/builder/.termux-build/_cache/android-r28c-api-24-v2 --sysroot=/home/builder/.termux-build/_cache/android-r28c-api-24-v2/sysroot -DFMT_HEADER_ONLY -D_FILE_OFFSET_BITS=64 -I/home/builder/.termux-build/btop/build -I/home/builder/.termux-build/btop/src -isystem /home/builder/.termux-build/btop/src/include -fstack-protector-strong -Oz --target=aarch64-linux-android24  -isystem/data/data/com.termux/files/usr/include/c++/v1 -isystem/data/data/com.termux/files/usr/include -O3 -DNDEBUG -std=c++20 -fPIE -fcolor-diagnostics -Wall -Wextra -Wpedantic -fstack-clash-protection -fstack-protector -pthread -MD -MT CMakeFiles/btop.dir/src/linux/btop_collect.cpp.o -MF CMakeFiles/btop.dir/src/linux/btop_collect.cpp.o.d -o CMakeFiles/btop.dir/src/linux/btop_collect.cpp.o -c /home/builder/.termux-build/btop/src/src/linux/btop_collect.cpp
/home/builder/.termux-build/btop/src/src/linux/btop_collect.cpp:937:7: error: use of undeclared identifier 'getloadavg'
  937 |                 if (getloadavg(cpu.load_avg.data(), cpu.load_avg.size()) < 0) {
      |                     ^
1 error generated.
[6/12] Building CXX object CMakeFiles/btop.dir/src/btop_tools.cpp.o
/home/builder/.termux-build/btop/src/src/btop_tools.cpp:217:30: warning: 'codecvt_utf8<wchar_t>' is deprecated [-Wdeprecated-declarations]
  217 |                         std::wstring_convert<std::codecvt_utf8<wchar_t>> conv;
      |                                                   ^
/home/builder/.termux-build/_cache/android-r28c-api-24-v2/sysroot/usr/include/c++/v1/codecvt:193:28: note: 'codecvt_utf8<wchar_t>' has been explicitly marked deprecated here
  193 | class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf8 : public __codecvt_utf8<_Elem> {
      |                            ^
/home/builder/.termux-build/_cache/android-r28c-api-24-v2/sysroot/usr/include/c++/v1/__config:982:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
  982 | #    define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
      |                                         ^
/home/builder/.termux-build/_cache/android-r28c-api-24-v2/sysroot/usr/include/c++/v1/__config:955:49: note: expanded from macro '_LIBCPP_DEPRECATED'
  955 | #      define _LIBCPP_DEPRECATED __attribute__((__deprecated__))
      |                                                 ^
/home/builder/.termux-build/btop/src/src/btop_tools.cpp:217:9: warning: 'wstring_convert<std::codecvt_utf8<wchar_t>>' is deprecated [-Wdeprecated-declarations]
  217 |                         std::wstring_convert<std::codecvt_utf8<wchar_t>> conv;
      |                              ^
/home/builder/.termux-build/_cache/android-r28c-api-24-v2/sysroot/usr/include/c++/v1/locale:3114:28: note: 'wstring_convert<std::codecvt_utf8<wchar_t>>' has been explicitly marked deprecated here
 3114 | class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 wstring_convert {
      |                            ^
/home/builder/.termux-build/_cache/android-r28c-api-24-v2/sysroot/usr/include/c++/v1/__config:982:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
  982 | #    define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
      |                                         ^
/home/builder/.termux-build/_cache/android-r28c-api-24-v2/sysroot/usr/include/c++/v1/__config:955:49: note: expanded from macro '_LIBCPP_DEPRECATED'
  955 | #      define _LIBCPP_DEPRECATED __attribute__((__deprecated__))
      |                                                 ^
/home/builder/.termux-build/btop/src/src/btop_tools.cpp:247:31: warning: 'codecvt_utf8<wchar_t>' is deprecated [-Wdeprecated-declarations]
  247 |                                 std::wstring_convert<std::codecvt_utf8<wchar_t>> conv;
      |                                                           ^
/home/builder/.termux-build/_cache/android-r28c-api-24-v2/sysroot/usr/include/c++/v1/codecvt:193:28: note: 'codecvt_utf8<wchar_t>' has been explicitly marked deprecated here
  193 | class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf8 : public __codecvt_utf8<_Elem> {
      |                            ^
/home/builder/.termux-build/_cache/android-r28c-api-24-v2/sysroot/usr/include/c++/v1/__config:982:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
  982 | #    define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
      |                                         ^
/home/builder/.termux-build/_cache/android-r28c-api-24-v2/sysroot/usr/include/c++/v1/__config:955:49: note: expanded from macro '_LIBCPP_DEPRECATED'
  955 | #      define _LIBCPP_DEPRECATED __attribute__((__deprecated__))
      |                                                 ^
/home/builder/.termux-build/btop/src/src/btop_tools.cpp:247:10: warning: 'wstring_convert<std::codecvt_utf8<wchar_t>>' is deprecated [-Wdeprecated-declarations]
  247 |                                 std::wstring_convert<std::codecvt_utf8<wchar_t>> conv;
      |                                      ^
/home/builder/.termux-build/_cache/android-r28c-api-24-v2/sysroot/usr/include/c++/v1/locale:3114:28: note: 'wstring_convert<std::codecvt_utf8<wchar_t>>' has been explicitly marked deprecated here
 3114 | class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 wstring_convert {
      |                            ^
/home/builder/.termux-build/_cache/android-r28c-api-24-v2/sysroot/usr/include/c++/v1/__config:982:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
  982 | #    define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
      |                                         ^
/home/builder/.termux-build/_cache/android-r28c-api-24-v2/sysroot/usr/include/c++/v1/__config:955:49: note: expanded from macro '_LIBCPP_DEPRECATED'
  955 | #      define _LIBCPP_DEPRECATED __attribute__((__deprecated__))
      |                                                 ^
4 warnings generated.
[11/12] Building CXX object CMakeFiles/btop.dir/src/btop_draw.cpp.o
ninja: build stopped: subcommand failed.
```

</p>
</details>

Should be a pretty easy patch, but I gotta call it a night.
There isn't that many references to `pthread` in the project, so shouldn't need a huge patch.
<img width="1677" height="933" alt="image" src="https://github.com/user-attachments/assets/d665aaf9-c762-49bf-8fd8-23a7ac07cde6" />

No idea if it's gonna work as expected once it builds, but I can't test that without a package to test.