### PR TITLE
addpkg(root/usbutils): 019

### DIFF
--- a/root-packages/usbutils/build.sh
+++ b/root-packages/usbutils/build.sh
@@ -1,0 +1,25 @@
+TERMUX_PKG_HOMEPAGE=http://www.linux-usb.org/
+TERMUX_PKG_DESCRIPTION="Collection of USB tools to query connected USB devices"
+TERMUX_PKG_LICENSE="CC0-1.0, GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-only, LGPL-2.1-or-later, MIT"
+TERMUX_PKG_LICENSE_FILE="
+LICENSES/CC0-1.0.txt
+LICENSES/GPL-2.0-only.txt
+LICENSES/GPL-2.0-or-later.txt
+LICENSES/GPL-3.0-only.txt
+LICENSES/LGPL-2.1-or-later.txt
+LICENSES/MIT.txt
+"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="019"
+TERMUX_PKG_SRCURL="https://www.kernel.org/pub/linux/utils/usb/usbutils/usbutils-$TERMUX_PKG_VERSION.tar.xz"
+TERMUX_PKG_SHA256=659f40c440e31ba865c52c818a33d3ba6a97349e3353f8b1985179cb2aa71ec5
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="hwdata, libiconv, libusb"
+
+termux_step_pre_configure() {
+	LDFLAGS+=" -liconv"
+}
+
+termux_step_post_make_install() {
+	install -vDm 755 "$TERMUX_PKG_BUILDDIR/usbreset" -t "$TERMUX_PREFIX/bin"
+}

--- a/root-packages/usbutils/disable-udev.patch
+++ b/root-packages/usbutils/disable-udev.patch
@@ -1,0 +1,57 @@
+--- a/meson.build
++++ b/meson.build
+@@ -105,10 +105,9 @@ lsusb_sources = [
+   'ccan/list/list.h',
+ ]
+ 
+-libudev = dependency('libudev', version: '>= 196')
+ libusb = dependency('libusb-1.0', version: '>= 1.0.22')
+ 
+-executable('lsusb', lsusb_sources, dependencies: [libusb, libudev], install: true)
++executable('lsusb', lsusb_sources, dependencies: [libusb], install: true)
+ 
+ ################################
+ # usbhid-dump build instructions
+diff --git a/names.c b/names.c
+index 6c25404..f7231d0 100644
+--- a/names.c
++++ b/names.c
+@@ -18,7 +18,6 @@
+ #include <stdbool.h>
+ 
+ #include <libusb.h>
+-#include <libudev.h>
+ 
+ #include "usb-spec.h"
+ #include "names.h"
+@@ -83,12 +82,6 @@ const char *names_countrycode(unsigned int countrycode)
+ 
+ static const char *hwdb_get(const char *modalias, const char *key)
+ {
+-	struct udev_list_entry *entry;
+-
+-	udev_list_entry_foreach(entry, udev_hwdb_get_properties_list_entry(hwdb, modalias, 0))
+-		if (strcmp(udev_list_entry_get_name(entry), key) == 0)
+-			return udev_list_entry_get_value(entry);
+-
+ 	return NULL;
+ }
+ 
+@@ -238,16 +231,9 @@ void get_vendor_product_with_fallback(char *vendor, int vendor_len,
+ 
+ int names_init(void)
+ {
+-	udev = udev_new();
+-	if (!udev)
+-		return -1;
+-
+-	hwdb = udev_hwdb_new(udev);
+-	return hwdb ? 0 : -1;
++	return -1;
+ }
+ 
+ void names_exit(void)
+ {
+-	hwdb = udev_hwdb_unref(hwdb);
+-	udev = udev_unref(udev);
+ }


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/20913

- The `lsusb` command from Desktop Linux

- Brief comparison with `/system/bin/lsusb` showcasing obvious benefits:

```
~ $ /system/bin/lsusb --help
Toybox 0.8.6-android multicall binary (see toybox --help)

usage: lsusb [-i]

List USB hosts/devices.

-i	ID database (default /etc/usb.ids[.gz])
~ $ lsusb --help
Usage: lsusb [options]...
List USB devices
  -v, --verbose
      Increase verbosity (show descriptors)
  -s [[bus]:][devnum]
      Show only devices with specified device and/or
      bus numbers (in decimal)
  -d vendor:[product]
      Show only devices with the specified vendor and
      product ID numbers (in hexadecimal)
  -D device
      Selects which device lsusb will examine
  -t, --tree
      Dump the physical USB device hierarchy as a tree
  -V, --version
      Show version of program
  -h, --help
      Show usage and help
~ $ sudo /system/bin/lsusb
Bus 001 Device 017: ID 17ef:a395
Bus 001 Device 018: ID 17ef:a38f
Bus 001 Device 001: ID 1d6b:0002
Bus 001 Device 016: ID 17ef:a394
Bus 001 Device 015: ID 17ef:a387
Bus 001 Device 014: ID 17ef:a392
Bus 001 Device 019: ID 17ef:30d1
Bus 002 Device 001: ID 1d6b:0003
~ $ sudo lsusb
unable to initialize usb specBus 001 Device 001: ID 1d6b:0002 Linux 4.14.190-lineage-gef0cb31b13 xhci-hcd xHCI Host Controller
Bus 001 Device 014: ID 17ef:a392 VIA Labs, Inc. USB2.0 Hub
Bus 001 Device 015: ID 17ef:a387 Realtek USB-C Dock Ethernet
Bus 001 Device 016: ID 17ef:a394 VIA Labs, Inc. USB2.0 Hub
Bus 001 Device 017: ID 17ef:a395 Lenovo USB2.0 Hub
Bus 001 Device 018: ID 17ef:a38f Cypress Semiconductor 40AS
Bus 001 Device 019: ID 17ef:30d1 Lenovo ThinkPad USB-C Dock Gen2 USB Audio
Bus 002 Device 001: ID 1d6b:0003 Linux 4.14.190-lineage-gef0cb31b13 xhci-hcd xHCI Host Controller
~ $
```

- Unfortunately, it seems like it must be in root-packages because it doesn't really show all the useful information such as device names if run through `termux-usb` rootlessly:

```
~ $ termux-usb -r -E -e "lsusb" /dev/bus/usb/001/019
unable to initialize usb specBus 001 Device 019: ID 17ef:30d1
~ $
```