### PR TITLE
fix(main/virglrenderer-android): fix on-device build

### DIFF
--- a/packages/virglrenderer-android/0010-disable-memfd_create-timespec_get.patch.beforehostbuild
+++ b/packages/virglrenderer-android/0010-disable-memfd_create-timespec_get.patch.beforehostbuild
@@ -1,0 +1,21 @@
+Android 7 does not have memfd_create or timespec_get,
+so do not allow them to be activated through detection
+in /system/lib64/libc.so via meson's has_function() method
+if virglrenderer-android is being compiled on an Android 14
+device that does not have the 'ndk-multilib' package installed.
+This virglrenderer-specific Meson code is used to compile
+some mesa-derived code, so here is a link to the solution currently in
+upstream mesa, the patch for which does not apply cleanly here:
+https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/37630
+
+--- a/meson.build
++++ b/meson.build
+@@ -228,7 +228,7 @@ foreach a : supported_function_attributes
+   endif
+ endforeach
+ 
+-foreach f : ['memfd_create', 'strtok_r', 'timespec_get']
++foreach f : ['strtok_r']
+   if cc.has_function(f)
+     conf_data.set('HAVE_@0@'.format(f.to_upper()), 1)
+   endif

--- a/packages/virglrenderer-android/build.sh
+++ b/packages/virglrenderer-android/build.sh
@@ -23,10 +23,12 @@ termux_step_post_get_source() {
 termux_step_host_build() {
 	# This package should use the Android NDK toolchain to compile, not
 	# our custom toolchain, so I'd like to compile it in the hostbuild step.
-	export PATH="$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
-	export CCTERMUX_HOST_PLATFORM=$TERMUX_HOST_PLATFORM$TERMUX_PKG_API_LEVEL
-	if [ $TERMUX_ARCH = arm ]; then
-		CCTERMUX_HOST_PLATFORM=armv7a-linux-androideabi$TERMUX_PKG_API_LEVEL
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		export PATH="$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
+		export CCTERMUX_HOST_PLATFORM="$TERMUX_HOST_PLATFORM$TERMUX_PKG_API_LEVEL"
+		if [[ "$TERMUX_ARCH" == "arm" ]]; then
+			CCTERMUX_HOST_PLATFORM="armv7a-linux-androideabi$TERMUX_PKG_API_LEVEL"
+		fi
 	fi
 
 	local _INSTALL_PREFIX=$TERMUX_PREFIX/opt/$TERMUX_PKG_NAME
@@ -42,8 +44,13 @@ termux_step_host_build() {
 	chmod +x $PKG_CONFIG
 
 	AR=$(command -v llvm-ar)
-	CC=$(command -v $CCTERMUX_HOST_PLATFORM-clang)
-	CXX=$(command -v $CCTERMUX_HOST_PLATFORM-clang++)
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		CC=$(command -v "$CCTERMUX_HOST_PLATFORM-clang")
+		CXX=$(command -v "$CCTERMUX_HOST_PLATFORM-clang++")
+	else
+		CC=$(command -v "$TERMUX_HOST_PLATFORM-clang")
+		CXX=$(command -v "$TERMUX_HOST_PLATFORM-clang++")
+	fi
 	LD=$(command -v ld.lld)
 	CFLAGS=""
 	CPPFLAGS=""


### PR DESCRIPTION
- For convenience of developers working within Termux to customize or debug this package

%ci:no-build