### PR TITLE
fix(main/coreutils): keep building `kill` command

### DIFF
--- a/packages/coreutils/build.sh
+++ b/packages/coreutils/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Basic file, shell and text manipulation utilities from t
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=9.10
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/coreutils/coreutils-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=16535a9adf0b10037364e2d612aad3d9f4eca3a344949ced74d12faf4bd51d25
 TERMUX_PKG_DEPENDS="libandroid-selinux, libandroid-support, libgmp, libiconv, openssl (>= 1:3.5.0-1)"
@@ -22,7 +23,8 @@ gl_cv_host_operating_system=Android
 ac_cv_func_getpass=yes
 --disable-xattr
 --with-packager=Termux
---enable-no-install-program=pinky,df,users,who,uptime
+--enable-no-install-program=pinky,df,users,who
+--enable-install-program=kill
 --enable-single-binary=symlinks
 --with-gmp
 "


### PR DESCRIPTION
`kill` and `uptime` were moved into "disabled_by_default_progs" in https://github.com/coreutils/coreutils/commit/6b399ad352, we were previously shipping coreutils -> kill,
so specify explicitly that we wanna build and install it and take uptime off the explicitly disabled list.
(Since it is now disabled by default.)