### PR TITLE
fix(main/libandroid-stub): fix build with `TERMUX_PKG_API_LEVEL=24` and disable RELR tags

### DIFF
--- a/packages/libandroid-stub/build.sh
+++ b/packages/libandroid-stub/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Version should be equal to TERMUX_NDK_{VERSION_NUM,REVISION} in
 # scripts/properties.sh
 TERMUX_PKG_VERSION=29
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_CONFLICTS="libandroid"
 TERMUX_PKG_REPLACES="libandroid"
@@ -13,7 +14,14 @@ TERMUX_PKG_SKIP_SRC_EXTRACT=true
 TERMUX_PKG_API_LEVEL=28
 
 termux_step_make() {
-	"${CC}" -shared -fPIC -o "${TERMUX_PREFIX}/lib/libandroid.so" "$TERMUX_PKG_BUILDER_DIR/libandroid-wrapper.c" -Wno-deprecated-declarations
-	"${CC}" -shared -fPIC -o "${TERMUX_PREFIX}/lib/libmediandk.so" "$TERMUX_PKG_BUILDER_DIR/libmediandk-wrapper.c" -Wno-deprecated-declarations
-	"${CC}" -shared -fPIC -o "${TERMUX_PREFIX}/lib/libOpenSLES.so" "$TERMUX_PKG_BUILDER_DIR/libOpenSLES-wrapper.c" -Wno-deprecated-declarations
+	local stub
+	for stub in android mediandk OpenSLES; do
+		"${CC}" -shared -fPIC \
+			-o "${TERMUX_PREFIX}/lib/lib${stub}.so" \
+			"${TERMUX_PKG_BUILDER_DIR}/lib${stub}-wrapper.c" \
+			$CFLAGS $LDFLAGS \
+			-Wno-deprecated-declarations \
+			-Wl,--no-use-android-relr-tags \
+			-Wl,--pack-dyn-relocs=android
+	done
 }

--- a/packages/libandroid-stub/libandroid-wrapper.c
+++ b/packages/libandroid-stub/libandroid-wrapper.c
@@ -26,6 +26,99 @@
 #define LIB "/system/lib/libandroid.so"
 #endif
 
+#if __ANDROID_API__ >= 26
+#define AHardwareBuffer_API26_FUNCTIONS_1(f) \
+    f(AHardwareBuffer_fromHardwareBuffer) \
+    f(AHardwareBuffer_toHardwareBuffer) \
+    f(AHardwareBuffer_allocate) \
+    f(AHardwareBuffer_acquire) \
+    f(AHardwareBuffer_release) \
+    f(AHardwareBuffer_describe) \
+    f(AHardwareBuffer_lock) \
+    f(AHardwareBuffer_unlock) \
+    f(AHardwareBuffer_sendHandleToUnixSocket) \
+    f(AHardwareBuffer_recvHandleFromUnixSocket)
+#else
+#define AHardwareBuffer_API26_FUNCTIONS_1(f)
+#endif
+
+#if __ANDROID_API__ >= 26
+#define ANativeWindow_API26_FUNCTIONS_1(f) \
+    f(ANativeWindow_toSurface)
+#else
+#define ANativeWindow_API26_FUNCTIONS_1(f)
+#endif
+
+#if __ANDROID_API__ >= 26
+#define ANativeWindow_API26_FUNCTIONS_2(f) \
+    f(ANativeWindow_setBuffersTransform)
+#else
+#define ANativeWindow_API26_FUNCTIONS_2(f)
+#endif
+
+#if __ANDROID_API__ >= 28
+#define ANativeWindow_API28_FUNCTIONS_1(f) \
+    f(ANativeWindow_setBuffersDataSpace) \
+    f(ANativeWindow_getBuffersDataSpace)
+#else
+#define ANativeWindow_API28_FUNCTIONS_1(f)
+#endif
+
+#if __ANDROID_API__ >= 26
+#define ASensorManager_API26_FUNCTIONS_1(f) \
+    f(ASensorManager_getInstanceForPackage)
+#else
+#define ASensorManager_API26_FUNCTIONS_1(f)
+#endif
+
+#if __ANDROID_API__ >= 26
+#define ASensorManager_API26_FUNCTIONS_2(f) \
+    f(ASensorManager_createSharedMemoryDirectChannel) \
+    f(ASensorManager_createHardwareBufferDirectChannel) \
+    f(ASensorManager_destroyDirectChannel) \
+    f(ASensorManager_configureDirectReport)
+#else
+#define ASensorManager_API26_FUNCTIONS_2(f)
+#endif
+
+#if __ANDROID_API__ >= 26
+#define ASensor_API26_FUNCTIONS_1(f) \
+    f(ASensor_isDirectChannelTypeSupported) \
+    f(ASensor_getHighestDirectReportRateLevel)
+#else
+#define ASensor_API26_FUNCTIONS_1(f)
+#endif
+
+#if __ANDROID_API__ >= 27
+#define ASharedMemory_API27_FUNCTIONS_1(f) \
+    f(ASharedMemory_dupFromJava)
+#else
+#define ASharedMemory_API27_FUNCTIONS_1(f)
+#endif
+
+#if __ANDROID_API__ >= 26
+#define ASharedMemory_API26_FUNCTIONS_1(f) \
+    f(ASharedMemory_create) \
+    f(ASharedMemory_getSize) \
+    f(ASharedMemory_setProt)
+#else
+#define ASharedMemory_API26_FUNCTIONS_1(f)
+#endif
+
+#if __ANDROID_API__ >= 28
+#define ASurfaceTexture_API28_FUNCTIONS_1(f) \
+    f(ASurfaceTexture_fromSurfaceTexture) \
+    f(ASurfaceTexture_release) \
+    f(ASurfaceTexture_acquireANativeWindow) \
+    f(ASurfaceTexture_attachToGLContext) \
+    f(ASurfaceTexture_detachFromGLContext) \
+    f(ASurfaceTexture_updateTexImage) \
+    f(ASurfaceTexture_getTransformMatrix) \
+    f(ASurfaceTexture_getTimestamp)
+#else
+#define ASurfaceTexture_API28_FUNCTIONS_1(f)
+#endif
+
 #define FUNCTIONS(f) \
     f(AAssetManager_openDir) \
     f(AAssetManager_open) \
