### PR TITLE
bump(x11/scrot): 2.0.0

### DIFF
--- a/x11-packages/scrot/build.sh
+++ b/x11-packages/scrot/build.sh
@@ -4,12 +4,11 @@ TERMUX_PKG_DESCRIPTION="Simple command-line screenshot utility for X"
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.12.1"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="2.0.0"
 TERMUX_PKG_SRCURL=https://github.com/resurrecting-open-source-projects/scrot/releases/download/${TERMUX_PKG_VERSION}/scrot-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=45bed70abd74ffeeec08b75089ba44900291e9c86309bcce892ccc7ece8f1e61
+TERMUX_PKG_SHA256=1b4b3acadfe07bf89234838675d1d23508a9a6810cb64584f1d9610103d6cdfa
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="imlib2, libx11, libxcomposite, libxext, libxfixes, libxinerama"
+TERMUX_PKG_DEPENDS="imlib2, libx11, libxcomposite, libxfixes, libxrandr"
 
 termux_step_pre_configure() {
 	local _inc="$TERMUX_PKG_SRCDIR/_getsubopt/include"

--- a/x11-packages/scrot/getsubopt.patch
+++ b/x11-packages/scrot/getsubopt.patch
@@ -6,6 +6,6 @@
  
 +#include "getsubopt.h"
 +
- #include "note.h"
  #include "options.h"
  #include "scrot.h"
+ #include "scrot_selection.h"


### PR DESCRIPTION
Xrandr is used instead of Xinerama for monitor capture.
https://github.com/resurrecting-open-source-projects/scrot/releases/tag/2.0.0

* Fixes #28927 