### PR TITLE
bump(main/python-pyppmd): 1.3.1

### DIFF
--- a/packages/python-pyppmd/build.sh
+++ b/packages/python-pyppmd/build.sh
@@ -2,13 +2,14 @@ TERMUX_PKG_HOMEPAGE=https://github.com/miurahr/pyppmd
 TERMUX_PKG_DESCRIPTION="PPM compression/decompression library"
 TERMUX_PKG_LICENSE="LGPL-2.1-only"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.2.0"
+TERMUX_PKG_VERSION="1.3.1"
 TERMUX_PKG_SRCURL="https://github.com/miurahr/pyppmd/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz"
-TERMUX_PKG_SHA256=7da07545b5764d91011d5f8e9740fab6eb92265ab04990a7815a139ca4757443
+TERMUX_PKG_SHA256=ca5328cfff8be532fe834f1844c281b503f3b069e6ccb6232971eaf82474dbd3
 TERMUX_PKG_DEPENDS="python, python-pip"
 TERMUX_PKG_PYTHON_COMMON_BUILD_DEPS="build, installer"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_TAG_TYPE=newest-tag
 
 termux_step_pre_configure() {
 	rm CMakeLists.txt

--- a/packages/python-pyppmd/no-pthread_cancel.patch
+++ b/packages/python-pyppmd/no-pthread_cancel.patch
@@ -2,21 +2,21 @@ diff --git a/src/lib/buffer/ThreadDecoder.c b/src/lib/buffer/ThreadDecoder.c
 index ca80a52..3216be6 100644
 --- a/src/lib/buffer/ThreadDecoder.c
 +++ b/src/lib/buffer/ThreadDecoder.c
-@@ -179,7 +179,7 @@ int Ppmd7T_decode(CPpmd7 *cPpmd7, CPpmd7z_RangeDec *rc, OutBuffer *out, int max_
- void Ppmd7T_Free(CPpmd7 *cPpmd7, ppmd_info *threadInfo, IAllocPtr allocator) {
-     ppmd_thread_control_t *tc = (ppmd_thread_control_t *)threadInfo->t;
-     if (!(tc->finished)) {
+@@ -199,7 +199,7 @@ void Ppmd7T_Free(CPpmd7 *cPpmd7, ppmd_info *threadInfo, IAllocPtr allocator) {
+         pthread_cond_broadcast(&tc->notEmpty);
+         pthread_mutex_unlock(&tc->mutex);
+ 
 -        pthread_cancel(tc->handle);
 +        pthread_kill(tc->handle, SIGTERM);
+         pthread_join(tc->handle, NULL);
          tc->finished = True;
      }
-     IAlloc_Free(allocator, tc);
-@@ -274,7 +274,7 @@ inempty:
- void Ppmd8T_Free(CPpmd8 *cPpmd8, ppmd_info *threadInfo, IAllocPtr allocator) {
-     ppmd_thread_control_t *tc = (ppmd_thread_control_t *)threadInfo->t;
-     if (!(tc->finished)) {
+@@ -308,7 +308,7 @@ void Ppmd8T_Free(CPpmd8 *cPpmd8, ppmd_info *threadInfo, IAllocPtr allocator) {
+         pthread_cond_broadcast(&tc->notEmpty);
+         pthread_mutex_unlock(&tc->mutex);
+ 
 -        pthread_cancel(tc->handle);
 +        pthread_kill(tc->handle, SIGTERM);
+         pthread_join(tc->handle, NULL);
          tc->finished = True;
      }
-     IAlloc_Free(allocator, tc);


### PR DESCRIPTION
- Switch to `TERMUX_PKG_UPDATE_TAG_TYPE=newest-tag`. I did not previously understand that the recent releases of pyppmd are only tags, not "releases".