### PR TITLE
bump(main/pipewire): v1.5.84

### DIFF
--- a/packages/pipewire/build.sh
+++ b/packages/pipewire/build.sh
@@ -3,10 +3,9 @@ TERMUX_PKG_DESCRIPTION="A server and user space API to deal with multimedia pipe
 TERMUX_PKG_LICENSE="MIT, LGPL-2.1, LGPL-3.0, GPL-2.0"
 TERMUX_PKG_LICENSE_FILE="COPYING, LICENSE"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.4.9"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="1.5.85"
 TERMUX_PKG_SRCURL="https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/${TERMUX_PKG_VERSION}/pipewire-${TERMUX_PKG_VERSION}.tar.bz2"
-TERMUX_PKG_SHA256=e606aa3f6d53ec4c56fe35034d35cadfe0bbea1a5275e4e006dd7d1abaec6b92
+TERMUX_PKG_SHA256=150b3c900160222ec8d52630997d1dcda9fc0ec637df8eeaae181767cd57050c
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="ffmpeg, glib, libc++, lua54, libopus, libsndfile, libwebrtc-audio-processing, lilv, ncurses, openssl, pulseaudio, readline"
 

--- a/packages/pipewire/no-pthread_mutexattr_setprotocol.patch
+++ b/packages/pipewire/no-pthread_mutexattr_setprotocol.patch
@@ -1,0 +1,19 @@
+`pthread_mutexattr_setprotocol` is introduced in Android 28.
+
+diff --git a/spa/plugins/support/loop.c b/spa/plugins/support/loop.c
+index e5e49849f..aca44c98a 100644
+--- a/spa/plugins/support/loop.c
++++ b/spa/plugins/support/loop.c
+@@ -1384,8 +1384,12 @@ impl_init(const struct spa_handle_factory *factory,
+ 	CHECK(pthread_mutexattr_init(&attr), error_exit);
+ 	CHECK(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE), error_exit_free_attr);
+ 	if (impl->prio_inherit)
++		#ifdef __ANDROID__
++			if (1)
++		#else
+ 		CHECK(pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT),
+ 					error_exit_free_attr)
++		#endif
+ 	CHECK(pthread_mutex_init(&impl->lock, &attr), error_exit_free_attr);
+ 	pthread_mutexattr_destroy(&attr);
+ 


### PR DESCRIPTION
- fixes https://github.com/termux/termux-packages/issues/27702
`pthread_mutexattr_setprotocol` is introduced in Android 28.

```
New libc functions in P (API level 28):
--snip--
pthread_mutexattr_getprotocol/pthread_mutexattr_setprotocol (mutex priority inheritance)
--snip--
```
Source: https://android.googlesource.com/platform/bionic/+/HEAD/docs/status.md