### PR TITLE
fix(x11/firefox): install icons

### DIFF
--- a/x11-packages/firefox/build.sh
+++ b/x11-packages/firefox/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Mozilla Firefox web browser"
 TERMUX_PKG_LICENSE="MPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="146.0.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://archive.mozilla.org/pub/firefox/releases/${TERMUX_PKG_VERSION}/source/firefox-${TERMUX_PKG_VERSION}.source.tar.xz
 TERMUX_PKG_SHA256=e9678a0e8473923953e1dc312c37919068623b6aa20adade16266049258191eb
 # ffmpeg and pulseaudio are dependencies through dlopen(3):
@@ -127,6 +128,19 @@ termux_step_make_install() {
 	./mach install
 
 	install -Dm644 -t "${TERMUX_PREFIX}/share/applications" "${TERMUX_PKG_BUILDER_DIR}/firefox.desktop"
+
+	# Install icons as Arch Linux does
+	local i theme=official
+	for i in 16 22 24 32 48 64 128 256; do
+		install -Dvm644 "browser/branding/$theme/default$i.png" \
+			"$TERMUX_PREFIX/share/icons/hicolor/${i}x${i}/apps/$TERMUX_PKG_NAME.png"
+	done
+	install -Dvm644 "browser/branding/$theme/content/about-logo.png" \
+		"$TERMUX_PREFIX/share/icons/hicolor/192x192/apps/$TERMUX_PKG_NAME.png"
+	install -Dvm644 "browser/branding/$theme/content/about-logo@2x.png" \
+		"$TERMUX_PREFIX/share/icons/hicolor/384x384/apps/$TERMUX_PKG_NAME.png"
+	install -Dvm644 "browser/branding/$theme/content/about-logo.svg" \
+		"$TERMUX_PREFIX/share/icons/hicolor/scalable/apps/$TERMUX_PKG_NAME.svg"
 }
 
 termux_step_post_make_install() {


### PR DESCRIPTION
- Like Arch Linux does https://gitlab.archlinux.org/archlinux/packaging/packages/firefox/-/blob/78b52eff1345d421fccb7bec42f039fb8c52e0cb/PKGBUILD#L256