### PR TITLE
enhance(scripts/lint-packages): suggested srcurl fix unexpanded

### DIFF
--- a/scripts/lint-packages.sh
+++ b/scripts/lint-packages.sh
@@ -501,6 +501,8 @@ lint_package() {
 						# If it's in archive/ anyway then it's probably a tag with the incorrect download path.
 						elif [[ "$ref_path" == archive/* ]]; then
 							tarball_type="can-fix"
+							# Get the unexpanded version of the SRCURL for the suggestion
+							url="$(grep -oe "$protocol//$host/$user/$repo/archive.*" "$package_script")"
 							printf -v lint_msg '%s\n' \
 								"PARTIAL PASS - Tag with potential ref confusion." \
 								"WARNING: GitHub tarball URLs should use /archive/refs/tags/ instead of /archive/" \
@@ -551,16 +553,6 @@ lint_package() {
 						echo "PASS - (${tarball_type+"${tarball_type}/"}${protocol_type}) ${host}/${user}/${repo}"
 					;;
 				esac
-			# Additional debug output
-				# printf '%s\n' \
-				# 	"  URL: $url" \
-				# 	"PROTO: $protocol" \
-				# 	"   _: " \
-				# 	" HOST: $host" \
-				# 	" USER: $user" \
-				# 	" REPO: $repo" \
-				# 	" PATH: $ref_path"
-
 			done
 			unset i url protocol host user repo ref_path protocol_type tarball_type lint_msg
 


### PR DESCRIPTION
- This is a follow up to #27483

The suggested fix for the GitHub tag ambiguity is more useful if the SRCURL isn't expanded when the suggestion is applied.

Example:
<img width="851" height="411" alt="image" src="https://github.com/user-attachments/assets/a1602900-0cb8-4cab-b0a2-fedbf353accd" />
