### PR TITLE
bump(main/lua-language-server): v3.16.4

### DIFF
--- a/packages/lua-language-server/android.diff
+++ b/packages/lua-language-server/android.diff
@@ -1,11 +1,11 @@
 --- lua-language-server/3rd/luamake/compile/ninja/android.ninja	2021-10-27 21:38:40.667928105 +0530
 +++ lua-language-server-patch/3rd/luamake/compile/ninja/android.ninja	2021-10-27 21:37:31.217928132 +0530
-@@ -116,7 +116,7 @@
- build $obj/source_bootstrap/progdir.obj: cxx_source_bootstrap $
-     3rd/bee.lua/bootstrap/progdir.cpp
- rule link_luamake
--  command = $cc $in -o $out -lm -ldl -Wl,-E -lstdc++ -s
-+  command = $cc $in -o $out -lm -ldl -Wl,-E -lstdc++ -landroid-spawn -s
+@@ -103,7 +103,7 @@
+ build $obj/source_bootstrap/main.obj: cxx_source_bootstrap $
+     bee.lua/bootstrap/main.cpp
+ rule link_bootstrap
+-  command = $cc $in -o $out -Wl,-E -lm -ldl -lstdc++ -Wl,-S,-x
++  command = $cc $in -o $out -Wl,-E -lm -ldl -lstdc++ -landroid-spawn -Wl,-S,-x
    description = Link    Exe $out
- build $bin/luamake: link_luamake $obj/source_bootstrap/main.obj $
-     $obj/source_bootstrap/progdir.obj $obj/source_bee/lua-seri.obj $
+ rule copy
+   command = cp -fv $in$input $out 1>/dev/null

--- a/packages/lua-language-server/build.sh
+++ b/packages/lua-language-server/build.sh
@@ -2,11 +2,10 @@ TERMUX_PKG_HOMEPAGE="https://github.com/sumneko/lua-language-server"
 TERMUX_PKG_DESCRIPTION="Sumneko Lua Language Server coded in Lua"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
-TERMUX_PKG_VERSION="3.16.1"
+TERMUX_PKG_VERSION="3.16.4"
 TERMUX_PKG_GIT_BRANCH="${TERMUX_PKG_VERSION}"
 TERMUX_PKG_SRCURL="git+https://github.com/sumneko/lua-language-server"
-TERMUX_PKG_DEPENDS="libandroid-spawn, libc++"
-TERMUX_PKG_BUILD_DEPENDS="binutils-libs"
+TERMUX_PKG_DEPENDS="libandroid-spawn, binutils-libs, libc++"
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
@@ -81,7 +80,7 @@ termux_step_make() {
 	echo "Applying patch: $(basename "$patch")"
 	test -f "$patch" && {
 		patch --silent -p1 -d "$TERMUX_PKG_SRCDIR/3rd/bee.lua/bee/crash/linux" < "$patch"
-		patch --silent -p1 -d "$TERMUX_PKG_SRCDIR/3rd/luamake/bee.lua/bee/crash" < "$patch"
+		patch --silent -p1 -d "$TERMUX_PKG_SRCDIR/3rd/luamake/bee.lua/bee/crash/linux" < "$patch"
 	}
 
 	"${TERMUX_PKG_HOSTBUILD_DIR}"/3rd/luamake/luamake \

--- a/packages/lua-language-server/hostbuild-force-link.diff
+++ b/packages/lua-language-server/hostbuild-force-link.diff
@@ -4,17 +4,17 @@
  build $obj/source_bee/format.obj: cxx_source_bee_1 bee.lua/3rd/fmt/format.cc
  rule cxx_source_bee_2
    command = $cc -MMD -MT $out -MF $out.d -std=c++17 -fno-rtti -O2 -Wall $
--    -fvisibility=hidden -Ibee.lua -Ibee.lua/3rd/lua54 -DNDEBUG -fPIC -o $
-+    -fvisibility=hidden -Ibee.lua -Ibee.lua/3rd/lua54 -I@TERMUX_PKG_HOSTBUILD_DIR@/ubuntu_packages/usr/include -I@TERMUX_PKG_HOSTBUILD_DIR@/ubuntu_packages/usr/include/x86_64-linux-gnu -DNDEBUG -fPIC -o $
+-    -fvisibility=hidden -Ibee.lua -Ibee.lua/3rd/lua55 -DNDEBUG -fPIC -o $
++    -fvisibility=hidden -Ibee.lua -Ibee.lua/3rd/lua55 -I@TERMUX_PKG_HOSTBUILD_DIR@/ubuntu_packages/usr/include -I@TERMUX_PKG_HOSTBUILD_DIR@/ubuntu_packages/usr/include/x86_64-linux-gnu -DNDEBUG -fPIC -o $
      $out -c $in
    description = Compile C++ $out
    deps = gcc
-@@ -145,7 +145,7 @@ rule test
+@@ -139,7 +139,7 @@ rule test
    description = Run test.
    pool = console
  rule link_luamake
--  command = $cc $in -o $out -lstdc++fs -lunwind -lbfd -pthread -lm -ldl $
-+  command = $cc $in -o $out -lstdc++fs -lunwind -lbfd -pthread -lm -ldl -L@TERMUX_PKG_HOSTBUILD_DIR@/ubuntu_packages/usr/lib/x86_64-linux-gnu $
-     -lstdc++ -s
+-  command = $cc $in -o $out -lstdc++fs -pthread -lm -ldl -lstdc++ -s
++  command = $cc $in -o $out -lstdc++fs -pthread -lm -ldl -lstdc++ -s -L@TERMUX_PKG_HOSTBUILD_DIR@/ubuntu_packages/usr/lib/x86_64-linux-gnu
    description = Link    Exe $out
  rule build_luamake_test
+   command = $bin/luamake bee.lua/test/test.lua


### PR DESCRIPTION
For #27758

It looks like [compile/ninja/android.ninja](https://github.com/actboy168/luamake/blob/master/compile/ninja/android.ninja) was updated.

From a quick glance, I can see that `link_luamake` was renamed to `link_bootstrap`(and a few flags were added). I only added the missing `-landroid-spawn` flag.

>[!NOTE]
> ~The current version available in `pkg` seems to be broken as executing it results in(at least for me),~
> ```
> CANNOT LINK EXECUTABLE "/data/data/com.termux/files/usr/share/lua-language-server/bin/lua-language-server": library "libbfd-2.45.1.so" not found: needed by main executable
> ```
>
> ~So, not sure if something else needs fixing.~
> No longer relevant as the issue is fixed by installing `binutils`.
> ```sh
> pkg i binutils
> ```