### PR TITLE
add(x11/librewolf): 148.0.2-2

### DIFF
--- a/x11-packages/librewolf/0001-configure-treat-termux-as-linux.patch
+++ b/x11-packages/librewolf/0001-configure-treat-termux-as-linux.patch
@@ -1,0 +1,1 @@
+../firefox/0001-configure-treat-termux-as-linux.patch

--- a/x11-packages/librewolf/0002-configure-fix-arm-options.patch
+++ b/x11-packages/librewolf/0002-configure-fix-arm-options.patch
@@ -1,0 +1,1 @@
+../firefox/0002-configure-fix-arm-options.patch

--- a/x11-packages/librewolf/0003-configure-fix-rustflags.patch
+++ b/x11-packages/librewolf/0003-configure-fix-rustflags.patch
@@ -1,0 +1,1 @@
+../firefox/0003-configure-fix-rustflags.patch

--- a/x11-packages/librewolf/0004-configure-do-not-check-libstdcxx-headers.patch
+++ b/x11-packages/librewolf/0004-configure-do-not-check-libstdcxx-headers.patch
@@ -1,0 +1,1 @@
+../firefox/0004-configure-do-not-check-libstdcxx-headers.patch

--- a/x11-packages/librewolf/0005-configure-do-not-append-sysroot.patch
+++ b/x11-packages/librewolf/0005-configure-do-not-append-sysroot.patch
@@ -1,0 +1,1 @@
+../firefox/0005-configure-do-not-append-sysroot.patch

--- a/x11-packages/librewolf/0006-configure-do-not-enable-alsa.patch
+++ b/x11-packages/librewolf/0006-configure-do-not-enable-alsa.patch
@@ -1,0 +1,1 @@
+../firefox/0006-configure-do-not-enable-alsa.patch

--- a/x11-packages/librewolf/0007-fix-link-with-libcxx-18.patch
+++ b/x11-packages/librewolf/0007-fix-link-with-libcxx-18.patch
@@ -1,0 +1,1 @@
+../firefox/0007-fix-link-with-libcxx-18.patch

--- a/x11-packages/librewolf/0008-fix-marcos.patch
+++ b/x11-packages/librewolf/0008-fix-marcos.patch
@@ -1,0 +1,1 @@
+../firefox/0008-fix-marcos.patch

--- a/x11-packages/librewolf/0009-impl-posix-shmem.patch
+++ b/x11-packages/librewolf/0009-impl-posix-shmem.patch
@@ -1,0 +1,1 @@
+../firefox/0009-impl-posix-shmem.patch

--- a/x11-packages/librewolf/0010-do-not-check-time_t-for-system-libevent.patch
+++ b/x11-packages/librewolf/0010-do-not-check-time_t-for-system-libevent.patch
@@ -1,0 +1,1 @@
+../firefox/0010-do-not-check-time_t-for-system-libevent.patch

--- a/x11-packages/librewolf/0011-use-UnderrunHandlerNoop.patch
+++ b/x11-packages/librewolf/0011-use-UnderrunHandlerNoop.patch
@@ -1,0 +1,1 @@
+../firefox/0011-use-UnderrunHandlerNoop.patch

--- a/x11-packages/librewolf/0012-do-not-use-adaptive-mutex.patch
+++ b/x11-packages/librewolf/0012-do-not-use-adaptive-mutex.patch
@@ -1,0 +1,1 @@
+../firefox/0012-do-not-use-adaptive-mutex.patch

--- a/x11-packages/librewolf/0013-fix-rust-compile.patch
+++ b/x11-packages/librewolf/0013-fix-rust-compile.patch
@@ -1,0 +1,1 @@
+../firefox/0013-fix-rust-compile.patch

--- a/x11-packages/librewolf/0014-unset-thread-priority-scheduling-macro.patch
+++ b/x11-packages/librewolf/0014-unset-thread-priority-scheduling-macro.patch
@@ -1,0 +1,1 @@
+../firefox/0014-unset-thread-priority-scheduling-macro.patch

--- a/x11-packages/librewolf/0015-skia-termux.patch
+++ b/x11-packages/librewolf/0015-skia-termux.patch
@@ -1,0 +1,1 @@
+../firefox/0015-skia-termux.patch

