### PR TITLE
dpkg: another hard link removed for debian sid packets

### DIFF
--- a/packages/dpkg/another-hardlink.patch
+++ b/packages/dpkg/another-hardlink.patch
@@ -1,0 +1,11 @@
+--- archives.c	2025-09-22 12:42:56.058534783 +0300
++++ src/src/main/archives.c	2025-09-22 12:43:12.130534772 +0300
+@@ -434,7 +434,7 @@
+     if (linknode->flags & (FNNF_DEFERRED_RENAME | FNNF_NEW_CONFF))
+       varbuf_add_str(&hardlinkfn, DPKGNEWEXT);
+     varbuf_end_str(&hardlinkfn);
+-    if (link(hardlinkfn.buf, path))
++    if (symlink(hardlinkfn.buf, path))
+       ohshite(_("error creating hard link '%.255s'"), te->name);
+     namenode->newhash = linknode->newhash;
+     debug(dbg_eachfiledetail, "tarobject hardlink digest=%s", namenode->newhash);


### PR DESCRIPTION
already put this in gpkg folder

here also if it gets lost

the reason I notice this now is because for last ten years hardly any one has used debian in termux apparently. the debian arm64 repo is at least five years old maybe ten.

R works out of the box with no error. dotnet worked for years probably but i only began using this last year  when I could not run a dotnet app

the termux packets don't use hard links and are not affected by this

 # hard link should fall back to soft link

 apps should be robust not fail on meaningless limitation

 this has nothing to do with android and should not be behind a pre compilation flag. any system could have this limit

 all builds should fall back to soft links before error is produced

 # my debian apt works again but proot repo is needed

I managed to break my debian root by using different status files for dpkg and apt. but I fixed it now and can  install again. R is what I need more than anything and it installs now with no error in debian Sid  also called unstable repo

it should be in /var/lib/dpkg/status but my dpkg build was using /data/data/... instead . so apt would just install everything over and over and never be satisfied

I have proposed a new proot folder for this specific purpose to get rid of /data/data
