### PR TITLE
bump(qemu): 10.2.1

### DIFF
--- a/packages/qemu-system-x86-64-headless/0007-fix-syscalls.patch
+++ b/packages/qemu-system-x86-64-headless/0007-fix-syscalls.patch
@@ -34,11 +34,10 @@ diff -uNr qemu-8.2.0/linux-user/syscall.c qemu-8.2.0.mod/linux-user/syscall.c
  #include <sys/statfs.h>
  #include <utime.h>
  #include <sys/sysinfo.h>
-@@ -85,12 +85,17 @@
- #endif
+@@ -87,12 +87,16 @@
  
  #define termios host_termios
-+#define termios2 host_termios2
+ #define termios2 host_termios2
 +#define ktermios host_ktermios
  #define winsize host_winsize
  #define termio host_termio

--- a/packages/qemu-system-x86-64-headless/0019-no-timespec_get.patch
+++ b/packages/qemu-system-x86-64-headless/0019-no-timespec_get.patch
@@ -1,0 +1,11 @@
+--- a/contrib/plugins/uftrace.c
++++ b/contrib/plugins/uftrace.c
+@@ -115,7 +115,7 @@ static CpuOps arch_ops;
+ 
+ static uint64_t gettime_ns(void)
+ {
+-#ifdef _WIN32
++#if defined(_WIN32) || (defined(__ANDROID__) && __ANDROID_API__ < 29)
+     /*
+      * On Windows, timespec_get is available only with UCRT, but not with
+      * MinGW64 environment. Simplify by using only gettimeofday on this

--- a/packages/qemu-system-x86-64-headless/build.sh
+++ b/packages/qemu-system-x86-64-headless/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.qemu.org
 TERMUX_PKG_DESCRIPTION="A generic and open source machine emulator and virtualizer (headless)"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1:10.1.2
-TERMUX_PKG_SRCURL=https://download.qemu.org/qemu-${TERMUX_PKG_VERSION:2}.tar.xz
-TERMUX_PKG_SHA256=9d75f331c1a5cb9b6eb8fd9f64f563ec2eab346c822cb97f8b35cd82d3f11479
+TERMUX_PKG_VERSION="1:10.2.1"
+TERMUX_PKG_SRCURL="https://download.qemu.org/qemu-${TERMUX_PKG_VERSION:2}.tar.xz"
+TERMUX_PKG_SHA256=a3717477d8e2c84d630bfffbc20f6cd3293eb45aa1e6dac6d0cc27689991c9e1
 TERMUX_PKG_DEPENDS="alsa-lib, dtc, glib, jack2, libbz2, libcurl, libdw, libgmp, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libslirp, libspice-server, libssh, libusb, libusbredir, ncurses, pulseaudio, qemu-common, resolv-conf, zlib, zstd"
 
 # Required by configuration script, but I can't find any binary that uses it.

--- a/x11-packages/qemu-system-x86-64/0019-no-timespec_get.patch
+++ b/x11-packages/qemu-system-x86-64/0019-no-timespec_get.patch
@@ -1,0 +1,1 @@
+../../packages/qemu-system-x86-64-headless/0019-no-timespec_get.patch

--- a/x11-packages/qemu-system-x86-64/build.sh
+++ b/x11-packages/qemu-system-x86-64/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.qemu.org
 TERMUX_PKG_DESCRIPTION="A generic and open source machine emulator and virtualizer"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1:10.1.2
-TERMUX_PKG_SRCURL=https://download.qemu.org/qemu-${TERMUX_PKG_VERSION:2}.tar.xz
-TERMUX_PKG_SHA256=9d75f331c1a5cb9b6eb8fd9f64f563ec2eab346c822cb97f8b35cd82d3f11479
+TERMUX_PKG_VERSION="1:10.2.1"
+TERMUX_PKG_SRCURL="https://download.qemu.org/qemu-${TERMUX_PKG_VERSION:2}.tar.xz"
+TERMUX_PKG_SHA256=a3717477d8e2c84d630bfffbc20f6cd3293eb45aa1e6dac6d0cc27689991c9e1
 TERMUX_PKG_DEPENDS="alsa-lib, dtc, gdk-pixbuf, glib, jack2, gtk3, libbz2, libcairo, libcurl, libdw, libepoxy, libgmp, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libslirp, libspice-server, libssh, libusb, libusbredir, libx11, mesa, ncurses, pulseaudio, qemu-common, resolv-conf, sdl2 | sdl2-compat, sdl2-image, virglrenderer, zlib, zstd"
 # Required by configuration script, but I can't find any binary that uses it.
 TERMUX_PKG_BUILD_DEPENDS="libtasn1"


### PR DESCRIPTION
- Rebase `0007-fix-syscalls.patch`

- Instance of `timespec_get()` appeared, but a codepath intended for Windows using `gettimeofday()` instead is available, so activate that codepath instead