### PR TITLE
bump(x11/codelldb): 1.12.0

### DIFF
--- a/x11-packages/codelldb/build.sh
+++ b/x11-packages/codelldb/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://github.com/vadimcn/codelldb
 TERMUX_PKG_DESCRIPTION="A native debugger extension for VSCode based on LLDB"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.11.8"
+TERMUX_PKG_VERSION="1.12.0"
 TERMUX_PKG_SRCURL="https://github.com/vadimcn/codelldb/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256=ea6a2d61a9d61fed6bdc0568851a5c95c1873bf0e088e509d6ee3743f85da1be
+TERMUX_PKG_SHA256=9dbeed978470d2c503a704f0ec90c2b28ad3e1a7ea6a6a7c4dae6a579f485dd7
 TERMUX_PKG_AUTO_UPDATE=true
 # codelldb does not work properly on 32-bit Android
 TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"

--- a/x11-packages/codelldb/disable-sbapi.patch
+++ b/x11-packages/codelldb/disable-sbapi.patch
@@ -2,7 +2,26 @@ This entire structure is used to detect whether the LLDB being used
 has SBInstruction::GetControlFlowKind(), which LLDB versions 16 and newer have.
 Termux has had LLDB version 16 or newer since 2023.
 
+sbcommandinterpreter.rs: partially revert https://github.com/vadimcn/codelldb/commit/bc1281e93d611deaa3670bfcc395bf095fcba659,
+which is for LLDB 17 and older, to prevent this error:
+error: 'is_default_constructible' cannot be specialized:
+Users are not allowed to specialize this standard library entity [-Winvalid-specialization]
 
