### PR TITLE
bump(main/php): 8.5.1

### DIFF
--- a/packages/php/build.sh
+++ b/packages/php/build.sh
@@ -4,16 +4,15 @@ TERMUX_PKG_LICENSE="PHP-3.01"
 TERMUX_PKG_LICENSE_FILE=LICENSE
 TERMUX_PKG_MAINTAINER="@termux"
 # Please revbump php-* extensions along with "minor" bump (e.g. 8.1.x to 8.2.0)
-TERMUX_PKG_VERSION="8.4.2"
-TERMUX_PKG_REVISION=4
+TERMUX_PKG_VERSION="8.5.1"
 TERMUX_PKG_SRCURL=https://github.com/php/php-src/archive/php-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=5adb0def4110fcba4b84ab11d960e4dc58cab78b2d4e0a59bbef340a5c819f14
+TERMUX_PKG_SHA256=846f7c5bdb8c2ebb313c4ec25d92339bcbaf733743c9f6a7646e9a5134b90a8e
 TERMUX_PKG_AUTO_UPDATE=false
 # Build native php for phar to build (see pear-Makefile.frag.patch):
 TERMUX_PKG_HOSTBUILD=true
 # Build the native php without xml support as we only need phar:
 TERMUX_PKG_EXTRA_HOSTBUILD_CONFIGURE_ARGS="--disable-libxml --disable-dom --disable-simplexml --disable-xml --disable-xmlreader --disable-xmlwriter --without-pear --disable-sqlite3 --without-libxml --without-sqlite3 --without-pdo-sqlite"
-TERMUX_PKG_DEPENDS="libandroid-glob, libandroid-support, libbz2, libc++, libcurl, libffi, libgmp, libiconv, libicu, libresolv-wrapper, libsqlite, libxml2, libxslt, libzip, oniguruma, openssl, pcre2, readline, tidy, zlib"
+TERMUX_PKG_DEPENDS="capstone, libandroid-glob, libandroid-support, libbz2, libc++, libcurl, libffi, libgmp, libiconv, libicu, libresolv-wrapper, libsqlite, libxml2, libxslt, libzip, oniguruma, openssl, pcre2, readline, tidy, zlib"
 TERMUX_PKG_BUILD_DEPENDS="postgresql"
 TERMUX_PKG_CONFLICTS="php-mysql, php-dev"
 TERMUX_PKG_REPLACES="php-mysql, php-dev"
@@ -33,7 +32,7 @@ php_cv_lib_gd_gdImageCreateFromTga=yes
 --enable-calendar
 --enable-exif
 --enable-mbstring
---enable-opcache
+--with-capstone
 --enable-pcntl
 --enable-sockets
 --mandir=$TERMUX_PREFIX/share/man
@@ -162,7 +161,7 @@ termux_step_post_make_install() {
 	# Shared extensions for PHP/Apache
 	mkdir -p $TERMUX_PREFIX/lib/php-apache
 	local f
-	for f in opcache ldap pdo_pgsql pgsql sodium; do
+	for f in ldap pdo_pgsql pgsql sodium; do
 		local so=$TERMUX_PREFIX/lib/php-apache/${f}.so
 		rm -f ${so}
 		cp -T $TERMUX_PREFIX/lib/php/${f}.so ${so}

--- a/packages/php/ext-opcache-config.m4.patch
+++ b/packages/php/ext-opcache-config.m4.patch
@@ -1,12 +1,11 @@
---- ./ext/opcache/config.m4.orig	2024-11-27 23:24:00.473417043 +0700
-+++ ./ext/opcache/config.m4	2024-11-27 23:34:36.000000000 +0700
-@@ -342,7 +342,8 @@
-     [$ext_shared],,
-     [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 $JIT_CFLAGS],,
-     [yes])
--
-+  OPCACHE_SHARED_LIBADD=-lpcre2-8
-+  PHP_SUBST(OPCACHE_SHARED_LIBADD)
-   PHP_ADD_EXTENSION_DEP(opcache, date)
-   PHP_ADD_EXTENSION_DEP(opcache, pcre)
+--- ./ext/opcache/config.m4.orig	2025-11-27 23:42:04.086935058 +0700
++++ ./ext/opcache/config.m4	2025-11-27 23:43:24.758935027 +0700
+@@ -342,6 +342,8 @@
+   [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 $JIT_CFLAGS],,
+   [yes])
+ 
++OPCACHE_SHARED_LIBADD=-lpcre2-8
++PHP_SUBST(OPCACHE_SHARED_LIBADD)
+ PHP_ADD_EXTENSION_DEP(opcache, date)
+ PHP_ADD_EXTENSION_DEP(opcache, pcre)
  

--- a/packages/php/php-apache-opcache.subpackage.sh
+++ b/packages/php/php-apache-opcache.subpackage.sh
@@ -1,3 +1,0 @@
-TERMUX_SUBPKG_INCLUDE="lib/php-apache/opcache.so"
-TERMUX_SUBPKG_DEPENDS="php-apache"
-TERMUX_SUBPKG_DESCRIPTION="OPcache module for PHP/Apache"


### PR DESCRIPTION
[<img src="https://www.php.net/images/logos/new-php-logo.svg">](https://www.php.net/releases/8.5/en.php)

[URI Extension](https://www.php.net/releases/8.5/en.php#new-uri-extension)
PHP 8.5 adds a built-in URI extension to parse, normalize, and handle URLs following RFC 3986 and WHATWG URL standards.

[Pipe Operator](https://www.php.net/releases/8.5/en.php#pipe-operator)
The |> operator enables chaining callables left-to-right, passing values smoothly through multiple functions without intermediary variables.

[Clone With](https://www.php.net/releases/8.5/en.php#clone-with)
Clone objects and update properties with the new clone() syntax, making the "with-er" pattern simple for readonly classes.

[#[\NoDiscard] Attribute](https://www.php.net/releases/8.5/en.php#no-discard-attribute)
The #[\NoDiscard] attribute warns when a return value isn’t used, helping prevent mistakes and improving overall API safety.

[Closures and First-Class Callables in Constant Expressions](https://www.php.net/releases/8.5/en.php#closures-in-const-expr)
Static closures and first-class callables can now be used in constant expressions, such as attribute parameters.

[Persistent cURL Share Handles](https://www.php.net/releases/8.5/en.php#persistent-curl-share-handles)
Handles can now be persisted across multiple PHP requests, avoiding the cost of repeated connection initialization to the same hosts.