### PR TITLE
fix(main/gh): allow executing shell script extensions

### DIFF
--- a/packages/gh/001-use-sh-for-extensions.patch
+++ b/packages/gh/001-use-sh-for-extensions.patch
@@ -1,0 +1,24 @@
+commit ae8bc425079a789eb340d1e8ad58f94a481fd93b
+Author: Elliana May <me@mause.me>
+Date:   Mon Nov 10 11:15:01 2025 +0800
+
+    execute extension shell scripts via sh
+    
+    this resolves the issue where the shebang refers to a non termux prefixed path
+
+diff --git a/pkg/cmd/extension/manager.go b/pkg/cmd/extension/manager.go
+index b7f1f1c0c..e8340ee70 100644
+--- a/pkg/cmd/extension/manager.go
++++ b/pkg/cmd/extension/manager.go
+@@ -112,9 +112,9 @@ func (m *Manager) Dispatch(args []string, stdin io.Reader, stdout, stderr io.Wri
+ 
+ 	var externalCmd *exec.Cmd
+ 
+-	if ext.IsBinary() || runtime.GOOS != "windows" {
++	if ext.IsBinary() {
+ 		externalCmd = m.newCommand(exe, forwardArgs...)
+-	} else if runtime.GOOS == "windows" {
++	} else {
+ 		// Dispatch all extension calls through the `sh` interpreter to support executable files with a
+ 		// shebang line on Windows.
+ 		shExe, err := m.findSh()

--- a/packages/gh/build.sh
+++ b/packages/gh/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="GitHub’s official command line tool"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Krishna kanhaiya @kcubeterm"
 TERMUX_PKG_VERSION="2.83.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/cli/cli/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=5053825b631fa240bba1bfdb3de6ac2c7af5e3c7884b755a6a5764994d02f999
 TERMUX_PKG_RECOMMENDS="openssh"


### PR DESCRIPTION
Without this patch, you just end up getting an error about not being able to find the shell script, which is quite confusing, as it tries to use the path specified in the shebang