### PR TITLE
fix(main/vulkan-tools): revert `VK_KHR_display` in `vulkaninfo`

### DIFF
--- a/packages/vulkan-tools/0003-revert-vk-khr-display.patch
+++ b/packages/vulkan-tools/0003-revert-vk-khr-display.patch
@@ -1,0 +1,21 @@
+VK_KHR_display does not work on Android
+Partially reverts https://github.com/KhronosGroup/Vulkan-Tools/commit/f5ba3301bdd000d925b4bf277a18ac0fa69c1fd2
+
+Fixes:
+WARNING: [../src/src/freedreno/vulkan/tu_knl_kgsl.cc:1716] Code 0 :
+I can't KHR_display (VK_ERROR_INITIALIZATION_FAILED)
+ERROR: [Loader Message] Code 0 : setup_loader_term_phys_devs: Call to 'vkEnumeratePhysicalDevices'
+in ICD /data/data/com.termux/files/usr/lib/libvulkan_freedreno.so failed with error code -3
+WARNING: [Loader Message] Code 0 : ICD for selected physical device does not export vkGetPhysicalDeviceDisplayPlanePropertiesKHR!
+WARNING: [Loader Message] Code 0 : ICD for selected physical device does not export vkGetPhysicalDeviceDisplayPropertiesKHR!
+
+--- a/vulkaninfo/CMakeLists.txt
++++ b/vulkaninfo/CMakeLists.txt
+@@ -93,7 +93,6 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux|BSD|GNU")
+         target_compile_definitions(vulkaninfo PRIVATE VK_USE_PLATFORM_DIRECTFB_EXT)
+         target_link_libraries(vulkaninfo PRIVATE PkgConfig::DirectFB)
+     endif()
+-    target_compile_definitions(vulkaninfo PRIVATE VK_USE_PLATFORM_DISPLAY)
+ endif()
+ 
+ if(APPLE)

--- a/packages/vulkan-tools/build.sh
+++ b/packages/vulkan-tools/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Vulkan Tools and Utilities"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.4.339"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/KhronosGroup/Vulkan-Tools/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=cf6ecfd5730e7f4781bb1e41f75e75fa2edbd1de8ed4e6d13d1284e96764007c
 TERMUX_PKG_DEPENDS="libc++, libwayland, libx11, libxcb, vulkan-loader"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/22542, but for `vulkaninfo`

- Unfortunately, this commit is causing `ERROR: [Loader Message] Code 0 : setup_loader_term_phys_devs: Call to 'vkEnumeratePhysicalDevices'` in Termux and failure of `vulkaninfo` to detect Turnip: https://github.com/KhronosGroup/Vulkan-Tools/commit/f5ba3301bdd000d925b4bf277a18ac0fa69c1fd2

- Partially reverts https://github.com/KhronosGroup/Vulkan-Tools/commit/f5ba3301bdd000d925b4bf277a18ac0fa69c1fd2 using condensed patch syntax, fixing the error