@@ -96,16 +189,7 @@
     f(AConfiguration_diff) \
     f(AConfiguration_match) \
     f(AConfiguration_isBetterThan) \
-    f(AHardwareBuffer_fromHardwareBuffer) \
-    f(AHardwareBuffer_toHardwareBuffer) \
-    f(AHardwareBuffer_allocate) \
-    f(AHardwareBuffer_acquire) \
-    f(AHardwareBuffer_release) \
-    f(AHardwareBuffer_describe) \
-    f(AHardwareBuffer_lock) \
-    f(AHardwareBuffer_unlock) \
-    f(AHardwareBuffer_sendHandleToUnixSocket) \
-    f(AHardwareBuffer_recvHandleFromUnixSocket) \
+    AHardwareBuffer_API26_FUNCTIONS_1(f) \
     f(AInputEvent_getType) \
     f(AInputEvent_getDeviceId) \
     f(AInputEvent_getSource) \
@@ -177,7 +261,7 @@
     f(ANativeActivity_showSoftInput) \
     f(ANativeActivity_hideSoftInput) \
     f(ANativeWindow_fromSurface) \
-    f(ANativeWindow_toSurface) \
+    ANativeWindow_API26_FUNCTIONS_1(f) \
     f(ANativeWindow_acquire) \
     f(ANativeWindow_release) \
     f(ANativeWindow_getWidth) \
@@ -186,25 +270,21 @@
     f(ANativeWindow_setBuffersGeometry) \
     f(ANativeWindow_lock) \
     f(ANativeWindow_unlockAndPost) \
-    f(ANativeWindow_setBuffersTransform) \
-    f(ANativeWindow_setBuffersDataSpace) \
-    f(ANativeWindow_getBuffersDataSpace) \
+    ANativeWindow_API26_FUNCTIONS_2(f) \
+    ANativeWindow_API28_FUNCTIONS_1(f) \
     f(AObbScanner_getObbInfo) \
     f(AObbInfo_delete) \
     f(AObbInfo_getPackageName) \
     f(AObbInfo_getVersion) \
     f(AObbInfo_getFlags) \
     f(ASensorManager_getInstance) \
-    f(ASensorManager_getInstanceForPackage) \
+    ASensorManager_API26_FUNCTIONS_1(f) \
     f(ASensorManager_getSensorList) \
     f(ASensorManager_getDefaultSensor) \
     f(ASensorManager_getDefaultSensorEx) \
     f(ASensorManager_createEventQueue) \
     f(ASensorManager_destroyEventQueue) \
