### PR TITLE
fix(main/bsd-finger): ensure `finger.1` manpage is installed correctly

### DIFF
--- a/packages/bsd-finger/build.sh
+++ b/packages/bsd-finger/build.sh
@@ -3,10 +3,13 @@ TERMUX_PKG_DESCRIPTION="User information lookup program"
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=0.17
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://salsa.debian.org/debian/bsd-finger/-/archive/upstream/${TERMUX_PKG_VERSION}/bsd-finger-upstream-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=56e18928a04b38eadea741f9f07db6155ce56b6992defba3c0e32f9caeee9109
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXTRA_MAKE_ARGS="
+MANDIR=$TERMUX_PREFIX/share/man
+"
 
 termux_step_post_get_source() {
 	sed -n '1,/*\//p' finger/finger.c > LICENSE


### PR DESCRIPTION
- closes #27741

<img width="961" height="635" alt="image" src="https://github.com/user-attachments/assets/c9ee35cf-0053-4e93-b4a0-4283db83062e" />
