### PR TITLE
fix(scripts/lint-packages): make sure `no_build` commit range is correct

### DIFF
--- a/scripts/lint-packages.sh
+++ b/scripts/lint-packages.sh
@@ -144,7 +144,7 @@ check_indentation() {
 
 # Also figure out if we have a `%ci:no-build` trailer in the commit range,
 # we may skip some checks later if yes.
-no_build="$(git log --fixed-strings --grep '%ci:no-build' --pretty=format:%H "$base_commit")"
+no_build="$(git log "$base_commit.." --fixed-strings --grep '%ci:no-build' --pretty=format:%H)"
 
 check_version() {
 	local package_dir="${1%/*}"


### PR DESCRIPTION
- Follows up: #27529, etc.

This is a related issue found while reproducing the heisenbug from Robert's testing.