### PR TITLE
fix(main/lua-language-server): use `termux_setup_ninja` appropriately for repeated builds

### DIFF
--- a/packages/lua-language-server/build.sh
+++ b/packages/lua-language-server/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Sumneko Lua Language Server coded in Lua"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION="3.15.0"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_GIT_BRANCH="${TERMUX_PKG_VERSION}"
 TERMUX_PKG_SRCURL="git+https://github.com/sumneko/lua-language-server"
 TERMUX_PKG_DEPENDS="libandroid-spawn, libc++"
@@ -32,6 +32,8 @@ termux_step_host_build() {
 }
 
 termux_step_make() {
+	termux_setup_ninja
+
 	CFLAGS+=" -DBEE_ENABLE_FILESYSTEM"     # without this, it tries to link against its own filesystem lib and fails.
 	CFLAGS+=" -Wno-unknown-warning-option" # for -Wno-maybe-uninitialized argument.
 


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/27334

- Fixes the command `scripts/run-docker.sh ./build-package.sh -I -f -a all lua-language-server`