### PR TITLE
add(main/sideloader): 1.0-pre4.2025.8.25

### DIFF
--- a/packages/sideloader/0001-Sideloader-Downgrade-some-syntax.patch
+++ b/packages/sideloader/0001-Sideloader-Downgrade-some-syntax.patch
@@ -1,0 +1,46 @@
+From eff23d97d39afc2e2465ab7e773421389913849d Mon Sep 17 00:00:00 2001
+From: alexytomi <60690056+alexytomi@users.noreply.github.com>
+Date: Wed, 10 Dec 2025 10:01:12 +0800
+Subject: [PATCH 1/5] [Sideloader] Downgrade some syntax
+
+This newer syntax is not understandable by the ancient ldc 1.30 version
+termux uses
+---
+ source/sideload/macho.d | 20 +++++++++++---------
+ 1 file changed, 11 insertions(+), 9 deletions(-)
+
+diff --git a/source/sideload/macho.d b/source/sideload/macho.d
+index e7d2799..7cefd6d 100644
+--- a/source/sideload/macho.d
++++ b/source/sideload/macho.d
+@@ -532,16 +532,18 @@ class CodeDirectoryBlob: Blob {
+         import std.string;
+         import std.stdio;
+         string s = cast(string) data[codeDirectory.identOffset..codeDirectory.identOffset + 5];
+-        return new CodeDirectoryBlob(
+-            hash: null,
+-            bundleIdentifier: (cast(immutable(char)*) (data.ptr + codeDirectory.identOffset)).fromStringz(),
+-            teamIdentifier: (cast(immutable(char)*) (data.ptr + codeDirectory.teamOffset)).fromStringz(),
+-            machO: null,
+-            entitlements: null,
+-            infoPlist: null,
+-            codeResources: null,
+-            isAlternate: false,
++        CodeDirectoryBlob blob = new CodeDirectoryBlob(
++           null,
++          (cast(immutable(char)*) (data.ptr + codeDirectory.identOffset)).fromStringz(),
++          (cast(immutable(char)*) (data.ptr + codeDirectory.teamOffset)).fromStringz(),
++           null,
++           null,
++           null,
++           null,
++           false,
+         );
++
++        return blob;
+     }
+ 
+     ubyte[] encode(ubyte[][] previousEncodedBlobs) {
+-- 
+2.51.2
+

--- a/packages/sideloader/0002-Sideloader-Remove-glibc-getpass-call.patch
+++ b/packages/sideloader/0002-Sideloader-Remove-glibc-getpass-call.patch
@@ -1,0 +1,27 @@
+From 02bb9aa64df706c756eedb1338883e084a7ae10d Mon Sep 17 00:00:00 2001
+From: alexytomi <60690056+alexytomi@users.noreply.github.com>
+Date: Sun, 21 Dec 2025 15:00:26 +0800
+Subject: [PATCH 2/5] [Sideloader] Remove glibc getpass call
+
+This is jank but it works
+---
+ frontends/cli/source/cli_frontend.d | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/frontends/cli/source/cli_frontend.d b/frontends/cli/source/cli_frontend.d
+index 8cc3968..ea3fc74 100644
+--- a/frontends/cli/source/cli_frontend.d
++++ b/frontends/cli/source/cli_frontend.d
+@@ -94,6 +94,9 @@ string readPasswordLine(string prompt) {
+     version (Windows) {
+         write(prompt.toStringz(), " [/!\\ The password will appear in clear text in the terminal]: ");
+         return readln().chomp();
++    } else version (Android){
++        write(prompt.toStringz(), " [/!\\ The password will appear in clear text in the terminal]: ");
++        return readln().chomp();
+     } else {
+         return fromStringz(cast(immutable) getpass(prompt.toStringz()));
+     }
+-- 
+2.51.2
+

--- a/packages/sideloader/0003-Sideloader-Bump-botan-to-master.patch
+++ b/packages/sideloader/0003-Sideloader-Bump-botan-to-master.patch
@@ -1,0 +1,121 @@
+From 281a78aade45ae933465015ef070ed6942ce03fa Mon Sep 17 00:00:00 2001
+From: alexytomi <60690056+alexytomi@users.noreply.github.com>
+Date: Mon, 22 Dec 2025 02:34:49 +0800
+Subject: [PATCH 3/5] [Sideloader] Bump botan to master
+
+Used `dub upgrade -s botan` after editing dub.json with the new value.
+
+This works around some weird cross-compiling android-specific TLS bug
+that I am not sure on the specifics of.
+---
+ dub.json                              | 2 +-
+ dub.selections.json                   | 3 +--
+ frontends/cli/dub.selections.json     | 2 +-
+ frontends/dlangui/dub.selections.json | 2 +-
+ frontends/gtk/dub.selections.json     | 2 +-
+ frontends/qt/dub.selections.json      | 2 +-
+ frontends/swiftui/dub.selections.json | 2 +-
+ 7 files changed, 7 insertions(+), 8 deletions(-)
+
+diff --git a/dub.json b/dub.json
+index 690cd16..51cfd1a 100644
+--- a/dub.json
++++ b/dub.json
+@@ -11,7 +11,7 @@
+     "buildRequirements": ["allowWarnings", "requireBoundsCheck"],
+ 
+     "dependencies": {
+-        "botan": "~>1.13",
++        "botan": "~master",
+         "dynamic-loader": {
+             "repository": "git+https://github.com/Dadoum/dynamicloader.git",
+             "version": "9202b389affa6be0740e7295dea8f0146537a784"
+diff --git a/dub.selections.json b/dub.selections.json
+index c6a6d7d..7cc573a 100644
+--- a/dub.selections.json
++++ b/dub.selections.json
+@@ -8,7 +8,7 @@
+ 		"bindbc-loader": "1.0.3",
+ 		"bindbc-opengl": "1.0.5",
+ 		"bindbc-sdl": "1.0.1",
+-		"botan": "1.13.6",
++		"botan": "~master",
+ 		"botan-math": "1.0.4",
+ 		"cachetools": "0.4.1",
+ 		"concepts": "0.0.9",
+@@ -34,7 +34,6 @@
+ 		"progress": "5.0.2",
+ 		"provision": {"version":"645d56d8e8c86c057893321843db00b21f1aaeb2","repository":"git+https://github.com/Dadoum/Provision.git"},
+ 		"requests": "2.1.2",
+-		"sideloader": {"path":"../../"},
+ 		"silly": "1.2.0-dev.2",
+ 		"slf4d": "2.4.3",
+ 		"test_allocator": "0.3.4",
+diff --git a/frontends/cli/dub.selections.json b/frontends/cli/dub.selections.json
+index c6a6d7d..e651f97 100644
+--- a/frontends/cli/dub.selections.json
++++ b/frontends/cli/dub.selections.json
+@@ -8,7 +8,7 @@
+ 		"bindbc-loader": "1.0.3",
+ 		"bindbc-opengl": "1.0.5",
+ 		"bindbc-sdl": "1.0.1",
+-		"botan": "1.13.6",
++		"botan": "~master",
+ 		"botan-math": "1.0.4",
+ 		"cachetools": "0.4.1",
+ 		"concepts": "0.0.9",
+diff --git a/frontends/dlangui/dub.selections.json b/frontends/dlangui/dub.selections.json
+index c6a6d7d..e651f97 100644
+--- a/frontends/dlangui/dub.selections.json
++++ b/frontends/dlangui/dub.selections.json
+@@ -8,7 +8,7 @@
+ 		"bindbc-loader": "1.0.3",
+ 		"bindbc-opengl": "1.0.5",
+ 		"bindbc-sdl": "1.0.1",
+-		"botan": "1.13.6",
++		"botan": "~master",
+ 		"botan-math": "1.0.4",
+ 		"cachetools": "0.4.1",
+ 		"concepts": "0.0.9",
+diff --git a/frontends/gtk/dub.selections.json b/frontends/gtk/dub.selections.json
+index c6a6d7d..e651f97 100644
+--- a/frontends/gtk/dub.selections.json
++++ b/frontends/gtk/dub.selections.json
+@@ -8,7 +8,7 @@
+ 		"bindbc-loader": "1.0.3",
+ 		"bindbc-opengl": "1.0.5",
+ 		"bindbc-sdl": "1.0.1",
+-		"botan": "1.13.6",
++		"botan": "~master",
+ 		"botan-math": "1.0.4",
+ 		"cachetools": "0.4.1",
+ 		"concepts": "0.0.9",
+diff --git a/frontends/qt/dub.selections.json b/frontends/qt/dub.selections.json
+index c6a6d7d..e651f97 100644
+--- a/frontends/qt/dub.selections.json
++++ b/frontends/qt/dub.selections.json
+@@ -8,7 +8,7 @@
+ 		"bindbc-loader": "1.0.3",
+ 		"bindbc-opengl": "1.0.5",
+ 		"bindbc-sdl": "1.0.1",
+-		"botan": "1.13.6",
++		"botan": "~master",
+ 		"botan-math": "1.0.4",
+ 		"cachetools": "0.4.1",
+ 		"concepts": "0.0.9",
+diff --git a/frontends/swiftui/dub.selections.json b/frontends/swiftui/dub.selections.json
+index c6a6d7d..e651f97 100644
+--- a/frontends/swiftui/dub.selections.json
++++ b/frontends/swiftui/dub.selections.json
+@@ -8,7 +8,7 @@
+ 		"bindbc-loader": "1.0.3",
+ 		"bindbc-opengl": "1.0.5",
+ 		"bindbc-sdl": "1.0.1",
+-		"botan": "1.13.6",
++		"botan": "~master",
+ 		"botan-math": "1.0.4",
+ 		"cachetools": "0.4.1",
+ 		"concepts": "0.0.9",
+-- 
+2.51.2
+

--- a/packages/sideloader/0004-Sideloader-Vendorize-Provision-and-plist-d.patch
+++ b/packages/sideloader/0004-Sideloader-Vendorize-Provision-and-plist-d.patch
@@ -1,0 +1,145 @@
+From 1206855211085e74932f07a05be859989b0b0a9f Mon Sep 17 00:00:00 2001
+From: alexytomi <60690056+alexytomi@users.noreply.github.com>
+Date: Mon, 22 Dec 2025 02:38:39 +0800
+Subject: [PATCH 4/5] [Sideloader] "Vendorize" Provision and plist-d
+
+Since we need to apply patches to it, let's do it the more official way
+and have it as a path source in dub rather than abusing `dub build` to
+clone it into .dub cache and patching the cache.
+
+This method also reduces build time!
+---
+ dub.json                              | 8 +++-----
+ dub.selections.json                   | 4 ++--
+ frontends/cli/dub.selections.json     | 4 ++--
+ frontends/dlangui/dub.selections.json | 4 ++--
+ frontends/gtk/dub.selections.json     | 4 ++--
+ frontends/qt/dub.selections.json      | 4 ++--
+ frontends/swiftui/dub.selections.json | 4 ++--
+ 7 files changed, 15 insertions(+), 17 deletions(-)
+
+diff --git a/dub.json b/dub.json
+index 51cfd1a..8d9bd07 100644
+--- a/dub.json
++++ b/dub.json
+@@ -18,12 +18,10 @@
+         },
+         "intel-intrinsics": "~>1.11.15",
+         "plist-d": {
+-            "repository": "git+https://github.com/Dadoum/libplist-d.git",
+-            "version": "6fdaa60d62bbf7c55044069e8f03cbe74401c444"
++            "path": "./libplist-d/"
+         },
+         "provision": {
+-            "repository": "git+https://github.com/Dadoum/Provision.git",
+-            "version": "645d56d8e8c86c057893321843db00b21f1aaeb2"
++            "path": "./Provision/"
+         },
+         "requests": "~>2.1",
+         "slf4d": "~>2"
+@@ -40,4 +38,4 @@
+         "frontends/qt",
+         "frontends/swiftui"
+     ]
+-}
+\ No newline at end of file
++}
+diff --git a/dub.selections.json b/dub.selections.json
+index 7cc573a..5fb8612 100644
+--- a/dub.selections.json
++++ b/dub.selections.json
+@@ -30,9 +30,9 @@
+ 		"memutils": "1.0.10",
+ 		"mir-core": "1.6.0",
+ 		"plist": "~master",
+-		"plist-d": {"version":"6fdaa60d62bbf7c55044069e8f03cbe74401c444","repository":"git+https://github.com/Dadoum/libplist-d.git"},
++		"plist-d": {"path":"libplist-d/"},
+ 		"progress": "5.0.2",
+-		"provision": {"version":"645d56d8e8c86c057893321843db00b21f1aaeb2","repository":"git+https://github.com/Dadoum/Provision.git"},
++		"provision": {"path":"Provision/"},
+ 		"requests": "2.1.2",
+ 		"silly": "1.2.0-dev.2",
+ 		"slf4d": "2.4.3",
+diff --git a/frontends/cli/dub.selections.json b/frontends/cli/dub.selections.json
+index e651f97..f0895d7 100644
+--- a/frontends/cli/dub.selections.json
++++ b/frontends/cli/dub.selections.json
+@@ -30,9 +30,9 @@
+ 		"memutils": "1.0.10",
+ 		"mir-core": "1.6.0",
+ 		"plist": "~master",
+-		"plist-d": {"version":"6fdaa60d62bbf7c55044069e8f03cbe74401c444","repository":"git+https://github.com/Dadoum/libplist-d.git"},
++		"plist-d": {"path":"../../libplist-d/"},
+ 		"progress": "5.0.2",
+-		"provision": {"version":"645d56d8e8c86c057893321843db00b21f1aaeb2","repository":"git+https://github.com/Dadoum/Provision.git"},
++		"provision": {"path":"../../Provision/"},
+ 		"requests": "2.1.2",
+ 		"sideloader": {"path":"../../"},
+ 		"silly": "1.2.0-dev.2",
+diff --git a/frontends/dlangui/dub.selections.json b/frontends/dlangui/dub.selections.json
+index e651f97..f0895d7 100644
+--- a/frontends/dlangui/dub.selections.json
++++ b/frontends/dlangui/dub.selections.json
+@@ -30,9 +30,9 @@
+ 		"memutils": "1.0.10",
+ 		"mir-core": "1.6.0",
+ 		"plist": "~master",
+-		"plist-d": {"version":"6fdaa60d62bbf7c55044069e8f03cbe74401c444","repository":"git+https://github.com/Dadoum/libplist-d.git"},
++		"plist-d": {"path":"../../libplist-d/"},
+ 		"progress": "5.0.2",
+-		"provision": {"version":"645d56d8e8c86c057893321843db00b21f1aaeb2","repository":"git+https://github.com/Dadoum/Provision.git"},
++		"provision": {"path":"../../Provision/"},
+ 		"requests": "2.1.2",
+ 		"sideloader": {"path":"../../"},
+ 		"silly": "1.2.0-dev.2",
+diff --git a/frontends/gtk/dub.selections.json b/frontends/gtk/dub.selections.json
+index e651f97..f0895d7 100644
+--- a/frontends/gtk/dub.selections.json
++++ b/frontends/gtk/dub.selections.json
+@@ -30,9 +30,9 @@
+ 		"memutils": "1.0.10",
+ 		"mir-core": "1.6.0",
+ 		"plist": "~master",
+-		"plist-d": {"version":"6fdaa60d62bbf7c55044069e8f03cbe74401c444","repository":"git+https://github.com/Dadoum/libplist-d.git"},
++		"plist-d": {"path":"../../libplist-d/"},
+ 		"progress": "5.0.2",
+-		"provision": {"version":"645d56d8e8c86c057893321843db00b21f1aaeb2","repository":"git+https://github.com/Dadoum/Provision.git"},
++		"provision": {"path":"../../Provision/"},
+ 		"requests": "2.1.2",
+ 		"sideloader": {"path":"../../"},
+ 		"silly": "1.2.0-dev.2",
+diff --git a/frontends/qt/dub.selections.json b/frontends/qt/dub.selections.json
+index e651f97..f0895d7 100644
+--- a/frontends/qt/dub.selections.json
++++ b/frontends/qt/dub.selections.json
+@@ -30,9 +30,9 @@
+ 		"memutils": "1.0.10",
+ 		"mir-core": "1.6.0",
+ 		"plist": "~master",
+-		"plist-d": {"version":"6fdaa60d62bbf7c55044069e8f03cbe74401c444","repository":"git+https://github.com/Dadoum/libplist-d.git"},
++		"plist-d": {"path":"../../libplist-d/"},
+ 		"progress": "5.0.2",
+-		"provision": {"version":"645d56d8e8c86c057893321843db00b21f1aaeb2","repository":"git+https://github.com/Dadoum/Provision.git"},
++		"provision": {"path":"../../Provision/"},
+ 		"requests": "2.1.2",
+ 		"sideloader": {"path":"../../"},
+ 		"silly": "1.2.0-dev.2",
+diff --git a/frontends/swiftui/dub.selections.json b/frontends/swiftui/dub.selections.json
+index e651f97..f0895d7 100644
+--- a/frontends/swiftui/dub.selections.json
++++ b/frontends/swiftui/dub.selections.json
+@@ -30,9 +30,9 @@
+ 		"memutils": "1.0.10",
+ 		"mir-core": "1.6.0",
+ 		"plist": "~master",
+-		"plist-d": {"version":"6fdaa60d62bbf7c55044069e8f03cbe74401c444","repository":"git+https://github.com/Dadoum/libplist-d.git"},
++		"plist-d": {"path":"../../libplist-d/"},
+ 		"progress": "5.0.2",
+-		"provision": {"version":"645d56d8e8c86c057893321843db00b21f1aaeb2","repository":"git+https://github.com/Dadoum/Provision.git"},
++		"provision": {"path":"../../Provision/"},
+ 		"requests": "2.1.2",
+ 		"sideloader": {"path":"../../"},
+ 		"silly": "1.2.0-dev.2",
+-- 
+2.51.2
+

--- a/packages/sideloader/0005-Sideloader-Add-filename-for-termux-libimobiledevice-.patch
+++ b/packages/sideloader/0005-Sideloader-Add-filename-for-termux-libimobiledevice-.patch
@@ -1,0 +1,26 @@
+From ef7cb8dc4fcec3bd72d52085bf1ffb03d7ba5e62 Mon Sep 17 00:00:00 2001
+From: alexytomi <60690056+alexytomi@users.noreply.github.com>
+Date: Thu, 1 Jan 2026 23:42:14 +0800
+Subject: [PATCH 5/5] [Sideloader] Add filename for termux
+ libimobiledevice-1.0.so
+
+---
+ source/imobiledevice/libimobiledevice.d | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/source/imobiledevice/libimobiledevice.d b/source/imobiledevice/libimobiledevice.d
+index 097d99d..11c0a1e 100644
+--- a/source/imobiledevice/libimobiledevice.d
++++ b/source/imobiledevice/libimobiledevice.d
+@@ -11,7 +11,7 @@ version (Windows) {
+ } else version (OSX) {
+     enum libimobiledevice = LibImport("libimobiledevice-1.0.6.dylib");
+ } else {
+-    enum libimobiledevice = LibImport("libimobiledevice-1.0.so.6", "libimobiledevice.so.1");
++    enum libimobiledevice = LibImport("libimobiledevice-1.0.so.6", "libimobiledevice-1.0.so" , "libimobiledevice.so.1");
+ }
+ 
+ mixin makeBindings;
+-- 
+2.51.2
+

--- a/packages/sideloader/Provision-Remove-glibc-backtrace-call.diff
+++ b/packages/sideloader/Provision-Remove-glibc-backtrace-call.diff
@@ -1,0 +1,40 @@
+From bfa2cb1ed5e9a4cd51fd00963f6d65139ccb9f9a Mon Sep 17 00:00:00 2001
+From: alexytomi <60690056+alexytomi@users.noreply.github.com>
+Date: Wed, 10 Dec 2025 13:24:19 +0800
+Subject: [PATCH] [Provision] Remove glibc backtrace call
+
+For some reason, putting Android first isn't enough, the linux block
+needs deleting.
+---
+ lib/provision/androidlibrary.d | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/lib/provision/androidlibrary.d b/lib/provision/androidlibrary.d
+index 485a168..c048312 100644
+--- a/lib/provision/androidlibrary.d
++++ b/lib/provision/androidlibrary.d
+@@ -378,13 +378,14 @@ AndroidLibrary memoryOwner(size_t address) {
+     return null;
+ }
+ 
+-version (linux) {
+-    import core.sys.linux.execinfo;
+-    pragma(inline, true) AndroidLibrary rootLibrary() {
+-        enum MAXFRAMES = 4;
+-        void*[MAXFRAMES] callstack;
+-        auto numframes = backtrace(callstack.ptr, MAXFRAMES);
+-        return memoryOwner(cast(size_t) callstack[numframes - 1]);
++version(Android) {
++    pragma(LDC_intrinsic, "llvm.returnaddress")
++    ubyte* return_address(int);
++
++    import core.sys.windows.stacktrace;
++    pragma(inline, true) AndroidLibrary rootLibrary(ubyte* address = return_address(0)) {
++        assert(address != null);
++        return memoryOwner(cast(size_t) address);
+     }
+ } else version (LDC) { // Seems to work consistently, but LLVM only.
+     pragma(LDC_intrinsic, "llvm.returnaddress")
+-- 
+2.51.2
+

--- a/packages/sideloader/build.sh
+++ b/packages/sideloader/build.sh
@@ -1,0 +1,53 @@
+TERMUX_PKG_HOMEPAGE="https://github.com/Dadoum/Sideloader"
+TERMUX_PKG_DESCRIPTION="Open-source cross-platform iOS app sideloader. Alternative to Sideloadly, AltServer, SideServer, Cydia Impactor, iOS App Signer…"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER=@termux
+_COMMIT="35f486caa3cb01127508958f5e057d6c834d9cf7"
+_COMMIT_DATE=2025.8.25
+TERMUX_PKG_VERSION="1.0~pre4.${_COMMIT_DATE}"
+TERMUX_PKG_DEPENDS="usbmuxd, libplist, libimobiledevice"
+TERMUX_PKG_BUILD_DEPENDS="ldc, ndk-sysroot, jq"
+TERMUX_PKG_SRCURL="https://github.com/Dadoum/Sideloader/archive/${_COMMIT}.zip"
+TERMUX_PKG_SHA256="9f3764b86ee596032d43302a4a4b900cea40b45c5f7f6e6ee58145e0cb65a4b7"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXCLUDED_ARCHES="arm, i686" # ldc 1.30 contains broken a std.range.repeat that causes argparse to not compile.
+
+termux_step_post_get_source() {
+	provision_git_url=$(jq -r '.versions.provision.repository' $TERMUX_PKG_SRCDIR/frontends/cli/dub.selections.json | cut -c5-)
+	provision_git_hash=$(jq -r '.versions.provision.version' $TERMUX_PKG_SRCDIR/frontends/cli/dub.selections.json)
+	plist_d_git_url=$(jq -r '.versions."plist-d".repository' $TERMUX_PKG_SRCDIR/frontends/cli/dub.selections.json | cut -c5-)
+	plist_d_git_hash=$(jq -r '.versions."plist-d".version' $TERMUX_PKG_SRCDIR/frontends/cli/dub.selections.json)
+}
+
+termux_step_configure() {
+	termux_setup_ldc
+	dub clean --all-packages
+	# Patch Provision
+	git init Provision # The vendorize patch is case-sensitive.
+	cd Provision
+	git remote add origin $provision_git_url
+	git fetch --depth 1 origin $provision_git_hash
+	git checkout FETCH_HEAD
+	patch -N -p1 -i $TERMUX_PKG_BUILDER_DIR/Provision-Remove-glibc-backtrace-call.diff || true # It might already be applied
+	cd ..
+	# Patch plist-d
+	git init libplist-d
+	cd libplist-d
+	git remote add origin $plist_d_git_url
+	git fetch --depth 1 origin $plist_d_git_hash
+	git checkout FETCH_HEAD
+	patch -N -p1 -i $TERMUX_PKG_BUILDER_DIR/plist-d-Add-filename-for-termux-libplist-2.0.so.diff || true # It might already be applied
+	cd ..
+}
+
+termux_step_make() {
+	export DFLAGS="-preview=shortenedMethods" # Workaround for using an ancient ldc version
+	dub build -b release-debug --arch ${TERMUX_HOST_PLATFORM} :cli-frontend
+}
+
+termux_step_make_install() {
+	install -Dm 700 -t $TERMUX_PREFIX/bin $TERMUX_PKG_SRCDIR/bin/sideloader
+}
+
+# Note for maintainers: In order to generate the "vendorize" patch, you should clone Provision and plist-d into the root directory of Sideloader and
+# run `dub upgrade -s <dependency>` after applying your edits to the top level `dub.json` to update all the `dub.selections.json` which is what the compiler actually uses.

--- a/packages/sideloader/plist-d-Add-filename-for-termux-libplist-2.0.so.diff
+++ b/packages/sideloader/plist-d-Add-filename-for-termux-libplist-2.0.so.diff
@@ -1,0 +1,25 @@
+From 3e35ee0ee9a2701198e4439373421173b0116ac0 Mon Sep 17 00:00:00 2001
+From: alexytomi <60690056+alexytomi@users.noreply.github.com>
+Date: Thu, 1 Jan 2026 23:53:31 +0800
+Subject: [PATCH] [plist-d] Add filename for termux libplist-2.0.so
+
+---
+ source/plist/c.d | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/source/plist/c.d b/source/plist/c.d
+index ca31040..1182a35 100644
+--- a/source/plist/c.d
++++ b/source/plist/c.d
+@@ -35,7 +35,7 @@ version (Windows) {
+ } else version (OSX) {
+     enum libplist = LibImport("libplist-2.0.3.dylib", "libplist-2.0.4.dylib");
+ } else {
+-    enum libplist = LibImport("libplist-2.0.so.3", "libplist.so.3", "libplist-2.0.so.4", "libplist.so.4");
++    enum libplist = LibImport("libplist-2.0.so", "libplist-2.0.so.3", "libplist.so.3", "libplist-2.0.so.4", "libplist.so.4");
+ }
+ 
+ mixin makeBindings;
+-- 
+2.51.2
+


### PR DESCRIPTION
# Why
Sideloader is another sideloader for iOS program like [iloader](https://github.com/termux/termux-packages/pull/29147) but as cli. It would be helpful to have a non-x11 option for sideloading iOS apps since most users wouldn't want to have to setup a whole xorg environment just to install sidestore.
