### PR TITLE
bump(main/ldd): 0.4

### DIFF
--- a/packages/ldd/build.sh
+++ b/packages/ldd/build.sh
@@ -2,21 +2,24 @@ TERMUX_PKG_HOMEPAGE=https://github.com/termux/termux-packages
 TERMUX_PKG_DESCRIPTION="Fake ldd command"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.3"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION="0.4"
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
-TERMUX_PKG_DEPENDS="bash, binutils"
+TERMUX_PKG_DEPENDS="bash, binutils (>= 2.46.0-3)"
 TERMUX_PKG_CONFLICTS="binutils (<< 2.39-1)"
 
 termux_step_make_install() {
 	local _READELF="$TERMUX_PREFIX/bin/greadelf"
+	local _ARCH_SUFFIX=""
+	if (( TERMUX_ARCH_BITS == 64 )); then
+		_ARCH_SUFFIX=64
+	fi
 
 	local ldd="$TERMUX_PREFIX/bin/ldd"
 	mkdir -p "$(dirname "${ldd}")"
 	rm -rf "${ldd}"
 	sed "$TERMUX_PKG_BUILDER_DIR/ldd.in" \
-		-e "s|@ARCH_BITS@|${TERMUX_ARCH_BITS}|g" \
+		-e "s|@ARCH_SUFFIX@|${_ARCH_SUFFIX}|g" \
 		-e "s|@READELF@|${_READELF}|g" \
 		> "${ldd}"
 	chmod 0700 "${ldd}"

--- a/packages/ldd/ldd.in
+++ b/packages/ldd/ldd.in
@@ -1,110 +1,112 @@
 #!/bin/bash
 
-KLIBPATH=lib
-if [ "@ARCH_BITS@" == "64" ]; then
-    KLIBPATH+=64
-fi
+KLIBPATH=lib@ARCH_SUFFIX@
 
 system_libs=(libEGL.so libGLESv1_CM.so libGLESv2.so libGLESv3.so libOpenMAXAL.so libOpenSLES.so libaaudio.so libandroid.so libc.so libcamera2ndk.so libdl.so libjnigraphics.so liblog.so libm.so libmediandk.so libstdc++.so libvulkan.so libz.so)
 
 do_search() {
-    local f="$1"
-    local s
-    for s in "${so_read[@]}"; do
-        if [ "$s" == "$f" ]; then
-            return
-        fi
-    done
-    so_read+=("$f")
-    local origin=$(dirname "$f")
-    local is_system_lib=
-    local runpath_sav
-    if [ "$origin" == "/system/$KLIBPATH" ]; then
+    local filename="$1"
+    local so_file
+    # Skip if we've already read this.
+    [[ " ${so_read[*]} " == *" $filename "* ]] && return
+    so_read+=("$filename")
+    local origin
+    local is_system_lib=""
+    local -a runpath_saved
+    local readelf_output
+
+    origin="$(dirname "$filename")"
+    readelf_output="$(@READELF@ -d "$filename")"
+    if [[ "$origin" == "/system/$KLIBPATH" ]]; then
+        # If this is a system library mark it as such,
+        # save the current runpath and restore the initial one for checks.
         is_system_lib=true
-        runpath_sav=("${runpath[@]}")
-        runpath=()
-        if test "$LD_LIBRARY_PATH"; then
-            IFS=: runpath+=($LD_LIBRARY_PATH)
-        fi
+        runpath_saved=("${runpath[@]}")
+        runpath=("${runpath_orig[@]}")
     else
-        IFS=: runpath+=($(@READELF@ -d "$f" | sed -n 's/^.*(RUNPATH).*\[\(.*\)\]$/\1/p'))
+        runpath+=($(sed -n '/(RUNPATH)/ { s/.*: \[\(.*\)\]/\1/; s/:/ /gp }' <<< "$readelf_output"))
     fi
     runpath+=("/system/$KLIBPATH")
+
     local needed
-    IFS=$'\n' needed=($(@READELF@ -d "$f" | sed -n 's/^.*(NEEDED).*\[\(.*\)\]$/\1/p'))
-    local libs=()
-    local l
-    for l in "${needed[@]}"; do
-        l="${l##*/}"
-        local target=
-        local d
-        for d in "${runpath[@]}"; do
-            if ! test "$d"; then
-                d=.
+    needed=($(sed -n '/(NEEDED)/ { s/.*: \[\(.*\)\]/\1/; p }' <<< "$readelf_output"))
+
+    local lib libs=()
+    for lib in "${needed[@]}"; do
+        lib="${lib##*/}"
+        local target=""
+        local dir
+        for dir in "${runpath[@]}"; do
+            # Does that runpath dir exist?
+            if [[ -d "$dir" ]]; then
+                # Then resolve the substitutions in it.
+                dir="${dir//\$ORIGIN/"$origin"}"
+                dir="${dir//\$LIB/"$KLIBPATH"}"
             else
-                d="${d//\$ORIGIN/"$origin"}"
-                d="${d//\$LIB/"$KLIBPATH"}"
+                dir=.
             fi
-            if test -f "$d/$l" && \
-                    [ "$(head -c 4 "$d/$l")" == "$(echo -ne '\0177ELF')" ]; then
-                target="$(readlink -f "$d")/$l"
+
+            # If this is this an ELF file we need to add it
+            # to $libs for recursion and as $target for output.
+            if [[ -f "$dir/$lib" && "$(< "$dir/$lib")" == $'\x7fELF'* ]]; then
+                target="$(readlink -f "$dir")/$lib"
                 libs+=("$target")
                 break
-            fi
+            # Bash complains about NULL bytes here even though $(<) is a
+            # file read, not a command substitution, so silence those.
+            #
+            # warning: command substitution: ignored null byte in input
+            fi 2> /dev/null
         done
-        if ! test "$target"; then
-            for s in "${system_libs[@]}"; do
-                if [ "$s" == "$l" ]; then
-                    target="/system/$KLIBPATH/$l"
-                    so_read+=("$target")
-                fi
-            done
+
+        # If we don't have a $target yet then check the $system_libs for a match
+        if [[ -z "$target" && " ${system_libs[*]} " == *" $lib "* ]]; then
+                target="/system/$KLIBPATH/$lib"
+                so_read+=("$target")
         fi
-        if test "$target"; then
-            while :; do
-                for s in "${so_found[@]}"; do
-                    if [ "$s" == "$target" ]; then
-                        break 2
-                    fi
-                done
-                so_found+=("$target")
-                echo -ne "\t$l => "
-                echo $target
-                break
-            done
-        else
-            echo -ne "\t$l => "
-            echo not found
+
+        # Missing target?
+        if [[ -z "$target" ]]; then
+            printf '\t%s => not found\n' "$lib"
+            continue
         fi
+
+        # Skip if we're already found this target before
+        [[ " ${so_found[*]} " == *" $target "* ]] && break
+
+        # Mark it as found and print it to the output.
+        so_found+=("$target")
+        printf '\t%s => %s\n' "$lib" "$target"
     done
-    for l in "${libs[@]}"; do
-        do_search "$l"
+
+    # Recursively search all found $libs
+    for lib in "${libs[@]}"; do
+        do_search "$lib"
     done
-    if test "$is_system_lib"; then
-        runpath=("${runpath_sav[@]}")
-    fi
+
+    [[ -n "$is_system_lib" ]] && runpath=("${runpath_saved[@]}")
 }
 
-num_args="$#"
-if [ "$num_args" -lt 1 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+if [[ "$#" == 0 || "$1" == "-h" || "$1" == "--help" ]]; then
     echo "Usage: ldd file..." >&2
     exit 1
 fi
 
-if [ "$1" = "--" ]; then
-    shift 1
-fi
+[[ "$1" == "--" ]] && shift 1
 
-for f in "$@"; do
-    if [ "$num_args" -gt 1 ]; then
-        echo "$f":
+for input_file in "$@"; do
+    if (( $# )); then
+        echo "$input_file":
     fi
     runpath=()
-    if test "$LD_LIBRARY_PATH"; then
-        IFS=: runpath+=($LD_LIBRARY_PATH)
+    if [[ -n "$LD_LIBRARY_PATH" ]]; then
+        readarray runpath <<< "${LD_LIBRARY_PATH//:/ }"
     fi
+    # Cache the original runpath for system libraries later
+    runpath_orig=("${runpath[@]}")
+
     so_read=()
     so_found=()
-    ff="$(readlink -f "$f")"
-    do_search "$ff"
+    file_location="$(readlink -f "$input_file")"
+    do_search "$file_location"
 done

--- a/packages/ldd/ldd.in
+++ b/packages/ldd/ldd.in
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+[[ -n "${DEBUG+y}" ]] && {
+    PS4='+$0 \[\e[32m\]${FUNCNAME[0]:-<global scope>}${FUNCNAME[*]:+()}:$LINENO\[\e[0m\] '
+    set -x
+}
+
 KLIBPATH=lib@ARCH_SUFFIX@
 
 system_libs=(libEGL.so libGLESv1_CM.so libGLESv2.so libGLESv3.so libOpenMAXAL.so libOpenSLES.so libaaudio.so libandroid.so libc.so libcamera2ndk.so libdl.so libjnigraphics.so liblog.so libm.so libmediandk.so libstdc++.so libvulkan.so libz.so)


### PR DESCRIPTION
Alright I think that's all the optimization I can reasonably do to this.
There is like one or two things I can still think of, but they wouldn't really impact the performance and would in turn hurt the readability.

Here's some of the highlights.
- We're now uniformly using `[[` bash test `]]` for test expressions across the full script.
This is somewhat more performant than `test` or `[` Old/POSIX test `]` from prior testing.
- I've managed to eliminate three of the nested loops that were performing array searches by doing a substring match instead.
- We are no longer running `readelf` twice to get the `(RUNPATH)` and `(NEEDED)` entries
- Restoring the `$runpath` for system libs no longer involves having to resplit `LD_LIBRARY_PATH`
- Use `readarray` for the `needed` array.
- Variable names changed for better readability and comments added for documentation.
- Trivial `if` statements replaced with `&&`

I would suggest taking a look at the file itself, both unified and split diff for this are quite busy.
I have manually verified that all changes retain equivalent behavior.