### PR TITLE
bump(root/ethtool): 6.19

### DIFF
--- a/root-packages/ethtool/build.sh
+++ b/root-packages/ethtool/build.sh
@@ -2,9 +2,12 @@ TERMUX_PKG_HOMEPAGE=https://mirrors.edge.kernel.org/pub/software/network/ethtool
 TERMUX_PKG_DESCRIPTION="standard Linux utility for controlling network drivers and hardware, particularly for wired Ethernet devices"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="6.15"
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=9477c365114d910120aaec5336a1d16196c833d8486f7c6da67bedef57880ade
+TERMUX_PKG_VERSION="6.19"
+TERMUX_PKG_SRCURL="https://git.kernel.org/pub/scm/network/ethtool/ethtool.git/snapshot/ethtool-$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=6361be91abdfe24b5bca652dc4bd4f94d8adce30aa6b8b1c474599a18c742a18
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libmnl"
+
+termux_step_pre_configure() {
+	autoreconf -fi
+}


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28485

- Change `TERMUX_PKG_SRCURL` to the source that is used by Arch Linux, which has enabled Arch Linux to get version 6.19 already, which caused the repology auto update method to attempt to update to the same version as Arch Linux and fail because it's not available at the current `TERMUX_PKG_SRCURL` used by Termux for `ethtool`