### PR TITLE
bump(main/neovim-nightly): 0.12.0~dev-2603+g9ab6c607cc

### DIFF
--- a/packages/neovim-nightly/build.sh
+++ b/packages/neovim-nightly/build.sh
@@ -3,9 +3,9 @@ TERMUX_PKG_DESCRIPTION="Ambitious Vim-fork focused on extensibility and agility 
 TERMUX_PKG_LICENSE="Apache-2.0, VIM License"
 TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
-TERMUX_PKG_VERSION="0.12.0~dev-2586+g16f7440cc7"
+TERMUX_PKG_VERSION="0.12.0~dev-2603+g9ab6c607cc"
 TERMUX_PKG_SRCURL="https://github.com/neovim/neovim/archive/${TERMUX_PKG_VERSION##*+g}.tar.gz"
-TERMUX_PKG_SHA256=9d6ddba6e91913349729621cfa510554b2eda305ef90d9317042436e7cf3bb20
+TERMUX_PKG_SHA256=a1bd2b757980e81db3af25e62db92f19f7f0d99493aa3f024f9c51ccc9d3d588
 TERMUX_PKG_REPOLOGY_METADATA_VERSION="${TERMUX_PKG_VERSION%%~*}"
 TERMUX_PKG_DEPENDS="libandroid-support, libiconv, libmsgpack, libunibilium, libuv, libvterm (>= 1:0.3-0), lua51-lpeg, luajit, luv, tree-sitter, tree-sitter-parsers, utf8proc"
 TERMUX_PKG_BREAKS="neovim"

--- a/packages/neovim-nightly/src-nvim-eval-funcs.c.patch
+++ b/packages/neovim-nightly/src-nvim-eval-funcs.c.patch
@@ -1,1 +1,0 @@
-../neovim/src-nvim-eval-funcs.c.patch


### PR DESCRIPTION
This PR drops `src-nvim-eval-funcs.c.patch` from our `neovim-nightly` package since the contents of that patch have now been upstreamed in the latest Nightly release.
- Upstream commit: https://github.com/neovim/neovim/commit/6edae880528b7a1494a7610b07e4415d68c463ff

I will not be dropping the patch from the `neovim` stable package at this time as there has been significant reshuffling of the docs for the `builtin`/`vimfn` modules between 0.11.x and 0.12.
So it makes more sense to keep the patch for the stable version for now and drop it when 0.12.0 releases as stable.