### PR TITLE
fix(main/erlang): remove more conflicting manpages

### DIFF
--- a/packages/erlang/build.sh
+++ b/packages/erlang/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="General-purpose concurrent functional programming langua
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="28.3"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/erlang/otp/archive/refs/tags/OTP-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=a91e10dbde8781a4c4126af2f7b65dcf677ece64f506381120e79cf5872f2da6
 TERMUX_PKG_AUTO_UPDATE=true
@@ -29,9 +29,18 @@ lib/erlang/man
 # https://github.com/erlang/otp/pull/10237
 # conflict with zlib
 # conflict with perl
+# conflict with libowfat
+# conflict with manpages
 TERMUX_PKG_RM_AFTER_INSTALL+="
 share/man/man3/zlib.3
 share/man/man3/re.3
+share/man/man3/array.3
+share/man/man3/inet.3
+share/man/man3/queue.3
+share/man/man3/rand.3
+share/man/man3/random.3
+share/man/man3/rpc.3
+share/man/man3/string.3
 "
 # will overwrite man pages of perl and zlib
 TERMUX_PKG_ON_DEVICE_BUILD_NOT_SUPPORTED=true


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/27603

- https://github.com/termux/termux-packages/pull/27608 again

- Also remove manpages that conflict with the packages `libowfat` and `manpages`