### PR TITLE
bump(main/gweather-locations): 2026.1

### DIFF
--- a/packages/gweather-locations/build.sh
+++ b/packages/gweather-locations/build.sh
@@ -2,8 +2,9 @@ TERMUX_PKG_HOMEPAGE="https://gitlab.gnome.org/GNOME/gweather-locations"
 TERMUX_PKG_DESCRIPTION="The GWeather locations database"
 TERMUX_PKG_LICENSE="GPL-2.0-or-later"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=2025.1
-TERMUX_PKG_SRCURL=https://download.gnome.org/sources/gweather-locations/${TERMUX_PKG_VERSION%.*}/gweather-locations-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=5609ee04cf6ac4cc7721f3241bd8d69ffebf0f1b60210fadd88c869a4b884d87
+TERMUX_PKG_VERSION="2026.1"
+# https://download.gnome.org/sources/gweather-locations/${TERMUX_PKG_VERSION%.*}/gweather-locations-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SRCURL=https://gitlab.gnome.org/GNOME/gweather-locations/-/archive/${TERMUX_PKG_VERSION}/gweather-locations-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=4f481a098f95c6a725b7d1729dec0bb873a387dfed36f7bfd5bd3e8f5e023dfc
 TERMUX_PKG_BUILD_DEPENDS="gettext"
 TERMUX_PKG_AUTO_UPDATE=true


### PR DESCRIPTION
Switch source URL to gitlab archive because new tarballs are not added in download.gnome.org.

* Fixes #28832 