### PR TITLE
bump(main/sbcl): 2.5.11

### DIFF
--- a/packages/sbcl/build.sh
+++ b/packages/sbcl/build.sh
@@ -3,15 +3,15 @@ TERMUX_PKG_DESCRIPTION="A high performance Common Lisp compiler"
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="2.5.10"
+TERMUX_PKG_VERSION="2.5.11"
 # sourceforge archive is a precompiled SBCL release for GNU/Linux to use as host Lisp for bootstrapping
 TERMUX_PKG_SRCURL=(
 	https://github.com/sbcl/sbcl/archive/refs/tags/sbcl-${TERMUX_PKG_VERSION}.tar.gz
 	https://sourceforge.net/projects/sbcl/files/sbcl/${TERMUX_PKG_VERSION}/sbcl-${TERMUX_PKG_VERSION}-x86-64-linux-binary.tar.bz2
 )
 TERMUX_PKG_SHA256=(
-	5c8aefa7b745b45a2d169f76845c4c75630662494f419307c256c3fa7d0805d1
-	1f7b0b7226bfcebc4027333b0ad170f36486b589e2c492edaa78ab7f7a6cbd88
+	a06ad98fb59611e5d66539bdc6c31fae7d9cf72b5039a23d7e2adc955f0b615e
+	4f229e3e4106080820d095bb30ded0cd475a5c3202cbb8e580179d6b1cbaad2a
 )
 TERMUX_PKG_DEPENDS="zstd"
 # TERMUX_ON_DEVICE_BUILD=true  build dependencies: ecl, strace

--- a/packages/sbcl/disable-failing-tests-that-were-only-enabled-on-x86.patch
+++ b/packages/sbcl/disable-failing-tests-that-were-only-enabled-on-x86.patch
@@ -19,12 +19,12 @@ effects that this test failing implies would be:
  (exit :code 2) ; otherwise skip the test
 --- a/tests/elfcore.test.sh
 +++ b/tests/elfcore.test.sh
-@@ -16,7 +16,7 @@
- . ./subr.sh
- 
+@@ -18,7 +18,7 @@
  run_sbcl <<EOF
+   (when (member :sb-cover-for-internals sb-impl::+internal-features+)
+     (exit :code 2)) ; breaks static linkage somehow. lp#2131956
 -  #+(and linux elf sb-thread)
 +  #+(and linux elf sb-thread (not android))
    (let ((s (find-symbol "IMMOBILE-SPACE-OBJ-P" "SB-KERNEL")))
      (when (and s (funcall s #'car)) (exit :code 0))) ; good
-  (exit :code 2) ; otherwise
+   (exit :code 2) ; otherwise


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/27485

- Rebase `disable-failing-tests-that-were-only-enabled-on-x86.patch`