### PR TITLE
fix(scripts/build/termux_download_ubuntu_packages): return to using a `for` loop

### DIFF
--- a/scripts/build/termux_download_ubuntu_packages.sh
+++ b/scripts/build/termux_download_ubuntu_packages.sh
@@ -21,7 +21,7 @@ termux_download_ubuntu_packages() {
 	mkdir -p "$DESTINATION"
 
 	local package
-	while read -r -d ' ' package; do
+	for package in $PACKAGES; do
 		local summary_url
 
 		echo "termux_download_ubuntu_packages(): Downloading summary page for '$package'"
@@ -61,7 +61,7 @@ termux_download_ubuntu_packages() {
 		mkdir -p "${TERMUX_PKG_TMPDIR}/${deb_name}"
 		ar x "${TERMUX_COMMON_CACHEDIR}/${deb_name}" --output="${TERMUX_PKG_TMPDIR}/${deb_name}"
 		tar xf "${TERMUX_PKG_TMPDIR}/${deb_name}"/data.tar.* -C "${DESTINATION}"
-	done <<< "$PACKAGES"
+	done
 
 	return 0
 }


### PR DESCRIPTION
- This is the syntax I originally tested with all packages that use `termux_download_ubuntu_packages`, but I changed it to that other kind of loop when requested, which is not working for `lowdown`

- Fixes `ln: failed to create symbolic link '/home/builder/.termux-build/lowdown/host-build/prefix/usr/bin/make': No such file or directory` in `lowdown`

- See https://github.com/termux/termux-packages/pull/27690#discussion_r2658926099