### PR TITLE
fix(main/qt5-qtbase): enable OpenGL and Vulkan

### DIFF
--- a/x11-packages/qt5-qtbase/build.sh
+++ b/x11-packages/qt5-qtbase/build.sh
@@ -3,12 +3,12 @@ TERMUX_PKG_DESCRIPTION="A cross-platform application and UI framework"
 TERMUX_PKG_LICENSE="LGPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="5.15.18"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL="https://download.qt.io/archive/qt/${TERMUX_PKG_VERSION%.*}/${TERMUX_PKG_VERSION}/submodules/qtbase-everywhere-opensource-src-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=7b632550ea1048fc10c741e46e2e3b093e5ca94dfa6209e9e0848800e247023b
-TERMUX_PKG_DEPENDS="dbus, double-conversion, freetype, glib, harfbuzz, krb5, libandroid-execinfo, libandroid-shmem, libandroid-posix-semaphore, libc++, libice, libicu, libjpeg-turbo, libpng, libsm, libuuid, libx11, libxcb, libxi, libxkbcommon, openssl, pcre2, postgresql, ttf-dejavu, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm, zlib"
+TERMUX_PKG_DEPENDS="dbus, double-conversion, freetype, glib, harfbuzz, krb5, libandroid-execinfo, libandroid-posix-semaphore, libandroid-shmem, libc++, libice, libicu, libjpeg-turbo, libpng, libsm, libuuid, libx11, libxcb, libxi, libxkbcommon, opengl, openssl, pcre2, postgresql, ttf-dejavu, vulkan-loader, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm, zlib"
 # gtk3 dependency is a run-time dependency only for the gtk platformtheme subpackage
-TERMUX_PKG_BUILD_DEPENDS="gtk3"
+TERMUX_PKG_BUILD_DEPENDS="gtk3, vulkan-headers"
 TERMUX_PKG_SUGGESTS="qt5-qmake"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_NO_STATICSPLIT=true
