### PR TITLE
change(main/ffmpeg): Link against openssl instead of gnutls

### DIFF
--- a/packages/ffmpeg/build.sh
+++ b/packages/ffmpeg/build.sh
@@ -4,10 +4,10 @@ TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # Please align version with `ffplay` package.
 TERMUX_PKG_VERSION="8.0.1"
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=https://www.ffmpeg.org/releases/ffmpeg-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=05ee0b03119b45c0bdb4df654b96802e909e0a752f72e4fe3794f487229e5a41
-TERMUX_PKG_DEPENDS="fontconfig, freetype, fribidi, game-music-emu, glslang, harfbuzz, libaom, libandroid-glob, libandroid-stub, libass, libbluray, libbs2b, libbz2, libdav1d, libgnutls, libiconv, liblzma, libmp3lame, libopencore-amr, libopenmpt, libopus, libplacebo, librav1e, libsoxr, libsrt, libssh, libtheora, libv4l, libvidstab, libvmaf, libvo-amrwbenc, libvorbis, libvpx, libwebp, libx264, libx265, libxml2, libzimg, libzmq, littlecms, ocl-icd, rubberband, svt-av1, vulkan-icd, xvidcore, zlib"
+TERMUX_PKG_DEPENDS="fontconfig, freetype, fribidi, game-music-emu, glslang, harfbuzz, libaom, libandroid-glob, libandroid-stub, libass, libbluray, libbs2b, libbz2, libdav1d, libiconv, liblzma, libmp3lame, libopencore-amr, libopenmpt, libopus, libplacebo, librav1e, libsoxr, libsrt, libssh, libtheora, libv4l, libvidstab, libvmaf, libvo-amrwbenc, libvorbis, libvpx, libwebp, libx264, libx265, libxml2, libzimg, libzmq, littlecms, ocl-icd, openssl, rubberband, svt-av1, vulkan-icd, xvidcore, zlib"
 TERMUX_PKG_BUILD_DEPENDS="opencl-headers, vulkan-headers"
 TERMUX_PKG_CONFLICTS="libav"
 TERMUX_PKG_BREAKS="ffmpeg-dev"
@@ -81,7 +81,6 @@ termux_step_configure() {
 		--disable-static \
 		--disable-symver \
 		--enable-cross-compile \
-		--enable-gnutls \
 		--enable-gpl \
 		--enable-version3 \
 		--enable-jni \
@@ -125,6 +124,7 @@ termux_step_configure() {
 		--enable-libzmq \
 		--enable-mediacodec \
 		--enable-opencl \
+		--enable-openssl \
 		--enable-shared \
 		--prefix="$TERMUX_PREFIX" \
 		--target-os=android \


### PR DESCRIPTION
Historically there was a license incompatibility problem - but that was fixed by the openssl 3.0 relicensing:

- https://github.com/FFmpeg/FFmpeg/commit/1d23e125b6f76e74b754560c3b6931507cacddce

The apt package has also switched from gnutls to openssl:

- https://salsa.debian.org/apt-team/apt/-/merge_requests/412
  - Coming in https://github.com/termux/termux-packages/pull/24212, after which gnutls no longer will be in the bootstrap packages.

So it probably makes sense to align on openssl as much as possible, to decrease duplication and behaviour spread.