### PR TITLE
bump(main/ncurses): 6.6.20260124

### DIFF
--- a/packages/ncurses/build.sh
+++ b/packages/ncurses/build.sh
@@ -8,16 +8,15 @@ TERMUX_PKG_MAINTAINER="@termux"
 # is checked in termux_step_pre_configure(), so the build will fail on a mistake.
 # Using this simplifies things (no need to avoid downloading and applying patches manually),
 # and uses github is a high available hosting.
-_SNAPSHOT_COMMIT=a480458efb0662531287f0c75116c0e91fe235cb
+_SNAPSHOT_COMMIT=607c49f34cc52dd88203c15ea09b0505c87a41b8
 
 # The subshell leaving the value in the outer scope unchanged is the point here.
 # shellcheck disable=SC2031
-TERMUX_PKG_VERSION=(6.5.20240831
+TERMUX_PKG_VERSION=(6.6.20260124
                     9.31
                     "$(. "$TERMUX_SCRIPTDIR/x11-packages/kitty/build.sh"; echo "$TERMUX_PKG_VERSION")"
                     "$(. "$TERMUX_SCRIPTDIR/x11-packages/alacritty/build.sh"; echo "$TERMUX_PKG_VERSION")"
                     "$(. "$TERMUX_SCRIPTDIR/x11-packages/foot/build.sh"; echo "$TERMUX_PKG_VERSION")")
-TERMUX_PKG_REVISION=3
 # shellcheck disable=SC2031
 TERMUX_PKG_SRCURL=("https://github.com/ThomasDickey/ncurses-snapshots/archive/${_SNAPSHOT_COMMIT}.tar.gz"
                    "https://dist.schmorp.de/rxvt-unicode/Attic/rxvt-unicode-${TERMUX_PKG_VERSION[1]}.tar.bz2"
@@ -25,7 +24,7 @@ TERMUX_PKG_SRCURL=("https://github.com/ThomasDickey/ncurses-snapshots/archive/${
                    "$(. "$TERMUX_SCRIPTDIR/x11-packages/alacritty/build.sh"; echo "$TERMUX_PKG_SRCURL")"
                    "$(. "$TERMUX_SCRIPTDIR/x11-packages/foot/build.sh"; echo "$TERMUX_PKG_SRCURL")")
 # shellcheck disable=SC2031
-TERMUX_PKG_SHA256=(ec6122c3b8ab930d1477a1dbfd90299e9f715555a98b6e6805d5ae1b0d72becd
+TERMUX_PKG_SHA256=(2c32b07ac7397ce19aefb9f38fe159cfdb18d5321d68e6fd93b03ccaf15b8f09
                    aaa13fcbc149fe0f3f391f933279580f74a96fd312d6ed06b8ff03c2d46672e8
                    "$(. "$TERMUX_SCRIPTDIR/x11-packages/kitty/build.sh"; echo "$TERMUX_PKG_SHA256")"
                    "$(. "$TERMUX_SCRIPTDIR/x11-packages/alacritty/build.sh"; echo "$TERMUX_PKG_SHA256")"

--- a/packages/ncurses/fix-paths.patch
+++ b/packages/ncurses/fix-paths.patch
@@ -1,23 +1,23 @@
-diff -uNr ncurses-6.1-20181117/progs/tic.c ncurses-6.1-20181117.mod/progs/tic.c
---- ncurses-6.1-20181117/progs/tic.c	2018-03-18 02:05:10.000000000 +0200
-+++ ncurses-6.1-20181117.mod/progs/tic.c	2019-03-01 20:40:56.193173489 +0200
-@@ -386,7 +386,7 @@
+diff -u -r ../cache/ncurses-snapshots-607c49f34cc52dd88203c15ea09b0505c87a41b8/progs/tic.c ./progs/tic.c
+--- ../cache/ncurses-snapshots-607c49f34cc52dd88203c15ea09b0505c87a41b8/progs/tic.c	2026-01-25 02:08:31.000000000 +0000
++++ ./progs/tic.c	2026-01-26 22:16:55.806606776 +0000
+@@ -390,7 +390,7 @@
  {
-     FILE *result = 0;
+     FILE *result = NULL;
  
 -    _nc_STRCPY(filename, "/tmp/XXXXXX", PATH_MAX);
 +    _nc_STRCPY(filename, "@TERMUX_PREFIX@/tmp/XXXXXX", PATH_MAX);
  #if HAVE_MKSTEMP
      {
  	int oldmask = (int) umask(077);
-@@ -900,7 +900,7 @@
+@@ -923,7 +923,7 @@
      } else {
  	if (infodump == TRUE) {
  	    /* captoinfo's no-argument case */
 -	    source_file = "/etc/termcap";
 +	    source_file = "@TERMUX_PREFIX@/etc/termcap";
- 	    if ((termcap = getenv("TERMCAP")) != 0
- 		&& (namelst = make_namelist(getenv("TERM"))) != 0) {
+ 	    if ((termcap = getenv("TERMCAP")) != NULL
+ 		&& (namelst = make_namelist(getenv("TERM"))) != NULL) {
  		if (access(termcap, F_OK) == 0) {
 diff -uNr ncurses-6.1-20181117/progs/tset.c ncurses-6.1-20181117.mod/progs/tset.c
 --- ncurses-6.1-20181117/progs/tset.c	2017-10-08 03:01:29.000000000 +0300


### PR DESCRIPTION
Update from `6.5.20240831` to `6.6.20260124`. Notes:

- Quite a lof of small changes: https://github.com/ThomasDickey/ncurses-snapshots/commits/master/
- Release notes of `6.6`: [Announcing ncurses 6.6](https://invisible-island.net/ncurses/announce.html)
- `ncurses` is a very central package in the dependency change - a lot depends on it directly or indirectly.
- The maintainer is generally quite careful with backward compatibility.
- Have done some basic testing with packages like `vim`, `tmux`, `less` and similar and haven't noticed anything yet.