### PR TITLE
fix(clean.sh): do not unmount overlayfs on device-build (termux)

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -94,7 +94,7 @@ fi
 	fi
 
 	# unmount overlayfs before we remove the parent directory
-	[ -d "$TERMUX_TOPDIR" ] && for dir in $(find "$TERMUX_TOPDIR" -type d); do
+	[[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]] && [ -d "$TERMUX_TOPDIR" ] && for dir in $(find "$TERMUX_TOPDIR" -type d); do
 		if mountpoint -q "$dir"; then
 			umount "$dir"
 		fi


### PR DESCRIPTION
When the `clean.sh` script is run on a device (termux), it cannot find the `mountpoint` command. Furthermore, mount points on a device (termux) do not occur without root access, so this algorithm should not be run on a device (termux).