### PR TITLE
ci: do go and zig validation inside docker

### DIFF
--- a/.github/workflows/golang_validation.yml
+++ b/.github/workflows/golang_validation.yml
@@ -51,11 +51,13 @@ jobs:
         size: 16G
         priority: 100
         device_name: /dev/zram0
-    - name: Prepare environment
+    - name: Load Docker image
+      if: ${{ steps.build-info.outputs.free-space == 'true' && steps.build-info.outputs.skip-building != 'true' }}
       run: |
-        ./scripts/setup-ubuntu.sh
-        ./scripts/setup-android-sdk.sh
-        sudo apt install ninja-build
+        ./scripts/run-docker.sh echo ""
+    - name: Free additional disk space (if needed)
+      if: ${{ steps.build-info.outputs.free-space == 'true' && steps.build-info.outputs.skip-building != 'true' }}
+      run: |
         ./scripts/free-space.sh
     - name: Golang validation
       run: ./scripts/bin/validation ${{ matrix.target_arch }} golang ${{ matrix.batch }} || exit 1

--- a/.github/workflows/golang_validation.yml
+++ b/.github/workflows/golang_validation.yml
@@ -52,7 +52,7 @@ jobs:
         device_name: /dev/zram0
     - name: Load Docker image
       run: |
-        ./scripts/run-docker.sh echo ""
+        ./scripts/run-docker.sh true
     - name: Free additional disk space
       run: |
         ./scripts/free-space.sh

--- a/.github/workflows/golang_validation.yml
+++ b/.github/workflows/golang_validation.yml
@@ -44,7 +44,6 @@ jobs:
       with:
         fetch-depth: 1
     - name: Enable zram
-      if: ${{ steps.build-info.outputs.skip-building != 'true' }}
       uses: ./.github/actions/zram
       with:
         algorithm: zstd
@@ -52,11 +51,9 @@ jobs:
         priority: 100
         device_name: /dev/zram0
     - name: Load Docker image
-      if: ${{ steps.build-info.outputs.free-space == 'true' && steps.build-info.outputs.skip-building != 'true' }}
       run: |
         ./scripts/run-docker.sh echo ""
-    - name: Free additional disk space (if needed)
-      if: ${{ steps.build-info.outputs.free-space == 'true' && steps.build-info.outputs.skip-building != 'true' }}
+    - name: Free additional disk space
       run: |
         ./scripts/free-space.sh
     - name: Golang validation

--- a/.github/workflows/package_updates.yml
+++ b/.github/workflows/package_updates.yml
@@ -113,7 +113,7 @@ jobs:
           device_name: /dev/zram0
       - name: Load Docker image
         run: |
-          ./scripts/run-docker.sh echo ""
+          ./scripts/run-docker.sh true
       - name: Free additional disk space
         run: ./scripts/free-space.sh
       - name: Install needed dependencies for package updates

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -247,7 +247,7 @@ jobs:
     - name: Load Docker image
       if: ${{ steps.build-info.outputs.free-space == 'true' && steps.build-info.outputs.skip-building != 'true' }}
       run: |
-        ./scripts/run-docker.sh echo ""
+        ./scripts/run-docker.sh true
 
     - name: Free additional disk space (if needed)
       if: ${{ steps.build-info.outputs.free-space == 'true' && steps.build-info.outputs.skip-building != 'true' }}

--- a/.github/workflows/zig_validation.yml
+++ b/.github/workflows/zig_validation.yml
@@ -52,7 +52,7 @@ jobs:
         device_name: /dev/zram0
     - name: Load Docker image
       run: |
-        ./scripts/run-docker.sh echo ""
+        ./scripts/run-docker.sh true
     - name: Free additional disk space
       run: |
         ./scripts/free-space.sh

--- a/.github/workflows/zig_validation.yml
+++ b/.github/workflows/zig_validation.yml
@@ -51,10 +51,13 @@ jobs:
         size: 16G
         priority: 100
         device_name: /dev/zram0
-    - name: Prepare environment
+    - name: Load Docker image
+      if: ${{ steps.build-info.outputs.free-space == 'true' && steps.build-info.outputs.skip-building != 'true' }}
       run: |
-        ./scripts/setup-ubuntu.sh
-        ./scripts/setup-android-sdk.sh
+        ./scripts/run-docker.sh echo ""
+    - name: Free additional disk space (if needed)
+      if: ${{ steps.build-info.outputs.free-space == 'true' && steps.build-info.outputs.skip-building != 'true' }}
+      run: |
         ./scripts/free-space.sh
     - name: Zig validation
       run: ./scripts/bin/validation ${{ matrix.target_arch }} zig ${{ matrix.batch }} || exit 1

--- a/.github/workflows/zig_validation.yml
+++ b/.github/workflows/zig_validation.yml
@@ -44,7 +44,6 @@ jobs:
       with:
         fetch-depth: 1
     - name: Enable zram
-      if: ${{ steps.build-info.outputs.skip-building != 'true' }}
       uses: ./.github/actions/zram
       with:
         algorithm: zstd
@@ -52,11 +51,9 @@ jobs:
         priority: 100
         device_name: /dev/zram0
     - name: Load Docker image
-      if: ${{ steps.build-info.outputs.free-space == 'true' && steps.build-info.outputs.skip-building != 'true' }}
       run: |
         ./scripts/run-docker.sh echo ""
-    - name: Free additional disk space (if needed)
-      if: ${{ steps.build-info.outputs.free-space == 'true' && steps.build-info.outputs.skip-building != 'true' }}
+    - name: Free additional disk space
       run: |
         ./scripts/free-space.sh
     - name: Zig validation

--- a/scripts/bin/validation
+++ b/scripts/bin/validation
@@ -192,7 +192,7 @@ maybe_cleanup() {
 		return
 	fi
 
-	./clean.sh
+	./scripts/run-docker.sh ./clean.sh
 	rm -rf ./output/*
 }
 
@@ -215,7 +215,7 @@ for package in "${PACKAGES[@]}"; do
 		# Header
 		echo "INFO: Building ${package} for ${ARCH}"
 		maybe_cleanup "${package}"
-		./build-package.sh -I -f -a "${ARCH}" "${package}"
+		./scripts/run-docker.sh ./build-package.sh -I -f -a "${ARCH}" "${package}"
 		status="${PIPESTATUS[0]}"
 		echo # newline
 		echo "INFO: Building ${package} for ${ARCH} took $(ms_to_human_readable $(( $(date +%10s%3N) - start )))"


### PR DESCRIPTION
Seems like we missed this during #28627 where we enabled docker builds to be the only ones supported for building packages. So catch up with it.
    
Detected by GitHub Copilot when asked to review for another unrelated change in private fork. See:

https://github.com/thunder-coding/termux-packages/pull/19#discussion_r2905347616
https://github.com/thunder-coding/termux-packages/pull/19#discussion_r2905347662