### PR TITLE
fix(x11/kitty): Treat Python 3.13 on Android as Linux

### DIFF
--- a/x11-packages/kitty/build.sh
+++ b/x11-packages/kitty/build.sh
@@ -3,8 +3,8 @@ TERMUX_PKG_DESCRIPTION="Cross-platform, fast, feature-rich, GPU based terminal"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.45.0"
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://github.com/kovidgoyal/kitty/releases/download/v${TERMUX_PKG_VERSION}/kitty-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_REVISION=2
+TERMUX_PKG_SRCURL="https://github.com/kovidgoyal/kitty/releases/download/v${TERMUX_PKG_VERSION}/kitty-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=93fcba4984a97ccb7d811f487a818d406e681912b6bbb8f0ca426103ddce7ca5
 # fontconfig is dlopen(3)ed:
 TERMUX_PKG_DEPENDS="dbus, fontconfig, harfbuzz, libpng, librsync, libx11, libxkbcommon, littlecms, ncurses, opengl, openssl, python, xxhash, zlib"

--- a/x11-packages/kitty/glfw-glfw.py.patch
+++ b/x11-packages/kitty/glfw-glfw.py.patch
@@ -1,0 +1,21 @@
+Prevents:
+RuntimeError: Failed to dlopen /data/data/com.termux/files/usr/lib/kitty/kitty/glfw-x11.so
+with error: dlopen failed: cannot locate symbol "_glfwDetectJoystickConnectionLinux"
+referenced by "/data/data/com.termux/files/usr/lib/kitty/kitty/glfw-x11.so"...
+After the update to Python 3.13
+
+(this patch is roughly analogous to x11-packages/glfw/src-CMakeLists.txt.patch,
+but in the build system of kitty/the kitty fork of GLFW,
+instead of the original build system of the official GLFW)
+
+--- a/glfw/glfw.py
++++ b/glfw/glfw.py
+@@ -11,7 +11,7 @@
+ from typing import Any, Callable, Dict, List, NamedTuple, Optional, Sequence, Tuple
+ 
+ _plat = sys.platform.lower()
+-is_linux = 'linux' in _plat
++is_linux = 'linux' in _plat or 'android' in _plat
+ is_openbsd = 'openbsd' in _plat
+ base = os.path.dirname(os.path.abspath(__file__))
+ 


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28830

- Kitty contains a vendored fork of GLFW. This patch is roughly analogous to this patch that is already in the Termux package of normal GLFW 

https://github.com/termux/termux-packages/blob/f128612f46f8d2319ba7b9c497c30cf7388382f6/x11-packages/glfw/src-CMakeLists.txt.patch#L8-L9

but applied to Kitty vendored GLFW's Python-based build system instead, where prior to Python 3.13 it was not necessary but is now necessary.