+--- a/src/lldb/src/sb/sbcommandinterpreter.rs
++++ b/src/lldb/src/sb/sbcommandinterpreter.rs
+@@ -1,12 +1,5 @@
+ use super::*;
+ 
+-cpp! {{
+-namespace std {
+-    // Prevent cpp from auto-deriving Default, which would use the default SBCommandInterpreter constructor
+-    // introduced in v18, causing codelldb to be incompatible with earlier versions.
+-    template<> struct is_default_constructible<lldb::SBCommandInterpreter> : std::false_type {};
+-}
+-}}
+ cpp_class!(pub unsafe struct SBCommandInterpreter as "SBCommandInterpreter");
+ 
+ unsafe impl Send for SBCommandInterpreter {}
 --- a/src/lldb-stub/build.rs
 +++ b/src/lldb-stub/build.rs
 @@ -32,21 +32,6 @@ fn main() -> Result<(), Error> {
@@ -38,6 +57,15 @@ Termux has had LLDB version 16 or newer since 2023.
              supports_stepping_granularity: Some(true),
              supports_write_memory_request: Some(true),
              ..Default::default()
+@@ -1434,7 +1434,7 @@ impl DebugSession {
+             self.handle_breakpoint_event(&bp_event);
+         } else if let Some(thread_event) = event.as_thread_event() {
+             self.handle_thread_event(&thread_event);
+-        } else if lldb_stub::v15.resolve().is_ok() {
++        } else {
+             if let Some(diag_event) = event.as_diagnostic_event() {
+                 self.handle_diagnostic_event(&diag_event);
+             }
 --- a/src/codelldb/src/debug_session/step_in.rs
 +++ b/src/codelldb/src/debug_session/step_in.rs
 @@ -32,7 +32,6 @@ impl super::DebugSession {
@@ -48,6 +76,14 @@ Termux has had LLDB version 16 or newer since 2023.
  
          // This is the typical case we aim to handle:
          // ```
+@@ -183,7 +183,6 @@ impl super::DebugSession {
+     }
+ 
+     fn step_into_target(&self, thread: &SBThread, step_target: &StepInTargetInternal) -> Result<(), Error> {
+-        let _token = lldb_stub::v16.resolve()?;
+         self.with_sync_mode(|| {
+             let start_frame = thread.frame_at_index(0);
+             thread.step_into(RunMode::OnlyThisThread)?;
 --- a/src/lldb/src/lib.rs
 +++ b/src/lldb/src/lib.rs
 @@ -26,5 +26,4 @@ fn test_init() {

--- a/x11-packages/codelldb/lldb-paths.patch
+++ b/x11-packages/codelldb/lldb-paths.patch
@@ -1,17 +1,26 @@
 Direct the extension to search for LLDB in $TERMUX_PREFIX/bin and $TERMUX_PREFIX/lib instead
 of in the extension's own installation folder
 
---- a/extension/main.ts
-+++ b/extension/main.ts
-@@ -383,7 +383,7 @@ class Extension implements DebugAdapterDescriptorFactory {
-             if (library) {
-                 this.liblldbPath = await adapter.findLibLLDB(library)
-             } else {
--                this.liblldbPath = await adapter.findLibLLDB(path.join(this.context.extensionPath, 'lldb'));
-+                this.liblldbPath = await adapter.findLibLLDB('@TERMUX_PREFIX@');
-             }
-         }
-         return this.liblldbPath;
+--- a/extension/adapterUtils.ts
++++ b/extension/adapterUtils.ts
+@@ -19,7 +19,7 @@ export async function alternateBackend(extensionPath: string) {
+                 let lldbDir = path.resolve(path.join(dirs.supportExeDir, '..'));
+                 let libraryPath = await adapter.findLibLLDB(lldbDir);
+                 let serverPath;
+-                if (process.platform == 'linux') {
++                if (process.platform == 'linux' || process.platform == 'android') {
+                     serverPath = await adapter.findFileByPattern(dirs.supportExeDir, /lldb-server(-.*)?/);
+                     if (serverPath) {
+                         let stats = await async.fs.stat(serverPath).catch(_ => null);
+@@ -40,7 +40,7 @@ export async function alternateBackend(extensionPath: string) {
+                     let message = `Located liblldb at: ${libraryPath}`;
+                     if (serverPath)
+                         message += `\r\nand lldb server at: ${serverPath}`;
+-                    else if (process.platform == 'linux')
++                    else if (process.platform == 'linux' || process.platform == 'android')
+                         message += '\r\nbut did not find lldb server.';
+ 
+                     let choice;
 --- a/cargo_config.unix.toml
 +++ b/cargo_config.unix.toml
 @@ -10,6 +10,6 @@ CXX_${LLVM_TRIPLE} = "${CMAKE_CXX_COMPILER}"

--- a/x11-packages/codelldb/move-adapter-outside-vsix.diff
+++ b/x11-packages/codelldb/move-adapter-outside-vsix.diff
@@ -69,15 +69,15 @@ package file to outside of it.
      Ok(interface)
 --- a/extension/novsc/adapter.ts
 +++ b/extension/novsc/adapter.ts
-@@ -26,7 +26,7 @@ export interface ProcessSpawnParams {
- export async function getSpawnParams(
-     options: AdapterStartOptions
- ): Promise<ProcessSpawnParams> {
--    let executable = path.join(options.extensionRoot, 'adapter', 'codelldb');
-+    let executable = '@TERMUX_PREFIX@/bin/codelldb';
+@@ -19,7 +19,7 @@ export interface AdapterStartOptions {
+ }
  
+ export async function start(options: AdapterStartOptions): Promise<async.cp.ChildProcess> {
+-    let executable = path.join(options.extensionPath, 'adapter', 'codelldb');
++    let executable = '@TERMUX_PREFIX@/bin/codelldb';
      let args: string[] = [];
      if (options.liblldb) {
+         args.push('--liblldb', options.liblldb);
 @@ -84,7 +84,7 @@ export async function findLibLLDB(pathHint: string): Promise<string | undefined>
  
      let libDir;


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/27492

- Rebase patches

- Add more SBAPI removals (SBAPI removals remove compatibility with old LLDB versions that Termux does not support)

- Add more patches of `process.platform == 'linux'` to `process.platform == 'android'` (`code-server` has `process.platform == 'android'`)