### PR TITLE
bump(main/postgresql): 18.1

### DIFF
--- a/packages/postgresql/build.sh
+++ b/packages/postgresql/build.sh
@@ -3,10 +3,9 @@ TERMUX_PKG_DESCRIPTION="Object-relational SQL database"
 TERMUX_PKG_LICENSE="PostgreSQL"
 TERMUX_PKG_LICENSE_FILE="COPYRIGHT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="17.0"
-TERMUX_PKG_REVISION=5
+TERMUX_PKG_VERSION="18.1"
 TERMUX_PKG_SRCURL=https://ftp.postgresql.org/pub/source/v$TERMUX_PKG_VERSION/postgresql-$TERMUX_PKG_VERSION.tar.bz2
-TERMUX_PKG_SHA256=7e276131c0fdd6b62588dbad9b3bb24b8c3498d5009328dba59af16e819109de
+TERMUX_PKG_SHA256=ff86675c336c46e98ac991ebb306d1b67621ece1d06787beaade312c2c915d54
 TERMUX_PKG_DEPENDS="libandroid-execinfo, libandroid-shmem, libicu, libuuid, libxml2, openssl, readline, zlib"
 # - pgac_cv_prog_cc_LDFLAGS_EX_BE__Wl___export_dynamic: Needed to fix PostgreSQL 16 that
 #   causes initdb failure: cannot locate symbol


### PR DESCRIPTION
- https://www.postgresql.org/docs/release/17.1/
- https://www.postgresql.org/docs/release/17.2/
- https://www.postgresql.org/docs/release/17.3/
- https://www.postgresql.org/docs/release/17.4/
- https://www.postgresql.org/docs/release/17.5/
- https://www.postgresql.org/docs/release/17.6/
- https://www.postgresql.org/docs/release/17.7/
- https://www.postgresql.org/docs/release/18.0/
- https://www.postgresql.org/docs/release/18.1/