### PR TITLE
fix(x11/kf6-purpose): Add dependency on kf6-kcmutils

### DIFF
--- a/x11-packages/kf6-purpose/build.sh
+++ b/x11-packages/kf6-purpose/build.sh
@@ -3,9 +3,10 @@ TERMUX_PKG_DESCRIPTION='Framework for providing abstractions to get the develope
 TERMUX_PKG_LICENSE="LGPL-2.0, LGPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="6.24.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://download.kde.org/stable/frameworks/${TERMUX_PKG_VERSION%.*}/purpose-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=e95dba236f79bf1655a0581e9f1c3ce64d342750135fde700d463dd205bebc47
-TERMUX_PKG_DEPENDS="kf6-kconfig (>= ${TERMUX_PKG_VERSION%.*}), kf6-kcoreaddons (>= ${TERMUX_PKG_VERSION%.*}), kf6-ki18n (>= ${TERMUX_PKG_VERSION%.*}), kf6-kio (>= ${TERMUX_PKG_VERSION%.*}), kf6-knotifications (>= ${TERMUX_PKG_VERSION%.*}), kf6-kservice (>= ${TERMUX_PKG_VERSION%.*}), kf6-kitemmodels (>= ${TERMUX_PKG_VERSION%.*}), kf6-prison (>= ${TERMUX_PKG_VERSION%.*}), libc++, qt6-qtbase, qt6-qtdeclarative"
+TERMUX_PKG_DEPENDS="kf6-kcmutils (>= ${TERMUX_PKG_VERSION%.*}), kf6-kconfig (>= ${TERMUX_PKG_VERSION%.*}), kf6-kcoreaddons (>= ${TERMUX_PKG_VERSION%.*}), kf6-ki18n (>= ${TERMUX_PKG_VERSION%.*}), kf6-kio (>= ${TERMUX_PKG_VERSION%.*}), kf6-knotifications (>= ${TERMUX_PKG_VERSION%.*}), kf6-kservice (>= ${TERMUX_PKG_VERSION%.*}), kf6-kitemmodels (>= ${TERMUX_PKG_VERSION%.*}), kf6-prison (>= ${TERMUX_PKG_VERSION%.*}), libc++, qt6-qtbase, qt6-qtdeclarative"
 # kaccounts-integration, libaccounts-qt, accounts-qml-module, kcmutils can be added to TERMUX_PKG_DEPENDS when available
 TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules (>= ${TERMUX_PKG_VERSION%.*}), kf6-kirigami (>= ${TERMUX_PKG_VERSION%.*}), intltool"
 TERMUX_PKG_AUTO_UPDATE=true


### PR DESCRIPTION
Fixes the build and sets up the necessary dependency:

> -- The following REQUIRED packages have not been found:
>
> * org.kde.kcmutils-QMLModule, QML module 'org.kde.kcmutils' is a dependency.