### PR TITLE
change(x11/libvncserver): Link against openssl instead of gnutls

### DIFF
--- a/x11-packages/libvncserver/build.sh
+++ b/x11-packages/libvncserver/build.sh
@@ -3,14 +3,15 @@ TERMUX_PKG_DESCRIPTION="Cross-platform C libraries that allow you to easily impl
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.9.15"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/LibVNC/libvncserver/archive/refs/tags/LibVNCServer-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=62352c7795e231dfce044beb96156065a05a05c974e5de9e023d688d8ff675d7
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="libgcrypt, libgnutls, libjpeg-turbo, liblzo, libpng, zlib"
+TERMUX_PKG_DEPENDS="libgcrypt, libjpeg-turbo, liblzo, libpng, openssl, zlib"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DCMAKE_POLICY_VERSION_MINIMUM=3.5
--DWITH_OPENSSL=OFF
+-DWITH_GNUTLS=OFF
+-DWITH_OPENSSL=ON
 -DWITH_SASL=OFF
 "
 


### PR DESCRIPTION
Part of an effort to align on openssl as much as possible:

- #28399
- #28971
- #28976