### PR TITLE
fix(x11/qt{5,6}-qtbase): Fix `QDesktopServices::openUrl()` to work on folders

### DIFF
--- a/x11-packages/qt5-qtbase/build.sh
+++ b/x11-packages/qt5-qtbase/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="A cross-platform application and UI framework"
 TERMUX_PKG_LICENSE="LGPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="5.15.18"
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL="https://download.qt.io/archive/qt/${TERMUX_PKG_VERSION%.*}/${TERMUX_PKG_VERSION}/submodules/qtbase-everywhere-opensource-src-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=7b632550ea1048fc10c741e46e2e3b093e5ca94dfa6209e9e0848800e247023b
-TERMUX_PKG_DEPENDS="dbus, double-conversion, freetype, glib, harfbuzz, krb5, libandroid-execinfo, libandroid-posix-semaphore, libandroid-shmem, libc++, libice, libicu, libjpeg-turbo, libpng, libsm, libuuid, libx11, libxcb, libxi, libxkbcommon, opengl, openssl, pcre2, postgresql, ttf-dejavu, vulkan-loader, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm, zlib"
+TERMUX_PKG_DEPENDS="dbus, double-conversion, freetype, glib, harfbuzz, krb5, libandroid-execinfo, libandroid-posix-semaphore, libandroid-shmem, libc++, libice, libicu, libjpeg-turbo, libpng, libsm, libuuid, libx11, libxcb, libxi, libxkbcommon, opengl, openssl, pcre2, postgresql, ttf-dejavu, vulkan-loader, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm, xdg-utils, zlib"
 # gtk3 dependency is a run-time dependency only for the gtk platformtheme subpackage
 TERMUX_PKG_BUILD_DEPENDS="gtk3, vulkan-headers"
 TERMUX_PKG_SUGGESTS="qt5-qmake"

--- a/x11-packages/qt5-qtbase/src-platformsupport-services-genericunix-qgenericunixservices.cpp.patch
+++ b/x11-packages/qt5-qtbase/src-platformsupport-services-genericunix-qgenericunixservices.cpp.patch
@@ -1,0 +1,16 @@
+xdg-open from termux-tools is not compatible with folders, only files and websites.
+in order to be compatible with folder-opening buttons, such as the "Show Settings Button"
+in obs-studio,
+xdg-utils-xdg-open from xdg-utils must be used instead.
+
+--- a/src/platformsupport/services/genericunix/qgenericunixservices.cpp
++++ b/src/platformsupport/services/genericunix/qgenericunixservices.cpp
+@@ -130,7 +130,7 @@ static inline bool detectWebBrowser(const QByteArray &desktop,
+     const char *browsers[] = {"google-chrome", "firefox", "mozilla", "opera"};
+ 
+     browser->clear();
+-    if (checkExecutable(QStringLiteral("xdg-open"), browser))
++    if (checkExecutable(QStringLiteral("xdg-utils-xdg-open"), browser))
+         return true;
+ 
+     if (checkBrowserVariable) {

--- a/x11-packages/qt6-qtbase/build.sh
+++ b/x11-packages/qt6-qtbase/build.sh
@@ -4,9 +4,10 @@ TERMUX_PKG_LICENSE="GPL-3.0-only"
 TERMUX_PKG_LICENSE_FILE="LICENSES/GPL-3.0-only.txt"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="6.11.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://download.qt.io/official_releases/qt/${TERMUX_PKG_VERSION%.*}/${TERMUX_PKG_VERSION}/submodules/qtbase-everywhere-src-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=231ad85979864d914dc9568a1b71c91d6cf20d7b2021d059103bf0eb51cb755e
-TERMUX_PKG_DEPENDS="brotli, double-conversion, freetype, glib, harfbuzz, krb5, libandroid-posix-semaphore, libandroid-shmem, libc++, libdrm, libice, libicu, libjpeg-turbo, libpng, libsm, libsqlite, libuuid, libx11, libxcb, libxi, libxkbcommon, libwayland, opengl, openssl, pcre2, vulkan-loader, xcb-util-cursor, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm, zlib, zstd"
+TERMUX_PKG_DEPENDS="brotli, double-conversion, freetype, glib, harfbuzz, krb5, libandroid-posix-semaphore, libandroid-shmem, libc++, libdrm, libice, libicu, libjpeg-turbo, libpng, libsm, libsqlite, libuuid, libx11, libxcb, libxi, libxkbcommon, libwayland, opengl, openssl, pcre2, vulkan-loader, xcb-util-cursor, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm, xdg-utils, zlib, zstd"
 # gtk3 dependency is a run-time dependency only for the gtk platformtheme subpackage
 TERMUX_PKG_BUILD_DEPENDS="binutils-cross, cups, gdk-pixbuf, gtk3, libwayland-protocols, pango, vulkan-headers, vulkan-loader-generic"
 # qt6-qtbase now contains include/qt6/QtWaylandClient/QWaylandClientExtension instead of qt6-qtwayland

--- a/x11-packages/qt6-qtbase/src-gui-platform-unix-qdesktopunixservices.cpp.patch
+++ b/x11-packages/qt6-qtbase/src-gui-platform-unix-qdesktopunixservices.cpp.patch
@@ -1,0 +1,16 @@
+xdg-open from termux-tools is not compatible with folders, only files and websites.
+in order to be compatible with folder-opening buttons, such as the "Show Settings Button"
+in obs-studio,
+xdg-utils-xdg-open from xdg-utils must be used instead.
+
+--- a/src/gui/platform/unix/qdesktopunixservices.cpp
++++ b/src/gui/platform/unix/qdesktopunixservices.cpp
+@@ -101,7 +101,7 @@ static inline bool detectWebBrowser(const QByteArray &desktop,
+     const char *browsers[] = {"google-chrome", "firefox", "mozilla", "opera"};
+ 
+     browser->clear();
+-    if (checkExecutable(QStringLiteral("xdg-open"), browser))
++    if (checkExecutable(QStringLiteral("xdg-utils-xdg-open"), browser))
+         return true;
+ 
+     if (checkBrowserVariable) {


### PR DESCRIPTION
- `xdg-open` from `termux-tools` is not compatible with folders, only files and websites. In order to be compatible with folder-opening buttons, such as the "Show Settings Folder" button in `obs-studio`, `xdg-utils-xdg-open` from `xdg-utils` must be used instead.
- Dependency of https://github.com/termux/termux-packages/pull/29412