### PR TITLE
bump(main/wiz): 2025.04.10

### DIFF
--- a/packages/wiz/build.sh
+++ b/packages/wiz/build.sh
@@ -2,14 +2,14 @@ TERMUX_PKG_HOMEPAGE=http://wiz-lang.org/
 TERMUX_PKG_DESCRIPTION="A high-level assembly language for writing homebrew software for retro console platforms"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-_COMMIT=a174205e1694ab225c11813d3a3ab9e81742869d
-TERMUX_PKG_VERSION=2022.06.02
-TERMUX_PKG_REVISION=1
+_COMMIT=5a8ea1ce15953d6ed9d222a54a31cb6447c79121
+TERMUX_PKG_VERSION=2025.04.10
 TERMUX_PKG_SRCURL=git+https://github.com/wiz-lang/wiz
-TERMUX_PKG_SHA256=9404438d6026ef90523388d2ec0ffa1ce03481b16c562b8ff4aa2c40357556ec
+TERMUX_PKG_SHA256=fb4feb428aee4b62966f33ad7197503c13b3511f636d0aee41e0d40881d7ba33
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_GIT_BRANCH=master
 TERMUX_PKG_DEPENDS="libc++"
+TERMUX_PKG_BUILD_DEPENDS="dos2unix"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_MAKE_ARGS="PREFIX=$TERMUX_PREFIX"
 
@@ -28,4 +28,16 @@ termux_step_post_get_source() {
 	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
 		termux_error_exit "Checksum mismatch for source files."
 	fi
+
+	# convert CRLF to LF like in libpluto package
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		DOS2UNIX="$TERMUX_PKG_TMPDIR/dos2unix"
+		(. "$TERMUX_SCRIPTDIR/packages/dos2unix/build.sh"; TERMUX_PKG_SRCDIR="$DOS2UNIX" termux_step_get_source)
+		pushd "$DOS2UNIX"
+		make dos2unix
+		popd # DOS2UNIX
+		export PATH="$DOS2UNIX:$PATH"
+	fi
+
+	find "$TERMUX_PKG_SRCDIR" -type f -print0 | xargs -0 dos2unix
 }

--- a/packages/wiz/deprecated-literal-operator.patch
+++ b/packages/wiz/deprecated-literal-operator.patch
@@ -1,0 +1,14 @@
+Fixes:
+error: identifier '_sv' preceded by whitespace in a literal operator declaration is deprecated
+
+--- a/src/wiz/utility/string_view.h
++++ b/src/wiz/utility/string_view.h
+@@ -209,7 +209,7 @@ namespace wiz {
+     };    
+ }
+ 
+-constexpr wiz::StringView operator "" _sv(const char* text, std::size_t length) {
++constexpr wiz::StringView operator ""_sv(const char* text, std::size_t length) {
+     return wiz::StringView(text, length);
+ }
+ 

--- a/packages/wiz/unused-variable.patch
+++ b/packages/wiz/unused-variable.patch
@@ -1,0 +1,13 @@
+Prevents:
+error: variable 'letParameter' set but not used
+
+--- a/src/wiz/compiler/compiler.cpp
++++ b/src/wiz/compiler/compiler.cpp
+@@ -5311,6 +5311,7 @@ namespace wiz {
+                         auto& argument = arguments[i];
+ 
+                         if (auto letParameter = parameter->tryGet<Definition::Let>()) {
++                            (void)letParameter;
+                             if (argument->info->context == EvaluationContext::RunTime) {
+                                 report->error("argument `" + parameter->name.toString() + "` is a `let` expression, so it cannot accept a run-time expression", argument->location);
+                             }


### PR DESCRIPTION
- Progress on https://github.com/termux/termux-packages/issues/23492

- Progress on https://github.com/termux/termux-packages/issues/11744

- Fix build with NDK r29 using `deprecated-literal-operator.patch` and `unused-variable.patch`

- Convert all source code to LF before building for easier maintenance of patches using UNIX-like development systems