### PR TITLE
fix(main/neovim-nightly): do not use `command -v` outside of a function

### DIFF
--- a/packages/neovim-nightly/build.sh
+++ b/packages/neovim-nightly/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="Apache-2.0, VIM License"
 TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
 TERMUX_PKG_VERSION="0.12.0~dev-2200+g396edf1e46"
-TERMUX_PKG_SRCURL=https://github.com/neovim/neovim/archive/${TERMUX_PKG_VERSION##*+g}.tar.gz
+TERMUX_PKG_SRCURL="https://github.com/neovim/neovim/archive/${TERMUX_PKG_VERSION##*+g}.tar.gz"
 TERMUX_PKG_SHA256=bbf08a7290436131a7770f5904e40e9c21b294ccf455451fc85d898330bd3624
 TERMUX_PKG_DEPENDS="libandroid-support, libiconv, libmsgpack, libunibilium, libuv, libvterm (>= 1:0.3-0), lua51-lpeg, luajit, luv, tree-sitter, tree-sitter-parsers, utf8proc"
 TERMUX_PKG_BREAKS="neovim"
@@ -17,10 +17,6 @@ TERMUX_PKG_UPDATE_VERSION_SED_REGEXP="s/-/~/"
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DENABLE_JEMALLOC=OFF
--DGETTEXT_MSGFMT_EXECUTABLE=$(command -v msgfmt)
--DGETTEXT_MSGMERGE_EXECUTABLE=$(command -v msgmerge)
--DPKG_CONFIG_EXECUTABLE=$(command -v pkg-config)
--DXGETTEXT_PRG=$(command -v xgettext)
 -DLUAJIT_INCLUDE_DIR=$TERMUX_PREFIX/include/luajit-2.1
 -DLPEG_LIBRARY=$TERMUX_PREFIX/lib/liblpeg-5.1.so
 -DCOMPILE_LUA=OFF
@@ -77,7 +73,16 @@ termux_step_host_build() {
 }
 
 termux_step_pre_configure() {
-	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DLUA_MATH_LIBRARY=$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib/$TERMUX_HOST_PLATFORM/$TERMUX_PKG_API_LEVEL/libm.so"
+	# msgfmt etc. need to be set here rather than globally, because if set globally,
+	# scripts/bin/update-checksum would fail to source this build.sh during the auto update
+	# workflow that doesn't have those commands present since it hasn't run setup-ubuntu.sh
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+="
+	-DLUA_MATH_LIBRARY=$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib/$TERMUX_HOST_PLATFORM/$TERMUX_PKG_API_LEVEL/libm.so
+	-DGETTEXT_MSGFMT_EXECUTABLE=$(command -v msgfmt)
+	-DGETTEXT_MSGMERGE_EXECUTABLE=$(command -v msgmerge)
+	-DPKG_CONFIG_EXECUTABLE=$(command -v pkg-config)
+	-DXGETTEXT_PRG=$(command -v xgettext)
+	"
 
 	# neovim has a weird CMake file that attempts to preprocess generated headers
 	# using the NDK Clang, but without ever adding the necessary --target argument

--- a/packages/neovim/build.sh
+++ b/packages/neovim/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
 TERMUX_PKG_VERSION="0.11.6"
 TERMUX_PKG_REVISION=2
-TERMUX_PKG_SRCURL=https://github.com/neovim/neovim/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SRCURL="https://github.com/neovim/neovim/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=d1c8e3f484ed1e231fd5f48f53b7345b628e52263d5eef489bb8b73ca8d90fca
 TERMUX_PKG_DEPENDS="libandroid-support, libiconv, libmsgpack, libunibilium, libuv, libvterm (>= 1:0.3-0), lua51-lpeg, luajit, luv, tree-sitter, tree-sitter-parsers, utf8proc"
 TERMUX_PKG_BREAKS="neovim-nightly"
@@ -17,10 +17,6 @@ TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+\.\d+"
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DENABLE_JEMALLOC=OFF
--DGETTEXT_MSGFMT_EXECUTABLE=$(command -v msgfmt)
--DGETTEXT_MSGMERGE_EXECUTABLE=$(command -v msgmerge)
--DPKG_CONFIG_EXECUTABLE=$(command -v pkg-config)
--DXGETTEXT_PRG=$(command -v xgettext)
 -DLUAJIT_INCLUDE_DIR=$TERMUX_PREFIX/include/luajit-2.1
 -DLPEG_LIBRARY=$TERMUX_PREFIX/lib/liblpeg-5.1.so
 -DCOMPILE_LUA=OFF
@@ -48,7 +44,16 @@ termux_step_host_build() {
 }
 
 termux_step_pre_configure() {
-	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DLUA_MATH_LIBRARY=$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib/$TERMUX_HOST_PLATFORM/$TERMUX_PKG_API_LEVEL/libm.so"
+	# msgfmt etc. need to be set here rather than globally, because if set globally,
+	# scripts/bin/update-checksum would fail to source this build.sh during the auto update
+	# workflow that doesn't have those commands present since it hasn't run setup-ubuntu.sh
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+="
+	-DLUA_MATH_LIBRARY=$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib/$TERMUX_HOST_PLATFORM/$TERMUX_PKG_API_LEVEL/libm.so
+	-DGETTEXT_MSGFMT_EXECUTABLE=$(command -v msgfmt)
+	-DGETTEXT_MSGMERGE_EXECUTABLE=$(command -v msgmerge)
+	-DPKG_CONFIG_EXECUTABLE=$(command -v pkg-config)
+	-DXGETTEXT_PRG=$(command -v xgettext)
+	"
 
 	# neovim has a weird CMake file that attempts to preprocess generated headers
 	# using the NDK Clang, but without ever adding the necessary --target argument


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28308

- Otherwise, this line will fail during the auto update routine because of `msgfmt` being unavailable during the auto update workflow:

https://github.com/termux/termux-packages/blob/4a29eaa61680711841f852af03f101f7e7ad1c4d/scripts/bin/update-checksum#L66