### PR TITLE
fix(x11/thunderbird): install icons

### DIFF
--- a/x11-packages/thunderbird/build.sh
+++ b/x11-packages/thunderbird/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Unofficial Thunderbird email client"
 TERMUX_PKG_LICENSE="MPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="146.0.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://archive.mozilla.org/pub/thunderbird/releases/${TERMUX_PKG_VERSION}/source/thunderbird-${TERMUX_PKG_VERSION}.source.tar.xz"
 TERMUX_PKG_SHA256=816c7add658c208ef6057ef86643ed9ecc0f4daafcae592a1ffe38d1a2108b38
 TERMUX_PKG_DEPENDS="botan3, ffmpeg, fontconfig, freetype, gdk-pixbuf, glib, gtk3, libandroid-shmem, libandroid-spawn, libc++, libcairo, libevent, libffi, libice, libicu, libjpeg-turbo, libnspr, libnss, libotr, libpixman, libsm, libvpx, libwebp, libx11, libxcb, libxcomposite, libxdamage, libxext, libxfixes, libxrandr, libxtst, pango, pulseaudio, zlib"
@@ -124,6 +125,19 @@ termux_step_make_install() {
 	./mach install
 
 	install -Dm644 -t "${TERMUX_PREFIX}/share/applications" "${TERMUX_PKG_BUILDER_DIR}/thunderbird.desktop"
+
+	# Install icons as Arch Linux does
+	local i theme=nightly
+	for i in 16 22 24 32 48 64 128 256; do
+		install -Dvm644 "comm/mail/branding/$theme/default$i.png" \
+			"$TERMUX_PREFIX/share/icons/hicolor/${i}x${i}/apps/$TERMUX_PKG_NAME.png"
+	done
+	install -Dvm644 "comm/mail/branding/$theme/content/about-logo.png" \
+		"$TERMUX_PREFIX/share/icons/hicolor/192x192/apps/$TERMUX_PKG_NAME.png"
+	install -Dvm644 "comm/mail/branding/$theme/content/about-logo@2x.png" \
+		"$TERMUX_PREFIX/share/icons/hicolor/384x384/apps/$TERMUX_PKG_NAME.png"
+	install -Dvm644 "comm/mail/branding/$theme/content/about-logo.svg" \
+		"$TERMUX_PREFIX/share/icons/hicolor/scalable/apps/$TERMUX_PKG_NAME.svg"
 }
 
 termux_step_post_make_install() {


### PR DESCRIPTION
- Like Arch Linux does https://gitlab.archlinux.org/archlinux/packaging/packages/thunderbird/-/blob/9864f8ea27dfa952f76a3997baa14f37fc44b49f/PKGBUILD#L151

- Note: @truboxl received permission from Mozilla to use official branding in Termux `firefox`, but Termux `thunderbird` does not currently use the official branding, and it's unclear whether it's OK to enable it, so this applies the icons that match the current internal icons of this `thunderbird` build (purple-colored icons) instead of the icons for the official build (blue-colored icons) https://github.com/termux/termux-packages/pull/17840#issuecomment-1915736050