### PR TITLE
bump(main/cmake): 4.2.0

### DIFF
--- a/packages/cmake/Source-CmakeLists.txt.patch
+++ b/packages/cmake/Source-CmakeLists.txt.patch
@@ -1,0 +1,13 @@
+Fixes ld.lld: error: undefined symbol: cmCPackAppImageGenerator::cmCPackAppImageGenerator()
+
+--- a/Source/CMakeLists.txt
++++ b/Source/CMakeLists.txt
+@@ -1265,7 +1265,7 @@ if(UNIX)
+   endif()
+ endif()
+ 
+-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
++if(ANDROID OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
+   target_sources(
+     CPackLib
+     PRIVATE

--- a/packages/cmake/build.sh
+++ b/packages/cmake/build.sh
@@ -4,9 +4,9 @@ TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_LICENSE_FILE="LICENSE.rst"
 TERMUX_PKG_MAINTAINER="@termux"
 # When updating version here, please update termux_setup_cmake.sh as well.
-TERMUX_PKG_VERSION="4.1.3"
+TERMUX_PKG_VERSION="4.2.0"
 TERMUX_PKG_SRCURL=https://www.cmake.org/files/v${TERMUX_PKG_VERSION:0:3}/cmake-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=765879a53d178bf1e1509768de4c9a672dabaa20047a9f3809571558e783be88
+TERMUX_PKG_SHA256=4104e94657d247c811cb29985405a360b78130b5d51e7f6daceb2447830bd579
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libarchive, libc++, libcurl, libexpat, jsoncpp, libuv, rhash, zlib"
 TERMUX_PKG_RECOMMENDS="clang, make"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/27349

- Fixes build error `ld.lld: error: undefined symbol: cmCPackAppImageGenerator::cmCPackAppImageGenerator()`

- The error is related to the new upstream feature "CPack AppImage generator". https://cmake.org/cmake/help/latest/cpack_gen/appimage.html There are two possible ways to fix it. One would be by entirely disabling all code related to the feature from the Termux build, and the other is to just fix the linking error, which is what this patch does.

- Currently, the feature is not useful on Android because AppImage is unimplemented for Termux or Android, but in my opinion it is better to leave the feature enabled in the code, since actually, it is theoretically possible for there to be a Termux/Android AppImage, just nobody to my knowledge has ever successfully made one. All that would be necessary for AppImage to be possible on Android would be for someone to fully implement a port of the `appimagetool` command. I tried to before in the past, but I wasn't able to completely make it work only because of problems that I believe are probably possible to fix some day with enough work. If the `appimagetool` command is implemented in the future by someone, CMake should be able to automatically detect and use it for this feature.