-    f(ASensorManager_createSharedMemoryDirectChannel) \
-    f(ASensorManager_createHardwareBufferDirectChannel) \
-    f(ASensorManager_destroyDirectChannel) \
-    f(ASensorManager_configureDirectReport) \
+    ASensorManager_API26_FUNCTIONS_2(f) \
     f(ASensorEventQueue_registerSensor) \
     f(ASensorEventQueue_enableSensor) \
     f(ASensorEventQueue_disableSensor) \
@@ -221,26 +301,16 @@
     f(ASensor_getStringType) \
     f(ASensor_getReportingMode) \
     f(ASensor_isWakeUpSensor) \
-    f(ASensor_isDirectChannelTypeSupported) \
-    f(ASensor_getHighestDirectReportRateLevel) \
-    f(ASharedMemory_dupFromJava) \
-    f(ASharedMemory_create) \
-    f(ASharedMemory_getSize) \
-    f(ASharedMemory_setProt) \
+    ASensor_API26_FUNCTIONS_1(f) \
+    ASharedMemory_API27_FUNCTIONS_1(f) \
+    ASharedMemory_API26_FUNCTIONS_1(f) \
     f(AStorageManager_new) \
     f(AStorageManager_delete) \
     f(AStorageManager_mountObb) \
     f(AStorageManager_unmountObb) \
     f(AStorageManager_isObbMounted) \
     f(AStorageManager_getMountedObbPath) \
-    f(ASurfaceTexture_fromSurfaceTexture) \
-    f(ASurfaceTexture_release) \
-    f(ASurfaceTexture_acquireANativeWindow) \
-    f(ASurfaceTexture_attachToGLContext) \
-    f(ASurfaceTexture_detachFromGLContext) \
-    f(ASurfaceTexture_updateTexImage) \
-    f(ASurfaceTexture_getTransformMatrix) \
-    f(ASurfaceTexture_getTimestamp) \
+    ASurfaceTexture_API28_FUNCTIONS_1(f) \
     f(ATrace_isEnabled) \
     f(ATrace_beginSection) \
     f(ATrace_endSection) \
@@ -542,6 +612,7 @@ int32_t AConfiguration_isBetterThan(AConfiguration* base, AConfiguration* test, 
     CALL(AConfiguration_isBetterThan, 0, base, test, requested);
 }
 
+#if __ANDROID_API__ >= 26
 AHardwareBuffer* AHardwareBuffer_fromHardwareBuffer(JNIEnv* env, jobject hardwareBufferObj) {
     CALL(AHardwareBuffer_fromHardwareBuffer, NULL, env, hardwareBufferObj);
 }
