### PR TITLE
chore(main/profanity): switch to meson from autotools

### DIFF
--- a/packages/profanity/build.sh
+++ b/packages/profanity/build.sh
@@ -6,15 +6,17 @@ TERMUX_PKG_MAINTAINER="Oliver Schmidhauser @Neo-Oli"
 # This package depends on libpython${TERMUX_PYTHON_VERSION}.so.
 # Please revbump and rebuild when bumping TERMUX_PYTHON_VERSION.
 TERMUX_PKG_VERSION="0.17.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/profanity-im/profanity/releases/download/$TERMUX_PKG_VERSION/profanity-$TERMUX_PKG_VERSION.tar.xz"
 TERMUX_PKG_SHA256=508e18c0e797d46cc38779eb207480fc3e93b814e202a351050f395c1b262804
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="glib, gpgme, libandroid-support, libassuan, libcurl, libgcrypt, libgpg-error, libotr, libsignal-protocol-c, libsqlite, libstrophe, ncurses, python, readline"
 TERMUX_PKG_BREAKS="profanity-dev"
 TERMUX_PKG_REPLACES="profanity-dev"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" --enable-plugins --without-xscreensaver"
-TERMUX_PKG_BUILD_IN_SRC=true
-
-termux_step_pre_configure() {
-	autoreconf -fi
-}
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-Dc-plugins=enabled
+-Domemo=enabled
+-Dotr=enabled
+-Dpgp=enabled
+-Dpython-plugins=enabled
+"


### PR DESCRIPTION
upstream recommends meson and autotools will be removed in next release.
see https://github.com/profanity-im/profanity/releases/tag/0.17.0

enable some meson options to keep it compatible with older releases.
* as requested here #29107