### PR TITLE
bump(main/virglrenderer-android): 1.3.0

### DIFF
--- a/packages/virglrenderer-android/0007-Ensure-EGL-GLES-ANGLE-help-and-socket-path.patch.beforehostbuild
+++ b/packages/virglrenderer-android/0007-Ensure-EGL-GLES-ANGLE-help-and-socket-path.patch.beforehostbuild
@@ -93,7 +93,7 @@ diff -ur orig/vtest/vtest_server.c mod/vtest/vtest_server.c
        default:
           printf("Usage: %s [--no-fork] [--no-loop-or-fork] [--multi-clients] "
 -                "[--use-glx] [--use-egl-surfaceless] [--use-gles] [--no-virgl]"
-+                "[--angle-gl] [--angle-gl] [--angle-null]"
++                "[--angle-gl] [--angle-vulkan] [--angle-null]"
                  "[--rendernode <dev>] [--socket-path <path>] "
  #ifdef ENABLE_VENUS
                  " [--venus]"

--- a/packages/virglrenderer-android/build.sh
+++ b/packages/virglrenderer-android/build.sh
@@ -2,7 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://virgil3d.github.io/
 TERMUX_PKG_DESCRIPTION="A virtual 3D GPU for use inside qemu virtual machines over OpenGLES libraries on Android"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@licy183"
-TERMUX_PKG_VERSION="1.2.0"
+TERMUX_PKG_VERSION="1.3.0"
 _LIBEPOXY_VERSION="1.5.10"
 
 TERMUX_PKG_SRCURL=(
@@ -10,7 +10,7 @@ TERMUX_PKG_SRCURL=(
 	https://github.com/anholt/libepoxy/archive/refs/tags/${_LIBEPOXY_VERSION}.tar.gz
 )
 TERMUX_PKG_SHA256=(
-	b181b668afae817953c84635fac2dc4c2e5786c710b7d225ae215d15674a15c7
+	56170f8caa1bb642a2624b649e3bcca095ec2834814e5c308efc8a85a709e4ce
 	a7ced37f4102b745ac86d6a70a9da399cc139ff168ba6b8002b4d8d43c900c15
 )
 TERMUX_PKG_DEPENDS="angle-android"


### PR DESCRIPTION
Bump version to 1.3.0 and fix help text error in virgl_test_server_android.