### PR TITLE
fix(x11/dunst): append to `LDFLAGS` rather than overwrite

### DIFF
--- a/x11-packages/dunst/build.sh
+++ b/x11-packages/dunst/build.sh
@@ -3,7 +3,8 @@ TERMUX_PKG_DESCRIPTION="Lightweight and customizable notification daemon"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.13.1"
-TERMUX_PKG_SRCURL=https://github.com/dunst-project/dunst/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://github.com/dunst-project/dunst/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=a578e5c2cdb546187355c710f1aa84c472e6e23828e692fe1cb0ebb9635b11a6
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libandroid-wordexp, dbus, gdk-pixbuf, glib, harfbuzz, libcairo, libnotify, libx11, libxext, libxinerama, libxrandr, libxss, pango"
@@ -13,5 +14,5 @@ termux_step_pre_configure() {
 	# TODO: Meson support is still considered experimental and may still have issues.
 	mv meson.build{,.orig}
 
-	LDFLAGS='-landroid-wordexp'
+	LDFLAGS+=" -landroid-wordexp"
 }


### PR DESCRIPTION
- Fixes `CANNOT LINK EXECUTABLE "dunst": library "libandroid-wordexp.so" not found: needed by main executable`