### PR TITLE
enhance(main/virglrenderer): enable Venus

### DIFF
--- a/packages/virglrenderer/anon_file.c.patch
+++ b/packages/virglrenderer/anon_file.c.patch
@@ -1,0 +1,24 @@
+diff --git a/src/mesa/util/anon_file.c b/src/mesa/util/anon_file.c
+index 4f8a5fb..cf22817 100644
+--- a/src/mesa/util/anon_file.c
++++ b/src/mesa/util/anon_file.c
+@@ -43,7 +43,7 @@
+ #include <stdio.h>
+ #endif
+
+-#if !(defined(__FreeBSD__) || defined(HAVE_MEMFD_CREATE) || defined(HAVE_MKOSTEMP) || defined(__ANDROID__))
++#if !(defined(__FreeBSD__) || defined(HAVE_MEMFD_CREATE) || defined(HAVE_MKOSTEMP) || (defined(__ANDROID__) && !defined(__TERMUX__)))
+ static int
+ set_cloexec_or_close(int fd)
+ {
+@@ -67,7 +67,7 @@ err:
+ }
+ #endif
+
+-#if !(defined(__FreeBSD__) || defined(HAVE_MEMFD_CREATE) || defined(__ANDROID__))
++#if !(defined(__FreeBSD__) || defined(HAVE_MEMFD_CREATE) || (defined(__ANDROID__) && !defined(__TERMUX__)))
+ static int
+ create_tmpfile_cloexec(char *tmpname)
+ {
+
+

--- a/packages/virglrenderer/build.sh
+++ b/packages/virglrenderer/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A virtual 3D GPU for use inside qemu virtual machines"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.2.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://gitlab.freedesktop.org/virgl/virglrenderer/-/archive/virglrenderer-${TERMUX_PKG_VERSION}/virglrenderer-virglrenderer-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=b181b668afae817953c84635fac2dc4c2e5786c710b7d225ae215d15674a15c7
 TERMUX_PKG_AUTO_UPDATE=true
@@ -14,4 +15,8 @@ termux_step_pre_configure() {
 	# error: using an array subscript expression within 'offsetof' is a Clang extension [-Werror,-Wgnu-offsetof-extensions]
 	# list_for_each_entry_safe(struct vrend_linked_shader_program, ent, &shader->programs, sl[shader->sel->type])
 	CPPFLAGS+=" -Wno-error=gnu-offsetof-extensions"
+
+	if [[ $TERMUX_ARCH != "arm" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -Dvenus=true"
+	fi
 }


### PR DESCRIPTION
Enable Venus which gives the ability to use Termux's Vulkan in other environment like a `glibc` distribution in proot-distro

Tested to work on multiple Vulkan setup (System Xclipse 920 included!)

It requires a working Vulkan setup in Termux itself, `llvmpipe` is useless as it should be included in all environment supporting Venus

To enable Venus in your environment you can pass the flag `--venus` to `virglrenderer` in Termux, you can now also disable VirGL with `--no-virgl`

To get Venus in an environment:
- a binding of the `virgl` socket should be done like for a VirGL setup (usually the flag `--shared-tmp` in proot-distro does it)
- the Mesa's Virtio-GPU Vulkan driver should be installed: for example, for Ubuntu the package is `mesa-vulkan-driver` (dependency of packages using Vulkan)
- include this environment variable to let Mesa recognize Venus in the environment: `VN_DEBUG=vtest`