### PR TITLE
bump(main/nushell): 0.109.0

### DIFF
--- a/packages/nushell/build.sh
+++ b/packages/nushell/build.sh
@@ -2,14 +2,13 @@ TERMUX_PKG_HOMEPAGE=https://www.nushell.sh
 TERMUX_PKG_DESCRIPTION="A new type of shell operating on structured data"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.108.0"
+TERMUX_PKG_VERSION="0.109.0"
 TERMUX_PKG_SRCURL=https://github.com/nushell/nushell/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=5995c211411ad1d5dd7da904b9db238a543958675b9e45f5e84fbdf217499eee
+TERMUX_PKG_SHA256=b6087622414448edc3cf2ab44a339ad7a1de24de92ed7dc425da504f767f25bb
 TERMUX_PKG_DEPENDS="openssl"
 TERMUX_PKG_RECOMMENDS="command-not-found, termux-api"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--no-default-features --features plugin,trash-support,sqlite,network,native-tls"
 
 termux_step_pre_configure() {
 	termux_setup_rust

--- a/packages/nushell/disable-feature-user.patch
+++ b/packages/nushell/disable-feature-user.patch
@@ -1,20 +1,20 @@
 diff --git a/Cargo.toml b/Cargo.toml
-index 34a0c5be..00d6e17b 100644
+index d439ffc..aa245fa 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -161,7 +161,9 @@ strip-ansi-escapes = "0.2.1"
+@@ -177,7 +177,9 @@ strip-ansi-escapes = "0.2.1"
  strum = "0.26"
- strum_macros = "0.26"
+ strum_macros = "0.27"
  syn = "2.0"
--sysinfo = "0.36"
+-sysinfo = "0.37.2"
 +# Starting from 0.36, the `user` feature uses `getpwent`, etc.
 +# These were added to Android in API 26, but termux currently targets API 24.
-+sysinfo = { version = "0.36", default-features = false, features = ["component", "disk", "network", "system"] }
++sysinfo = { version = "0.37.2", default-features = false, features = ["component", "disk", "network", "system"] }
  tabled = { version = "0.20", default-features = false }
- tempfile = "3.20"
+ tempfile = "3.23"
  thiserror = "2.0.12"
 diff --git a/crates/nu-command/src/system/sys/users.rs b/crates/nu-command/src/system/sys/users.rs
-index ffc84f05..985ea1f1 100644
+index 88b22f7..35ccd31 100644
 --- a/crates/nu-command/src/system/sys/users.rs
 +++ b/crates/nu-command/src/system/sys/users.rs
 @@ -1,6 +1,4 @@

--- a/packages/nushell/replace-osc-52-with-termux-clipboard-get.patch
+++ b/packages/nushell/replace-osc-52-with-termux-clipboard-get.patch
@@ -1,5 +1,5 @@
 diff --git a/crates/nu-std/std/clip/mod.nu b/crates/nu-std/std/clip/mod.nu
-index ef2da0bfd..eb7065916 100644
+index ef2da0b..d313485 100644
 --- a/crates/nu-std/std/clip/mod.nu
 +++ b/crates/nu-std/std/clip/mod.nu
 @@ -30,16 +30,13 @@ export def copy [


### PR DESCRIPTION
just regenerated patches

release notes: https://www.nushell.sh/blog/2025-11-29-nushell_v0_109_0.html

Closes https://github.com/termux/termux-packages/issues/27465