### PR TITLE
chore(scripts/override_config_scripts): fix shellcheck warnings

### DIFF
--- a/scripts/build/termux_step_override_config_scripts.sh
+++ b/scripts/build/termux_step_override_config_scripts.sh
@@ -1,5 +1,6 @@
+# shellcheck disable=SC2031 # this warning is triggering erroneously because of the `$(. pkg/build.sh; echo "$var")`
 termux_step_override_config_scripts() {
-	if [ "$TERMUX_ON_DEVICE_BUILD" = true ] || [ "$TERMUX_PACKAGE_LIBRARY" = "glibc" ]; then
+	if [[ "$TERMUX_ON_DEVICE_BUILD" = true || "$TERMUX_PACKAGE_LIBRARY" = "glibc" ]]; then
 		return
 	fi
 
@@ -7,43 +8,48 @@ termux_step_override_config_scripts() {
 	# scripts can assume that it works on both builder and host later on:
 	ln -sf /bin/sh "$TERMUX_PREFIX/bin/sh"
 
-	if [ "$TERMUX_PKG_DEPENDS" != "${TERMUX_PKG_DEPENDS/libllvm/}" ] ||
-		[ "$TERMUX_PKG_BUILD_DEPENDS" != "${TERMUX_PKG_BUILD_DEPENDS/libllvm/}" ]; then
-		LLVM_DEFAULT_TARGET_TRIPLE=$TERMUX_HOST_PLATFORM
-		if [ $TERMUX_ARCH = "arm" ]; then
-			LLVM_TARGET_ARCH=ARM
-		elif [ $TERMUX_ARCH = "aarch64" ]; then
-			LLVM_TARGET_ARCH=AArch64
-		elif [ $TERMUX_ARCH = "i686" ]; then
-			LLVM_TARGET_ARCH=X86
-		elif [ $TERMUX_ARCH = "x86_64" ]; then
-			LLVM_TARGET_ARCH=X86
-		fi
-		LIBLLVM_VERSION=$(. $TERMUX_SCRIPTDIR/packages/libllvm/build.sh; echo $TERMUX_PKG_VERSION)
-		sed $TERMUX_SCRIPTDIR/packages/libllvm/llvm-config.in \
-			-e "s|@TERMUX_PKG_VERSION@|$LIBLLVM_VERSION|g" \
+	# Does this package or its build depend on 'libllvm'?
+	if [[ "$TERMUX_PKG_DEPENDS" != "${TERMUX_PKG_DEPENDS/libllvm/}" ||
+		"$TERMUX_PKG_BUILD_DEPENDS" != "${TERMUX_PKG_BUILD_DEPENDS/libllvm/}" ]]; then
+		LLVM_DEFAULT_TARGET_TRIPLE="$TERMUX_HOST_PLATFORM"
+		case "$TERMUX_ARCH" in
+			"arm") LLVM_TARGET_ARCH=ARM;;
+			"aarch64") LLVM_TARGET_ARCH=AArch64;;
+			"i686") LLVM_TARGET_ARCH=X86;;
+			"x86_64") LLVM_TARGET_ARCH=X86;;
+		esac
+
+		local libllvm_version
+		libllvm_version="$(. "$TERMUX_SCRIPTDIR/packages/libllvm/build.sh"; echo "$TERMUX_PKG_VERSION")"
+		sed "$TERMUX_SCRIPTDIR/packages/libllvm/llvm-config.in" \
+			-e "s|@TERMUX_PKG_VERSION@|$libllvm_version|g" \
 			-e "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|g" \
 			-e "s|@LLVM_TARGET_ARCH@|$LLVM_TARGET_ARCH|g" \
 			-e "s|@LLVM_DEFAULT_TARGET_TRIPLE@|$LLVM_DEFAULT_TARGET_TRIPLE|g" \
-			-e "s|@TERMUX_ARCH@|$TERMUX_ARCH|g" > $TERMUX_PREFIX/bin/llvm-config
-		chmod 755 $TERMUX_PREFIX/bin/llvm-config
+			-e "s|@TERMUX_ARCH@|$TERMUX_ARCH|g" \
+			> "$TERMUX_PREFIX/bin/llvm-config"
+		chmod 755 "$TERMUX_PREFIX/bin/llvm-config"
 	fi
 
