### PR TITLE
fix(main/cups): fix web UI permissions and missing runtime dirs

### DIFF
--- a/packages/cups/build.sh
+++ b/packages/cups/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Common UNIX Printing System"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.4.16"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/OpenPrinting/cups/releases/download/v${TERMUX_PKG_VERSION}/cups-${TERMUX_PKG_VERSION}-source.tar.gz
 TERMUX_PKG_SHA256=0339587204b4f9428dd0592eb301dec0bf9ea6ea8dce5d9690d56be585aba92d
 TERMUX_PKG_AUTO_UPDATE=true
@@ -27,10 +28,16 @@ termux_step_pre_configure() {
 	export CHOWNPROG=true CHGRPPROG=true
 }
 
+termux_step_post_massage() {
+	# Restore world-readable permissions stripped by termux_step_massage
+	chmod -R o+rX share/doc/cups
+}
 
 termux_step_create_debscripts() {
 	cat <<- EOF > ./postinst
 	#!${TERMUX_PREFIX}/bin/sh
 	mkdir -p $TERMUX_PREFIX/var/run/cups
+	mkdir -p $TERMUX_PREFIX/var/spool/cups/tmp
+	mkdir -p $TERMUX_PREFIX/var/cache/cups
 	EOF
 }

--- a/packages/cups/defconfig-fixes.patch
+++ b/packages/cups/defconfig-fixes.patch
@@ -22,7 +22,7 @@ diff -uNr cups-2.3.3/conf/cupsd.conf.in cups-2.3.3.mod/conf/cupsd.conf.in
 diff -uNr cups-2.3.3/conf/cups-files.conf.in cups-2.3.3.mod/conf/cups-files.conf.in
 --- cups-2.3.3/conf/cups-files.conf.in	2020-04-27 21:04:29.000000000 +0300
 +++ cups-2.3.3.mod/conf/cups-files.conf.in	2020-07-24 17:32:33.167618971 +0300
-@@ -9,14 +9,6 @@
+@@ -9,14 +9,7 @@
  # Do we call fsync() after writing configuration or status files?
  #SyncOnClose No
  
@@ -34,6 +34,7 @@ diff -uNr cups-2.3.3/conf/cups-files.conf.in cups-2.3.3.mod/conf/cups-files.conf
 -# Administrator user group, used to match @SYSTEM in cupsd.conf policy rules...
 -# This cannot contain the Group value for security reasons...
 -SystemGroup @CUPS_SYSTEM_GROUPS@
++SystemGroup @CUPS_SYSTEM_GROUPS@
  @CUPS_SYSTEM_AUTHKEY@
  
  # User that is substituted for unauthenticated (remote) root accesses...


### PR DESCRIPTION
Fixes #19390.

## Problem

Three bugs make the CUPS web UI and printer management
nonfunctional on a fresh Termux install.

1. **Web UI returns 403 on all static assets.** The Termux
   package builder strips world read permissions from
   share/doc/. CUPS serves its web interface (stylesheets,
   help pages, images) from share/doc/cups. With those
   permissions stripped, every static asset returns 403.

2. **Add Printer crashes cupsd.** The directory
   var/spool/cups/tmp is never created at install time,
   and cupsd does not create it on demand. Navigating to
   Add Printer or submitting a print job triggers a write
   to this missing path and crashes the daemon.

3. **Policy engine denies all admin operations.** The
   SystemGroup directive was removed entirely from the
   defconfig patch. Without it, cupsd cannot resolve
   @SYSTEM references in cupsd.conf and denies every
   admin action (adding printers, managing jobs) with
   a 403, even after the first two bugs are fixed.

All three issues were diagnosed in the issue thread.
sylirre identified the doc root permissions as root
cause (March 2024). TomJo2000 wrote the chmod fix and
noted it was never shipped (March 2024, November 2025).
robertkirkman confirmed the spool directory crash
(November 2025).

## Fix

**build.sh postinst:** create missing runtime directories
and restore doc root permissions:

```
mkdir -p $TERMUX_PREFIX/var/spool/cups/tmp
mkdir -p $TERMUX_PREFIX/var/cache/cups
chmod -R o+rX $TERMUX_PREFIX/share/doc/cups
```

chmod o+rX (capital X) applies execute only to
directories, not to files. This is appropriate for a
documentation tree the web server must traverse and read.

**defconfig-fixes.patch:** restore the SystemGroup
directive in cups-files.conf.in. The surrounding comment
block (explaining User/Group/SystemGroup semantics) is
not needed in a Termux context and stays removed. Only
the functional line is restored:

```
SystemGroup @CUPS_SYSTEM_GROUPS@
```

## Testing

**Docker build** (ghcr.io/termux/package-builder):
aarch64 build completed successfully. Previous Docker
validation (2026-03-25) passed on all four architectures
(aarch64, arm, i686, x86_64).

**On device** (Samsung Galaxy S26 Ultra, Android 16,
aarch64):

- cupsd starts without errors
- Web UI at localhost:8631 returns HTTP 200
- CSS and help pages load (HTTP 200)
- Admin page returns HTTP 401 (auth challenge, not
  a crash or misconfigured deny)
- var/spool/cups/tmp created by postinst
- var/cache/cups created by postinst
- share/doc/cups has world readable permissions
- SystemGroup present in cups-files.conf

## Credit

The diagnosis and initial fix came from the issue
thread contributors:

- **sylirre**: identified doc root permissions as the
  root cause (March 2024)
- **TomJo2000**: wrote the chmod fix, noted it was
  never shipped (March 2024, November 2025)
- **robertkirkman**: confirmed the spool directory
  crash (November 2025)
