### PR TITLE
change(main/aria2): Link against openssl instead of gnutls

### DIFF
--- a/packages/aria2/build.sh
+++ b/packages/aria2/build.sh
@@ -3,17 +3,17 @@ TERMUX_PKG_DESCRIPTION="Download utility supporting HTTP/HTTPS, FTP, BitTorrent 
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.37.0"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL="https://github.com/aria2/aria2/releases/download/release-${TERMUX_PKG_VERSION}/aria2-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=60a420ad7085eb616cb6e2bdf0a7206d68ff3d37fb5a956dc44242eb2f79b66b
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+\.\d+"
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag" # As of 2022-05-11T00:08:00 no github releases are available.
-TERMUX_PKG_DEPENDS="libc++, c-ares, libgnutls, libxml2, zlib"
+TERMUX_PKG_DEPENDS="libc++, c-ares, openssl, libxml2, zlib"
 # sqlite3 is only used for loading cookies from firefox or chrome:
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
---without-openssl
---with-gnutls
+--with-openssl
+--without-gnutls
 --without-libuv
 --without-sqlite3
 --without-libssh2


### PR DESCRIPTION
Part of aligning on openssl instead of gnutls as much as possible (see https://github.com/termux/termux-packages/pull/28399).