### PR TITLE
feat(main/ndk-{sysroot,multilib}): provide `libc++experimental.a`

### DIFF
--- a/packages/ndk-multilib/build.sh
+++ b/packages/ndk-multilib/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Version should be equal to TERMUX_NDK_{VERSION_NUM,REVISION} in
 # scripts/properties.sh
 TERMUX_PKG_VERSION=29
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://dl.google.com/android/repository/android-ndk-r${TERMUX_PKG_VERSION}-linux.zip
 TERMUX_PKG_SHA256=4abbbcdc842f3d4879206e9695d52709603e52dd68d3c1fff04b3b5e7a308ecf
 TERMUX_PKG_AUTO_UPDATE=false
@@ -45,7 +46,7 @@ prepare_libs() {
 	cp $BASEDIR/${TERMUX_PKG_API_LEVEL}/lib{c,dl,log,m}.so $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/opt/ndk-multilib/$SUFFIX/lib
 	cp $BASEDIR/libc++_shared.so $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib
 	cp $BASEDIR/lib{c,dl,m}.a $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/opt/ndk-multilib/$SUFFIX/lib
-	cp $BASEDIR/lib{c++_static,c++abi}.a $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib
+	cp $BASEDIR/lib{c++_static,c++abi,c++experimental}.a $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib
 	echo 'INPUT(-lc++_static -lc++abi)' > $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib/libc++_shared.a
 
 	local f

--- a/packages/ndk-sysroot/build.sh
+++ b/packages/ndk-sysroot/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Version should be equal to TERMUX_NDK_{VERSION_NUM,REVISION} in
 # scripts/properties.sh
 TERMUX_PKG_VERSION=29
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://dl.google.com/android/repository/android-ndk-r${TERMUX_PKG_VERSION}-linux.zip
 TERMUX_PKG_SHA256=4abbbcdc842f3d4879206e9695d52709603e52dd68d3c1fff04b3b5e7a308ecf
 TERMUX_PKG_AUTO_UPDATE=false
@@ -83,6 +84,9 @@ termux_step_make_install() {
 		$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/lib
 
 	cp toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/$TERMUX_HOST_PLATFORM/libcompiler_rt-extras.a \
+		$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/lib/
+
+	cp toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/$TERMUX_HOST_PLATFORM/libc++experimental.a \
 		$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/lib/
 
 	NDK_ARCH=$TERMUX_ARCH

--- a/scripts/build/termux_step_setup_toolchain.sh
+++ b/scripts/build/termux_step_setup_toolchain.sh
@@ -7,7 +7,7 @@ termux_step_setup_toolchain() {
 		# toolchain setup to ensure that everyone gets an updated
 		# toolchain
 		if [ "${TERMUX_NDK_VERSION}" = "29" ]; then
-			TERMUX_STANDALONE_TOOLCHAIN+="-v1"
+			TERMUX_STANDALONE_TOOLCHAIN+="-v2"
 			termux_setup_toolchain_29
 		elif [ "${TERMUX_NDK_VERSION}" = 23c ]; then
 			TERMUX_STANDALONE_TOOLCHAIN+="-v9"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/27447

- Chosen Termux locations for `libc++experimental.a`:

```diff
--- ndk-sysroot-old.txt	2025-11-28 06:45:58.973316009 -0600
+++ ndk-sysroot-new.txt	2025-11-28 06:54:45.613315808 -0600
@@ -2656,6 +2656,7 @@
 /data/data/com.termux/files/usr/lib/crtend_android.o
 /data/data/com.termux/files/usr/lib/crtend_so.o
 /data/data/com.termux/files/usr/lib/libatomic.a
+/data/data/com.termux/files/usr/lib/libc++experimental.a
 /data/data/com.termux/files/usr/lib/libcompiler_rt-extras.a
 /data/data/com.termux/files/usr/lib/libpthread.so
 /data/data/com.termux/files/usr/lib/librt.so
--- ndk-multilib-old.txt	2025-11-28 06:46:09.793316005 -0600
+++ ndk-multilib-new.txt	2025-11-28 06:54:50.593315806 -0600
@@ -17,6 +17,7 @@
 /data/data/com.termux/files/usr/aarch64-linux-android/lib/libc++_shared.so
 /data/data/com.termux/files/usr/aarch64-linux-android/lib/libc++_static.a
 /data/data/com.termux/files/usr/aarch64-linux-android/lib/libc++abi.a
+/data/data/com.termux/files/usr/aarch64-linux-android/lib/libc++experimental.a
 /data/data/com.termux/files/usr/aarch64-linux-android/lib/libunwind.a
 /data/data/com.termux/files/usr/arm-linux-androideabi
 /data/data/com.termux/files/usr/arm-linux-androideabi/lib
@@ -31,6 +32,7 @@
 /data/data/com.termux/files/usr/arm-linux-androideabi/lib/libc++_shared.so
 /data/data/com.termux/files/usr/arm-linux-androideabi/lib/libc++_static.a
 /data/data/com.termux/files/usr/arm-linux-androideabi/lib/libc++abi.a
+/data/data/com.termux/files/usr/arm-linux-androideabi/lib/libc++experimental.a
 /data/data/com.termux/files/usr/arm-linux-androideabi/lib/libunwind.a
 /data/data/com.termux/files/usr/i686-linux-android
 /data/data/com.termux/files/usr/i686-linux-android/lib
@@ -45,6 +47,7 @@
 /data/data/com.termux/files/usr/i686-linux-android/lib/libc++_shared.so
 /data/data/com.termux/files/usr/i686-linux-android/lib/libc++_static.a
 /data/data/com.termux/files/usr/i686-linux-android/lib/libc++abi.a
+/data/data/com.termux/files/usr/i686-linux-android/lib/libc++experimental.a
 /data/data/com.termux/files/usr/i686-linux-android/lib/libunwind.a
 /data/data/com.termux/files/usr/opt
 /data/data/com.termux/files/usr/opt/ndk-multilib
@@ -252,5 +255,6 @@
 /data/data/com.termux/files/usr/x86_64-linux-android/lib/libc++_shared.so
 /data/data/com.termux/files/usr/x86_64-linux-android/lib/libc++_static.a
 /data/data/com.termux/files/usr/x86_64-linux-android/lib/libc++abi.a
+/data/data/com.termux/files/usr/x86_64-linux-android/lib/libc++experimental.a
 /data/data/com.termux/files/usr/x86_64-linux-android/lib/libunwind.a
 /data/data/com.termux/files/usr/share/doc/ndk-multilib/copyright
```