### PR TITLE
bump(main/wasmedge): 0.16.0

### DIFF
--- a/packages/wasmedge/build.sh
+++ b/packages/wasmedge/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="A lightweight, high-performance, and extensible WebAssem
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_LICENSE_FILE="LICENSE, LICENSE.spdx"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.15.0"
+TERMUX_PKG_VERSION="0.16.0"
 # Use source tarball from release assets to get VERSION file for proper version number
 TERMUX_PKG_SRCURL=https://github.com/WasmEdge/WasmEdge/releases/download/${TERMUX_PKG_VERSION}/WasmEdge-${TERMUX_PKG_VERSION}-src.tar.gz
-TERMUX_PKG_SHA256=17915c4d047bc7a02aca862f4852101ec8d35baab7b659593687ab8c84b00938
+TERMUX_PKG_SHA256=6a12152c1d7fd27e4f4fb6486c63e4c2f2663bb0c6be0edb287ef5796ed32610
 TERMUX_PKG_DEPENDS="libc++, libspdlog"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
@@ -23,6 +23,13 @@ termux_step_pre_configure() {
 		CXXFLAGS+=" -malign-double"
 		;;
 	esac
+
+	# upstream has explicitly stated that it's OK to disable this error
+	# in order to force the build with LLVM 21 to complete successfully
+	# error: 'is_class' cannot be specialized:
+	# Users are not allowed to specialize this standard library entity
+	# https://github.com/WasmEdge/WasmEdge/issues/4071#issuecomment-2763100292
+	export CXXFLAGS+=" -Wno-invalid-specialization"
 }
 
 # wasmedge does not support LLVM 17 yet

--- a/packages/wasmedge/lib-system-allocator.cpp.patch
+++ b/packages/wasmedge/lib-system-allocator.cpp.patch
@@ -1,12 +1,12 @@
 diff -uNr WasmEdge-0.13.3/lib/system/allocator.cpp WasmEdge-0.13.3.mod/lib/system/allocator.cpp
 --- WasmEdge-0.13.3/lib/system/allocator.cpp	2023-07-25 18:13:24.000000000 +0800
 +++ WasmEdge-0.13.3.mod/lib/system/allocator.cpp	2023-09-02 11:04:52.146376442 +0800
-@@ -10,7 +10,7 @@
- #if WASMEDGE_OS_WINDOWS
+@@ -11,7 +11,7 @@
  #include "system/winapi.h"
  #elif defined(HAVE_MMAP) && defined(__x86_64__) || defined(__aarch64__) ||     \
--    defined(__arm__) || (defined(__riscv) && __riscv_xlen == 64)
-+    defined(__arm__) || (defined(__riscv) && __riscv_xlen == 64) || defined(__i386__)
+     defined(__arm__) || (defined(__riscv) && __riscv_xlen == 64) ||            \
+-    defined(__s390x__)
++    defined(__s390x__) || defined(__i386__)
  #include <sys/mman.h>
  #else
  #include <cctype>


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/27808

- Progress on https://github.com/termux/termux-packages/issues/23492

- Rebase `lib-system-allocator.cpp.patch`

- Apply `-Wno-invalid-specialization` to fix build with NDK r29
  - Normally I would not do this, but in this case, upstream has become aware of the error, and [explicitly stated that disabling this error and proceeding is fine](https://github.com/WasmEdge/WasmEdge/issues/4071#issuecomment-2763100292)