### PR TITLE
bump(main/libpoco): 1.15.0

### DIFF
--- a/packages/libpoco/build.sh
+++ b/packages/libpoco/build.sh
@@ -2,12 +2,16 @@ TERMUX_PKG_HOMEPAGE=https://pocoproject.org/
 TERMUX_PKG_DESCRIPTION="A comprehensive set of C++ libraries that cover all modern-day programming needs"
 TERMUX_PKG_LICENSE="BSL-1.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.14.2"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="1.15.0"
 TERMUX_PKG_SRCURL=https://github.com/pocoproject/poco/archive/refs/tags/poco-${TERMUX_PKG_VERSION}-release.tar.gz
-TERMUX_PKG_SHA256=47394ea7ddb7b0a40e1a5be896f8f5dc77cfdc4f561d2e7131ecf582df5a0c3a
-TERMUX_PKG_DEPENDS="libc++, libexpat, libsqlite, openssl, pcre2, utf8proc, zlib"
+TERMUX_PKG_SHA256=5042931e043c127ee7eb7f5274c1aef9af77cb1f38247f6c8acdb6498104d0e3
+TERMUX_PKG_DEPENDS="libandroid-posix-semaphore, libc++, libexpat, libsqlite, openssl, pcre2, utf8proc, zlib"
+TERMUX_PKG_BUILD_DEPENDS="libpng"
 TERMUX_PKG_FORCE_CMAKE=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DPOCO_UNBUNDLED=ON"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP='\d+\.\d+\.\d+(?=-release)'
+
+termux_step_pre_configure() {
+	LDFLAGS+=" -landroid-posix-semaphore"
+}


### PR DESCRIPTION
* Fixes #28415 

Add libpng in build dependencies to fix the following build error.

CMake Error at dependencies/hpdf/CMakeLists.txt:21 (target_link_libraries):
Target "_BUNDLED_HPDF" links to:
PNG::PNG
