### PR TITLE
bump(main/openjdk-25): 25.0.3

### DIFF
--- a/packages/openjdk-25/0003-Define-sys-gettid-on-arm-and-aarch64.patch
+++ b/packages/openjdk-25/0003-Define-sys-gettid-on-arm-and-aarch64.patch
@@ -9,19 +9,18 @@ Subject: [PATCH 03/37] Define sys gettid on arm and aarch64
 
 --- a/src/hotspot/os/linux/os_linux.cpp
 +++ b/src/hotspot/os/linux/os_linux.cpp
-@@ -461,13 +461,15 @@ bool os::Linux::get_tick_information(CPUPerfTicks* pticks, int which_logical_cpu
+@@ -478,11 +478,14 @@ bool os::Linux::get_tick_information(CPUPerfTicks* pticks, int which_logical_cpu
  }
  
  #ifndef SYS_gettid
--// i386: 224, amd64: 186, sparc: 143
+-// i386: 224, amd64: 186
 -  #if defined(__i386__)
-+// i386 & arm: 224, amd64: 186, sparc: 143, aarch64: 178
++// i386 & arm: 224, amd64: 186, aarch64: 178
 +  #if defined(__i386__) || defined(__arm__)
++     #define SYS_gettid 224
      #define SYS_gettid 224
    #elif defined(__amd64__)
      #define SYS_gettid 186
-   #elif defined(__sparc__)
-     #define SYS_gettid 143
 +  #elif defined(__arm64__) || defined(__aarch64__)
 +    #define SYS_gettid 178
    #else

--- a/packages/openjdk-25/build.sh
+++ b/packages/openjdk-25/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://openjdk.java.net
 TERMUX_PKG_DESCRIPTION="Java development kit and runtime"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="25.0.2"
-TERMUX_PKG_SRCURL=https://github.com/openjdk/jdk25u/archive/refs/tags/jdk-${TERMUX_PKG_VERSION}-ga.tar.gz
-TERMUX_PKG_SHA256=e4b935e999a28ee732dfb932dcef4a8591b42f6fcd182099319db68e9d8017ff
+TERMUX_PKG_VERSION="25.0.3"
+TERMUX_PKG_SRCURL="https://github.com/openjdk/jdk25u/archive/refs/tags/jdk-${TERMUX_PKG_VERSION}-ga.tar.gz"
+TERMUX_PKG_SHA256=24080b39d5bb28c34d1fa738e8704db411c6fc7dac0962cc33305536b0391b9e
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP='25\.\d+\.\d+(?=-ga)'
 TERMUX_PKG_DEPENDS="libandroid-shmem, libandroid-spawn, libiconv, libjpeg-turbo, zlib, littlecms, alsa-plugins"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/29456

- Rebase `Define-sys-gettid-on-arm-and-aarch64.patch`