### PR TITLE
fix(main/fish): remove warnings from pacman completions

### DIFF
--- a/packages/fish/0008-share-functions-__fish_print_pacman_repos.fish.patch
+++ b/packages/fish/0008-share-functions-__fish_print_pacman_repos.fish.patch
@@ -1,0 +1,10 @@
+diff --git a/share/functions/__fish_print_pacman_repos.fish b/share/functions/__fish_print_pacman_repos.fish
+index a317b50..8e88447 100644
+--- a/share/functions/__fish_print_pacman_repos.fish
++++ b/share/functions/__fish_print_pacman_repos.fish
+@@ -1,4 +1,4 @@
+ # localization: skip(private)
+ function __fish_print_pacman_repos --description "Print the repositories configured for arch's pacman package manager"
+-    string match -er "\[.*\]" </etc/pacman.conf | string match -r -v "^#|options" | string replace -ra "\[|\]" ""
++    string match -er "\[.*\]" <@TERMUX_PREFIX@/etc/pacman.conf | string match -r -v "^#|options" | string replace -ra "\[|\]" ""
+ end

--- a/packages/fish/build.sh
+++ b/packages/fish/build.sh
@@ -3,12 +3,12 @@ TERMUX_PKG_DESCRIPTION="The user-friendly command line shell"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="4.4.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/fish-shell/fish-shell/releases/download/$TERMUX_PKG_VERSION/fish-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=529e1072c034f6c9d21a922c359886df75129c3d81a15bd8656a3c4860993ad5
-TERMUX_PKG_AUTO_UPDATE=true
 # fish calls 'tput' from ncurses-utils, at least when cancelling (Ctrl+C) a command line.
 # man is needed since fish calls apropos during command completion.
-TERMUX_PKG_DEPENDS="bc, libandroid-support, libc++, ncurses, ncurses-utils, mandoc, pcre2"
+TERMUX_PKG_DEPENDS="bc, libandroid-support, libc++, mandoc, ncurses, ncurses-utils, pcre2"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DWITH_DOCS=OFF
@@ -16,6 +16,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DMAC_CODESIGN_ID=OFF
 -DWITH_MESSAGE_LOCALIZATION=OFF
 "
+TERMUX_PKG_AUTO_UPDATE=true
 
 termux_step_pre_configure() {
 	termux_setup_cmake


### PR DESCRIPTION
completions for pacman output warning because of this function

```bash
__fish_print_pacman_repos
warning: An error occurred while redirecting file '/etc/pacman.conf'
warning: Path '/etc/pacman.conf' does not exist
```

<img width="827" height="334" alt="Screenshot_20260210_180808_niri" src="https://github.com/user-attachments/assets/e128d032-ed66-49e7-9a1c-8c1cc6b544e9" />

this pr patches the function to use termux's config path