### PR TITLE
enhance(main/util-linux): explicitly list binaries for each dependency

### DIFF
--- a/packages/util-linux/build.sh
+++ b/packages/util-linux/build.sh
@@ -11,9 +11,18 @@ TERMUX_PKG_LICENSE_FILE="
 "
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.41.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.kernel.org/pub/linux/utils/util-linux/v${TERMUX_PKG_VERSION:0:4}/util-linux-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=6062a1d89b571a61932e6fc0211f36060c4183568b81ee866cf363bce9f6583e
-# libcrypt is required for only newgrp and sulogin, which are not built anyways
+# <dependency>: <binaries linking to that dependency>
+# libandroid-glob: lsclocks
+# libandroid-posix-semaphore: lsipc and the lib{blkid,smartcols,uuid} subpackages
+# libcap-ng: setpriv
+# libsmartcols: cal, column, fincore, irqtop, losetup, lsclocks, lscpu, lsfd, lsipc, lsirq, prlimit, wdctl, zramctl
+# ncurses: cal, dmesg, hexdump, irqtop, setterm, ul
+# zlib: fsck.cramfs
+#
+# libcrypt would be required for newgrp and sulogin, which we are not building
 TERMUX_PKG_DEPENDS="libandroid-glob, libandroid-posix-semaphore, libcap-ng, libsmartcols, ncurses, zlib"
 TERMUX_PKG_ESSENTIAL=true
 TERMUX_PKG_BREAKS="util-linux-dev"

--- a/packages/util-linux/libblkid.subpackage.sh
+++ b/packages/util-linux/libblkid.subpackage.sh
@@ -1,6 +1,7 @@
 TERMUX_SUBPKG_DESCRIPTION="Block device identification library"
 TERMUX_SUBPKG_BREAKS="util-linux (<< 2.38.1-1)"
 TERMUX_SUBPKG_REPLACES="util-linux (<< 2.38.1-1)"
+TERMUX_SUBPKG_DEPENDS="libandroid-posix-semaphore"
 TERMUX_SUBPKG_DEPEND_ON_PARENT=false
 TERMUX_SUBPKG_INCLUDE="
 include/blkid/blkid.h

--- a/packages/util-linux/libsmartcols.subpackage.sh
+++ b/packages/util-linux/libsmartcols.subpackage.sh
@@ -1,6 +1,7 @@
 TERMUX_SUBPKG_DESCRIPTION="Library for smart adaptive formatting of tabular data"
 TERMUX_SUBPKG_BREAKS="util-linux (<< 2.38.1-1)"
 TERMUX_SUBPKG_REPLACES="util-linux (<< 2.38.1-1)"
+TERMUX_SUBPKG_DEPENDS="libandroid-posix-semaphore"
 TERMUX_SUBPKG_DEPEND_ON_PARENT=false
 TERMUX_SUBPKG_INCLUDE="
 lib/libsmartcols.so

--- a/packages/util-linux/libuuid.subpackage.sh
+++ b/packages/util-linux/libuuid.subpackage.sh
@@ -1,6 +1,7 @@
 TERMUX_SUBPKG_DESCRIPTION="Library for handling universally unique identifiers"
 TERMUX_SUBPKG_BREAKS="libuuid-dev"
 TERMUX_SUBPKG_REPLACES="libuuid-dev"
+TERMUX_SUBPKG_DEPENDS="libandroid-posix-semaphore"
 TERMUX_SUBPKG_DEPEND_ON_PARENT=false
 TERMUX_SUBPKG_INCLUDE="
 lib/pkgconfig/uuid.pc


### PR DESCRIPTION
- closes #27185

This PR makes the `libandroid-posix-semaphore` dependency direct for the 
`libblkid`, `libsmartcols` and `libuuid` subpackages of `util-linux`.
This dependency was previously fulfilled indirectly by `util-linux` being essential.
However it remains undetected on old installations.

`blk-utils`, `fdisk`, `libblkid`, `libfdisk`, `libmount`, `mount-utils` and `uuid-utils` already explicitly specify their (inter)dependencies, they will adequately receive a transitive dependency on `libandroid-posix-semaphore` through one of their existing dependencies.

I also listed out the binaries that need all of the specific dependencies of the main `util-linux` package
I also plan to look at `coreutils` for the same thing since this should help us with identifying any future dependency issues with a component utility.