### PR TITLE
bump(main/mesa): 25.3.2

### DIFF
--- a/packages/mesa/build.sh
+++ b/packages/mesa/build.sh
@@ -3,9 +3,9 @@ TERMUX_PKG_DESCRIPTION="An open-source implementation of the OpenGL specificatio
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="docs/license.rst"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="25.3.1"
+TERMUX_PKG_VERSION="25.3.2"
 TERMUX_PKG_SRCURL=https://archive.mesa3d.org/mesa-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=059d0d985622f49588f01aa29152804f4da8ffe6add046e00a52923379c2d8da
+TERMUX_PKG_SHA256=e69dab0d0ea03e3e8cb141b032f58ea9fcf3b9c1f61b31f6592cb4bbd8d0185d
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libandroid-shmem, libc++, libdrm, libglvnd, libllvm (<< $TERMUX_LLVM_NEXT_MAJOR_VERSION), libwayland, libx11, libxext, libxfixes, libxshmfence, libxxf86vm, ncurses, vulkan-loader, zlib, zstd"
 TERMUX_PKG_SUGGESTS="mesa-dev"
@@ -32,11 +32,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dglvnd=enabled
 -Dxmlconfig=disabled
 "
-
-termux_pkg_auto_update() {
-	read -r latest < <(curl -fsSL "https://archive.mesa3d.org/" | grep -v rc | sed -rn 's/.*mesa-([0-9]+(\.[0-9]+)*).*/\1/p' | sort -Vr);
-	termux_pkg_upgrade_version "${latest}"
-}
 
 termux_step_post_get_source() {
 	# Do not use meson wrap projects


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/27639

- Switch to repology auto update method

- Partially reverts https://github.com/termux/termux-packages/pull/24680