### PR TITLE
bump(main/openexr): 3.4.4

### DIFF
--- a/packages/openexr/build.sh
+++ b/packages/openexr/build.sh
@@ -2,10 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.openexr.com/
 TERMUX_PKG_DESCRIPTION="Provides the specification and reference implementation of the EXR file format"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="3.4.0"
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=d7b31637d7adc359f5e5a7517ba918cb5997bc1a4ae7a808ec874cdf91da93c0
+TERMUX_PKG_VERSION="3.4.4"
+TERMUX_PKG_SRCURL="https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=7c663c3c41da9354b5af277bc2fd1d2360788050b4e0751a32bcd50e8abaef8f
 TERMUX_PKG_DEPENDS="imath, libc++, zlib"
 TERMUX_PKG_CONFLICTS="openexr2"
 TERMUX_PKG_REPLACES="openexr2"
@@ -20,6 +19,11 @@ termux_step_pre_configure() {
 	local v=$(sed -En 's/^set\(OPENEXR_LIB_SOVERSION\s+([0-9]+).*/\1/p' CMakeLists.txt)
 	if [ "${v}" != "${_SOVERSION}" ]; then
 		termux_error_exit "SOVERSION guard check failed."
+	fi
+
+	# for code in openjph, which is downloaded by CMakeLists.txt of openexr at build-time
+	if [[ "$TERMUX_PKG_API_LEVEL" -lt 28 ]]; then
+		CPPFLAGS+=" -Daligned_alloc=memalign"
 	fi
 }
 


### PR DESCRIPTION
- Vendored `openjph` now depends on `aligned_alloc()`, which is not available before API level 28, so define it to `memalign`