### PR TITLE
fix(main/mujs): condense `build.sh`

### DIFF
--- a/packages/mujs/build.sh
+++ b/packages/mujs/build.sh
@@ -3,26 +3,14 @@ TERMUX_PKG_DESCRIPTION="A lightweight Javascript interpreter designed for embedd
 TERMUX_PKG_LICENSE="ISC"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.3.7
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://codeberg.org/ccxvii/mujs/archive/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=5701ac8314d7cb9c792d620c066d93682a74c43f2a49a8966014de05afec5d6a
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="readline"
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXTRA_MAKE_ARGS="HAVE_READLINE=yes"
 
 termux_step_pre_configure() {
-	CFLAGS+=" -I$TERMUX_PREFIX/include"
-	LDFLAGS+=" -L$TERMUX_PREFIX/lib"
-}
-
-termux_step_make() {
-	make release \
-		prefix=$TERMUX_PREFIX \
-		HAVE_READLINE=yes \
-		CC="$CC" \
-		CFLAGS="$CFLAGS $CPPFLAGS" \
-		LDFLAGS="$LDFLAGS"
-}
-
-termux_step_make_install() {
-	make install prefix=$TERMUX_PREFIX
+	CFLAGS+=" $CPPFLAGS"
 }

--- a/packages/mujs/ldflags.patch
+++ b/packages/mujs/ldflags.patch
@@ -1,10 +1,25 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -109,7 +109,7 @@ build/release/libmujs.a: build/release/libmujs.o
- 	$(AR) cr $@ $^
- build/release/mujs: main.c build/release/libmujs.o
--	$(CC) $(CFLAGS) $(OPTIM) -o $@ $^ -lm $(READLINE_CFLAGS) $(READLINE_LIBS)
-+	$(CC) $(CFLAGS) $(OPTIM) $(LDFLAGS) -o $@ $^ -lm $(READLINE_CFLAGS) $(READLINE_LIBS)
- build/release/mujs-pp: pp.c build/release/libmujs.o
- 	$(CC) $(CFLAGS) $(OPTIM) -o $@ $^ -lm
+@@ -4,11 +4,11 @@
  
+ default: build/debug/mujs build/debug/mujs-pp
+ 
+-CFLAGS = -std=c99 -pedantic -Wall -Wextra -Wno-unused-parameter
++CFLAGS ?= -std=c99 -pedantic -Wall -Wextra -Wno-unused-parameter
+ 
+ OPTIM = -O3
+ 
+-prefix = /usr/local
++prefix ?= /usr/local
+ bindir = $(prefix)/bin
+ incdir = $(prefix)/include
+ libdir = $(prefix)/lib
+@@ -33,7 +33,7 @@ HDRS = mujs.h jsi.h regexp.h utf.h astnames.h opnames.h utfdata.h
+ 
+ ifneq ($(HAVE_READLINE),no)
+   READLINE_CFLAGS = -DHAVE_READLINE
+-  READLINE_LIBS = -lreadline
++  READLINE_LIBS = $(LDFLAGS) -lreadline
+ endif
+ 
+ SRCS = \


### PR DESCRIPTION
- See https://github.com/termux/termux-packages/pull/26862#issuecomment-3397630045

- Prefer `$CPPFLAGS` over explicit `-I$TERMUX_PREFIX/include`

- Prefer `TERMUX_PKG_EXTRA_MAKE_ARGS` over explicit `termux_step_make()`

- Fix `Makefile` to respect environment `CFLAGS` and `prefix`