### PR TITLE
fix(main/wasmtime): implement support for 32-bit ARM Android

### DIFF
--- a/packages/wasmtime/listenfd-32-bit-android.diff
+++ b/packages/wasmtime/listenfd-32-bit-android.diff
@@ -1,0 +1,38 @@
+--- a/src/unix.rs
++++ b/src/unix.rs
+@@ -7,6 +7,7 @@ use std::os::unix::net::{UnixDatagram, UnixListener};
+ 
+ pub type FdType = RawFd;
+ 
++#[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
+ fn is_sock(fd: FdType) -> bool {
+     unsafe {
+         let mut stat: libc::stat = mem::zeroed();
+@@ -15,6 +16,15 @@ fn is_sock(fd: FdType) -> bool {
+     }
+ }
+ 
++#[cfg(all(target_os = "android", target_pointer_width = "32"))]
++fn is_sock(fd: FdType) -> bool {
++    unsafe {
++        let mut stat: libc::stat = mem::zeroed();
++        libc::fstat(fd as libc::c_int, &mut stat);
++        (stat.st_mode as u16 & libc::S_IFMT) == libc::S_IFSOCK
++    }
++}
++
+ fn validate_socket(
+     fd: FdType,
+     sock_fam: libc::c_int,
+@@ -30,9 +40,9 @@ fn validate_socket(
+ 
+     let is_valid = unsafe {
+         let mut ty: libc::c_int = mem::zeroed();
+-        let mut ty_len = mem::size_of_val(&ty) as libc::c_uint;
++        let mut ty_len = mem::size_of_val(&ty) as libc::socklen_t;
+         let mut sockaddr: libc::sockaddr = mem::zeroed();
+-        let mut sockaddr_len = mem::size_of_val(&sockaddr) as libc::c_uint;
++        let mut sockaddr_len = mem::size_of_val(&sockaddr) as libc::socklen_t;
+         libc::getsockname(fd, &mut sockaddr, &mut sockaddr_len) == 0
+             && libc::getsockopt(
+                 fd,


### PR DESCRIPTION
- Concepts used to implement `listenfd-32-bit-android.diff` based on similar patches found in other packages like `fish` and `below`
  - `S_IFMT` is not the same type as `st_mode` on 32-bit Android
  - `socklen_t` should be passed to `getsockname()` and `getsockopt()`, not `unsigned int`

- Based on this comment, `wasmtime` now has a codepath that supports 32-bit ARM: https://github.com/bytecodealliance/wasmtime/issues/1173#issuecomment-2557605936

- This build of `wasmtime` has been tested on a 32-bit ARM Android device to run a precompiled `wasi-hello-world.wasm` that was copied from a different device, and is working successfully:
  - The `wasi-hello-world.wasm` was compiled using a GNU/Linux PC running the `cargo install cargo-component` tool via a Rust toolchain https://github.com/bytecodealliance/cargo-component

```
~ $ wasmtime wasi-hello-world.wasm
Hello, world!
~ $ uname -a
Linux localhost 3.4.112-Lineage-g716f00ee2e8 #1 SMP PREEMPT Sun Oct 13 11:16:54 CDT 2019 armv7l Android
~ $
```

- 32-bit x86 still has an error which is different and does not appear during the build for 32-bit ARM