### PR TITLE
fix(ci/check_repository_health): do not use `local` outside of function

### DIFF
--- a/.github/workflows/check_repository_health.yml
+++ b/.github/workflows/check_repository_health.yml
@@ -35,7 +35,6 @@ jobs:
           ISSUE_TITLE="Repository Health Check Failed"
           ISSUE_BODY=$(cat repository-health.txt)
           # if any previous Repository Health Check Failed issues are open, close them first
-          local number
           while read -r number; do
             echo "INFO: Closing issue number: $number"
             sleep 5


### PR DESCRIPTION
- In https://github.com/termux/termux-packages/pull/27165, I had fixed this in https://github.com/robertkirkman/termux-packages/commit/71cb3aaf29faf4132a9a2ff83c62487cbb150143, but when I reverted the content of the PR to an earlier state before merging it at the request of truboxl, I accidentally copied and pasted the oldest state instead of https://github.com/robertkirkman/termux-packages/commit/71cb3aaf29faf4132a9a2ff83c62487cbb150143, and I forgot to reapply this fix.

- I assume that if I do not remove this line before the next time the workflow runs, there will be an error `bash: local: can only be used in a function`.