### PR TITLE
fix(x11/mogan): fix build with NDK r29 and CMake 4

### DIFF
--- a/x11-packages/mogan/lolly.diff
+++ b/x11-packages/mogan/lolly.diff
@@ -1,3 +1,7 @@
+file.cpp: prepend @TERMUX_PREFIX@ to /tmp path
+
+hashtree.ipp: https://github.com/MoganLab/lolly/pull/346
+
 --- a/System/Files/file.cpp
 +++ b/System/Files/file.cpp
 @@ -290,7 +290,7 @@
@@ -9,3 +13,14 @@
  #endif
    static url tmp_dir= main_tmp_dir * url (as_string (get_process_id ()));
    return (tmp_dir);
+--- a/Kernel/Containers/hashtree.ipp
++++ b/Kernel/Containers/hashtree.ipp
+@@ -102,7 +102,7 @@ hashtree<K, V>::operator->(void) {
+ template <class K, class V>
+ inline hashtree<K, V>
+ hashtree<K, V>::operator[] (K key) {
+-  if (*this->contains (key)) return *this->children (key);
++  if ((*this)->contains (key)) return (*this)->children (key);
+   else TM_FAILED ("read-access to non-existent node requested");
+ }
+ 

--- a/x11-packages/mogan/moebius.diff
+++ b/x11-packages/mogan/moebius.diff
@@ -1,0 +1,13 @@
+Prevents the error about "please add -DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+
+--- a/xmake.lua
++++ b/xmake.lua
+@@ -32,7 +32,7 @@ local moe_includedirs = {
+ 
+ add_repositories("moe-repo xmake")
+ 
+-local DOCTEST_VERSION = "2.4.11"
++local DOCTEST_VERSION = "2.4.12"
+ 
+ add_requires("lolly")
+ local tbox_configs = {hash=true, ["force-utf8"]=true, charset=true}

--- a/x11-packages/mogan/xmake-packages-l-lolly.patch
+++ b/x11-packages/mogan/xmake-packages-l-lolly.patch
@@ -4,7 +4,7 @@
      add_urls("https://github.com/XmacsLabs/lolly.git")
      add_urls("https://gitee.com/XmacsLabs/lolly.git")
      add_versions("1.4.28", "v1.4.28")
-+    add_patches("1.4.28", "lolly.diff", "b5253738e894c2f5d6633da8c33959f0e64f8daf71f9a147651b03f50f2ded1a")
++    add_patches("1.4.28", "lolly.diff", "d58775888f5ec760422bcdc61fd84424204e7a5297b42ceedcdbb93a9b08530d")
  
      add_deps("tbox")
      if not is_plat("wasm") then

--- a/x11-packages/mogan/xmake-packages-m-moebius.patch
+++ b/x11-packages/mogan/xmake-packages-m-moebius.patch
@@ -1,0 +1,12 @@
+diff --git a/xmake/packages/m/moebius/xmake.lua b/xmake/packages/m/moebius/xmake.lua
+index 233b876..8c30731 100644
+--- a/xmake/packages/m/moebius/xmake.lua
++++ b/xmake/packages/m/moebius/xmake.lua
+@@ -25,6 +25,7 @@ package("moebius")
+     add_urls("https://github.com/XmacsLabs/moebius.git")
+     add_urls("https://gitee.com/XmacsLabs/moebius.git")
+     add_versions("0.1.21", "v0.1.21")
++    add_patches("0.1.21", "moebius.diff", "6ddd295110dd2c224f9ffe3a94ba16209df1a86f9d3522d047b847090b0456f8")
+ 
+     add_deps("lolly")
+ 


### PR DESCRIPTION
- Progress on https://github.com/termux/termux-packages/issues/23492

- Apply https://github.com/MoganLab/lolly/pull/346 to fix `error: ‘class hashtree<K, V>’ has no member named ‘contains’` with NDK r29

- Apply `DOCTEST_VERSION = "2.4.12"` to `moebius` dependency to fix build with CMake 4

- Apply `XMAKE_GLOBALDIR="$TERMUX_PKG_TMPDIR"` to fix `ld.lld: error: /home/builder/.xmake/packages/s/s7/20241122/2613d5544f43431dad530be0c61b8a28/lib/libs7.a(s7.c.o) is incompatible with armelf_linux_eabi`

- Apply backup and restore of `libcurl.so` and `xmake` to work around corruption of those binaries by something inside `mogan`