### PR TITLE
fix(main/mesa): Build with RTTI since LLVM now has it

### DIFF
--- a/packages/mesa/build.sh
+++ b/packages/mesa/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="docs/license.rst"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="25.3.0"
+TERMUX_PKG_REVISION=1
 _LLVM_MAJOR_VERSION=$(. $TERMUX_SCRIPTDIR/packages/libllvm/build.sh; echo "${LLVM_MAJOR_VERSION}")
 _LLVM_MAJOR_VERSION_NEXT=$((_LLVM_MAJOR_VERSION + 1))
 TERMUX_PKG_SRCURL=https://archive.mesa3d.org/mesa-${TERMUX_PKG_VERSION}.tar.xz
@@ -19,7 +20,6 @@ TERMUX_PKG_REPLACES="libmesa, osmesa"
 # FIXME: Set `shared-llvm` to disabled if possible
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --cmake-prefix-path $TERMUX_PREFIX
--Dcpp_rtti=false
 -Dgbm=enabled
 -Dopengl=true
 -Degl=enabled


### PR DESCRIPTION
Fix the build error:

> ../src/meson.build:1808:8: ERROR:
> Problem encountered: LLVM was built with RTTI, cannot build Mesa with RTTI disabled.
> Remove cpp_rtti disable switch or use LLVM built without LLVM_ENABLE_RTTI.