-	if [ "$TERMUX_PKG_DEPENDS" != "${TERMUX_PKG_DEPENDS/postgresql/}" ] ||
-		[ "$TERMUX_PKG_BUILD_DEPENDS" != "${TERMUX_PKG_BUILD_DEPENDS/postgresql/}" ]; then
-		local postgresql_version=$(. $TERMUX_SCRIPTDIR/packages/postgresql/build.sh; echo $TERMUX_PKG_VERSION)
-		sed $TERMUX_SCRIPTDIR/packages/postgresql/pg_config.in \
+	# Does this package or its build depend on 'postgresql'?
+	if [[ "$TERMUX_PKG_DEPENDS" != "${TERMUX_PKG_DEPENDS/postgresql/}" ||
+		"$TERMUX_PKG_BUILD_DEPENDS" != "${TERMUX_PKG_BUILD_DEPENDS/postgresql/}" ]]; then
+		local postgresql_version
+		postgresql_version="$(. "$TERMUX_SCRIPTDIR/packages/postgresql/build.sh"; echo "$TERMUX_PKG_VERSION")"
+		sed "$TERMUX_SCRIPTDIR/packages/postgresql/pg_config.in" \
 			-e "s|@POSTGRESQL_VERSION@|$postgresql_version|g" \
 			-e "s|@TERMUX_HOST_PLATFORM@|$TERMUX_HOST_PLATFORM|g" \
-			-e "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|g" > $TERMUX_PREFIX/bin/pg_config
-		chmod 755 $TERMUX_PREFIX/bin/pg_config
+			-e "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|g" \
+			> "$TERMUX_PREFIX/bin/pg_config"
+		chmod 755 "$TERMUX_PREFIX/bin/pg_config"
 	fi
 
-	if [ "$TERMUX_PKG_DEPENDS" != "${TERMUX_PKG_DEPENDS/libprotobuf/}" ]; then
-		rm -f $TERMUX_PREFIX/lib/cmake/protobuf/protobuf-targets{,-release}.cmake
-		cp $TERMUX_PREFIX/opt/protobuf-cmake/shared/protobuf-targets{,-release}.cmake $TERMUX_PREFIX/lib/cmake/protobuf/
-	elif [ "$TERMUX_PKG_BUILD_DEPENDS" != "${TERMUX_PKG_BUILD_DEPENDS/protobuf-static/}" ]; then
-		rm -f $TERMUX_PREFIX/lib/cmake/protobuf/protobuf-targets{,-release}.cmake
-		cp $TERMUX_PREFIX/opt/protobuf-cmake/static/protobuf-targets{,-release}.cmake $TERMUX_PREFIX/lib/cmake/protobuf/
+	# Does this package or its build depend on 'protobuf' or 'protobuf-static'?
+	if [[ "$TERMUX_PKG_DEPENDS" != "${TERMUX_PKG_DEPENDS/libprotobuf/}" ]]; then
+		rm -f "$TERMUX_PREFIX/lib/cmake/protobuf"/protobuf-targets{,-release}.cmake
+		cp "$TERMUX_PREFIX/opt/protobuf-cmake/shared"/protobuf-targets{,-release}.cmake "$TERMUX_PREFIX/lib/cmake/protobuf/"
+	elif [[ "$TERMUX_PKG_BUILD_DEPENDS" != "${TERMUX_PKG_BUILD_DEPENDS/protobuf-static/}" ]]; then
+		rm -f "$TERMUX_PREFIX/lib/cmake/protobuf"/protobuf-targets{,-release}.cmake
+		cp "$TERMUX_PREFIX/opt/protobuf-cmake/static"/protobuf-targets{,-release}.cmake "$TERMUX_PREFIX/lib/cmake/protobuf/"
 	fi
 }


### PR DESCRIPTION
- Another breakout PR from #27470

Adopting the new `$TERMUX_LLVM_VERSION` variable for that part of this build step will be part of that PR.