### PR TITLE
rebuild(main/delve): rebuild after golang 1.25 update

### DIFF
--- a/packages/delve/build.sh
+++ b/packages/delve/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A debugger for the Go programming language"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Krishna kanhaiya @kcubeterm"
 TERMUX_PKG_VERSION="1.25.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_DEPENDS="golang, git"
 TERMUX_PKG_SRCURL=https://github.com/go-delve/delve/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=dda9adaafefa469662846d49a82cb7053605bce90bf2986d3f31be6929440ed0


### PR DESCRIPTION
This rebuild fixes following runtime error.

~/example/hello $ dlv debug
To debug executables using DWARFv5 or later Delve must be built with Go version 1.25.0 or later

* Fixes #27437 