### PR TITLE
fix(main/ffmpeg): Fix MediaCodec hanging on Android15+

### DIFF
--- a/packages/ffmpeg/build.sh
+++ b/packages/ffmpeg/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # Please align version with `ffplay` package.
 TERMUX_PKG_VERSION="7.1.2"
+TERMUX_PKG_REVISION="1"
 TERMUX_PKG_SRCURL=https://www.ffmpeg.org/releases/ffmpeg-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=089bc60fb59d6aecc5d994ff530fd0dcb3ee39aa55867849a2bbc4e555f9c304
 TERMUX_PKG_DEPENDS="fontconfig, freetype, fribidi, game-music-emu, glslang, harfbuzz, libaom, libandroid-glob, libandroid-stub, libass, libbluray, libbz2, libdav1d, libgnutls, libiconv, liblzma, libmp3lame, libopencore-amr, libopenmpt, libopus, libplacebo, librav1e, libsoxr, libsrt, libssh, libtheora, libv4l, libvidstab, libvmaf, libvo-amrwbenc, libvorbis, libvpx, libwebp, libx264, libx265, libxml2, libzimg, libzmq, littlecms, ocl-icd, rubberband, svt-av1, vulkan-icd, xvidcore, zlib"

--- a/packages/ffmpeg/fftools-Fix-MediaCodec-on-Android15.patch
+++ b/packages/ffmpeg/fftools-Fix-MediaCodec-on-Android15.patch
@@ -1,0 +1,265 @@
+From e5f127019b7af730744651a266bb7f017e322c6c Mon Sep 17 00:00:00 2001
+From: Dmitrii Okunev <xaionaro@dx.center>
+Date: Sun, 9 Nov 2025 17:40:55 +0000
+Subject: [PATCH] fftools: Fix MediaCodec on Android15+
+
+On Android15+ MediaCodec HAL backend was switched from HIDL to AIDL.
+As a result, MediaCodec operations started to hang, see:
+
+    https://github.com/termux/termux-packages/issues/21264
+
+To fix that it is necessary to initialize binder thread pool.
+
+Signed-off-by: Dmitrii Okunev <xaionaro@dx.center>
+---
+ fftools/Makefile         |   3 +
+ fftools/android_binder.c | 131 +++++++++++++++++++++++++++++++++++++++
+ fftools/android_binder.h |  31 +++++++++
+ fftools/ffmpeg.c         |   4 ++
+ fftools/ffmpeg.h         |   1 +
+ fftools/ffplay.c         |   5 ++
+ 6 files changed, 175 insertions(+)
+ create mode 100644 fftools/android_binder.c
+ create mode 100644 fftools/android_binder.h
+
+diff --git a/fftools/Makefile b/fftools/Makefile
+index bdb44fc5ce..00d1c503f3 100644
+--- a/fftools/Makefile
++++ b/fftools/Makefile
+@@ -53,6 +53,9 @@ OBJS-ffprobe +=                       \
+ 
+ OBJS-ffplay += fftools/ffplay_renderer.o
+ 
++OBJS-ffmpeg-$(CONFIG_MEDIACODEC) += fftools/android_binder.o
++OBJS-ffplay-$(CONFIG_MEDIACODEC) += fftools/android_binder.o
++
+ define DOFFTOOL
+ OBJS-$(1) += fftools/cmdutils.o fftools/opt_common.o fftools/$(1).o $(OBJS-$(1)-yes)
+ ifdef HAVE_GNU_WINDRES
+diff --git a/fftools/android_binder.c b/fftools/android_binder.c
+new file mode 100644
+index 0000000000..e16c7f4b31
+--- /dev/null
++++ b/fftools/android_binder.c
+@@ -0,0 +1,131 @@
++/*
++ * Android Binder handler
++ *
++ * Copyright (c) 2025 Dmitrii Okunev
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++
++#if defined(__ANDROID__)
++
++#include <dlfcn.h>
++#include <stdint.h>
++#include <stdlib.h>
++#include <errno.h>
++
++#include "config.h"
++#include "libavutil/log.h"
++#include "android_binder.h"
++
++#define DEFAULT_THREAD_POOL_SIZE 4
++#define MAX_THREAD_POOL_SIZE     256
++
++static unsigned get_thread_pool_size(void)
++{
++    const char *tps_str = getenv("FFMPEG_ANDROID_BINDER_THREAD_POOL_SIZE");
++    if (tps_str == NULL || !*tps_str) {
++        av_log(NULL, AV_LOG_DEBUG,
++               "android/binder: FFMPEG_ANDROID_BINDER_THREAD_POOL_SIZE not set, using default %u\n",
++               DEFAULT_THREAD_POOL_SIZE);
++        return DEFAULT_THREAD_POOL_SIZE;
++    }
++
++    errno = 0;
++    unsigned long thread_pool_size = strtoul(tps_str, NULL, 10);
++    if (errno != 0 || thread_pool_size <= 0
++        || thread_pool_size > UINT32_MAX) {
++        av_log(NULL, AV_LOG_ERROR,
++               "android/binder: invalid value of FFMPEG_ANDROID_BINDER_THREAD_POOL_SIZE: '%s' (errno: %d), using the default one, instead: %u\n",
++               tps_str, errno, DEFAULT_THREAD_POOL_SIZE);
++        return DEFAULT_THREAD_POOL_SIZE;
++    }
++
++    if (thread_pool_size > MAX_THREAD_POOL_SIZE) {
++        av_log(NULL, AV_LOG_WARNING,
++               "android/binder: too large FFMPEG_ANDROID_BINDER_THREAD_POOL_SIZE: '%s', clamping to %d\n",
++               tps_str, MAX_THREAD_POOL_SIZE);
++        thread_pool_size = MAX_THREAD_POOL_SIZE;
++    }
++
++    av_log(NULL, AV_LOG_DEBUG,
++           "android/binder: thread pool size: %lu\n", thread_pool_size);
++    return (unsigned) thread_pool_size;
++}
++
++static void *dlopen_libbinder_ndk(void)
++{
++    /*
++     * To make ffmpeg builds reusable at different Android versions we intentionally
++     * avoid including linking with libbinder_ndk.so at the link time. Instead, we
++     * resolve the symbols at runtime using dlopen()/dlsym().
++     *
++     * See also: https://source.android.com/docs/core/architecture/aidl/aidl-backends
++     */
++
++    void *h = dlopen("libbinder_ndk.so", RTLD_NOW | RTLD_LOCAL);
++    if (h != NULL)
++        return h;
++
++    av_log(NULL, AV_LOG_VERBOSE,
++           "android/binder: libbinder_ndk.so not found; skipping binder threadpool init\n");
++    return NULL;
++}
++
++void android_binder_threadpool_init(void)
++{
++    typedef int (*set_thread_pool_max_fn)(uint32_t);
++    typedef void (*start_thread_pool_fn)(void);
++
++    set_thread_pool_max_fn set_thread_pool_max = NULL;
++    start_thread_pool_fn start_thread_pool = NULL;
++
++    void *h = dlopen_libbinder_ndk();
++    if (h == NULL) {
++        return;
++    }
++
++    unsigned thead_pool_size = get_thread_pool_size();
++
++    set_thread_pool_max =
++        (set_thread_pool_max_fn) dlsym(h,
++                                       "ABinderProcess_setThreadPoolMaxThreadCount");
++    start_thread_pool =
++        (start_thread_pool_fn) dlsym(h, "ABinderProcess_startThreadPool");
++
++    if (start_thread_pool == NULL) {
++        av_log(NULL, AV_LOG_VERBOSE,
++               "android/binder: ABinderProcess_startThreadPool not found; skipping threadpool init\n");
++        return;
++    }
++
++    if (set_thread_pool_max != NULL) {
++        int ok = set_thread_pool_max(thead_pool_size);
++        av_log(NULL, AV_LOG_DEBUG,
++               "android/binder: ABinderProcess_setThreadPoolMaxThreadCount(%u) => %s\n",
++               thead_pool_size, ok ? "ok" : "fail");
++    } else {
++        av_log(NULL, AV_LOG_DEBUG,
++               "android/binder: ABinderProcess_setThreadPoolMaxThreadCount is unavailable; using the library default\n");
++    }
++
++    start_thread_pool();
++    av_log(NULL, AV_LOG_DEBUG,
++           "android/binder: ABinderProcess_startThreadPool() called\n");
++}
++
++#endif                          /* __ANDROID__ */
+diff --git a/fftools/android_binder.h b/fftools/android_binder.h
+new file mode 100644
+index 0000000000..56c487fe4c
+--- /dev/null
++++ b/fftools/android_binder.h
+@@ -0,0 +1,31 @@
++/*
++ * Android Binder handler
++ *
++ * Copyright (c) 2025 Dmitrii Okunev
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#ifndef FFTOOLS_ANDROID_BINDER_H
++#define FFTOOLS_ANDROID_BINDER_H
++
++/**
++ * Initialize Android Binder thread pool.
++ */
++void android_binder_threadpool_init(void);
++
++#endif                          // FFTOOLS_ANDROID_BINDER_H
+diff --git a/fftools/ffmpeg.c b/fftools/ffmpeg.c
+index 444d027c15..7b250ac5da 100644
+--- a/fftools/ffmpeg.c
++++ b/fftools/ffmpeg.c
+@@ -1019,6 +1019,10 @@ int main(int argc, char **argv)
+         goto finish;
+     }
+ 
++#if defined(__ANDROID__)
++    android_binder_threadpool_init();
++#endif
++
+     current_time = ti = get_benchmark_time_stamps();
+     ret = transcode(sch);
+     if (ret >= 0 && do_benchmark) {
+diff --git a/fftools/ffmpeg.h b/fftools/ffmpeg.h
+index cc2ea1a56e..6c6ef0509a 100644
+--- a/fftools/ffmpeg.h
++++ b/fftools/ffmpeg.h
+@@ -26,6 +26,7 @@
+ #include <stdio.h>
+ #include <signal.h>
+ 
++#include "android_binder.h"
+ #include "cmdutils.h"
+ #include "ffmpeg_sched.h"
+ #include "sync_queue.h"
+diff --git a/fftools/ffplay.c b/fftools/ffplay.c
+index dc2627521e..14fde65f27 100644
+--- a/fftools/ffplay.c
++++ b/fftools/ffplay.c
+@@ -54,6 +54,7 @@
+ #include <SDL.h>
+ #include <SDL_thread.h>
+ 
++#include "android_binder.h"
+ #include "cmdutils.h"
+ #include "ffplay_renderer.h"
+ #include "opt_common.h"
+@@ -3892,6 +3893,10 @@ int main(int argc, char **argv)
+         }
+     }
+ 
++#if defined(__ANDROID__)
++    android_binder_threadpool_init();
++#endif
++
+     is = stream_open(input_filename, file_iformat);
+     if (!is) {
+         av_log(NULL, AV_LOG_FATAL, "Failed to initialize VideoState!\n");
+-- 
+2.48.1
+


### PR DESCRIPTION
On Android15+ MediaCodec HAL backend was switched from HIDL to AIDL.
As a result, MediaCodec operations started to hang.    
To fix that it is necessary to initialize binder thread pool.

Issue: https://github.com/termux/termux-packages/issues/21264
