### PR TITLE
ndk: fix version include

### DIFF
--- a/packages/ndk-sysroot/build.sh
+++ b/packages/ndk-sysroot/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Version should be equal to TERMUX_NDK_{VERSION_NUM,REVISION} in
 # scripts/properties.sh
 TERMUX_PKG_VERSION=29
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://dl.google.com/android/repository/android-ndk-r${TERMUX_PKG_VERSION}-linux.zip
 TERMUX_PKG_SHA256=4abbbcdc842f3d4879206e9695d52709603e52dd68d3c1fff04b3b5e7a308ecf
 TERMUX_PKG_AUTO_UPDATE=false
@@ -64,7 +64,7 @@ termux_step_post_get_source() {
 			-e "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" \
 			"$patch" | patch --silent -p1
 	done
-	grep -lrw usr/include/c++/v1 -e '<version>' | xargs -n 1 sed -i 's/<version>/\"version\"/g'
+	grep -lrw usr/include/c++/v1 -e 'include <version>' | xargs -n 1 sed -i 's/include <version>/include \"version\"/g'
 	popd
 }
 

--- a/scripts/build/termux_step_setup_toolchain.sh
+++ b/scripts/build/termux_step_setup_toolchain.sh
@@ -7,10 +7,10 @@ termux_step_setup_toolchain() {
 		# toolchain setup to ensure that everyone gets an updated
 		# toolchain
 		if [ "${TERMUX_NDK_VERSION}" = "29" ]; then
-			TERMUX_STANDALONE_TOOLCHAIN+="-v2"
+			TERMUX_STANDALONE_TOOLCHAIN+="-v3"
 			termux_setup_toolchain_29
 		elif [ "${TERMUX_NDK_VERSION}" = 23c ]; then
-			TERMUX_STANDALONE_TOOLCHAIN+="-v9"
+			TERMUX_STANDALONE_TOOLCHAIN+="-v10"
 			termux_setup_toolchain_23c
 		else
 			termux_error_exit "We do not have a setup_toolchain function for NDK version $TERMUX_NDK_VERSION"

--- a/scripts/build/toolchain/termux_setup_toolchain_23c.sh
+++ b/scripts/build/toolchain/termux_setup_toolchain_23c.sh
@@ -223,6 +223,6 @@ termux_setup_toolchain_23c() {
 		echo 'INPUT(-lunwind)' > $dir/libgcc.a
 	done
 
-	grep -lrw $_TERMUX_TOOLCHAIN_TMPDIR/sysroot/usr/include/c++/v1 -e '<version>' | xargs -n 1 sed -i 's/<version>/\"version\"/g'
+	grep -lrw $_TERMUX_TOOLCHAIN_TMPDIR/sysroot/usr/include/c++/v1 -e 'include <version>' | xargs -n 1 sed -i 's/include <version>/include \"version\"/g'
 	mv $_TERMUX_TOOLCHAIN_TMPDIR $TERMUX_STANDALONE_TOOLCHAIN
 }

--- a/scripts/build/toolchain/termux_setup_toolchain_29.sh
+++ b/scripts/build/toolchain/termux_setup_toolchain_29.sh
@@ -226,6 +226,6 @@ termux_setup_toolchain_29() {
 		echo 'INPUT(-lunwind)' > $dir/libgcc.a
 	done
 
-	grep -lrw $_TERMUX_TOOLCHAIN_TMPDIR/sysroot/usr/include/c++/v1 -e '<version>' | xargs -n 1 sed -i 's/<version>/\"version\"/g'
+	grep -lrw $_TERMUX_TOOLCHAIN_TMPDIR/sysroot/usr/include/c++/v1 -e 'include <version>' | xargs -n 1 sed -i 's/include <version>/include \"version\"/g'
 	mv $_TERMUX_TOOLCHAIN_TMPDIR $TERMUX_STANDALONE_TOOLCHAIN
 }


### PR DESCRIPTION
It will replace the deprecated message in `c++/v1/ciso646` and cause build failure.