### PR TITLE
bump(main/gitoxide): 0.50.0

### DIFF
--- a/packages/gitoxide/aws-lc-sys.diff
+++ b/packages/gitoxide/aws-lc-sys.diff
@@ -1,0 +1,15 @@
+Prevents error:
+gitoxide/src/vendor/aws-lc-sys/aws-lc/crypto/rand_extra/getentropy.c:35:9: error: call to undeclared function 'getentropy'
+
+--- a/aws-lc/crypto/rand_extra/internal.h
++++ b/aws-lc/crypto/rand_extra/internal.h
+@@ -13,7 +13,8 @@
+ #elif defined(OPENSSL_MACOS) || defined(OPENSSL_OPENBSD) || \
+     defined(OPENSSL_FREEBSD)  || defined(OPENSSL_NETBSD) || \
+     defined(OPENSSL_SOLARIS) || \
+-    (defined(OPENSSL_LINUX) && !defined(HAVE_LINUX_RANDOM_H))
++    (defined(OPENSSL_LINUX) && !defined(HAVE_LINUX_RANDOM_H) && \
++    !defined(__ANDROID__) || __ANDROID_API__ >= 28)
+ #define OPENSSL_RAND_GETENTROPY
+ #elif defined(OPENSSL_IOS)
+ #define OPENSSL_RAND_CCRANDOMGENERATEBYTES

--- a/packages/gitoxide/hickory-resolver.diff
+++ b/packages/gitoxide/hickory-resolver.diff
@@ -1,12 +1,11 @@
 --- a/src/system_conf/unix.rs
 +++ b/src/system_conf/unix.rs
-@@ -27,7 +27,7 @@
+@@ -29,7 +29,7 @@ use crate::proto::xfer::Protocol;
  const DEFAULT_PORT: u16 = 53;
  
- pub fn read_system_conf() -> io::Result<(ResolverConfig, ResolverOpts)> {
+ pub fn read_system_conf() -> Result<(ResolverConfig, ResolverOpts), ResolveError> {
 -    read_resolv_conf("/etc/resolv.conf")
 +    read_resolv_conf("@TERMUX_PREFIX@/etc/resolv.conf")
  }
  
- fn read_resolv_conf<P: AsRef<Path>>(path: P) -> io::Result<(ResolverConfig, ResolverOpts)> {
-
+ fn read_resolv_conf<P: AsRef<Path>>(


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28126

- New patches:
  - `hickory-resolver.diff`: replaces `trust-dns-resolver.diff`
  - `aws-lc-sys.diff`: fixes `error: call to undeclared function 'getentropy'`