### PR TITLE
bump(main/at-spi2-core): 2.60.1

### DIFF
--- a/packages/at-spi2-core/build.sh
+++ b/packages/at-spi2-core/build.sh
@@ -2,9 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://wiki.gnome.org/Accessibility
 TERMUX_PKG_DESCRIPTION="Assistive Technology Service Provider Interface (AT-SPI)"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="2.60.0"
-TERMUX_PKG_SRCURL=https://download.gnome.org/sources/at-spi2-core/${TERMUX_PKG_VERSION%.*}/at-spi2-core-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=80e50c1a97d8fd660a3fadb02ca35876df881c266d3d6108fc5b4c113614cb99
+TERMUX_PKG_VERSION="2.60.1"
+# https://download.gnome.org/sources/at-spi2-core/${TERMUX_PKG_VERSION%.*}/at-spi2-core-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SRCURL=https://gitlab.gnome.org/GNOME/at-spi2-core/-/archive/${TERMUX_PKG_VERSION}/at-spi2-core-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=385d616ae796eccc5652082edeb1cf1f5ee5a4eaa87e223b0406a79efb28d104
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="dbus, glib, libx11, libxi, libxtst"
 TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, libxml2"


### PR DESCRIPTION
Change source URL to gitlab.gnome.org because tarball is not added in download.gnome.org.
* Fixes #29304 