### PR TITLE
bump(x11/openimageio): 3.1.11.0

### DIFF
--- a/x11-packages/openimageio/build.sh
+++ b/x11-packages/openimageio/build.sh
@@ -2,10 +2,9 @@ TERMUX_PKG_HOMEPAGE=http://www.openimageio.org/
 TERMUX_PKG_DESCRIPTION="A library for reading and writing images, including classes, utilities, and applications"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="3.1.10.0"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="3.1.11.0"
 TERMUX_PKG_SRCURL="https://github.com/OpenImageIO/oiio/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256=6b62ceb83c8131ec49a999e0008750b52d98162d79265af47430cf83ed03ec0b
+TERMUX_PKG_SHA256=992269ed9b24b17d283a2a05dd11dce582886e97b13b1793eca63b96251b095b
 # configure-time error if ptex and ptex-static are not both installed
 TERMUX_PKG_DEPENDS="boost, dcmtk, ffmpeg, fmt, freetype, glew, imath, libc++, libhdf5, libheif, libjpeg-turbo, libjxl, libpng, libraw, libtbb, libtiff, libwebp, libyaml-cpp, opencolorio, opencv, openexr, openjpeg, openvdb, ptex, pybind11, python, qt6-qtbase"
 TERMUX_PKG_BUILD_DEPENDS="boost-headers, fontconfig, libjpeg-turbo-static, libpugixml, libxrender, mesa, ptex-static, robin-map"
@@ -30,5 +29,12 @@ termux_step_post_get_source() {
 
 	if [[ "${v}" != "${_SOVERSION}" ]]; then
 		termux_error_exit "SOVERSION guard check failed."
+	fi
+}
+
+termux_step_pre_configure() {
+	# for code in openjph, which is downloaded by CMakeLists.txt of openexr at build-time
+	if [[ "$TERMUX_PKG_API_LEVEL" -lt 28 ]]; then
+		CPPFLAGS+=" -Daligned_alloc=memalign"
 	fi
 }


### PR DESCRIPTION
Add smiliar workaround from 5f63044159a2acd824437a2f9c4713d5d4f56765 of openexr.

* Fixes #28663 