### PR TITLE
bump(x11/atril): 1.28.3

### DIFF
--- a/x11-packages/atril/build.sh
+++ b/x11-packages/atril/build.sh
@@ -2,10 +2,10 @@ TERMUX_PKG_HOMEPAGE=https://mate-desktop.org
 TERMUX_PKG_DESCRIPTION="MATE document viewer"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.28.1"
-TERMUX_PKG_REVISION=5
-TERMUX_PKG_SRCURL="https://pub.mate-desktop.org/releases/${TERMUX_PKG_VERSION%.*}/atril-${TERMUX_PKG_VERSION}.tar.xz"
-TERMUX_PKG_SHA256=74c4f42979f3ead52def23767448d06ad7f715421e03c9b509404b096de8193e
+TERMUX_PKG_VERSION="1.28.3"
+# https://pub.mate-desktop.org/releases/${TERMUX_PKG_VERSION%.*}/atril-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SRCURL="https://github.com/mate-desktop/atril/releases/download/v${TERMUX_PKG_VERSION}/atril-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256=1a89724cdfb8af83fa44f08d89d66049f9aac053b28be9cef13eb27148a970da
 TERMUX_PKG_AUTO_UPDATE=true
 # links with poppler-glib, not poppler
 TERMUX_PKG_DEPENDS="atk, djvulibre, gdk-pixbuf, glib, gtk3, harfbuzz, libarchive, libc++, libcairo, libice, libsecret, libsm, libsoup3, libtiff, libxml2, mate-desktop, pango, poppler, texlive-bin, webkit2gtk-4.1, zlib"


### PR DESCRIPTION
Change source URL to github release artifact because new releases are absent in previous link.
* Fixes #24782 