### PR TITLE
addpkg(main/libngtcp2): 1.19.0

### DIFF
--- a/packages/libcurl/build.sh
+++ b/packages/libcurl/build.sh
@@ -3,11 +3,12 @@ TERMUX_PKG_DESCRIPTION="Easy-to-use client-side URL transfer library"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="8.18.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/curl/curl/releases/download/curl-${TERMUX_PKG_VERSION//./_}/curl-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=40df79166e74aa20149365e11ee4c798a46ad57c34e4f68fd13100e2c9a91946
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+_\d+_\d+$"
-TERMUX_PKG_DEPENDS="libnghttp2, libnghttp3, libssh2, openssl (>= 1:3.2.1-1), zlib"
+TERMUX_PKG_DEPENDS="libnghttp2, libnghttp3, libngtcp2, libssh2, openssl (>= 1:3.2.1-1), zlib"
 TERMUX_PKG_BREAKS="libcurl-dev"
 TERMUX_PKG_REPLACES="libcurl-dev"
 TERMUX_PKG_ESSENTIAL=true
@@ -17,6 +18,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --with-ca-bundle=$TERMUX_PREFIX/etc/tls/cert.pem
 --with-ca-path=$TERMUX_PREFIX/etc/tls/certs
 --with-nghttp2
+--with-ngtcp2
 --without-libidn
 --without-libidn2
 --without-librtmp
@@ -25,7 +27,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --with-libssh2
 --with-ssl
 --with-openssl
---with-openssl-quic
 --with-nghttp3
 --disable-ares
 "

--- a/packages/libngtcp2/build.sh
+++ b/packages/libngtcp2/build.sh
@@ -1,0 +1,35 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/ngtcp2/ngtcp2
+TERMUX_PKG_DESCRIPTION="Implementation of IETF QUIC protocol"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="1.19.0"
+TERMUX_PKG_SRCURL="https://github.com/ngtcp2/ngtcp2/releases/download/v$TERMUX_PKG_VERSION/ngtcp2-$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=b8aae6b438c3dbc8223bae208e9e2798e0797ecd61d5a945d480896e04307c79
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_FORCE_CMAKE=true
+TERMUX_PKG_DEPENDS="openssl"
+TERMUX_PKG_BUILD_DEPENDS="brotli"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DENABLE_GNUTLS=false
+-DENABLE_OPENSSL=true
+-DENABLE_LIB_ONLY=true
+-DHAVE_LIBBROTLIENC=true
+-DHAVE_LIBBROTLIDEC=true
+-DLIBBROTLIENC_LIBRARIES=$TERMUX_PREFIX/lib/libbrotlienc.so
+-DLIBBROTLIDEC_LIBRARIES=$TERMUX_PREFIX/lib/libbrotlidec.so
+"
+
+termux_step_post_get_source() {
+	# Do not forget to bump revision of reverse dependencies and rebuild them
+	# after SOVERSION is changed.
+
+	local a
+	for a in LT_CURRENT LT_AGE; do
+		local _${a}="$(sed -nE "s/^set\(${a}\s*([0-9]+)\)/\1/p" CMakeLists.txt)"
+	done
+
+	local _SOVERSION=16 v="$(( _LT_CURRENT - _LT_AGE ))"
+	if [[ ! "${_LT_CURRENT}" || "${v}" != "${_SOVERSION}" ]]; then
+		termux_error_exit "SOVERSION guard check failed."
+	fi
+}

--- a/packages/libunbound/build.sh
+++ b/packages/libunbound/build.sh
@@ -3,10 +3,11 @@ TERMUX_PKG_DESCRIPTION="A validating, recursive, caching DNS resolver"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.24.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://nlnetlabs.nl/downloads/unbound/unbound-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=44e7b53e008a6dcaec03032769a212b46ab5c23c105284aa05a4f3af78e59cdb
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="libevent, libnghttp2, openssl, resolv-conf"
+TERMUX_PKG_DEPENDS="libevent, libnghttp2, libngtcp2, openssl, resolv-conf"
 TERMUX_PKG_BUILD_DEPENDS="python, swig"
 TERMUX_PKG_BREAKS="unbound (<< 1.17.1-1)"
 TERMUX_PKG_REPLACES="unbound (<< 1.17.1-1)"
@@ -30,6 +31,7 @@ ac_cv_func_getpwnam=no
 --with-pyunbound
 --without-pythonmodule
 --with-libnghttp2=$TERMUX_PREFIX
+--with-libngtcp2=$TERMUX_PREFIX
 --with-ssl=$TERMUX_PREFIX
 --with-pidfile=$TERMUX_PREFIX/var/run/unbound.pid
 --with-username=


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28058

- Enable in reverse dependencies `libunbound` and `libcurl`

- `--with-openssl-quic` was replaced with `--with-ngtcp2` in Arch Linux
  in https://gitlab.archlinux.org/archlinux/packaging/packages/curl/-/commit/bbc12027e6aaa28ed814f726206b4c765b256713