### PR TITLE
chore(scripts/big-pkgs.list): add `awscli`

### DIFF
--- a/scripts/big-pkgs.list
+++ b/scripts/big-pkgs.list
@@ -1,5 +1,6 @@
 angle-android
 aosp-libs
+awscli
 carbonyl
 carbonyl-host-tools
 chromium


### PR DESCRIPTION
- I didn't catch this in time to put it in #28092

`awscli`'s build volume grows to nearly 1.0GiB, so it is probably prudent to mark it as a big package.
A rebuild of the package should not be necessary for this.