### PR TITLE
fix(x11/plasma-pa): enable displaying virtual devices by default

### DIFF
--- a/x11-packages/plasma-pa/build.sh
+++ b/x11-packages/plasma-pa/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Plasma applet for audio volume management using PulseAud
 TERMUX_PKG_LICENSE="LGPL-2.0-or-later"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="6.6.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://download.kde.org/stable/plasma/${TERMUX_PKG_VERSION}/plasma-pa-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=9452255cbca5eecb545fb17417b1abe6471103f0e2aeac7eb7c0022bcaa19754
 TERMUX_PKG_AUTO_UPDATE=true

--- a/x11-packages/plasma-pa/enable-virtual-devices-by-default.patch
+++ b/x11-packages/plasma-pa/enable-virtual-devices-by-default.patch
@@ -1,0 +1,11 @@
+--- a/applet/main.xml
++++ b/applet/main.xml
+@@ -39,7 +39,7 @@
+       <default>false</default>
+     </entry>
+     <entry name="showVirtualDevices" type="Bool">
+-      <default>false</default>
++      <default>true</default>
+     </entry>
+     <entry name="migrated" type="Bool">
+       <default>false</default>


### PR DESCRIPTION
Now plasma shows virtual devices by default.
![pa-qt](https://github.com/user-attachments/assets/2547cce0-b43d-43ea-92ab-c4e4296b4f28)
