### PR TITLE
fix(main/python-pip): recommend `clang` instead of depending on it

### DIFF
--- a/packages/python-pip/build.sh
+++ b/packages/python-pip/build.sh
@@ -3,13 +3,14 @@ TERMUX_PKG_DESCRIPTION="The PyPA recommended tool for installing Python packages
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="26.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/pypa/pip/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=d50d2b52693ce377496752d30c7b5736364dbe16e9c924521df740fad108d31d
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
 TERMUX_PKG_UPDATE_VERSION_REGEXP='\d+(?:\.\d+){1,2}(?!b)' # matches '25.3', '25.3.1' but not '26.0b1'
-TERMUX_PKG_DEPENDS="clang, make, pkg-config, python (>= 3.11.1-1)"
-TERMUX_PKG_ANTI_BUILD_DEPENDS="clang"
+TERMUX_PKG_DEPENDS="python (>= 3.11.1-1)"
+TERMUX_PKG_RECOMMENDS="clang, make, pkg-config"
 TERMUX_PKG_BREAKS="python (<< 3.11.1-1)"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_BUILD_IN_SRC=true


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28271

- Partially reverts https://github.com/termux/termux-packages/commit/be3cfa11950a89e72e2614396d1ee6f8d7910b7e

- It is not absolutely necessary to have `clang` for installing all PyPi packages, but it is necessary for some of them, so still install `clang` by default, but give users the option of using the command `apt install --no-install-recommends python-pip` to install with fewer dependencies that take up less storage space.

- Arch Linux and other distros do not make `python-pip` depend on a C compiler: https://archlinux.org/packages/extra/any/python-pip/