### PR TITLE
fix(main/librsvg): remove cycle `graphviz`->`librsvg`->`valadoc`->`graphviz`

### DIFF
--- a/packages/librsvg/build.sh
+++ b/packages/librsvg/build.sh
@@ -7,7 +7,8 @@ TERMUX_PKG_SRCURL=https://download.gnome.org/sources/librsvg/${TERMUX_PKG_VERSIO
 TERMUX_PKG_SHA256=a56d2c80d744ad2f2718f85df466fe71d24ff1f9bc3e5ef588bde4d7e87815f2
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="fontconfig, freetype, gdk-pixbuf, glib, harfbuzz, libcairo, libdav1d, libpng, libxml2, pango"
-TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, valac"
+# Note: Do not add valac which prevents bootstrapping due to cyclic dependency (#27567)
+TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner"
 TERMUX_PKG_BREAKS="librsvg-dev"
 TERMUX_PKG_REPLACES="librsvg-dev"
 TERMUX_PKG_VERSIONED_GIR=false


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/27567 (the error `Package 'libgvc' not found` in the command `scripts/run-docker.sh ./build-package.sh graphviz`)

- See https://github.com/termux/termux-packages/pull/26910 for more information

%ci:no-build