### PR TITLE
translate-shell: Make hunspell and mpv optional suggestions

### DIFF
--- a/packages/translate-shell/build.sh
+++ b/packages/translate-shell/build.sh
@@ -3,13 +3,14 @@ TERMUX_PKG_DESCRIPTION="Command-line translator using Google Translate, Bing Tra
 TERMUX_PKG_LICENSE="Public Domain"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.9.7.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/soimort/translate-shell/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=f949f379779b9e746bccb20fcd180d041fb90da95816615575b49886032bcefa
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="bash, curl, gawk, less, rlwrap"
 # hunspell - spell checking
 # mpv - text-to-speech functionality
-TERMUX_PKG_RECOMMENDS="hunspell, mpv"
+TERMUX_PKG_SUGGESTS="hunspell, mpv"
 TERMUX_PKG_EXTRA_MAKE_ARGS="PREFIX=$TERMUX_PREFIX"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true


### PR DESCRIPTION
`hunspell` and `mpv` are optional features of `translate-shell`, used for spell checking and text-to-speech.

Currently, these are listed under RECOMMENDS, which causes them to be installed by default. In the case of `mpv`, this pulls in a huge dependency chain (including clang, python, X11), often blowing up the install size in minimal Termux setups.

Since both features are non-essential and only used in specific scenarios, it would be more appropriate to classify them under SUGGESTS instead.

Comparing default installation to stripped-down installation, one appears < 1MB and the other appears < 1GB.
```console
$ apt install translate-shell
The following NEW packages will be installed:
  alsa-lib clang dbus ffmpeg fftw fontconfig freetype fribidi game-music-emu gdbm gdk-pixbuf giflib glib glslang harfbuzz hunspell
  hunspell-en-us imlib2 jack jack2 libandroid-execinfo libandroid-shmem libandroid-stub libandroid-sysv-semaphore libaom
  libarchive libass libavif libbluray libbs2b libcaca libcairo libcompiler-rt libcrypt libdav1d libde265 libdrm libffi libflac
  libgd libgraphite libheif libid3tag libjpeg-turbo libjxl libllvm libltdl liblzo libmp3lame libmpg123 libogg libopencore-amr
  libopenmpt libopus libpixman libplacebo libpng librav1e librsvg libsamplerate libsixel libsndfile libsodium libsoxr libsrt
  libssh libtheora libtiff libuchardet libudfread libv4l libvidstab libvmaf libvo-amrwbenc libvorbis libvpx libwayland libwebp
  libwebrtc-audio-processing libx11 libx264 libx265 libxau libxcb libxdmcp libxext libxft libxrender libxshmfence libzimg libzmq
  littlecms lld llvm make mesa-vulkan-icd-swrast mpv ncurses-ui-libs ndk-sysroot ocl-icd openal-soft openjpeg pango pkg-config
  pulseaudio python python-ensurepip-wheels python-pip rlwrap rubberband speexdsp svt-av1 translate-shell ttf-dejavu vulkan-icd
  vulkan-loader-generic xvidcore
0 upgraded, 117 newly installed, 0 to remove and 0 not upgraded.
Need to get 148 MB of archives.
After this operation, 841 MB of additional disk space will be used.
Do you want to continue? [Y/n]
```
```console
$ apt install --no-install-recommends translate-shell
The following additional packages will be installed:
  rlwrap
Recommended packages:
  hunspell mpv
The following NEW packages will be installed:
  rlwrap translate-shell
0 upgraded, 2 newly installed, 0 to remove and 0 not upgraded.
Need to get 141 kB of archives.
After this operation, 741 kB of additional disk space will be used.
Do you want to continue? [Y/n]
```