### PR TITLE
tar: another hard link bites the dust

### DIFF
--- a/packages/tar/another-hardlink.patch
+++ b/packages/tar/another-hardlink.patch
@@ -1,0 +1,11 @@
+--- tar-1.35/src/extract.c	2023-07-10 13:13:55.000000000 +0300
++++ src/src/extract.c	2025-09-22 11:47:15.534159916 +0300
+@@ -1507,7 +1507,7 @@
+     {
+       struct stat st1, st2;
+       int e;
+-      int status = linkat (chdir_fd, link_name, chdir_fd, file_name, 0);
++      int status = symlinkat (link_name, chdir_fd, file_name);
+       e = errno;
+ 
+       if (status == 0)


### PR DESCRIPTION
this hard link caused unzip to fail to install in debian proot

proot -r ../debian /bin/bash
apt install unzip

this aborted my hundred packets large R install from r-base-core packet

try to find a message about this up stream . the world is going mobile every one is away . need debian on the go. debian has a gazillion packet and many work you can use it on the train

 the debian must be freed from tyranny of the hard links. we have suffered too much for too long. we must rise up against the tyrant over mind and drape the world in soft links

 # the road ahead for proot debian . new minimal debian proot boot strap . minimal down load

 this might be included in termux on first use and recommend in /etc/motd . some people have never heard about debian repo in termux or avoid the large pre download image for proot-distro . only around fifty meg is necessary to boot strap debian with apt config file

a new debian.conf file for apt can be included to boot strap new debian proot

 apt -c debian.conf install apt bash

I avoided proot-distro in the longest because of the large pre download several hundred meg . try to work on my dpkgx boot strap approach where only fifty meg is required to start a distro. it should show up in a search I am offline now so I can't try it

gh search commits dpkgx

gh search ...  --author john-peterson dpkgx

all distro work with the same principle all placket manager can be tricked to install itself in a folder . that can then live on its own

I can only ask every one to try debian on their phone so I don't have to patch every thing for it myself . It has one killer app R that i need on my phone more than anything . x86  compiler to test qemu and endless more useful packets already built for arm64 and running in termux with no or minimal patches needed