--- a/x11-packages/librewolf/0016-protobuf-no-android-log.patch
+++ b/x11-packages/librewolf/0016-protobuf-no-android-log.patch
@@ -1,0 +1,1 @@
+../firefox/0016-protobuf-no-android-log.patch

--- a/x11-packages/librewolf/0017-fix-include-dir-for-cpufeatures.patch
+++ b/x11-packages/librewolf/0017-fix-include-dir-for-cpufeatures.patch
@@ -1,0 +1,1 @@
+../firefox/0017-fix-include-dir-for-cpufeatures.patch

--- a/x11-packages/librewolf/0018-fix-sigbus.patch
+++ b/x11-packages/librewolf/0018-fix-sigbus.patch
@@ -1,0 +1,1 @@
+../firefox/0018-fix-sigbus.patch

--- a/x11-packages/librewolf/0019-do-not-call-get-pci-status.patch
+++ b/x11-packages/librewolf/0019-do-not-call-get-pci-status.patch
@@ -1,0 +1,1 @@
+../firefox/0019-do-not-call-get-pci-status.patch

--- a/x11-packages/librewolf/0020-fix-missing-include-for-zlib-module.patch
+++ b/x11-packages/librewolf/0020-fix-missing-include-for-zlib-module.patch
@@ -1,0 +1,1 @@
+../firefox/0020-fix-missing-include-for-zlib-module.patch

--- a/x11-packages/librewolf/0021-configure-no-pack-relative-relocs.patch
+++ b/x11-packages/librewolf/0021-configure-no-pack-relative-relocs.patch
@@ -1,0 +1,1 @@
+../firefox/0021-configure-no-pack-relative-relocs.patch

--- a/x11-packages/librewolf/0022-check-if-dlpi_name-is-nullptr-before-using.patch
+++ b/x11-packages/librewolf/0022-check-if-dlpi_name-is-nullptr-before-using.patch
@@ -1,0 +1,1 @@
+../firefox/0022-check-if-dlpi_name-is-nullptr-before-using.patch

--- a/x11-packages/librewolf/0023-fix-missing-include-for-macro-MOZ_TRY-in-TimeZone.cpp.patch
+++ b/x11-packages/librewolf/0023-fix-missing-include-for-macro-MOZ_TRY-in-TimeZone.cpp.patch
@@ -1,0 +1,1 @@
+../firefox/0023-fix-missing-include-for-macro-MOZ_TRY-in-TimeZone.cpp.patch

--- a/x11-packages/librewolf/0025-webextensions.storage.sync.kinto-true.patch
+++ b/x11-packages/librewolf/0025-webextensions.storage.sync.kinto-true.patch
@@ -1,0 +1,1 @@
+../firefox/0025-webextensions.storage.sync.kinto-true.patch

--- a/x11-packages/librewolf/0026-fix-popup-white-borders.patch
+++ b/x11-packages/librewolf/0026-fix-popup-white-borders.patch
@@ -1,0 +1,1 @@
+../firefox/0026-fix-popup-white-borders.patch

--- a/x11-packages/librewolf/0027-fix-tagged-pointer.patch
+++ b/x11-packages/librewolf/0027-fix-tagged-pointer.patch
@@ -1,0 +1,1 @@
+../firefox/0027-fix-tagged-pointer.patch

--- a/x11-packages/librewolf/0029-rust-cc-do-not-concatenates-all-the-CFLAGS.patch
+++ b/x11-packages/librewolf/0029-rust-cc-do-not-concatenates-all-the-CFLAGS.patch
@@ -1,0 +1,1 @@
+../firefox/0029-rust-cc-do-not-concatenates-all-the-CFLAGS.patch

