### PR TITLE
bump(x11/cinnamon-settings-daemon): 6.6.0

### DIFF
--- a/x11-packages/cinnamon-settings-daemon/0001-fix-paths.patch
+++ b/x11-packages/cinnamon-settings-daemon/0001-fix-paths.patch
@@ -90,27 +90,21 @@ diff --git a/plugins/color/generate-tz-header.py b/plugins/color/generate-tz-hea
 index cc1d399..4b53e6a 100755
 --- a/plugins/color/generate-tz-header.py
 +++ b/plugins/color/generate-tz-header.py
-@@ -1,11 +1,11 @@
--#!/usr/bin/python3
-+#!@TERMUX_PREFIX@/bin/python3
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!@TERMUX_PREFIX@/bin/env python3
  
  import re
+ from argparse import ArgumentParser
+@@ -10,7 +10,7 @@ d = {}
  
- d = {}
+ parser = ArgumentParser(prog='generate-tz-header',
+                         description='Generate tz-coords.h header from timezone-data')
+-parser.add_argument('-i', '--zone_tab', nargs='?', default='/usr/share/zoneinfo/zone.tab', type=Path)
++parser.add_argument('-i', '--zone_tab', nargs='?', default='@TERMUX_PREFIX@/share/zoneinfo/zone.tab', type=Path)
+ parser.add_argument('-o', '--out_file', nargs='?', default='tz-coords.h', type=Path)
+ args = parser.parse_args()
  
- 
--with open("/usr/share/zoneinfo/zone.tab", "r") as f:
-+with open("@TERMUX_PREFIX@/share/zoneinfo/zone.tab", "r") as f:
-     for line in f:
-         if line.startswith("#"):
-             continue
-@@ -47,4 +47,4 @@ header += "};"
- with open("tz-coords.h", "w") as f:
-     f.write(header)
- 
--quit()
-\ No newline at end of file
-+quit()
 diff --git a/plugins/datetime/csd-datetime-mechanism-debian.c b/plugins/datetime/csd-datetime-mechanism-debian.c
 index e554881..a4e3b79 100644
 --- a/plugins/datetime/csd-datetime-mechanism-debian.c

--- a/x11-packages/cinnamon-settings-daemon/build.sh
+++ b/x11-packages/cinnamon-settings-daemon/build.sh
@@ -1,11 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/linuxmint/cinnamon-settings-daemon
-TERMUX_PKG_DESCRIPTION="The settings daemon for the Cinnamon desktop "
+TERMUX_PKG_DESCRIPTION="The settings daemon for the Cinnamon desktop"
 TERMUX_PKG_LICENSE="GPL-2.0, LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="6.4.3"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION="6.6.0"
 TERMUX_PKG_SRCURL="https://github.com/linuxmint/cinnamon-settings-daemon/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256=e7acab8453d084dbc97347145be287a65fc513b1a5629d16587be60367a97fdd
+TERMUX_PKG_SHA256=e76a2d307f8f55c7baf1ff74d79de7f1b0a9c9995e3625f7b5ff109f4cd30f2d
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+\.\d+"
 TERMUX_PKG_DEPENDS="glib, cinnamon-desktop, libcanberra, libcolord, fontconfig, libgnomekbd, gtk3, libnotify, pango, libxfixes, pulseaudio-glib, upower, libx11, libxklavier, littlecms"


### PR DESCRIPTION
Changelog: https://github.com/linuxmint/cinnamon-settings-daemon/blob/6.6.0/debian/changelog

* Fixes #27415 

<details><summary>👉 Here is the list of removed files</summary>

```diff
@@ -33,14 +33,8 @@
 ./data/data/com.termux/files/usr/etc/xdg/autostart/cinnamon-settings-daemon-screensaver-proxy.desktop
 ./data/data/com.termux/files/usr/etc/xdg/autostart/cinnamon-settings-daemon-settings-remap.desktop
 ./data/data/com.termux/files/usr/etc/xdg/autostart/cinnamon-settings-daemon-xsettings.desktop
-./data/data/com.termux/files/usr/include/
-./data/data/com.termux/files/usr/include/cinnamon-settings-daemon-3.0/
-./data/data/com.termux/files/usr/include/cinnamon-settings-daemon-3.0/cinnamon-settings-daemon/
-./data/data/com.termux/files/usr/include/cinnamon-settings-daemon-3.0/cinnamon-settings-daemon/csd-enums.h
 ./data/data/com.termux/files/usr/lib/
 ./data/data/com.termux/files/usr/lib/cinnamon-settings-daemon/
-./data/data/com.termux/files/usr/lib/cinnamon-settings-daemon-3.0/
-./data/data/com.termux/files/usr/lib/cinnamon-settings-daemon-3.0/libcsd.so
 ./data/data/com.termux/files/usr/lib/cinnamon-settings-daemon/csd-a11y-settings
 ./data/data/com.termux/files/usr/lib/cinnamon-settings-daemon/csd-automount
 ./data/data/com.termux/files/usr/lib/cinnamon-settings-daemon/csd-background
@@ -68,24 +62,11 @@
 ./data/data/com.termux/files/usr/libexec/csd-screensaver-proxy
 ./data/data/com.termux/files/usr/libexec/csd-settings-remap
 ./data/data/com.termux/files/usr/libexec/csd-xsettings
-./data/data/com.termux/files/usr/lib/pkgconfig/
-./data/data/com.termux/files/usr/lib/pkgconfig/cinnamon-settings-daemon.pc
 ./data/data/com.termux/files/usr/share/
 ./data/data/com.termux/files/usr/share/applications/
 ./data/data/com.termux/files/usr/share/applications/csd-automount.desktop
-./data/data/com.termux/files/usr/share/cinnamon-settings-daemon/
 ./data/data/com.termux/files/usr/share/cinnamon-settings-daemon-3.0/
 ./data/data/com.termux/files/usr/share/cinnamon-settings-daemon-3.0/input-device-example.sh
-./data/data/com.termux/files/usr/share/cinnamon-settings-daemon/icons/
-./data/data/com.termux/files/usr/share/cinnamon-settings-daemon/icons/hicolor/
-./data/data/com.termux/files/usr/share/cinnamon-settings-daemon/icons/hicolor/64x64/
-./data/data/com.termux/files/usr/share/cinnamon-settings-daemon/icons/hicolor/64x64/devices/
-./data/data/com.termux/files/usr/share/cinnamon-settings-daemon/icons/hicolor/64x64/devices/kbd-capslock-off.png
-./data/data/com.termux/files/usr/share/cinnamon-settings-daemon/icons/hicolor/64x64/devices/kbd-capslock-on.png
-./data/data/com.termux/files/usr/share/cinnamon-settings-daemon/icons/hicolor/64x64/devices/kbd-numlock-off.png
-./data/data/com.termux/files/usr/share/cinnamon-settings-daemon/icons/hicolor/64x64/devices/kbd-numlock-on.png
-./data/data/com.termux/files/usr/share/cinnamon-settings-daemon/icons/hicolor/64x64/devices/kbd-scrolllock-off.png
-./data/data/com.termux/files/usr/share/cinnamon-settings-daemon/icons/hicolor/64x64/devices/kbd-scrolllock-on.png
 ./data/data/com.termux/files/usr/share/dbus-1/
 ./data/data/com.termux/files/usr/share/dbus-1/system.d/
 ./data/data/com.termux/files/usr/share/dbus-1/system.d/org.cinnamon.SettingsDaemon.DateTimeMechanism.conf
```

</details>
