### PR TITLE
fix(main/gomuks): fix version flags

### DIFF
--- a/packages/gomuks/build.sh
+++ b/packages/gomuks/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A terminal Matrix client written in Go"
 TERMUX_PKG_LICENSE="AGPL-V3"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="26.04"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/gomuks/gomuks/archive/refs/tags/v0.${TERMUX_PKG_VERSION/.}.0.tar.gz"
 TERMUX_PKG_SHA256=d01e3b23fe759f62e7619304b6cab8f6676978ed685869f1ce55a7157ac8c409
 TERMUX_PKG_AUTO_UPDATE=true
@@ -10,11 +11,20 @@ TERMUX_PKG_UPDATE_VERSION_REGEXP="0\.\K\d+(?=\.0)"
 TERMUX_PKG_UPDATE_VERSION_SED_REGEXP="s/([0-9][0-9])([0-9][0-9])/\1.\2/"
 TERMUX_PKG_DEPENDS="libolm, resolv-conf"
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_HOSTBUILD=true
 # i686 fails to compile:
-# go.mau.fi/goheif/libde265
-# In file included from libde265.cc:2:
-# ./libde265-all.inl:10:10: fatal error: 'alloc_pool.cc' file not found
-TERMUX_PKG_EXCLUDED_ARCHES="i686"
+# go.mau.fi/goheif/dav1d
+# In file included from dav1d-tmpl-16.c:2:
+# In file included from ./dav1d-tmpl.inl:1:
+# In file included from ./src/cdef_apply_tmpl.c:28:
+# go/pkg/mod/go.mau.fi/goheif@v0.0.0-20260413100809-7ec7087b8d7d/dav1d/config.h:30:2: error: "Unsupported architecture. Only x86_64, ARM64, and RISC-V are supported."
+TERMUX_PKG_EXCLUDED_ARCHES=i686
+
+termux_step_host_build() {
+	termux_setup_golang
+
+	GOBIN="$TERMUX_PKG_HOSTBUILD_DIR" GOOS=linux GOARCH=amd64 go install go.mau.fi/util/cmd/maubuild@latest
+}
 
 termux_step_post_get_source() {
 	termux_setup_golang
@@ -34,20 +44,11 @@ termux_step_pre_configure() {
 
 termux_step_make() {
 	export GOPATH="$TERMUX_PKG_SRCDIR/go"
-	local ldflags tag_commit
 	# This is adapted directly from the upstream `./build-noweb.sh`
 	# https://github.com/gomuks/gomuks/blob/v0.2511.0/build-noweb.sh
 	mkdir -p web/dist/
 	touch web/dist/empty
-	MAUTRIX_VERSION=$(cat go.mod | grep 'maunium.net/go/mautrix ' | head -n1 | awk '{ print $2 }')
-	export MAUTRIX_VERSION
-	read -r tag_commit _ < <(git ls-remote https://github.com/gomuks/gomuks "refs/tags/v0.${TERMUX_PKG_VERSION/.}.0")
-	ldflags+=" -X go.mau.fi/gomuks/version.Tag=${TERMUX_PKG_VERSION}"
-	ldflags+=" -X go.mau.fi/gomuks/version.Commit=${tag_commit}"
-	ldflags+=" -X 'go.mau.fi/gomuks/version.BuildTime=$(date --utc -Iseconds)'"
-	ldflags+=" -X 'maunium.net/go/mautrix.GoModVersion=$MAUTRIX_VERSION'"
-
-	go build -ldflags "$ldflags" ./cmd/gomuks "$@"
+	BINARY_NAME=gomuks MAU_VERSION_PACKAGE=go.mau.fi/gomuks/version $TERMUX_PKG_HOSTBUILD_DIR/maubuild "$@"
 }
 
 termux_step_make_install() {


### PR DESCRIPTION
Our gomuks package (and previous version 26.03) fails to start with something like:

```
panic: invalid semver: 26.04

goroutine 1 [running]:
go.mau.fi/util/progver.semverToCalver({0x62a4e35fa0, 0x5})
	/home/builder/.termux-build/gomuks/src/go/pkg/mod/go.mau.fi/util@v0.9.8/progver/progver.go:110 +0x148
go.mau.fi/util/progver.ProgramVersion.Init({{0x62a4bdc19c, 0x6}, {0x62a4c069b5, 0x20}, {0x62a4bdaa99, 0x5}, 0x1, {0x0, 0x0}, {0x62a4e35fa0, ...}, ...}, ...)
	/home/builder/.termux-build/gomuks/src/go/pkg/mod/go.mau.fi/util@v0.9.8/progver/progver.go:64 +0x180
go.mau.fi/gomuks/version.init()
	/home/builder/.termux-build/gomuks/src/version/version.go:37 +0x84
```

Due to upstream having changed how the version string is constructed in https://github.com/gomuks/gomuks/commit/d6508eec4255. Ajust our build in the same way as in
https://github.com/gomuks/gomuks/commit/ae66b6d69fc7 to fix it, which requires host-building and running `maubuild`.