### PR TITLE
fix(main/lux-cli): Exclude 32-bit builds

### DIFF
--- a/packages/lux-cli/build.sh
+++ b/packages/lux-cli/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A package manager for Lua, similar to luarocks"
 TERMUX_PKG_LICENSE="LGPL-3.0-or-later"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.26.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/lumen-oss/lux/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=6541060d2d739dc218d916d503100ea83c3a92c181b37cc5a3d7ff5bececb449
 TERMUX_PKG_DEPENDS="bzip2, gpgme, libgit2, libgpg-error, lua54, openssl, xz-utils"
@@ -10,6 +11,7 @@ TERMUX_PKG_PROVIDES="lx"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_HOSTBUILD=true
+TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"
 
 termux_pkg_auto_update() {
 	# based on `termux_github_api_get_tag.sh`


### PR DESCRIPTION
Exclude 32-bit builds as they fail:

- [arm build](https://github.com/termux/termux-packages/actions/runs/23032082175/job/66892330804)
- [i686 build](https://github.com/termux/termux-packages/actions/runs/23032082175/job/66892330816)

This might be straightforward to patch instead.

But in general, it seems that supporting 32-bit platforms with updated packages is becoming more and more of an issue, as projects stop testing for it and users stop using it.