### PR TITLE
fix(main/vim,x11/vim-gtk): ensure base 10 handling of patch versions

### DIFF
--- a/packages/vim/build.sh
+++ b/packages/vim/build.sh
@@ -55,8 +55,11 @@ termux_pkg_auto_update() {
 	# remember to apply that change to the other as well.
 	local latest_tag current_patch latest_patch
 	latest_tag="$(termux_github_api_get_tag)"
-	latest_patch="${latest_tag##*.}"
-	current_patch="${TERMUX_PKG_VERSION##*.}"
+	# Specify Base 10 with the `10#` prefix.
+	# This is necessary to suppress automatic interpretation
+	# of the value as octal when there is a leading 0.
+	latest_patch="10#${latest_tag##*.}"
+	current_patch="10#${TERMUX_PKG_VERSION##*.}"
 
 	# Vim releases nearly every commit as a new tag.
 	# To avoid auto update spam, we only update Vim every 50th patch.
@@ -69,7 +72,8 @@ termux_pkg_auto_update() {
 		return
 	fi
 
-	termux_pkg_upgrade_version "${latest_tag%.*}.${latest_patch}"
+	# Pad the patch component of the version back to 4 digits in accordance with Vim's tag naming.
+	termux_pkg_upgrade_version "$(printf '%s.%04d' "${latest_tag%.*}" "${latest_patch}")"
 }
 
 termux_step_pre_configure() {

--- a/x11-packages/vim-gtk/build.sh
+++ b/x11-packages/vim-gtk/build.sh
@@ -55,8 +55,11 @@ termux_pkg_auto_update() {
 	# remember to apply that change to the other as well.
 	local latest_tag current_patch latest_patch
 	latest_tag="$(termux_github_api_get_tag)"
-	latest_patch="${latest_tag##*.}"
-	current_patch="${TERMUX_PKG_VERSION##*.}"
+	# Specify Base 10 with the `10#` prefix.
+	# This is necessary to suppress automatic interpretation
+	# of the value as octal when there is a leading 0.
+	latest_patch="10#${latest_tag##*.}"
+	current_patch="10#${TERMUX_PKG_VERSION##*.}"
 
 	# Vim releases nearly every commit as a new tag.
 	# To avoid auto update spam, we only update Vim every 50th patch.
@@ -69,7 +72,8 @@ termux_pkg_auto_update() {
 		return
 	fi
 
-	termux_pkg_upgrade_version "${latest_tag%.*}.${latest_patch}"
+	# Pad the patch component of the version back to 4 digits in accordance with Vim's tag naming.
+	termux_pkg_upgrade_version "$(printf '%s.%04d' "${latest_tag%.*}" "${latest_patch}")"
 }
 
 termux_step_pre_configure() {


### PR DESCRIPTION
This PR is a follow up to https://github.com/termux/termux-packages/commit/666743e568fd3c9df14a6b408e98728ec61fae88 and https://github.com/termux/termux-packages/commit/2ced47b84ab555e56b92e722b418400a6af16e6e, which exposed a previously unhandled edgecase in how the patch math in the `vim`/`vim-gtk` auto update function is handled.

To quote from the `bash.1` man page.
```console
Integer constants follow the C language definition, without suffixes or character constants.
Constants with a leading 0 are interpreted as octal numbers. A leading 0x or 0X denotes
hexadecimal. Otherwise, numbers take the form [base#]n, where the optional base is a
decimal number between 2 and 64 representing the arithmetic base, and n is a number in
that base. If base# is omitted, then base 10 is used. When specifying n, if a non-digit is
required, the digits greater than 9 are represented by the lowercase letters, the uppercase
letters, @, and _, in that order. If base is less than or equal to 36, lowercase and uppercase
letters may be used interchangeably to represent numbers between 10 and 35.
```
###### https://man.archlinux.org/man/bash.1#ARITHMETIC_EVALUATION:~:text=Constants%20with%20a%20leading%200%20are%20interpreted%20as%20octal%20numbers.

This means that a value of `0018` is interpreted as *octal*, however 8 is not a valid digit in octal.
So the expression short-circuits.
https://github.com/termux/termux-packages/actions/runs/22151874494/job/64045174468#step:6:8230

https://github.com/termux/termux-packages/blob/2ced47b84ab555e56b92e722b418400a6af16e6e/packages/vim/build.sh#L61-L65
When it short-circuits this evidently causes it to fail in such a way that it is unable to take the modulo 50 of the patch.
Meaning the two results didn't match.
Meaning the skip condition wasn't true.
Meaning it proceeded with the update.

Explicitly specifying Base 10 for the patch versions fixes this.
We need to pad the patch version back to 4 digits with leading 0's in the event of a real success since that is the tag format used by Vim.