### PR TITLE
bump(main/neovim-nightly): 0.12.0-dev-2496+gf1c82be1a1

### DIFF
--- a/packages/neovim-nightly/build.sh
+++ b/packages/neovim-nightly/build.sh
@@ -3,9 +3,9 @@ TERMUX_PKG_DESCRIPTION="Ambitious Vim-fork focused on extensibility and agility 
 TERMUX_PKG_LICENSE="Apache-2.0, VIM License"
 TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
-TERMUX_PKG_VERSION="0.12.0~dev-2435+g18c5f06c9f"
+TERMUX_PKG_VERSION="0.12.0~dev-2496+gf1c82be1a1"
 TERMUX_PKG_SRCURL="https://github.com/neovim/neovim/archive/${TERMUX_PKG_VERSION##*+g}.tar.gz"
-TERMUX_PKG_SHA256=3518260bbe8e755204b8d6fc25d1238be940b7138792fa3934022450c8a959cd
+TERMUX_PKG_SHA256=e8c27d7504fc1fd9c0086b0cc80fb933f25114e79a43324688dde7aa95aa833a
 TERMUX_PKG_REPOLOGY_METADATA_VERSION="${TERMUX_PKG_VERSION%%~*}"
 TERMUX_PKG_DEPENDS="libandroid-support, libiconv, libmsgpack, libunibilium, libuv, libvterm (>= 1:0.3-0), lua51-lpeg, luajit, luv, tree-sitter, tree-sitter-parsers, utf8proc"
 TERMUX_PKG_BREAKS="neovim"

--- a/packages/neovim-nightly/src-nvim-CMakeLists.txt.patch
+++ b/packages/neovim-nightly/src-nvim-CMakeLists.txt.patch
@@ -1,1 +1,19 @@
-../neovim/src-nvim-CMakeLists.txt.patch
+diff --git a/src/nvim/CMakeLists.txt b/src/nvim/CMakeLists.txt
+index 0b5f2e0d62..e08659a835 100644
+--- a/src/nvim/CMakeLists.txt
++++ b/src/nvim/CMakeLists.txt
+@@ -527,12 +527,12 @@ if(CMAKE_CROSSCOMPILING AND NLUA0_HOST_PRG)
+   set(LUA_GEN ${LUA_GEN_PRG} ${GENERATOR_PRELOAD} ${PROJECT_SOURCE_DIR} ${NLUA0_HOST_PRG} ${PROJECT_BINARY_DIR})
+   set(LUA_GEN_DEPS ${GENERATOR_PRELOAD} ${NLUA0_HOST_PRG})
+ else()
+-  set(LUA_GEN ${LUA_GEN_PRG} ${GENERATOR_PRELOAD} ${PROJECT_SOURCE_DIR} $<TARGET_FILE:nlua0> ${PROJECT_BINARY_DIR})
++  set(LUA_GEN ${LUA_GEN_PRG} ${GENERATOR_PRELOAD} ${PROJECT_SOURCE_DIR} "${PROJECT_BINARY_DIR}/../host-build/libnlua0.so" ${PROJECT_BINARY_DIR})
+   set(LUA_GEN_DEPS ${GENERATOR_PRELOAD} $<TARGET_FILE:nlua0>)
+ endif()
+
+ # Like LUA_GEN but includes also vim.fn, vim.api, vim.uv, etc
+-set(NVIM_LUA $<TARGET_FILE:nvim_bin> -u NONE -l ${NVIM_LUA_PRELOAD} ${PROJECT_SOURCE_DIR})
++set(NVIM_LUA "${PROJECT_BINARY_DIR}/../host-build/bin/nvim" -u NONE -l ${NVIM_LUA_PRELOAD} ${PROJECT_SOURCE_DIR})
+
+ # NVIM_GENERATED_FOR_HEADERS: generated headers to be included in headers
+ # NVIM_GENERATED_FOR_SOURCES: generated headers to be included in sources


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28660
NOTE: the `src-nvim-CMakeLists.txt.patch` sym link has been replaced with a normal file of the same name cus if the symlink exists the updating the patch file would enable `neovim-nightly` to be compiled but then `neovim` cannot be compiled so the sym link is removed