@@ -581,6 +652,7 @@ int AHardwareBuffer_sendHandleToUnixSocket(const AHardwareBuffer* _Nonnull buffe
 int AHardwareBuffer_recvHandleFromUnixSocket(int socketFd, AHardwareBuffer* _Nullable* _Nonnull outBuffer) {
     CALL(AHardwareBuffer_recvHandleFromUnixSocket, 0, socketFd, outBuffer);
 }
+#endif
 
 int32_t AInputEvent_getType(const AInputEvent* event) {
     CALL(AInputEvent_getType, 0, event);
@@ -866,9 +938,11 @@ ANativeWindow* ANativeWindow_fromSurface(JNIEnv* env, jobject surface) {
     CALL(ANativeWindow_fromSurface, NULL, env, surface);
 }
 
+#if __ANDROID_API__ >= 26
 jobject ANativeWindow_toSurface(JNIEnv* env, ANativeWindow* window) {
     CALL(ANativeWindow_toSurface, NULL, env, window);
 }
+#endif
 
 void ANativeWindow_acquire(ANativeWindow* window) {
     CALL(ANativeWindow_acquire,, window);
@@ -902,10 +976,13 @@ int32_t ANativeWindow_unlockAndPost(ANativeWindow* window) {
     CALL(ANativeWindow_unlockAndPost, 0, window);
 }
 
+#if __ANDROID_API__ >= 26
 int32_t ANativeWindow_setBuffersTransform(ANativeWindow* window, int32_t transform) {
     CALL(ANativeWindow_setBuffersTransform, 0, window, transform);
 }
+#endif
 
+#if __ANDROID_API__ >= 28
 int32_t ANativeWindow_setBuffersDataSpace(ANativeWindow* window, int32_t dataSpace) {
     CALL(ANativeWindow_setBuffersDataSpace, 0, window, dataSpace);
 }
@@ -913,6 +990,7 @@ int32_t ANativeWindow_setBuffersDataSpace(ANativeWindow* window, int32_t dataSpa
 int32_t ANativeWindow_getBuffersDataSpace(ANativeWindow* window) {
     CALL(ANativeWindow_getBuffersDataSpace, 0, window);
 }
+#endif
 
 AObbInfo* AObbScanner_getObbInfo(const char* filename) {
     CALL(AObbScanner_getObbInfo, NULL, filename);
@@ -938,9 +1016,11 @@ ASensorManager* ASensorManager_getInstance() {
     CALL(ASensorManager_getInstance, NULL);
 }
 
+#if __ANDROID_API__ >= 26
 ASensorManager* ASensorManager_getInstanceForPackage(const char* packageName) {
     CALL(ASensorManager_getInstanceForPackage, NULL, packageName);
 }
+#endif
 
 int ASensorManager_getSensorList(ASensorManager* manager, ASensorList* list) {
     CALL(ASensorManager_getSensorList, 0, manager, list);
@@ -962,6 +1042,7 @@ int ASensorManager_destroyEventQueue(ASensorManager* manager, ASensorEventQueue*
     CALL(ASensorManager_destroyEventQueue, 0, manager, queue);
 }
 
+#if __ANDROID_API__ >= 26
 int ASensorManager_createSharedMemoryDirectChannel(ASensorManager* manager, int fd, size_t size) {
     CALL(ASensorManager_createSharedMemoryDirectChannel, 0, manager, fd, size);
 }
@@ -977,6 +1058,7 @@ void ASensorManager_destroyDirectChannel(ASensorManager* manager, int channelId)
 int ASensorManager_configureDirectReport(ASensorManager* manager, ASensor const* sensor, int channelId, int rate) {
     CALL(ASensorManager_configureDirectReport, 0, manager, sensor, channelId, rate);
 }
+#endif
 
 int ASensorEventQueue_registerSensor(ASensorEventQueue* queue, ASensor const* sensor, int32_t samplingPeriodUs, int64_t maxBatchReportLatencyUs) {
     CALL(ASensorEventQueue_registerSensor, 0, queue, sensor, samplingPeriodUs, maxBatchReportLatencyUs);
@@ -1042,6 +1124,7 @@ bool ASensor_isWakeUpSensor(ASensor const* sensor) {
     CALL(ASensor_isWakeUpSensor, false, sensor);
 }
 
+#if __ANDROID_API__ >= 26
 bool ASensor_isDirectChannelTypeSupported(ASensor const* sensor, int channelType) {
     CALL(ASensor_isDirectChannelTypeSupported, false, sensor, channelType);
 }
@@ -1049,11 +1132,15 @@ bool ASensor_isDirectChannelTypeSupported(ASensor const* sensor, int channelType
 int ASensor_getHighestDirectReportRateLevel(ASensor const* sensor) {
     CALL(ASensor_getHighestDirectReportRateLevel, 0, sensor);
 }
+#endif
 
+#if __ANDROID_API__ >= 27
 int ASharedMemory_dupFromJava(JNIEnv* env, jobject sharedMemory) {
     CALL(ASharedMemory_dupFromJava, 0, env, sharedMemory);
 }
+#endif
 
+#if __ANDROID_API__ >= 26
 int ASharedMemory_create(const char *name, size_t size) {
     CALL(ASharedMemory_create, -1, name, size);
 }
@@ -1065,6 +1152,7 @@ size_t ASharedMemory_getSize(int fd) {
 int ASharedMemory_setProt(int fd, int prot) {
     CALL(ASharedMemory_setProt, 0, fd, prot);
 }
+#endif
 
 AStorageManager* AStorageManager_new() {
     CALL(AStorageManager_new, NULL);
@@ -1090,6 +1178,7 @@ const char* AStorageManager_getMountedObbPath(AStorageManager* mgr, const char* 
     CALL(AStorageManager_getMountedObbPath, NULL, mgr, filename);
 }
 
+#if __ANDROID_API__ >= 28
 ASurfaceTexture* ASurfaceTexture_fromSurfaceTexture(JNIEnv* env, jobject surfacetexture) {
     CALL(ASurfaceTexture_fromSurfaceTexture, NULL, env, surfacetexture);
 }
@@ -1121,6 +1210,7 @@ void ASurfaceTexture_getTransformMatrix(ASurfaceTexture* st, float mtx[16]) {
 int64_t ASurfaceTexture_getTimestamp(ASurfaceTexture* st) {
     CALL(ASurfaceTexture_getTimestamp, 0, st);
 }
+#endif
 
 bool ATrace_isEnabled() {
     CALL(ATrace_isEnabled, false);

--- a/packages/libandroid-stub/libmediandk-wrapper.c
+++ b/packages/libandroid-stub/libmediandk-wrapper.c
@@ -15,6 +15,89 @@
 #define LIB "/system/lib/libmediandk.so"
 #endif
 
+#if __ANDROID_API__ >= 26
+#define AImage_API26_FUNCTIONS_1(f) \
+    f(AImage_deleteAsync) \
+    f(AImage_getHardwareBuffer)
+#else
+#define AImage_API26_FUNCTIONS_1(f)
+#endif
+
+#if __ANDROID_API__ >= 26
+#define AImageReader_API26_FUNCTIONS_1(f) \
+    f(AImageReader_newWithUsage) \
+    f(AImageReader_acquireNextImageAsync) \
+    f(AImageReader_acquireLatestImageAsync) \
+    f(AImageReader_setBufferRemovedListener)
+#else
+#define AImageReader_API26_FUNCTIONS_1(f)
+#endif
+
+#if __ANDROID_API__ >= 26
+#define AMediaCodec_API26_FUNCTIONS_1(f) \
+    f(AMediaCodec_createInputSurface) \
+    f(AMediaCodec_createPersistentInputSurface) \
+    f(AMediaCodec_setInputSurface) \
+    f(AMediaCodec_setParameters) \
+    f(AMediaCodec_signalEndOfInputStream)
+#else
+#define AMediaCodec_API26_FUNCTIONS_1(f)
+#endif
+
+#if __ANDROID_API__ >= 28
+#define AMediaCodec_API28_FUNCTIONS_1(f) \
+    f(AMediaCodec_getBufferFormat) \
+    f(AMediaCodec_getName) \
+    f(AMediaCodec_releaseName) \
+    f(AMediaCodec_setAsyncNotifyCallback) \
+    f(AMediaCodec_releaseCrypto) \
+    f(AMediaCodec_getInputFormat) \
+    f(AMediaCodecActionCode_isRecoverable) \
+    f(AMediaCodecActionCode_isTransient)
+#else
+#define AMediaCodec_API28_FUNCTIONS_1(f)
+#endif
+
+#if __ANDROID_API__ >= 28
+#define AMediaDataSource_API28_FUNCTIONS_1(f) \
+    f(AMediaDataSource_new) \
+    f(AMediaDataSource_delete) \
+    f(AMediaDataSource_setUserdata) \
+    f(AMediaDataSource_setReadAt) \
+    f(AMediaDataSource_setGetSize) \
+    f(AMediaDataSource_setClose)
+#else
+#define AMediaDataSource_API28_FUNCTIONS_1(f)
+#endif
+
+#if __ANDROID_API__ >= 28
+#define AMediaExtractor_API28_FUNCTIONS_1(f) \
+    f(AMediaExtractor_setDataSourceCustom)
+#else
+#define AMediaExtractor_API28_FUNCTIONS_1(f)
+#endif
+
+#if __ANDROID_API__ >= 28
+#define AMediaExtractor_API28_FUNCTIONS_2(f) \
+    f(AMediaExtractor_getFileFormat) \
+    f(AMediaExtractor_getSampleSize) \
+    f(AMediaExtractor_getCachedDuration) \
+    f(AMediaExtractor_getSampleFormat)
+#else
+#define AMediaExtractor_API28_FUNCTIONS_2(f)
+#endif
+
+#if __ANDROID_API__ >= 28
+#define AMediaFormat_API28_FUNCTIONS_1(f) \
+    f(AMediaFormat_getDouble) \
+    f(AMediaFormat_getRect) \
+    f(AMediaFormat_setDouble) \
+    f(AMediaFormat_setSize) \
+    f(AMediaFormat_setRect)
+#else
+#define AMediaFormat_API28_FUNCTIONS_1(f)
+#endif
+
 #define FUNCTIONS(f) \
     f(AImage_delete) \
     f(AImage_getWidth) \
@@ -26,8 +109,7 @@
     f(AImage_getPlanePixelStride) \
     f(AImage_getPlaneRowStride) \
     f(AImage_getPlaneData) \
-    f(AImage_deleteAsync) \
-    f(AImage_getHardwareBuffer) \
+    AImage_API26_FUNCTIONS_1(f) \
     f(AImageReader_new) \
     f(AImageReader_delete) \
     f(AImageReader_getWindow) \
@@ -38,10 +120,7 @@
     f(AImageReader_acquireNextImage) \
     f(AImageReader_acquireLatestImage) \
     f(AImageReader_setImageListener) \
-    f(AImageReader_newWithUsage) \
-    f(AImageReader_acquireNextImageAsync) \
-    f(AImageReader_acquireLatestImageAsync) \
-    f(AImageReader_setBufferRemovedListener) \
+    AImageReader_API26_FUNCTIONS_1(f) \
     f(AMediaCodec_createCodecByName) \
     f(AMediaCodec_createDecoderByType) \
     f(AMediaCodec_createEncoderByType) \
@@ -60,19 +139,8 @@
     f(AMediaCodec_releaseOutputBuffer) \
     f(AMediaCodec_setOutputSurface) \
     f(AMediaCodec_releaseOutputBufferAtTime) \
-    f(AMediaCodec_createInputSurface) \
-    f(AMediaCodec_createPersistentInputSurface) \
-    f(AMediaCodec_setInputSurface) \
-    f(AMediaCodec_setParameters) \
-    f(AMediaCodec_signalEndOfInputStream) \
-    f(AMediaCodec_getBufferFormat) \
-    f(AMediaCodec_getName) \
-    f(AMediaCodec_releaseName) \
-    f(AMediaCodec_setAsyncNotifyCallback) \
-    f(AMediaCodec_releaseCrypto) \
-    f(AMediaCodec_getInputFormat) \
-    f(AMediaCodecActionCode_isRecoverable) \
-    f(AMediaCodecActionCode_isTransient) \
+    AMediaCodec_API26_FUNCTIONS_1(f) \
+    AMediaCodec_API28_FUNCTIONS_1(f) \
     f(AMediaCodecCryptoInfo_new) \
     f(AMediaCodecCryptoInfo_delete) \
     f(AMediaCodecCryptoInfo_setPattern) \
@@ -86,12 +154,7 @@
     f(AMediaCrypto_requiresSecureDecoderComponent) \
     f(AMediaCrypto_new) \
     f(AMediaCrypto_delete) \
-    f(AMediaDataSource_new) \
-    f(AMediaDataSource_delete) \
-    f(AMediaDataSource_setUserdata) \
-    f(AMediaDataSource_setReadAt) \
-    f(AMediaDataSource_setGetSize) \
-    f(AMediaDataSource_setClose) \
+    AMediaDataSource_API28_FUNCTIONS_1(f) \
     f(AMediaDrm_isCryptoSchemeSupported) \
     f(AMediaDrm_createByUUID) \
     f(AMediaDrm_release) \
@@ -119,7 +182,7 @@
     f(AMediaExtractor_delete) \
     f(AMediaExtractor_setDataSourceFd) \
     f(AMediaExtractor_setDataSource) \
-    f(AMediaExtractor_setDataSourceCustom) \
+    AMediaExtractor_API28_FUNCTIONS_1(f) \
     f(AMediaExtractor_getTrackCount) \
     f(AMediaExtractor_getTrackFormat) \
     f(AMediaExtractor_selectTrack) \
@@ -132,10 +195,7 @@
     f(AMediaExtractor_seekTo) \
     f(AMediaExtractor_getPsshInfo) \
     f(AMediaExtractor_getSampleCryptoInfo) \
-    f(AMediaExtractor_getFileFormat) \
-    f(AMediaExtractor_getSampleSize) \
-    f(AMediaExtractor_getCachedDuration) \
-    f(AMediaExtractor_getSampleFormat) \
+    AMediaExtractor_API28_FUNCTIONS_2(f) \
     f(AMediaFormat_new) \
     f(AMediaFormat_delete) \
     f(AMediaFormat_toString) \
@@ -150,11 +210,7 @@
     f(AMediaFormat_setFloat) \
     f(AMediaFormat_setString) \
     f(AMediaFormat_setBuffer) \
-    f(AMediaFormat_getDouble) \
-    f(AMediaFormat_getRect) \
-    f(AMediaFormat_setDouble) \
-    f(AMediaFormat_setSize) \
-    f(AMediaFormat_setRect) \
+    AMediaFormat_API28_FUNCTIONS_1(f) \
     f(AMediaMuxer_new) \
     f(AMediaMuxer_delete) \
     f(AMediaMuxer_setLocation) \
@@ -222,6 +278,7 @@ media_status_t AImage_getPlaneData(const AImage* image, int planeIdx, /*out*/uin
     CALL(AImage_getPlaneData, 0, image, planeIdx, data, dataLength);
 }
 
+#if __ANDROID_API__ >= 26
 void AImage_deleteAsync(AImage* image, int releaseFenceFd) {
     CALL(AImage_deleteAsync,, image, releaseFenceFd);
 }
@@ -229,6 +286,7 @@ void AImage_deleteAsync(AImage* image, int releaseFenceFd) {
 media_status_t AImage_getHardwareBuffer(const AImage* image, /*out*/AHardwareBuffer** buffer) {
     CALL(AImage_getHardwareBuffer, 0, image, buffer);
 }
+#endif
 
 media_status_t AImageReader_new(int32_t width, int32_t height, int32_t format, int32_t maxImages, /*out*/AImageReader** reader) {
     CALL(AImageReader_new, 0, width, height, format, maxImages, reader);
@@ -270,6 +328,7 @@ media_status_t AImageReader_setImageListener(AImageReader* reader, AImageReader_
     CALL(AImageReader_setImageListener, 0, reader, listener);
 }
 
+#if __ANDROID_API__ >= 26
 media_status_t AImageReader_newWithUsage(int32_t width, int32_t height, int32_t format, uint64_t usage, int32_t maxImages, /*out*/ AImageReader** reader) {
     CALL(AImageReader_newWithUsage, 0, width, height, format, usage, maxImages, reader);
 }
@@ -285,6 +344,7 @@ media_status_t AImageReader_acquireLatestImageAsync(AImageReader* reader, /*out*
 media_status_t AImageReader_setBufferRemovedListener(AImageReader* reader, AImageReader_BufferRemovedListener* listener) {
     CALL(AImageReader_setBufferRemovedListener, 0, reader, listener);
 }
+#endif
 
 AMediaCodec* AMediaCodec_createCodecByName(const char *name) {
     CALL(AMediaCodec_createCodecByName, NULL, name);
@@ -366,6 +426,7 @@ media_status_t AMediaCodec_releaseOutputBufferAtTime(AMediaCodec *mData, size_t 
     CALL(AMediaCodec_releaseOutputBufferAtTime, 0, mData, idx, timestampNs);
 }
 
+#if __ANDROID_API__ >= 26
 media_status_t AMediaCodec_createInputSurface(AMediaCodec *mData, ANativeWindow **surface) {
     CALL(AMediaCodec_createInputSurface, 0, mData, surface);
 }
@@ -385,7 +446,9 @@ media_status_t AMediaCodec_setParameters(AMediaCodec *mData, const AMediaFormat*
 media_status_t AMediaCodec_signalEndOfInputStream(AMediaCodec *mData) {
     CALL(AMediaCodec_signalEndOfInputStream, 0, mData);
 }
+#endif
 
+#if __ANDROID_API__ >= 28
 AMediaFormat* AMediaCodec_getBufferFormat(AMediaCodec* mData, size_t index) {
     CALL(AMediaCodec_getBufferFormat, 0, mData, index);
 }
@@ -417,6 +480,7 @@ bool AMediaCodecActionCode_isRecoverable(int32_t actionCode) {
 bool AMediaCodecActionCode_isTransient(int32_t actionCode) {
     CALL(AMediaCodecActionCode_isTransient, false, actionCode);
 }
+#endif
 
 AMediaCodecCryptoInfo *AMediaCodecCryptoInfo_new(int numsubsamples, uint8_t key[16], uint8_t iv[16], cryptoinfo_mode_t mode, size_t *clearbytes, size_t *encryptedbytes) {
     CALL(AMediaCodecCryptoInfo_new, NULL, numsubsamples, key, iv, mode, clearbytes, encryptedbytes);
@@ -470,6 +534,7 @@ void AMediaCrypto_delete(AMediaCrypto* crypto) {
     CALL(AMediaCrypto_delete,, crypto);
 }
 
+#if __ANDROID_API__ >= 28
 AMediaDataSource* AMediaDataSource_new() {
     CALL(AMediaDataSource_new, NULL);
 }
@@ -493,6 +558,7 @@ void AMediaDataSource_setGetSize(AMediaDataSource* source, AMediaDataSourceGetSi
 void AMediaDataSource_setClose(AMediaDataSource* source, AMediaDataSourceClose cb) {
     CALL(AMediaDataSource_setClose,, source, cb);
 }
+#endif
 
 bool AMediaDrm_isCryptoSchemeSupported(const uint8_t *uuid, const char *mimeType) {
     CALL(AMediaDrm_isCryptoSchemeSupported, false, uuid, mimeType);
@@ -602,9 +668,11 @@ media_status_t AMediaExtractor_setDataSource(AMediaExtractor* ex, const char *lo
     CALL(AMediaExtractor_setDataSource, 0, ex, location);
 }
 
+#if __ANDROID_API__ >= 28
 media_status_t AMediaExtractor_setDataSourceCustom(AMediaExtractor* ex, AMediaDataSource *src) {
     CALL(AMediaExtractor_setDataSourceCustom, 0, ex, src);
 }
+#endif
 
 size_t AMediaExtractor_getTrackCount(AMediaExtractor* ex) {
     CALL(AMediaExtractor_getTrackCount, 0, ex);
@@ -654,6 +722,7 @@ AMediaCodecCryptoInfo *AMediaExtractor_getSampleCryptoInfo(AMediaExtractor *ex) 
     CALL(AMediaExtractor_getSampleCryptoInfo, NULL, ex);
 }
 
+#if __ANDROID_API__ >= 28
 AMediaFormat* AMediaExtractor_getFileFormat(AMediaExtractor* ex) {
     CALL(AMediaExtractor_getFileFormat, NULL, ex);
 }
@@ -669,6 +738,7 @@ int64_t AMediaExtractor_getCachedDuration(AMediaExtractor* ex) {
 media_status_t AMediaExtractor_getSampleFormat(AMediaExtractor *ex, AMediaFormat *fmt) {
     CALL(AMediaExtractor_getSampleFormat, 0, ex, fmt);
 }
+#endif
 
 AMediaFormat *AMediaFormat_new() {
     CALL(AMediaFormat_new, NULL);
@@ -726,6 +796,7 @@ void AMediaFormat_setBuffer(AMediaFormat* mData, const char* name, const void* d
     CALL(AMediaFormat_setBuffer,, mData, name, data, size);
 }
 
+#if __ANDROID_API__ >= 28
 bool AMediaFormat_getDouble(AMediaFormat* mData, const char *name, double *out) {
     CALL(AMediaFormat_getDouble, false, mData, name, out);
 }
@@ -745,6 +816,7 @@ void AMediaFormat_setSize(AMediaFormat* mData, const char* name, size_t value) {
 void AMediaFormat_setRect(AMediaFormat* mData, const char* name, int32_t left, int32_t top, int32_t right, int32_t bottom) {
     CALL(AMediaFormat_setRect,, mData, name, left, top, right, bottom);
 }
+#endif
 
 AMediaMuxer* AMediaMuxer_new(int fd, OutputFormat format) {
     CALL(AMediaMuxer_new, NULL, fd, format);


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/27498

- Fixes runtime behavior on Android 7 and 8 when built with NDK r29

```
WARNING: linker: "/data/data/com.termux/files/usr/lib/libandroid.so" unused DT entry: type 0x6fffe000 arg 0x3788
WARNING: linker: "/data/data/com.termux/files/usr/lib/libandroid.so" unused DT entry: type 0x6fffe001 arg 0x10
WARNING: linker: "/data/data/com.termux/files/usr/lib/libandroid.so" unused DT entry: type 0x6fffe003 arg 0x8
WARNING: linker: "/data/data/com.termux/files/usr/lib/libmediandk.so" unused DT entry: type 0x6fffe000 arg 0x25f8
WARNING: linker: "/data/data/com.termux/files/usr/lib/libmediandk.so" unused DT entry: type 0x6fffe001 arg 0x10
WARNING: linker: "/data/data/com.termux/files/usr/lib/libmediandk.so" unused DT entry: type 0x6fffe003 arg 0x8
WARNING: linker: "/data/data/com.termux/files/usr/lib/libandroid.so" unused DT entry: type 0x6fffe000 arg 0x3788
WARNING: linker: "/data/data/com.termux/files/usr/lib/libandroid.so" unused DT entry: type 0x6fffe001 arg 0x10
WARNING: linker: "/data/data/com.termux/files/usr/lib/libandroid.so" unused DT entry: type 0x6fffe003 arg 0x8
Segmentation fault
```