### PR TITLE
fix(main/python-onnxruntime): reorganize `capi` `.so` files

### DIFF
--- a/packages/onnxruntime/build.sh
+++ b/packages/onnxruntime/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Cross-platform, high performance ML inferencing and trai
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.24.3"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/microsoft/onnxruntime
 TERMUX_PKG_DEPENDS="abseil-cpp, libc++, protobuf, libre2"
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -64,5 +65,15 @@ termux_step_make_install() {
 
 	local _pyver="${TERMUX_PYTHON_VERSION//./}"
 	local _wheel="onnxruntime-${TERMUX_PKG_VERSION}-cp${_pyver}-cp${_pyver}-android_${TERMUX_ARCH}.whl"
-	pip install --no-deps --prefix="$TERMUX_PREFIX" "$TERMUX_PKG_SRCDIR/dist/${_wheel}"
+	pip install --force-reinstall --no-deps --prefix="$TERMUX_PREFIX" "$TERMUX_PKG_SRCDIR/dist/${_wheel}"
+}
+
+termux_step_post_make_install() {
+	# for some reason in python 3.13, these are no longer getting installed automatically
+	install -Dm644 onnxruntime_pybind11_state.so \
+		-t "$TERMUX_PYTHON_HOME/site-packages/onnxruntime/capi"
+	ln -sf "$TERMUX_PREFIX/lib/libonnxruntime.so" \
+		"$TERMUX_PYTHON_HOME/site-packages/onnxruntime/capi/libonnxruntime.so"
+	ln -sf "$TERMUX_PREFIX/lib/libonnxruntime_providers_shared.so" \
+		"$TERMUX_PYTHON_HOME/site-packages/onnxruntime/capi/libonnxruntime_providers_shared.so"
 }

--- a/packages/onnxruntime/python-onnxruntime.subpackage.sh
+++ b/packages/onnxruntime/python-onnxruntime.subpackage.sh
@@ -4,4 +4,3 @@ bin
 lib/python*
 "
 TERMUX_SUBPKG_DEPENDS="python, python-numpy, python-pip"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=deps


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28769

- They stopped being installed automatically for some reason in Python 3.13, so install them manually, and implement the `libonnxruntime.so` and `libonnxruntime_providers_shared.so` files for Python using symbolic links and a dependency on the parent package