### PR TITLE
enhance(main/iproute2): globally set --color=auto

### DIFF
--- a/packages/iproute2/build.sh
+++ b/packages/iproute2/build.sh
@@ -3,11 +3,14 @@ TERMUX_PKG_DESCRIPTION="Utilities for controlling networking"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="6.18.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=6ba520e1975e4c50dc931eeae91ea37c198b8a173744885f8895b84325f9d456
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libandroid-glob, libandroid-support"
 TERMUX_PKG_BUILD_IN_SRC=true
+
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--color=auto"
 
 termux_step_pre_configure() {
 	CFLAGS+=" -fPIC"


### PR DESCRIPTION
arch linux also adds that flag here: https://gitlab.archlinux.org/archlinux/packaging/packages/iproute2/-/blob/main/PKGBUILD?ref_type=heads#L45