### PR TITLE
bump(main/lua-lpeg): 1.1.0-2

### DIFF
--- a/packages/lua-lpeg/build.sh
+++ b/packages/lua-lpeg/build.sh
@@ -2,12 +2,23 @@ TERMUX_PKG_HOMEPAGE=https://www.inf.puc-rio.br/~roberto/lpeg
 TERMUX_PKG_DESCRIPTION="Pattern-matching library for Lua 5.4"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
-TERMUX_PKG_VERSION=1.1.0
-TERMUX_PKG_REVISION=4
-TERMUX_PKG_SRCURL=https://www.inf.puc-rio.br/~roberto/lpeg/lpeg-$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_SHA256=4b155d67d2246c1ffa7ad7bc466c1ea899bbc40fef0257cc9c03cecbaed4352a
+TERMUX_PKG_VERSION="1.1.0-2"
+TERMUX_PKG_SRCURL="https://luarocks.org/manifests/gvvaughan/lpeg-$TERMUX_PKG_VERSION.src.rock"
+TERMUX_PKG_SHA256=836d315b920a5cdd62e21786c6c9fad547c4faa131d5583ebca64f0b6595ee76
 TERMUX_PKG_BUILD_DEPENDS="lua51, lua52, lua53, lua54, lua55"
 TERMUX_PKG_DEPENDS="lua55"
+
+termux_extract_src_archive() {
+	local file="$TERMUX_PKG_CACHEDIR/$(basename "${TERMUX_PKG_SRCURL}")"
+	local folder
+	set +o pipefail
+	folder=$(unzip -qql "$file" | head -n1 | tr -s ' ' | cut -d' ' -f5-)
+	rm -Rf "$folder"
+	unzip -q "$file"
+	mkdir -p "$TERMUX_PKG_SRCDIR"
+	tar xf "$TERMUX_PKG_TMPDIR/lpeg-${TERMUX_PKG_VERSION%-*}.tar.gz" -C "$TERMUX_PKG_SRCDIR" --strip-components=1
+	set -o pipefail
+}
 
 termux_step_pre_configure() {
 	declare -ag LUA=('5.1' '5.2' '5.3' '5.4' '5.5')
@@ -33,9 +44,9 @@ termux_step_make_install() {
 	for lua in "${LUA[@]}"; do
 		install -Dm600 lpeg-"${lua//./}"/liblpeg.so "$TERMUX_PREFIX/lib/liblpeg-$lua".so
 		mkdir -p "${TERMUX_PREFIX}/lib/lua/$lua"
-		ln -s "${TERMUX_PREFIX}/lib/liblpeg-$lua.so" "${TERMUX_PREFIX}/lib/lua/$lua/lpeg.so"
+		ln -sf "${TERMUX_PREFIX}/lib/liblpeg-$lua.so" "${TERMUX_PREFIX}/lib/lua/$lua/lpeg.so"
 		install -Dm600 lpeg-"${lua//./}"/re.lua "$TERMUX_PREFIX/share/lua/$lua"/re.lua
 	done
 	# make liblpeg-5.5.so the default one
-	ln -s "${TERMUX_PREFIX}/lib/liblpeg-5.5.so" "${TERMUX_PREFIX}/lib/liblpeg.so"
+	ln -sf "${TERMUX_PREFIX}/lib/liblpeg-5.5.so" "${TERMUX_PREFIX}/lib/liblpeg.so"
 }


### PR DESCRIPTION
- The current source URL https://www.inf.puc-rio.br/~roberto/lpeg/lpeg-1.1.0.tar.gz is not working because its SSL certificate has expired, but I found a mirror of the same source archive that Termux builds inside of a `.rock` file distributed at `luarocks.org` that can be used instead if it is extracted using a custom `termux_extract_src_archive()` that I made.

- Arch Linux also uses this same source URL currently: https://gitlab.archlinux.org/archlinux/packaging/packages/lpeg/-/blob/6759a9203957163dc682805621f340b41f633f1c/PKGBUILD#L28