### PR TITLE
bump(main/asymptote): 3.06

### DIFF
--- a/packages/asymptote/build.sh
+++ b/packages/asymptote/build.sh
@@ -2,17 +2,21 @@ TERMUX_PKG_HOMEPAGE=https://asymptote.sourceforge.io/
 TERMUX_PKG_DESCRIPTION="A powerful descriptive vector graphics language for technical drawing"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="3.05"
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/asymptote/asymptote-${TERMUX_PKG_VERSION}.src.tgz
-TERMUX_PKG_SHA256=35c16d0a3bdd869a56e4efff4638f81c3a88b2f6b664d196471015dbf4c69a87
+TERMUX_PKG_VERSION="3.06"
+TERMUX_PKG_SRCURL="https://downloads.sourceforge.net/asymptote/asymptote-${TERMUX_PKG_VERSION}.src.tgz"
+TERMUX_PKG_SHA256=5cc861968fe8102fc5564b6075db2837dd5698672688b3bfb71406c0da0f8cef
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="fftw, libc++, libtirpc, zlib, ncurses, readline"
 TERMUX_PKG_BUILD_DEPENDS="glm"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-gc
+--disable-lsp
 "
+
+termux_step_pre_configure() {
+	rm -f CMakeLists.txt
+}
 
 termux_step_make_install() {
 	install -Dm700 -t $TERMUX_PREFIX/bin asy

--- a/packages/asymptote/disable-x11.patch
+++ b/packages/asymptote/disable-x11.patch
@@ -1,0 +1,14 @@
+asymptote's GUI has dependency on PySide6, but this asymptote package is minimal
+and is not in the x11-packages folder.
+
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -134,7 +134,7 @@ endif
+ 
+ export prefix docdir exampledir mandir infodir INSTALL MAKE DESTDIR TEXI2DVI
+ 
+-asy: base/version.asy $(FILES:=.o) $(XNAME) revision.o $(GCLIB) @LSPLIB@ @GLEW@
++asy: base/version.asy $(FILES:=.o) revision.o $(GCLIB) @LSPLIB@ @GLEW@
+ 	$(CXX) $(OPTS) -o $(NAME) $(FILES:=.o) revision.o $(LIBS)
+ 
+ $(XNAME): $(PYFILES)


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28304

- Disable LSP to avoid `/bin/sh: 1: cmake: not found`

- Disable GUI to avoid `ERROR: PySide6 is not installed`

- Remove `CMakeLists.txt` to continue using Autotools build