### PR TITLE
fix(main/android-tools): fix build with NDK r29

### DIFF
--- a/packages/android-tools/build.sh
+++ b/packages/android-tools/build.sh
@@ -4,14 +4,13 @@ TERMUX_PKG_LICENSE="Apache-2.0, BSD 2-Clause"
 TERMUX_PKG_LICENSE_FILE="LICENSE, vendor/core/fastboot/LICENSE"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="35.0.2"
-TERMUX_PKG_REVISION=6
+TERMUX_PKG_REVISION=7
 TERMUX_PKG_SRCURL=https://github.com/nmeum/android-tools/releases/download/$TERMUX_PKG_VERSION/android-tools-$TERMUX_PKG_VERSION.tar.xz
 TERMUX_PKG_SHA256=d2c3222280315f36d8bfa5c02d7632b47e365bfe2e77e99a3564fb6576f04097
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="abseil-cpp, brotli, libc++, liblz4, libprotobuf, pcre2, zlib, zstd"
+TERMUX_PKG_DEPENDS="abseil-cpp, brotli, fmt, libc++, liblz4, libprotobuf, pcre2, zlib, zstd"
 TERMUX_PKG_BUILD_DEPENDS="googletest"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--DANDROID_TOOLS_USE_BUNDLED_FMT=ON
 -DANDROID_TOOLS_USE_BUNDLED_LIBUSB=ON
 "
 


### PR DESCRIPTION
- Progress on https://github.com/termux/termux-packages/issues/23492

- Unvendor `fmt`

- Fixes `error: call to consteval function 'fmt::basic_format_string<char, fmt::basic_string_view<char> &, const char (&)[3]>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression`