### PR TITLE
bump(main/pueue): 4.0.2

### DIFF
--- a/packages/pueue/patches.patch
+++ b/packages/pueue/patches.patch
@@ -1,15 +1,15 @@
 --- a/pueue/Cargo.toml
 +++ b/pueue/Cargo.toml
-@@ -68,7 +68,7 @@ similar-asserts = "1"
+@@ -67,7 +67,7 @@ similar-asserts = "1"
  # --- Platform specific dependencies ---
  
  # Linux
 -[target.'cfg(target_os = "linux")'.dependencies]
 +[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
- procfs = { version = "0.17", default-features = false }
+ procfs = { version = "0.18", default-features = false }
  
  # Linux + Mac OS
---- a/pueue/src/process_helper/mod.rs
+-- a/pueue/src/process_helper/mod.rs
 +++ b/pueue/src/process_helper/mod.rs
 @@ -21,6 +21,6 @@ pub use self::unix::*;
  

--- a/packages/pueue/tempfile-bump-rustix.diff
+++ b/packages/pueue/tempfile-bump-rustix.diff
@@ -1,0 +1,13 @@
+Fixes: https://github.com/bytecodealliance/rustix/issues/1519
+
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -81,7 +81,7 @@ default-features = false
+ version = "0.3"
+ 
+ [target.'cfg(any(unix, target_os = "wasi"))'.dependencies.rustix]
+-version = "1.0.0"
++version = "1.1.3"
+ features = ["fs"]
+ 
+ [target.'cfg(any(unix, windows, target_os = "wasi"))'.dependencies.getrandom]


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/27677

- Force bump dependency crate `rustix` to 1.1.3 to fix error `failed to resolve: use of unresolved module or unlinked crate 'linux_raw_sys'`