### PR TITLE
bump(main/neovim-nightly): v0.12.0~dev-2200+g396edf1e46

### DIFF
--- a/packages/neovim-nightly/build.sh
+++ b/packages/neovim-nightly/build.sh
@@ -3,10 +3,9 @@ TERMUX_PKG_DESCRIPTION="Ambitious Vim-fork focused on extensibility and agility 
 TERMUX_PKG_LICENSE="Apache-2.0, VIM License"
 TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
-TERMUX_PKG_VERSION="0.12.0~dev-2112+gb6befc7b03"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="0.12.0~dev-2200+g396edf1e46"
 TERMUX_PKG_SRCURL=https://github.com/neovim/neovim/archive/${TERMUX_PKG_VERSION##*+g}.tar.gz
-TERMUX_PKG_SHA256=2fcd862dbba9082a661ba3d4e0bfe254774a3a19eed8f1f189ef820d7cbb2b96
+TERMUX_PKG_SHA256=bbf08a7290436131a7770f5904e40e9c21b294ccf455451fc85d898330bd3624
 TERMUX_PKG_DEPENDS="libandroid-support, libiconv, libmsgpack, libunibilium, libuv, libvterm (>= 1:0.3-0), lua51-lpeg, luajit, luv, tree-sitter, tree-sitter-parsers, utf8proc"
 TERMUX_PKG_BREAKS="neovim"
 TERMUX_PKG_CONFLICTS="neovim"
@@ -99,6 +98,7 @@ termux_step_post_make_install() {
 	mkdir -p "$_CONFIG_DIR"
 
 	# Tree-sitter grammars are packaged separately and installed into TERMUX_PREFIX/lib/tree_sitter.
+	rm -f "${TERMUX_PREFIX}"/share/nvim/runtime/parser
 	ln -sf "${TERMUX_PREFIX}"/lib/tree_sitter "${TERMUX_PREFIX}"/share/nvim/runtime/parser
 
 	# Move the `nvim` binary to $PREFIX/libexec

--- a/packages/neovim/build.sh
+++ b/packages/neovim/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="Apache-2.0, VIM License"
 TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
 TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
 TERMUX_PKG_VERSION="0.11.6"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/neovim/neovim/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=d1c8e3f484ed1e231fd5f48f53b7345b628e52263d5eef489bb8b73ca8d90fca
 TERMUX_PKG_DEPENDS="libandroid-support, libiconv, libmsgpack, libunibilium, libuv, libvterm (>= 1:0.3-0), lua51-lpeg, luajit, luv, tree-sitter, tree-sitter-parsers, utf8proc"
@@ -69,6 +69,7 @@ termux_step_post_make_install() {
 	mkdir -p "$_CONFIG_DIR"
 
 	# Tree-sitter grammars are packaged separately and installed into TERMUX_PREFIX/lib/tree_sitter.
+	rm -f "${TERMUX_PREFIX}"/share/nvim/runtime/parser
 	ln -sf "${TERMUX_PREFIX}"/lib/tree_sitter "${TERMUX_PREFIX}"/share/nvim/runtime/parser
 
 	# Move the `nvim` binary to $PREFIX/libexec


### PR DESCRIPTION
current neovim nightly package gives errors when loading default parsers

running `nvim --clean -u NONE test.lua`
<img width="1920" height="421" alt="Screenshot_20260206_024133_niri" src="https://github.com/user-attachments/assets/70a4b0ee-56fe-45c0-a797-afc41077c576" />

neovim nightly doesnt seem to create symlink for parsers in `build.sh`

```sh
	# Tree-sitter grammars are packaged separately and installed into TERMUX_PREFIX/lib/tree_sitter.
	ln -sf "${TERMUX_PREFIX}"/lib/tree_sitter "${TERMUX_PREFIX}"/share/nvim/runtime/parser
```

my guess is this is broken if you try to build both stable and nightly at the same time without cleaning cache, which the last commit did