### PR TITLE
fix(x11/kf6-kio): do not pass `AT_SYMLINK_NOFOLLOW` to `faccessat()`

### DIFF
--- a/x11-packages/kf6-kio/build.sh
+++ b/x11-packages/kf6-kio/build.sh
@@ -3,10 +3,11 @@ TERMUX_PKG_DESCRIPTION='Resource and network access abstraction'
 TERMUX_PKG_LICENSE="LGPL-2.0, LGPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="6.22.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://download.kde.org/stable/frameworks/${TERMUX_PKG_VERSION%.*}/kio-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=04aaf8eb2b3bcac6d921fc3a1d033d67df89d9af8f69355185edf1af61c93370
 TERMUX_PKG_DEPENDS="kf6-karchive (>= ${TERMUX_PKG_VERSION%.*}), kf6-kauth (>= ${TERMUX_PKG_VERSION%.*}), kf6-kbookmarks (>= ${TERMUX_PKG_VERSION%.*}), kf6-kcolorscheme (>= ${TERMUX_PKG_VERSION%.*}), kf6-kcompletion (>= ${TERMUX_PKG_VERSION%.*}), kf6-kconfig (>= ${TERMUX_PKG_VERSION%.*}), kf6-kcoreaddons (>= ${TERMUX_PKG_VERSION%.*}), kf6-kdbusaddons (>= ${TERMUX_PKG_VERSION%.*}), kf6-kguiaddons (>= ${TERMUX_PKG_VERSION%.*}), kf6-ki18n (>= ${TERMUX_PKG_VERSION%.*}), kf6-kiconthemes (>= ${TERMUX_PKG_VERSION%.*}), kf6-kitemviews (>= ${TERMUX_PKG_VERSION%.*}), kf6-kjobwidgets (>= ${TERMUX_PKG_VERSION%.*}), kf6-kservice (>= ${TERMUX_PKG_VERSION%.*}), kf6-kwallet (>= ${TERMUX_PKG_VERSION%.*}), kf6-kwidgetsaddons (>= ${TERMUX_PKG_VERSION%.*}), kf6-kwindowsystem (>= ${TERMUX_PKG_VERSION%.*}), kf6-solid (>= ${TERMUX_PKG_VERSION%.*}), libacl, libandroid-shmem, libc++, libmount, libxml2, libxslt, qt6-qtbase, util-linux"
-TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules (>= ${TERMUX_PKG_VERSION%.*}), qt6-qttools"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules (>= ${TERMUX_PKG_VERSION%.*}), kf6-kdoctools (>= ${TERMUX_PKG_VERSION%.*}), kf6-kdoctools-cross-tools (>= ${TERMUX_PKG_VERSION%.*}), qt6-qttools"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DCMAKE_SYSTEM_NAME=Linux
@@ -16,4 +17,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 
 termux_step_pre_configure() {
 	LDFLAGS+=" -landroid-shmem"
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake"
+	fi
 }

--- a/x11-packages/kf6-kio/faccessat.patch
+++ b/x11-packages/kf6-kio/faccessat.patch
@@ -1,0 +1,15 @@
+Fixes:
+kf.kio.workers.trash: No trash directory found for  "/" ! TrashImpl::findTrashDirectory returned -3
+when sending anything to Trash in Dolphin on Samsung Galaxy A70 SM-A705FN
+
+--- a/src/kioworkers/trash/trashimpl.cpp
++++ b/src/kioworkers/trash/trashimpl.cpp
+@@ -250,7 +251,7 @@ bool TrashImpl::createInfo(const QString &origPath, int &trashId, QString &fileI
+         }
+         return false;
+     }
+-    if (::faccessat(AT_FDCWD, origPath_c.constData(), W_OK, AT_SYMLINK_NOFOLLOW) == -1) {
++    if (::faccessat(AT_FDCWD, origPath_c.constData(), W_OK, 0) == -1) {
+         error(KIO::ERR_ACCESS_DENIED, origPath);
+         return false;
+     }


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28338#issuecomment-3855865613 (Dolphin having an error when moving anything to Trash)

- In Android, `faccessat()` does not support `AT_SYMLINK_NOFOLLOW` and will return an error if it is passed that https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:bionic/libc/bionic/faccessat.cpp;l=55