### PR TITLE
bump(main/fresh-editor): 0.2.20

### DIFF
--- a/packages/fresh-editor/build.sh
+++ b/packages/fresh-editor/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://getfresh.dev/
 TERMUX_PKG_DESCRIPTION="Text editor for your terminal: easy, powerful and fast"
 TERMUX_PKG_LICENSE="GPL-2.0-only"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.2.18"
+TERMUX_PKG_VERSION="0.2.20"
 TERMUX_PKG_SRCURL="https://github.com/sinelaw/fresh/releases/download/v$TERMUX_PKG_VERSION/fresh-editor-$TERMUX_PKG_VERSION-source.tar.gz"
-TERMUX_PKG_SHA256=44a658b8d642584953561c4fcc9f302ee5d60c351c3e522073eea4fc3d8cd999
+TERMUX_PKG_SHA256=a68a90eca2a4cc7a75a6c257dc1dc3b72038cd0cf2db4c1bdde1e255c2ebc75f
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
 

--- a/packages/fresh-editor/enable-rquickjs-bindgen.patch
+++ b/packages/fresh-editor/enable-rquickjs-bindgen.patch
@@ -1,0 +1,24 @@
+Reverts this commit:
+https://github.com/sinelaw/fresh/commit/016c7be229be5d13596aeb04dd9439b69bf9d796
+in order to fix this error:
+error: couldn't read `/home/builder/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/
+rquickjs-sys-0.11.0/src/bindings/aarch64-linux-android.rs`: No such file or directory (os error 2)
+  --> /home/builder/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rquickjs-sys-0.11.0/src/lib.rs:19:1
+   |
+19 | include!(concat!("bindings/", bindings_env!("TARGET"), ".rs"));
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: rquickjs-sys@0.11.0: rquickjs probably doesn't ship bindings for platform
+`aarch64-linux-android(n/a)`. try the `bindgen` feature instead.
+
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -48,7 +48,7 @@ once_cell = "1.20"
+ tracing = "0.1"
+ rust-i18n = "3.1.5"
+ schemars = { version = "1.2", features = ["preserve_order"] }
+-rquickjs = { version = "0.11", features = ["futures", "macro"] }
++rquickjs = { version = "0.11", features = ["futures", "macro", "bindgen"] }
+ rquickjs-serde = "0.5"
+ oxc_allocator = "0.115.0"
+ oxc_ast = "0.115.0"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/29153

- Revert https://github.com/sinelaw/fresh/commit/016c7be229be5d13596aeb04dd9439b69bf9d796 because it disables running bindgen, but `rquickjs` does not have pregenerated bindings for Android, so bindgen is required in order to build the dependency crate `rquickjs`