### PR TITLE
addpkg(main/mise): 2026.5.15

### DIFF
--- a/packages/mise/build.sh
+++ b/packages/mise/build.sh
@@ -1,0 +1,72 @@
+TERMUX_PKG_HOMEPAGE=https://mise.jdx.dev/
+TERMUX_PKG_DESCRIPTION="dev tools, env vars, task runner"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="2026.5.15"
+TERMUX_PKG_SRCURL="https://github.com/jdx/mise/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=b955c45638a32f1bba263854e4b2e8babd65fcd66cfbcc997b02b74e609a738f
+TERMUX_PKG_DEPENDS="bzip2, openssl"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_TAG_TYPE=latest-release-tag
+
+termux_step_pre_configure() {
+	termux_setup_rust
+
+	# Vendor cargo deps to ./vendor-termux/ - not ./vendor/ - because mise's
+	# tree ships ./vendor/aqua-registry/ as build-time data (build.rs reads
+	# vendor/aqua-registry/registry.yml). `cargo vendor` overwrites its
+	# target directory, so pointing it at ./vendor/ deletes aqua-registry
+	# and the build fails with `os error 2`.
+	cargo vendor vendor-termux
+	find ./vendor-termux \
+		-mindepth 1 -maxdepth 1 -type d \
+		! -wholename ./vendor-termux/rattler_pty \
+		-exec rm -rf '{}' \;
+
+	patch="$TERMUX_PKG_BUILDER_DIR/rattler_pty-android-target.diff"
+	dir="vendor-termux/rattler_pty"
+	echo "Applying patch: $patch"
+	patch -p1 -d "$dir" < "$patch"
+
+	cat <<-EOL >> Cargo.toml
+
+		[patch.crates-io]
+		rattler_pty = { path = "./vendor-termux/rattler_pty" }
+	EOL
+
+	local -u env_host="${CARGO_TARGET_NAME//-/_}"
+	export CARGO_TARGET_"${env_host}"_RUSTFLAGS+=" -C link-arg=$(${CC} -print-libgcc-file-name)"
+
+	# The `openssl-sys` crate fails to compile if we don't set this.
+	# Declare and export separately, see http://shellcheck.net/wiki/SC2155
+	HOST_TRIPLET="$(gcc -dumpmachine)"
+	PKG_CONFIG_PATH_x86_64_unknown_linux_gnu="$(grep 'DefaultSearchPaths:' "/usr/share/pkgconfig/personality.d/${HOST_TRIPLET}.personality" | cut -d ' ' -f 2)"
+	export PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
+
+	# This variable specifically **does not** use SHOUT_CASE naming like the CARGO_TARGET_* variable above.
+	# The `sys-info` crate fails to compile if we don't set this.
+	export CFLAGS_"${CARGO_TARGET_NAME//-/_}"+=" -Dindex=strchr"
+}
+
+termux_step_make() {
+	cargo build --jobs "$TERMUX_PKG_MAKE_PROCESSES" --target "$CARGO_TARGET_NAME" --release
+}
+
+termux_step_make_install() {
+	# mise binary
+	install -vDm755 "target/${CARGO_TARGET_NAME}/release/${TERMUX_PKG_NAME}" \
+		-t "$TERMUX_PREFIX/bin"
+	# man page
+	install -vDm644 "man/man1/mise.1" \
+		-t "${TERMUX_PREFIX}/share/man/man1"
+	# shell completions
+	install -vDm644 "completions/_${TERMUX_PKG_NAME}" \
+		-t "${TERMUX_PREFIX}/share/zsh/site-functions"
+	# The bash completion has a .bash extension which it shouldn't so fix that before installing it.
+	mv -v "completions/${TERMUX_PKG_NAME}"{.bash,}
+	install -vDm644 "completions/${TERMUX_PKG_NAME}" \
+		-t "${TERMUX_PREFIX}/share/bash-completion/completions"
+	install -vDm644 "completions/${TERMUX_PKG_NAME}.fish" \
+		-t "${TERMUX_PREFIX}/share/fish/vendor_completions.d"
+}

--- a/packages/mise/rattler_pty-android-target.diff
+++ b/packages/mise/rattler_pty-android-target.diff
@@ -1,0 +1,11 @@
+--- a/src/unix/pty_process.rs
++++ b/src/unix/pty_process.rs
+@@ -24,7 +24,7 @@ use tokio::{
+     time::{sleep, Duration, Instant},
+ };
+
+-#[cfg(target_os = "linux")]
++#[cfg(any(target_os = "linux", target_os = "android"))]
+ use nix::pty::ptsname_r;
+
+ /// Start a process in a forked tty so you can interact with it the same as you would


### PR DESCRIPTION
- closes #17797 (project has since been renamed)

As pointed out in the package request, the tool versioning component of `mise` won't work on Termux.
But the task runner and env management components should still work as expected.

<h1><em></em></h1> <!-- thin separator -->

Feedback on this package would be greatly appreciated.
To that end I have included instructions for testing PR artifacts below.

<sup>(This is a pre-written, saved reply.)</sup>
If you want to test this PR please download the appropriate DEB package(s)
from the build artifacts of the [associated PR's latest CI run](https://github.com/termux/termux-packages/actions/runs/23458215003?pr=29075).

<img width="1029" height="1665" alt="image" src="
> [!WARNING]
> This asset could not be copied from your saved reply. Please try again later.

" />

After downloading the build artifact, make sure to `unzip` and un-`tar` it.
<details><summary>Detailed instructions, if needed.</summary>
<p>

```bash
# finding out what architecture you need
# architecture is just below the TERMUX_VERSION
termux-info

# e.g.
# [...]
# TERMUX__UID=10228
# TERMUX__USER_ID=0
# Packages CPU architecture:
# aarch64
# [...]

# =======================

# make sure `unzip` and `tar` are installed using
pkg install unzip tar

# unzip the artifact (if you have a different architecture this might be arm, i686 or x86_64 instead)
unzip debs-aarch64-*.zip

# untar the artifact
tar xf debs-aarch64-*.tar

# You should now have a debs/ directory in your current working directory
# Install the packages from the local source using
pkg install -- ./debs/*.deb

# to clean up, you can remove the debs/ directory, .tar file and .zip file
rm -rfi debs debs-aarch64-*.zip debs-aarch64-*.tar
```

</p>
</details> 