### PR TITLE
fix(main/openssh): fix fortify error

### DIFF
--- a/packages/openssh/0001-scp-only-clear-special-bits-for-non-android.patch
+++ b/packages/openssh/0001-scp-only-clear-special-bits-for-non-android.patch
@@ -1,0 +1,35 @@
+From 2a70036ec807cd39c66993ac81c74d938fb7b791 Mon Sep 17 00:00:00 2001
+From: Henrik Grimler <grimler@termux.dev>
+Date: Fri, 24 Apr 2026 13:23:09 +0200
+Subject: [PATCH] scp: only clear special bits for non-android
+
+On android we run into a fortify error if we try to clear the special
+bits:
+
+```
+$ scp -t .
+FORTIFY: umask: called with invalid mask 7077
+```
+
+Fixes: https://github.com/termux/termux-packages/issues/29411
+---
+ scp.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/scp.c b/scp.c
+index 1faa9a555..64f2dfcfa 100644
+--- a/scp.c
++++ b/scp.c
+@@ -1679,7 +1679,9 @@ sink(int argc, char **argv, const char *src)
+ 	setimes = targisdir = 0;
+ 	mask = umask(0);
+ 	if (!pflag) {
++#ifndef __ANDROID__
+ 		mask |= 07000;
++#endif
+ 		(void) umask(mask);
+ 	}
+ 	if (argc != 1) {
+-- 
+2.43.0
+

--- a/packages/openssh/build.sh
+++ b/packages/openssh/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Secure shell for logging into a remote machine"
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
 TERMUX_PKG_VERSION="10.3p1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/openssh/openssh-portable/archive/refs/tags/V_$(sed 's/\./_/g; s/p/_P/g' <<< $TERMUX_PKG_VERSION).tar.gz
 TERMUX_PKG_SHA256=c1a4420b1a25ba7336f62afd42ed5974d93455a2ab8c769b5e8e0c8ff8eedadc
 TERMUX_PKG_DEPENDS="krb5, ldns, libandroid-support, libedit, openssh-sftp-server, openssl, termux-auth, zlib"


### PR DESCRIPTION
With latest openssh certain commands fail with errors like:

```
FORTIFY: umask: called with invalid mask 7077
```

This started after commit https://github.com/openssh/openssh-portable/commit/487e8ac146f7.

Fixes: https://github.com/termux/termux-packages/issues/29411