### PR TITLE
bump(x11/ardour): 9.2

### DIFF
--- a/x11-packages/ardour/build.sh
+++ b/x11-packages/ardour/build.sh
@@ -2,11 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://ardour.org/
 TERMUX_PKG_DESCRIPTION="A professional digital workstation for working with audio and MIDI"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="8.12"
-TERMUX_PKG_REVISION=7
+TERMUX_PKG_VERSION="9.2"
 TERMUX_PKG_SRCURL=git+https://github.com/Ardour/ardour
 TERMUX_PKG_GIT_BRANCH="$TERMUX_PKG_VERSION"
-TERMUX_PKG_DEPENDS="aubio, fftw, fontconfig, gdk-pixbuf, glib, gtk2, gtkmm2, libandroid-execinfo, libarchive, libatkmm-1.6, libc++, libcairo, libcairomm-1.0, libcurl, libglibmm-2.4, liblo, liblrdf, libpangomm-1.4, libsamplerate, libsigc++-2.0, libsndfile, libusb, libwebsockets, libx11, libxml2, lilv, pango, pulseaudio, rubberband, suil, taglib, vamp-plugin-sdk"
+TERMUX_PKG_DEPENDS="aubio, fftw, fontconfig, gdk-pixbuf, glib, libandroid-execinfo, libarchive, libatkmm-1.6, libc++, libcairo, libcairomm-1.0, libcurl, libglibmm-2.4, liblo, liblrdf, libpangomm-1.4, libsamplerate, libsigc++-2.0, libsndfile, libusb, libwebsockets, libx11, libxml2, lilv, pango, pulseaudio, rubberband, suil, taglib, vamp-plugin-sdk"
 TERMUX_PKG_BUILD_DEPENDS="boost, boost-headers"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
@@ -16,7 +15,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --freedesktop
 --no-nls
 --no-phone-home
---no-ytk
 --noconfirm
 --optimize
 "
