### PR TITLE
bump(main/txikijs): 26.4.0

### DIFF
--- a/packages/txikijs/build.sh
+++ b/packages/txikijs/build.sh
@@ -2,16 +2,15 @@ TERMUX_PKG_HOMEPAGE=https://github.com/saghul/txiki.js
 TERMUX_PKG_DESCRIPTION="A small and powerful JavaScript runtime"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1:26.3.1"
+TERMUX_PKG_VERSION="1:26.4.0"
 TERMUX_PKG_SRCURL=git+https://github.com/saghul/txiki.js
-TERMUX_PKG_DEPENDS="libcurl, libffi"
+TERMUX_PKG_DEPENDS="libandroid-spawn, libc++, libcurl, libffi"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DBUILD_NATIVE=OFF
 -DUSE_EXTERNAL_FFI=ON
 -DFFI_INCLUDE_DIR=$TERMUX_PREFIX/include
 -DFFI_LIB=$TERMUX_PREFIX/lib/libffi.so
--DCMAKE_POLICY_VERSION_MINIMUM=3.5
 "
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_HOSTBUILD=true
@@ -23,7 +22,7 @@ termux_step_host_build() {
 
 	termux_setup_cmake
 
-	cmake . -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+	cmake .
 	make -j "$TERMUX_PKG_MAKE_PROCESSES"
 }
 
@@ -39,6 +38,8 @@ termux_step_pre_configure() {
 	else
 		termux_error_exit "Unsupported arch: $TERMUX_ARCH"
 	fi
+
+	LDFLAGS+=" -landroid-spawn"
 }
 
 termux_step_post_configure() {


### PR DESCRIPTION
* Add libandroid-spawn for libuv submodule.
* Remove old minimum cmake version option.
* Fixes #29223 