### PR TITLE
bump(main/starship): 1.25.0

### DIFF
--- a/packages/starship/0001-Cargo.toml.patch
+++ b/packages/starship/0001-Cargo.toml.patch
@@ -1,5 +1,5 @@
 diff --git a/Cargo.toml b/Cargo.toml
-index 4758ddc..86286d6 100644
+index e98dce39..e6c31fd5 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
 @@ -29,8 +29,7 @@ The minimal, blazing-fast, and infinitely customizable prompt for any shell! ☄
@@ -12,12 +12,12 @@ index 4758ddc..86286d6 100644
  config-schema = ["schemars"]
  notify = ["notify-rust"]
  
-@@ -71,7 +70,7 @@ sha1 = "0.10.6"
- shadow-rs = { version = "1.4.0", default-features = false, features = ["build"] }
+@@ -71,7 +70,7 @@ sha1 = "0.11.0"
+ shadow-rs = { version = "1.7.1", default-features = false, features = ["build"] }
  # battery is optional (on by default) because the crate doesn't currently build for Termux
  # see: https://github.com/svartalf/rust-battery/issues/33
--starship-battery = { version = "0.10.3", optional = true }
-+# starship-battery = { version = "0.10.3", optional = true }
+-starship-battery = { version = "0.11.0", optional = true }
++# starship-battery = { version = "0.11.0", optional = true }
  strsim = "0.11.1"
- systemstat = "=0.2.5"
- terminal_size = "0.4.3"
+ systemstat = "=0.2.6"
+ terminal_size = "0.4.4"

--- a/packages/starship/build.sh
+++ b/packages/starship/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://starship.rs
 TERMUX_PKG_DESCRIPTION="A minimal, blazing fast, and extremely customizable prompt for any shell"
 TERMUX_PKG_LICENSE="ISC"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
-TERMUX_PKG_VERSION="1.24.2"
+TERMUX_PKG_VERSION="1.25.0"
 TERMUX_PKG_SRCURL=https://github.com/starship/starship/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=b7ab0ef364f527395b46d2fb7f59f9592766b999844325e35f62c8fa4d528795
+TERMUX_PKG_SHA256=e77f3c23683eb544f6dae7171e3c80676aefc66329225bdcd58e40846bb6445f
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_DEPENDS="zlib"
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -13,6 +13,20 @@ TERMUX_PKG_SUGGESTS="nerdfix, taplo"
 
 termux_step_pre_configure() {
 	termux_setup_rust
+	cargo vendor
+	find ./vendor \
+		-mindepth 1 -maxdepth 1 -type d \
+		! -wholename ./vendor/systemstat \
+		-exec rm -rf '{}' \;
+
+	local patch="$TERMUX_PKG_BUILDER_DIR/systemstat-android-is-linux.diff"
+	echo "Applying patch: $patch"
+	patch -p1 < "$patch"
+
+	echo "" >> Cargo.toml
+	echo '[patch.crates-io]' >> Cargo.toml
+	echo "systemstat = { path = \"./vendor/systemstat\" }" >> Cargo.toml
+
 	termux_setup_cmake
 	: "${CARGO_HOME:=${HOME}/.cargo}"
 	export CARGO_HOME

--- a/packages/starship/systemstat-android-is-linux.diff
+++ b/packages/starship/systemstat-android-is-linux.diff
@@ -1,0 +1,13 @@
+diff --git a/vendor/systemstat/src/platform/mod.rs b/vendor/systemstat/src/platform/mod.rs
+index 1ebc9fec..8bebe135 100644
+--- a/vendor/systemstat/src/platform/mod.rs
++++ b/vendor/systemstat/src/platform/mod.rs
+@@ -10,7 +10,7 @@ pub use self::windows::PlatformImpl;
+ #[cfg(unix)]
+ pub mod unix;
+ 
+-#[cfg(any(target_os = "linux", target_os = "hurd"))]
++#[cfg(any(target_os = "android", target_os = "linux", target_os = "hurd"))]
+ mod procfs;
+ 
+ #[cfg(any(


### PR DESCRIPTION
- closes #29400

Can't get the `systemstat` crate compiling yet.
Should be as simple as:
```patch
diff --git a/vendor/systemstat/src/platform/mod.rs b/vendor/systemstat/src/platform/mod.rs
index 1ebc9fec..8bebe135 100644
--- a/vendor/systemstat/src/platform/mod.rs
+++ b/vendor/systemstat/src/platform/mod.rs
@@ -10,7 +10,7 @@ pub use self::windows::PlatformImpl;
 #[cfg(unix)]
 pub mod unix;
 
-#[cfg(any(target_os = "linux", target_os = "hurd"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "hurd"))]
 mod procfs;
 
 #[cfg(any(
```

<details><summary>But when I <code>cargo vendor</code> to apply that as a patch I get errors with another crate.</summary>
<p>

```console
     Locking 1 package to latest Rust 1.90 compatible version
      Adding systemstat v0.2.6 (/home/builder/.termux-build/starship/src/vendor/systemstat)
  Installing starship v1.25.0 (/home/builder/.termux-build/starship/src)
    Updating crates.io index
   Compiling proc-macro2 v1.0.106
   Compiling quote v1.0.45
   Compiling unicode-ident v1.0.24
   Compiling libc v0.2.184
   Compiling memchr v2.8.0
   Compiling cfg-if v1.0.4
   Compiling crossbeam-utils v0.8.21
   Compiling regex-syntax v0.8.10
   Compiling fastrand v2.4.1
   Compiling once_cell v1.21.4
   Compiling thiserror v2.0.18
   Compiling smallvec v1.15.1
error[E0463]: can't find crate for `core`
  |
  = note: the `aarch64-linux-android` target may not be installed
  = help: consider downloading the target with `rustup target add aarch64-linux-android`

For more information about this error, try `rustc --explain E0463`.
error: could not compile `cfg-if` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `fastrand` (lib) due to 1 previous error
error[E0463]: can't find crate for `std`
  |
  = note: the `aarch64-linux-android` target may not be installed
  = help: consider downloading the target with `rustup target add aarch64-linux-android`

error: could not compile `smallvec` (lib) due to 1 previous error
error: could not compile `once_cell` (lib) due to 1 previous error
error: could not compile `memchr` (lib) due to 1 previous error
error: could not compile `regex-syntax` (lib) due to 1 previous error
error: failed to compile `starship v1.25.0 (/home/builder/.termux-build/starship/src)`, intermediate artifacts can be found at `/home/builder/.termux-build/starship/src/target`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
```

</p>
</details> 