### PR TITLE
fix(scripts/build/termux_step_get_dependencies): if a dependency failed to build, terminate on `termux_run_build-package` instead of `ar`

### DIFF
--- a/scripts/build/termux_step_get_dependencies.sh
+++ b/scripts/build/termux_step_get_dependencies.sh
@@ -45,7 +45,10 @@ termux_step_get_dependencies() {
 				fi
 			fi
 			if [[ "$cyclic_dependence" == "false" ]]; then
-				[[ "$build_dependency" == "true" ]] && termux_run_build-package && continue
+				if [[ "$build_dependency" == "true" ]]; then
+					termux_run_build-package
+					continue
+				fi
 				termux_add_package_to_built_packages_list "$PKG"
 			fi
 			if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then


### PR DESCRIPTION
- Partially revert https://github.com/termux/termux-packages/commit/622d79668a18b12f56c300d78f25c56423de3bae

Before:

```
Downloading grep@3.12 source from 'https://mirrors.kernel.org/gnu/grep/grep-3.12.tar.xz' if necessary...
Downloading https://mirrors.kernel.org/gnu/grep/grep-3.12.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1873k  100 1873k    0     0  6212k      0 --:--:-- --:--:-- --:--:-- 6224k
Applying patch: fix-locale.patch
ERROR: test error
extracting grep to /home/builder/.termux-build/_cache-aarch64...
ar: grep_3.12-4_aarch64.deb: No such file or directory
xz: (stdin): File format not recognized
tar: Child returned status 1
tar: Error is not recoverable: exiting now
builder@5933999a1b6c:~/termux-packages$
```

After:

```
Downloading grep@3.12 source from 'https://mirrors.kernel.org/gnu/grep/grep-3.12.tar.xz' if necessary...
Applying patch: fix-locale.patch
ERROR: test error
builder@5933999a1b6c:~/termux-packages$
```