### PR TITLE
bump(x11/pcsx-rearmed): 26

### DIFF
--- a/x11-packages/pcsx-rearmed/build.sh
+++ b/x11-packages/pcsx-rearmed/build.sh
@@ -2,8 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://github.com/notaz/pcsx_rearmed
 TERMUX_PKG_DESCRIPTION="Yet another PCSX fork based on the PCSX-Reloaded project"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=23
-TERMUX_PKG_REVISION=5
+TERMUX_PKG_VERSION="26"
 TERMUX_PKG_SRCURL=git+https://github.com/notaz/pcsx_rearmed
 TERMUX_PKG_GIT_BRANCH=r${TERMUX_PKG_VERSION}
 TERMUX_PKG_SHA256=887e9b5ee7b8115d35099c730372b4158fd3e215955a06d68e20928b339646af
@@ -22,12 +21,28 @@ termux_pkg_auto_update() {
 	fi
 }
 
+termux_step_post_get_source() {
+	# convert CRLF to LF globally while working with this package in termux
+	# https://github.com/termux/termux-packages/issues/11744
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		DOS2UNIX="$TERMUX_PKG_TMPDIR/dos2unix"
+		(. "$TERMUX_SCRIPTDIR/packages/dos2unix/build.sh"; TERMUX_PKG_SRCDIR="$DOS2UNIX" termux_step_get_source)
+		pushd "$DOS2UNIX"
+		make dos2unix
+		popd # DOS2UNIX
+		export PATH="$DOS2UNIX:$PATH"
+	fi
+
+	find "$TERMUX_PKG_SRCDIR" -type f -print0 | xargs -0 dos2unix
+}
+
 termux_step_pre_configure() {
 	CFLAGS+=" $CPPFLAGS"
 	CFLAGS="${CFLAGS/-Oz/-Os}"
 	if [ "$TERMUX_ARCH" = "arm" ]; then
 		termux_setup_no_integrated_as
 	fi
+	export SDL_CONFIG="$TERMUX_PREFIX/bin/sdl-config"
 }
 
 termux_step_configure() {

--- a/x11-packages/pcsx-rearmed/configure.patch
+++ b/x11-packages/pcsx-rearmed/configure.patch
@@ -9,26 +9,3 @@
    exit 1
  }
  
-@@ -398,7 +400,7 @@
-     sound_drivers="$sound_drivers pulseaudio"
-     MAIN_LDLIBS="-lpulse $MAIN_LDLIBS"
-   fi
--  if [ "$need_sdl" = "yes" ] || check_sdl `sdl-config --cflags --libs`; then
-+  if [ "$need_sdl" = "yes" ] || check_sdl `bash @TERMUX_PREFIX@/bin/sdl-config --cflags --libs`; then
-     sound_drivers="$sound_drivers sdl"
-     need_sdl="yes"
-   fi
-@@ -417,10 +419,10 @@
- fi
- 
- if [ "$need_sdl" = "yes" ]; then
--  which sdl-config > /dev/null || \
-+  which @TERMUX_PREFIX@/bin/sdl-config > /dev/null || \
-     fail "sdl-config is missing; please install libsdl (libsdl1.2-dev)"
--  CFLAGS="$CFLAGS `sdl-config --cflags`"
--  MAIN_LDLIBS="`sdl-config --libs` $MAIN_LDLIBS"
-+  CFLAGS="$CFLAGS `bash @TERMUX_PREFIX@/bin/sdl-config --cflags`"
-+  MAIN_LDLIBS="`bash @TERMUX_PREFIX@/bin/sdl-config --libs` $MAIN_LDLIBS"
-   check_sdl || fail "please install libsdl (libsdl1.2-dev)"
- fi
- 

--- a/x11-packages/pcsx-rearmed/libpicofe_menu.c.patch
+++ b/x11-packages/pcsx-rearmed/libpicofe_menu.c.patch
@@ -10,12 +10,12 @@
  	unsigned char *fd, *fds;
  	char buff[256];
  	FILE *f;
-@@ -313,7 +314,7 @@
+@@ -318,7 +318,7 @@ void menu_init_base_scale(unsigned int scale)
  	}
  
  	// load custom font and selector (stored as 1st symbol in font table)
 -	pos = plat_get_skin_dir(buff, sizeof(buff));
 +	pos = plat_get_skin_dir(buff);
