### PR TITLE
bump(x11/firefox): 148.0

### DIFF
--- a/x11-packages/firefox/0024-disable-native-https-dns-resolve.patch
+++ b/x11-packages/firefox/0024-disable-native-https-dns-resolve.patch
@@ -2,10 +2,10 @@ It uses `android_res_nquery`, but this function only got added in API level 29
 
 --- a/netwerk/dns/nsHostResolver.cpp
 +++ b/netwerk/dns/nsHostResolver.cpp
-@@ -210,6 +210,8 @@
+@@ -174,6 +174,8 @@ nsresult nsHostResolver::Init() MOZ_NO_THREAD_SAFETY_ANALYSIS {
+   // It returns a success code, but no records. We only allow
    // native HTTPS records on Win 11 for now.
-   sNativeHTTPSSupported = StaticPrefs::network_dns_native_https_query_win10() ||
-                           mozilla::IsWin11OrLater();
+   sNativeHTTPSSupported = mozilla::IsWin11OrLater();
 +#elif defined(__TERMUX__)
 +  sNativeHTTPSSupported = false;
  #elif defined(MOZ_WIDGET_ANDROID)

--- a/x11-packages/firefox/build.sh
+++ b/x11-packages/firefox/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.mozilla.org/firefox
 TERMUX_PKG_DESCRIPTION="Mozilla Firefox web browser"
 TERMUX_PKG_LICENSE="MPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="147.0.4"
+TERMUX_PKG_VERSION="148.0"
 TERMUX_PKG_SRCURL="https://archive.mozilla.org/pub/firefox/releases/${TERMUX_PKG_VERSION}/source/firefox-${TERMUX_PKG_VERSION}.source.tar.xz"
-TERMUX_PKG_SHA256=bc0742ac62b177987d3312352194d4a088396ccf7b02e94be88f8072d82e94f7
+TERMUX_PKG_SHA256=ec93e5040a23b7dbe9ec77eb4a7ccda9820856d7851bf2f617f3673b6354cb6f
 # ffmpeg and pulseaudio are dependencies through dlopen(3):
 TERMUX_PKG_DEPENDS="ffmpeg, fontconfig, freetype, gdk-pixbuf, glib, gtk3, libandroid-shmem, libandroid-spawn, libc++, libcairo, libevent, libffi, libice, libicu, libjpeg-turbo, libnspr, libnss, libpixman, libsm, libvpx, libwebp, libx11, libxcb, libxcomposite, libxdamage, libxext, libxfixes, libxrandr, libxtst, pango, pulseaudio, zlib"
 TERMUX_PKG_BUILD_DEPENDS="libcpufeatures, libice, libsm"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28611

- Rebase `0024-disable-native-https-dns-resolve.patch`