### PR TITLE
fix(main/tar): enable ACLs and SELinux

### DIFF
--- a/packages/tar/build.sh
+++ b/packages/tar/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="GNU tar for manipulating tar archives"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.35
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/tar/tar-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=4d62ff37342ec7aed748535323930c7cf94acf71c3591882b26a7ea50f3edc16
-TERMUX_PKG_DEPENDS="libandroid-glob, libiconv"
+TERMUX_PKG_DEPENDS="libacl, libandroid-glob, libandroid-selinux, libiconv"
 TERMUX_PKG_ESSENTIAL=true
 
 # When cross-compiling configure guesses that d_ino in struct dirent only exists
@@ -15,6 +15,9 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="gl_cv_struct_dirent_d_ino=yes"
 # this needed to disable tar's implementation of mkfifoat() so it is possible
 # to use own implementation (see patch 'mkfifoat.patch').
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_func_mkfifoat=yes"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --enable-acl"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-posix-acls"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-selinux"
 
 termux_step_pre_configure() {
 	CPPFLAGS+=" -D__USE_FORTIFY_LEVEL=0"

--- a/packages/tar/selinux.patch
+++ b/packages/tar/selinux.patch
@@ -1,0 +1,11 @@
+--- a/configure
++++ b/configure
+@@ -22381,7 +22381,7 @@ return setfilecon ();
+   return 0;
+ }
+ _ACEOF
+-for ac_lib in '' selinux
++for ac_lib in '' android-selinux
+ do
+   if test -z "$ac_lib"; then
+     ac_res="none required"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/21267

- Tested to work by making the warnings `tar: POSIX ACL support is not available` and `tar: SELinux support is not available`  disappear without errors
