### PR TITLE
bump(main/liborc): 0.4.42

### DIFF
--- a/packages/liborc/build.sh
+++ b/packages/liborc/build.sh
@@ -3,10 +3,9 @@ TERMUX_PKG_DESCRIPTION="Library of Optimized Inner Loops Runtime Compiler"
 TERMUX_PKG_LICENSE="BSD 2-Clause, BSD 3-Clause"
 TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.4.41"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="0.4.42"
 TERMUX_PKG_SRCURL=https://gitlab.freedesktop.org/gstreamer/orc/-/archive/${TERMUX_PKG_VERSION}/orc-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=5ae39f7d715a0b358e54c94ac7a4adceca31f9f3ea199a059a53b9219611fe66
+TERMUX_PKG_SHA256=1f5c3f614de5bd4a6522ba3c24a93b99d06c9f773ef5618252269d7f40251456
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
 
@@ -15,5 +14,5 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dtests=disabled
 -Dbenchmarks=disabled
 -Dexamples=disabled
--Dgtk_doc=disabled
+-Dhotdoc=disabled
 "


### PR DESCRIPTION
gtk-doc option was replaced with hotdoc in the following upstream commit.
https://gitlab.freedesktop.org/gstreamer/orc/-/commit/0ad1f5884c654b614cf1ddd114a7ec9140311a3a

* Fixes #27946 