### PR TITLE
chore(main/jq): Update URLs

### DIFF
--- a/packages/jq/build.sh
+++ b/packages/jq/build.sh
@@ -1,10 +1,10 @@
-TERMUX_PKG_HOMEPAGE=https://stedolan.github.io/jq/
+TERMUX_PKG_HOMEPAGE=https://jqlang.org/
 TERMUX_PKG_DESCRIPTION="Command-line JSON processor"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.8.1"
 TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://github.com/stedolan/jq/releases/download/jq-$TERMUX_PKG_VERSION/jq-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SRCURL=https://github.com/jqlang/jq/releases/download/jq-$TERMUX_PKG_VERSION/jq-$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=2be64e7129cecb11d5906290eba10af694fb9e3e7f9fc208a311dc33ca837eb0
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+(\.\d+)?"


### PR DESCRIPTION
The previous URLs currently still work due to redirects. Updating them to avoid problems in case of changes in the redirect.

Old URLs (click to see the redirects):
- https://stedolan.github.io/jq/
- https://github.com/stedolan/jq