### PR TITLE
bump(main/fresh-editor): 0.2.9

### DIFF
--- a/packages/fresh-editor/smithay-client-toolkit-no-shm.diff
+++ b/packages/fresh-editor/smithay-client-toolkit-no-shm.diff
@@ -1,0 +1,61 @@
+--- a/src/shm/raw.rs
++++ b/src/shm/raw.rs
+@@ -5,7 +5,6 @@
+ 
+ use rustix::{
+     io::Errno,
+-    shm::{Mode, ShmOFlags},
+ };
+ use std::{
+     fs::File,
+@@ -175,49 +174,11 @@ impl RawPool {
+                 Ok(fd) => return Ok(fd),
+ 
+                 // Not supported, use fallback.
+-                Err(Errno::NOSYS) => (),
++                Err(Errno::NOSYS) => return Err(Errno::NOSYS.into()),
+ 
+                 Err(err) => return Err(Into::<io::Error>::into(err)),
+             };
+         }
+-
+-        let time = SystemTime::now();
+-        let mut mem_file_handle = format!(
+-            "/smithay-client-toolkit-{}",
+-            time.duration_since(UNIX_EPOCH).unwrap().subsec_nanos()
+-        );
+-
+-        loop {
+-            let flags = ShmOFlags::CREATE | ShmOFlags::EXCL | ShmOFlags::RDWR;
+-
+-            let mode = Mode::RUSR | Mode::WUSR;
+-
+-            match rustix::shm::shm_open(mem_file_handle.as_str(), flags, mode) {
+-                Ok(fd) => match rustix::shm::shm_unlink(mem_file_handle.as_str()) {
+-                    Ok(_) => return Ok(fd),
+-
+-                    Err(errno) => {
+-                        return Err(errno.into());
+-                    }
+-                },
+-
+-                Err(Errno::EXIST) => {
+-                    // Change the handle if we happen to be duplicate.
+-                    let time = SystemTime::now();
+-
+-                    mem_file_handle = format!(
+-                        "/smithay-client-toolkit-{}",
+-                        time.duration_since(UNIX_EPOCH).unwrap().subsec_nanos()
+-                    );
+-
+-                    continue;
+-                }
+-
+-                Err(Errno::INTR) => continue,
+-
+-                Err(err) => return Err(err.into()),
+-            }
+-        }
+     }
+ 
+     #[cfg(target_os = "linux")]

--- a/packages/fresh-editor/trash-rs-implement-get_mount_points-android.diff
+++ b/packages/fresh-editor/trash-rs-implement-get_mount_points-android.diff
@@ -1,14 +1,24 @@
 This dirty implementation of get_mount_points() for trash-rs for Android
 has been tested and confirmed to work good enough to suceessfully move files to trash
 in reverse dependency Yazi on Samsung Galaxy A70 SM-A705FN with LineageOS 20 Android 13 SELinux Enabled
+"linux" will get replaced with "android" in the bulk-patch and vice versa
 
 --- a/src/freedesktop.rs
 +++ b/src/freedesktop.rs
+@@ -728,7 +728,7 @@ fn get_sorted_mount_points() -> Result<Vec<MountPoint>, Error> {
+     Ok(mount_points)
+ }
+ 
+-#[cfg(target_os = "linux")]
++#[cfg(target_os = "android")]
+ fn get_mount_points() -> Result<Vec<MountPoint>, Error> {
+     use once_cell::sync::Lazy;
+     use scopeguard::defer;
 @@ -784,6 +784,28 @@ fn get_mount_points() -> Result<Vec<MountPoint>, Error> {
      Ok(result)
  }
  
-+#[cfg(target_os = "android")]
++#[cfg(target_os = "linux")]
 +fn get_mount_points() -> Result<Vec<MountPoint>, Error> {
 +    // assume '/data' and '/strorage/emulated/0' are mounted
 +    // for some reason, 'getmntent()' is not available in Rust on Android,
@@ -39,7 +49,7 @@ in reverse dependency Yazi on Samsung Galaxy A70 SM-A705FN with LineageOS 20 And
      target_os = "openbsd",
 -    target_os = "netbsd"
 +    target_os = "netbsd",
-+    target_os = "android"
++    target_os = "linux"
  )))]
  fn get_mount_points() -> Result<Vec<MountPoint>, Error> {
      // On platforms that don't have support yet, return an error

--- a/packages/fresh-editor/wayland-cursor-no-shm.diff
+++ b/packages/fresh-editor/wayland-cursor-no-shm.diff
@@ -1,0 +1,51 @@
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -59,7 +59,6 @@ use rustix::fs::Mode;
+ #[cfg(any(target_os = "linux", target_os = "android"))]
+ use rustix::fs::{memfd_create, MemfdFlags};
+ use rustix::io::Errno;
+-use rustix::shm;
+ #[cfg(any(target_os = "linux", target_os = "android"))]
+ use std::ffi::CStr;
+ 
+@@ -445,39 +444,10 @@ fn create_shm_fd() -> IoResult<OwnedFd> {
+         ) {
+             Ok(fd) => return Ok(fd),
+             Err(Errno::INTR) => continue,
+-            Err(Errno::NOSYS) => break,
++            Err(Errno::NOSYS) => return Err(Errno::NOSYS.into()),
+             Err(errno) => return Err(errno.into()),
+         }
+     }
+-
+-    // Fallback to using shm_open.
+-    let sys_time = SystemTime::now();
+-    let mut mem_file_handle = format!(
+-        "/wayland-cursor-rs-{}",
+-        sys_time.duration_since(UNIX_EPOCH).unwrap().subsec_nanos()
+-    );
+-    loop {
+-        match shm::open(
+-            mem_file_handle.as_str(),
+-            shm::OFlags::CREATE | shm::OFlags::EXCL | shm::OFlags::RDWR,
+-            Mode::RUSR | Mode::WUSR,
+-        ) {
+-            Ok(fd) => match shm::unlink(mem_file_handle.as_str()) {
+-                Ok(_) => return Ok(fd),
+-                Err(errno) => return Err(IoError::from(errno)),
+-            },
+-            Err(Errno::EXIST) => {
+-                // If a file with that handle exists then change the handle
+-                mem_file_handle = format!(
+-                    "/wayland-cursor-rs-{}",
+-                    sys_time.duration_since(UNIX_EPOCH).unwrap().subsec_nanos()
+-                );
+-                continue;
+-            }
+-            Err(Errno::INTR) => continue,
+-            Err(errno) => return Err(IoError::from(errno)),
+-        }
+-    }
+ }
+ 
+ struct IgnoreObjectData;


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28624

- `fresh-editor` now pulls in the entire Rust windowing stack, so apply the patches that I have written and used in the past to somewhat successfully use X11 with GUI Rust applications in Termux