### PR TITLE
fix(x11/ark): check for LZO support in `libarchive` at build-time, not run-time

### DIFF
--- a/x11-packages/ark/build.sh
+++ b/x11-packages/ark/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="KDE Archiving Tool"
 TERMUX_PKG_LICENSE="GPL-2.0-or-later"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="25.12.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/ark-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=abd7350914c65a763cac513cd679f635555b618c1df183b331134f7b3229a478
 TERMUX_PKG_AUTO_UPDATE=true
@@ -18,4 +19,21 @@ termux_step_pre_configure() {
 	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
 		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
 	fi
+
+	# check libarchive at build-time, not runtime, because checking it at runtime
+	# completely ruins the performance of right-clicking
+	# in dolphin file browser when ark and dolphin are both installed at the same time
+	local libarchive_has_lzo=false
+	local libarchive_build_sh="$TERMUX_SCRIPTDIR/packages/libarchive/build.sh"
+	local libarchive_has_lzo_str
+	for libarchive_has_lzo_str in ENABLE_LZO={1,ON,YES,TRUE,Y} with-lzo; do
+		if grep -q "$libarchive_has_lzo_str" "$libarchive_build_sh"; then
+			libarchive_has_lzo=true
+		fi
+	done
+
+	local patch="$TERMUX_PKG_BUILDER_DIR/check-libarchive-at-build-time.diff"
+	echo "Applying patch: $patch"
+	sed -e "s%\@LIBARCHIVE_HAS_LZO\@%${libarchive_has_lzo}%g" \
+		"$patch" | patch --silent -p1 -d "${TERMUX_PKG_SRCDIR}"
 }

--- a/x11-packages/ark/check-libarchive-at-build-time.diff
+++ b/x11-packages/ark/check-libarchive-at-build-time.diff
@@ -1,0 +1,10 @@
+--- a/kerfuffle/pluginmanager.cpp
++++ b/kerfuffle/pluginmanager.cpp
+@@ -257,6 +257,7 @@ QStringList PluginManager::sortByComment(const QSet<QString> &mimeTypes)
+ 
+ bool PluginManager::libarchiveHasLzo()
+ {
++    return @LIBARCHIVE_HAS_LZO@;
+     // Step 1: look for the libarchive plugin, which is built against libarchive.
+     const QString pluginPath = QPluginLoader(QStringLiteral("kerfuffle/kerfuffle_libarchive")).fileName();
+ 


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28338

- `ark` contains code that, if `dolphin` detects `ark`, essentially causes `dolphin` to perform an operation that is equivalent to this command every first time that `dolphin` is used to right click on a file:

```
ldd $PREFIX/lib/qt6/plugins/kerfuffle/kerfuffle_libarchive.so | grep lzo
```

Understandably, this is inefficient and causes a long hang in `dolphin`.

This PR resolves the problem by precalculating the boolean value needed by `ark`'s `PluginManager::libarchiveHasLzo()` method at build-time instead of at run-time.