### PR TITLE
bump(main/rust): 1.93.0

### DIFF
--- a/packages/rust/0009-always-export-emutls.patch
+++ b/packages/rust/0009-always-export-emutls.patch
@@ -1,15 +1,16 @@
---- a/compiler/rustc_codegen_ssa/src/back/linker.rs
-+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
-@@ -17,7 +17,7 @@
+diff -u -r ../cache/rustc-1.93.0-src/compiler/rustc_codegen_ssa/src/back/linker.rs ./compiler/rustc_codegen_ssa/src/back/linker.rs
+--- ../cache/rustc-1.93.0-src/compiler/rustc_codegen_ssa/src/back/linker.rs	2026-01-19 16:34:28.000000000 +0000
++++ ./compiler/rustc_codegen_ssa/src/back/linker.rs	2026-01-25 21:16:31.635516508 +0000
+@@ -18,7 +18,7 @@
  use rustc_middle::ty::TyCtxt;
  use rustc_session::Session;
  use rustc_session::config::{self, CrateType, DebugInfo, LinkerPluginLto, Lto, OptLevel, Strip};
--use rustc_target::spec::{Cc, LinkOutputKind, LinkerFlavor, Lld};
-+use rustc_target::spec::{Cc, LinkOutputKind, LinkerFlavor, Lld, TlsModel};
+-use rustc_target::spec::{Abi, Arch, Cc, LinkOutputKind, LinkerFlavor, Lld, Os};
++use rustc_target::spec::{Abi, Arch, Cc, LinkOutputKind, LinkerFlavor, Lld, Os, TlsModel};
  use tracing::{debug, warn};
  
  use super::command::Command;
-@@ -869,6 +869,14 @@
+@@ -870,6 +870,14 @@
                          writeln!(f, "    {sym};")?;
                      }
                  }
@@ -24,7 +25,7 @@
                  writeln!(f, "\n  local:\n    *;\n}};")?;
              };
              if let Err(error) = res {
-@@ -876,6 +884,13 @@
+@@ -877,6 +885,13 @@
              }
              if self.sess.target.is_like_solaris {
                  self.link_arg("-M").link_arg(path);

--- a/packages/rust/build.sh
+++ b/packages/rust/build.sh
@@ -3,9 +3,9 @@ TERMUX_PKG_HOMEPAGE=https://www.rust-lang.org/
 TERMUX_PKG_DESCRIPTION="Systems programming language focused on safety, speed and concurrency"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.92.0"
+TERMUX_PKG_VERSION="1.93.0"
 TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/rustc-${TERMUX_PKG_VERSION}-src.tar.xz
-TERMUX_PKG_SHA256=ebee170bfe4c4dfc59521a101de651e5534f4dae889756a5c97ca9ea40d0c307
+TERMUX_PKG_SHA256=e30d898272c587a22f77679f03c5e8192b5645c7c9ccc3407ad1106761507cea
 TERMUX_PKG_DEPENDS="clang, libandroid-execinfo, libc++, libllvm (<< $TERMUX_LLVM_NEXT_MAJOR_VERSION), lld, openssl, zlib"
 TERMUX_PKG_BUILD_DEPENDS="wasi-libc"
 TERMUX_PKG_SUGGESTS="rust-analyzer"
@@ -144,7 +144,7 @@ termux_step_configure() {
 	# like 30 to 40 + minutes ... so lets get it right
 
 	# upstream tests build using versions N and N-1
-	local BOOTSTRAP_VERSION=1.91.1
+	local BOOTSTRAP_VERSION=1.92.0
 	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "false" ]]; then
 		if ! rustup install "${BOOTSTRAP_VERSION}"; then
 			echo "WARN: ${BOOTSTRAP_VERSION} is unavailable, fallback to stable version!"


### PR DESCRIPTION
See https://blog.rust-lang.org/2026/01/22/Rust-1.93.0/.

Fixes #28131