### PR TITLE
bump(x11/gimp): 3.2.0

### DIFF
--- a/x11-packages/gimp/build.sh
+++ b/x11-packages/gimp/build.sh
@@ -2,8 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://www.gimp.org/
 TERMUX_PKG_DESCRIPTION="GNU Image Manipulation Program"
 TERMUX_PKG_LICENSE="GPL-3.0, LGPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="3.0.8"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION="3.2.0"
 TERMUX_PKG_SRCURL=git+https://gitlab.gnome.org/GNOME/gimp
 TERMUX_PKG_GIT_BRANCH="GIMP_${TERMUX_PKG_VERSION//./_}"
 TERMUX_PKG_AUTO_UPDATE=true
@@ -39,7 +38,7 @@ termux_step_pre_configure() {
 	if [ "$TERMUX_ON_DEVICE_BUILD" = "false" ]; then
 		# Gimp requires using cross-compiled or prebuilt gimp during cross-compilation which is hard to achive here
 		# gimp is required only to generate splash image, so it will be fine to use official appimage.
-		termux_download https://download.gimp.org/gimp/v${TERMUX_PKG_VERSION%.*}/linux/GIMP-${TERMUX_PKG_VERSION}-x86_64.AppImage "$TERMUX_PKG_CACHEDIR/gimp.appimage" d19a8f83e06f9ec6a00927d895b822c7c8490ec19a6cb9f369498fdfdbcbea34
+		termux_download https://download.gimp.org/gimp/v${TERMUX_PKG_VERSION%.*}/linux/GIMP-${TERMUX_PKG_VERSION}-x86_64.AppImage "$TERMUX_PKG_CACHEDIR/gimp.appimage" e7794ebd6ed90fe32f6dede3917216aaceee833bdc794f2a0fe925e1d96cc899
 		chmod +x "$TERMUX_PKG_CACHEDIR/gimp.appimage"
 		[ -d $TERMUX_PKG_CACHEDIR/squashfs-root ] || (cd "$TERMUX_PKG_CACHEDIR"; "$TERMUX_PKG_CACHEDIR/gimp.appimage" --appimage-extract)
 

--- a/x11-packages/gimp/gir/Gimp-3.0.xml
+++ b/x11-packages/gimp/gir/Gimp-3.0.xml
@@ -289,6 +289,14 @@
     <member name="GIMP_TEXT_JUSTIFY_RIGHT" nick="right" value="1"/>
     <member name="GIMP_TEXT_JUSTIFY_CENTER" nick="center" value="2"/>
     <member name="GIMP_TEXT_JUSTIFY_FILL" nick="fill" value="3"/>
+  </enum>  <enum name="GimpTextOutline" get-type="gimp_text_outline_get_type">
+    <member name="GIMP_TEXT_OUTLINE_NONE" nick="none" value="0"/>
+    <member name="GIMP_TEXT_OUTLINE_STROKE_ONLY" nick="stroke-only" value="1"/>
+    <member name="GIMP_TEXT_OUTLINE_STROKE_FILL" nick="stroke-fill" value="2"/>
+  </enum>  <enum name="GimpTextOutlineDirection" get-type="gimp_text_outline_direction_get_type">
+    <member name="GIMP_TEXT_OUTLINE_DIRECTION_OUTER" nick="outer" value="0"/>
+    <member name="GIMP_TEXT_OUTLINE_DIRECTION_INNER" nick="inner" value="1"/>
+    <member name="GIMP_TEXT_OUTLINE_DIRECTION_CENTERED" nick="centered" value="2"/>
   </enum>  <enum name="GimpTransferMode" get-type="gimp_transfer_mode_get_type">
     <member name="GIMP_TRANSFER_SHADOWS" nick="shadows" value="0"/>
     <member name="GIMP_TRANSFER_MIDTONES" nick="midtones" value="1"/>
@@ -435,6 +443,12 @@
     <member name="GIMP_CONVERT_DITHER_FS" nick="fs" value="1"/>
     <member name="GIMP_CONVERT_DITHER_FS_LOWBLEED" nick="fs-lowbleed" value="2"/>
     <member name="GIMP_CONVERT_DITHER_FIXED" nick="fixed" value="3"/>
+  </enum>  <enum name="GimpCurvePointType" get-type="gimp_curve_point_type_get_type">
+    <member name="GIMP_CURVE_POINT_SMOOTH" nick="smooth" value="0"/>
+    <member name="GIMP_CURVE_POINT_CORNER" nick="corner" value="1"/>
+  </enum>  <enum name="GimpCurveType" get-type="gimp_curve_type_get_type">
+    <member name="GIMP_CURVE_SMOOTH" nick="smooth" value="0"/>
+    <member name="GIMP_CURVE_FREE" nick="free" value="1"/>
   </enum>  <enum name="GimpHistogramChannel" get-type="gimp_histogram_channel_get_type">
     <member name="GIMP_HISTOGRAM_VALUE" nick="value" value="0"/>
     <member name="GIMP_HISTOGRAM_RED" nick="red" value="1"/>
@@ -518,6 +532,7 @@
     <member name="GIMP_LAYER_MODE_SPLIT" nick="split" value="60"/>
     <member name="GIMP_LAYER_MODE_PASS_THROUGH" nick="pass-through" value="61"/>
     <member name="GIMP_LAYER_MODE_REPLACE" nick="replace" value="62"/>
+    <member name="GIMP_LAYER_MODE_OVERWRITE" nick="overwrite" value="63"/>
   </enum>  <enum name="GimpTRCType" get-type="gimp_trc_type_get_type">
     <member name="GIMP_TRC_LINEAR" nick="linear" value="0"/>
     <member name="GIMP_TRC_NON_LINEAR" nick="non-linear" value="1"/>
@@ -542,6 +557,14 @@
   <class name="GimpDrawable" get-type="gimp_drawable_get_type" parents="GimpItem,GObject" abstract="1">
   </class>
   <class name="GimpChannel" get-type="gimp_channel_get_type" parents="GimpDrawable,GimpItem,GObject">
+  </class>
+  <class name="GimpCurve" get-type="gimp_curve_get_type" parents="GObject">
+    <property name="curve-type" type="GimpCurveType" flags="1073743079" default-value="GIMP_CURVE_SMOOTH"/>
+    <property name="n-samples" type="gint" flags="1073743079" default-value="256"/>
+    <signal name="points-changed" return="void" when="first">
+    </signal>
+    <signal name="samples-changed" return="void" when="first">
+    </signal>
   </class>
   <class name="GimpDisplay" get-type="gimp_display_get_type" parents="GObject">
     <property name="id" type="gint" flags="235" default-value="0"/>
@@ -579,6 +602,9 @@
   </class>
   <class name="GimpLayerMask" get-type="gimp_layer_mask_get_type" parents="GimpChannel,GimpDrawable,GimpItem,GObject">
   </class>
+  <class name="GimpLinkLayer" get-type="gimp_link_layer_get_type" parents="GimpLayer,GimpDrawable,GimpItem,GObject">
+    <implements name="GimpRasterizable"/>
+  </class>
   <class name="GimpLoadProcedure" get-type="gimp_load_procedure_get_type" parents="GimpFileProcedure,GimpProcedure,GObject">
   </class>
   <class name="GimpPalette" get-type="gimp_palette_get_type" parents="GimpResource,GObject">
@@ -593,6 +619,12 @@
   <fundamental name="GimpParamLayer" get-type="gimp_param_layer_get_type" instantiatable="1" parents="GimpParamDrawable,GimpParamItem,GParamObject,GParam">
   </fundamental>
   <fundamental name="GimpParamTextLayer" get-type="gimp_param_text_layer_get_type" instantiatable="1" parents="GimpParamLayer,GimpParamDrawable,GimpParamItem,GParamObject,GParam">
+  </fundamental>
+  <fundamental name="GimpParamVectorLayer" get-type="gimp_param_vector_layer_get_type" instantiatable="1" parents="GimpParamLayer,GimpParamDrawable,GimpParamItem,GParamObject,GParam">
+  </fundamental>
+  <fundamental name="GimpParamLinkLayer" get-type="gimp_param_link_layer_get_type" instantiatable="1" parents="GimpParamLayer,GimpParamDrawable,GimpParamItem,GParamObject,GParam">
+  </fundamental>
+  <fundamental name="GimpParamRasterizable" get-type="gimp_param_rasterizable_get_type" instantiatable="1" parents="GimpParamDrawable,GimpParamItem,GParamObject,GParam">
   </fundamental>
   <fundamental name="GimpParamGroupLayer" get-type="gimp_param_group_layer_get_type" instantiatable="1" parents="GimpParamLayer,GimpParamDrawable,GimpParamItem,GParamObject,GParam">
   </fundamental>
@@ -620,6 +652,8 @@
   </fundamental>
   <fundamental name="GimpParamFont" get-type="gimp_param_font_get_type" instantiatable="1" parents="GimpParamResource,GimpParamObject,GParamObject,GParam">
   </fundamental>
+  <fundamental name="GimpParamCurve" get-type="gimp_param_curve_get_type" instantiatable="1" parents="GParamObject,GParam">
+  </fundamental>
   <class name="GimpPath" get-type="gimp_path_get_type" parents="GimpItem,GObject">
   </class>
   <class name="GimpPattern" get-type="gimp_pattern_get_type" parents="GimpResource,GObject">
@@ -635,11 +669,18 @@
   <class name="GimpProcedureConfig" get-type="gimp_procedure_config_get_type" parents="GObject" abstract="1">
     <property name="procedure" type="GimpProcedure" flags="235"/>
   </class>
+  <interface name="GimpRasterizable" get-type="gimp_rasterizable_get_type">
+    <prerequisite name="GimpDrawable"/>
+  </interface>
   <class name="GimpSelection" get-type="gimp_selection_get_type" parents="GimpChannel,GimpDrawable,GimpItem,GObject">
   </class>
   <class name="GimpTextLayer" get-type="gimp_text_layer_get_type" parents="GimpLayer,GimpDrawable,GimpItem,GObject">
+    <implements name="GimpRasterizable"/>
   </class>
   <class name="GimpThumbnailProcedure" get-type="gimp_thumbnail_procedure_get_type" parents="GimpProcedure,GObject">
+  </class>
+  <class name="GimpVectorLayer" get-type="gimp_vector_layer_get_type" parents="GimpLayer,GimpDrawable,GimpItem,GObject">
+    <implements name="GimpRasterizable"/>
   </class>
   <class name="GimpVectorLoadProcedure" get-type="gimp_vector_load_procedure_get_type" parents="GimpLoadProcedure,GimpFileProcedure,GimpProcedure,GObject" final="1">
   </class>

--- a/x11-packages/gimp/gir/GimpUi-3.0.xml
+++ b/x11-packages/gimp/gir/GimpUi-3.0.xml
@@ -50,6 +50,8 @@
       <param type="gchararray"/>
       <param type="gint"/>
     </signal>
+    <signal name="stop-search" return="void" when="last">
+    </signal>
   </class>
   <class name="GimpBusyBox" get-type="gimp_busy_box_get_type" parents="GtkBox,GtkContainer,GtkWidget,GInitiallyUnowned,GObject">
     <implements name="AtkImplementorIface"/>
@@ -217,7 +219,7 @@
     <property name="value" type="gdouble" flags="227" default-value="1.000000"/>
     <property name="lower" type="gdouble" flags="231" default-value="0.000000"/>
     <property name="upper" type="gdouble" flags="231" default-value="1.000000"/>
-    <property name="digits" type="gint" flags="227" default-value="-1"/>
+    <property name="digits" type="gint" flags="231" default-value="-1"/>
     <signal name="value-changed" return="void" when="first">
     </signal>
   </class>
@@ -227,6 +229,18 @@
     <implements name="GtkOrientable"/>
   </class>
   <class name="GimpColorScaleEntry" get-type="gimp_color_scale_entry_get_type" parents="GimpScaleEntry,GimpLabelSpin,GimpLabeled,GtkGrid,GtkContainer,GtkWidget,GInitiallyUnowned,GObject">
+    <implements name="AtkImplementorIface"/>
+    <implements name="GtkBuildable"/>
+    <implements name="GtkOrientable"/>
+  </class>
+  <class name="GimpColorScales" get-type="gimp_color_scales_get_type" parents="GimpColorSelector,GtkBox,GtkContainer,GtkWidget,GInitiallyUnowned,GObject">
+    <implements name="AtkImplementorIface"/>
+    <implements name="GtkBuildable"/>
+    <implements name="GtkOrientable"/>
+    <property name="show-rgb-u8" type="gboolean" flags="231" default-value="FALSE"/>
+    <property name="show-hsv" type="gboolean" flags="231" default-value="FALSE"/>
+  </class>
+  <class name="GimpColorSelect" get-type="gimp_color_select_get_type" parents="GimpColorSelector,GtkBox,GtkContainer,GtkWidget,GInitiallyUnowned,GObject">
     <implements name="AtkImplementorIface"/>
     <implements name="GtkBuildable"/>
     <implements name="GtkOrientable"/>
@@ -552,11 +566,28 @@
     <implements name="GtkBuildable"/>
     <implements name="GtkOrientable"/>
   </class>
+  <class name="GimpImageChooser" get-type="gimp_image_chooser_get_type" parents="GtkBox,GtkContainer,GtkWidget,GInitiallyUnowned,GObject" final="1">
+    <implements name="AtkImplementorIface"/>
+    <implements name="GtkBuildable"/>
+    <implements name="GtkOrientable"/>
+    <property name="title" type="gchararray" flags="235" default-value="Image Selection"/>
+    <property name="label" type="gchararray" flags="235" default-value="NULL"/>
+    <property name="image" type="GimpImage" flags="1073742051"/>
+  </class>
   <class name="GimpImageComboBox" get-type="gimp_image_combo_box_get_type" parents="GimpIntComboBox,GtkComboBox,GtkBin,GtkContainer,GtkWidget,GInitiallyUnowned,GObject">
     <implements name="AtkImplementorIface"/>
     <implements name="GtkBuildable"/>
     <implements name="GtkCellLayout"/>
     <implements name="GtkCellEditable"/>
+  </class>
+  <class name="GimpItemChooser" get-type="gimp_item_chooser_get_type" parents="GtkBox,GtkContainer,GtkWidget,GInitiallyUnowned,GObject" final="1">
+    <implements name="AtkImplementorIface"/>
+    <implements name="GtkBuildable"/>
+    <implements name="GtkOrientable"/>
+    <property name="title" type="gchararray" flags="235" default-value="Item Selection"/>
+    <property name="label" type="gchararray" flags="235" default-value="NULL"/>
+    <property name="item" type="GimpItem" flags="1073742051"/>
+    <property name="item-type" type="GType" flags="235"/>
   </class>
   <class name="GimpDrawableComboBox" get-type="gimp_drawable_combo_box_get_type" parents="GimpIntComboBox,GtkComboBox,GtkBin,GtkContainer,GtkWidget,GInitiallyUnowned,GObject">
     <implements name="AtkImplementorIface"/>

--- a/x11-packages/gimp/meson.build.patch
+++ b/x11-packages/gimp/meson.build.patch
@@ -1,14 +1,15 @@
-+++ ./meson.build
-@@ -441,7 +441,7 @@
- lcms              = dependency('lcms2',              version: '>='+lcms_minver)
- libmypaint_minver = '1.3.0'
- libmypaint        = dependency('libmypaint',         version: '>='+libmypaint_minver)
--mypaint_brushes   = dependency('mypaint-brushes-1.0',version: '>='+libmypaint_minver)
-+mypaint_brushes   = dependency('mypaint-brushes-2.0',version: '>='+libmypaint_minver)
- if not libmypaint.version().version_compare('>=1.4.0')
-   libmypaint_warning='''
+--- a/meson.build
++++ b/meson.build
+@@ -571,7 +571,7 @@
+   pangoft2     = dependency('pangoft2',    version: '>='+pango_minver)
+ endif
  
-@@ -1545,28 +1541,7 @@
+-if cc.run('''
++if not meson.is_cross_build() and cc.run('''
+   #include <pango/pango.h>
+   #include <string.h>
+   #include <stdlib.h>
+@@ -1572,28 +1572,7 @@
  endif
  
  if shmem_choice == 'sysv'
@@ -38,24 +39,26 @@
    conf.set('USE_SYSV_SHM', true)
  elif shmem_choice == 'posix'
    conf.set('USE_POSIX_SHM', true)
-@@ -1963,7 +1938,7 @@
-  gimp_run_env.set('GIMP_DEBUG_SELF', '1')
+@@ -1994,7 +1973,7 @@
  endif
+ gimp_run_env.set('GIMP_PYTHON_WITH_GI', python.full_path())
  
 -if meson.can_run_host_binaries() and have_gobject_introspection
 +if have_gobject_introspection
    if enable_console_bin
      gimp_real_exe = gimpconsole_exe
    else
-+++ ./gimp-data/images/meson.build
-@@ -1,5 +1,6 @@
+--- a/gimp-data/images/meson.build
++++ b/gimp-data/images/meson.build
+@@ -3,6 +3,7 @@
+ 
  ## Splash Image and Welcome Dialog ##
  
 +if not meson.is_cross_build()
  splash = custom_target('gimp-splash.png',
                         input : [ 'export-splash.py' ],
                         output: [ 'gimp-splash.png', ],
-@@ -13,6 +14,9 @@
+@@ -16,6 +17,9 @@
                         env: gimp_run_env,
                         install_dir: gimpdatadir / 'images',
                         install: true)


### PR DESCRIPTION
* Remove meson patch for mypaint-brushes which was changes to 2.0 in upstream.
  https://gitlab.gnome.org/GNOME/gimp/-/commit/f4bdd69f73f26adf643d915ebf606fc0008a7fa4

* Disable running pango test in meson.build due to cross-compilation.

* Convert patch file to git style patch.

* Fixes #28939 