### PR TITLE
fix(x11/ibus): for ibus-setup

### DIFF
--- a/x11-packages/ibus/0001-add-python-path-for-ibus-setup.patch
+++ b/x11-packages/ibus/0001-add-python-path-for-ibus-setup.patch
@@ -1,0 +1,23 @@
+From 5a0697aa6d71d1c3c11ec623f02bb0192c85c914 Mon Sep 17 00:00:00 2001
+From: cnjhb <hikariz@qq.com>
+Date: Sat, 3 Jan 2026 22:32:47 +0800
+Subject: [PATCH] add python path for ibus-setup
+
+---
+ setup/ibus-setup.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/setup/ibus-setup.in b/setup/ibus-setup.in
+index 474ce8a8..dce67ea4 100644
+--- a/setup/ibus-setup.in
++++ b/setup/ibus-setup.in
+@@ -27,5 +27,6 @@ export IBUS_PREFIX=@prefix@
+ export IBUS_DATAROOTDIR=@datarootdir@
+ export IBUS_LOCALEDIR=@localedir@
+ export IBUS_LIBEXECDIR=${libexecdir}
++export PYTHON=@TERMUX_PREFIX@/bin/python3
+ exec ${PYTHON:-@PYTHON@} @prefix@/share/ibus/setup/main.py "$@"
+ 
+-- 
+2.52.0
+

--- a/x11-packages/ibus/build.sh
+++ b/x11-packages/ibus/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Intelligent Input Bus for Linux/Unix"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.5.33"
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL="https://github.com/ibus/ibus/releases/download/$TERMUX_PKG_VERSION/ibus-$TERMUX_PKG_VERSION.tar.gz"
 TERMUX_PKG_SHA256=58941c9b8285891c776b67fb2039eebe0d61d63a51578519febfc5481b91e831
 TERMUX_PKG_DEPENDS="dconf, glib, gobject-introspection, gtk3, gtk4, ibus-data, libdbusmenu, libnotify, libwayland, libx11, libxfixes, libxi, libxkbcommon"
@@ -15,7 +16,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --enable-introspection
 --disable-vala
 --disable-gtk2
---disable-dconf
+--enable-dconf
 --enable-gtk4
 --disable-memconf
 --enable-ui
@@ -42,5 +43,8 @@ termux_step_pre_configure() {
 		HERE
 		chmod +x "$TERMUX_PKG_TMPDIR"/host-pkg-config/pkg-config
 		export PKG_CONFIG_FOR_BUILD="$TERMUX_PKG_TMPDIR"/host-pkg-config/pkg-config
+
+		termux_download_ubuntu_packages dconf-cli "$TERMUX_PKG_TMPDIR/prefix"
+		export PATH="$TERMUX_PKG_TMPDIR/prefix/usr/bin:$PATH"
 	fi
 }


### PR DESCRIPTION
ibus-setup requires a schema to run, and generating the schema requires dconf to be enabled.