### PR TITLE
fix(main/atuin): fix `panicked: Expect rustls-platform-verifier to be initialized`

### DIFF
--- a/packages/atuin/build.sh
+++ b/packages/atuin/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="../../LICENSE"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="18.12.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/atuinsh/atuin/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=8643a7df1e366e9ad3134514b9bcaf4d6440accb13c64340ec9ec1923d58eb6e
 TERMUX_PKG_AUTO_UPDATE=true
@@ -24,6 +25,23 @@ termux_step_pre_configure() {
 
 	# clash with rust host build
 	unset CFLAGS
+
+	cargo vendor
+	find ./vendor \
+		-mindepth 1 -maxdepth 1 -type d \
+		! -wholename ./vendor/rustls-platform-verifier \
+		-exec rm -rf '{}' \;
+
+	find vendor/rustls-platform-verifier -type f -print0 | \
+		xargs -0 sed -i \
+		-e 's|"android"|"disabling_this_because_it_is_for_building_an_apk"|g' \
+		-e "s|ANDROID|DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK|g" \
+		-e 's|"linux"|"android"|g'
+
+	echo "" >> Cargo.toml
+	echo '[patch.crates-io]' >> Cargo.toml
+	echo 'rustls-platform-verifier = { path = "./vendor/rustls-platform-verifier" }' >> Cargo.toml
+
 }
 
 termux_step_post_make_install() {


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28849

- Like https://github.com/termux/termux-packages/pull/28631 and https://github.com/termux/termux-packages/pull/28323, but for `atuin`