### PR TITLE
bump(x11/eom): 1.28.1

### DIFF
--- a/x11-packages/eom/build.sh
+++ b/x11-packages/eom/build.sh
@@ -2,17 +2,16 @@ TERMUX_PKG_HOMEPAGE=https://mate-desktop.org/
 TERMUX_PKG_DESCRIPTION="Image viewer for MATE"
 TERMUX_PKG_LICENSE="GPL-2.0-or-later"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.28.0"
+TERMUX_PKG_VERSION="1.28.1"
 TERMUX_PKG_SRCURL="https://github.com/mate-desktop/eom/releases/download/v$TERMUX_PKG_VERSION/eom-$TERMUX_PKG_VERSION.tar.xz"
-TERMUX_PKG_SHA256=9a01cab2995a1a8c7258c865eae5f182ed4730c44672afdc3a07e423edd53abc
-# version 1.28.1 has a build failure not only in Termux, but also the same error in upstream's own CI;
-# wait for them to fix it
-TERMUX_PKG_AUTO_UPDATE=false
-TERMUX_PKG_DEPENDS="dbus-glib, gobject-introspection, gettext, librsvg, littlecms, libexif, libjpeg-turbo, mate-desktop, libpeas"
+TERMUX_PKG_SHA256=ccc169b8e240828b36965dfd84fa1478957dec2028ffeba553ae97e542e15120
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="dbus-glib, gobject-introspection, gettext, imagemagick, librsvg, littlecms, libexif, libjpeg-turbo, mate-desktop, libpeas"
 TERMUX_PKG_RECOMMENDS="webp-pixbuf-loader"
 TERMUX_PKG_BUILD_DEPENDS="autoconf-archive, glib, mate-common"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --localstatedir=$TERMUX_PREFIX/var
