### PR TITLE
fix(main/whois): do not auto-update to `debian/` tags, only `v` tags

### DIFF
--- a/packages/whois/build.sh
+++ b/packages/whois/build.sh
@@ -14,7 +14,7 @@ HAVE_ICONV=1
 "
 
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
+TERMUX_PKG_UPDATE_VERSION_REGEXP='v\d+\.\d+\.\d+'
 
 termux_step_pre_configure() {
 	CPPFLAGS+=" -DHAVE_CRYPT_H"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28483

%ci:no-build