### PR TITLE
scripts(lint-packages.sh): warn for GitHub URLs not using /archive/refs/tags/

### DIFF
--- a/scripts/lint-packages.sh
+++ b/scripts/lint-packages.sh
@@ -456,26 +456,113 @@ lint_package() {
 
 		echo -n "TERMUX_PKG_SRCURL: "
 		if (( ${#TERMUX_PKG_SRCURL} )); then
-			urls_ok=true
-			for url in "${TERMUX_PKG_SRCURL[@]}"; do
-				if (( ${#url} )); then
-					case "$url" in
-						https://*|git+https://*) continue;;
-						*) echo "NON-HTTPS (acceptable)" ; urls_ok=false; break ;;
-					esac
-				else
-					echo "NOT SET (one of the array elements)"
-					urls_ok=false
+			for (( i = 0; i < ${#TERMUX_PKG_SRCURL[@]}; i++ )); do
+				url="${TERMUX_PKG_SRCURL[$i]}"
+				(( ${#url} )) || {
+					echo "NOT SET (\${TERMUX_PKG_SRCURL[$i]} has no value)"
 					pkg_lint_error=true
 					break
-				fi
-			done
-			unset url
+				}
+				# Example:
+				# https://github.com/openssh/openssh-portable/archive/refs/tags/V_10_2_P1.tar.gz
+				# protocol="https:"
+				#        _=""
+				#     host="github.com"
+				#     user="openssh"
+				#     repo="openssh-portable"
+				# ref_path="archive/refs/tags/V_10_2_P1.tar.gz"
+				IFS='/' read -r protocol _ host user repo ref_path <<< "$url"
+				case "${protocol}" in
+					https:) protocol_type="HTTPS";;
+					git+https:) protocol_type="Git/HTTPS";;
+					file:)
+						if [[ -d "${url#file://}" ]]; then
+							protocol_type="Local source directory"
+						else
+							protocol_type="Local tarball"
+						fi
+					;;
+					git+file:) protocol_type="Local Git repository";;
+					git+*) protocol_type="Git/NON-HTTPS (acceptable)";;
+					*) protocol_type="NON-HTTPS (acceptable)";;
+				esac
 
-			if [[ "$urls_ok" == 'true' ]]; then
-				echo "PASS"
-			fi
-			unset urls_ok
+				case "${host}" in
+					"github.com")
+						# Is this a release tarball?
+						if [[ "$ref_path" == releases/download/* ]]; then
+							tarball_type="Release"
+						# Is it a tag tarball?
+						elif [[ "$ref_path" == archive/refs/tags/* ]]; then
+							tarball_type="Tag"
+						# Is it an untagged commit tarball?
+						elif [[ "$ref_path" =~ archive/[0-9a-f]{7,64} ]]; then
+							tarball_type="Commit"
+						# If it's in archive/ anyway then it's probably a tag with the incorrect download path.
+						elif [[ "$ref_path" == archive/* ]]; then
+							tarball_type="can-fix"
+							printf -v lint_msg '%s\n' \
+								"PARTIAL PASS - Tag with potential ref confusion." \
+								"WARNING: GitHub tarball URLs should use /archive/refs/tags/ instead of /archive/" \
+								"to avoid potential ref confusion with branches sharing the name of a tag." \
+								"See: https://lore.kernel.org/buildroot/87edqhwvd0.fsf@dell.be.48ers.dk/T/" \
+								"  Current:   $url" \
+								"  Suggested: ${url/\/archive\//\/archive\/refs\/tags\/}"
+						else
+							# Is this a git repo or local source? If so, it makes sense we don't have a $ref_path
+							case "${protocol}" in
+								file:|git+file:)
+									tarball_type="local"
+									printf -v lint_msg '%s\n' \
+										"PASS - "
+								;;
+								git+*);;
+								*) # If we still have no match at this point declare it an error.
+									tarball_type="invalid"
+									printf -v lint_msg '%s\n' \
+										"FAIL (Unknown tarball path pattern for host '$host')" \
+										"  Url: $url" \
+										"  Tarball path: $ref_path" \
+										"  This isn't a typical tarball location for $host."
+								;;
+							esac
+						fi
+					;;
+					# For other hosts we don't know the typical pattern so don't try guessing the tarball_type.
+					*);;
+				esac
+
+				# Print the appropriate result based on our findings from above
+				case "$tarball_type" in
+					"invalid") # Known host, unknown tarball url pattern.
+						pkg_lint_error=true
+						echo "$lint_msg"
+						break
+					;;
+					"can-fix") # Known host, known pattern, but should be changed.
+						echo "$lint_msg"
+					;;
+					"local") # Local source.
+						echo "$lint_msg"
+					;;
+					*) # Known host, known pattern, or host with no checked tarball URL patterns.
+						# $user and $repo corresponds to those URL components for e.g. GitHub.
+						# but it may not do so for other tarball hosts, they are included for additional context.
+						echo "PASS - (${tarball_type+"${tarball_type}/"}${protocol_type}) ${host}/${user}/${repo}"
+					;;
+				esac
+			# Additional debug output
+				# printf '%s\n' \
+				# 	"  URL: $url" \
+				# 	"PROTO: $protocol" \
+				# 	"   _: " \
+				# 	" HOST: $host" \
+				# 	" USER: $user" \
+				# 	" REPO: $repo" \
+				# 	" PATH: $ref_path"
+
+			done
+			unset i url protocol host user repo ref_path protocol_type tarball_type lint_msg
 
 			echo -n "TERMUX_PKG_SHA256: "
 			if (( ${#TERMUX_PKG_SHA256} )); then


### PR DESCRIPTION
GitHub archive URLs using `/archive/<tag>.tar.gz` can be ambiguous when both a tag and branch exist with the same name. Using the format `/archive/refs/tags/<tag>.tar.gz` explicitly references the tag.

This adds a warning (not error) to the linter when a GitHub archive URL doesn't use the `/archive/refs/tags/` format.

**Reference:** https://lore.kernel.org/buildroot/87edqhwvd0.fsf@dell.be.48ers.dk/T/

**Example Output:**
```
TERMUX_PKG_SRCURL: PASS
WARNING: GitHub archive URL should use /archive/refs/tags/ instead of /archive/
  Current:   https://github.com/assimp/assimp/archive/v5.0.0.tar.gz
  Suggested: https://github.com/assimp/assimp/archive/refs/tags/v5.0.0.tar.gz
```

Fixes #23623