### PR TITLE
fix(root/minikube): disable building `libvirt` backend

### DIFF
--- a/root-packages/minikube/build.sh
+++ b/root-packages/minikube/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="minikube implements a local Kubernetes cluster."
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.38.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/kubernetes/minikube/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=0938a1839bd5c5cb78eac2ff7da931dbbc062d83437351906e4d8d2b53b398c6
 TERMUX_PKG_AUTO_UPDATE=true

--- a/root-packages/minikube/disable-libvirt.patch
+++ b/root-packages/minikube/disable-libvirt.patch
@@ -1,0 +1,24 @@
+Prevents this build error when building for 64-bit x86 Termux:
+
+# libvirt.org/go/libvirt
+# [/home/builder/.termux-build/_cache/android-r29-api-24-v3/bin/pkg-config --cflags
+-- libvirt-admin libvirt-admin libvirt libvirt libvirt libvirt libvirt libvirt libvirt
+libvirt libvirt libvirt libvirt libvirt libvirt libvirt-admin libvirt libvirt libvirt
+libvirt libvirt libvirt libvirt libvirt libvirt libvirt libvirt libvirt libvirt
+libvirt libvirt-lxc libvirt-qemu libvirt libvirt libvirt libvirt libvirt libvirt
+libvirt libvirt libvirt libvirt libvirt libvirt libvirt libvirt libvirt libvirt
+libvirt libvirt libvirt libvirt libvirt libvirt]
+Package libvirt-admin was not found in the pkg-config search path.
+Perhaps you should add the directory containing `libvirt-admin.pc'
+to the PKG_CONFIG_PATH environment variable
+
+--- a/pkg/minikube/registry/drvs/init.go
++++ b/pkg/minikube/registry/drvs/init.go
+@@ -22,7 +22,6 @@ import (
+ 	_ "k8s.io/minikube/pkg/minikube/registry/drvs/hyperkit"
+ 	_ "k8s.io/minikube/pkg/minikube/registry/drvs/hyperv"
+ 	_ "k8s.io/minikube/pkg/minikube/registry/drvs/krunkit"
+-	_ "k8s.io/minikube/pkg/minikube/registry/drvs/kvm2"
+ 	_ "k8s.io/minikube/pkg/minikube/registry/drvs/none"
+ 	_ "k8s.io/minikube/pkg/minikube/registry/drvs/parallels"
+ 	_ "k8s.io/minikube/pkg/minikube/registry/drvs/podman"


### PR DESCRIPTION
- Fixes this error in `scripts/run-docker.sh ./build-package.sh -I -f -a x86_64 minikube`:

```
-- libvirt-admin libvirt-admin libvirt libvirt libvirt libvirt libvirt libvirt libvirt
libvirt libvirt libvirt libvirt libvirt libvirt libvirt-admin libvirt libvirt libvirt
libvirt libvirt libvirt libvirt libvirt libvirt libvirt libvirt libvirt libvirt
libvirt libvirt-lxc libvirt-qemu libvirt libvirt libvirt libvirt libvirt libvirt
libvirt libvirt libvirt libvirt libvirt libvirt libvirt libvirt libvirt libvirt
libvirt libvirt libvirt libvirt libvirt libvirt]
Package libvirt-admin was not found in the pkg-config search path.
Perhaps you should add the directory containing `libvirt-admin.pc'
to the PKG_CONFIG_PATH environment variable
```