### PR TITLE
[TESTERS WANTED!!!] - enhance(x11/vim-gtk): enable `--with-wayland` features

### DIFF
--- a/packages/vim/build.sh
+++ b/packages/vim/build.sh
@@ -2,15 +2,16 @@ TERMUX_PKG_HOMEPAGE=https://www.vim.org
 TERMUX_PKG_DESCRIPTION="Vi IMproved - enhanced vi editor"
 TERMUX_PKG_LICENSE="VIM License"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
-TERMUX_PKG_BUILD_DEPENDS="luajit, perl, python, ruby, tcl"
+TERMUX_PKG_BUILD_DEPENDS="libwayland, luajit, perl, python, ruby, tcl"
 TERMUX_PKG_DEPENDS="libiconv, libsodium, ncurses"
-TERMUX_PKG_SUGGESTS="luajit, perl, python, ruby, tcl"
+TERMUX_PKG_SUGGESTS="libwayland, luajit, perl, python, ruby, tcl"
 TERMUX_PKG_RECOMMENDS="diffutils, xxd"
 TERMUX_PKG_CONFLICTS="vim-gtk"
 TERMUX_PKG_BREAKS="vim-python, vim-runtime"
 TERMUX_PKG_REPLACES="vim-python, vim-runtime"
 TERMUX_PKG_PROVIDES="vim-python"
 TERMUX_PKG_VERSION="9.2.0192"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/vim/vim/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=96108375ce605418f3c752da41cc2eea007f2d56aea49aef254df10c9fa4a8b7
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -45,8 +46,10 @@ vi_cv_var_python3_version=${TERMUX_PYTHON_VERSION}
 --enable-rubyinterp=dynamic
 --enable-tclinterp=dynamic
 --enable-gui=no
+--with-wayland
 --without-x
 "
+# --with-wayland only enables wayland protocol support, not windowing
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag" # Vim doesn't use release tags
 
@@ -78,6 +81,7 @@ termux_pkg_auto_update() {
 }
 
 termux_step_pre_configure() {
+	termux_setup_wayland_cross_pkg_config_wrapper
 	make distclean
 
 	# Remove eventually existing symlinks from previous builds so that they get re-created.

--- a/x11-packages/vim-gtk/build.sh
+++ b/x11-packages/vim-gtk/build.sh
@@ -2,15 +2,16 @@ TERMUX_PKG_HOMEPAGE=https://www.vim.org
 TERMUX_PKG_DESCRIPTION="Vi IMproved - enhanced vi editor"
 TERMUX_PKG_LICENSE="VIM License"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
-TERMUX_PKG_BUILD_DEPENDS="luajit, perl, python, ruby, tcl"
+TERMUX_PKG_BUILD_DEPENDS="libwayland, luajit, perl, python, ruby, tcl"
 TERMUX_PKG_DEPENDS="gdk-pixbuf, glib, gtk3, libcairo, libcanberra, libice, libiconv, libsm, libsodium, libx11, libxt, ncurses, pango"
 TERMUX_PKG_SUGGESTS="luajit, perl, python, ruby, tcl"
-TERMUX_PKG_RECOMMENDS="diffutils, xxd"
+TERMUX_PKG_RECOMMENDS="diffutils, libwayland, xxd"
 TERMUX_PKG_CONFLICTS="vim"
 TERMUX_PKG_BREAKS="vim-python"
 TERMUX_PKG_REPLACES="vim-python"
 TERMUX_PKG_PROVIDES="vim-python"
 TERMUX_PKG_VERSION="9.2.0192"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/vim/vim/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=96108375ce605418f3c752da41cc2eea007f2d56aea49aef254df10c9fa4a8b7
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -45,6 +46,7 @@ vi_cv_var_python3_version=${TERMUX_PYTHON_VERSION}
 --enable-rubyinterp=dynamic
 --enable-tclinterp=dynamic
 --enable-gui=gtk3
+--with-wayland
 --with-x
 "
 TERMUX_PKG_AUTO_UPDATE=true
@@ -78,6 +80,7 @@ termux_pkg_auto_update() {
 }
 
 termux_step_pre_configure() {
+	termux_setup_wayland_cross_pkg_config_wrapper
 	LDFLAGS+=" -landroid-shmem"
 
 	make distclean


### PR DESCRIPTION
This PR is intended to determine to what extent Vim-GTK's `--with-wayland` features[^1] work in Termux currently and whether that is a good enough state of things for us to ship a `--with-wayland` enabled `vim-gtk` package.

[^1]: https://vimhelp.org/wayland.txt.html

# Testing for this PR would be greatly appreciated!

<sup>(This is a pre-written, saved reply.)</sup>
If you want to test this PR please download the appropriate DEB package(s)
from the build artifacts of the [associated PR's latest CI run](https://github.com/termux/termux-packages/actions/runs/22890980884?pr=28863).

<img width="1029" height="1665" alt="image" src="https://github.com/user-attachments/assets/25aaf49a-c35a-4d3a-8130-5cf711dfc5ed" />

After downloading the build artifact, make sure to `unzip` and un-`tar` it.
<details><summary>Detailed instructions, if needed.</summary>
<p>

```bash
# finding out what architecture you need
# this is listed as part of `termux-info`.
termux-info

# e.g.
# [...]
# TERMUX__UID=10228
# TERMUX__USER_ID=0
# Packages CPU architecture:
# aarch64
# [...]

# =======================

# make sure `unzip` and `tar` are installed using
pkg install unzip tar

# unzip the artifact (if you have a different architecture this might be arm, i686 or x86_64 instead)
unzip debs-aarch64-*.zip

# untar the artifact
tar xf debs-aarch64-*.tar

# You should now have a debs/ directory in your current working directory
# Install the packages from the local source using
pkg install -- ./debs/*.deb

# to clean up, you can remove the debs/ directory, .tar file and .zip file
rm -rfi debs debs-aarch64-*.zip debs-aarch64-*.tar
```

</p>
</details> 