@@ -25,7 +23,7 @@ termux_step_pre_configure() {
 	# this is a workaround for build-all.sh issue
 	TERMUX_PKG_DEPENDS+=", ardour-data"
 
-	LDFLAGS+=" -landroid-execinfo"
+	LDFLAGS+=" -landroid-execinfo -landroid-shmem"
 }
 
 termux_step_configure() {

--- a/x11-packages/ardour/fix-hardcoded-paths.patch
+++ b/x11-packages/ardour/fix-hardcoded-paths.patch
@@ -1,25 +1,3 @@
---- a/gtk2_ardour/ardour_http.cc
-+++ b/gtk2_ardour/ardour_http.cc
-@@ -84,6 +84,7 @@
- 	 */
- 	assert (!ca_path && !ca_info); // call once
- 
-+#ifndef __ANDROID__
- 	if (Glib::file_test ("/etc/pki/tls/certs/ca-bundle.crt", Glib::FILE_TEST_IS_REGULAR)) {
- 		// Fedora / RHEL, Arch
- 		ca_info = "/etc/pki/tls/certs/ca-bundle.crt";
-@@ -96,6 +97,11 @@
- 		// GNU/TLS can keep extra stuff here
- 		ca_info = "/etc/pki/tls/cert.pem";
- 	}
-+#else // __ANDROID__
-+	if (Glib::file_test ("@TERMUX_PREFIX@/etc/tls/cert.pem", Glib::FILE_TEST_IS_REGULAR)) {
-+		ca_info = "@TERMUX_PREFIX@/etc/tls/cert.pem";
-+	}
-+#endif
- 	// else NULL: use default (currently) "/etc/ssl/certs/ca-certificates.crt" if it exists
- 
- 	/* If we don't set anything defaults are used. at the time of writing we compile bundled curl on debian
 --- a/gtk2_ardour/bundle_env_linux.cc
 +++ b/gtk2_ardour/bundle_env_linux.cc
 @@ -104,9 +104,9 @@

--- a/x11-packages/ardour/libs-pbd-ccurl.cc.patch
+++ b/x11-packages/ardour/libs-pbd-ccurl.cc.patch
@@ -1,0 +1,23 @@
+diff -u -r ../cache/tmp-checkout/libs/pbd/ccurl.cc ./libs/pbd/ccurl.cc
+--- ../cache/tmp-checkout/libs/pbd/ccurl.cc	2026-02-16 09:42:47.548725178 +0000
++++ ./libs/pbd/ccurl.cc	2026-02-16 10:24:07.009321377 +0000
+@@ -209,6 +209,11 @@
+ 	 */
+ 	assert (!ca_path && !ca_info); // call once
+ 
++#ifdef __ANDROID__
++	if (Glib::file_test ("@TERMUX_PREFIX@/etc/tls/cert.pem", Glib::FILE_TEST_IS_REGULAR)) {
++		ca_info = "@TERMUX_PREFIX@/etc/tls/cert.pem";
++	}
++#else
+ 	if (Glib::file_test ("/etc/pki/tls/certs/ca-bundle.crt", Glib::FILE_TEST_IS_REGULAR)) {
+ 		// Fedora / RHEL, Arch
+ 		ca_info = "/etc/pki/tls/certs/ca-bundle.crt";
+@@ -219,6 +224,7 @@
+ 		// GNU/TLS can keep extra stuff here
+ 		ca_info = "/etc/pki/tls/cert.pem";
+ 	}
++#endif
+ 	// else NULL: use default (currently) "/etc/ssl/certs/ca-certificates.crt" if it exists
+ 
+ 	/* If we don't set anything, defaults are used. At the time of writing we compile bundled curl on debian

--- a/x11-packages/ardour/pthread_cancel.patch
+++ b/x11-packages/ardour/pthread_cancel.patch
@@ -130,29 +130,3 @@
  	pthread_mutex_unlock (&thread_map_lock);
  }
  
---- a/libs/surfaces/frontier/tranzport/tranzport_control_protocol.cc
-+++ b/libs/surfaces/frontier/tranzport/tranzport_control_protocol.cc
-@@ -1029,8 +1029,10 @@
- 
- 
- 	PBD::notify_gui_about_thread_creation ("gui", pthread_self(), X_("Tranzport"));
-+#ifndef __ANDROID__
- 	pthread_setcancelstate (PTHREAD_CANCEL_ENABLE, 0);
- 	pthread_setcanceltype (PTHREAD_CANCEL_ASYNCHRONOUS, 0);
-+#endif
- 	next_track ();
- 	rtpriority_set();
- 	inflight=0;
---- a/libs/surfaces/tranzport/init.cc
-+++ b/libs/surfaces/tranzport/init.cc
-@@ -155,8 +155,10 @@
- 	uint8_t offline = 0;
- 
- 	register_thread (X_("Tranzport"));
-+#ifndef __ANDROID__
- 	pthread_setcancelstate (PTHREAD_CANCEL_ENABLE, 0);
- 	pthread_setcanceltype (PTHREAD_CANCEL_ASYNCHRONOUS, 0);
-+#endif
- 	rtpriority_set();
- 	inflight=0;
- 	//int intro = 20;

--- a/x11-packages/ardour/ytk.patch
+++ b/x11-packages/ardour/ytk.patch
@@ -1,0 +1,25 @@
+--- a/libs/tk/ytk/config.h
++++ b/libs/tk/ytk/config.h
+@@ -28,7 +28,7 @@
+ #define HAVE_GETRESUID 1
+ #endif
+ 
+-#if !defined(__APPLE__) && !defined(__NetBSD__)
++#if !defined(__APPLE__) && !defined(__NetBSD__) && !defined(__ANDROID__)
+ /* Have GNU ftw */
+ #define HAVE_GNU_FTW 1
+ #endif
+diff --git a/libs/tk/ydk/config.h b/libs/tk/ydk/config.h
+index 484758b..8b8bc15 100644
+--- a/libs/tk/ydk/config.h
++++ b/libs/tk/ydk/config.h
+@@ -27,7 +27,7 @@
+ #define HAVE_GETRESUID 1
+ #endif
+ 
+-#if !defined(__APPLE__) && !defined(__NetBSD__)
++#if !defined(__APPLE__) && !defined(__NetBSD__) && !defined(__ANDROID___)
+ /* Have GNU ftw */
+ #define HAVE_GNU_FTW 1
+ #endif
+


### PR DESCRIPTION
Fixes #27909.

Removes the dependency on `gtk2` and `gtkmm2`, as [ardour 9 uses an internal fork of gtk2](https://www.phoronix.com/news/Ardour-Removes-GTK-Option). This will remove the last user of `gtkmm2`, which can be removed afterwards.

Not yet tested. Related to that, note the problem reported in #27501, which seems to affect both ardour 8 and 9 (not yet confirmed if any changes since 9.0-rc2 changes that).