### PR TITLE
addpkg(main/yt-dlp-ejs): 0.3.1

### DIFF
--- a/packages/yt-dlp-ejs/build.sh
+++ b/packages/yt-dlp-ejs/build.sh
@@ -1,0 +1,26 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/yt-dlp/ejs
+TERMUX_PKG_DESCRIPTION="External JavaScript for yt-dlp supporting many runtimes"
+TERMUX_PKG_LICENSE="Unlicense"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.3.1"
+TERMUX_PKG_SRCURL="https://github.com/yt-dlp/ejs/releases/download/$TERMUX_PKG_VERSION/yt_dlp_ejs-$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=7f2119eb02864800f651fa33825ddfe13d152a1f730fa103d9864f091df24227
+TERMUX_PKG_PYTHON_COMMON_DEPS="build, hatchling, hatch-vcs"
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS='nodejs | nodejs-lts, python'
+if (( TERMUX_ARCH_BITS == 64 )); then
+	TERMUX_PKG_DEPENDS='deno | nodejs | nodejs-lts, python'
+fi
+
+termux_step_make() {
+	termux_setup_nodejs
+	npm install
+	python -m build --wheel --no-isolation
+}
+
+termux_step_make_install() {
+	local _whl="yt_dlp_ejs-$TERMUX_PKG_VERSION-py3-none-any.whl"
+	pip install --no-deps --prefix="$TERMUX_PREFIX" "$TERMUX_PKG_SRCDIR/dist/$_whl"
+}


### PR DESCRIPTION
ejs is a newly introduced dependency for yt-dlp
https://github.com/termux/termux-packages/pull/26714

this currently skips 32bit systems because they dont have deno support but npm should also work fine for building ejs