### PR TITLE
bump(main/proton-bridge): 3.22.0

### DIFF
--- a/packages/proton-bridge/build.sh
+++ b/packages/proton-bridge/build.sh
@@ -1,10 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/ProtonMail/proton-bridge
 TERMUX_PKG_DESCRIPTION="ProtonMail Bridge application"
 TERMUX_PKG_LICENSE="GPL-3.0"
-TERMUX_PKG_VERSION="3.21.2"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="3.22.0"
 TERMUX_PKG_SRCURL=git+https://github.com/ProtonMail/proton-bridge
-TERMUX_PKG_GIT_BRANCH=v${TERMUX_PKG_VERSION}
+TERMUX_PKG_GIT_BRANCH="v${TERMUX_PKG_VERSION}"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_DEPENDS="glib, libsecret"
 TERMUX_PKG_AUTO_UPDATE=true
@@ -18,6 +17,9 @@ termux_step_make() {
 	termux_setup_golang
 	export GOPATH="${TERMUX_PKG_BUILDDIR}"
 	cd "${TERMUX_PKG_SRCDIR}" || exit 1
+
+	rm -rf internal/fido \
+			internal/frontend/grpc/fido.go
 
 	make build-nogui
 }

--- a/packages/proton-bridge/disable-fido.patch
+++ b/packages/proton-bridge/disable-fido.patch
@@ -1,0 +1,63 @@
+--- a/internal/frontend/cli/accounts.go
++++ b/internal/frontend/cli/accounts.go
+@@ -27,7 +27,5 @@ import (
+ 	"github.com/ProtonMail/proton-bridge/v3/internal/bridge"
+ 	"github.com/ProtonMail/proton-bridge/v3/internal/certs"
+ 	"github.com/ProtonMail/proton-bridge/v3/internal/constants"
+-	"github.com/ProtonMail/proton-bridge/v3/internal/fido"
+ 	"github.com/ProtonMail/proton-bridge/v3/internal/hv"
+-	"github.com/ProtonMail/proton-bridge/v3/internal/unleash"
+ 	"github.com/ProtonMail/proton-bridge/v3/internal/vault"
+@@ -176,7 +176,6 @@ func (f *frontendCLI) loginAccount(c *ishell.Context) {
+ 		return
+ 	}
+ 
+-	u2fLoginEnabled := f.bridge.GetFeatureFlagValue(unleash.InboxBridgeU2FLoginEnabled)
+ 
+ 	switch auth.TwoFA.Enabled {
+ 	case proton.HasTOTP:
+@@ -187,30 +186,12 @@ func (f *frontendCLI) loginAccount(c *ishell.Context) {
+ 		}
+ 
+ 	case proton.HasFIDO2:
+-		if !u2fLoginEnabled {
+-			// This case may only occur for internal users.
+-			f.printAndLogError("Cannot login: Security key authentication required but not enabled in server configuration.")
+-			return
+-		}
+-
+-		if len(auth.TwoFA.FIDO2.RegisteredKeys) == 0 {
+-			f.printAndLogError("Cannot login: Security key login is required, but no registered keys were provided.")
+-		}
+-		if err := fido.AuthWithHardwareKeyCLI(f, client, auth); err != nil {
+-			f.printAndLogError("Cannot login: ", err)
+-			return
+-		}
++		f.printAndLogError("Cannot login: Termux does not currently build proton-bridge with FIDO support.")
++		return
+ 
+ 	case proton.HasFIDO2AndTOTP:
+-		if u2fLoginEnabled && len(auth.TwoFA.FIDO2.RegisteredKeys) > 0 && f.yesNoQuestion("Do you want to use a security key for Two-factor authentication") {
+-			if err := fido.AuthWithHardwareKeyCLI(f, client, auth); err != nil {
+-				f.printAndLogError("Cannot login: ", err)
+-				return
+-			}
+-		} else if err := f.loginTOTP(c, client); err != nil {
+-			f.printAndLogError("Cannot login: ", err)
+-			return
+-		}
++		f.printAndLogError("Cannot login: Termux does not currently build proton-bridge with FIDO support.")
++		return
+ 	}
+ 
+ 	var keyPass []byte
+--- a/Makefile
++++ b/Makefile
+@@ -134,7 +134,6 @@ endif
+ ifneq "${GOOS}" "darwin"
+ ifneq "${GOOS}" "windows"
+ 	go-build-finalize= \
+-		CGO_LDFLAGS="${LIBFIDO2_LDFLAGS}" \
+ 		$(call go-build,$(1),$(2),$(3))
+ endif
+ endif


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28390

- Disable `libfido2` because Termux does not currently have a `libfido2` package