### PR TITLE
bump(main/dnote): 0.16.0

### DIFF
--- a/packages/dnote/build.sh
+++ b/packages/dnote/build.sh
@@ -1,10 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://www.getdnote.com/
 TERMUX_PKG_DESCRIPTION="A simple command line notebook for programmers"
-TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="Ravener <ravener.anime@gmail.com>"
-TERMUX_PKG_VERSION="1:0.15.5"
+TERMUX_PKG_VERSION="1:0.16.0"
 TERMUX_PKG_SRCURL=https://github.com/dnote/dnote/archive/refs/tags/cli-v${TERMUX_PKG_VERSION:2}.tar.gz
-TERMUX_PKG_SHA256=923e959d32885f01e426e37e7240bf9a66addbdfd95620846fa535e4b7f7d2e4
+TERMUX_PKG_SHA256=fb63c6099ca441a2027a9e8ae2a3c38376e5c0950bef9e8028b96ca2b8b6427f
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+\.\d+"
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -27,13 +27,6 @@ termux_step_make_install() {
 		"$TERMUX_PREFIX"/share/bash-completion/completions/dnote
 	install -Dm600 "$TERMUX_PKG_SRCDIR"/pkg/cli/dnote-completion.zsh \
 		"$TERMUX_PREFIX"/share/zsh/site-functions/_dnote
-}
-
-termux_step_install_license() {
-	install -Dm600 -t "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}" \
-		"${TERMUX_PKG_SRCDIR}/licenses/GPLv3.txt"
-	install -Dm600 -t "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}" \
-		"${TERMUX_PKG_SRCDIR}/LICENSE"
 }
 
 termux_pkg_auto_update() {


### PR DESCRIPTION
dnote project license was changed to Apache-2.0 from GPL-3.0. So, remove the old license file from installing.
https://github.com/dnote/dnote/commit/e0c4cb1545307978a3d6a8b362196553e05a3558

* Fixes #27154 