### PR TITLE
fix(main/gegl): fix build of `gegl` 0.4.66 for 32-bit ARM

### DIFF
--- a/packages/gegl/build.sh
+++ b/packages/gegl/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Data flow based image processing framework"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.4.66"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://gitlab.gnome.org/GNOME/gegl/-/archive/GEGL_${TERMUX_PKG_VERSION//./_}/gegl-GEGL_${TERMUX_PKG_VERSION//./_}.tar.gz
 TERMUX_PKG_SHA256=fef15939aad59a34596a1fa89ddadfe409fee37ccd8e3a4df4d13fd30890183e
 TERMUX_PKG_DEPENDS="babl, ffmpeg, gdk-pixbuf, glib, imath, json-glib, libandroid-support, libc++, libcairo, libjasper, libjpeg-turbo, libpng, libraw, librsvg, libtiff, libwebp, littlecms, openexr, pango, poppler"

--- a/packages/gegl/gegl-arm-def.patch
+++ b/packages/gegl/gegl-arm-def.patch
@@ -1,0 +1,39 @@
+Fixes error
+
+Problem found in gegl/gegl.def
+  the following symbols are in the library,
+  but are not listed in the .def-file:
+     + gegl_downscale_2x2_arm_neon
+     + gegl_downscale_2x2_get_fun_arm_neon
+     + gegl_downscale_2x2_nearest_arm_neon
+     + gegl_resample_bilinear_arm_neon
+     + gegl_resample_boxfilter_arm_neon
+     + gegl_resample_nearest_arm_neon
+
+in build for 32-bit ARM
+after commit
+https://gitlab.gnome.org/GNOME/gegl/-/commit/5055e2418558aacca7341aba7b3145f482433da0
+
+diff --git a/gegl/gegl-arm.def b/gegl/gegl-arm.def
+new file mode 100644
+index 0000000..cb8277c
+--- /dev/null
++++ b/gegl/gegl-arm.def
+@@ -0,0 +1,6 @@
++  gegl_downscale_2x2_arm_neon
++  gegl_downscale_2x2_get_fun_arm_neon
++  gegl_downscale_2x2_nearest_arm_neon
++  gegl_resample_bilinear_arm_neon
++  gegl_resample_boxfilter_arm_neon
++  gegl_resample_nearest_arm_neon
+--- a/gegl/meson.build
++++ b/gegl/meson.build
+@@ -102,7 +102,7 @@ if host_cpu_family == 'x86_64'
+   simd_extra_def = ['gegl-x86_64.def']
+ elif host_cpu_family == 'arm'
+   simd_extra = [lib_gegl_arm_neon]
+-  simd_extra_def = []
++  simd_extra_def = ['gegl-arm.def']
+ else
+   simd_extra = []
+   simd_extra_def = []


### PR DESCRIPTION
- After upstream commit https://gitlab.gnome.org/GNOME/gegl/-/commit/5055e2418558aacca7341aba7b3145f482433da0, this error began in the build for 32-bit ARM:

```
Problem found in gegl/gegl.def
  the following symbols are in the library,
  but are not listed in the .def-file:
     + gegl_downscale_2x2_arm_neon
     + gegl_downscale_2x2_get_fun_arm_neon
     + gegl_downscale_2x2_nearest_arm_neon
     + gegl_resample_bilinear_arm_neon
     + gegl_resample_boxfilter_arm_neon
     + gegl_resample_nearest_arm_neon
```

it appears that the upstream commit was not tested for 32-bit ARM before releasing, and upstream's CI does not test building for 32-bit ARM.