### PR TITLE
bump(main/marksman): 2026.01.28

### DIFF
--- a/packages/marksman/build.sh
+++ b/packages/marksman/build.sh
@@ -2,34 +2,23 @@ TERMUX_PKG_HOMEPAGE="https://github.com/artempyanykh/marksman"
 TERMUX_PKG_DESCRIPTION="LSP language server for editing Markdown files"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
-TERMUX_PKG_VERSION="2025.11.30"
-TERMUX_PKG_SRCURL="git+https://github.com/artempyanykh/marksman"
-TERMUX_PKG_SHA256=ed97ca1c99aa93895f9692339c9e066055229f1cc4fa8d2b14893f29a86ca4bf
-TERMUX_PKG_GIT_BRANCH="main"
+TERMUX_PKG_VERSION="2026.01.28"
+TERMUX_PKG_SRCURL="https://github.com/artempyanykh/marksman/archive/refs/tags/${TERMUX_PKG_VERSION//\./-}.tar.gz"
+TERMUX_PKG_SHA256=e6f1b96f8c43447ed4fb408d54b350441f1c5da843d22e0e2acbc2cda320ca74
 TERMUX_PKG_DEPENDS="dotnet-host, dotnet-runtime-9.0"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXCLUDED_ARCHES="arm"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_SED_REGEXP="s/-/./g"
 
-termux_step_post_get_source() {
-	git fetch --tags
-	git checkout "${TERMUX_PKG_VERSION//\./-}"
-
-	local s
-	s="$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)"
-	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
-		printf '%s\n' \
-			"Wrong checksum for ${TERMUX_PKG_SRCURL}" \
-			"Expected: ${TERMUX_PKG_SHA256}" \
-			"Actual:   ${s::64}" >&2
-		return 1
-	fi
-}
-
 termux_step_pre_configure() {
 	TERMUX_DOTNET_VERSION=9.0
 	termux_setup_dotnet
+
+	local patch="$TERMUX_PKG_BUILDER_DIR/version.diff"
+	echo "Applying patch: $patch"
+	sed -e "s%\@TERMUX_PKG_VERSION\@%${TERMUX_PKG_VERSION}%g" \
+		"$patch" | patch --silent -p1
 }
 
 termux_step_make() {

--- a/packages/marksman/version.diff
+++ b/packages/marksman/version.diff
@@ -1,0 +1,14 @@
+Prevents:
+error MSB3073: The command "git describe --tags --always --dirty" exited with code 128
+when building from tar archive instead of git repository
+
+--- a/Marksman/Marksman.fsproj
++++ b/Marksman/Marksman.fsproj
+@@ -4,6 +4,7 @@
+         <OutputType>Exe</OutputType>
+         <AssemblyName>marksman</AssemblyName>
+         <VersionPrefix>1.0.0</VersionPrefix>
++        <VersionString>@TERMUX_PKG_VERSION@</VersionString>
+         <TargetFramework>net9.0</TargetFramework>
+         <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+     </PropertyGroup>


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28213

- Switch to building from release archive instead of git repository