### PR TITLE
Add katifetch package

### DIFF
--- a/packages/katifetch/build.sh
+++ b/packages/katifetch/build.sh
@@ -4,11 +4,19 @@ TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="LICENSE"
 TERMUX_PKG_MAINTAINER="Katifetch Support <katifetchs@gmail.com>"
 TERMUX_PKG_VERSION=13.1
-TERMUX_PKG_SRCURL=https://github.com/ximimoments/katifetch/releases/download/${TERMUX_PKG_VERSION}/katifetch-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=9e0f8d6e20cd7dc874c748732e500121b4c6de0f1ea8438ec7d52d461936410c
+TERMUX_PKG_AUTO_UPDATE=true
+
+TERMUX_PKG_SRCURL=https://github.com/ximimoments/katifetch/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=57018797a61ab6befb80a0b76cdf7ca457421ef8cfc030fe41d77a78b017fd30
+
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 
 termux_step_make_install() {
-    install -Dm755 katifetch $TERMUX_PREFIX/bin/katifetch
+    install -Dm755 katifetch.sh \
+        $TERMUX_PREFIX/bin/katifetch
+
+    install -d $TERMUX_PREFIX/share/katifetch
+    cp -r logos themes assets \
+        $TERMUX_PREFIX/share/katifetch/
 }


### PR DESCRIPTION
Add new package: katifetch

Katifetch is a lightweight and customizable system information
tool written in POSIX shell.

The package is platform independent and has no compiled components.

Tested successfully on aarch64.

License: MIT
Homepage: https://github.com/ximimoments/katifetch