### PR TITLE
fix(x11/celluloid): apply `-Wno-format-nonliteral` instead of `s/-Werror/-Wno-error/g`

### DIFF
--- a/x11-packages/celluloid/build.sh
+++ b/x11-packages/celluloid/build.sh
@@ -10,7 +10,7 @@ TERMUX_PKG_DEPENDS="gdk-pixbuf, glib, gtk4, libadwaita, libepoxy, mpv-x"
 
 termux_step_pre_configure() {
 	# Workaround strict compiler error
-	sed -i "s/-Werror/-Wno-error/g" meson.build
+	CFLAGS+=" -Wno-format-nonliteral"
 
 	termux_setup_glib_cross_pkg_config_wrapper
 }


### PR DESCRIPTION
- Like `dia`

https://github.com/termux/termux-packages/blob/73a8289488e66c9c61b688bf271faa1728aee4a5/x11-packages/dia/build.sh#L38

%ci:no-build