### PR TITLE
addpkg(main/python-trash-cli): 0.24.5.26

### DIFF
--- a/packages/python-psutil/android.patch
+++ b/packages/python-psutil/android.patch
@@ -11,3 +11,18 @@ https://github.com/giampaolo/psutil/issues/2743
  MACOS = sys.platform.startswith("darwin")
  OSX = MACOS  # deprecated alias
  FREEBSD = sys.platform.startswith(("freebsd", "midnightbsd"))
+--- a/psutil/_pslinux.py
++++ b/psutil/_pslinux.py
+@@ -1209,8 +1209,11 @@ def disk_partitions(all=False):
+     """Return mounted disk partitions as a list of namedtuples."""
+     fstypes = set()
+     procfs_path = get_procfs_path()
++    proc_filesystems_path = procfs_path + "/filesystems"
++    if not os.access(proc_filesystems_path, os.R_OK):
++        proc_filesystems_path = "@TERMUX_PREFIX@/etc/psutil/filesystems"
+     if not all:
+-        with open_text(f"{procfs_path}/filesystems") as f:
++        with open_text(proc_filesystems_path) as f:
+             for line in f:
+                 line = line.strip()
+                 if not line.startswith("nodev"):

--- a/packages/python-psutil/android.patch
+++ b/packages/python-psutil/android.patch
@@ -11,3 +11,59 @@ https://github.com/giampaolo/psutil/issues/2743
  MACOS = sys.platform.startswith("darwin")
  OSX = MACOS  # deprecated alias
  FREEBSD = sys.platform.startswith(("freebsd", "midnightbsd"))