- 	strcpy(buff + pos, "font.png");
- 	readpng(menu_font_data, buff, READPNG_FONT,
- 		MENU_X2 ? 256 : 128, MENU_X2 ? 320 : 160);
+ 	if (scale > 1)
+ 		snprintf(buff + pos, sizeof(buff) - pos, "fontx%d.png", scale);
+ 	else

--- a/x11-packages/pcsx-rearmed/libpicofe_plat.c.patch
+++ b/x11-packages/pcsx-rearmed/libpicofe_plat.c.patch
@@ -1,72 +1,58 @@
---- a/frontend/libpicofe/linux/plat.c	2023-01-14 16:15:27.853589338 -0300
-+++ b/frontend/libpicofe/linux/plat.c	2024-07-21 13:30:28.033306193 -0300
-@@ -22,6 +22,7 @@
- #include <sys/stat.h>
+--- a/frontend/libpicofe/linux/plat.c
++++ b/frontend/libpicofe/linux/plat.c
+@@ -25,6 +25,7 @@
+ #endif
  
  #include "../plat.h"
 +#include "../../main.h"
+ #include "../posix.h"
  
  /* XXX: maybe unhardcode pagesize? */
- #define HUGETLB_PAGESIZE (2 * 1024 * 1024)
-@@ -49,56 +50,13 @@
- 	return strlen(dst);
+@@ -81,6 +81,15 @@ static int plat_get_exe_dir(char *dst, int len)
+ #endif
  }
  
--static int plat_get_exe_dir(char *dst, int len)
++#ifdef __ANDROID__
 +size_t plat_get_skin_dir(char *dst)
