### PR TITLE
bump(x11/filelight): 25.12.3

### DIFF
--- a/x11-packages/filelight/build.sh
+++ b/x11-packages/filelight/build.sh
@@ -2,11 +2,11 @@ TERMUX_PKG_HOMEPAGE="https://apps.kde.org/filelight/"
 TERMUX_PKG_DESCRIPTION="View disk usage information"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="25.12.2"
+TERMUX_PKG_VERSION="25.12.3"
 TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/filelight-${TERMUX_PKG_VERSION}.tar.xz"
-TERMUX_PKG_SHA256=e9c0ba3136caf4e048ddcadc1e60fccffd455876e89e753694bf0c90bf2f4ee0
+TERMUX_PKG_SHA256=914876f16e0a07da4c84fbac66b260a5b03ecebeb55c2ff3743781fe5039d3dc
 TERMUX_PKG_DEPENDS="kf6-kconfig, kf6-kcoreaddons, kf6-kcrash, kf6-ki18n, kf6-kio, kf6-kirigami, kf6-kwidgetsaddons, kf6-qqc2-desktop-style, kirigami-addons, libc++, qt6-qtbase, qt6-qtdeclarative"
-TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kdoctools"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DBUILD_TESTING=OFF
@@ -14,3 +14,9 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DKDE_INSTALL_QMLDIR=lib/qt6/qml
 -DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
 "
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}


### PR DESCRIPTION
Use host kf6 doctools to fix the following error.
/bin/sh: 1: /data/data/com.termux/files/usr/bin/meinproc6: Exec format error

* Fixes #28811 