### PR TITLE
fix: setting /proc/sys/kernel/pid_max for proot

### DIFF
--- a/.github/workflows/golang_validation.yml
+++ b/.github/workflows/golang_validation.yml
@@ -43,8 +43,6 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 1
-    - name: Set process id limit for 32-bit builds depending on aosp-libs
-      run: echo 65535 | sudo tee /proc/sys/kernel/pid_max
     - name: Enable zram
       if: ${{ steps.build-info.outputs.skip-building != 'true' }}
       uses: ./.github/actions/zram

--- a/.github/workflows/package_updates.yml
+++ b/.github/workflows/package_updates.yml
@@ -104,8 +104,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.TERMUXBOT2_TOKEN }}
-      - name: Set process id limit for 32-bit builds depending on aosp-libs
-        run: echo 65535 | sudo tee /proc/sys/kernel/pid_max
       - name: Enable zram
         uses: ./.github/actions/zram
         with:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -47,8 +47,6 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 1000
-    - name: Set process id limit for 32-bit builds depending on aosp-libs
-      run: echo 65535 | sudo tee /proc/sys/kernel/pid_max
 
     - name: Gather build summary
       id: build-info

--- a/.github/workflows/zig_validation.yml
+++ b/.github/workflows/zig_validation.yml
@@ -43,8 +43,6 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 1
-    - name: Set process id limit for 32-bit builds depending on aosp-libs
-      run: echo 65535 | sudo tee /proc/sys/kernel/pid_max
     - name: Enable zram
       if: ${{ steps.build-info.outputs.skip-building != 'true' }}
       uses: ./.github/actions/zram

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e -u
+set -eou pipefail
 
 TERMUX_SCRIPTDIR=$(cd "$(realpath "$(dirname "$0")")"; cd ..; pwd)
 : ${TERMUX_BUILDER_IMAGE_NAME:=ghcr.io/termux/package-builder}
@@ -171,6 +171,24 @@ $SUDO docker start $CONTAINER_NAME >/dev/null 2>&1 || {
 			$SUDO docker exec $DOCKER_TTY $TERMUX_DOCKER_EXEC_EXTRA_ARGS $CONTAINER_NAME sudo chown -R $(id -u):$(id -g) /data
 			$SUDO docker exec $DOCKER_TTY $TERMUX_DOCKER_EXEC_EXTRA_ARGS $CONTAINER_NAME sudo usermod -u $(id -u) builder
 			$SUDO docker exec $DOCKER_TTY $TERMUX_DOCKER_EXEC_EXTRA_ARGS $CONTAINER_NAME sudo groupmod -g $(id -g) builder
+		fi
+		echo "Changing /proc/sys/kernel/pid_max to 65535 for packages that need to run native executables using proot (for 32-bit architectures)"
+		if [[ "$($SUDO docker exec $CONTAINER_NAME cat /proc/sys/kernel/pid_max)" -le 65535 ]]; then
+			echo "No need to change /proc/sys/kernel/pid_max, current value is $($SUDO docker exec $DOCKER_TTY $CONTAINER_NAME cat /proc/sys/kernel/pid_max)"
+		else
+			# On kernel versions >= 6.14, the pid_max value is pid namespaced, so we need to set it in the container namespace instead of host.
+			# But some distributions may backport the pid namespacing to older kernels, so we check whether it's effective by checking the value in the container after setting it.
+			$SUDO docker run --privileged --pid="container:$CONTAINER_NAME" --rm "$TERMUX_BUILDER_IMAGE_NAME" sh -c "echo 65535 | sudo tee /proc/sys/kernel/pid_max > /dev/null" || :
+			if [[ "$($SUDO docker exec $CONTAINER_NAME cat /proc/sys/kernel/pid_max)" -eq 65535 ]]; then
+				echo "Successfully changed /proc/sys/kernel/pid_max for container namespace"
+			else
+				echo "Failed to change /proc/sys/kernel/pid_max for container, failing back to setting it on host..."
+				if ( echo 65535 | sudo tee /proc/sys/kernel/pid_max >/dev/null ); then
+					echo "Successfully changed /proc/sys/kernel/pid_max on host, but it may affect other processes on the host system"
+				else
+					echo "Failed to change /proc/sys/kernel/pid_max on host as well, some packages that need to run native executables using proot (for 32-bit architectures) may not work properly"
+				fi
+			fi
 		fi
 	fi
 }

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eou pipefail
+set -euo pipefail
 
 TERMUX_SCRIPTDIR=$(cd "$(realpath "$(dirname "$0")")"; cd ..; pwd)
 : ${TERMUX_BUILDER_IMAGE_NAME:=ghcr.io/termux/package-builder}
