### PR TITLE
enhance(x11/mpv-x): enable Vulkan

### DIFF
--- a/x11-packages/mpv-x/build.sh
+++ b/x11-packages/mpv-x/build.sh
@@ -4,11 +4,12 @@ TERMUX_PKG_LICENSE="GPL-2.0-or-later"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
 # Update both mpv and mpv-x to the same version in one PR.
 TERMUX_PKG_VERSION="0.41.0"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/mpv-player/mpv/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=ee21092a5ee427353392360929dc64645c54479aefdb5babc5cfbb5fad626209
 TERMUX_PKG_AUTO_UPDATE=false
-TERMUX_PKG_DEPENDS="alsa-lib, ffmpeg, jack, libandroid-glob, libandroid-shmem, libarchive, libass, libbluray, libcaca, libdrm, libdvdnav, libiconv, libjpeg-turbo, luajit, libplacebo, libsixel, libuchardet, libx11, libxext, libxinerama, libxpresent, libxrandr, libxss, libzimg, littlecms, openal-soft, opengl, pipewire, pulseaudio, rubberband, zlib"
+TERMUX_PKG_DEPENDS="alsa-lib, ffmpeg, jack, libandroid-glob, libandroid-shmem, libarchive, libass, libbluray, libcaca, libdrm, libdvdnav, libiconv, libjpeg-turbo, libplacebo, libsixel, libuchardet, libx11, libxext, libxinerama, libxpresent, libxrandr, libxss, libzimg, littlecms, luajit, openal-soft, opengl, pipewire, pulseaudio, rubberband, vulkan-icd, zlib"
+TERMUX_PKG_BUILD_DEPENDS="vulkan-headers, vulkan-loader-generic"
 TERMUX_PKG_CONFLICTS="mpv"
 TERMUX_PKG_REPLACES="mpv"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
@@ -21,7 +22,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dgl-x11=enabled
 -Dvdpau=disabled
 -Dvaapi=disabled
--Dvulkan=disabled
+-Dvulkan=enabled
 -Dxv=disabled
 -Dandroid-media-ndk=disabled
 "


### PR DESCRIPTION
Makes this command work. Tested using `mesa-vulkan-icd-freedreno` on Samsung Galaxy S9 SM-G960U with Adreno 630.

```bash
mpv --vo=gpu-next --gpu-api=vulkan  BigBuckBunny_320x180.mp4
```

> [!NOTE]
> This makes video **rendering** use Vulkan. Video **decoding** is a different kind of routine, and may work with `--hwdec=vulkan` on a compatible GPU, but doesn't work for me because I see `h264: Device does not support the VK_KHR_video_decode_queue extension!` with that.