### PR TITLE
test: fix(main/llvm): link LLVM `readelf` to libLLVM statically

### DIFF
--- a/packages/flang/build.sh
+++ b/packages/flang/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_LICENSE_FILE="flang/LICENSE.TXT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="21.1.8"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=(
 	"https://github.com/llvm/llvm-project/releases/download/llvmorg-${TERMUX_PKG_VERSION}/llvm-project-${TERMUX_PKG_VERSION}.src.tar.xz"
 	"https://github.com/llvm/llvm-project/releases/download/llvmorg-${TERMUX_PKG_VERSION}/LLVM-${TERMUX_PKG_VERSION}-Linux-X64.tar.xz"

--- a/packages/ldd/build.sh
+++ b/packages/ldd/build.sh
@@ -3,14 +3,14 @@ TERMUX_PKG_DESCRIPTION="Fake ldd command"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.3"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
-TERMUX_PKG_DEPENDS="bash, binutils"
+TERMUX_PKG_DEPENDS="bash, llvm (>= 21.1.8-3)"
 TERMUX_PKG_CONFLICTS="binutils (<< 2.39-1)"
 
 termux_step_make_install() {
-	local _READELF="$TERMUX_PREFIX/bin/greadelf"
+	local _READELF="$TERMUX_PREFIX/bin/readelf"
 
 	local ldd="$TERMUX_PREFIX/bin/ldd"
 	mkdir -p "$(dirname "${ldd}")"

--- a/packages/libllvm/build.sh
+++ b/packages/libllvm/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_LICENSE_FILE="llvm/LICENSE.TXT"
 TERMUX_PKG_MAINTAINER="@finagolfin"
 # Keep flang version and revision in sync when updating (enforced by check in termux_step_pre_configure).
 TERMUX_PKG_VERSION="21.1.8"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SHA256=4633a23617fa31a3ea51242586ea7fb1da7140e426bd62fc164261fe036aa142
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_SRCURL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${TERMUX_PKG_VERSION}/llvm-project-${TERMUX_PKG_VERSION}.src.tar.xz"

--- a/packages/libllvm/llvm-tools-llvm-readobj-CMakeLists.txt.patch
+++ b/packages/libllvm/llvm-tools-llvm-readobj-CMakeLists.txt.patch
@@ -1,0 +1,14 @@
+statically link llvm-readelf to libLLVM, significantly increasing the runtime performance
+of llvm-readelf for use with the Termux implementation of ldd,
+making it similar to the performance of GNU readelf.
+
+--- a/llvm/tools/llvm-readobj/CMakeLists.txt
++++ b/llvm/tools/llvm-readobj/CMakeLists.txt
+@@ -28,6 +28,7 @@ add_llvm_tool(llvm-readobj
+   DEPENDS
+   ReadobjOptsTableGen
+   GENERATE_DRIVER
++  DISABLE_LLVM_LINK_LLVM_DYLIB
+   )
+ 
+ setup_host_tool(llvm-readobj LLVM_READOBJ llvm_readobj_exe llvm_readobj_target)


### PR DESCRIPTION
- Experiment for testing related to https://github.com/termux/termux-packages/issues/28904