### PR TITLE
fix(x11/chromium-host-tools): Fix network interface discovery for WebRTC

### DIFF
--- a/x11-packages/chromium-host-tools/build.sh
+++ b/x11-packages/chromium-host-tools/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Chromium web browser (Host tools)"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@licy183"
 TERMUX_PKG_VERSION="146.0.7680.177"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$TERMUX_PKG_VERSION-lite.tar.xz
 TERMUX_PKG_SHA256=e66465f7b26c91dfa06b31aba3c56f6e65edac6b227c6bd2edc04535ef8966cb
 TERMUX_PKG_DEPENDS="atk, cups, dbus, fontconfig, gtk3, krb5, libc++, libevdev, libxkbcommon, libminizip, libnss, libx11, mesa, openssl, pango, pulseaudio, zlib"

--- a/x11-packages/chromium-host-tools/cr-patches/1021-chromium-net-address-tracker.patch
+++ b/x11-packages/chromium-host-tools/cr-patches/1021-chromium-net-address-tracker.patch
@@ -1,0 +1,65 @@
+--- a/net/base/address_tracker_linux.cc
++++ b/net/base/address_tracker_linux.cc
+@@ -240,9 +240,18 @@ void AddressTrackerLinux::Init() {
+     rv = bind(netlink_fd_.get(), reinterpret_cast<struct sockaddr*>(&addr),
+               sizeof(addr));
+     if (rv < 0) {
++#ifdef __TERMUX__
++      // Android SELinux denies subscribing to NETLINK_ROUTE multicast groups
++      // from the Termux app context. Keep the socket and do a one-shot address
++      // dump below; this is enough for consumers such as WebRTC to discover
++      // local interfaces, even though live network-change notifications are
++      // unavailable.
++      PLOG(WARNING) << "Could not bind NETLINK socket for notifications";
++#else
+       PLOG(ERROR) << "Could not bind NETLINK socket";
+       AbortAndForceOnline();
+       return;
++#endif
+     }
+   }
+ 
+@@ -373,6 +382,20 @@ void AddressTrackerLinux::DumpInitialAddressesAndWatch() {
+   bool tunnel_changed;
+   ReadMessages(&address_change_type, &link_changed, &tunnel_changed);
+ 
++#ifdef __TERMUX__
++  // Android SELinux denies RTM_GETLINK to apps targeting recent Android
++  // releases. Treat interfaces with assigned non-loopback addresses as online
++  // so GetNetworkListImpl() can still return useful interfaces.
++  {
++    AddressMap address_map = GetAddressMap();
++    AddressTrackerAutoLock lock(*this, online_links_lock_);
++    for (const auto& [address, ifaddr] : address_map) {
++      if (!address.IsLoopback())
++        online_links_.insert(ifaddr.ifa_index);
++    }
++  }
++  UpdateCurrentConnectionType();
++#else
+   // Request dump of link state
+   request.header.nlmsg_type = RTM_GETLINK;
+ 
+@@ -387,12 +410,14 @@ void AddressTrackerLinux::DumpInitialAddressesAndWatch() {
+ 
+   // Consume pending message to populate links_online_, but don't notify.
+   ReadMessages(&address_change_type, &link_changed, &tunnel_changed);
++#endif
+   {
+     AddressTrackerAutoLock lock(*this, connection_type_lock_);
+     connection_type_initialized_ = true;
+     connection_type_initialized_cv_.Broadcast();
+   }
+ 
++#ifndef __TERMUX__
+   if (tracking_) {
+     DCHECK(!sequenced_task_runner_ ||
+            sequenced_task_runner_->RunsTasksInCurrentSequence());
+@@ -402,6 +427,7 @@ void AddressTrackerLinux::DumpInitialAddressesAndWatch() {
+         base::BindRepeating(&AddressTrackerLinux::OnFileCanReadWithoutBlocking,
+                             base::Unretained(this)));
+   }
++#endif
+ }
+ 
+ void AddressTrackerLinux::ReadMessages(


### PR DESCRIPTION
Fixes #29481.

`chromium`'s Linux network address tracker assumes that it can subscribe to `NETLINK_ROUTE` multicast groups and query link state with `RTM_GETLINK`. In the Termux app context, SELinux denies those operations. When the initial netlink bind fails, Chromium currently aborts address tracking entirely, leaving consumers such as WebRTC without usable local network interface information. This causes web apps (e.g. Google Meet) relying on WebRTC to fail.

This patch keeps the netlink socket alive on Termux when subscribing to route notifications is denied. `chromium` can still perform the one-shot `RTM_GETADDR` dump, so the patch uses those discovered non-loopback addresses to mark interfaces as online and skips installing a readable watcher because live netlink notifications are unavailable. This preserves useful initial interface discovery while avoiding the denied `RTM_GETLINK` path.

I'm not entirely sure if this patch is technically sound, but I _did_ build a reliable reproducer that bootstraps an Android emulator using the stock package and triggers the error in Google Meet; when swapped with the patched `chromium` package the call starts actually loading other participants' videos and stays alive.

I also tested on my phone. Am able to do sreenshares etc. through the browser with this patch on.

Before the patch:

```log
pw:browser [pid=4563][err] [4563:4578:0425/214644.154294:ERROR:../src/net/base/address_tracker_linux.cc:243] Could not bind NETLINK socket: Permission denied (13) +0ms
```

After the patch, the same run no longer has this line as expected, since we explicitly branch out from that error.