### PR TITLE
scripts: guard bootstrap force-cleanup paths

### DIFF
--- a/scripts/build-bootstraps.sh
+++ b/scripts/build-bootstraps.sh
@@ -397,8 +397,12 @@ main() {
 		termux_step_handle_buildarch
 
 		if [[ $FORCE_BUILD_PACKAGES == "1" ]]; then
-			rm -f "$TERMUX_BUILT_PACKAGES_DIRECTORY_FOR_ARCH"/*
-			rm -f "$TERMUX_BUILT_DEBS_DIRECTORY"/*
+			if [ -n "${TERMUX_BUILT_PACKAGES_DIRECTORY:-}" ] && [ -d "$TERMUX_BUILT_PACKAGES_DIRECTORY" ]; then
+				find "$TERMUX_BUILT_PACKAGES_DIRECTORY" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+			fi
+			if [ -n "${TERMUX_BUILT_DEBS_DIRECTORY:-}" ] && [ -d "$TERMUX_BUILT_DEBS_DIRECTORY" ]; then
+				find "$TERMUX_BUILT_DEBS_DIRECTORY" -mindepth 1 -maxdepth 1 -exec rm -f {} +
+			fi
 		fi
 
 		BOOTSTRAP_ROOTFS="$BOOTSTRAP_TMPDIR/rootfs-${TERMUX_ARCH}"


### PR DESCRIPTION
The -f path in build-bootstraps.sh tried to remove "$TERMUX_BUILT_PACKAGES_DIRECTORY_FOR_ARCH"/*, but that variable is not defined.

When the variable expands to an empty string, the cleanup command targets /* inside the builder container. That causes the force-build path to try to remove top-level system paths such as /bin, /etc, and /usr before the bootstrap build proceeds.

Replace the direct rm calls with guarded directory cleanup.

Check that each target variable is non-empty and that the directory exists before removing only entries inside the expected directories.

This keeps the force-build cleanup behavior, but prevents an empty variable from turning the cleanup step into a root-level delete attempt.