### PR TITLE
new proot repo: no prefix . works in  any terminal . less patches.  faster updates . fix debian proot. safe build 

### DIFF
--- a/packages/test/Makefile.am
+++ b/packages/test/Makefile.am
@@ -1,0 +1,4 @@
+
+bin_PROGRAMS = test
+
+test_SOURCES = test.c

--- a/packages/test/build.sh
+++ b/packages/test/build.sh
@@ -1,23 +1,88 @@
 TERMUX_PKG_DESCRIPTION="empty test packet for build system "
 TERMUX_PKG_VERSION=0
 TERMUX_PKG_LICENSE="WTFPL"
+TERMUX_PKG_NO_ELF_CLEANER=true
+
+termux_step_post_get_source() {
+
+cp  $TERMUX_PKG_BUILDER_DIR/* $TERMUX_PKG_SRCDIR/ -r
+}
 
 termux_step_pre_configure() {
+	:
+	set +e
+	pwd
+	# exit
+	# tree
+	(echo CC=$CC)
+	(echo CXXFLAGS=$CXXFLAGS)
+	# CC=gcc
+	# exit
+	
+# tree $TERMUX_PKG_MASSAGEDIR
+# exit
+
 # echo $TERMUX_PREFIX
 # echo $TERMUX_PREFIX_CLASSICAL
 # echo $TERMUX_TOPDIR
 # exit
-$TERMUX_ON_DEVICE_BUILD && test TERMUX_PREFIX = TERMUX_PREFIX_CLASSICAL && echo unsafe prefix detected && exit
-pwd
-touch a
+$TERMUX_FAST_BUILD && echo fast build detected
+$TERMUX_PKG_PROOT && echo proot build detected
+$TERMUX_SAFE_BUILD && echo safe build detected
+# exit
+# $TERMUX_ON_DEVICE_BUILD && test TERMUX_PREFIX = TERMUX_PREFIX_CLASSICAL && echo unsafe prefix detected && exit
+# pwd
+# touch a
 # touch configure.in
 # exit
+set -e
+# autoreconf -fi
+# ack CXXFLAGS
+}
+
+termux_step_post_configure() {
+	pwd
+	mkdir bin etc -vp
+echo prefix=$TERMUX_PREFIX_INSTALL | tee etc/a
+touch bin/b
+
+# mkdir man
+# touch man/c
+
+tree $TERMUX_PKG_MASSAGEDIR
 }
 
 termux_step_post_make_install() {
 	pwd
-	mkdir -p $TERMUX_PREFIX
-	cp $TERMUX_PKG_SRCDIR/* $TERMUX_PREFIX/
+	
+tree $TERMUX_PKG_MASSAGEDIR
+# exit
+
+	# echo base=$TERMUX_PKG_MASSAGEDIR_BASE
+	# exit
+	# mkdir -p $TERMUX_PREFIX_INSTALL
+	# mkdir -p $TERMUX_PKG_MASSAGEDIR_PAK
+	mkdir -p $TERMUX_PKG_MASSAGEDIR_BASE
+
+	# install results 
+	cp $TERMUX_PKG_BUILDDIR/* $TERMUX_PKG_MASSAGEDIR_BASE/ -r 
+	# cp $TERMUX_PKG_BUILDDIR/* $TERMUX_PREFIX_INSTALL/ -rv
 # install -Dm700 -t $TERMUX_PREFIX/ $TERMUX_PKG_SRCDIR/a
+echo install done
+echo
+
 # cat $TERMUX_PKG_SRCDIR/configure.in
+}
+
+termux_step_post_massage() {
+	set +e
+	pwd
+	tree
+	# tree $TERMUX_PKG_MASSAGEDIR
+	cat etc/a
+	# env | sort | ack ANDROID
+	# env | sort | ack CFLAG
+	(echo CC=$CC)
+	$TERMUX_PKG_BUILDDIR/test
+	set -e
 }

--- a/packages/test/configure.ac
+++ b/packages/test/configure.ac
@@ -1,0 +1,8 @@
+AC_INIT([test], [1.0])
+AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+AC_ARG_ENABLE
+AC_PROG_CC
+AC_PROG_CXX
+AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/packages/test/test.c
+++ b/packages/test/test.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+int main() {
+	printf("test program running\n");
+#ifdef __ANDROID__
+	printf("android flag detected\n");
+#endif
+#ifdef __BIONIC__
+	printf("bionic flag detected\n");
+#endif
+#ifdef __GLIBC__
+	printf("glibc flag detected\n");
+#endif
+#ifdef __TERMUX__
+	printf("termux flag detected\n");
+#endif
+	return 0;
+}

--- a/scripts/build/configure/termux_step_configure_autotools.sh
+++ b/scripts/build/configure/termux_step_configure_autotools.sh
@@ -22,7 +22,7 @@ termux_step_configure_autotools() {
 		HOST_FLAG=""
 	fi
 
-	local LIBEXEC_FLAG="--libexecdir=$TERMUX_PREFIX/libexec"
+	local LIBEXEC_FLAG="--libexecdir=$TERMUX_PREFIX_BASE/libexec"
 	if [ "$TERMUX_PKG_EXTRA_CONFIGURE_ARGS" != "${TERMUX_PKG_EXTRA_CONFIGURE_ARGS/--libexecdir=/}" ]; then
 		LIBEXEC_FLAG=""
 	fi
@@ -103,9 +103,9 @@ termux_step_configure_autotools() {
 	# shellcheck disable=SC2086
 	env $AVOID_GNULIB "$TERMUX_PKG_SRCDIR/configure" \
 		--disable-dependency-tracking \
-		--prefix=$TERMUX_PREFIX \
-		--libdir=$TERMUX_PREFIX/lib \
-		--sbindir=$TERMUX_PREFIX/bin \
+		--prefix=$TERMUX_PREFIX_BASE \
+		--libdir=$TERMUX_PREFIX_BASE/lib \
+		--sbindir=$TERMUX_PREFIX_BASE/usr/bin \
 		--disable-rpath --disable-rpath-hack \
 		$HOST_FLAG \
 		$TERMUX_PKG_EXTRA_CONFIGURE_ARGS \

--- a/scripts/build/setup/termux_setup_ninja.sh
+++ b/scripts/build/setup/termux_setup_ninja.sh
@@ -19,7 +19,7 @@ termux_setup_ninja() {
 			chmod 755 $NINJA_FOLDER/ninja
 		fi
 		export PATH=$NINJA_FOLDER:$PATH
-	else
+	elif ! $TERMUX_FORCE_BUILD; then
 		local NINJA_PKG_VERSION=$(bash -c ". $TERMUX_SCRIPTDIR/packages/ninja/build.sh; echo \$TERMUX_PKG_VERSION")
 		if ([ ! -e "$TERMUX_BUILT_PACKAGES_DIRECTORY/ninja" ] ||
 		    [ "$(cat "$TERMUX_BUILT_PACKAGES_DIRECTORY/ninja")" != "$NINJA_PKG_VERSION" ]) &&

--- a/scripts/build/termux_create_debian_subpackages.sh
+++ b/scripts/build/termux_create_debian_subpackages.sh
@@ -151,6 +151,6 @@ termux_create_debian_subpackages() {
 				   "$SUB_PKG_PACKAGE_DIR/data.tar.xz"
 
 		# Go back to main package:
-		cd "$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX_CLASSICAL"
+		cd "$TERMUX_PKG_MASSAGEDIR_BASE"
 	done
 }

--- a/scripts/build/termux_create_pacman_subpackages.sh
+++ b/scripts/build/termux_create_pacman_subpackages.sh
@@ -213,6 +213,6 @@ termux_create_pacman_subpackages() {
 		shopt -u dotglob globstar
 
 		# Go back to main package:
-		cd "$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX_CLASSICAL"
+		cd "$TERMUX_PKG_MASSAGEDIR_BASE"
 	done
 }

--- a/scripts/build/termux_step_extract_into_massagedir.sh
+++ b/scripts/build/termux_step_extract_into_massagedir.sh
@@ -1,4 +1,5 @@
 termux_step_extract_into_massagedir() {
+	echo running tar -N on system. use --safe to skip ... 
 	local TARBALL_ORIG=$TERMUX_PKG_PACKAGEDIR/${TERMUX_PKG_NAME}_orig.tar.gz
 
 	# Build diff tar with what has changed during the build:

--- a/scripts/build/termux_step_setup_build_folders.sh
+++ b/scripts/build/termux_step_setup_build_folders.sh
@@ -35,10 +35,11 @@ termux_step_setup_build_folders() {
 		 "$TERMUX_PKG_TMPDIR" \
 		 "$TERMUX_PKG_CACHEDIR" \
 		 "$TERMUX_PKG_MASSAGEDIR"
+	# $TERMUX_SAFE_BUILD && return || true
 	if [ "$TERMUX_PACKAGE_LIBRARY" = "bionic" ]; then
-		mkdir -p $TERMUX_PREFIX/{bin,etc,lib,libexec,share,share/LICENSES,tmp,include}
+		mkdir -p $TERMUX_PREFIX_BUILD/{bin,etc,lib,libexec,share,share/LICENSES,tmp,include}
 	elif [ "$TERMUX_PACKAGE_LIBRARY" = "glibc" ]; then
-		mkdir -p $TERMUX_PREFIX/{bin,etc,lib,share,share/LICENSES,include}
-		mkdir -p $TERMUX_PREFIX_CLASSICAL/{bin,etc,tmp}
+		mkdir -p $TERMUX_PREFIX_BUILD/{bin,etc,lib,share,share/LICENSES,include}
+		mkdir -p $TERMUX_PREFIX_BUILD_CLASSICAL/{bin,etc,tmp}
 	fi
 }

--- a/scripts/build/termux_step_start_build.sh
+++ b/scripts/build/termux_step_start_build.sh
@@ -62,7 +62,7 @@ termux_step_start_build() {
 		fi
 	fi
 
-	echo "termux - building $TERMUX_PKG_NAME for arch $TERMUX_ARCH..."
+	echo "termux - building $TERMUX_PKG_NAME for $TERMUX_PACKAGE_LIBRARY $($TERMUX_PKG_PROOT && echo "proot ")$TERMUX_ARCH from $TERMUX_PKG_BUILDER_SCRIPT ..."
 	test -t 1 && printf "\033]0;%s...\007" "$TERMUX_PKG_NAME"
 
 	# Avoid exporting PKG_CONFIG_LIBDIR until after termux_step_host_build.
@@ -88,7 +88,7 @@ termux_step_start_build() {
 		termux_error_exit "Package '$TERMUX_PKG_NAME' is not available for on-device builds."
 	fi
 
-	if [ "$TERMUX_PACKAGE_LIBRARY" = "bionic" ]; then
+	if ! $TERMUX_PKG_NO_ELF_CLEANER && [ "$TERMUX_PACKAGE_LIBRARY" = "bionic" ]; then
 		if [ "$TERMUX_ON_DEVICE_BUILD" = "true" ]; then
 			case "$TERMUX_APP_PACKAGE_MANAGER" in
 				"apt") apt install -y termux-elf-cleaner;;

--- a/scripts/build/toolchain/termux_setup_toolchain_gnu.sh
+++ b/scripts/build/toolchain/termux_setup_toolchain_gnu.sh
@@ -1,5 +1,5 @@
 termux_setup_toolchain_gnu() {
-	export CFLAGS="-O2 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection"
+	export CFLAGS="-O2 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -D__ANDROID__"
 	export CPPFLAGS=""
 	export LDFLAGS=""
 
@@ -20,10 +20,10 @@ termux_setup_toolchain_gnu() {
 		export CXXFILT=$TERMUX_HOST_PLATFORM-c++filt
 	fi
 
-	if [ ! -d "$TERMUX_PREFIX/lib/" ]; then
+	if [ ! -d "$TERMUX_PREFIX_BUILD/lib/" ]; then
 		termux_error_exit "glibc library directory was not found ('$TERMUX_PREFIX/lib/')"
 	fi
-	if [ ! -d "$TERMUX_PREFIX/include/" ]; then
+	if [ ! -d "$TERMUX_PREFIX_BUILD/include/" ]; then
 		termux_error_exit "glibc header directory was not found ('$TERMUX_PREFIX/include/')"
 	fi
 
@@ -40,9 +40,9 @@ termux_setup_toolchain_gnu() {
 		CFLAGS+=" -march=i686"
 		export DYNAMIC_LINKER="ld-linux.so.2"
 	fi
-	export PATH_DYNAMIC_LINKER="$TERMUX_PREFIX/lib/$DYNAMIC_LINKER"
+	export PATH_DYNAMIC_LINKER="$TERMUX_PREFIX_RUN/lib/$DYNAMIC_LINKER"
 
-	if [ ! -f "$PATH_DYNAMIC_LINKER" ]; then
+	if ! $TERMUX_PKG_PROOT && [ ! -f "$PATH_DYNAMIC_LINKER" ]; then
 		termux_error_exit "glibc dynamic linker was not found ('$PATH_DYNAMIC_LINKER')"
 	fi
 

--- a/scripts/proot
+++ b/scripts/proot
@@ -1,0 +1,118 @@
+#!/bin/env bash
+# set -x
+
+# remove prefix from non proot build 
+
+# repack_to_proot dpkg
+
+TERMUX_PKG_REPACK=false
+
+repack_to_proot(){
+	local app=$1
+
+down load
+un pack
+
+termux_replace_prefix $PREFIX ""
+
+# if bionic
+# 	patchelf --set-rpath /bionic $elf
+# if glibc
+# patchelf --set-interpreter /usr/lib/ld-linux-aarch64.so.1 $elf
+
+repack
+upload
+}
+
+termux_replace_prefix() {
+	set +e
+	local  old new count
+	old=$1
+	new=$2
+
+	count=$(ls -R|wc|tr -s " "|cut -f2 -d" ")
+	test $count -gt 200 && echo $(pwd) contains $count files. aborting && return
+	printf '%s\0' "${replaced_prefix[@]}" | grep -q -F -x -z -- "$old" && return
+	replaced_prefix+=($old)
+	test $old = "$new" && return
+
+	echo termux - massage - replacing prefix $old with $new ...
+	while IFS= read -r f; do
+		# echo $f
+		if file $f | grep -q "ASCII"; then
+			# echo found text file $f
+			if grep -q $old $f; then
+				if ! $TERMUX_PKG_REPACK; then
+					echo prefix found inside $f . this should not happen . add -f -C to ignore and replace
+					$TERMUX_FORCE_BUILD || exit
+				fi
+				sed -i "s,$old,$new,g" $f
+			fi
+		fi
+
+		if file $f | grep -q "ELF"; then
+			# echo found bin file $f
+			(patchelf --set-interpreter $PATH_DYNAMIC_LINKER $f)
+			if $TERMUX_PKG_REPACK && [ "$TERMUX_PACKAGE_LIBRARY" = "bionic" ]; then
+				(patchelf --set-rpath /bionic $f)
+			fi
+			if strings $f | grep -q $old; then
+				if ! $TERMUX_PKG_REPACK; then
+					echo prefix found inside $f . this should not happen . add -f -C to ignore and replace
+					$TERMUX_FORCE_BUILD || exit
+				fi
+				replace_in_binary $f $old "$new"
+			fi
+		fi
+
+	done < <(find -type f)
+	# exit
+	set -e
+}
+
+# by Johan hedin
+replace_in_binary() {
+local FILE="$1"
+local PATTERN="$2"
+local REPLACEMENT="$3"
+
+# Find all unique strings in FILE that contain the pattern 
+STRINGS=$(strings ${FILE} | grep ${PATTERN} | sort -u -r)
+
+if [ "${STRINGS}" = "" ] ; then
+	echo "File '${FILE}' not contain strings with '${PATTERN}' in them:"
+	return
+fi
+
+echo "File '${FILE}' contain strings with '${PATTERN}' in them:"
+
+for OLD_STRING in ${STRINGS} ; do
+	# Create the new string with a simple bash-replacement
+	NEW_STRING=${OLD_STRING//${PATTERN}/${REPLACEMENT}}
+
+	# Create null terminated ASCII HEX representations of the strings
+	OLD_STRING_HEX="$(echo -n ${OLD_STRING} | xxd -g 0 -u -ps -c 256)00"
+	NEW_STRING_HEX="$(echo -n ${NEW_STRING} | xxd -g 0 -u -ps -c 256)00"
+
+	if [ ${#NEW_STRING_HEX} -le ${#OLD_STRING_HEX} ] ; then
+		# Pad the replacement string with null terminations so the
+		# length matches the original string
+		while [ ${#NEW_STRING_HEX} -lt ${#OLD_STRING_HEX} ] ; do
+			NEW_STRING_HEX="${NEW_STRING_HEX}00"
+		done
+
+		# Now, replace every occurrence of OLD_STRING with NEW_STRING 
+		echo -n "Replacing ${OLD_STRING} with ${NEW_STRING}... "
+		hexdump -ve '1/1 "%.2X"' ${FILE} | \
+			sed "s/${OLD_STRING_HEX}/${NEW_STRING_HEX}/g" | \
+			xxd -r -p > ${FILE}.tmp
+					chmod --reference ${FILE} ${FILE}.tmp
+					mv ${FILE}.tmp ${FILE}
+					echo "Done!"
+				else
+					echo "New string '${NEW_STRING}' is longer than old" \
+						"string '${OLD_STRING}'. Skipping."
+	fi
+done
+}
+


### PR DESCRIPTION
new proot repo: no prefix . works in  any terminal . less patches.  faster updates . fix debian proot. safe build 

vim:ft=text

the following down to  double horizontal rule is updates since  first post  



# should I split the patch 


I can split this patch  to make is easier to merge 

--fast is smallest 

--safe changes make install to install DESTDIR=massage . and adds replace function because cargo doesn't support safe builds 

--proot for prefix= blank changes massage setup folders configure 

the rest was necessary to even test this and can be another patch 



# new repo name only proot not  termux-proot 

update I would like the new repo to be called only proot not termux-proot . since the whole point is to get rid of the termux name . it doesn't have any mention of the word termux the prefix is gone

so the address is

deb https://packages.termux.dev/apt/proot/ proot sid

not 

deb https://packages.termux.dev/apt/termux-proot/ proot sid




# tentative  cargo safe build  . cargo patch needed to separate root and install path

this patch is in proot5 john-peterson/termux-packages@proot5

this is the best solution I could find to change the prefix essentially . apps will break if they try to use this path . it's only for staging the install not the actual install path

the new replace function can be used on the massage folder to get rid of the root for safe builds . or is already used

I haven't found any actual app that use the root flag . this has to be solved when when the problem appears . when some one needs a safe cargo build

 # there is no cargo staging dir for side loading install

cargo doesn't separate prefix and install path the same way as auto tools . this could be patched in future cargo versions

I  found this flag but it's not correct it still install to abc

	CARGO_INSTALL_ROOT=123 cargo install --path . --root abc

I tried these with no effect

	CARGO_DESTDIR=123
	CARGO_DEST_DIR=123
	CARGO_INSTALL_DIR=123

I'm looking for the cargo equivalent of

	configure --prefix=abc
	make install DESTDIR=123

this command should not install $PREFIX/bin/test

	bash build-package.sh -s -f test --safe --fast
	$PREFIX/bin/test
  

# update I think I found a way to use termux-main packets in my other terminal 

just like proot can fake access to / it can fake access to /data/data/com.termux from another terminal with  different name

instead of binding /data:/data I bind to my data folder $DATA . so I get access to  /data

I tried this in termux

DATA=/data/data/com.termux
mkdir $DATA/data
ln -s $DATA $DATA/data/com.termux
proot -r $PREFIX ... -b $DATA:/data /bin/bash

termux bionic still works . and I now have  access to /data and can put anything I want there

ls /data
$DATA content ...

tree $DATA/data
/data/data/com.termux/data
├── com.termux -> /data
└── open.term
3 directories, 0 files

this same proot now also has access to /data/data/open.term . which could contain another terminal 

I should be able to run apps from any terminal now . for instance this packet 

configure --prefix=/data/data/open.term/bionic

if I create a proot for that terminal 

the reverse should work from another terminal . so with a crux termux-main packets still work with proot  in another terminal with another name . that don't have access to the real /data/data/com.termux folder . albeit some what more convoluted  than a blank prefix 

until there is a proot repo this might work also . I think all this should be linked and explained from /etc/motd because it's prime importance to new users . to decide the best approach 

---

I would still  prefer to not use the prefix at all . I might be biased but I am so utterly sick of it I can't stand it . it's nothing but a thorn in my side and a beak in my eye . only create problems for no reason 

I have not promoted this idea any where .  if this is merged some one that use the build system might notice it . so merging this is a promotion in itself . some one might see the --proot flag and learn about it that way 

I have infinite patience with all this 

I realised proot can also run termux-main in another terminal . the prefix can also be faked just like blank prefix  . so I don't need another android repo for my other terminals 

I can still use this for safe builds for myself . or debian proot fixes . and so can anyone else that find this patch 


---
---

here is the original message 

instead of mixing proot and non-proot packets it's best to keep them separate. to make it clear that proot is required and expected

I need to update packets in gpkg folder and remove patches and build from master  and need a separate folder for this to not disturb the regular build

I need packets for my broken debian proot that I can extract over the broken files . hard links is the most common cause. the killer app for me is R that I need to install. this purpose would only cause confusion and disagreement in the same folder  there has to be two separate folders gpkg and proot

I need to run several terminals with different names and need to host terminal agnostic android packets with no reference to /data/data folder 

I need safe build on device that don't disturb system files . I don't want to write any thing to system folder. and not wait for tar -N to find a needle in a hay stack . I want every thing in a separate folder before I test and install it

  proot packets should work in any android terminal or Ubuntu or debian .  system agnostic

this will improve debian sid packets in proot and bug hunting in debian proot. if the packet works in this repo the debian build should work too . if the android pre compilation flag can be avoided  

for instance should help me find the strange bug that prevents apt from reading the cert file and download files that I encountered in the gpkg folder . even in glibc proot . perhaps building with blank prefix solve it

the end result is that debian proot finally works and everything is latest version and should build from master.  this is a desirable goal

the work flow running and testing apps  is then

debian > proot > glibc prefix proot > glibc non proot > bionic

more and more bugs appear in this succession 

test debian proot packet in termux if it works no problem why bother further the packet exists and works. if broken create termux proot build file. find bug . push fix up stream

patches that are not needed in proot repo is less likely to be accepted up stream . they can be considered use less or too specific for android 

the proot folder should contain minimum amount of  patches . it is the fastest place to add and update apps. I am adding R language from r-base-core but only for prot. it has many dependency one hundred . and creating patches takes too long that could be why no one has added it . maybe with this build flag more packets can be added  

it still takes time to create new build.sh file . even if you find the debian/control and rules files for reference from debian build . but this is the minimal effort build with least possible patches needed . and the best place to start 

the packet will install in home folder or inside Ubuntu  or any android terminal because the /data/data/com.termux prefix is finally gone. the prefix is completely gone from the final files 

this is another step for bug hunting by running the termux proot packet inside Ubuntu or debian . if the problem can be reproduced in another root or if the same build works in another root . can help finding the bug



 # repo name and suite 

I want to host this  where others can find it that need it . the best place would be along the other termux repos

deb https://packages.termux.dev/apt/termux-proot/ proot sid

 the  suite name sid mirror the debian sid repo that is an inspiration for this repo . sid means staging in development also called unstable to indicate recent  version . the only difference being the android pre compilation flag was not used in debian packets . they should other wise be identical

 help to upload these packets is appreciated by some one else that likes this idea 


 # different terminals along side each other in parallel  

 i need to run the other android terminals and my experimental forks and possibly older versions  along side each other and not over write each other every single time  . it is dangerous and practical impossible 

 or use the same data folder . I sync my home folder and let the rest be separate for testing 

 I have changed the name com.termux to open.term for  my experimental patches to let me use my fork along side the main line terminal that every one else use . at the same time with out over writing the same app

 if there is a version code mis match all files may be deleted . I would rather not take that chance 

   my  collaborator monet change versionCode 118 to 1020 by accident so I can't over write it with the main line build  with out deleting all files 

  down grades are not allowed so you have to delete the app and all app files . effectively down grades in version code delete all files 




 # how to add new proot auto builds

this is an incubating feature that require effort to get started. it depends on every one adding the packet they need.  and patching the build system as needed to separate install and run paths 

I tried auto tools with dpkg and tar 

off device first test the normal glibc build 

bash build-package.sh -I --library glibc abc

then proot

bash build-package.sh -s --proot abc

this build should be identical but with blank prefix and debian paths usr/bin instead of bin etc

. if prefix is still detected build system will protest and will offer option to remove it from all app files  by brute replacement 


--proot implies  --safe build in  next section that give more control over the build  


 # WIP --safe builds with new prefix vars 

this flag also works with out proot for safe builds that don't touch the system of building on device 

bash build-package.sh -s  abc --safe 

now another thing can happen first 

the massage folder is empty meaning the install went to the old TERMUX_PREFIX instead of the new

TERMUX_PREFIX_INSTALL=$TERMUX_PKG_MASSAGEDIR$TERMUX_PREFIX_RUN

the first step is to install to the new prefix . to single out where the install prefix was inserted and get a handle on where the prefix comes from  
various disabled code in the patch is for this purpose . for instance changing the old prefix whole sale and see what happens 

once the files install to the new prefix the next step is to get rid of it completely if possible or insert the run or base prefix instead of the install prefix 

TERMUX_PREFIX_BASE=
TERMUX_PREFIX_BUILD=$TERMUX_PREFIX
TERMUX_PREFIX_RUN=/usr

if the build or install prefix is detected in the resulting binary file the various prefix has to be inserted in some way to  replace it with the run prefix

most build systems should allow this other wise cross compiling would be impossible because it requires different folders for build and install 

 auto tools use make install DESTDIR=abc to redirect the files else where .  I only tested auto tools make . cmake should also work with make . the other build systems ninja meson etc may need more patches

the prefix itself is inflexible . there is no --disable-prefix to read prefix from $PREFIX. it is always decided at compilation and hard coded . the only possible universal prefix is no prefix . empty blank prefix  


if it  is impossible in some packet  to install in arbitrary location the build file has to be patched where it is inserting the install prefix as run path

or  use the new repack function that should not be needed when building from scratch  . this will replace all strings in both text and elf files 

termux_replace_prefix old new


 if you have any ideas or goals similar to mine message me on Google chat with your ideas. if you like this idea we can work towards that goal of creating proot packets that have standard paths every where. for debian proot or any distro or termux proot or any terminal

if you are also interested in proot auto builds that makes two of us . that's twice the fun . more friends than Copernicus . I have built dpkg and tar so far tell me which you built. you can solicit more interest in this through the discussion pages or a google chat group 

the goal is a proot packet that is guaranteed to use the right paths. it might not work immediately but this is a step in that direction. the right implementation will materialise eventually even if it is cloudy now



 # manual build with proot

if you only need a single packet for yourself you don't need this patch . just set prefix=/usr or blank

on device build require proot. off device build require arm and -s flag and sudo and can only use system libs


 # implementation. no -proot suffix in dependency tree or packet names 

it's impossible to reference bionic directly to avoid a -proot  suffix but pakages will be searched last when building 

packet name test   will search for proot/test gpkg/test packages/test in that order   . test-glibc is gpkg/test only but I prefer to remove the glibc suffix also 

there is no -proot suffix  in the dpkg status file and dependency tree. the first to add a proot dependency link has the honour of testing it. I have only built against -glibc dependency 

when the repo exists on line dependency down load can be tested


 # generous retention policy in new repo to save battery  on poor connection


since I am involved in a new repo I have one wish  don't delete old packets. to avoid down load new Packages file and especially Contents  . if only one version is online apt down load constantly report error and ask for index update 

on a desktop this is not noticeable only on mobile with poor connection it could drain all battery to down load a few meg . the radio will attempt up to three watts on a poor signal and down load slow  . I usually have a week's battery on one charge if I don't waste it on bad connection 

keep all packets for at least a year at least small files . and calculate the additional cost .     it is not expensive if every one donate a small amount  

this has limited implication for this new tiny repo . but hopefully my wish can be extended beyond this repo . the bionic main and x11 repos are ten meg un compressed  . debian sid is seventy thousand packets and fifty meg file index compressed millions of files

many packets are only a few hundred k and can easily be fetched with a poor connection if they still exist . the Packages files are several meg compressed  

and old versions can still be useful . some times the old library file can be extracted to lib if it's a different name based on version . if it still exist if the packet can still be down loaded apt or links with the http folder name in the apt error message . if the packet is gone all hope is lost 

 ## partial solution disable apt-file.conf and reduce update size 

if apt-file try to update the Contents file the problem is ten times worse .  I don't need an updated contents file the old one is fine

the Contents file is ten times the Packages file compressed . packages is stored un compressed but I think it's down loaded compressed . if apt-file.conf is present Contents is also updated at the same time

if I delete apt.conf.d/50apt-file.conf apt-file stop working also. if I disable it and don't update the Contents file it reports version mismatch . probably from  check sum in InRelease

I think I have solved it with a separate config file and lists folder for apt-file

mv  $P/etc/apt/apt.conf.d/50apt-file.conf{,.disabled}
cp $P/var/lib/apt/{lists/*,old/}
alias apt-file="apt-file -c ~/etc/apt-file.conf"
Dir::State::lists "lists/old";



 # test. build dpkg for debian and run R

the bionic build of dpkg require --admindir flag  and debian build fail on hard links. so no repo has a working android version with default paths . and two new hard link patches were needed for dpkg and tar

I was able to build dpkg on device to replace the broken debian version from gpkg/dpkg from john-peterson/glibc-packages@apt

ln -s ~/glibc-packages/gpkg gpkg
bash build-package.sh -s --proot dpkg -f 
DATA=/data/data/com.termux
D=$DATA/debian
dpkg -x proot/dpkg_* $D/
proot ... -r $D /bin/bash

I use a boot strap to get started not the image file that proot-distro use. I also need a different shorter path for $D

john-peterson/john-peterson@master /dpkgx
john-peterson/glibc-packages@debian

if the resolve file is empty apt can not down load. but this is all that is needed around fifty meg for a working debian root

cp $P/etc/inputrc ~/.inputrc
cp $G/etc/resolv.conf /etc/

here is in debian proot

R
t.test(rnorm(15, mean=2))

  One Sample t-test

data:  rnorm(15, mean = 2)
t = 7.0658, df = 14, p-value = 5.632e-06
alternative hypothesis: true mean is not equal to 0
95 percent confidence interval:
 1.553405 2.907495
sample estimates:
mean of x
  2.23045

the following picture demonstrate working plots from the linear model demo

https://imgur.com/gallery/QJDrk9a
https://imgur.com/gallery/e6mXD2d

success. this was my aim to install R for mobile use

---

this is more explanation of --safe flag


 this patch print that tar -N is running and allow cancel if that was a mistake . previously it was silent for a minute with no message that it was comparing millions of file records to find a single new file in a hay stack

 # --safe flag. avoiding tar -N on device and safe build on device 


new --safe flag avoid tar -N  on device and make all builds safe on device  

I don't like waiting for tar -N and I don't know if it's wearing out the disk or only battery from computation 

I have a million files and hate tar  -N, --newer=DATE, --after-date=DATE on device . it is one minute of pure agony in what it is doing to my flash drive. I have no idea what it is doing for so long

maybe some one can comfort me with what it is doing exactly . it is reading millions of records but maybe it is mostly compute time not disk trashing . mostly CPU and hardly any disk activity. are the records in one contiguous section that is read to memory in one read operation or is it many reads. are all records always in memory or do they go in and out when needed

  how much memory is needed for one million files. how many read operation are use to load one million records scattered anywhere . it sounds like a horrible idea compared to different build and run folder. does it matter for a flash drive where the data is. it must be faster to read a continuous block than separate bits

I still want to explore the idea of avoiding tar -N on device even if it is not as bad as I think it is. it should be possible to use different build and run paths to avoid this

even worse is installing the files inside my live system when the build is broken or if I only want them else where. if I am compiling a packet for use else where like in my debian folder $DATA/debian and not in $DATA/files/usr/glibc for instance


 # new --fast flag 

 other stream lines comes from --fast flag to build as fast as possible on device . when trying and testing over and over


 ---

 this is another minor change to even build dpkg for glibc . the android flag was not set on device . I guess I am the only one that build on device 


 # aarch64-linux-gnu-gcc error on device . android flag unset with --library glibc

 even with --fast that skip tool chain setup it's not using gcc but aarch64-linux-gnu-gcc that lack termux and android flags breaking all patches  

 bash build-package.sh -s -f  test 
CC=aarch64-linux-android-clang

 bash build-package.sh -s -f  test --fast
 /data/data/com.termux/files/home/termux-packages/packages/test/build.sh: line 13: CC: unbound variable

 bash build-package.sh -s -f  test  --library glibc
 CC=aarch64-linux-gnu-gcc

 bash build-package.sh -s -f  test  --library glibc --fast
 /data/data/com.termux/files/home/termux-packages/packages/test/build.sh: line 13: CC: unbound variable
 aarch64-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I/data/data/com.termux/files/home/.termux-build/test-glibc/src     -g -O2 -c -o test.o /data/data/com.termux/files/home/.termux-build/test-glibc/src/test.c

no CC but still GNU compiler. how do I get android or plain gcc

 aarch64-linux-android-gcc test.c ; a.out
android flag detected
bionic flag detected
termux flag detected

 aarch64-linux-gnu-gcc test.c ; a.out
glibc flag detected

what happened to android flag. this is glibc for android right . this program don't set android and termux flags. so all dpkg patches fail




---

this topic always gives me a head ache because of the trouble outside simple systems like git lab and git hub . where I already have an. account and know exactly how to publish a patch with out leaving the terminal . if I have to leave the terminal I am already in a bad mood and half way to the Congo jungle and hollering chimps 

my number one goal on this planet is a direct public route to patch mistakes as simple as possible . any friction between public and management is wasted effort . every thing is always completely broken all the time . 

and nobody wants help proud apes hate help they already know every thing .  so how do I delicately help a brain dead ape that doesn't need any help

I hate email because I can not verify instantly if my message is online . I will email it to dpkg if I can even find it . it doesn't say the email or patch contact in the man pages . tar is <bug-tar@gnu.org> and tar balls at kernel.org . dpkg is at salsa but I don't know how they want patches or if that is a private git lab  . I have no motivation to register an account for a single patch 

I don't want any build any where to break because of hard link limits . it has nothing to do with android in particular . just bad design 


 # up stream patches for hard links fall back to soft link 

one purpose of the proot repo is to identify and push crucial patches up stream .

for example dpkg should never require root user to write files in home folder. this is necessary when running old Ubuntu apps from home folder by down loading an old apt file. inside regular Ubuntu with --root or chroot. nothing to do with android 

I need help with up stream patches for debian packets in proot in termux. first of all dpkg that all else depend on.

you could possibly message me in Google chat if you have the same idea and have tried to speak with them. and explain what happened or why it failed since I am in the same boat. I need to patch tar and dpkg for all builds not just android 

or write a list of all debian packet problems in android and status or links. if you also use a debian root on the go on your phone and run into similar problem as me

I will eventually host the patches in

john-peterson/dpkg@link
john-peterson/dpkg@sudo
john-peterson/tar@link

and try to figure out where to submit them. if I need a written signature I hope some one else can merge them for me. I have no interest in credit for any patches  I just need the build to work  for my purpose 

I have for a decade hosted patches in github.com/mirror  because of endless problems with this. my wget patch failed because I was supposed to fax a written signature or mail it to Boston united states

dpkg up stream contain sudo and hard links. i found another one in john-peterson/glibc-packages@apt gpkg/dpkg/another* that was blocking the R install in debian proot

if the only possible compromise is an android pre compilation macro the termux proot repo is necessary to use it. since the debian sid arm64 repo packet will still be broken then because the android macro variable was unset

I want to avoid pre compilation flags as much as possible and make all builds work in all Linux versions. there is no debian or alpine compilation flag so why should android have one . unless there is a unique sub system like hw_get_module gralloc that is the only way to get a GL device in android 

hard links can fall back to soft link with out error . sudo can fall back to current user with out error 

apps should work in android too makes no sense to host all patches here

I understand the stupid /data/data prefix and path problems are annoying  up stream but hard links and no sudo are sensible limitation. generic limits that should not break any build 


---

this patch contains the skeleton of a repack function from non proot to proot

 # WIP repack non-proot to proot with null padded prefix removal 

I tried null padded replace in dpkg and it works .   this is from a blog post by Johan hedin about string replacement in binaries  

cp $PREFIX/bin/dpkg .
replace dpkg $PREFIX ""

the new strings are

prefix/var/lib/dpkg -> /var/lib/dpkg000000
prefix/etc/dpkg -> /etc/dpkg000000
...

it reads the status file from /var/lib/dpkg/status in all roots. this is a bionic regular build from $PREFIX/bin/dpkg

 gpkg could be repacked for proot repo initially before any cumbersome builds 

  and bionic because the system linker /system/bin/linker64 should be found in all proot systems. and --set-rpath will resolve the other links to the new bionic root .  but it might not always work or require more expertise that I not have.

  loading from other apps some times fail . for instance dpkg claim it can't see bionic diff  despite being in the path . it is found by which and whereis and runs in the shell. but dpkg claim it doesn't exist . when copied to /bin it works. mystery. essentially a bug probably  . another dpkg bug

  if glibc/bin is before bionic in the path some of these problems are solved . apps can load other apps from glibc but not bionic 

  if you are also interested in this let me know  


---

the following is not implemented in this patch . it requires patches for dpkg and glibc-repo


 ## todo remove prefix shell from all packets in favour of  --instdir=prefix for parsimony 

 this simple wrapper would accomplish the same thing as the matroska doll of paths before the app files 

vim $prefix/bin/dpkg
../libexec/dpkg --instdir=prefix --admindir=prefix/var/lib/dpkg $@

simpler is better . the logic for the massage folder would be simpler . less use of the prefix when it is not needed 

dpkg -c output/test_*deb

is easier to read  

bin
etc
...

instead of gigantic prefix on every line

data
data/data
...
prefix/bin
...

notice that this doesn't help install in another terminal not called com.termux . many prefix packets are still useless inside another terminal . the prefix is hard coded every where and many apps crash in another terminal . only proot packet  with blank prefix works in another terminal with proot for virtual paths




 ## todo remove -glibc suffix from packet names and update glibc-repo packet  

a -proot suffix is pointless for proot repo  and so is -glibc suffix for glibc repo. it's an independent repo it doesn't need any suffix 

the glibc suffix exist because some one  wanted to mash every thing into the same bowl . or make it easier to install glibc packets 

glibc is a different root it has nothing to do with bionic there is nothing useful about this

 a separate shell with a different PATH  is already necessary for running glibc apps so I can't even understand the reasoning behind installing glibc from bionic apt instead of glibc apt

 every thing is done in the root shell including apt . don't run apt in bionic and expect it to act outside bionic 

 I will push an updated glibc-repo packet that use a config file to get started like john-peterson/glibc-packages@debian

 apt -c $P/etc/apt/glibc.conf update

create  a separate cache file for glibc

 $P/glibc/var/cache/apt/pkgcache.bin

the same config file can install apt and bash for the glibc shell 

 apt -c $P/etc/apt/glibc.conf install bash apt

 after this the glibc shell is ready to use with glibc/bin/apt from john-peterson/glibc-packages@apt . no suffix needed 

 the regular apt command should only display bionic from bionic shell and glibc from glibc shell . just like all other roots

when the glibc-repo packet is updated the -glibc suffix can be removed 

the glibc and proot repo shoul not be merged into the bionic apt cache it will cause  mayhem . I have added a separate apt build in gpkg folder that only use glibc repos. the glibc shell will prefer glibc/bin/apt and the apt command will only display glibc packets there . and the glibc cache  should be removed from bionic apt cache 

it is not convenient to use the same shell and path for every thing  . the only sensible way is complete separation  . a single letter a b d g etc can be used to switch shell fast and simple  

vim ~/.bashrc
alias g=$PREFIX/glibc/bin/bash
cmd=$($p/readlink -f /proc/$$/exe)
if [[ "$cmd" = *glibc* ]]; then
elif [ -f /glibc ]; then

other wise you will live in endless confusion. if you insist stubbornly you will run the wrong app constantly . the shell can print its name so you know what she'll you are in

ps1="g "
PS1="$ps1\w "


 build dependency should be resolved by searching first in packages  then gpkg folder. -glibc suffix is not needed when building and can be removed  

 apt dependency should be resolved by copying packet build recipe from packages to gpkg folder . and there by to glibc repo. this rarely happens the repos are already independent or nearly so 


I don't mix bionic glibc musl in the same apt cache neither should anyone .  this suffix makes no sense and should not exist 

you don't see -alpine -debian -ubuntu in their packet list. termux glibc is the first one I have seen that do this

it's like putting a suffix on everything -debian in the entire debian repo and -alpine or -ubuntu it's unnecessary they don't reference each other and should not mix




---

the following is not about this patch specifically and may not interest you 

it relates to proot in general and the purpose of using proot packets across different roots

best way to deal with roots:

 ### root confusion . /etc or /usr/etc
 
 termux packets use a flat directory structure every thing is under prefix   including usr/bin usr/etc usr/share usr/var . prefix/usr is forbidden 

this comes from auto tools because /etc and /var is prefix/etc prefix/var . the classic example being prefix=/usr/local that is completely separate from the system with separate settings  

 the proot need a link or bind to correct this

 soft link .. to usr folder

ln -s .. usr

if dpkg over write the link use a bind instead 

proot -b $DATA/files/usr:/usr

my roots are

DATA=/data/data/com.termux
$DATA/alpine
$DATA/bionic or $DATA/files/usr
$DATA/debian
$DATA/glibc or $DATA/files/usr/glibc
$DATA/proot
$DATA/ubuntu


debian contain the latest versions but proot might catch up when it comes online. bionic and glibc contain android patches that others lack 

my default shell  is glibc proot with many outside apps like /opt/devkitpro and bionic in the last path as fall back

my bionic only contain bionic repos and glibc only glibc repos. this has led me to ask that the -glibc suffix is dropped and outside dependency is resolved by folder order instead "gpkg packets"



---

when copying termux proot packets to debian root in termux these problems occurred to me

 ### dependency hack for debian root. extract instead of install 

 it's nearly impossible to get all dependency identical with debian repo to be able to install a packet  so extract it instead . install the regular and broken debian packet  and extract the proot build to / with dpkg -x not -i to keep the old status 

 or manual change dependency with vim /var/lib/dpkg/status

 it should be possible the fix all debian repo bugs in android if more people use the debian root and need to get rid of all sudo and hard links


 ### make sure apt and dpkg use the same status file 

dpkg --root=abc is actually abc/prefix . in the  prefix confusion dpkg and apt used separate status files . apt doesn't warn about this in any obvious way

dpkg --root therefore only works with proot build when boot strapping outside prefix . for a prefix build only --instdir works 

apt-config dump print the status file but dpkg lack a similar command . it could offer a way to print the full path of the status file if this happens . it's unclear what file it is using it doesn't say clearly any where. apt could warn when dpkg use a different status file . I will look into this possibility 

---

this is a related idea about the default shell and the best approach to compatibility . and the first impression of termux for new users  

it is not addressed in this patch . the bash and boot strap packets can be patched for this purpose to launch glibc proot instead of bionic  

or termux-tools /etc/motd could say how to launch other roots that can run outside apps like /opt/devkitpro and build all apps or install them from debian arm64 repo . and explain that bionic has advanced problems and is not suitable for beginners  

 ### promote glibc proot to default shell for  better first impression 

bionic gives a bad first impression that nothing works. it should be an advanced option for any one that understand the problems it introduce


 my first problem in termux was running a plethora of other apps. I tried every wrong solution before finding the right one. building for bionic . endless hours of agony . on line cloud shell that require a constant connection that I rarely have. finally I tried proot -r $PREFIX/glibc and bingo every thing works. wish I had known that sooner

it doesn't help that Linux say file not found with out saying what file it is  I thought it was linux-vdso.so.1 because I had used ldd before to find missing files . I never encountered a missing interpreter before . one day I will patch Linux to say the interpreter is missing 

 even later I finally boot strapped a minimal debian root that has much of what I was missing like dosemu and x86 compiler . because I need a test program for qemu that use ld-linux-x86-64.so.2  


proot could be  promoted as the right solution and crucially default for new comers. to learn the right way from the start . my first problem was running other apps which doesn't work outside proot . I had to run dev kit pro to build nds app and it works in glibc proot out of the box no errors. this fact was hidden from me for a long time

much later when I learned about the glibc proot I could run every thing i needed. much less need for a gcloud shell and even a connection because every thing runs in termux off line even in a long flight that doesn't have satellite internet

glibc proot could be default termux shell because every one needs some thing no one else does. like Dev kit pro or whatever . bionic proot is hampered and can't run other apps from outside


there was never any reason to not use proot except fear of the unknown . all my /tmp TMPDIR patches have been needles noise up stream now that I need to push hard link patches . I've been crying wolf already and been ignored. I should have began with proot and let some one else deal with bionic and  prefix patches that I consider use less noise now that I need hard link patches in all builds including debian and alpine 
