### PR TITLE
fix(main/monero): fix build of version 0.18.4.5 for x86 targets

### DIFF
--- a/packages/monero/CMakeLists.txt.patch
+++ b/packages/monero/CMakeLists.txt.patch
@@ -1,3 +1,9 @@
+Disabling stack trace for x86 avoids these two errors when building for Android-x86:
+CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
+Please set them or make sure they are set and tested correctly in the CMake files:
+LIBUNWIND_LIBRARIES (ADVANCED)
+src/common/stack_trace.cpp:155:19: error: invalid operands to binary expression ('Writer' and '__iom_t6')
+
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -244,7 +244,7 @@
@@ -9,6 +15,15 @@
    forbid_undefined_symbols()
  endif()
  
+@@ -541,7 +541,7 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND NOT MINGW)
+   set(DEFAULT_STACK_TRACE ON)
+   set(STACK_TRACE_LIB "easylogging++") # for diag output only
+   set(LIBUNWIND_LIBRARIES "")
+-elseif (ARM)
++elseif (ARM OR ANDROID)
+   set(DEFAULT_STACK_TRACE OFF)
+   set(LIBUNWIND_LIBRARIES "")
+ else()
 @@ -993,7 +993,7 @@
    endif(ARM)
  

--- a/packages/monero/build.sh
+++ b/packages/monero/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A private, secure, untraceable, decentralised digital cu
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.18.4.5"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_SRCURL=git+https://github.com/monero-project/monero
 TERMUX_PKG_DEPENDS="boost, libc++, libprotobuf, libsodium, libunbound, libusb, libzmq, miniupnpc, openssl, readline"


### PR DESCRIPTION
- Disabling stack trace for x86 avoids these two errors when building for Android-x86:

```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
LIBUNWIND_LIBRARIES (ADVANCED)
```

```
src/common/stack_trace.cpp:155:19: error: invalid operands to binary expression ('Writer' and '__iom_t6')
```