### PR TITLE
fix(main/rq): invoke `termux_setup_rust`

### DIFF
--- a/packages/rq/build.sh
+++ b/packages/rq/build.sh
@@ -3,7 +3,11 @@ TERMUX_PKG_DESCRIPTION="A tool for doing record analysis and transformation"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.0.4
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/dflemstr/rq/archive/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=4c3fc4427d02271c93a2cf4a784887982e97f9aba4946900aad1a35b142f9a47
 TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+	termux_setup_rust
+}


### PR DESCRIPTION
- Progress on https://github.com/termux/termux-packages/issues/23492

- Fixes `ERROR: cargo command is not found! Please add termux_setup_rust in package's build.sh!`