### PR TITLE
fix(main/libx265): enable high bit depth pixel formats

### DIFF
--- a/packages/libx265/build.sh
+++ b/packages/libx265/build.sh
@@ -3,12 +3,18 @@ TERMUX_PKG_DESCRIPTION="H.265/HEVC video stream encoder library"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="4.1"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://bitbucket.org/multicoreware/x265_git/downloads/x265_${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=a31699c6a89806b74b0151e5e6a7df65de4b49050482fe5ebf8a4379d7af8f29
 TERMUX_PKG_DEPENDS="libandroid-posix-semaphore, libc++"
 TERMUX_PKG_BREAKS="libx265-dev"
 TERMUX_PKG_REPLACES="libx265-dev"
+# note: -DHIGH_BIT_DEPTH=ON and -DMAIN12=ON have no effect on 32-bit targets
+# https://bitbucket.org/multicoreware/x265_git/src/9e551a994f970a24f0e49bcebe3d43ef08448b01/source/CMakeLists.txt#lines-690
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DHIGH_BIT_DEPTH=ON
+-DMAIN12=ON
+"
 
 termux_step_pre_configure() {
 	# Do not forget to bump revision of reverse dependencies and rebuild them
@@ -25,13 +31,13 @@ termux_step_pre_configure() {
 
 	# Not sure if this is necessary for on-device build
 	# Follow termux_step_configure_cmake.sh for now
-	if [ "$TERMUX_ON_DEVICE_BUILD" = false ]; then
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
 		_TERMUX_CLANG_TARGET="--target=${CCTERMUX_HOST_PLATFORM}"
 	fi
 
-	if [ "$TERMUX_ARCH" = arm ] || [ "$TERMUX_ARCH" = i686 ]; then
+	if [[ "$TERMUX_ARCH" = arm || "$TERMUX_ARCH" = i686 ]]; then
 		# Avoid text relocations and/or build failure.
-		TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DENABLE_ASSEMBLY=OFF"
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DENABLE_ASSEMBLY=OFF"
 	fi
 
 	TERMUX_PKG_SRCDIR="$TERMUX_PKG_SRCDIR/source"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/27938

- Makes the command `ffmpeg -h encoder=libx265` show this

```
Supported pixel formats: yuv420p yuvj420p yuv422p yuvj422p yuv444p yuvj444p gbrp yuv420p10le yuv422p10le yuv444p10le gbrp10le yuv420p12le yuv422p12le yuv444p12le gbrp12le gray gray10le gray12le yuva420p yuva420p10le
```

instead of this

```
Supported pixel formats: yuv420p yuvj420p yuv422p yuvj422p yuv444p yuvj444p gbrp gray yuva420p
```

- Not necessary to recompile `ffmpeg`; it will automatically get the updated `libx265`

- Not supported for 32-bit targets and automatically disabled for them by upstream code

- `libx264` does not need this since it seems to have 10-bit depth already by default and does not appear to support 12-bit depth