### PR TITLE
fix(main/neovim{,-nightly}): fix package relation between `neovim` and `neovim-nightly`

### DIFF
--- a/packages/neovim-nightly/build.sh
+++ b/packages/neovim-nightly/build.sh
@@ -1,17 +1,18 @@
 TERMUX_PKG_HOMEPAGE=https://neovim.io/
-TERMUX_PKG_DESCRIPTION="Ambitious Vim-fork focused on extensibility and agility (nvim)"
+TERMUX_PKG_DESCRIPTION="Ambitious Vim-fork focused on extensibility and agility (nvim-nightly)"
 TERMUX_PKG_LICENSE="Apache-2.0, VIM License"
 TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION="0.12.0~dev-1961+gdf62cb3e69"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/neovim/neovim/archive/${TERMUX_PKG_VERSION##*+g}.tar.gz
 TERMUX_PKG_SHA256=ab8e86878c1775c396b1df3231f518f3488cf4a8e490107c5fd8e3fb9eef857e
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="v.*-dev.*\+g[0-9a-f]*"
 TERMUX_PKG_UPDATE_VERSION_SED_REGEXP="s/-/~/"
 TERMUX_PKG_DEPENDS="libiconv, libuv, luv, libmsgpack, libvterm (>= 1:0.3-0), libluajit, libunibilium, libandroid-support, lua51-lpeg, tree-sitter, tree-sitter-parsers, utf8proc"
+TERMUX_PKG_BREAKS="neovim"
 TERMUX_PKG_CONFLICTS="neovim"
-TERMUX_PKG_REPLACES="neovim"
 TERMUX_PKG_HOSTBUILD=true
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="

--- a/packages/neovim/build.sh
+++ b/packages/neovim/build.sh
@@ -4,14 +4,14 @@ TERMUX_PKG_LICENSE="Apache-2.0, VIM License"
 TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION="0.11.5"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/neovim/neovim/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=c63450dfb42bb0115cd5e959f81c77989e1c8fd020d5e3f1e6d897154ce8b771
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+\.\d+$"
 TERMUX_PKG_DEPENDS="libiconv, libuv, luv, libmsgpack, libvterm (>= 1:0.3-0), libluajit, libunibilium, libandroid-support, lua51-lpeg, tree-sitter, tree-sitter-parsers, utf8proc"
+TERMUX_PKG_BREAKS="neovim-nightly"
 TERMUX_PKG_CONFLICTS="neovim-nightly"
-TERMUX_PKG_REPLACES="neovim-nightly"
 TERMUX_PKG_HOSTBUILD=true
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="


### PR DESCRIPTION
This should work in theory, but I don't know how to actually test this.

Edit: I realized apt and pacman has different semantics for `replaces`, so this will most likely break apt package. I will see what I can do

## Current issue
Right now it will prompt to switch between `neovim` and `neovim-nightly` upon every update. This is because `neovim` replace `neovim-nightly` and vice-versa.

![20260105_021303](https://github.com/user-attachments/assets/6c62697b-f94f-41e3-b64c-5461bcd3d192)
![SmartSelect_20260105-021914_Termux](https://github.com/user-attachments/assets/88c6c137-d1ac-4a5e-b026-68d73a983ff4)

