### PR TITLE
bump(main/openjdk-21): 21.0.11

### DIFF
--- a/packages/openjdk-21/0037-Fix-hardcoded-paths-in-jdk.attach.patch
+++ b/packages/openjdk-21/0037-Fix-hardcoded-paths-in-jdk.attach.patch
@@ -7,19 +7,14 @@ Subject: [PATCH 37/40] Fix: hardcoded paths in jdk.attach
  .../linux/classes/sun/tools/attach/VirtualMachineImpl.java      | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java b/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
-index 6a70d5d9f71..c0c571c5e57 100644
 --- a/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
 +++ b/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
-@@ -46,7 +46,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
+@@ -49,7 +49,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
      // location is the same for all processes, otherwise the tools
      // will not be able to find all Hotspot processes.
      // Any changes to this needs to be synchronized with HotSpot.
--    private static final String tmpdir = "/tmp";
-+    private static final String tmpdir = "@TERMUX_PREFIX@/tmp";
-     String socket_path;
-     /**
-      * Attaches to the target VM
--- 
-2.50.1
-
+-    private static final Path TMPDIR = Path.of("/tmp");
++    private static final Path TMPDIR = Path.of("@TERMUX_PREFIX@/tmp");
+ 
+     private static final Path PROC     = Path.of("/proc");
+     private static final Path STATUS   = Path.of("status");

--- a/packages/openjdk-21/build.sh
+++ b/packages/openjdk-21/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://openjdk.java.net
 TERMUX_PKG_DESCRIPTION="Java development kit and runtime"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="21.0.10"
-TERMUX_PKG_SRCURL=https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-${TERMUX_PKG_VERSION}-ga.tar.gz
-TERMUX_PKG_SHA256=133a864987b4732d46cca5084b7cde8ffef168bde4e4b0118ebd2b38c1fda2f1
+TERMUX_PKG_VERSION="21.0.11"
+TERMUX_PKG_SRCURL="https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-${TERMUX_PKG_VERSION}-ga.tar.gz"
+TERMUX_PKG_SHA256=76b8310966649ea8a6340f92d4f19f6f84e3083b682a514c8f1999c93373385f
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP='21\.\d+\.\d+(?=-ga)'
 TERMUX_PKG_DEPENDS="libandroid-shmem, libandroid-spawn, libiconv, libjpeg-turbo, zlib, littlecms, alsa-plugins"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/29457

- Rebase `Fix-hardcoded-paths-in-jdk.attach.patch`