### PR TITLE
fix(scripts/bin/update-packages): add `export TERMUX_PKG_NAME` to `_run_update()`

### DIFF
--- a/scripts/bin/update-packages
+++ b/scripts/bin/update-packages
@@ -354,6 +354,8 @@ _gh_check_issue_exists() {
 _run_update() {
 	local pkg_dir="$1" pkg_name
 	pkg_name="$(basename "${pkg_dir}")"
+	# needed for 'termux_pkg_is_update_needed'
+	export TERMUX_PKG_NAME="${pkg_name}"
 	# Run each package update in separate process since we include their environment variables.
 	local output="" _CURRENT_VERSION _NEWEST_VERSION _ISSUE
 	# shellcheck disable=SC1091 # Ignore shellcheck's inability to follow the source

--- a/scripts/updates/utils/termux_pkg_is_update_needed.sh
+++ b/scripts/updates/utils/termux_pkg_is_update_needed.sh
@@ -11,7 +11,8 @@ termux_pkg_is_update_needed() {
 
 	# Is this even a validly formatted version number?
 	if ! dpkg --validate-version "${LATEST_VERSION}" &> /dev/null; then
-		termux_error_exit "::warning::${TERMUX_PKG_NAME:-}: $(dpkg --validate-version "${LATEST_VERSION}" &> /dev/stdout)"
+		echo "::warning::${TERMUX_PKG_NAME:-}: $(dpkg --validate-version "${LATEST_VERSION}" &> /dev/stdout)" >&2
+		return 1
 	fi
 
 	# Compare versions.


### PR DESCRIPTION
- Needed for showing the name of what package failed in `termux_pkg_is_update_needed()`, which is called from this function: https://github.com/termux/termux-packages/actions/runs/21467727026/job/61833279546
- Also warn and cancel the update instead of quitting the entire workflow run