- {
--#ifdef PICO_DATA_DIR
--	memcpy(dst, PICO_DATA_DIR, sizeof PICO_DATA_DIR);
--	return sizeof(PICO_DATA_DIR) - 1;
--#else
--	int j, ret = readlink("/proc/self/exe", dst, len - 1);
--	if (ret < 0) {
--		perror("readlink");
--		ret = 0;
--	}
--	dst[ret] = 0;
--
--	for (j = ret - 1; j > 0; j--)
--		if (dst[j] == '/') {
--			dst[++j] = 0;
--			break;
--		}
--	return j;
--#endif
--}
--
--int plat_get_skin_dir(char *dst, int len)
--{
--	int ret = plat_get_exe_dir(dst, len);
--	if (ret < 0)
--		return ret;
--
--	memcpy(dst + ret, "skin/", sizeof "skin/");
--	return ret + sizeof("skin/") - 1;
--}
++{
 +	static const char path[] = PCSX_DOT_DIR "skin/";
 +	static const size_t len = sizeof path / sizeof path[0];
- 
--#ifndef PICO_HOME_DIR
--#define PICO_HOME_DIR "/.picodrive/"
--#endif
--int plat_get_root_dir(char *dst, int len)
--{
--#if !defined(NO_HOME_DIR) && !defined(__GP2X__) && !defined(PANDORA)
--	const char *home = getenv("HOME");
--	int ret;
--
--	if (home != NULL) {
--		ret = snprintf(dst, len, "%s%s", home, PICO_HOME_DIR);
--		if (ret >= len)
--			ret = len - 1;
--		mkdir(dst, 0755);
--		return ret;
--	}
--#endif
--	return plat_get_exe_dir(dst, len);
 +	memcpy(dst, path, len);
 +	return len - 1;
++}
++#else
+ int plat_get_skin_dir(char *dst, int len)
+ {
+ 	int ret = plat_get_exe_dir(dst, len);
+@@ -90,6 +99,7 @@ int plat_get_skin_dir(char *dst, int len)
+ 	memcpy(dst + ret, "skin/", sizeof "skin/");
+ 	return ret + sizeof("skin/") - 1;
  }
++#endif
+ 
+ #ifndef PICO_HOME_DIR
+ #define PICO_HOME_DIR "/.picodrive/"
+@@ -104,6 +105,15 @@ int plat_get_skin_dir(char *dst, int len)
+ #ifndef PICO_HOME_DIR
+ #define PICO_HOME_DIR "/.picodrive/"
+ #endif
++#ifdef __ANDROID__
++size_t plat_get_root_dir(char *dst)
++{
++	static const char path[] = PCSX_DOT_DIR;
++	static const size_t len = sizeof path / sizeof path[0];
++	memcpy(dst, path, len);
++	return len - 1;
++}
++#else
+ int plat_get_root_dir(char *dst, int len)
+ {
+ #if !defined(NO_HOME_DIR) && !defined(__GP2X__) && !defined(PANDORA)
+@@ -120,6 +130,7 @@ int plat_get_root_dir(char *dst, int len)
+ #endif
+ 	return plat_get_exe_dir(dst, len);
+ }
++#endif
  
  #ifdef __GP2X__
+ /* Wiz has a borked gettimeofday().. */

--- a/x11-packages/pcsx-rearmed/libpicofe_plat.h.patch
+++ b/x11-packages/pcsx-rearmed/libpicofe_plat.h.patch
@@ -1,12 +1,13 @@
 --- a/frontend/libpicofe/plat.h	2023-01-14 16:15:27.861589338 -0300
 +++ b/frontend/libpicofe/plat.h	2023-01-15 03:29:10.852522982 -0300
-@@ -101,11 +101,8 @@
+@@ -101,11 +101,11 @@
  void plat_video_flip(void);
  void plat_video_wait_vsync(void);
  
--/* return the dir/ where configs, saves, bios, etc. are found */
+ /* return the dir/ where configs, saves, bios, etc. are found */
 -int  plat_get_root_dir(char *dst, int len);
--
++size_t plat_get_root_dir(char *dst);
+ 
  /* return the dir/ where skin files are found */
 -int  plat_get_skin_dir(char *dst, int len);
 +size_t plat_get_skin_dir(char *dst);

--- a/x11-packages/pcsx-rearmed/main.c.patch
+++ b/x11-packages/pcsx-rearmed/main.c.patch
@@ -1,85 +1,34 @@
---- a/frontend/main.c	2023-01-14 16:15:08.053589352 -0300
-+++ b/frontend/main.c	2023-01-17 15:57:47.596011448 -0300
-@@ -57,9 +57,9 @@
- static void make_path(char *buf, size_t size, const char *dir, const char *fname)
+--- a/frontend/main.c
++++ b/frontend/main.c
+@@ -501,6 +501,10 @@ void emu_core_ask_exit(void)
+ 
+ static const char *get_home_dir(void)
  {
- 	if (fname)
--		snprintf(buf, size, ".%s%s", dir, fname);
-+		snprintf(buf, size, "%s%s", dir, fname);
- 	else
--		snprintf(buf, size, ".%s", dir);
-+		snprintf(buf, size, "%s", dir);
- }
- #define MAKE_PATH(buf, dir, fname) \
- 	make_path(buf, sizeof(buf), dir, fname)
-@@ -103,13 +104,13 @@
- static void set_default_paths(void)
- {
- #ifndef NO_FRONTEND
--	snprintf(Config.PatchesDir, sizeof(Config.PatchesDir), "." PATCHES_DIR);
-+	snprintf(Config.PatchesDir, sizeof(Config.PatchesDir), PATCHES_DIR);
- 	MAKE_PATH(Config.Mcd1, MEMCARD_DIR, "card1.mcd");
- 	MAKE_PATH(Config.Mcd2, MEMCARD_DIR, "card2.mcd");
--	strcpy(Config.BiosDir, "bios");
-+	strcpy(Config.BiosDir, PCSX_DOT_DIR "bios");
++#ifdef __TERMUX__
++	// in Termux, we have PCSX_DOT_DIR strictly hardcoded as "@TERMUX_PREFIX@/etc/pcsx/"
++	return "";
++#else
+ #if defined(PANDORA) || !defined(__unix__) || defined(MIYOO)
+ 	return ".";
+ #else
+@@ -515,6 +519,7 @@ static const char *get_home_dir(void)
+ 		home = ".";
+ 	return home;
  #endif
- 
--	strcpy(Config.PluginsDir, "plugins");
-+	strcpy(Config.PluginsDir, PCSX_DOT_DIR "plugins");
- 	strcpy(Config.Gpu, "builtin_gpu");
- 	strcpy(Config.Spu, "builtin_spu");
- 	strcpy(Config.Cdr, "builtin_cdr");
-@@ -246,7 +247,7 @@
- 
- 			scrbuf = pl_prepare_screenshot(&w, &h, &bpp);
- 			get_gameid_filename(buf, sizeof(buf),
--				"screenshots/%.32s-%.9s.%d.png", ti);
-+				SCREENSHOTS_DIR "%.32s-%.9s.%d.png", ti);
- 			ret = -1;
- 			if (scrbuf != 0 && bpp == 16)
- 				ret = writepng(buf, scrbuf, w, h);
-@@ -483,7 +484,7 @@
- 	create_profile_dir(CHEATS_DIR);
- 	create_profile_dir(PATCHES_DIR);
- 	create_profile_dir(PCSX_DOT_DIR "cfg");
--	create_profile_dir("/screenshots/");
-+	create_profile_dir(SCREENSHOTS_DIR);
++#endif
  }
  
