### PR TITLE
Fix typo in README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Termux packages
+# Termux packagesl
 
 ![GitHub repo size](https://img.shields.io/github/repo-size/termux/termux-packages)
 [![Packages last build status](https://github.com/termux/termux-packages/actions/workflows/packages.yml/badge.svg?branch=master)](https://github.com/termux/termux-packages/actions)


### PR DESCRIPTION
Corrected a typo in the header from 'packagesl' to 'packages'.