### PR TITLE
add(x11/iloader): 2.2.5

### DIFF
--- a/x11-packages/iloader/0001-Disable-Tauri-Android-Support.patch
+++ b/x11-packages/iloader/0001-Disable-Tauri-Android-Support.patch
@@ -1,0 +1,40 @@
+From 571e305840a70cd03006328ae637a25394d558c9 Mon Sep 17 00:00:00 2001
+From: alexytomi <60690056+alexytomi@users.noreply.github.com>
+Date: Sat, 20 Dec 2025 23:25:36 +0800
+Subject: [PATCH 1/3] Disable Tauri Android Support
+
+Tauri has android APK/AAB support. We can't have that so we have to
+resort to this jank.
+
+Co-authored-by: Robert Kirkman <rkirkman@termux.dev>
+---
+ src-tauri/Cargo.toml | 2 +-
+ src-tauri/src/lib.rs | 1 -
+ 2 files changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src-tauri/Cargo.toml b/src-tauri/Cargo.toml
+index a6e4e44b..e7515525 100644
+--- a/src-tauri/Cargo.toml
++++ b/src-tauri/Cargo.toml
+@@ -38,5 +38,5 @@ tracing = "0.1.44"
+ tracing-appender = "0.2"
+ rustls = "0.23.36"
+ 
+-[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
++[target.'cfg(not(any(target_os = "disabling_this_because_it_is_for_building_an_apk", target_os = "ios")))'.dependencies]
+ tauri-plugin-updater = "2"
+diff --git a/src-tauri/src/lib.rs b/src-tauri/src/lib.rs
+index 1cbf97e1..f9592b48 100644
+--- a/src-tauri/src/lib.rs
++++ b/src-tauri/src/lib.rs
+@@ -22,7 +22,6 @@ use crate::{
+ use tauri::Manager;
+ use tracing_subscriber::{Layer, Registry, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+ 
+-#[cfg_attr(mobile, tauri::mobile_entry_point)]
+ pub fn run() {
+     tauri::Builder::default()
+         .plugin(tauri_plugin_process::init())
+-- 
+2.53.0
+

--- a/x11-packages/iloader/0002-Disable-Tauri-auto-update.patch
+++ b/x11-packages/iloader/0002-Disable-Tauri-auto-update.patch
@@ -1,0 +1,25 @@
+From e8d639cc48764dc548f36aedd5cd687c503bfee8 Mon Sep 17 00:00:00 2001
+From: alexytomi <60690056+alexytomi@users.noreply.github.com>
+Date: Sun, 29 Mar 2026 19:42:29 +0800
+Subject: [PATCH 2/3] Disable Tauri auto-update
+
+We can't have the user auto-updating
+---
+ src-tauri/src/lib.rs | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src-tauri/src/lib.rs b/src-tauri/src/lib.rs
+index f9592b48..0ce7f1f7 100644
+--- a/src-tauri/src/lib.rs
++++ b/src-tauri/src/lib.rs
+@@ -25,7 +25,6 @@ use tracing_subscriber::{Layer, Registry, fmt, layer::SubscriberExt, util::Subsc
+ pub fn run() {
+     tauri::Builder::default()
+         .plugin(tauri_plugin_process::init())
+-        .plugin(tauri_plugin_updater::Builder::new().build())
+         .plugin(tauri_plugin_opener::init())
+         .plugin(tauri_plugin_dialog::init())
+         .plugin(tauri_plugin_store::Builder::new().build())
+-- 
+2.53.0
+

--- a/x11-packages/iloader/0003-Fix-webkit-not-properly-rendering-with-dmabuf.patch
+++ b/x11-packages/iloader/0003-Fix-webkit-not-properly-rendering-with-dmabuf.patch
@@ -1,0 +1,28 @@
+From 611ec1a99d263a3e87f40ff88dbd5d9b50b09e97 Mon Sep 17 00:00:00 2001
+From: alexytomi <60690056+alexytomi@users.noreply.github.com>
+Date: Sun, 29 Mar 2026 19:59:00 +0800
+Subject: [PATCH 3/3] Fix webkit not properly rendering with dmabuf
+
+Not setting this causes rendering to be very slow or just not happen
+---
+ src-tauri/src/main.rs | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src-tauri/src/main.rs b/src-tauri/src/main.rs
+index 2417d18c..048160a1 100644
+--- a/src-tauri/src/main.rs
++++ b/src-tauri/src/main.rs
+@@ -11,6 +11,10 @@ fn main() {
+             }
+         }
+     }
++    #[cfg(target_os = "android")]
++    unsafe {
++        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
++    }
+ 
+     // To be quite honest, I have no idea how ring has made its way into the dependence tree in some cases.
+     rustls::crypto::aws_lc_rs::default_provider()
+-- 
+2.53.0
+

--- a/x11-packages/iloader/build.sh
+++ b/x11-packages/iloader/build.sh
@@ -1,0 +1,91 @@
+TERMUX_PKG_HOMEPAGE="https://github.com/nab138/iloader"
+TERMUX_PKG_DESCRIPTION="User friendly sideloader. Install SideStore (or other apps) and import your pairing file with ease"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="2.2.5"
+TERMUX_PKG_SRCURL="https://github.com/nab138/iloader/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256="781d077514461804391c6991f9ee5f9a05f092ff0a8497e1b099e5890b53b985"
+TERMUX_PKG_DEPENDS="webkit2gtk-4.1, usbmuxd"
+
+termux_step_make() {
+	termux_setup_rust
+	termux_setup_nodejs
+
+	cd $TERMUX_PKG_SRCDIR/src-tauri
+	cargo clean
+	cargo vendor vendor/
+
+	# We patch idevice because it hardcodes usbmuxd socket at /var/run/usbmuxd
+	# To do this we cargo vendor to fetch it and then patch it then modify Cargo.toml to use our patched version
+	# Since we have to preserve the features block of idevice in the original Cargo.toml, we patch Cargo.toml for idevice here
+	sed -i 's|idevice = { version = "[^"]*"\(.*\)}|idevice = { path = "./vendor/idevice"\1}|g' $TERMUX_PKG_SRCDIR/src-tauri/Cargo.toml
+	# We skip patching it again because it will become a duplicate in Cargo.toml
+	crates_to_skip_cargo_toml=(
+		idevice
+	)
+
+	echo "" >> Cargo.toml
+	echo '[patch.crates-io]' >> Cargo.toml
+	crates_to_patch=(
+		softbuffer
+		tao
+		tauri-macros
+		tauri-plugin-dialog
+		tauri-plugin-fs
+		tauri-plugin-opener
+		tauri-runtime-wry
+		tauri-runtime
+		tauri-utils
+		tauri
+		tauri-plugin
+		wry
+		muda
+		rfd
+		reqwest
+		rustls-platform-verifier
+		idevice
+	)
+	# # If there is an issue with the automated patching, uncomment these to make it save the patches in src-tauri/patches. You can simply git am this dir.
+	# git add -A && git commit -m "add vendored folders" && git tag -d unpatched
+	# git tag unpatched
+	for crate in "${crates_to_patch[@]}"; do
+			echo "termuxifying '$crate'..."
+			find "vendor/$crate" -type f | \
+					xargs -n 1 sed -i \
+					-e 's|"android"|"disabling_this_because_it_is_for_building_an_apk"|g' \
+					-e "s|ANDROID|DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK|g" \
+					-e 's|"linux"|"android"|g' \
+					-e "s|libxkbcommon.so.0|libxkbcommon.so|g" \
+					-e "s|libxkbcommon-x11.so.0|libxkbcommon-x11.so|g" \
+					-e "s|libxcb.so.1|libxcb.so|g" \
+					-e "s|/tmp/|$TERMUX_PREFIX/tmp/|g" \
+					-e "s|/var/|$TERMUX_PREFIX/var/|g"
+
+			if [[ " ${crates_to_skip_cargo_toml[*]} " == *" $crate "* ]]; then
+					echo "skipping Cargo.toml entry of '$crate'..."
+					continue
+			fi
+			echo "$crate = { path = \"./vendor/$crate\" }" >> Cargo.toml
+
+			# git add -A && git commit -m "automated termux patch for $crate"
+	done
+	# git format-patch unpatched -o patches
+
+	# Generates the dist folder. Required else build fails.
+	npm install && npm run build
+	cd $TERMUX_PKG_SRCDIR/src-tauri
+	echo "idevice = { path = \"./vendor/idevice\" }" >> Cargo.toml
+	if [[ "$TERMUX_DEBUG_BUILD" == "true" ]]; then
+		cargo build --bins --features tauri/custom-protocol --target $CARGO_TARGET_NAME
+	else
+		cargo build --bins --features tauri/custom-protocol --release --target $CARGO_TARGET_NAME
+	fi
+}
+
+termux_step_make_install() {
+	if [[ "$TERMUX_DEBUG_BUILD" == "true" ]]; then
+		install -Dm700 -t $TERMUX_PREFIX/bin $TERMUX_PKG_SRCDIR/src-tauri/target/$CARGO_TARGET_NAME/debug/iloader
+	else
+		install -Dm700 -t $TERMUX_PREFIX/bin $TERMUX_PKG_SRCDIR/src-tauri/target/$CARGO_TARGET_NAME/release/iloader
+	fi
+}


### PR DESCRIPTION
# Why
iloader is the main official method for installing [Sidestore](https://docs.sidestore.io/docs/installation/prerequisites), an iOS sideloading app. Having this be packaged allows android phones to sideload Sidestore for iOS phones via USB
# Current issues
- ~~Severe lag/fails to render unless exporting `WEBKIT_DISABLE_DMABUF_RENDERER=1`.~~
- ~~Crashes if you trigger lots of animations in a short amount of time (button hover, popup fade, etc.)
These issues seem to be from webkit however I have no idea how to start troubleshooting them. The program itself works fine though.~~ Fixed with the webkitgtk update
- `usbmuxd` seems to be broken

~~Should there be a wrapper to export the env var? The program can be unusable without it.~~ Set using a patch.