### PR TITLE
fix(main/libunibilium): fix pkgconfig file

### DIFF
--- a/packages/libunibilium/build.sh
+++ b/packages/libunibilium/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://github.com/neovim/unibilium
 TERMUX_PKG_DESCRIPTION="Terminfo parsing library"
 TERMUX_PKG_LICENSE="LGPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=2.1.2
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://github.com/neovim/unibilium/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_VERSION="2.1.2"
+TERMUX_PKG_REVISION=2
+TERMUX_PKG_SRCURL="https://github.com/neovim/unibilium/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=370ecb07fbbc20d91d1b350c55f1c806b06bf86797e164081ccc977fc9b3af7a
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BREAKS="libunibilium-dev"
@@ -42,9 +42,9 @@ termux_step_make_install() {
 	$CC -shared -fPIC $LDFLAGS -o $TERMUX_PREFIX/lib/libunibilium.so unibilium.o uninames.o uniutil.o
 	cp unibilium.h $TERMUX_PREFIX/include/
 
-	mkdir -p $PKG_CONFIG_LIBDIR
+	mkdir -p "$TERMUX_PREFIX/lib/pkgconfig"
 	sed "s|@VERSION@|$TERMUX_PKG_VERSION|" unibilium.pc.in | \
 		sed "s|@INCDIR@|$TERMUX_PREFIX/include|" | \
 		sed "s|@LIBDIR@|$TERMUX_PREFIX/lib|" > \
-		$PKG_CONFIG_LIBDIR/unibilium.pc
+		"$TERMUX_PREFIX/lib/pkgconfig/unibilium.pc"
 }


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28988

- Packages which use commands like `mkdir -p $PKG_CONFIG_LIBDIR` are incorrect, because `$PKG_CONFIG_LIBDIR` can sometimes be a colon-delimited list, not a path