### PR TITLE
fix(main/pacman): fix on-device build

### DIFF
--- a/packages/pacman/doc-meson.build.patch
+++ b/packages/pacman/doc-meson.build.patch
@@ -1,0 +1,14 @@
+Fixes on-device build of
+./build-package.sh -I -f pacman
+
+--- a/doc/meson.build
++++ b/doc/meson.build
+@@ -101,7 +101,7 @@ foreach page: manpages + sitepages
+ endforeach
+ 
+ run_target('html',
+-           command : ['/bin/true'],
++           command : ['true'],
+            depends : html_targets)
+ 
+ meson.add_install_script(MESON_MAKE_SYMLINK,


### PR DESCRIPTION
- `/bin/true` does not exist in Termux, but `$TERMUX_PREFIX/bin/true` is detected in `PATH` if the absolute path is removed like this

%ci:no-build