### PR TITLE
bump(main/sbcl): 2.6.2

### DIFF
--- a/packages/sbcl/build.sh
+++ b/packages/sbcl/build.sh
@@ -3,15 +3,15 @@ TERMUX_PKG_DESCRIPTION="A high performance Common Lisp compiler"
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="2.6.1"
+TERMUX_PKG_VERSION="2.6.2"
 # sourceforge archive is a precompiled SBCL release for GNU/Linux to use as host Lisp for bootstrapping
 TERMUX_PKG_SRCURL=(
 	https://github.com/sbcl/sbcl/archive/refs/tags/sbcl-${TERMUX_PKG_VERSION}.tar.gz
 	https://sourceforge.net/projects/sbcl/files/sbcl/${TERMUX_PKG_VERSION}/sbcl-${TERMUX_PKG_VERSION}-x86-64-linux-binary.tar.bz2
 )
 TERMUX_PKG_SHA256=(
-	3e48fdad322cd726dcd96c065f33fc9cd22cbbf1eb5a9b113149b49baf3525f0
-	bd524eccce6f64941092450580abf7ccff99b6ccec6bde449e0e8de6c7ceec9e
+	1f94d08eab67686bcd6576110e885dfbcf3262eb5756434f7109cdfdfa0efa4e
+	1758d003f60fa166db014999a73cf9af02726ca7803ab9057dec32a92e2b6322
 )
 TERMUX_PKG_DEPENDS="zstd"
 # TERMUX_ON_DEVICE_BUILD=true  build dependencies: ecl, strace

--- a/packages/sbcl/disable-elfination-tests.patch
+++ b/packages/sbcl/disable-elfination-tests.patch
@@ -19,12 +19,12 @@ effects that this test failing implies would be:
  (exit :code 2) ; otherwise skip the test
 --- a/tests/elfcore.test.sh
 +++ b/tests/elfcore.test.sh
-@@ -16,7 +16,7 @@
- . ./subr.sh
- 
+@@ -19,7 +19,7 @@
+ # tests in this file do, so try it first. If this can't be run, neither can
+ # anything else.
  run_sbcl <<EOF
--  #+(and linux elf sb-thread)
-+  #+(and linux elf sb-thread (not android))
-   (let ((s (find-symbol "IMMOBILE-SPACE-OBJ-P" "SB-KERNEL")))
-     (when (and s (funcall s #'car)) (exit :code 0))) ; good
+-  #+(and linux (or arm64 x86-64)) (exit :code 0) ; good
++  #+(and linux (or arm64 x86-64) (not android)) (exit :code 0) ; good
    (exit :code 2) ; otherwise
+ EOF
+ status=$?


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28644

- Rebase `disable-failing-tests-that-were-only-enabled-on-x86.patch` and rename to `disable-elfination-tests.patch`