### PR TITLE
bump(main/gomuks): 26.01

### DIFF
--- a/packages/gomuks/build.sh
+++ b/packages/gomuks/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://go.mau.fi/gomuks
 TERMUX_PKG_DESCRIPTION="A terminal Matrix client written in Go"
 TERMUX_PKG_LICENSE="AGPL-V3"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="25.11"
-TERMUX_PKG_SRCURL=https://github.com/gomuks/gomuks/archive/refs/tags/v0.${TERMUX_PKG_VERSION/.}.0.tar.gz
-TERMUX_PKG_SHA256=b581393db960fd91d22942317af11e869821a14fca716e446cf2b9eaacfccf7e
+TERMUX_PKG_VERSION="26.01"
+TERMUX_PKG_SRCURL="https://github.com/gomuks/gomuks/archive/refs/tags/v0.${TERMUX_PKG_VERSION/.}.0.tar.gz"
+TERMUX_PKG_SHA256=954370d1eec42cecbfd05c9e9736e9d4be2cad4201d1c74246ce3500b1d55a67
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="0\.\K\d+(?=\.0)"
 TERMUX_PKG_UPDATE_VERSION_SED_REGEXP="s/([0-9][0-9])([0-9][0-9])/\1.\2/"
@@ -16,11 +16,24 @@ TERMUX_PKG_BUILD_IN_SRC=true
 # ./libde265-all.inl:10:10: fatal error: 'alloc_pool.cc' file not found
 TERMUX_PKG_EXCLUDED_ARCHES="i686"
 
+termux_step_post_get_source() {
+	termux_setup_golang
+	export GOPATH="$TERMUX_PKG_SRCDIR/go"
+	go get ./cmd/gomuks
+	chmod +w "$GOPATH" -R
+
+	local d
+	for d in go/pkg/mod/go.mau.fi/goheif*; do
+		patch -p1 -d "${d}" < "$TERMUX_PKG_BUILDER_DIR/goheif-no-pthread_getaffinity_np.diff"
+	done
+}
+
 termux_step_pre_configure() {
 	termux_setup_golang
 }
 
 termux_step_make() {
+	export GOPATH="$TERMUX_PKG_SRCDIR/go"
 	local ldflags tag_commit
 	# This is adapted directly from the upstream `./build-noweb.sh`
 	# https://github.com/gomuks/gomuks/blob/v0.2511.0/build-noweb.sh

--- a/packages/gomuks/goheif-no-pthread_getaffinity_np.diff
+++ b/packages/gomuks/goheif-no-pthread_getaffinity_np.diff
@@ -1,0 +1,13 @@
+--- a/dav1d/config.h
++++ b/dav1d/config.h
+@@ -76,8 +76,8 @@
+ 
+ /* Thread functions */
+ #if !defined(_WIN32)
+-#define HAVE_PTHREAD_GETAFFINITY_NP 1
+-#define HAVE_PTHREAD_SETAFFINITY_NP 1
++#define HAVE_PTHREAD_GETAFFINITY_NP 0
++#define HAVE_PTHREAD_SETAFFINITY_NP 0
+ #define HAVE_PTHREAD_SETNAME_NP 1
+ #define HAVE_PTHREAD_SET_NAME_NP 0
+ #endif


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28214

- Add `goheif-no-pthread_getaffinity_np.diff` to disable `pthread_getaffinity_np()` and `pthread_setaffinity_np()`, because they do not work on lower Android API levels than 36.