### PR TITLE
fix(main/python-sabyenc3): disable `std::aligned_alloc()`

### DIFF
--- a/packages/python-sabyenc3/build.sh
+++ b/packages/python-sabyenc3/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="C implementations of functions for use within SABnzbd"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="9.1.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/sabnzbd/sabctools/releases/download/v${TERMUX_PKG_VERSION}/sabctools-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=4f944bcd34b3844102ec073f6ae2eb7837b9d95825906b25c0dce7a95a8714a5
 TERMUX_PKG_AUTO_UPDATE=true

--- a/packages/python-sabyenc3/no-aligned-alloc.patch
+++ b/packages/python-sabyenc3/no-aligned-alloc.patch
@@ -1,0 +1,11 @@
+--- a/src/yencode/common.h
++++ b/src/yencode/common.h
+@@ -44,7 +44,7 @@
+ 	// len needs to be a multiple of alignment, although it sometimes works if it isn't...
+ 	#define ALIGN_ALLOC(buf, len, align) *(void**)&(buf) = aligned_alloc(align, ((len) + (align)-1) & ~((align)-1))
+ 	#define ALIGN_FREE free
+-#elif defined(__cplusplus) && __cplusplus >= 201700
++#elif defined(__cplusplus) && __cplusplus >= 201700 && (!defined(__ANDROID__) || (defined(__ANDROID__) && __ANDROID_API__ >= 26))
+ 	// C++17 method
+ 	#include <cstdlib>
+ 	#define ALIGN_ALLOC(buf, len, align) *(void**)&(buf) = std::aligned_alloc(align, ((len) + (align)-1) & ~((align)-1))


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/27509