### PR TITLE
chore(x11/sdl2-mixer): Disable auto-update

### DIFF
--- a/x11-packages/sdl2-mixer/build.sh
+++ b/x11-packages/sdl2-mixer/build.sh
@@ -7,7 +7,8 @@ TERMUX_PKG_VERSION="2.8.1"
 TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://github.com/libsdl-org/SDL_mixer/releases/download/release-${TERMUX_PKG_VERSION}/SDL2_mixer-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=cb760211b056bfe44f4a1e180cc7cb201137e4d1572f2002cc1be728efd22660
-TERMUX_PKG_AUTO_UPDATE=true
+# Prevent updating to SDL3 version
+TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_DEPENDS="fluidsynth, libxmp, libflac, libmodplug, libvorbis, libmpg123, opusfile, sdl2 | sdl2-compat"
 TERMUX_PKG_ANTI_BUILD_DEPENDS="sdl2-compat"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="


### PR DESCRIPTION
This prevents updating to SDL3 version. Also, there is sdl3-mixer now.

%ci:no-build

* Fixes #28858 