- static void check_memcards(void)
-@@ -493,7 +494,7 @@
- 	int i;
+ void emu_make_path(char *buf, size_t size, const char *dir, const char *fname)
+@@ -528,10 +535,10 @@ void emu_make_path(char *buf, size_t size, const char *dir, const char *fname)
  
- 	for (i = 1; i <= 9; i++) {
--		snprintf(buf, sizeof(buf), ".%scard%d.mcd", MEMCARD_DIR, i);
-+		snprintf(buf, sizeof(buf), "%scard%d.mcd", MEMCARD_DIR, i);
+ void emu_make_data_path(char *buff, const char *end, int size)
+ {
+-	int pos, end_len;
++	size_t pos, end_len;
  
- 		f = fopen(buf, "rb");
- 		if (f == NULL) {
-@@ -596,7 +597,7 @@
- 		// FIXME: this recovery doesn't work, just delete bad config and bail out
- 		// SysMessage("could not load plugins, retrying with defaults\n");
- 		set_default_paths();
--		snprintf(path, sizeof(path), "." PCSX_DOT_DIR "%s", cfgfile_basename);
-+		snprintf(path, sizeof(path), PCSX_DOT_DIR "%s", cfgfile_basename);
- 		remove(path);
- 		SysMessage("Failed loading plugins!");
- 		return 1;
-@@ -753,7 +754,7 @@
- 
- int get_state_filename(char *buf, int size, int i) {
- 	return get_gameid_filename(buf, size,
--		"." STATES_DIR "%.32s-%.9s.%3.3d", i);
-+		STATES_DIR "%.32s-%.9s.%3.3d", i);
- }
- 
- int emu_check_state(int slot)
-@@ -876,7 +877,7 @@
- 		char path[MAXPATHLEN];
- 		char dotdir[MAXPATHLEN];
- 
--		MAKE_PATH(dotdir, "/.pcsx/plugins/", NULL);
-+		MAKE_PATH(dotdir, PCSX_DOT_DIR "plugins/", NULL);
- 
- 		strcpy(info.EmuName, "PCSX");
- 		strncpy(info.CdromID, CdromId, 9);
+ 	end_len = strlen(end);
+-	pos = plat_get_root_dir(buff, size);
++	pos = plat_get_root_dir(buff);
+ 	strncpy(buff + pos, end, size - pos);
+ 	buff[size - 1] = 0;
+ 	if (pos + end_len > size - 1)

--- a/x11-packages/pcsx-rearmed/main.h.patch
+++ b/x11-packages/pcsx-rearmed/main.h.patch
@@ -1,30 +1,14 @@
---- a/frontend/main.h	2023-01-14 16:14:07.969589395 -0300
-+++ b/frontend/main.h	2023-01-14 16:51:46.017587780 -0300
-@@ -21,16 +21,17 @@
- 
+--- a/frontend/main.h
++++ b/frontend/main.h
+@@ -22,7 +22,11 @@
+ #include <stdlib.h>
  #include "config.h"
  
--#define DEFAULT_MEM_CARD_1 "/.pcsx/memcards/card1.mcd"
--#define DEFAULT_MEM_CARD_2 "/.pcsx/memcards/card2.mcd"
--#define MEMCARD_DIR "/.pcsx/memcards/"
--#define PLUGINS_DIR "/.pcsx/plugins/"
--#define PLUGINS_CFG_DIR "/.pcsx/plugins/cfg/"
--#define PCSX_DOT_DIR "/.pcsx/"
--#define STATES_DIR "/.pcsx/sstates/"
--#define CHEATS_DIR "/.pcsx/cheats/"
--#define PATCHES_DIR "/.pcsx/patches/"
--#define BIOS_DIR "/bios/"
-+#define DEFAULT_MEM_CARD_1 "@TERMUX_PREFIX@/etc/pcsx/memcards/card1.mcd"
-+#define DEFAULT_MEM_CARD_2 "@TERMUX_PREFIX@/etc/pcsx/memcards/card2.mcd"
-+#define MEMCARD_DIR "@TERMUX_PREFIX@/etc/pcsx/memcards/"
-+#define PLUGINS_DIR "@TERMUX_PREFIX@/etc/pcsx/plugins/"
-+#define PLUGINS_CFG_DIR "@TERMUX_PREFIX@/etc/pcsx/plugins/cfg/"
++#ifdef __TERMUX__
 +#define PCSX_DOT_DIR "@TERMUX_PREFIX@/etc/pcsx/"
-+#define STATES_DIR "@TERMUX_PREFIX@/etc/pcsx/sstates/"
-+#define CHEATS_DIR "@TERKUX_PREFIX@/etc/pcsx/cheats/"
-+#define PATCHES_DIR "@TERMUX_PREFIX@/etc/pcsx/patches/"
-+#define BIOS_DIR "@TERMUX_PREFIX@/etc/pcsx/bios/"
-+#define SCREENSHOTS_DIR "@TERMUX_PREFIX@/etc/pcsx/screenshots/"
- 
- extern char cfgfile_basename[MAXPATHLEN];
- 
++#else
+ #define PCSX_DOT_DIR "/.pcsx/"
++#endif
+ #define DEFAULT_MEM_CARD_1 PCSX_DOT_DIR "memcards/card1.mcd"
+ #define DEFAULT_MEM_CARD_2 PCSX_DOT_DIR "memcards/card2.mcd"
+ #define MEMCARD_DIR        PCSX_DOT_DIR "memcards/"

--- a/x11-packages/pcsx-rearmed/menu.c.patch
+++ b/x11-packages/pcsx-rearmed/menu.c.patch
@@ -1,49 +1,19 @@
---- a/frontend/menu.c	2023-01-14 16:15:08.057589352 -0300
-+++ b/frontend/menu.c	2023-01-17 07:16:17.161202440 -0300
-@@ -131,18 +131,6 @@
- static int min(int x, int y) { return x < y ? x : y; }
- static int max(int x, int y) { return x > y ? x : y; }
- 
--void emu_make_path(char *buff, const char *end, int size)
--{
--	int pos, end_len;
--
--	end_len = strlen(end);
--	pos = plat_get_root_dir(buff, size);
--	strncpy(buff + pos, end, size - pos);
--	buff[size - 1] = 0;
--	if (pos + end_len > size - 1)
--		printf("Warning: path truncated: %s\n", buff);
--}
--
- static int emu_check_save_file(int slot, int *time)
- {
- 	char fname[MAXPATHLEN];
-@@ -481,9 +469,9 @@
- static void make_cfg_fname(char *buf, size_t size, int is_game)
- {
- 	if (is_game)
--		snprintf(buf, size, "." PCSX_DOT_DIR "cfg/%.32s-%.9s.cfg", get_cd_label(), CdromId);
-+		snprintf(buf, size, PCSX_DOT_DIR "cfg/%.32s-%.9s.cfg", get_cd_label(), CdromId);
- 	else
--		snprintf(buf, size, "." PCSX_DOT_DIR "%s", cfgfile_basename);
-+		snprintf(buf, size, PCSX_DOT_DIR "%s", cfgfile_basename);
- }
- 
- static void keys_write_all(FILE *f);
-@@ -534,39 +522,24 @@
+diff --git a/frontend/menu.c b/frontend/menu.c
+index b28e53d..a6abaed 100644
+--- a/frontend/menu.c
++++ b/frontend/menu.c
+@@ -579,39 +579,24 @@ static int menu_write_config(int is_game)
  
  static int menu_do_last_cd_img(int is_get)
  {
 -	static const char *defaults[] = { "/media", "/mnt/sd", "/mnt" };
-+	static const char default_dir[] = "@TERMUX_ANDROID_HOME@";
++	static const char default_dir[] = "@TERMUX_HOME@";
  	char path[256];
--	struct stat64 st;
+-	struct STAT st;
  	FILE *f;
 -	int i, ret = -1;
  
--	snprintf(path, sizeof(path), "." PCSX_DOT_DIR "lastcdimg.txt");
-+	snprintf(path, sizeof(path), PCSX_DOT_DIR "lastcdimg.txt");
+ 	emu_make_path(path, sizeof(path), PCSX_DOT_DIR, "lastcdimg.txt");
  	f = fopen(path, is_get ? "r" : "w");
  	if (f == NULL) {
 -		ret = -1;
@@ -67,7 +37,7 @@
 -out:
 -	if (is_get) {
 -		for (i = 0; last_selected_fname[0] == 0
--		       || stat64(last_selected_fname, &st) != 0; i++)
+-		       || STAT(last_selected_fname, &st) != 0; i++)
 -		{
 -			if (i >= ARRAY_SIZE(defaults))
 -				break;
@@ -78,69 +48,3 @@
  	return 0;
  }
  
-@@ -697,14 +670,14 @@
- 		if (memcard1_sel == 0)
- 			strcpy(Config.Mcd1, "none");
- 		else if (memcards[memcard1_sel] != NULL)
--			snprintf(Config.Mcd1, sizeof(Config.Mcd1), ".%s%s",
-+			snprintf(Config.Mcd1, sizeof(Config.Mcd1), "%s%s",
- 				MEMCARD_DIR, memcards[memcard1_sel]);
- 	}
- 	if ((unsigned int)memcard2_sel < ARRAY_SIZE(memcards)) {
- 		if (memcard2_sel == 0)
- 			strcpy(Config.Mcd2, "none");
- 		else if (memcards[memcard2_sel] != NULL)
--			snprintf(Config.Mcd2, sizeof(Config.Mcd2), ".%s%s",
-+			snprintf(Config.Mcd2, sizeof(Config.Mcd2), "%s%s",
- 				MEMCARD_DIR, memcards[memcard2_sel]);
- 	}
- 	if (strcmp(mcd1_old, Config.Mcd1) || strcmp(mcd2_old, Config.Mcd2))
-@@ -1806,10 +1779,10 @@
- {
- 	strcpy(Config.Mcd1, "none");
- 	if (memcard1_sel != 0)
--		snprintf(Config.Mcd1, sizeof(Config.Mcd1), ".%s%s", MEMCARD_DIR, memcards[memcard1_sel]);
-+		snprintf(Config.Mcd1, sizeof(Config.Mcd1), "%s%s", MEMCARD_DIR, memcards[memcard1_sel]);
- 	strcpy(Config.Mcd2, "none");
- 	if (memcard2_sel != 0)
--		snprintf(Config.Mcd2, sizeof(Config.Mcd2), ".%s%s", MEMCARD_DIR, memcards[memcard2_sel]);
-+		snprintf(Config.Mcd2, sizeof(Config.Mcd2), "%s%s", MEMCARD_DIR, memcards[memcard2_sel]);
- 	LoadMcds(Config.Mcd1, Config.Mcd2);
- 	draw_mc_bg();
- }
-@@ -2489,7 +2462,7 @@
- 	closedir(dir);
- 
- do_memcards:
--	dir = opendir("." MEMCARD_DIR);
-+	dir = opendir(MEMCARD_DIR);
- 	if (dir == NULL) {
- 		perror("scan_bios_plugins memcards opendir");
- 		return;
-@@ -2509,7 +2482,7 @@
- 		if (ent->d_type != DT_REG && ent->d_type != DT_LNK)
- 			continue;
- 
--		snprintf(fname, sizeof(fname), "." MEMCARD_DIR "%s", ent->d_name);
-+		snprintf(fname, sizeof(fname), MEMCARD_DIR "%s", ent->d_name);
- 		if (stat(fname, &st) != 0) {
- 			printf("bad memcard file: %s\n", ent->d_name);
- 			continue;
-@@ -2533,6 +2505,7 @@
- {
- 	char buff[MAXPATHLEN];
- 	int i;
-+	size_t pos;
- 
- 	cpu_clock_st = cpu_clock = plat_target_cpu_clock_get();
- 
-@@ -2553,7 +2526,8 @@
- 		exit(1);
- 	}
- 
--	emu_make_path(buff, "skin/background.png", sizeof(buff));
-+	pos = plat_get_skin_dir(buff);
-+	strcpy(buff + pos, "background.png");
- 	readpng(g_menubg_src_ptr, buff, READPNG_BG, g_menuscreen_w, g_menuscreen_h);
- 
- 	i = plat_target.cpu_clock_set != NULL


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/29140

- `@TERMUX_ANDROID_HOME@` in `menu.c.patch` does not work and causes `menu_loop_romsel failed, dir: @TERMUX_ANDROID_HOME@` at runtime; use `@TERMUX_HOME@` instead, which is correct and is working

- `configure.patch` needs to be replaced with `export SDL_CONFIG="$TERMUX_PREFIX/bin/sdl-config"` instead

- After this commit, huge chunks of `main.c.patch`, `main.h.patch`, and `menu.c.patch` appear to no longer be necessary, having been  replaced with an upstream equivalent of the same thing https://github.com/notaz/pcsx_rearmed/commit/1ae743b1f67e225d74fa08839dc794630c1f8e7c . The remaining code unqiue to Termux not found in the upstream implementation is small.