@@ -100,8 +100,8 @@ termux_step_configure () {
 		-no-system-proxies \
 		-no-cups \
 		-system-harfbuzz \
-		-no-opengl \
-		-no-vulkan \
+		-opengl \
+		-vulkan \
 		-qpa xcb \
 		-no-eglfs \
 		-no-gbm \


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/27940

Successful Test:

```
git clone -b 5.15.17 --depth=1 https://code.qt.io/qt/qtbase.git
cp -r qtbase/examples/opengl/hellogl2/ .
cd hellogl2
qmake -project \
    "QMAKE_CXXFLAGS+=-I$PREFIX/include/QtWidgets" \
    "QMAKE_LFLAGS+=-lQt5Widgets"
qmake
make
termux-x11 -xstartup icewm-session &
export DISPLAY=:0
./hellogl2
```

<img width="2960" height="1440" alt="Screenshot_20260108-063035_Termux_X11" src="https://github.com/user-attachments/assets/295863ce-26b6-4c96-97ec-e6145f9ee9d8" />


<details>
<summary>new files in qt5-qtbase</summary>

```diff
--- /data/data/com.termux/files/home/qt5-qtbase-old.txt	2026-01-08 05:33:42.689340478 -0600
+++ /data/data/com.termux/files/home/qt5-qtbase-new.txt	2026-01-08 05:34:19.033340452 -0600
@@ -873,6 +873,20 @@
 /data/data/com.termux/files/usr/include/QtEdidSupport/QtEdidSupportDepends
 /data/data/com.termux/files/usr/include/QtEdidSupport/QtEdidSupportVersion
 /data/data/com.termux/files/usr/include/QtEdidSupport/qtedidsupportversion.h
+/data/data/com.termux/files/usr/include/QtEglSupport
+/data/data/com.termux/files/usr/include/QtEglSupport/5.15.18
+/data/data/com.termux/files/usr/include/QtEglSupport/5.15.18/QtEglSupport
+/data/data/com.termux/files/usr/include/QtEglSupport/5.15.18/QtEglSupport/private
+/data/data/com.termux/files/usr/include/QtEglSupport/5.15.18/QtEglSupport/private/qeglconvenience_p.h
+/data/data/com.termux/files/usr/include/QtEglSupport/5.15.18/QtEglSupport/private/qeglpbuffer_p.h
+/data/data/com.termux/files/usr/include/QtEglSupport/5.15.18/QtEglSupport/private/qeglplatformcontext_p.h
+/data/data/com.termux/files/usr/include/QtEglSupport/5.15.18/QtEglSupport/private/qeglstreamconvenience_p.h
+/data/data/com.termux/files/usr/include/QtEglSupport/5.15.18/QtEglSupport/private/qt_egl_p.h
+/data/data/com.termux/files/usr/include/QtEglSupport/5.15.18/QtEglSupport/private/qxlibeglintegration_p.h
+/data/data/com.termux/files/usr/include/QtEglSupport/QtEglSupport
+/data/data/com.termux/files/usr/include/QtEglSupport/QtEglSupportDepends
+/data/data/com.termux/files/usr/include/QtEglSupport/QtEglSupportVersion
+/data/data/com.termux/files/usr/include/QtEglSupport/qteglsupportversion.h
 /data/data/com.termux/files/usr/include/QtEventDispatcherSupport
 /data/data/com.termux/files/usr/include/QtEventDispatcherSupport/5.15.18
 /data/data/com.termux/files/usr/include/QtEventDispatcherSupport/5.15.18/QtEventDispatcherSupport
@@ -919,6 +933,15 @@
 /data/data/com.termux/files/usr/include/QtFontDatabaseSupport/QtFontDatabaseSupportDepends
 /data/data/com.termux/files/usr/include/QtFontDatabaseSupport/QtFontDatabaseSupportVersion
 /data/data/com.termux/files/usr/include/QtFontDatabaseSupport/qtfontdatabasesupportversion.h
+/data/data/com.termux/files/usr/include/QtGlxSupport
+/data/data/com.termux/files/usr/include/QtGlxSupport/5.15.18
+/data/data/com.termux/files/usr/include/QtGlxSupport/5.15.18/QtGlxSupport
+/data/data/com.termux/files/usr/include/QtGlxSupport/5.15.18/QtGlxSupport/private
+/data/data/com.termux/files/usr/include/QtGlxSupport/5.15.18/QtGlxSupport/private/qglxconvenience_p.h
+/data/data/com.termux/files/usr/include/QtGlxSupport/QtGlxSupport
+/data/data/com.termux/files/usr/include/QtGlxSupport/QtGlxSupportDepends
+/data/data/com.termux/files/usr/include/QtGlxSupport/QtGlxSupportVersion
+/data/data/com.termux/files/usr/include/QtGlxSupport/qtglxsupportversion.h
 /data/data/com.termux/files/usr/include/QtGui
 /data/data/com.termux/files/usr/include/QtGui/5.15.18
 /data/data/com.termux/files/usr/include/QtGui/5.15.18/QtGui
@@ -1768,6 +1791,65 @@
 /data/data/com.termux/files/usr/include/QtNetwork/qtnetworkglobal.h
 /data/data/com.termux/files/usr/include/QtNetwork/qtnetworkversion.h
 /data/data/com.termux/files/usr/include/QtNetwork/qudpsocket.h
+/data/data/com.termux/files/usr/include/QtOpenGL
+/data/data/com.termux/files/usr/include/QtOpenGL/5.15.18
+/data/data/com.termux/files/usr/include/QtOpenGL/5.15.18/QtOpenGL
+/data/data/com.termux/files/usr/include/QtOpenGL/5.15.18/QtOpenGL/private
+/data/data/com.termux/files/usr/include/QtOpenGL/5.15.18/QtOpenGL/private/qgl2pexvertexarray_p.h
+/data/data/com.termux/files/usr/include/QtOpenGL/5.15.18/QtOpenGL/private/qgl_p.h
+/data/data/com.termux/files/usr/include/QtOpenGL/5.15.18/QtOpenGL/private/qglcustomshaderstage_p.h
+/data/data/com.termux/files/usr/include/QtOpenGL/5.15.18/QtOpenGL/private/qglengineshadermanager_p.h
+/data/data/com.termux/files/usr/include/QtOpenGL/5.15.18/QtOpenGL/private/qglengineshadersource_p.h
+/data/data/com.termux/files/usr/include/QtOpenGL/5.15.18/QtOpenGL/private/qglframebufferobject_p.h
+/data/data/com.termux/files/usr/include/QtOpenGL/5.15.18/QtOpenGL/private/qglgradientcache_p.h
+/data/data/com.termux/files/usr/include/QtOpenGL/5.15.18/QtOpenGL/private/qglpaintdevice_p.h
+/data/data/com.termux/files/usr/include/QtOpenGL/5.15.18/QtOpenGL/private/qglpixelbuffer_p.h
+/data/data/com.termux/files/usr/include/QtOpenGL/5.15.18/QtOpenGL/private/qglshadercache_p.h
+/data/data/com.termux/files/usr/include/QtOpenGL/5.15.18/QtOpenGL/private/qgraphicsshadereffect_p.h
+/data/data/com.termux/files/usr/include/QtOpenGL/5.15.18/QtOpenGL/private/qpaintengineex_opengl2_p.h
+/data/data/com.termux/files/usr/include/QtOpenGL/5.15.18/QtOpenGL/private/qtextureglyphcache_gl_p.h
+/data/data/com.termux/files/usr/include/QtOpenGL/QGL
+/data/data/com.termux/files/usr/include/QtOpenGL/QGLBuffer
+/data/data/com.termux/files/usr/include/QtOpenGL/QGLColormap
+/data/data/com.termux/files/usr/include/QtOpenGL/QGLContext
+/data/data/com.termux/files/usr/include/QtOpenGL/QGLFormat
+/data/data/com.termux/files/usr/include/QtOpenGL/QGLFramebufferObject
+/data/data/com.termux/files/usr/include/QtOpenGL/QGLFramebufferObjectFormat
+/data/data/com.termux/files/usr/include/QtOpenGL/QGLFunctions
+/data/data/com.termux/files/usr/include/QtOpenGL/QGLFunctionsPrivate
+/data/data/com.termux/files/usr/include/QtOpenGL/QGLPixelBuffer
+/data/data/com.termux/files/usr/include/QtOpenGL/QGLShader
+/data/data/com.termux/files/usr/include/QtOpenGL/QGLShaderProgram
+/data/data/com.termux/files/usr/include/QtOpenGL/QGLWidget
+/data/data/com.termux/files/usr/include/QtOpenGL/QtOpenGL
+/data/data/com.termux/files/usr/include/QtOpenGL/QtOpenGLDepends
+/data/data/com.termux/files/usr/include/QtOpenGL/QtOpenGLVersion
+/data/data/com.termux/files/usr/include/QtOpenGL/qgl.h
+/data/data/com.termux/files/usr/include/QtOpenGL/qglbuffer.h
+/data/data/com.termux/files/usr/include/QtOpenGL/qglcolormap.h
+/data/data/com.termux/files/usr/include/QtOpenGL/qglframebufferobject.h
+/data/data/com.termux/files/usr/include/QtOpenGL/qglfunctions.h
+/data/data/com.termux/files/usr/include/QtOpenGL/qglpixelbuffer.h
+/data/data/com.termux/files/usr/include/QtOpenGL/qglshaderprogram.h
+/data/data/com.termux/files/usr/include/QtOpenGL/qtopenglglobal.h
+/data/data/com.termux/files/usr/include/QtOpenGL/qtopenglversion.h
+/data/data/com.termux/files/usr/include/QtOpenGLExtensions
+/data/data/com.termux/files/usr/include/QtOpenGLExtensions/QOpenGLExtensions
+/data/data/com.termux/files/usr/include/QtOpenGLExtensions/QtOpenGLExtensions
+/data/data/com.termux/files/usr/include/QtOpenGLExtensions/QtOpenGLExtensionsDepends
+/data/data/com.termux/files/usr/include/QtOpenGLExtensions/QtOpenGLExtensionsVersion
+/data/data/com.termux/files/usr/include/QtOpenGLExtensions/qopenglextensions.h
+/data/data/com.termux/files/usr/include/QtOpenGLExtensions/qtopenglextensionsversion.h
+/data/data/com.termux/files/usr/include/QtPlatformCompositorSupport
+/data/data/com.termux/files/usr/include/QtPlatformCompositorSupport/5.15.18
+/data/data/com.termux/files/usr/include/QtPlatformCompositorSupport/5.15.18/QtPlatformCompositorSupport
+/data/data/com.termux/files/usr/include/QtPlatformCompositorSupport/5.15.18/QtPlatformCompositorSupport/private
+/data/data/com.termux/files/usr/include/QtPlatformCompositorSupport/5.15.18/QtPlatformCompositorSupport/private/qopenglcompositor_p.h
+/data/data/com.termux/files/usr/include/QtPlatformCompositorSupport/5.15.18/QtPlatformCompositorSupport/private/qopenglcompositorbackingstore_p.h
+/data/data/com.termux/files/usr/include/QtPlatformCompositorSupport/QtPlatformCompositorSupport
+/data/data/com.termux/files/usr/include/QtPlatformCompositorSupport/QtPlatformCompositorSupportDepends
+/data/data/com.termux/files/usr/include/QtPlatformCompositorSupport/QtPlatformCompositorSupportVersion
+/data/data/com.termux/files/usr/include/QtPlatformCompositorSupport/qtplatformcompositorsupportversion.h
 /data/data/com.termux/files/usr/include/QtPlatformHeaders
 /data/data/com.termux/files/usr/include/QtPlatformHeaders/QCocoaNativeContext
 /data/data/com.termux/files/usr/include/QtPlatformHeaders/QCocoaWindowFunctions
@@ -2001,6 +2083,16 @@
 /data/data/com.termux/files/usr/include/QtThemeSupport/QtThemeSupportDepends
 /data/data/com.termux/files/usr/include/QtThemeSupport/QtThemeSupportVersion
 /data/data/com.termux/files/usr/include/QtThemeSupport/qtthemesupportversion.h
+/data/data/com.termux/files/usr/include/QtVulkanSupport
+/data/data/com.termux/files/usr/include/QtVulkanSupport/5.15.18
+/data/data/com.termux/files/usr/include/QtVulkanSupport/5.15.18/QtVulkanSupport
+/data/data/com.termux/files/usr/include/QtVulkanSupport/5.15.18/QtVulkanSupport/private
+/data/data/com.termux/files/usr/include/QtVulkanSupport/5.15.18/QtVulkanSupport/private/qbasicvulkanplatforminstance_p.h
+/data/data/com.termux/files/usr/include/QtVulkanSupport/5.15.18/QtVulkanSupport/private/qvkconvenience_p.h
+/data/data/com.termux/files/usr/include/QtVulkanSupport/QtVulkanSupport
+/data/data/com.termux/files/usr/include/QtVulkanSupport/QtVulkanSupportDepends
+/data/data/com.termux/files/usr/include/QtVulkanSupport/QtVulkanSupportVersion
+/data/data/com.termux/files/usr/include/QtVulkanSupport/qtvulkansupportversion.h
 /data/data/com.termux/files/usr/include/QtWidgets
 /data/data/com.termux/files/usr/include/QtWidgets/5.15.18
 /data/data/com.termux/files/usr/include/QtWidgets/5.15.18/QtWidgets
@@ -2572,6 +2664,9 @@
 /data/data/com.termux/files/usr/lib/cmake/Qt5EdidSupport
 /data/data/com.termux/files/usr/lib/cmake/Qt5EdidSupport/Qt5EdidSupportConfig.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5EdidSupport/Qt5EdidSupportConfigVersion.cmake
+/data/data/com.termux/files/usr/lib/cmake/Qt5EglSupport
+/data/data/com.termux/files/usr/lib/cmake/Qt5EglSupport/Qt5EglSupportConfig.cmake
+/data/data/com.termux/files/usr/lib/cmake/Qt5EglSupport/Qt5EglSupportConfigVersion.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5EventDispatcherSupport
 /data/data/com.termux/files/usr/lib/cmake/Qt5EventDispatcherSupport/Qt5EventDispatcherSupportConfig.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5EventDispatcherSupport/Qt5EventDispatcherSupportConfigVersion.cmake
@@ -2581,6 +2676,9 @@
 /data/data/com.termux/files/usr/lib/cmake/Qt5FontDatabaseSupport
 /data/data/com.termux/files/usr/lib/cmake/Qt5FontDatabaseSupport/Qt5FontDatabaseSupportConfig.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5FontDatabaseSupport/Qt5FontDatabaseSupportConfigVersion.cmake
+/data/data/com.termux/files/usr/lib/cmake/Qt5GlxSupport
+/data/data/com.termux/files/usr/lib/cmake/Qt5GlxSupport/Qt5GlxSupportConfig.cmake
+/data/data/com.termux/files/usr/lib/cmake/Qt5GlxSupport/Qt5GlxSupportConfigVersion.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5Gui
 /data/data/com.termux/files/usr/lib/cmake/Qt5Gui/Qt5GuiConfig.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5Gui/Qt5GuiConfigExtras.cmake
@@ -2594,6 +2692,7 @@
 /data/data/com.termux/files/usr/lib/cmake/Qt5Gui/Qt5Gui_QOffscreenIntegrationPlugin.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5Gui/Qt5Gui_QTuioTouchPlugin.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5Gui/Qt5Gui_QVncIntegrationPlugin.cmake
+/data/data/com.termux/files/usr/lib/cmake/Qt5Gui/Qt5Gui_QXcbGlxIntegrationPlugin.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5Gui/Qt5Gui_QXcbIntegrationPlugin.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5Gui/Qt5Gui_QXdgDesktopPortalThemePlugin.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5InputSupport
@@ -2605,6 +2704,15 @@
 /data/data/com.termux/files/usr/lib/cmake/Qt5Network/Qt5Network_QConnmanEnginePlugin.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5Network/Qt5Network_QGenericEnginePlugin.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5Network/Qt5Network_QNetworkManagerEnginePlugin.cmake
+/data/data/com.termux/files/usr/lib/cmake/Qt5OpenGL
+/data/data/com.termux/files/usr/lib/cmake/Qt5OpenGL/Qt5OpenGLConfig.cmake
+/data/data/com.termux/files/usr/lib/cmake/Qt5OpenGL/Qt5OpenGLConfigVersion.cmake
+/data/data/com.termux/files/usr/lib/cmake/Qt5OpenGLExtensions
+/data/data/com.termux/files/usr/lib/cmake/Qt5OpenGLExtensions/Qt5OpenGLExtensionsConfig.cmake
+/data/data/com.termux/files/usr/lib/cmake/Qt5OpenGLExtensions/Qt5OpenGLExtensionsConfigVersion.cmake
+/data/data/com.termux/files/usr/lib/cmake/Qt5PlatformCompositorSupport
+/data/data/com.termux/files/usr/lib/cmake/Qt5PlatformCompositorSupport/Qt5PlatformCompositorSupportConfig.cmake
+/data/data/com.termux/files/usr/lib/cmake/Qt5PlatformCompositorSupport/Qt5PlatformCompositorSupportConfigVersion.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5PrintSupport
 /data/data/com.termux/files/usr/lib/cmake/Qt5PrintSupport/Qt5PrintSupportConfig.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5PrintSupport/Qt5PrintSupportConfigVersion.cmake
@@ -2623,6 +2731,9 @@
 /data/data/com.termux/files/usr/lib/cmake/Qt5ThemeSupport
 /data/data/com.termux/files/usr/lib/cmake/Qt5ThemeSupport/Qt5ThemeSupportConfig.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5ThemeSupport/Qt5ThemeSupportConfigVersion.cmake
+/data/data/com.termux/files/usr/lib/cmake/Qt5VulkanSupport
+/data/data/com.termux/files/usr/lib/cmake/Qt5VulkanSupport/Qt5VulkanSupportConfig.cmake
+/data/data/com.termux/files/usr/lib/cmake/Qt5VulkanSupport/Qt5VulkanSupportConfigVersion.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5Widgets
 /data/data/com.termux/files/usr/lib/cmake/Qt5Widgets/Qt5WidgetsConfig.cmake
 /data/data/com.termux/files/usr/lib/cmake/Qt5Widgets/Qt5WidgetsConfigExtras.cmake
@@ -2652,18 +2763,28 @@
 /data/data/com.termux/files/usr/lib/libQt5DeviceDiscoverySupport.prl
 /data/data/com.termux/files/usr/lib/libQt5EdidSupport.a
 /data/data/com.termux/files/usr/lib/libQt5EdidSupport.prl
+/data/data/com.termux/files/usr/lib/libQt5EglSupport.a
+/data/data/com.termux/files/usr/lib/libQt5EglSupport.prl
 /data/data/com.termux/files/usr/lib/libQt5EventDispatcherSupport.a
 /data/data/com.termux/files/usr/lib/libQt5EventDispatcherSupport.prl
 /data/data/com.termux/files/usr/lib/libQt5FbSupport.a
 /data/data/com.termux/files/usr/lib/libQt5FbSupport.prl
 /data/data/com.termux/files/usr/lib/libQt5FontDatabaseSupport.a
 /data/data/com.termux/files/usr/lib/libQt5FontDatabaseSupport.prl
+/data/data/com.termux/files/usr/lib/libQt5GlxSupport.a
+/data/data/com.termux/files/usr/lib/libQt5GlxSupport.prl
 /data/data/com.termux/files/usr/lib/libQt5Gui.prl
 /data/data/com.termux/files/usr/lib/libQt5Gui.so.5.15.18
 /data/data/com.termux/files/usr/lib/libQt5InputSupport.a
 /data/data/com.termux/files/usr/lib/libQt5InputSupport.prl
 /data/data/com.termux/files/usr/lib/libQt5Network.prl
 /data/data/com.termux/files/usr/lib/libQt5Network.so.5.15.18
+/data/data/com.termux/files/usr/lib/libQt5OpenGL.prl
+/data/data/com.termux/files/usr/lib/libQt5OpenGL.so.5.15.18
+/data/data/com.termux/files/usr/lib/libQt5OpenGLExtensions.a
+/data/data/com.termux/files/usr/lib/libQt5OpenGLExtensions.prl
+/data/data/com.termux/files/usr/lib/libQt5PlatformCompositorSupport.a
+/data/data/com.termux/files/usr/lib/libQt5PlatformCompositorSupport.prl
 /data/data/com.termux/files/usr/lib/libQt5PrintSupport.prl
 /data/data/com.termux/files/usr/lib/libQt5PrintSupport.so.5.15.18
 /data/data/com.termux/files/usr/lib/libQt5ServiceSupport.a
@@ -2674,6 +2795,8 @@
 /data/data/com.termux/files/usr/lib/libQt5Test.so.5.15.18
 /data/data/com.termux/files/usr/lib/libQt5ThemeSupport.a
 /data/data/com.termux/files/usr/lib/libQt5ThemeSupport.prl
+/data/data/com.termux/files/usr/lib/libQt5VulkanSupport.a
+/data/data/com.termux/files/usr/lib/libQt5VulkanSupport.prl
 /data/data/com.termux/files/usr/lib/libQt5Widgets.prl
 /data/data/com.termux/files/usr/lib/libQt5Widgets.so.5.15.18
 /data/data/com.termux/files/usr/lib/libQt5XcbQpa.prl
@@ -2693,6 +2816,8 @@
 /data/data/com.termux/files/usr/lib/pkgconfig/Qt5DBus.pc
 /data/data/com.termux/files/usr/lib/pkgconfig/Qt5Gui.pc
 /data/data/com.termux/files/usr/lib/pkgconfig/Qt5Network.pc
+/data/data/com.termux/files/usr/lib/pkgconfig/Qt5OpenGL.pc
+/data/data/com.termux/files/usr/lib/pkgconfig/Qt5OpenGLExtensions.pc
 /data/data/com.termux/files/usr/lib/pkgconfig/Qt5PrintSupport.pc
 /data/data/com.termux/files/usr/lib/pkgconfig/Qt5Sql.pc
 /data/data/com.termux/files/usr/lib/pkgconfig/Qt5Test.pc
@@ -3249,14 +3374,21 @@
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_dbus_private.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_devicediscovery_support_private.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_edid_support_private.pri
+/data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_egl_support_private.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_eventdispatcher_support_private.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_fb_support_private.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_fontdatabase_support_private.pri
+/data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_glx_support_private.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_gui.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_gui_private.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_input_support_private.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_network.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_network_private.pri
+/data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_opengl.pri
+/data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_opengl_private.pri
+/data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_openglextensions.pri
+/data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_openglextensions_private.pri
+/data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_platformcompositor_support_private.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_printsupport.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_printsupport_private.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_service_support_private.pri
@@ -3265,6 +3397,7 @@
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_testlib.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_testlib_private.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_theme_support_private.pri
+/data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_vulkan_support_private.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_widgets.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_widgets_private.pri
 /data/data/com.termux/files/usr/lib/qt/mkspecs/modules/qt_lib_xcb_qpa_lib_private.pri
@@ -3424,6 +3557,8 @@
 /data/data/com.termux/files/usr/libexec/qt/sqldrivers
 /data/data/com.termux/files/usr/libexec/qt/sqldrivers/libqsqlite.so
 /data/data/com.termux/files/usr/libexec/qt/sqldrivers/libqsqlpsql.so
+/data/data/com.termux/files/usr/libexec/qt/xcbglintegrations
+/data/data/com.termux/files/usr/libexec/qt/xcbglintegrations/libqxcb-glx-integration.so
 /data/data/com.termux/files/usr/share
 /data/data/com.termux/files/usr/share/doc
 /data/data/com.termux/files/usr/share/doc/qt
@@ -3570,6 +3705,9 @@
 /data/data/com.termux/files/usr/lib/libQt5Network.so
 /data/data/com.termux/files/usr/lib/libQt5Network.so.5
 /data/data/com.termux/files/usr/lib/libQt5Network.so.5.15
+/data/data/com.termux/files/usr/lib/libQt5OpenGL.so
+/data/data/com.termux/files/usr/lib/libQt5OpenGL.so.5
+/data/data/com.termux/files/usr/lib/libQt5OpenGL.so.5.15
 /data/data/com.termux/files/usr/lib/libQt5PrintSupport.so
 /data/data/com.termux/files/usr/lib/libQt5PrintSupport.so.5
 /data/data/com.termux/files/usr/lib/libQt5PrintSupport.so.5.15
```

</details>