### PR TITLE
fix(x11/konsole): apply `-DKDE_INSTALL_` variables to match other KDE applications

### DIFF
--- a/x11-packages/konsole/build.sh
+++ b/x11-packages/konsole/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="KDE terminal emulator"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="25.12.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/konsole-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=8220069844051b584c553b7e7da4c3c1ec66f9a79f2f386baa1a9b91436f5046
 TERMUX_PKG_AUTO_UPDATE=true
@@ -10,6 +11,8 @@ TERMUX_PKG_DEPENDS="kf6-kbookmarks, kf6-kconfig, kf6-kconfigwidgets, kf6-kcoread
 TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DUSE_DBUS=ON
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
 "
 
 termux_step_pre_configure() {


### PR DESCRIPTION
- Fixes `kf.coreaddons: "Could not find plugin kf6/parts/konsolepart"` and "Konsole is not installed" errors when opening `dolphin` while `konsole` is installed