### PR TITLE
addpkg(main/flint): 3.4.0

### DIFF
--- a/packages/flint/build.sh
+++ b/packages/flint/build.sh
@@ -1,0 +1,32 @@
+TERMUX_PKG_HOMEPAGE=http://www.flintlib.org
+TERMUX_PKG_DESCRIPTION="C library for doing number theory"
+TERMUX_PKG_LICENSE="LGPL-3.0-only"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="3.4.0"
+TERMUX_PKG_SRCURL="https://github.com/flintlib/flint/releases/download/v$TERMUX_PKG_VERSION/flint-$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=9497679804dead926e3affeb8d4c58739d1c7684d60c2c12827550d28e454a33
+TERMUX_PKG_DEPENDS="blas-openblas, libgmp, libmpfr"
+TERMUX_PKG_FORCE_CMAKE=true
+TERMUX_PKG_AUTO_UPDATE=true
+# ENABLE_ARCH is for adding `-march` argument to compiler; -DENABLE_ARCH=NO avoids that,
+# allowing Termux's own `-march` setting from termux_setup_toolchain_* to apply
+# Disable AVX2 like Arch Linux, because Arch Linux documented an issue related to it:
+# https://gitlab.archlinux.org/archlinux/packaging/packages/flint/-/work_items/1
+# (ENABLE_AVX2=OFF will reportedly be necessary to avoid Sagemath crashing)
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_INSTALL_LIBDIR=$TERMUX__PREFIX__LIB_SUBDIR
+-DENABLE_ARCH=NO
+-DENABLE_AVX2=OFF
+"
+
+termux_step_pre_configure() {
+	# upstream discourages the use of the CMakeLists.txt on UNIX-like platforms,
+	# but Arch Linux forcibly runs the CMakeLists.txt anyway using this,
+	# so try to follow Arch Linux's example first unless a problem occurs.
+	# https://gitlab.archlinux.org/archlinux/packaging/packages/flint/-/blob/0f05d716db948e16d699749ee5c71dab43461857/PKGBUILD#L26
+	sed -e 's|NOT WIN32|FALSE|' -i CMakeLists.txt
+
+	if [[ "$TERMUX_PKG_API_LEVEL" -lt 28 ]]; then
+		CPPFLAGS+=" -Daligned_alloc=memalign"
+	fi
+}

--- a/packages/flint/cherry-pick-32-bit-support.patch
+++ b/packages/flint/cherry-pick-32-bit-support.patch
@@ -1,0 +1,80 @@
+From a0649a7993d29eeff39182b3464fd3054eb70dc2 Mon Sep 17 00:00:00 2001
+From: Julien Schueller <schueller@phimeca.com>
+Date: Mon, 19 Jan 2026 21:28:44 +0100
+Subject: [PATCH] CMake: Do not pollute srcdir
+
+---
+ CMakeLists.txt                              | 25 ++++++++++-----------
+ src/nmod_poly/evaluate_geometric_nmod_vec.c |  4 ++--
+ 2 files changed, 14 insertions(+), 15 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9d6cdf5da3..0bf0c2b727 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -342,38 +342,36 @@ endif()
+ # Populate headers
+ configure_file(
+     ${CMAKE_CURRENT_SOURCE_DIR}/CMake/cmake_config.h.in
+-    ${CMAKE_CURRENT_SOURCE_DIR}/src/flint-config.h
++    ${CMAKE_CURRENT_BINARY_DIR}/src/flint-config.h
+ )
+ configure_file(
+     ${CMAKE_CURRENT_SOURCE_DIR}/src/flint.h.in
+-    ${CMAKE_CURRENT_SOURCE_DIR}/src/flint.h
++    ${CMAKE_CURRENT_BINARY_DIR}/src/flint.h
+ )
+ configure_file(
+     ${CMAKE_CURRENT_SOURCE_DIR}/src/fmpz/link/fmpz_${MEMORY_MANAGER}.c
+-    ${CMAKE_CURRENT_SOURCE_DIR}/src/fmpz/fmpz.c
++    ${CMAKE_CURRENT_BINARY_DIR}/src/fmpz/fmpz.c
+     COPYONLY
+ )
+ if(FLINT_LONG_LONG)
+     configure_file(
+         ${CMAKE_CURRENT_SOURCE_DIR}/src/gmpcompat-longlong.h.in
+-        ${CMAKE_CURRENT_SOURCE_DIR}/src/gmpcompat.h
++        ${CMAKE_CURRENT_BINARY_DIR}/src/gmpcompat.h
+         COPYONLY
+     )
+ else()
+     configure_file(
+         ${CMAKE_CURRENT_SOURCE_DIR}/src/gmpcompat.h.in
+-        ${CMAKE_CURRENT_SOURCE_DIR}/src/gmpcompat.h
++        ${CMAKE_CURRENT_BINARY_DIR}/src/gmpcompat.h
+         COPYONLY
+     )
+ endif()
+ 
+-if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+-    configure_file(
+-        ${CMAKE_CURRENT_SOURCE_DIR}/src/mpn_extras/generic/flint-mparam.h
+-        ${CMAKE_CURRENT_SOURCE_DIR}/src/flint-mparam.h
+-        COPYONLY
+-    )   
+-endif()
++configure_file(
++    ${CMAKE_CURRENT_SOURCE_DIR}/src/mpn_extras/generic/flint-mparam.h
++    ${CMAKE_CURRENT_BINARY_DIR}/src/flint-mparam.h
++    COPYONLY
++)
+ 
+ 
+ foreach (build_dir IN LISTS BUILD_DIRS)
+@@ -382,6 +380,7 @@ foreach (build_dir IN LISTS BUILD_DIRS)
+     file(GLOB TEMP RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${build_dir}/*.h")
+     list(APPEND HEADERS ${TEMP})
+ endforeach ()
++list(APPEND SOURCES ${CMAKE_CURRENT_BINARY_DIR}/src/fmpz/fmpz.c)
+ 
+ set(TEMP ${HEADERS})
+ set(HEADERS )
+@@ -414,7 +413,7 @@ endif()
+ # Include directories
+ 
+ target_include_directories(flint PUBLIC
+-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src;${CMAKE_CURRENT_BINARY_DIR}>"
++    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src;${CMAKE_CURRENT_BINARY_DIR};${CMAKE_CURRENT_BINARY_DIR}/src>"
+     "$<INSTALL_INTERFACE:include/flint>"
+     ${PThreads_INCLUDE_DIRS}
+ )


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/29273

- Progress toward https://github.com/termux/termux-packages/issues/450

- Force CMake like Arch Linux and cherry-pick https://github.com/flintlib/flint/pull/2560 to fix CMake build for 32-bit targets