### PR TITLE
fix(main/cmake): disable `ld.gold` completely

### DIFF
--- a/packages/cmake/Modules-Compiler-Clang.cmake.patch
+++ b/packages/cmake/Modules-Compiler-Clang.cmake.patch
@@ -1,0 +1,19 @@
+Fixes
+clang++: error: invalid linker name in argument '-fuse-ld=gold'
+in
+pip install levenshtein
+Termux does not have ld.gold anymore
+
+--- a/Modules/Compiler/Clang.cmake
++++ b/Modules/Compiler/Clang.cmake
+@@ -81,10 +81,6 @@ else()
+       set(CMAKE_${lang}_COMPILE_OPTIONS_IPO "-flto")
+     endif()
+ 
+-    if(ANDROID AND NOT CMAKE_ANDROID_NDK_VERSION VERSION_GREATER_EQUAL "22")
+-      # https://github.com/android-ndk/ndk/issues/242
+-      set(CMAKE_${lang}_LINK_OPTIONS_IPO "-fuse-ld=gold")
+-    endif()
+ 
+     if(ANDROID OR __is_apple_clang)
+       set(__ar "${CMAKE_AR}")

--- a/packages/cmake/build.sh
+++ b/packages/cmake/build.sh
@@ -5,7 +5,8 @@ TERMUX_PKG_LICENSE_FILE="LICENSE.rst"
 TERMUX_PKG_MAINTAINER="@termux"
 # When updating version here, please update termux_setup_cmake.sh as well.
 TERMUX_PKG_VERSION="4.2.3"
-TERMUX_PKG_SRCURL=https://www.cmake.org/files/v${TERMUX_PKG_VERSION:0:3}/cmake-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://www.cmake.org/files/v${TERMUX_PKG_VERSION:0:3}/cmake-${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=7efaccde8c5a6b2968bad6ce0fe60e19b6e10701a12fce948c2bf79bac8a11e9
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libarchive, libc++, libcurl, libexpat, jsoncpp, libuv, rhash, zlib"
@@ -23,7 +24,8 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DCMAKE_USE_SYSTEM_LIBRHASH=ON
 -DCMAKE_USE_SYSTEM_LIBUV=ON
 -DCMAKE_USE_SYSTEM_ZLIB=ON
--DBUILD_CursesDialog=ON"
+-DBUILD_CursesDialog=ON
+"
 
 termux_pkg_auto_update() {
 	local TERMUX_SETUP_CMAKE="${TERMUX_SCRIPTDIR}/scripts/build/setup/termux_setup_cmake.sh"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28784
- Fixes `clang++: error: invalid linker name in argument '-fuse-ld=gold'` in `pip install levenshtein`
- Termux does not have `ld.gold` anymore