### PR TITLE
enhance(x11/codeblocks): attempt to fix everything, mainly the compiler plugin

### DIFF
--- a/x11-packages/codeblocks/build.sh
+++ b/x11-packages/codeblocks/build.sh
@@ -2,31 +2,97 @@ TERMUX_PKG_HOMEPAGE=https://www.codeblocks.org/
 TERMUX_PKG_DESCRIPTION="Code::Blocks is the Integrated Development Environment (IDE)"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=25.03
-TERMUX_PKG_SRCURL=https://sourceforge.net/projects/codeblocks/files/Sources/${TERMUX_PKG_VERSION}/codeblocks_${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_VERSION="25.03"
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://sourceforge.net/projects/codeblocks/files/Sources/${TERMUX_PKG_VERSION}/codeblocks_${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=b0f6aa5908d336d7f41f9576b2418ac7d27efbc59282aa8c9171d88cea74049e
-TERMUX_PKG_DEPENDS="codeblocks-data, glib, gtk3, libc++, wxwidgets, zip"
+TERMUX_PKG_DEPENDS="aterm, codeblocks-data, glib, gtk3, hunspell, libc++, wxwidgets, zip"
+TERMUX_PKG_BUILD_DEPENDS="boost, boost-headers"
 TERMUX_PKG_HOSTBUILD=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--without-contrib-plugins --disable-compiler"
 
 termux_step_host_build() {
 	"${TERMUX_PKG_SRCDIR}/configure"
-	make -j $TERMUX_PKG_MAKE_PROCESSES -C src/base
-	make -j $TERMUX_PKG_MAKE_PROCESSES -C src/build_tools
+	make -j "$TERMUX_PKG_MAKE_PROCESSES" -C src/base
+	make -j "$TERMUX_PKG_MAKE_PROCESSES" -C src/build_tools
 }
 
 termux_step_pre_configure() {
 	local _libgcc_file="$($CC -print-libgcc-file-name)"
-	local _libgcc_path="$(dirname $_libgcc_file)"
-	local _libgcc_name="$(basename $_libgcc_file)"
+	local _libgcc_path="$(dirname "$_libgcc_file")"
+	local _libgcc_name="$(basename "$_libgcc_file")"
 	LDFLAGS+=" -L$_libgcc_path -l:$_libgcc_name"
 
+	LDFLAGS+=" -Wl,-rpath=$TERMUX_PREFIX/lib/codeblocks/wxContribItems"
+
+	find "$TERMUX_PKG_SRCDIR/src" -type f -print0 | \
+		xargs -0 sed -i \
+		-e "s|/usr|$TERMUX_PREFIX|g"
+
 	autoreconf -fi
+
+	# make sure that when this file no longer exists, this block is removed.
+	# (context: the Ubuntu 24.04 builder image has autoconf-archive 20220903-3,
+	# and this conflicts with the use of 'autoreconf -fi'
+	# in packages which are being built against boost 1.89 or newer)
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		local file=/usr/share/aclocal/ax_boost_system.m4
+		if [[ ! -f "$file" ]]; then
+			termux_error_exit "$file no longer exists. Please edit $TERMUX_PKG_NAME's build.sh to remove this block."
+		fi
+		# remove this line too after the above check fails
+		# (it willl no longer be necessary when the above check fails):
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ax_cv_boost_system=yes --without-boost-system"
+	fi
+
+	local plugins=''
+	plugins+="AutoVersioning,"
+	plugins+="BrowseTracker,"
+	plugins+="byogames,"
+	plugins+="cbkoders,"
+	plugins+="Cccc,"
+	plugins+="clangd_client,"
+	plugins+="codesnippets,"
+	plugins+="codestat,"
+	plugins+="copystrings,"
+	plugins+="CppCheck,"
+	plugins+="Cscope,"
+	plugins+="DoxyBlocks,"
+	plugins+="dragscroll,"
+	plugins+="EditorConfig,"
+	plugins+="EditorTweaks,"
+	plugins+="envvars,"
+	plugins+="exporter,"
+	# Arch Linux disables FileManager because it has an issue involving wxwidgets
+	#plugins+="FileManager,"
+	plugins+="headerfixup,"
+	plugins+="help,"
+	plugins+="hexeditor,"
+	plugins+="incsearch,"
+	plugins+="keybinder,"
+	plugins+="libfinder,"
+	plugins+="MouseSap,"
+	plugins+="NassiShneiderman,"
+	plugins+="profiler,"
+	plugins+="ProjectOptionsManipulator,"
+	plugins+="regex,"
+	plugins+="ReopenEditor,"
+	plugins+="rndgen,"
+	plugins+="smartindent,"
+	plugins+="spellchecker,"
+	plugins+="symtab,"
+	plugins+="ThreadSearch,"
+	plugins+="ToolsPlus,"
+	plugins+="Valgrind"
+	# plugins+="wxcontrib,"
+	# plugins+="wxsmith,"
+	# plugins+="wxsmithaui,"
+	# plugins+="wxsmithcontrib"
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-contrib-plugins=$plugins"
 }
 
 termux_step_post_configure() {
 	sed -i 's/ -shared / -Wl,-O1,--as-needed\0/g' ./libtool
-	cp -r $TERMUX_PKG_HOSTBUILD_DIR/src/build_tools ./src/
+	cp -r "$TERMUX_PKG_HOSTBUILD_DIR/src/build_tools" ./src/
 
 	# We need to make sure the files are edited (or have their last modified date)
 	# in a specific order to avoid accidentally triggering a recompilation.

--- a/x11-packages/codeblocks/fix-redefinition-header-x86.patch
+++ b/x11-packages/codeblocks/fix-redefinition-header-x86.patch
@@ -1,0 +1,39 @@
+Fixes:
+In file included from /home/builder/.termux-build/codeblocks/src/src/
+plugins/compilergcc/depslib/src/headers.c:24:
+/home/builder/.termux-build/codeblocks/src/src/plugins/compilergcc/
+depslib/src/headers.h:25:8: error: redefinition of '_header'
+   25 | struct _header
+      |        ^
+/home/builder/.termux-build/_cache/android-r29-api-24-v4/bin/
+../sysroot/usr/include/x86_64-linux-android/asm/sigcontext.h:81:8:
+note: previous definition is here
+   81 | struct _header {
+      |        ^
+due to conflict with preexisting overly-general varaible name '_header'
+in Android-x86 headers.
+
+--- a/src/plugins/compilergcc/depslib/src/headers.h
++++ b/src/plugins/compilergcc/depslib/src/headers.h
+@@ -9,17 +9,17 @@
+  *
+  * ALL WARRANTIES ARE HEREBY DISCLAIMED.
+  */
+-typedef struct _headers HEADERS;
+-typedef struct _header HEADER;
++typedef struct codeblocks_headers HEADERS;
++typedef struct codeblocks_header HEADER;
+ 
+-struct _headers
++struct codeblocks_headers
+ {
+ 	HEADERS *next;
+ 	HEADERS *tail;
+ 	HEADER *header;
+ };
+ 
+-struct _header
++struct codeblocks_header
+ {
+ 	const char *key;
+ 	LIST *includes;

--- a/x11-packages/codeblocks/wxwidgets-3.3.1.patch
+++ b/x11-packages/codeblocks/wxwidgets-3.3.1.patch
@@ -1,0 +1,99 @@
+diff --git a/src/plugins/contrib/wxSmith/wxwidgets/properties/wxscolourproperty.cpp b/src/plugins/contrib/wxSmith/wxwidgets/properties/wxscolourproperty.cpp
+index eab13d9..d0eb3f7 100644
+--- a/src/plugins/contrib/wxSmith/wxwidgets/properties/wxscolourproperty.cpp
++++ b/src/plugins/contrib/wxSmith/wxwidgets/properties/wxscolourproperty.cpp
+@@ -205,7 +205,11 @@ namespace
+         else
+             cpv.Init( type, *wxWHITE );
+ 
++#if wxCHECK_VERSION(3, 3, 0)
++        m_flags |= wxPGFlags::Reserved_1; // Colour selection cannot be changed.
++#else
+         m_flags |= wxPG_PROP_STATIC_CHOICES; // Colour selection cannot be changed.
++#endif
+         m_value << cpv;
+         OnSetValue();
+     }
+@@ -411,18 +415,27 @@ namespace
+     {
+         if ( index == wxNOT_FOUND )
+         {
+-            if ( (argFlags & wxPG_FULL_VALUE) ||
+-                 GetAttributeAsLong(wxPG_COLOUR_HAS_ALPHA, 0) )
++#if wxCHECK_VERSION(3, 3, 0)
++            wxPGPropValFormatFlags pgFlags          = static_cast<wxPGPropValFormatFlags>(argFlags);
++            wxPGPropValFormatFlags pgFlagsFullValue = pgFlags & wxPGPropValFormatFlags::FullValue;
++            if ( (wxPGPropValFormatFlags::FullValue == pgFlagsFullValue) || (0!=GetAttributeAsLong(wxPG_COLOUR_HAS_ALPHA, 0)) )
++#else
++            if ( (argFlags & wxPG_FULL_VALUE) || GetAttributeAsLong(wxPG_COLOUR_HAS_ALPHA, 0) )
++#endif
++            {
+                 return wxString::Format(wxS("(%i,%i,%i,%i)"),
+                                         (int)col.Red(),
+                                         (int)col.Green(),
+                                         (int)col.Blue(),
+                                         (int)col.Alpha());
++            }
+             else
++            {
+                 return wxString::Format(wxT("(%i,%i,%i)"),
+                                         (int)col.Red(),
+                                         (int)col.Green(),
+                                         (int)col.Blue());
++            }
+         }
+         else
+             return m_choices.GetLabel(index);
+@@ -435,7 +448,13 @@ namespace
+ 
+         int index;
+ 
++#if wxCHECK_VERSION(3, 3, 0)
++        wxPGPropValFormatFlags pgFlags               = static_cast<wxPGPropValFormatFlags>(argFlags);
++        wxPGPropValFormatFlags pgFlagsValueIsCurrent = pgFlags & wxPGPropValFormatFlags::ValueIsCurrent;
++        if ( wxPGPropValFormatFlags::ValueIsCurrent == pgFlagsValueIsCurrent )
++#else
+         if ( argFlags & wxPG_VALUE_IS_CURRENT )
++#endif
+         {
+             // GetIndex() only works reliably if wxPG_VALUE_IS_CURRENT flag is set,
+             // but we should use it whenever possible.
+@@ -583,7 +602,11 @@ namespace
+             int index = paintdata.m_choiceItem;
+             value = wxsColourValues[index];
+         }
++#if wxCHECK_VERSION(3, 3, 1)
++        else if ( !(m_flags & static_cast <wxPGFlags> (wxPG_PROP_UNSPECIFIED)) )
++#else
+         else if ( !(m_flags & (wxPGPropertyFlags)wxPG_PROP_UNSPECIFIED) )
++#endif
+         {
+             value = GetVal().m_type;
+         }
+@@ -650,7 +673,12 @@ namespace
+         if ( colourRGB.length() == 0 && m_choices.GetCount() &&
+              colourName == m_choices.GetLabel(GetCustomColourIndex()) )
+         {
+-            if ( !(argFlags & wxPG_EDITABLE_VALUE ) )
++#if wxCHECK_VERSION(3, 3, 0)
++            wxPGPropValFormatFlags pgFlags = static_cast<wxPGPropValFormatFlags>(argFlags);
++            if ( !( pgFlags & wxPGPropValFormatFlags::EditableValue ) )
++#else
++            if ( !( argFlags & wxPG_EDITABLE_VALUE ) )
++#endif
+             {
+                 // This really should not occur...
+                 // wxASSERT(false);
+@@ -668,7 +696,12 @@ namespace
+             if ( colourName.length() )
+             {
+                 // Try predefined colour first
++#if wxCHECK_VERSION(3, 3, 0)
++                wxPGPropValFormatFlags pgFlags = static_cast<wxPGPropValFormatFlags>(argFlags);
++                bool res = wxEnumProperty::StringToValue(value, colourName, pgFlags);
++#else
+                 bool res = wxEnumProperty::StringToValue(value, colourName, argFlags);
++#endif
+                 if ( res && GetIndex() >= 0 )
+                 {
+                     val.m_type = GetIndex();


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/29443

- Enable all plugins, especially the compiler plugin

- Mark as depending on `aterm`

- fix build for x86 archiectures

- Replace all instances of `/usr` with `$TERMUX_PREFIX` (checked and thought to make sense in this package)

- Apply workaround for boost 1.89 with Ubuntu 24.04

- Fix build of `wxSmith` plugin with wxwidgets 3.3.1

<img width="700" alt="Screenshot_20260420-174220_Termux_X11" src="https://github.com/user-attachments/assets/b4ed049d-f0fe-419f-9f5f-33dca823187e" />

<img width="700" alt="Screenshot_20260420-174521_Termux_X11" src="https://github.com/user-attachments/assets/7cd9c25f-0aef-4e9c-817d-c759f895a754" />