+-Dgdk-pixbuf-thumbnailer=false
 "
 
 termux_step_pre_configure() {

--- a/x11-packages/eom/disable-help.patch
+++ b/x11-packages/eom/disable-help.patch
@@ -1,0 +1,13 @@
+Prevents:
+Error: cannot open XML file ../src/help/C/index.docbook
+
+--- a/meson.build
++++ b/meson.build
+@@ -218,7 +218,6 @@ subdir('cut-n-paste')
+ subdir('src')
+ subdir('man')
+ subdir('plugins')
+-subdir('help')
+ subdir('data')
+ subdir('doc')
+ 

--- a/x11-packages/eom/fix-girepository-error.patch
+++ b/x11-packages/eom/fix-girepository-error.patch
@@ -1,0 +1,43 @@
+From 92f1d8e710749f43d5bf80afe6955da8785bd63d Mon Sep 17 00:00:00 2001
+From: raveit65 <raveit65.sun@gmail.com>
+Date: Wed, 28 Jan 2026 11:21:21 +0100
+Subject: [PATCH] CI: fix some workflow issues (#371)
+
+* CI: update NEWS which caused some workflow issues
+
+* CI: disable gdk-pixbuf-thumbnailer for meson workflows
+
+ - gdk-pixbuf-thumbnailer is obsolete and should be replaced
+   with glycin-thumbnailer
+
+* meson: Only use girepository-2.0 if libpeas uses it too
+
+Fixes header conflicts on systems where glib has girepository-2.0 but
+libpeas still uses the old gobject-introspection-1.0 headers.
+
+---------
+
+Co-authored-by: Victor Kareh <vkareh@redhat.com>
+
+--- a/meson.build
++++ b/meson.build
+@@ -178,9 +178,17 @@ endif
+ if gobject_introspection.found()
+   conf.set('HAVE_INTROSPECTION', 1)
+   # Check for girepository-2.0 API (moved to glib in version 1.80+)
++  # We can only use girepository-2.0 if libpeas also uses it, otherwise we get conflicts
+   girepository2 = dependency('girepository-2.0', required: false)
+   if girepository2.found()
+-    conf.set('HAVE_GIREPOSITORY_2', 1)
++    # Check if libpeas requires girepository-2.0
++    pkgconfig = find_program('pkg-config', required: false)
++    if pkgconfig.found()
++      libpeas_requires = run_command(pkgconfig, '--print-requires', 'libpeas-1.0', check: false)
++      if libpeas_requires.returncode() == 0 and libpeas_requires.stdout().contains('girepository-2.0')
++        conf.set('HAVE_GIREPOSITORY_2', 1)
++      endif
++    endif
+   endif
+ endif
+ 
+

--- a/x11-packages/eom/gir/1.28.1/eom.xml
+++ b/x11-packages/eom/gir/1.28.1/eom.xml
@@ -1,0 +1,246 @@
+<?xml version="1.0"?>
+<dump>
+  <class name="EomListStore" get-type="eom_list_store_get_type" parents="GtkListStore,GObject">
+    <implements name="GtkTreeModel"/>
+    <implements name="GtkTreeDragSource"/>
+    <implements name="GtkTreeDragDest"/>
+    <implements name="GtkTreeSortable"/>
+    <implements name="GtkBuildable"/>
+  </class>
+  <class name="EomTransform" get-type="eom_transform_get_type" parents="GObject">
+  </class>
+  <class name="EomJob" get-type="eom_job_get_type" parents="GObject">
+    <signal name="finished" return="void" when="last">
+    </signal>
+    <signal name="progress" return="void" when="last">
+      <param type="gfloat"/>
+    </signal>
+  </class>
+  <class name="EomJobThumbnail" get-type="eom_job_thumbnail_get_type" parents="EomJob,GObject">
+  </class>
+  <class name="EomJobLoad" get-type="eom_job_load_get_type" parents="EomJob,GObject">
+  </class>
+  <class name="EomJobModel" get-type="eom_job_model_get_type" parents="EomJob,GObject">
+  </class>
+  <class name="EomJobTransform" get-type="eom_job_transform_get_type" parents="EomJob,GObject">
+  </class>
+  <class name="EomJobSave" get-type="eom_job_save_get_type" parents="EomJob,GObject">
+  </class>
+  <class name="EomJobSaveAs" get-type="eom_job_save_as_get_type" parents="EomJobSave,EomJob,GObject">
+  </class>
+  <class name="EomJobCopy" get-type="eom_job_copy_get_type" parents="EomJob,GObject">
+  </class>
+  <class name="EomImageSaveInfo" get-type="eom_image_save_info_get_type" parents="GObject">
+  </class>
+  <class name="EomImage" get-type="eom_image_get_type" parents="GObject">
+    <signal name="size-prepared" return="void" when="last">
+      <param type="gint"/>
+      <param type="gint"/>
+    </signal>
+    <signal name="changed" return="void" when="last">
+    </signal>
+    <signal name="thumbnail-changed" return="void" when="last">
+    </signal>
+    <signal name="save-progress" return="void" when="last">
+      <param type="gfloat"/>
+    </signal>
+    <signal name="next-frame" return="void" when="last">
+      <param type="gint"/>
+    </signal>
+    <signal name="file-changed" return="void" when="last">
+    </signal>
+  </class>
+  <class name="EomWindow" get-type="eom_window_get_type" parents="GtkApplicationWindow,GtkWindow,GtkBin,GtkContainer,GtkWidget,GInitiallyUnowned,GObject">
+    <implements name="AtkImplementorIface"/>
+    <implements name="GtkBuildable"/>
+    <implements name="GActionGroup"/>
+    <implements name="GActionMap"/>
+    <property name="collection-position" type="EomWindowCollectionPos" flags="35" default-value="EOM_WINDOW_COLLECTION_POS_BOTTOM"/>
+    <property name="collection-resizable" type="gboolean" flags="35" default-value="FALSE"/>
+    <property name="startup-flags" type="EomStartupFlags" flags="11" default-value="0"/>
+    <signal name="prepared" return="void" when="last">
+    </signal>
+  </class>
+  <class name="EomApplication" get-type="eom_application_get_type" parents="GtkApplication,GApplication,GObject">
+    <implements name="GActionGroup"/>
+    <implements name="GActionMap"/>
+  </class>
+  <interface name="EomApplicationActivatable" get-type="eom_application_activatable_get_type">
+    <property name="app" type="EomApplication" flags="235"/>
+  </interface>
+  <interface name="EomWindowActivatable" get-type="eom_window_activatable_get_type">
+    <property name="window" type="EomWindow" flags="235"/>
+  </interface>
+  <class name="EomSidebar" get-type="eom_sidebar_get_type" parents="GtkBox,GtkContainer,GtkWidget,GInitiallyUnowned,GObject">
+    <implements name="AtkImplementorIface"/>
+    <implements name="GtkBuildable"/>
+    <implements name="GtkOrientable"/>
+    <property name="current-page" type="GtkWidget" flags="3"/>
+    <signal name="page-added" return="void" when="first">
+      <param type="GtkWidget"/>
+    </signal>
+    <signal name="page-removed" return="void" when="first">
+      <param type="GtkWidget"/>
+    </signal>
+  </class>
+  <class name="EomThumbView" get-type="eom_thumb_view_get_type" parents="GtkIconView,GtkContainer,GtkWidget,GInitiallyUnowned,GObject">
+    <implements name="AtkImplementorIface"/>
+    <implements name="GtkBuildable"/>
+    <implements name="GtkCellLayout"/>
+    <implements name="GtkScrollable"/>
+    <implements name="GtkOrientable"/>
+  </class>
+  <class name="EomPropertiesDialog" get-type="eom_properties_dialog_get_type" parents="GtkDialog,GtkWindow,GtkBin,GtkContainer,GtkWidget,GInitiallyUnowned,GObject">
+    <implements name="AtkImplementorIface"/>
+    <implements name="GtkBuildable"/>
+    <property name="thumbview" type="EomThumbView" flags="235"/>
+    <property name="netbook-mode" type="gboolean" flags="227" default-value="FALSE"/>
+  </class>
+  <class name="EomFileChooser" get-type="eom_file_chooser_get_type" parents="GtkFileChooserDialog,GtkDialog,GtkWindow,GtkBin,GtkContainer,GtkWidget,GInitiallyUnowned,GObject">
+    <implements name="AtkImplementorIface"/>
+    <implements name="GtkBuildable"/>
+    <implements name="GtkFileChooser"/>
+  </class>
+  <class name="EomStatusbar" get-type="eom_statusbar_get_type" parents="GtkStatusbar,GtkBox,GtkContainer,GtkWidget,GInitiallyUnowned,GObject">
+    <implements name="AtkImplementorIface"/>
+    <implements name="GtkBuildable"/>
+    <implements name="GtkOrientable"/>
+  </class>
+  <class name="EomThumbNav" get-type="eom_thumb_nav_get_type" parents="GtkBox,GtkContainer,GtkWidget,GInitiallyUnowned,GObject">
+    <implements name="AtkImplementorIface"/>
+    <implements name="GtkBuildable"/>
+    <implements name="GtkOrientable"/>
+    <property name="show-buttons" type="gboolean" flags="3" default-value="TRUE"/>
+    <property name="thumbview" type="EomThumbView" flags="11"/>
+    <property name="mode" type="gint" flags="3" default-value="0"/>
+  </class>
+  <class name="EomScrollView" get-type="eom_scroll_view_get_type" parents="GtkGrid,GtkContainer,GtkWidget,GInitiallyUnowned,GObject">
+    <implements name="AtkImplementorIface"/>
+    <implements name="GtkBuildable"/>
+    <implements name="GtkOrientable"/>
+    <property name="antialiasing-in" type="gboolean" flags="35" default-value="TRUE"/>
+    <property name="antialiasing-out" type="gboolean" flags="35" default-value="TRUE"/>
+    <property name="background-color" type="GdkRGBA" flags="35"/>
+    <property name="image" type="EomImage" flags="35"/>
+    <property name="scrollwheel-zoom" type="gboolean" flags="35" default-value="TRUE"/>
+    <property name="transparency-color" type="GdkRGBA" flags="34"/>
+    <property name="transparency-style" type="EomTransparencyStyle" flags="35" default-value="EOM_TRANSP_CHECKED"/>
+    <property name="use-background-color" type="gboolean" flags="35" default-value="FALSE"/>
+    <property name="zoom-multiplier" type="gdouble" flags="35" default-value="0.050000"/>
+    <signal name="zoom-changed" return="void" when="last">
+      <param type="gdouble"/>
+    </signal>
+  </class>
+  <class name="EomClipboardHandler" get-type="eom_clipboard_handler_get_type" parents="GInitiallyUnowned,GObject">
+    <property name="pixbuf" type="GdkPixbuf" flags="235"/>
+    <property name="uri" type="gchararray" flags="235" default-value="NULL"/>
+  </class>
+  <boxed name="EomExifData" get-type="eom_exif_data_get_type"/>
+  <flags name="EomDebug" get-type="eom_debug_get_type">
+    <member name="EOM_DEBUG_NO_DEBUG" nick="no-debug" value="0"/>
+    <member name="EOM_DEBUG_WINDOW" nick="window" value="1"/>
+    <member name="EOM_DEBUG_VIEW" nick="view" value="2"/>
+    <member name="EOM_DEBUG_JOBS" nick="jobs" value="4"/>
+    <member name="EOM_DEBUG_THUMBNAIL" nick="thumbnail" value="8"/>
+    <member name="EOM_DEBUG_IMAGE_DATA" nick="image-data" value="16"/>
+    <member name="EOM_DEBUG_IMAGE_LOAD" nick="image-load" value="32"/>
+    <member name="EOM_DEBUG_IMAGE_SAVE" nick="image-save" value="64"/>
+    <member name="EOM_DEBUG_LIST_STORE" nick="list-store" value="128"/>
+    <member name="EOM_DEBUG_PREFERENCES" nick="preferences" value="256"/>
+    <member name="EOM_DEBUG_PRINTING" nick="printing" value="512"/>
+    <member name="EOM_DEBUG_LCMS" nick="lcms" value="1024"/>
+    <member name="EOM_DEBUG_PLUGINS" nick="plugins" value="2048"/>
+  </flags>
+  <flags name="EomImageData" get-type="eom_image_data_get_type">
+    <member name="EOM_IMAGE_DATA_IMAGE" nick="image" value="1"/>
+    <member name="EOM_IMAGE_DATA_DIMENSION" nick="dimension" value="2"/>
+    <member name="EOM_IMAGE_DATA_EXIF" nick="exif" value="4"/>
+    <member name="EOM_IMAGE_DATA_XMP" nick="xmp" value="8"/>
+  </flags>
+  <enum name="EomImageError" get-type="eom_image_error_get_type">
+    <member name="EOM_IMAGE_ERROR_SAVE_NOT_LOCAL" nick="save-not-local" value="0"/>
+    <member name="EOM_IMAGE_ERROR_NOT_LOADED" nick="not-loaded" value="1"/>
+    <member name="EOM_IMAGE_ERROR_VFS" nick="vfs" value="2"/>
+    <member name="EOM_IMAGE_ERROR_FILE_EXISTS" nick="file-exists" value="3"/>
+    <member name="EOM_IMAGE_ERROR_TMP_FILE_FAILED" nick="tmp-file-failed" value="4"/>
+    <member name="EOM_IMAGE_ERROR_GENERIC" nick="generic" value="5"/>
+    <member name="EOM_IMAGE_ERROR_UNKNOWN" nick="unknown" value="6"/>
+  </enum>  <enum name="EomImageStatus" get-type="eom_image_status_get_type">
+    <member name="EOM_IMAGE_STATUS_UNKNOWN" nick="unknown" value="0"/>
+    <member name="EOM_IMAGE_STATUS_LOADING" nick="loading" value="1"/>
+    <member name="EOM_IMAGE_STATUS_LOADED" nick="loaded" value="2"/>
+    <member name="EOM_IMAGE_STATUS_SAVING" nick="saving" value="3"/>
+    <member name="EOM_IMAGE_STATUS_FAILED" nick="failed" value="4"/>
+  </enum>  <enum name="EomImageMetadataStatus" get-type="eom_image_metadata_status_get_type">
+    <member name="EOM_IMAGE_METADATA_NOT_READ" nick="not-read" value="0"/>
+    <member name="EOM_IMAGE_METADATA_NOT_AVAILABLE" nick="not-available" value="1"/>
+    <member name="EOM_IMAGE_METADATA_READY" nick="ready" value="2"/>
+  </enum>  <enum name="EomJobSaveResponse" get-type="eom_job_save_response_get_type">
+    <member name="EOM_SAVE_RESPONSE_NONE" nick="none" value="0"/>
+    <member name="EOM_SAVE_RESPONSE_RETRY" nick="retry" value="1"/>
+    <member name="EOM_SAVE_RESPONSE_SKIP" nick="skip" value="2"/>
+    <member name="EOM_SAVE_RESPONSE_OVERWRITE" nick="overwrite" value="3"/>
+    <member name="EOM_SAVE_RESPONSE_CANCEL" nick="cancel" value="4"/>
+    <member name="EOM_SAVE_RESPONSE_LAST" nick="last" value="5"/>
+  </enum>  <enum name="EomListStoreColumn" get-type="eom_list_store_column_get_type">
+    <member name="EOM_LIST_STORE_THUMBNAIL" nick="thumbnail" value="0"/>
+    <member name="EOM_LIST_STORE_THUMB_SET" nick="thumb-set" value="1"/>
+    <member name="EOM_LIST_STORE_EOM_IMAGE" nick="eom-image" value="2"/>
+    <member name="EOM_LIST_STORE_EOM_JOB" nick="eom-job" value="3"/>
+    <member name="EOM_LIST_STORE_NUM_COLUMNS" nick="num-columns" value="4"/>
+  </enum>  <enum name="EomPropertiesDialogPage" get-type="eom_properties_dialog_page_get_type">
+    <member name="EOM_PROPERTIES_DIALOG_PAGE_GENERAL" nick="page-general" value="0"/>
+    <member name="EOM_PROPERTIES_DIALOG_PAGE_EXIF" nick="page-exif" value="1"/>
+    <member name="EOM_PROPERTIES_DIALOG_PAGE_DETAILS" nick="page-details" value="2"/>
+    <member name="EOM_PROPERTIES_DIALOG_N_PAGES" nick="n-pages" value="3"/>
+  </enum>  <enum name="EomTransparencyStyle" get-type="eom_transparency_style_get_type">
+    <member name="EOM_TRANSP_BACKGROUND" nick="background" value="0"/>
+    <member name="EOM_TRANSP_CHECKED" nick="checked" value="1"/>
+    <member name="EOM_TRANSP_COLOR" nick="color" value="2"/>
+  </enum>  <enum name="EomThumbNavMode" get-type="eom_thumb_nav_mode_get_type">
+    <member name="EOM_THUMB_NAV_MODE_ONE_ROW" nick="one-row" value="0"/>
+    <member name="EOM_THUMB_NAV_MODE_ONE_COLUMN" nick="one-column" value="1"/>
+    <member name="EOM_THUMB_NAV_MODE_MULTIPLE_ROWS" nick="multiple-rows" value="2"/>
+    <member name="EOM_THUMB_NAV_MODE_MULTIPLE_COLUMNS" nick="multiple-columns" value="3"/>
+  </enum>  <enum name="EomThumbViewSelectionChange" get-type="eom_thumb_view_selection_change_get_type">
+    <member name="EOM_THUMB_VIEW_SELECT_CURRENT" nick="current" value="0"/>
+    <member name="EOM_THUMB_VIEW_SELECT_LEFT" nick="left" value="1"/>
+    <member name="EOM_THUMB_VIEW_SELECT_RIGHT" nick="right" value="2"/>
+    <member name="EOM_THUMB_VIEW_SELECT_FIRST" nick="first" value="3"/>
+    <member name="EOM_THUMB_VIEW_SELECT_LAST" nick="last" value="4"/>
+    <member name="EOM_THUMB_VIEW_SELECT_RANDOM" nick="random" value="5"/>
+  </enum>  <enum name="EomTransformType" get-type="eom_transform_type_get_type">
+    <member name="EOM_TRANSFORM_NONE" nick="none" value="0"/>
+    <member name="EOM_TRANSFORM_ROT_90" nick="rot-90" value="1"/>
+    <member name="EOM_TRANSFORM_ROT_180" nick="rot-180" value="2"/>
+    <member name="EOM_TRANSFORM_ROT_270" nick="rot-270" value="3"/>
+    <member name="EOM_TRANSFORM_FLIP_HORIZONTAL" nick="flip-horizontal" value="4"/>
+    <member name="EOM_TRANSFORM_FLIP_VERTICAL" nick="flip-vertical" value="5"/>
+    <member name="EOM_TRANSFORM_TRANSPOSE" nick="transpose" value="6"/>
+    <member name="EOM_TRANSFORM_TRANSVERSE" nick="transverse" value="7"/>
+  </enum>  <enum name="EomWindowMode" get-type="eom_window_mode_get_type">
+    <member name="EOM_WINDOW_MODE_UNKNOWN" nick="unknown" value="0"/>
+    <member name="EOM_WINDOW_MODE_NORMAL" nick="normal" value="1"/>
+    <member name="EOM_WINDOW_MODE_FULLSCREEN" nick="fullscreen" value="2"/>
+    <member name="EOM_WINDOW_MODE_SLIDESHOW" nick="slideshow" value="3"/>
+  </enum>  <enum name="EomWindowCollectionPos" get-type="eom_window_collection_pos_get_type">
+    <member name="EOM_WINDOW_COLLECTION_POS_BOTTOM" nick="bottom" value="0"/>
+    <member name="EOM_WINDOW_COLLECTION_POS_LEFT" nick="left" value="1"/>
+    <member name="EOM_WINDOW_COLLECTION_POS_TOP" nick="top" value="2"/>
+    <member name="EOM_WINDOW_COLLECTION_POS_RIGHT" nick="right" value="3"/>
+  </enum>  <enum name="EomWindowError" get-type="eom_window_error_get_type">
+    <member name="EOM_WINDOW_ERROR_CONTROL_NOT_FOUND" nick="control-not-found" value="0"/>
+    <member name="EOM_WINDOW_ERROR_UI_NOT_FOUND" nick="ui-not-found" value="1"/>
+    <member name="EOM_WINDOW_ERROR_NO_PERSIST_FILE_INTERFACE" nick="no-persist-file-interface" value="2"/>
+    <member name="EOM_WINDOW_ERROR_IO" nick="io" value="3"/>
+    <member name="EOM_WINDOW_ERROR_TRASH_NOT_FOUND" nick="trash-not-found" value="4"/>
+    <member name="EOM_WINDOW_ERROR_GENERIC" nick="generic" value="5"/>
+    <member name="EOM_WINDOW_ERROR_UNKNOWN" nick="unknown" value="6"/>
+  </enum>  <flags name="EomStartupFlags" get-type="eom_startup_flags_get_type">
+    <member name="EOM_STARTUP_FULLSCREEN" nick="fullscreen" value="1"/>
+    <member name="EOM_STARTUP_SLIDE_SHOW" nick="slide-show" value="2"/>
+    <member name="EOM_STARTUP_DISABLE_COLLECTION" nick="disable-collection" value="4"/>
+    <member name="EOM_STARTUP_PRESERVE_ORDER" nick="preserve-order" value="8"/>
+  </flags>
+  <error-quark function="eom_image_error_quark" domain="eom-image-error-quark"/>
+</dump>


### PR DESCRIPTION
- Cherry-pick https://github.com/mate-desktop/eom/commit/92f1d8e710749f43d5bf80afe6955da8785bd63d to fix a girepository-related build error

- Disable help to prevent `Error: cannot open XML file ../src/help/C/index.docbook`

- Use `-Dgdk-pixbuf-thumbnailer=false` because `gdk-pixbuf` does not support building `gdk-pixbuf-thumbnailer` during cross-compilation, so Termux does not provide it