### PR TITLE
fix(main/libsodium): rebuild with correct version

### DIFF
--- a/packages/libsodium/build.sh
+++ b/packages/libsodium/build.sh
@@ -3,8 +3,9 @@ TERMUX_PKG_DESCRIPTION="Network communication, cryptography and signaturing libr
 TERMUX_PKG_LICENSE="ISC"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.0.22"
-TERMUX_PKG_SRCURL=https://github.com/jedisct1/libsodium/archive/refs/tags/${TERMUX_PKG_VERSION}-RELEASE.tar.gz
-TERMUX_PKG_SHA256=b97e76fb560940a2499e253c45ffee96526f741ef3b378be3bb7e587fe2fd494
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://github.com/jedisct1/libsodium/archive/refs/tags/${TERMUX_PKG_VERSION}-RELEASE.tar.gz"
+TERMUX_PKG_SHA256=5838bb0c3da6148c24ebe531d1ed1297de9a87aea77d426bcd99f289e681631c
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE=latest-release-tag
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+\.\d+(?=-RELEASE)"


### PR DESCRIPTION
- `libsodium` 1.0.22 was retagged because the original tag was associated with the wrong version of the code: https://github.com/jedisct1/libsodium/discussions/1533