### PR TITLE
bump(main/lua-language-server): 3.16.1

### DIFF
--- a/packages/lua-language-server/bee.lua-project-common.patch
+++ b/packages/lua-language-server/bee.lua-project-common.patch
@@ -4,7 +4,7 @@
          }
      },
      android = {
-+        ldflags = "-landroid-spawn",
++        ldflags = "-landroid-spawn -lbfd",
          sources = need {
              "linux",
              "posix",

--- a/packages/lua-language-server/force-cast-unw_context_t.diff
+++ b/packages/lua-language-server/force-cast-unw_context_t.diff
@@ -1,0 +1,11 @@
+--- a/unwind_linux.cpp
++++ b/unwind_linux.cpp
+@@ -6,7 +6,7 @@
+ namespace bee::crash {
+     void unwind(ucontext_t *ctx, uint16_t skip, unwind_callback func, void *ud) noexcept {
+         unw_cursor_t cursor;
+-#if defined(__aarch64__)
++#if 1
+         unw_context_t *unw_ctx = (unw_context_t *)ctx;
+         unw_init_local(&cursor, unw_ctx);
+ #else

--- a/packages/lua-language-server/hostbuild-force-link.diff
+++ b/packages/lua-language-server/hostbuild-force-link.diff
@@ -1,0 +1,20 @@
+--- a/3rd/luamake/compile/ninja/linux.ninja
++++ b/3rd/luamake/compile/ninja/linux.ninja
+@@ -30,7 +30,7 @@ rule cxx_source_bee_1
+ build $obj/source_bee/format.obj: cxx_source_bee_1 bee.lua/3rd/fmt/format.cc
+ rule cxx_source_bee_2
+   command = $cc -MMD -MT $out -MF $out.d -std=c++17 -fno-rtti -O2 -Wall $
+-    -fvisibility=hidden -Ibee.lua -Ibee.lua/3rd/lua54 -DNDEBUG -fPIC -o $
++    -fvisibility=hidden -Ibee.lua -Ibee.lua/3rd/lua54 -I@TERMUX_PKG_HOSTBUILD_DIR@/ubuntu_packages/usr/include -I@TERMUX_PKG_HOSTBUILD_DIR@/ubuntu_packages/usr/include/x86_64-linux-gnu -DNDEBUG -fPIC -o $
+     $out -c $in
+   description = Compile C++ $out
+   deps = gcc
+@@ -145,7 +145,7 @@ rule test
+   description = Run test.
+   pool = console
+ rule link_luamake
+-  command = $cc $in -o $out -lstdc++fs -lunwind -lbfd -pthread -lm -ldl $
++  command = $cc $in -o $out -lstdc++fs -lunwind -lbfd -pthread -lm -ldl -L@TERMUX_PKG_HOSTBUILD_DIR@/ubuntu_packages/usr/lib/x86_64-linux-gnu $
+     -lstdc++ -s
+   description = Link    Exe $out
+ rule build_luamake_test

--- a/packages/lua-language-server/loslib.patch
+++ b/packages/lua-language-server/loslib.patch
@@ -1,6 +1,21 @@
---- lua-language-server/3rd/bee.lua/3rd/lua/loslib.c	2021-08-09 14:37:07.223522941 +0530
-+++ lua-language-server-patch/3rd/bee.lua/3rd/lua/loslib.c	2021-08-10 00:15:30.293997622 +0530
-@@ -114,10 +114,10 @@
+--- lua-language-server/3rd/bee.lua/3rd/lua54/loslib.c
++++ lua-language-server-patch/3rd/bee.lua/3rd/lua54/loslib.c
+@@ -105,10 +105,10 @@
+ 
+ #include <unistd.h>
+ 
+-#define LUA_TMPNAMBUFSIZE	32
++#define LUA_TMPNAMBUFSIZE	128
+ 
+ #if !defined(LUA_TMPNAMTEMPLATE)
+-#define LUA_TMPNAMTEMPLATE	"/tmp/lua_XXXXXX"
++#define LUA_TMPNAMTEMPLATE	"@TERMUX_PREFIX@/tmp/lua_XXXXXX"
+ #endif
+ 
+ #define lua_tmpnam(b,e) { \
+--- lua-language-server/3rd/bee.lua/3rd/lua55/loslib.c
++++ lua-language-server-patch/3rd/bee.lua/3rd/lua55/loslib.c
+@@ -106,10 +106,10 @@
  
  #include <unistd.h>
  

--- a/packages/lua-language-server/luaconf.patch
+++ b/packages/lua-language-server/luaconf.patch
@@ -1,6 +1,17 @@
---- lua-language-server/3rd/bee.lua/3rd/lua/luaconf.h	2021-08-09 14:37:07.223522941 +0530
-+++ lua-language-server-patch/3rd/bee.lua/3rd/lua/luaconf.h	2021-08-10 00:18:08.283997562 +0530
-@@ -227,7 +227,7 @@
+--- lua-language-server/3rd/bee.lua/3rd/lua54/luaconf.h
++++ lua-language-server/3rd/bee.lua/3rd/lua54/luaconf.h
+@@ -223,7 +223,7 @@
+ 
+ #else			/* }{ */
+ 
+-#define LUA_ROOT	"/usr/local/"
++#define LUA_ROOT	"@TERMUX_PREFIX@/"
+ #define LUA_LDIR	LUA_ROOT "share/lua/" LUA_VDIR "/"
+ #define LUA_CDIR	LUA_ROOT "lib/lua/" LUA_VDIR "/"
+ 
+--- lua-language-server/3rd/bee.lua/3rd/lua55/luaconf.h
++++ lua-language-server/3rd/bee.lua/3rd/lua55/luaconf.h
+@@ -239,7 +239,7 @@
  
  #else			/* }{ */
  

--- a/packages/lua-language-server/no-kernel_sigaction.patch
+++ b/packages/lua-language-server/no-kernel_sigaction.patch
@@ -1,0 +1,11 @@
+--- a/3rd/bee.lua/bee/crash/linux/handler_linux.cpp
++++ b/3rd/bee.lua/bee/crash/linux/handler_linux.cpp
+@@ -73,7 +73,7 @@ namespace bee::crash {
+     }
+
+     static void install_default_handler(int sig) noexcept {
+-#if defined(__ANDROID__)
++#if 0
+         struct kernel_sigaction sa;
+         memset(&sa, 0, sizeof(sa));
+         sys_sigemptyset(&sa.sa_mask);


### PR DESCRIPTION
Closes https://github.com/termux/termux-packages/issues/27505

builds were fixed by the maintainer (https://github.com/LuaLS/lua-language-server/issues/3301#issuecomment-3625003183) and version 3.16.1 was releases