### PR TITLE
Clean up `build-package.sh` shellcheck warnings and simplify as appropriate.

### DIFF
--- a/scripts/build/termux_download_deb_pac.sh
+++ b/scripts/build/termux_download_deb_pac.sh
@@ -43,7 +43,7 @@ termux_download_deb_pac() {
 			for arch in 'aarch64' 'arm' 'i686' 'x86_64'; do
 				if [ -f "${TERMUX_COMMON_CACHEDIR}-${arch}/${PACKAGE_FILE_PATH}" ]; then
 					if [ "$TERMUX_REPO_PKG_FORMAT" = "debian" ]; then
-						read -d "\n" PKG_PATH PKG_HASH <<<$(./scripts/get_hash_from_file.py "${TERMUX_COMMON_CACHEDIR}-${arch}/$PACKAGE_FILE_PATH" $PACKAGE $VERSION)
+						read -rd "\n" PKG_PATH PKG_HASH < <(./scripts/get_hash_from_file.py "${TERMUX_COMMON_CACHEDIR}-${arch}/$PACKAGE_FILE_PATH" "$PACKAGE" "$VERSION")
 					elif [ "$TERMUX_REPO_PKG_FORMAT" = "pacman" ]; then
 						if [ "$TERMUX_WITHOUT_DEPVERSION_BINDING" = "true" ] || [ $(jq -r '."'$PACKAGE'"."VERSION"' "${TERMUX_COMMON_CACHEDIR}-${arch}/$PACKAGE_FILE_PATH") = "${VERSION_PACMAN}" ]; then
 							PKG_HASH=$(jq -r '."'$PACKAGE'"."SHA256SUM"' "${TERMUX_COMMON_CACHEDIR}-${arch}/$PACKAGE_FILE_PATH")
@@ -71,9 +71,9 @@ termux_download_deb_pac() {
 			# check for package in aarch64 Packages
 			# instead.
 			if [ "$TERMUX_REPO_PKG_FORMAT" = "debian" ]; then
-				read -d "\n" PKG_PATH PKG_HASH <<<$(./scripts/get_hash_from_file.py "${TERMUX_COMMON_CACHEDIR}-aarch64/$PACKAGE_FILE_PATH" $PACKAGE $VERSION)
+				read -rd "\n" PKG_PATH PKG_HASH < <(./scripts/get_hash_from_file.py "${TERMUX_COMMON_CACHEDIR}-aarch64/$PACKAGE_FILE_PATH" "$PACKAGE" "$VERSION")
 			elif [ "$TERMUX_REPO_PKG_FORMAT" = "pacman" ]; then
-				if [ "$TERMUX_WITHOUT_DEPVERSION_BINDING" = "true" ] || [ $(jq -r '."'$PACKAGE'"."VERSION"' "${TERMUX_COMMON_CACHEDIR}-aarch64/$PACKAGE_FILE_PATH") = "${VERSION_PACMAN}"]; then
+				if [ "$TERMUX_WITHOUT_DEPVERSION_BINDING" = "true" ] || [ $(jq -r '."'$PACKAGE'"."VERSION"' "${TERMUX_COMMON_CACHEDIR}-aarch64/$PACKAGE_FILE_PATH") = "${VERSION_PACMAN}" ]; then
 					PKG_HASH=$(jq -r '."'$PACKAGE'"."SHA256SUM"' "${TERMUX_COMMON_CACHEDIR}-aarch64/$PACKAGE_FILE_PATH")
 					PKG_PATH=$(jq -r '."'$PACKAGE'"."FILENAME"' "${TERMUX_COMMON_CACHEDIR}-aarch64/$PACKAGE_FILE_PATH")
 					PKG_PATH="aarch64/${PKG_PATH}"
@@ -91,7 +91,7 @@ termux_download_deb_pac() {
 			fi
 		elif [ -f "${TERMUX_COMMON_CACHEDIR}-${PACKAGE_ARCH}/${PACKAGE_FILE_PATH}" ]; then
 			if [ "$TERMUX_REPO_PKG_FORMAT" = "debian" ]; then
-				read -d "\n" PKG_PATH PKG_HASH <<<$(./scripts/get_hash_from_file.py "${TERMUX_COMMON_CACHEDIR}-${PACKAGE_ARCH}/$PACKAGE_FILE_PATH" $PACKAGE $VERSION)
+				read -rd "\n" PKG_PATH PKG_HASH < <(./scripts/get_hash_from_file.py "${TERMUX_COMMON_CACHEDIR}-${PACKAGE_ARCH}/$PACKAGE_FILE_PATH" "$PACKAGE" "$VERSION")
 			elif [ "$TERMUX_REPO_PKG_FORMAT" = "pacman" ]; then
 				if [ "$TERMUX_WITHOUT_DEPVERSION_BINDING" = "true" ] || [ $(jq -r '."'$PACKAGE'"."VERSION"' "${TERMUX_COMMON_CACHEDIR}-${PACKAGE_ARCH}/$PACKAGE_FILE_PATH") = "${VERSION_PACMAN}" ]; then
 					PKG_HASH=$(jq -r '."'$PACKAGE'"."SHA256SUM"' "${TERMUX_COMMON_CACHEDIR}-${PACKAGE_ARCH}/$PACKAGE_FILE_PATH")


### PR DESCRIPTION
This PR is a refactor of the `build-package.sh` script to eliminate all remaining shellcheck warnings from the script and simplify some of the nastier parts of the script as appropriate.

I have done local build tests with this refactored version and haven't found any issues with it so far.
All the changes in here are purely logic changes in the control flow and minor errata.
I have double checked all of these, however it is always possible I missed some edgecase.

I have broken the changes out into 9, very topic specific, commits for the time being.
This can be reshuffled and rebased as required.

There is also some minor shellcheck fixes to `termux_download_deb_pac.sh` which were necessary to make Shellcheck parse it properly and not throw a warning at it's `source` call.
This PR is not intended to refactor that script, that would probably warrant its own PR and I already nerd sniped[^1] myself enough for one day.

[^1]: https://xkcd.com/356/