--- a/x11-packages/librewolf/1001-disable-native-https-dns-resolve.patch
+++ b/x11-packages/librewolf/1001-disable-native-https-dns-resolve.patch
@@ -1,0 +1,32 @@
+--- a/netwerk/dns/nsHostResolver.cpp
++++ b/netwerk/dns/nsHostResolver.cpp
+@@ -174,6 +174,8 @@ nsresult nsHostResolver::Init() MOZ_NO_THREAD_SAFETY_ANALYSIS {
+   // It returns a success code, but no records. We only allow
+   // native HTTPS records on Win 11 for now.
+   sNativeHTTPSSupported = mozilla::IsWin11OrLater();
++#elif defined(__TERMUX__)
++  sNativeHTTPSSupported = false;
+ #elif defined(MOZ_WIDGET_ANDROID)
+   // android_res_nquery only got added in API level 29
+   sNativeHTTPSSupported = jni::GetAPIVersion() >= 29;
+--- a/netwerk/dns/moz.build
++++ b/netwerk/dns/moz.build
+@@ -53,17 +53,7 @@
+     "nsEffectiveTLDService.cpp",  # Excluded from UNIFIED_SOURCES due to special build flags.
+ ]
+ 
+-if CONFIG["MOZ_WIDGET_TOOLKIT"] == "windows":
+-    SOURCES += ["PlatformDNSWin.cpp"]
+-elif CONFIG["OS_TARGET"] == "Linux":
+-    SOURCES += ["PlatformDNSUnix.cpp"]
+-    OS_LIBS += ["resolv"]
+-elif CONFIG["MOZ_WIDGET_TOOLKIT"] == "cocoa":
+-    SOURCES += ["PlatformDNSMac.cpp"]
+-elif CONFIG["MOZ_WIDGET_TOOLKIT"] == "android":
+-    SOURCES += ["PlatformDNSAndroid.cpp"]
+-else:
+-    DEFINES["MOZ_NO_HTTPS_IMPL"] = 1
++DEFINES["MOZ_NO_HTTPS_IMPL"] = 1
+ 
+ UNIFIED_SOURCES += [
+     "ChildDNSService.cpp",

--- a/x11-packages/librewolf/1002-prepend-prefix-to-nsXREDirProvider-absolute-paths.patch
+++ b/x11-packages/librewolf/1002-prepend-prefix-to-nsXREDirProvider-absolute-paths.patch
@@ -1,0 +1,29 @@
+--- a/toolkit/xre/nsXREDirProvider.cpp	2026-02-24 12:06:24.000000000 -0500
++++ b/toolkit/xre/nsXREDirProvider.cpp	2026-03-03 20:20:37.501153213 -0500
+@@ -334,7 +334,7 @@
+ #    elif defined(__OpenBSD__) || defined(__FreeBSD__)
+       "/usr/local/lib/"_ns + aName
+ #    else
+-      "/usr/lib/"_ns + aName
++      "@TERMUX_PREFIX@/lib/mozilla"_ns
+ #    endif
+       ;
+   rv = NS_NewNativeLocalFile(dirname, getter_AddRefs(localDir));
+@@ -452,7 +452,7 @@
+ #    if defined(__OpenBSD__) || defined(__FreeBSD__)
+     static const char* const sysLExtDir = "/usr/local/share/librewolf/extensions";
+ #    else
+-    static const char* const sysLExtDir = "/usr/share/librewolf/extensions";
++    static const char* const sysLExtDir = "@TERMUX_PREFIX@/share/mozilla/extensions";
+ #    endif
+     rv = NS_NewNativeLocalFile(nsDependentCString(sysLExtDir),
+                                getter_AddRefs(file));
+@@ -465,7 +465,7 @@
+ #endif
+   } else if (!strcmp(aProperty, XRE_USER_RUNTIME_DIR)) {
+ #if defined(XP_UNIX)
+-    nsPrintfCString path("/run/user/%d/%s/", getuid(), GetAppName());
++    nsPrintfCString path("@TERMUX_PREFIX@/var/run/user/%d/%s/", getuid(), GetAppName());
+     ToLowerCase(path);
+     rv = NS_NewNativeLocalFile(path, getter_AddRefs(file));
+ #endif

--- a/x11-packages/librewolf/build.sh
+++ b/x11-packages/librewolf/build.sh
@@ -1,0 +1,154 @@
+TERMUX_PKG_HOMEPAGE=https://librewolf.net/
+TERMUX_PKG_DESCRIPTION="A custom version of Firefox, focused on privacy, security and freedom."
+TERMUX_PKG_LICENSE="MPL-2.0"
+TERMUX_PKG_MAINTAINER="@3ls-it"
+TERMUX_PKG_VERSION="148.0.2-2"
+TERMUX_PKG_SRCURL="https://codeberg.org/api/packages/librewolf/generic/librewolf-source/${TERMUX_PKG_VERSION}/librewolf-${TERMUX_PKG_VERSION}.source.tar.gz"
+TERMUX_PKG_SHA256=659e320b09ab5a71a05c3183e0f0592ea79d707f377fb8c301233e299183876c
+# ffmpeg and pulseaudio are dependencies through dlopen(3):
+TERMUX_PKG_DEPENDS="ffmpeg, fontconfig, freetype, gdk-pixbuf, glib, gtk3, libandroid-shmem, libandroid-spawn, libc++, libcairo, libevent, libffi, libice, libicu, libjpeg-turbo, libnspr, libnss, libpixman, libsm, libvpx, libwebp, libx11, libxcb, libxcomposite, libxdamage, libxext, libxfixes, libxrandr, libxtst, pango, pulseaudio, zlib"
+TERMUX_PKG_BUILD_DEPENDS="libcpufeatures, libice, libsm"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+
+
+termux_pkg_auto_update() {
+	local api_url="https://codeberg.org/api/v1/repos/librewolf/source/releases?draft=false&pre-release=false"
+	local e=0
+	local latest_version
+	latest_version="$(
+		curl -fsL \
+			-A "Termux update checker 1.1 (github.com/termux/termux-packages)" \
+			-H "accept: application/json" \
+			"$api_url" \
+		| jq -r '.[0].tag_name'
+	)"
+
+	local uptime_now=$(cat /proc/uptime)
+	local uptime_s="${uptime_now//.*}"
+	local uptime_h_limit=2
+	local uptime_s_limit=$((uptime_h_limit*60*60))
+	[[ -z "${uptime_s}" ]] && [[ "$(uname -o)" != "Android" ]] && e=1
+	[[ "${uptime_s}" == 0 ]] && [[ "$(uname -o)" != "Android" ]] && e=1
+	[[ "${uptime_s}" -gt "${uptime_s_limit}" ]] && e=1
+
+	if [[ "${e}" != 0 ]]; then
+		cat <<- EOL >&2
+		WARN: Auto update failure!
+		api_url_r=${api_url_r}
+		latest_version=${latest_version}
+		uptime_now=${uptime_now}
+		uptime_s=${uptime_s}
+		uptime_s_limit=${uptime_s_limit}
+		EOL
+		return
+	fi
+
+	termux_pkg_upgrade_version "$latest_version"
+}
+
+termux_step_post_get_source() {
+	local f="media/ffvpx/config_unix_aarch64.h"
+	echo "Applying sed substitution to ${f}"
+	sed -E '/^#define (CONFIG_LINUX_PERF|HAVE_SYSCTL) /s/1$/0/' -i ${f}
+
+	# Update Cargo.toml to use the patched cc
+	sed -i 's|^\(\[patch\.crates-io\]\)$|\1\ncc = { path = "third_party/rust/cc" }|g' \
+		Cargo.toml
+	(
+		termux_setup_rust
+		cargo update -p cc
+	)
+}
+
+termux_step_pre_configure() {
+	termux_setup_nodejs
+	termux_setup_rust
+
+	# https://github.com/rust-lang/rust/issues/49853
+	# https://github.com/rust-lang/rust/issues/45854
+	# Out of memory when building gkrust
+	# CI shows (signal: 9, SIGKILL: kill)
+	if [ "$TERMUX_DEBUG_BUILD" = false ]; then
+		local env_host=$(printf $CARGO_TARGET_NAME | tr a-z A-Z | sed s/-/_/g)
+		export CARGO_TARGET_${env_host}_RUSTFLAGS+=" -C debuginfo=1"
+	fi
+
+	cargo install cbindgen --locked
+
+	export HOST_CC=$(command -v clang)
+	export HOST_CXX=$(command -v clang++)
+
+	export BINDGEN_CFLAGS="--target=$CCTERMUX_HOST_PLATFORM --sysroot=$TERMUX_STANDALONE_TOOLCHAIN/sysroot"
+	local env_name=BINDGEN_EXTRA_CLANG_ARGS_${CARGO_TARGET_NAME@U}
+	env_name=${env_name//-/_}
+	export $env_name="$BINDGEN_CFLAGS"
+
+	# https://reviews.llvm.org/D141184
+	CXXFLAGS+=" -U__ANDROID__ -D_LIBCPP_HAS_NO_C11_ALIGNED_ALLOC"
+	LDFLAGS+=" -landroid-shmem -landroid-spawn -llog"
+
+	if [ "$TERMUX_ARCH" = "arm" ]; then
+		# For symbol android_getCpuFeatures
+		LDFLAGS+=" -l:libndk_compat.a"
+	fi
+}
+
+termux_step_configure() {
+	if [ "$TERMUX_CONTINUE_BUILD" == "true" ]; then
+		termux_step_pre_configure
+		cd $TERMUX_PKG_SRCDIR
+	fi
+
+	# There can be only one!
+	rm -f .mozconfig mozconfig
+	sed \
+		-e "s|@TERMUX_HOST_PLATFORM@|${TERMUX_HOST_PLATFORM}|" \
+		-e "s|@TERMUX_PREFIX@|${TERMUX_PREFIX}|" \
+		-e "s|@CARGO_TARGET_NAME@|${CARGO_TARGET_NAME}|" \
+		"$TERMUX_PKG_BUILDER_DIR/mozconfig.cfg" > .mozconfig
+
+	if [ "$TERMUX_DEBUG_BUILD" = true ]; then
+		cat >>.mozconfig - <<END
+ac_add_options --enable-debug-symbols
+ac_add_options --disable-install-strip
+END
+	fi
+
+	./mach configure
+}
+
+termux_step_make() {
+	./mach build -j "$TERMUX_PKG_MAKE_PROCESSES"
+	./mach buildsymbols
+}
+
+termux_step_make_install() {
+	./mach install
+
+	install -Dm644 -t "${TERMUX_PREFIX}/share/applications" "${TERMUX_PKG_BUILDER_DIR}/librewolf.desktop"
+
+	# Install icons for LibreWolf branding
+	local i theme=librewolf
+	# LibreWolf icon sizes: 16, 31, 48, 64, 128
+	for i in 16 32 48 64 128; do
+		install -Dvm644 "browser/branding/$theme/default$i.png" \
+			"$TERMUX_PREFIX/share/icons/hicolor/${i}x${i}/apps/$TERMUX_PKG_NAME.png"
+	done
+	install -Dvm644 "browser/branding/$theme/content/about-logo.png" \
+		"$TERMUX_PREFIX/share/icons/hicolor/192x192/apps/$TERMUX_PKG_NAME.png"
+	install -Dvm644 "browser/branding/$theme/content/about-logo@2x.png" \
+		"$TERMUX_PREFIX/share/icons/hicolor/384x384/apps/$TERMUX_PKG_NAME.png"
+	install -Dvm644 "browser/branding/$theme/content/about-logo.svg" \
+		"$TERMUX_PREFIX/share/icons/hicolor/scalable/apps/$TERMUX_PKG_NAME.svg"
+}
+
+termux_step_post_make_install() {
+	# https://github.com/termux/termux-packages/issues/18429
+	# https://phabricator.services.mozilla.com/D181687
+	# Android 8.x and older not support "-z pack-relative-relocs" / DT_RELR
+	local r=$("${READELF}" -d "${TERMUX_PREFIX}/bin/librewolf")
+	if [[ -n "$(echo "${r}" | grep "(RELR)")" ]]; then
+		termux_error_exit "DT_RELR is unsupported on Android 8.x and older\n${r}"
+	fi
+}

--- a/x11-packages/librewolf/librewolf.desktop
+++ b/x11-packages/librewolf/librewolf.desktop
@@ -1,0 +1,24 @@
+[Desktop Entry]
+Version=1.0
+Name=LibreWolf Web Browser
+Comment=Browse the World Wide Web
+GenericName=Web Browser
+Keywords=Internet;WWW;Browser;Web;Explorer
+Exec=librewolf %u
+Terminal=false
+X-MultipleArgs=false
+Type=Application
+Icon=librewolf
+Categories=GNOME;GTK;Network;WebBrowser;
+MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;video/webm;application/x-xpinstall;
+StartupNotify=true
+StartupWMClass=librewolf
+Actions=new-window;new-private-window;
+
+[Desktop Action new-window]
+Name=Open a New Window
+Exec=librewolf -new-window
+
+[Desktop Action new-private-window]
+Name=Open a New Private Window
+Exec=librewolf -private-window

--- a/x11-packages/librewolf/mozconfig.cfg
+++ b/x11-packages/librewolf/mozconfig.cfg
@@ -1,0 +1,57 @@
+# Cross compile options
+ac_add_options --target=@TERMUX_HOST_PLATFORM@
+ac_add_options --prefix=@TERMUX_PREFIX@
+ac_add_options --with-sysroot=@TERMUX_PREFIX@
+ac_add_options --custom-rust-target-triple=@CARGO_TARGET_NAME@
+ac_add_options --libdir=@TERMUX_PREFIX@/lib
+
+# LibreWolf identity
+ac_add_options --enable-application=browser
+ac_add_options --with-branding=browser/branding/librewolf
+ac_add_options --disable-default-browser-agent
+
+# LibreWolf privacy posture
+export MOZ_REQUIRE_SIGNING=
+ac_add_options --with-unsigned-addon-scopes=app,system
+mk_add_options MOZ_DATA_REPORTING=0
+mk_add_options MOZ_TELEMETRY_REPORTING=0
+mk_add_options MOZ_SERVICES_HEALTHREPORT=0
+mk_add_options MOZ_CRASHREPORTER=0
+
+# System libraries (keep Firefox recipe choices)
+ac_add_options --enable-system-ffi
+ac_add_options --enable-system-pixman
+ac_add_options --with-system-icu
+ac_add_options --with-system-jpeg=@TERMUX_PREFIX@
+ac_add_options --with-system-libevent
+ac_add_options --with-system-libvpx
+ac_add_options --with-system-nspr
+ac_add_options --with-system-nss
+ac_add_options --with-system-webp
+ac_add_options --with-system-zlib
+
+# Features
+ac_add_options --enable-audio-backends=pulseaudio
+ac_add_options --enable-default-toolkit=cairo-gtk3-x11-only
+ac_add_options --enable-minify=properties
+ac_add_options --enable-mobile-optimize
+ac_add_options --enable-printing
+# Hardening: builds and runs on-device; RELRO+BIND_NOW and NX stack verified
+ac_add_options --enable-hardening
+ac_add_options --disable-jemalloc
+ac_add_options --disable-updater
+ac_add_options --disable-sandbox
+ac_add_options --disable-tests
+ac_add_options --disable-accessibility
+ac_add_options --disable-crashreporter
+ac_add_options --disable-dbus
+ac_add_options --disable-necko-wifi
+ac_add_options --disable-parental-controls
+ac_add_options --disable-webspeech
+ac_add_options --disable-synth-speechd
+ac_add_options --disable-elf-hack
+ac_add_options --disable-address-sanitizer-reporter
+ac_add_options --without-wasm-sandboxed-libraries
+# System addons
+ac_add_options --allow-addon-sideload
+


### PR DESCRIPTION
### This PR adds a new package: `x11-packages/librewolf` targeting LibreWolf **148.0.2-2**

- New package: LibreWolf 148.0.2-2 (Firefox-based, privacy-focused browser)
- Builds from upstream tarball at https://codeberg.org/api/packages/librewolf/generic/librewolf-source/148.0.2-2/librewolf-148.0.2-2.source.tar.gz
- Reuses Firefox patchset; regenerated only `0024-` and `0028-` for shifted hunks
  - `0024-disable-native-https-dns-resolve.patch` (nsHostResolver.cpp)
  - `0028-prepend-prefix-to-nsXREDirProvider-absolute-paths.patch` (nsXREDirProvider.cpp)
- LibreWolf branding + privacy defaults via `mozconfig.cfg`
- Enabled hardening (builds and runs on-device; RELRO/NX confirmed)
- Co-installable with Firefox package (`$PREFIX/bin/librewolf` and `$PREFIX/lib/librewolf/`)
- Builds in package-builder Docker image
- Installed and tested under Termux:X11