### PR TITLE
bump(main/fennel): 1.6.1

### DIFF
--- a/packages/fennel/build.sh
+++ b/packages/fennel/build.sh
@@ -2,15 +2,15 @@ TERMUX_PKG_HOMEPAGE="https://fennel-lang.org"
 TERMUX_PKG_DESCRIPTION="A Lisp that compiles to Lua"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.5.3"
-TERMUX_PKG_SRCURL="https://github.com/bakpakin/Fennel/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz"
-TERMUX_PKG_SHA256=6fccadb7942dcbebf7325d1427d2ef0c7fa0e9f871b9ef81e48320f193235549
+TERMUX_PKG_VERSION="1.6.1"
+TERMUX_PKG_SRCURL="https://git.sr.ht/~technomancy/fennel/archive/$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=f0f188e9a4424851d9263ab69302b6b2ffc5c6efb67a25fffc52187a29c94024
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="lua53"
+TERMUX_PKG_DEPENDS="lua54"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_pre_configure() {
-	export LUA_VERSION=5.3
-	export LUA=lua5.3
+	export LUA_VERSION=5.4
+	export LUA=lua5.4
 }


### PR DESCRIPTION
This PR updates the source URL for `fennel` to the upstream sourcehut repo.
This will also implicitly cause `fennel` to use the Repology update method rather than the GitHub update method.

I would like to build `fennel` against all available Lua versions similar to what Alpine does.
<sup>https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/fennel/APKBUILD#L35-61</sup>
However I have not been able to get that working, so I just updated it to build against Lua 5.4 for now.