### PR TITLE
bump(main/dropbear): 2025.89

### DIFF
--- a/packages/dropbear/build.sh
+++ b/packages/dropbear/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://matt.ucc.asn.au/dropbear/dropbear.html
 TERMUX_PKG_DESCRIPTION="Small SSH server and client"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="2025.88"
+TERMUX_PKG_VERSION="2025.89"
 TERMUX_PKG_SRCURL=https://matt.ucc.asn.au/dropbear/releases/dropbear-${TERMUX_PKG_VERSION}.tar.bz2
-TERMUX_PKG_SHA256=783f50ea27b17c16da89578fafdb6decfa44bb8f6590e5698a4e4d3672dc53d4
+TERMUX_PKG_SHA256=0d1f7ca711cfc336dc8a85e672cab9cfd8223a02fe2da0a4a7aeb58c9e113634
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_DEPENDS="termux-auth, zlib"
 TERMUX_PKG_SUGGESTS="openssh-sftp-server"
@@ -16,6 +16,8 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-syslog --disable-utmp --disable-utmpx
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_lib_crypt_crypt=no"
 # BIonic is special case, as usuas.
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_func_htole64=yes"
+# setresgid() is blocked by Android for non-root users, so disable it
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_func_setresgid=no"
 # build a multi-call binary & enable progress info in 'scp'
 TERMUX_PKG_EXTRA_MAKE_ARGS="MULTI=1 SCPPROGRESS=1"
 

--- a/packages/dropbear/default_options.h.patch
+++ b/packages/dropbear/default_options.h.patch
@@ -70,7 +70,7 @@
  
  /* Specify the number of clients we will allow to be connected but
   * not yet authenticated. After this limit, connections are rejected */
-@@ -313,11 +313,11 @@
+@@ -319,11 +319,11 @@
   * scripts etc. This can be overridden with the -P flag.
   * Homedir is prepended if path begins with ~/
   */
@@ -84,7 +84,7 @@
  
  
  /* If you want to enable running an sftp server (such as the one included with
-@@ -326,11 +326,11 @@
+@@ -332,11 +332,11 @@
   * Homedir is prepended if path begins with ~/
   */
  #define DROPBEAR_SFTPSERVER 1
@@ -98,7 +98,7 @@
  
  /* Whether to log commands executed by a client. This only logs the
   * (single) command sent to the server, not what a user did in a
-@@ -366,7 +366,7 @@
+@@ -372,7 +372,7 @@
  #define DEFAULT_IDLE_TIMEOUT 0
  
  /* The default path. This will often get replaced by the shell */

--- a/packages/dropbear/loginrec.c.patch
+++ b/packages/dropbear/loginrec.c.patch
@@ -1,5 +1,5 @@
 +++ ./src/loginrec.c
-@@ -275,7 +275,7 @@
+@@ -267,7 +267,7 @@
  
  	if (username) {
  		strlcpy(li->username, username, sizeof(li->username));

--- a/packages/dropbear/svr-agentfwd.c.patch
+++ b/packages/dropbear/svr-agentfwd.c.patch
@@ -8,3 +8,39 @@
  
  static int send_msg_channel_open_agent(int fd);
  static int bindagent(int fd, struct ChanSess * chansess);
+@@ -151,7 +151,7 @@
+ 
+ 	if (chansess->agentfile != NULL && chansess->agentdir != NULL) {
+ 
+-#if !DROPBEAR_SVR_DROP_PRIVS
++#if DROPBEAR_SVR_MULTIUSER
+ 		/* Remove the dir as the user. That way they can't cause problems except
+ 		 * for themselves */
+ 		uid = getuid();
+@@ -175,7 +175,7 @@
+ 
+ 		rmdir(chansess->agentdir);
+ 
+-#if !DROPBEAR_SVR_DROP_PRIVS
++#if DROPBEAR_SVR_MULTIUSER
+ 		if ((seteuid(uid)) < 0 ||
+ 			(setegid(gid)) < 0) {
+ 			dropbear_exit("Failed to revert euid");
+@@ -222,7 +222,7 @@
+ 	gid_t gid;
+ 	int ret = DROPBEAR_FAILURE;
+ 
+-#if !DROPBEAR_SVR_DROP_PRIVS
++#if DROPBEAR_SVR_MULTIUSER
+ 	/* drop to user privs to make the dir/file */
+ 	uid = getuid();
+ 	gid = getgid();
+@@ -273,7 +273,7 @@ bindsocket:
+ 
+ 
+ out:
+-#if !DROPBEAR_SVR_DROP_PRIVS
++#if DROPBEAR_SVR_MULTIUSER
+ 	if ((seteuid(uid)) < 0 ||
+ 		(setegid(gid)) < 0) {
+ 		dropbear_exit("Failed to revert euid");

--- a/packages/dropbear/svr-chansession.c.patch
+++ b/packages/dropbear/svr-chansession.c.patch
@@ -1,5 +1,5 @@
 +++ ./src/svr-chansession.c
-@@ -608,7 +608,7 @@
+@@ -612,7 +612,7 @@
  		dropbear_exit("Out of memory"); /* TODO disconnect */
  	}
  
@@ -8,7 +8,7 @@
  	if (!pw)
  		dropbear_exit("getpwnam failed after succeeding previously");
  	pty_setowner(pw, chansess->tty);
-@@ -965,6 +965,8 @@
+@@ -973,6 +973,8 @@
  #endif
  
  	/* clear environment if -e was not set */
@@ -17,16 +17,14 @@
  	/* if we're debugging using valgrind etc, we need to keep the LD_PRELOAD
  	 * etc. This is hazardous, so should only be used for debugging. */
  	if ( !svr_opts.pass_on_env) {
-@@ -979,6 +981,7 @@
+@@ -987,11 +989,14 @@
  #endif /* HAVE_CLEARENV */
  #endif /* DEBUG_VALGRIND */
  	}
 +#endif /* 0 */
  
- #if DROPBEAR_SVR_MULTIUSER
- 	/* We can only change uid/gid as root ... */
-@@ -1006,6 +1009,8 @@
- 	}
+ #if !DROPBEAR_SVR_DROP_PRIVS
+ 	svr_switch_user();
  #endif
  
 +	/* termux: do not modify environment since we did not clean it */
@@ -34,7 +32,7 @@
  	/* set env vars */
  	addnewvar("USER", ses.authstate.pw_name);
  	addnewvar("LOGNAME", ses.authstate.pw_name);
-@@ -1016,6 +1021,7 @@
+@@ -1002,6 +1007,7 @@
  	} else {
  		addnewvar("PATH", DEFAULT_PATH);
  	}


### PR DESCRIPTION
Reverted some codes of svr-agentfwd.c file to actually disable `setresgid()`, now dropbear is working.

~~Sent as draft for anyone to figure out how to disable `setresgid()`, as I am unable to figured out how to disable it.~~

~~For those who wondering, `setresgid()` is blocked by Android for non-root users thus it will cause crash.~~

~~And yes, I tried several ways to disable (`DROPBEAR_SVR_DROP_PRIVS 0`, etc...), despite that being explicit disabled, generator ignored it.~~

diff:
https://github.com/mkj/dropbear/compare/DROPBEAR_2025.88...DROPBEAR_2025.89