### PR TITLE
bump(main/pyrefly): 0.57.1

### DIFF
--- a/packages/pyrefly/build.sh
+++ b/packages/pyrefly/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://github.com/facebook/pyrefly.git
 TERMUX_PKG_DESCRIPTION="A fast type checker and language server for Python"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@AhmadNaruto"
-TERMUX_PKG_VERSION="0.56.0"
+TERMUX_PKG_VERSION="0.57.1"
 TERMUX_PKG_SRCURL="https://github.com/facebook/pyrefly/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256=5facd8d1fa4adcd69e7d4268ab74ced7836c8a7013b78aa7d89cfaed24621c06
+TERMUX_PKG_SHA256=8e03327b65498a8fe43e51436a9142b73c765e7376f5fb727a01b13d87c45700
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 

--- a/packages/pyrefly/rust-cc-do-not-concatenate-all-the-CFLAGS.diff
+++ b/packages/pyrefly/rust-cc-do-not-concatenate-all-the-CFLAGS.diff
@@ -17,8 +17,8 @@ This patch will restore the old behaviour. For Termux we know how it is going.
 take from x11-packages/firefox/0029-rust-cc-do-not-concatenates-all-the-CFLAGS.patch by @robertkirkman
 --- a/src/lib.rs
 +++ b/src/lib.rs
-@@ -3806,14 +3806,13 @@
-
+@@ -3924,14 +3924,13 @@ impl Build {
+ 
      /// Get values from CFLAGS-style environment variable.
      fn envflags(&self, env: &str) -> Result<Option<Vec<String>>, Error> {
 -        // Collect from all environment variables, in reverse order as in
@@ -29,10 +29,10 @@ take from x11-packages/firefox/0029-rust-cc-do-not-concatenates-all-the-CFLAGS.p
          let mut res = vec![];
 -        for env in self.target_envs(env)?.iter().rev() {
 +        for env in self.target_envs(env)?.iter() {
-             if let Some(var) = self.getenv(env) {
+             if let Some(var) = self.get_env(env) {
 +                if any_set {
 +                    continue;
 +                }
                  any_set = true;
-
+ 
                  let var = var.to_string_lossy();


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/28999

- Rebase `rust-cc-do-not-concatenate-all-the-CFLAGS.diff`