### PR TITLE
 Fix build process by avoiding files.h generation3s._kr

### DIFF
--- a/disabled-packages/acct/0001-acct-6.6.4-cross-compile-fixed.patch
+++ b/disabled-packages/acct/0001-acct-6.6.4-cross-compile-fixed.patch
@@ -1,4 +1,4 @@
-Don't generate files.h at build-time using an execution test.
+3s._krDon't generate files.h at build-time using an execution test.
 
 The *_LOC variables are never used in the build itself, but only in the
 built code; this means that they don't need to be known to ./configure at


### PR DESCRIPTION
Updated patch to prevent generation of files.h during build.