### PR TITLE
fix(main/openssh): force disable `pw_gecos`

### DIFF
--- a/packages/openssh/build.sh
+++ b/packages/openssh/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Secure shell for logging into a remote machine"
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
 TERMUX_PKG_VERSION="10.2p1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/openssh/openssh-portable/archive/refs/tags/V_$(sed 's/\./_/g; s/p/_P/g' <<< $TERMUX_PKG_VERSION).tar.gz
 TERMUX_PKG_SHA256=8d3083bca4864cbc760bfcc3e67d86d401e27faa5eaafa1482c2316f5d5186b3
 TERMUX_PKG_DEPENDS="krb5, ldns, libandroid-support, libedit, openssh-sftp-server, openssl, termux-auth, zlib"
@@ -47,6 +48,7 @@ ac_cv_header_sys_un_h=yes
 ac_cv_lib_crypt_crypt=no
 ac_cv_search_getrrsetbyname=no
 ac_cv_func_bzero=yes
+ac_cv_member_struct_passwd_pw_gecos=no
 "
 # Configure script requires this variable to set prefixed path to program 'passwd'
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+="PATH_PASSWD_PROG=${TERMUX_PREFIX}/bin/passwd"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/27344

- 32-bit Android has `#define pw_gecos pw_passwd` in `struct passwd`
  - therefore `free(pw->pw_passwd)` followed by `free(pw->pw_gecos)` in OpenSSH is a double-free undefined behavior when run on 32-bit Android
  - because `openssh` Autotools build system detects the `#define pw_gecos pw_passwd` as implicit support for `pw_gecos` that does not exist in 32-bit Android
  - and this undefined behavior happens to result in no crash on 32-bit Android 10 and older, but a crash `SIGABRT` on 32-bit Android 11 and newer because Android 11+ have a different memory allocator from older Android (Scudo)
  - https://source.android.com/docs/security/test/scudo
  - https://github.com/openssh/openssh-portable/blob/47828dbd95c095d0cad327e12bb6859a510833c8/misc.c#L563
  - https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:bionic/libc/include/pwd.h;l=77