@@ -153,17 +153,7 @@ load_apparmor_profile() {
 # Load the relaxed AppArmor profile first as we might need to change permissions
 load_apparmor_profile ./scripts/profile-relaxed.apparmor
 
-$SUDO docker start $CONTAINER_NAME >/dev/null 2>&1 || {
-	echo "Creating new container..."
-	$SUDO docker run \
-		--detach \
-		--init \
-		--name $CONTAINER_NAME \
-		--volume $VOLUME \
-		$SEC_OPT \
-		--tty \
-		$TERMUX_DOCKER_RUN_EXTRA_ARGS \
-		$TERMUX_BUILDER_IMAGE_NAME
+__change_builder_uid_gid() {
 	if [ "$UNAME" != Darwin ]; then
 		if [ $(id -u) -ne 1001 -a $(id -u) -ne 0 ]; then
 			echo "Changed builder uid/gid... (this may take a while)"
@@ -172,6 +162,11 @@ $SUDO docker start $CONTAINER_NAME >/dev/null 2>&1 || {
 			$SUDO docker exec $DOCKER_TTY $TERMUX_DOCKER_EXEC_EXTRA_ARGS $CONTAINER_NAME sudo usermod -u $(id -u) builder
 			$SUDO docker exec $DOCKER_TTY $TERMUX_DOCKER_EXEC_EXTRA_ARGS $CONTAINER_NAME sudo groupmod -g $(id -g) builder
 		fi
+	fi
+}
+
+__change_container_pid_max() {
+	if [ "$UNAME" != Darwin ]; then
 		echo "Changing /proc/sys/kernel/pid_max to 65535 for packages that need to run native executables using proot (for 32-bit architectures)"
 		if [[ "$($SUDO docker exec $CONTAINER_NAME cat /proc/sys/kernel/pid_max)" -le 65535 ]]; then
 			echo "No need to change /proc/sys/kernel/pid_max, current value is $($SUDO docker exec $DOCKER_TTY $CONTAINER_NAME cat /proc/sys/kernel/pid_max)"
@@ -192,6 +187,27 @@ $SUDO docker start $CONTAINER_NAME >/dev/null 2>&1 || {
 		fi
 	fi
 }
+
+
+if ! $SUDO docker container inspect $CONTAINER_NAME > /dev/null 2>&1; then
+	echo "Creating new container..."
+	$SUDO docker run \
+		--detach \
+		--init \
+		--name $CONTAINER_NAME \
+		--volume $VOLUME \
+		$SEC_OPT \
+		--tty \
+		$TERMUX_DOCKER_RUN_EXTRA_ARGS \
+		$TERMUX_BUILDER_IMAGE_NAME
+	__change_builder_uid_gid
+	__change_container_pid_max
+fi
+
+if [[ "$($SUDO docker container inspect -f '{{ .State.Running }}' $CONTAINER_NAME)" == "false" ]]; then
+	$SUDO docker start $CONTAINER_NAME >/dev/null 2>&1
+	__change_container_pid_max
+fi
 
 load_apparmor_profile ./scripts/profile-restricted.apparmor "Loading restricted AppArmor profile"
 

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -177,7 +177,7 @@ __change_container_pid_max() {
 			if [[ "$($SUDO docker exec $CONTAINER_NAME cat /proc/sys/kernel/pid_max)" -eq 65535 ]]; then
 				echo "Successfully changed /proc/sys/kernel/pid_max for container namespace"
 			else
-				echo "Failed to change /proc/sys/kernel/pid_max for container, failing back to setting it on host..."
+				echo "Failed to change /proc/sys/kernel/pid_max for container, falling back to setting it on host..."
 				if ( echo 65535 | sudo tee /proc/sys/kernel/pid_max >/dev/null ); then
 					echo "Successfully changed /proc/sys/kernel/pid_max on host, but it may affect other processes on the host system"
 				else


### PR DESCRIPTION
I've tested this on Linux 6.18 shipped by Arch. I wanted to check if this is working on users who have kernel versions < 6.14. As pid_max value isn't namespaced on older kernels.

Also this changes the place where we change the pid_max value from GitHub Actions workflow script to `./scripts/run-docker.sh`
