### PR TITLE
bump(main/fresh-editor): 0.2.18

### DIFF
--- a/packages/fresh-editor/build.sh
+++ b/packages/fresh-editor/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://getfresh.dev/
 TERMUX_PKG_DESCRIPTION="Text editor for your terminal: easy, powerful and fast"
 TERMUX_PKG_LICENSE="GPL-2.0-only"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.2.17"
+TERMUX_PKG_VERSION="0.2.18"
 TERMUX_PKG_SRCURL="https://github.com/sinelaw/fresh/releases/download/v$TERMUX_PKG_VERSION/fresh-editor-$TERMUX_PKG_VERSION-source.tar.gz"
-TERMUX_PKG_SHA256=e3eda70b12ee45be6f613cb3c4661bdb67025cd465eecc36c55bcf065dba6161
+TERMUX_PKG_SHA256=44a658b8d642584953561c4fcc9f302ee5d60c351c3e522073eea4fc3d8cd999
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
 

--- a/packages/fresh-editor/rust-cc-do-not-concatenate-all-the-CFLAGS.diff
+++ b/packages/fresh-editor/rust-cc-do-not-concatenate-all-the-CFLAGS.diff
@@ -17,8 +17,8 @@ This patch will restore the old behaviour. For Termux we know how it is going.
 take from x11-packages/firefox/0029-rust-cc-do-not-concatenates-all-the-CFLAGS.patch by @robertkirkman
 --- a/src/lib.rs
 +++ b/src/lib.rs
-@@ -3806,14 +3806,13 @@
-
+@@ -3924,14 +3924,13 @@ impl Build {
+ 
      /// Get values from CFLAGS-style environment variable.
      fn envflags(&self, env: &str) -> Result<Option<Vec<String>>, Error> {
 -        // Collect from all environment variables, in reverse order as in
@@ -29,10 +29,10 @@ take from x11-packages/firefox/0029-rust-cc-do-not-concatenates-all-the-CFLAGS.p
          let mut res = vec![];
 -        for env in self.target_envs(env)?.iter().rev() {
 +        for env in self.target_envs(env)?.iter() {
-             if let Some(var) = self.getenv(env) {
+             if let Some(var) = self.get_env(env) {
 +                if any_set {
 +                    continue;
 +                }
                  any_set = true;
-
+ 
                  let var = var.to_string_lossy();


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/29057

- Rebase `rust-cc-do-not-concatenate-all-the-CFLAGS.diff`