+--- a/psutil/_pslinux.py
++++ b/psutil/_pslinux.py
+@@ -672,7 +672,13 @@ if os.path.exists("/sys/devices/system/cpu/cpufreq/policy0") or os.path.exists(
+                     msg = "can't find current frequency file"
+                     raise NotImplementedError(msg)
+             curr = int(curr) / 1000
+-            max_ = int(bcat(pjoin(path, "scaling_max_freq"))) / 1000
++            max_ = bcat(pjoin(path, "scaling_max_freq"), fallback=None)
++            if max_ is None:
++                max_ = bcat(pjoin(path, "cpuinfo_max_freq"), fallback=None)
++                if max_ is None:
++                    msg = "can't find max frequency file"
++                    raise NotImplementedError(msg)
++            max_ = int(max_) / 1000
+             min_ = int(bcat(pjoin(path, "scaling_min_freq"))) / 1000
+             ret.append(ntp.scpufreq(curr, min_, max_))
+         return ret
+@@ -1209,17 +1209,28 @@ def disk_partitions(all=False):
+     """Return mounted disk partitions as a list of namedtuples."""
+     fstypes = set()
+     procfs_path = get_procfs_path()
++    proc_filesystems_path = procfs_path + "/filesystems"
++    proc_self_mountinfo_path = procfs_path + "/self/mountinfo"
+     if not all:
+-        with open_text(f"{procfs_path}/filesystems") as f:
+-            for line in f:
+-                line = line.strip()
+-                if not line.startswith("nodev"):
+-                    fstypes.add(line.strip())
+-                else:
+-                    # ignore all lines starting with "nodev" except "nodev zfs"
+-                    fstype = line.split("\t")[1]
+-                    if fstype == "zfs":
+-                        fstypes.add("zfs")
++        if os.access(proc_filesystems_path, os.R_OK):
++            with open_text(proc_filesystems_path) as f:
++                for line in f:
++                    line = line.strip()
++                    if not line.startswith("nodev"):
++                        fstypes.add(line.strip())
++                    else:
++                        # ignore all lines starting with "nodev" except "nodev zfs"
++                        fstype = line.split("\t")[1]
++                        if fstype == "zfs":
++                            fstypes.add("zfs")
++        else:
++            with open_text(proc_self_mountinfo_path) as f:
++                for line in f:
++                    line = line.strip().split()
++                    if len(line) > 1:
++                        for i in range(len(line) - 1):
++                             if line[i] == "-":
++                                  fstypes.add(line[i + 1])
+ 
+     # See: https://github.com/giampaolo/psutil/issues/1307
+     if procfs_path == "/proc" and os.path.isfile('/etc/mtab'):

--- a/packages/python-psutil/build.sh
+++ b/packages/python-psutil/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Cross-platform process and system utilities module for P
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="7.2.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/giampaolo/psutil/archive/refs/tags/release-$TERMUX_PKG_VERSION.tar.gz"
 TERMUX_PKG_SHA256=38f406bf21acc67e45f414b7980463b2e6e6270ba3616ffd41995d997078cbe6
 TERMUX_PKG_DEPENDS="python, python-pip"
@@ -10,3 +11,71 @@ TERMUX_PKG_SETUP_PYTHON=true
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+\.\d+"
+
+termux_step_post_make_install() {
+	# extracted from 'sudo cat /proc/filesystems'
+	# on a Samsung Galaxy A70 SM-A705FN with Android 13,
+	# a Samsung Galaxy S III SPH-L710 with Android 7,
+	# two Android 15 devices, one of which is Samsung Galaxy S8+ SM-G955F,
+	# and a 64-bit Android-x86 PC.
+	# makes the command
+	# 'python -c "import psutil; print(psutil.disk_partitions())"'
+	# work successfully without root on Termux.
+	mkdir -p "$TERMUX_PREFIX/etc/psutil"
+	cat > "$TERMUX_PREFIX/etc/psutil/filesystems" << EOF
+	btrfs
+	cramfs
+	erofs
+	exfat
+	ext2
+	ext3
+	ext4
+	f2fs
+	fuseblk
+	msdos
+	sdfat
+	vfat
+	xfs
+nodev	anon_inodefs
+nodev	autofs
+nodev	bdev
+nodev	binder
+nodev	binfmt_misc
+nodev	bpf
+nodev	cgroup
+nodev	cgroup2
+nodev	cifs
+nodev	configfs
+nodev	cpuset
+nodev	dax
+nodev	debugfs
+nodev	devpts
+nodev	devtmpfs
+nodev	ecryptfs
+nodev	efivarfs
+nodev	functionfs
+nodev	fuse
+nodev	fusectl
+nodev	hugetlbfs
+nodev	incremental-fs
+nodev	mqueue
+nodev	nfs
+nodev	nfs4
+nodev	overlay
+nodev	pipefs
+nodev	proc
+nodev	pstore
+nodev	ramfs
+nodev	resctrl
+nodev	rootfs
+nodev	rpc_pipefs
+nodev	sdcardfs
+nodev	securityfs
+nodev	selinuxfs
+nodev	sockfs
+nodev	sysfs
+nodev	tmpfs
+nodev	tracefs
+nodev	virtiofs
+EOF
+}

--- a/packages/python-psutil/build.sh
+++ b/packages/python-psutil/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Cross-platform process and system utilities module for P
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="7.2.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/giampaolo/psutil/archive/refs/tags/release-$TERMUX_PKG_VERSION.tar.gz"
 TERMUX_PKG_SHA256=38f406bf21acc67e45f414b7980463b2e6e6270ba3616ffd41995d997078cbe6
 TERMUX_PKG_DEPENDS="python, python-pip"

--- a/packages/python-trash-cli/build.sh
+++ b/packages/python-trash-cli/build.sh
@@ -1,0 +1,23 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/andreafrancia/trash-cli
+TERMUX_PKG_DESCRIPTION="Command line trashcan (recycle bin) interface"
+TERMUX_PKG_LICENSE="GPL-2.0-only"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.24.5.26"
+TERMUX_PKG_SRCURL="https://github.com/andreafrancia/trash-cli/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=1d7dec1ad8f0264ceb1b0211d25fffee99c9409cd2e1d36dcc82ac5540f39ce5
+TERMUX_PKG_DEPENDS="python, python-psutil, python-pip"
+TERMUX_PKG_PYTHON_TARGET_DEPS="six"
+TERMUX_PKG_PYTHON_COMMON_BUILD_DEPS="six, shtab, build, installer"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_TAG_TYPE=newest-tag
+
+termux_step_post_make_install() {
+	local cmd
+	for cmd in trash-empty trash-list trash-restore trash-put trash; do
+		./$cmd --print-completion bash > ./"$cmd"-completion
+		./$cmd --print-completion zsh > ./_"$cmd"-completion
+		install -vDm 644 ./"$cmd"-completion "$TERMUX_PREFIX/share/bash-completion/completions/$cmd"
+		install -vDm 644 ./_"$cmd"-completion "$TERMUX_PREFIX/share/zsh/site-functions/_$cmd"
+	done
+}

--- a/packages/python-trash-cli/pretend-storage-emulated-0-mountpoint.patch
+++ b/packages/python-trash-cli/pretend-storage-emulated-0-mountpoint.patch
@@ -1,0 +1,55 @@
+In some Termux packages, a fake mountpoint at /storage/emulated/0
+is mocked because it successfully causes Trashing files from /storage/emulated/0
+and subfolders to go to a new or existing .Trash-$(id -u) folder in /storage/emulated/0 instead of
+/storage/emulated being detected as the real mountpoint (it is) and causing
+permission denied errors because Termux only has permission for /storage/emulated/0,
+not /storage/emulated.
+Doing that also reportedly allows Termux to detect and manage .Trash folders
+created in /storage/emulated/0 by desktop PCs when the Android
+device was plugged into them and files were then Trashed from the PC file browser,
+because there, that location does technically use a real mountpoint.
+While such a behavior of special-casing /storage/emulated/0 when it's not
+actually a real mountpoint is not part of the XDG Trash specification,
+it has been reported that the most natural expected behavior for users trying to
+use XDG Trash tools in Termux is for them to treat /storage/emulated/0 as though
+it were a mountpoint that should be calculated as a valid directory for .Trash-$(id -u) folders.
+
+This is like https://github.com/termux/termux-packages/pull/28186, but for
+python trash-cli instead of rust trash-rs
+
+The trashcli/fstab/volume_listing.py patch makes this series of commands work on Termux:
+
+termux-setup-storage
+cd /storage/emulated/0
+touch tempfile
+trash-put tempfile
+
+The trashcli/fstab/mount_points_listing.py patch makes this series of commands work on Termux:
+
+trash-list # shows the tempfile Trashed in the four commands above
+trash-rm tempfile # removes the tempfile
+trash-list # tempfile now successfully cleaned from the /storage/emulated/0 Trash directory
+
+--- a/trashcli/fstab/volume_listing.py
++++ b/trashcli/fstab/volume_listing.py
+@@ -49,4 +49,4 @@ class NoVolumesListing(VolumesListing):
+ 
+ class RealIsMount:
+     def is_mount(self, path):
+-        return os.path.ismount(path)
++        return os.path.ismount(path) or path == "/storage/emulated/0"
+--- a/trashcli/fstab/mount_points_listing.py
++++ b/trashcli/fstab/mount_points_listing.py
+@@ -49,6 +49,12 @@ def os_mount_points():
+     partitions = Partitions(fstypes)
+ 
+     for p in psutil.disk_partitions(all=True):
++        if (
++            p.mountpoint == "/storage/emulated" and
++            os.path.isdir("/storage/emulated/0") and
++            partitions.should_used_by_trashcli(p)
++        ):
++            yield "/storage/emulated/0"
+         if os.path.isdir(p.mountpoint) and \
+                 partitions.should_used_by_trashcli(p):
+             yield p.mountpoint


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/29844

- https://github.com/termux/termux-packages/pull/28186 but for Python ecosystem instead of Rust ecosystem

- Implement the fake `/storage/emulated/0` mountpoint for the Termux derivative of the XDG Trash specification in `python-trash-cli`

In some Termux packages, a fake mountpoint at `/storage/emulated/0`
is mocked because it successfully causes Trashing files from `/storage/emulated/0`
and subfolders to go to a new or existing `.Trash-$(id -u)` folder in `/storage/emulated/0` instead of
`/storage/emulated` being detected as the real mountpoint (it is) and causing
permission denied errors because Termux only has permission for `/storage/emulated/0`,
not `/storage/emulated`.
Doing that also reportedly allows Termux to detect and manage `.Trash-$(id -u)` folders
created in `/storage/emulated/0` by desktop PCs when the Android
device was plugged into them and files were then Trashed from the PC file browser,
because there, that location does technically use a real mountpoint.

While such a behavior of special-casing `/storage/emulated/0` when it's not
actually a real mountpoint is not part of the XDG Trash specification,
it has been reported that the most natural expected behavior for users trying to
use XDG Trash tools in Termux is for them to treat `/storage/emulated/0` as though
it were a mountpoint that should be calculated as a valid directory for `.Trash-$(id -u)` folders, so this is deviating from the XDG Trash specification in the same way as the Rust packages currently are, meaning that this will allow Python to be able to find and manage the same Trashed files that were Trashed from the Rust packages like `yazi`, and vice versa.

- Fixes the error `Permission denied: '/proc/filesystems'` in the command `python -c "import psutil; print(psutil.disk_partitions())"`

- Fixes this series of commands:

```
pip install trash-cli
termux-setup-storage
cd /storage/emulated/0
touch tempfile
trash-put tempfile
```