### PR TITLE
bump(main/ruby): 4.0.3, enable YJIT and ZJIT

### DIFF
--- a/packages/ruby/Makefile.in.patch
+++ b/packages/ruby/Makefile.in.patch
@@ -1,11 +1,12 @@
 --- a/template/Makefile.in
 +++ b/template/Makefile.in
-@@ -240,7 +240,7 @@
+@@ -338,7 +338,7 @@
  $(LIBRUBY_SO):
- 		@-$(PRE_LIBRUBY_UPDATE)
+ 		@-[ -n "$(EXTSTATIC)" ] || $(PRE_LIBRUBY_UPDATE)
  		$(ECHO) linking shared-library $@
 -		$(Q) $(LDSHARED) $(DLDFLAGS) $(OBJS) $(DLDOBJS) $(SOLIBS) $(EXTSOLIBS) $(OUTFLAG)$@
 +		$(Q) $(LDSHARED) $(LDFLAGS) $(DLDFLAGS) $(OBJS) $(DLDOBJS) $(SOLIBS) $(EXTSOLIBS) $(OUTFLAG)$@
- 		-$(Q) $(OBJCOPY) -w -L '$(SYMBOL_PREFIX)Init_*' -L '$(SYMBOL_PREFIX)ruby_static_id_*' \
- 			-L '$(SYMBOL_PREFIX)*_threadptr_*' $@
- 		$(Q) $(POSTLINK)
+ 		-$(Q) $(OBJCOPY) -w -L '$(SYMBOL_PREFIX)Init_*' -L '$(SYMBOL_PREFIX)InitVM_*' \
+ 			-L '$(SYMBOL_PREFIX)ruby_static_id_*' \
+ 			-L '$(SYMBOL_PREFIX)*_threadptr_*' -L '$(SYMBOL_PREFIX)*_ec_*' $@
+

--- a/packages/ruby/build.sh
+++ b/packages/ruby/build.sh
@@ -5,17 +5,16 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Packages which should be rebuilt after "minor" bump (e.g. 3.1.x to 3.2.0):
 # - asciidoctor
 # - weechat
-TERMUX_PKG_VERSION="3.4.1"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION="4.0.3"
 TERMUX_PKG_SRCURL=https://cache.ruby-lang.org/pub/ruby/$(echo $TERMUX_PKG_VERSION | cut -d . -f 1-2)/ruby-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=018d59ffb52be3c0a6d847e22d3fd7a2c52d0ddfee249d3517a0c8c6dbfa70af
+TERMUX_PKG_SHA256=22cf6005d25bbe496b5ebe9224d63a1aaabfbfe02591bb5d612517c5a7836f29
 # libbffi is used by the fiddle extension module:
 TERMUX_PKG_DEPENDS="libandroid-execinfo, libandroid-support, libffi, libgmp, readline, openssl, libyaml, zlib"
 TERMUX_PKG_RECOMMENDS="clang, make, pkg-config, resolv-conf"
 TERMUX_PKG_BREAKS="ruby-dev"
 TERMUX_PKG_REPLACES="ruby-dev"
 # Needed to fix compilation on android:
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="ac_cv_func_setgroups=no ac_cv_func_setresuid=no ac_cv_func_setreuid=no --enable-rubygems"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="ac_cv_func_setgroups=no ac_cv_func_setresuid=no ac_cv_func_setreuid=no --enable-rubygems --enable-yjit --enable-zjit"
 # Do not link in libcrypt.so if available (now in disabled-packages):
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" ac_cv_lib_crypt_crypt=no"
 # Fix DEPRECATED_TYPE macro clang compatibility:
@@ -45,6 +44,17 @@ termux_step_pre_configure() {
 		-e "s|@RUBY_API_VERSION@|${_RUBY_API_VERSION}|g" \
 		$TERMUX_PKG_BUILDER_DIR/tool-rbinstall.rb.diff \
 		| patch --silent -p1
+
+	# Install/locate a rustup-managed Rust toolchain that has std for
+	# ${CARGO_TARGET_NAME} (e.g. aarch64-linux-android). The Termux toolchain
+	# setup already exports CARGO_TARGET_NAME and the
+	# CARGO_TARGET_<TARGET>_LINKER variables, so we just need rustup + std.
+	termux_setup_rust
+
+	# Pass the rust target through to configure.ac (see configure.ac.patch),
+	# which injects "--target=$JIT_RUST_TARGET" into RUSTC for the JIT crates,
+	# so libyjit/libzjit/libruby.a are built for Android instead of the host.
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" JIT_RUST_TARGET=$CARGO_TARGET_NAME"
 
 	autoreconf -fi
 

--- a/packages/ruby/configure.ac.patch
+++ b/packages/ruby/configure.ac.patch
@@ -1,0 +1,28 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -3904,6 +3904,12 @@
+ 
+ [begin]_group "JIT section" && {
+ AC_CHECK_PROG(RUSTC, [rustc], [rustc], [no]) dnl no ac_tool_prefix
++
++dnl Allow injecting a Rust --target for cross-compiling YJIT/ZJIT (Termux-specific).
++AC_ARG_VAR([JIT_RUST_TARGET], [Target triple passed to rustc for JIT cross-compile])
++AS_IF([test "$RUSTC" != "no" && test -n "$JIT_RUST_TARGET"], [
++    RUSTC="$RUSTC --target=$JIT_RUST_TARGET"
++])
+ 
+ dnl check if rustc is recent enough to build YJIT (rustc >= 1.58.0)
+ JIT_RUSTC_OK=no
+@@ -3926,10 +3932,10 @@
+ dnl check if we can build YJIT/ZJIT on this target platform
+ dnl we can't easily cross-compile with rustc so we don't support that
+ JIT_TARGET_OK=no
+-AS_IF([test "$cross_compiling" = no],
++AS_IF([test "$cross_compiling" = no || test -n "$JIT_RUST_TARGET"],
+     AS_CASE(["$target_cpu-$target_os"],
+         [*android*], [
+-            JIT_TARGET_OK=no
++            JIT_TARGET_OK=yes
+         ],
+         [arm64-darwin*|aarch64-darwin*|x86_64-darwin*], [
+             JIT_TARGET_OK=yes

--- a/packages/ruby/fix-paths.patch
+++ b/packages/ruby/fix-paths.patch
@@ -1,28 +1,28 @@
-diff -uNr ruby-3.0.0/addr2line.c ruby-3.0.0.mod/addr2line.c
---- ruby-3.0.0/addr2line.c	2020-12-25 05:33:01.000000000 +0200
-+++ ruby-3.0.0.mod/addr2line.c	2021-02-09 17:44:23.586601868 +0200
-@@ -545,7 +545,7 @@
+diff -uNr ruby-4.0.3/addr2line.c ruby-4.0.3.mod/addr2line.c
+--- ruby-4.0.3/addr2line.c	2024-12-25 07:43:20.000000000 +0000
++++ ruby-4.0.3.mod/addr2line.c	2025-02-04 23:00:22.000000000 +0000
+@@ -604,7 +604,7 @@
  follow_debuglink(const char *debuglink, int num_traces, void **traces,
- 		 obj_info_t **objp, line_info_t *lines, int offset)
+                  obj_info_t **objp, line_info_t *lines, int offset, FILE *errout)
  {
 -    static const char global_debug_dir[] = "/usr/lib/debug";
 +    static const char global_debug_dir[] = "@TERMUX_PREFIX@/lib/debug";
      const size_t global_debug_dir_len = sizeof(global_debug_dir) - 1;
      char *p;
      obj_info_t *o1 = *objp, *o2;
-@@ -577,7 +577,7 @@
+@@ -636,7 +636,7 @@
  follow_debuglink_build_id(const char *build_id, size_t build_id_size, int num_traces, void **traces,
-                           obj_info_t **objp, line_info_t *lines, int offset)
+                           obj_info_t **objp, line_info_t *lines, int offset, FILE *errout)
  {
 -    static const char global_debug_dir[] = "/usr/lib/debug/.build-id/";
 +    static const char global_debug_dir[] = "@TERMUX_PREFIX@/lib/debug/.build-id/";
+     static const char debug_suffix[] = ".debug";
      const size_t global_debug_dir_len = sizeof(global_debug_dir) - 1;
      char *p;
-     obj_info_t *o1 = *objp, *o2;
-diff -uNr ruby-3.0.0/dln_find.c ruby-3.0.0.mod/dln_find.c
---- ruby-3.0.0/dln_find.c	2020-12-25 05:33:01.000000000 +0200
-+++ ruby-3.0.0.mod/dln_find.c	2021-02-09 17:35:46.039359196 +0200
-@@ -72,10 +72,7 @@
+diff -uNr ruby-4.0.3/dln_find.c ruby-4.0.3.mod/dln_find.c
+--- ruby-4.0.3/dln_find.c	2024-12-25 07:43:20.000000000 +0000
++++ ruby-4.0.3.mod/dln_find.c	2025-02-04 23:00:22.000000000 +0000
+@@ -66,10 +66,7 @@
  
      if (!path) {
          path =
@@ -34,10 +34,10 @@ diff -uNr ruby-3.0.0/dln_find.c ruby-3.0.0.mod/dln_find.c
              ".";
      }
      buf = dln_find_1(fname, path, buf, size, 1 DLN_FIND_EXTRA_ARG);
-diff -uNr ruby-3.0.0/ext/etc/etc.c ruby-3.0.0.mod/ext/etc/etc.c
---- ruby-3.0.0/ext/etc/etc.c	2020-12-25 05:33:01.000000000 +0200
-+++ ruby-3.0.0.mod/ext/etc/etc.c	2021-02-09 17:41:07.618382244 +0200
-@@ -672,7 +672,7 @@
+diff -uNr ruby-4.0.3/ext/etc/etc.c ruby-4.0.3.mod/ext/etc/etc.c
+--- ruby-4.0.3/ext/etc/etc.c	2024-12-25 07:43:20.000000000 +0000
++++ ruby-4.0.3.mod/ext/etc/etc.c	2025-02-04 23:00:22.000000000 +0000
+@@ -744,7 +744,7 @@
      if (!len) return Qnil;
      tmpdir = rb_w32_conv_from_wchar(path, rb_filesystem_encoding());
  #else
@@ -46,10 +46,10 @@ diff -uNr ruby-3.0.0/ext/etc/etc.c ruby-3.0.0.mod/ext/etc/etc.c
      const char *tmpstr = default_tmp;
      size_t tmplen = strlen(default_tmp);
  # if defined _CS_DARWIN_USER_TEMP_DIR
-diff -uNr ruby-3.0.0/ext/pty/pty.c ruby-3.0.0.mod/ext/pty/pty.c
---- ruby-3.0.0/ext/pty/pty.c	2020-12-25 05:33:01.000000000 +0200
-+++ ruby-3.0.0.mod/ext/pty/pty.c	2021-02-09 17:45:16.473977053 +0200
-@@ -176,7 +176,7 @@
+diff -uNr ruby-4.0.3/ext/pty/pty.c ruby-4.0.3.mod/ext/pty/pty.c
+--- ruby-4.0.3/ext/pty/pty.c	2024-12-25 07:43:20.000000000 +0000
++++ ruby-4.0.3.mod/ext/pty/pty.c	2025-02-04 23:00:22.000000000 +0000
+@@ -207,7 +207,7 @@
      char		errbuf[32];
  
      if (argc == 0) {
@@ -58,10 +58,10 @@ diff -uNr ruby-3.0.0/ext/pty/pty.c ruby-3.0.0.mod/ext/pty/pty.c
  
          if ((p = getenv("SHELL")) != NULL) {
              shellname = p;
-diff -uNr ruby-3.0.0/hash.c ruby-3.0.0.mod/hash.c
---- ruby-3.0.0/hash.c	2020-12-25 05:33:01.000000000 +0200
-+++ ruby-3.0.0.mod/hash.c	2021-02-09 17:43:01.683876134 +0200
-@@ -717,11 +717,11 @@
+diff -uNr ruby-4.0.3/hash.c ruby-4.0.3.mod/hash.c
+--- ruby-4.0.3/hash.c	2024-12-25 07:43:20.000000000 +0000
++++ ruby-4.0.3.mod/hash.c	2025-02-04 23:00:22.000000000 +0000
+@@ -637,11 +637,11 @@
              else {
  #if 0
                  static int pid;
@@ -75,10 +75,10 @@ diff -uNr ruby-3.0.0/hash.c ruby-3.0.0.mod/hash.c
                      if ((fp = fopen(fname, "w")) == NULL) rb_bug("fopen");
                  }
  
-diff -uNr ruby-3.0.0/lib/mkmf.rb ruby-3.0.0.mod/lib/mkmf.rb
---- ruby-3.0.0/lib/mkmf.rb	2020-12-25 05:33:01.000000000 +0200
-+++ ruby-3.0.0.mod/lib/mkmf.rb	2021-02-09 17:35:46.039359196 +0200
-@@ -1580,7 +1580,7 @@
+diff -uNr ruby-4.0.3/lib/mkmf.rb ruby-4.0.3.mod/lib/mkmf.rb
+--- ruby-4.0.3/lib/mkmf.rb	2024-12-25 07:43:20.000000000 +0000
++++ ruby-4.0.3.mod/lib/mkmf.rb	2025-02-04 23:00:22.000000000 +0000
+@@ -1708,7 +1708,7 @@
      if path ||= ENV['PATH']
        path = path.split(File::PATH_SEPARATOR)
      else
@@ -87,31 +87,31 @@ diff -uNr ruby-3.0.0/lib/mkmf.rb ruby-3.0.0.mod/lib/mkmf.rb
      end
      file = nil
      path.each do |dir|
-diff -uNr ruby-3.0.0/lib/resolv.rb ruby-3.0.0.mod/lib/resolv.rb
---- ruby-3.0.0/lib/resolv.rb	2020-12-25 05:33:01.000000000 +0200
-+++ ruby-3.0.0.mod/lib/resolv.rb	2021-02-09 17:35:46.043359300 +0200
-@@ -173,7 +173,7 @@
-       rescue LoadError
+diff -uNr ruby-4.0.3/lib/resolv.rb ruby-4.0.3.mod/lib/resolv.rb
+--- ruby-4.0.3/lib/resolv.rb	2024-12-25 07:43:20.000000000 +0000
++++ ruby-4.0.3.mod/lib/resolv.rb	2025-02-04 23:00:22.000000000 +0000
+@@ -187,7 +187,7 @@
        end
      end
--    DefaultFileName ||= '/etc/hosts'
-+    DefaultFileName ||= '@TERMUX_PREFIX@/etc/hosts'
+     # The default file name for host names
+-    DefaultFileName = hosts || '/etc/hosts'
++    DefaultFileName = hosts || '@TERMUX_PREFIX@/etc/hosts'
  
      ##
      # Creates a new Resolv::Hosts, using +filename+ for its data source.
-@@ -985,7 +985,7 @@
-         return { :nameserver => nameserver, :search => search, :ndots => ndots }
+@@ -1020,7 +1020,7 @@
+         return { :nameserver => nameserver.freeze, :search => search.freeze, :ndots => ndots.freeze }.freeze
        end
  
 -      def Config.default_config_hash(filename="/etc/resolv.conf")
 +      def Config.default_config_hash(filename="@TERMUX_PREFIX@/etc/resolv.conf")
          if File.exist? filename
-           config_hash = Config.parse_resolv_conf(filename)
-         else
-diff -uNr ruby-3.0.0/process.c ruby-3.0.0.mod/process.c
---- ruby-3.0.0/process.c	2020-12-25 05:33:01.000000000 +0200
-+++ ruby-3.0.0.mod/process.c	2021-02-09 17:49:30.716668413 +0200
-@@ -1810,9 +1810,9 @@
+           Config.parse_resolv_conf(filename)
+         elsif defined?(Win32::Resolv)
+diff -uNr ruby-4.0.3/process.c ruby-4.0.3.mod/process.c
+--- ruby-4.0.3/process.c	2024-12-25 07:43:20.000000000 +0000
++++ ruby-4.0.3.mod/process.c	2025-02-04 23:00:22.000000000 +0000
+@@ -1617,9 +1617,9 @@
      *argv = (char *)prog;
      *--argv = (char *)"sh";
      if (envp)
@@ -123,7 +123,7 @@ diff -uNr ruby-3.0.0/process.c ruby-3.0.0.mod/process.c
  }
  
  #else
-@@ -1880,9 +1880,9 @@
+@@ -1687,9 +1687,9 @@
      }
  #else
      if (envp_str)
@@ -135,10 +135,10 @@ diff -uNr ruby-3.0.0/process.c ruby-3.0.0.mod/process.c
  #endif	/* _WIN32 */
      return errno;
  }
-diff -uNr ruby-3.1.0/ruby.c ruby-3.1.0.mod/ruby.c
---- ruby-3.1.0/ruby.c
-+++ ruby-3.1.0.mod/ruby.c
-@@ -684,7 +684,7 @@
+diff -uNr ruby-4.0.3/ruby.c ruby-4.0.3.mod/ruby.c
+--- ruby-4.0.3/ruby.c	2024-12-25 07:43:20.000000000 +0000
++++ ruby-4.0.3.mod/ruby.c	2025-02-04 23:00:22.000000000 +0000
+@@ -699,7 +699,7 @@
              RUBY_ARCH_PATH;
          const ptrdiff_t libdir_len = (ptrdiff_t)sizeof(libdir)
              - rb_strlen_lit(RUBY_ARCH_PATH) - 1;
@@ -147,9 +147,9 @@ diff -uNr ruby-3.1.0/ruby.c ruby-3.1.0.mod/ruby.c
          const ptrdiff_t bindir_len = (ptrdiff_t)sizeof(bindir) - 1;
  
          const char *p2 = NULL;
-diff -uNr ruby-3.0.0/spec/ruby/core/dir/shared/pwd.rb ruby-3.0.0.mod/spec/ruby/core/dir/shared/pwd.rb
---- ruby-3.0.0/spec/ruby/core/dir/shared/pwd.rb	2020-12-25 05:33:01.000000000 +0200
-+++ ruby-3.0.0.mod/spec/ruby/core/dir/shared/pwd.rb	2021-02-09 17:50:07.720664849 +0200
+diff -uNr ruby-4.0.3/spec/ruby/core/dir/shared/pwd.rb ruby-4.0.3.mod/spec/ruby/core/dir/shared/pwd.rb
+--- ruby-4.0.3/spec/ruby/core/dir/shared/pwd.rb	2024-12-25 07:43:20.000000000 +0000
++++ ruby-4.0.3.mod/spec/ruby/core/dir/shared/pwd.rb	2025-02-04 23:00:22.000000000 +0000
 @@ -14,7 +14,7 @@
      # The following uses inode rather than file names to account for
      # case insensitive file systems like default OS/X file systems
@@ -159,9 +159,9 @@ diff -uNr ruby-3.0.0/spec/ruby/core/dir/shared/pwd.rb ruby-3.0.0.mod/spec/ruby/c
      end
      platform_is :windows do
        File.stat(pwd).ino.should == File.stat(File.expand_path(`cd`.chomp)).ino
-diff -uNr ruby-3.0.0/spec/ruby/core/process/spawn_spec.rb ruby-3.0.0.mod/spec/ruby/core/process/spawn_spec.rb
---- ruby-3.0.0/spec/ruby/core/process/spawn_spec.rb	2020-12-25 05:33:01.000000000 +0200
-+++ ruby-3.0.0.mod/spec/ruby/core/process/spawn_spec.rb	2021-02-09 17:50:41.692695143 +0200
+diff -uNr ruby-4.0.3/spec/ruby/core/process/spawn_spec.rb ruby-4.0.3.mod/spec/ruby/core/process/spawn_spec.rb
+--- ruby-4.0.3/spec/ruby/core/process/spawn_spec.rb	2024-12-25 07:43:20.000000000 +0000
++++ ruby-4.0.3.mod/spec/ruby/core/process/spawn_spec.rb	2025-02-04 23:00:22.000000000 +0000
 @@ -133,7 +133,7 @@
    describe "with a command array" do
      it "uses the first element as the command name and the second as the argv[0] value" do
@@ -180,10 +180,10 @@ diff -uNr ruby-3.0.0/spec/ruby/core/process/spawn_spec.rb ruby-3.0.0.mod/spec/ru
          -> { Process.wait Process.spawn(o, "-c", "echo $0") }.should output_to_fd("argv_zero\n")
        end
        platform_is :windows do
-diff -uNr ruby-3.0.0/st.c ruby-3.0.0.mod/st.c
---- ruby-3.0.0/st.c	2020-12-25 05:33:01.000000000 +0200
-+++ ruby-3.0.0.mod/st.c	2021-02-09 17:39:08.594113373 +0200
-@@ -496,10 +496,10 @@
+diff -uNr ruby-4.0.3/st.c ruby-4.0.3.mod/st.c
+--- ruby-4.0.3/st.c	2024-12-25 07:43:20.000000000 +0000
++++ ruby-4.0.3.mod/st.c	2025-02-04 23:00:22.000000000 +0000
+@@ -493,10 +493,10 @@
  static void
  stat_col(void)
  {

--- a/packages/ruby/libandroid-execinfo.patch
+++ b/packages/ruby/libandroid-execinfo.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -3112,6 +3112,11 @@
+@@ -3304,6 +3304,11 @@
      ])
      ])
  AS_CASE(["$target_cpu-$target_os"],

--- a/packages/ruby/process.c.patch
+++ b/packages/ruby/process.c.patch
@@ -1,7 +1,7 @@
 diff '--color=auto' -uNr a/process.c b/process.c
---- a/process.c	2024-12-25 15:43:20.000000000 +0800
-+++ b/process.c	2025-03-06 02:18:48.124897314 +0800
-@@ -4221,6 +4221,20 @@
+--- a/process.c	2024-12-25 07:43:20.000000000 +0000
++++ b/process.c	2025-02-04 23:00:22.000000000 +0000
+@@ -4120,6 +4120,20 @@
      return result;
  }
  
@@ -22,20 +22,20 @@ diff '--color=auto' -uNr a/process.c b/process.c
  rb_pid_t
  rb_fork_ruby(int *status)
  {
-@@ -4229,6 +4243,12 @@
-     int try_gc = 1, err;
+@@ -4128,6 +4142,12 @@
+     rb_pid_t pid;
+     int try_gc = 1, err = 0;
      struct child_handler_disabler_state old;
- 
++
 +#ifdef __ANDROID__
 +    if ((err = pthread_atfork(__rb_atfork_prepare, __rb_atfork_parent, __rb_atfork_child))) {
 +        rb_bug_errno("pthread_atfork", err);
 +    }
 +#endif
-+
+ 
      do {
          prefork();
- 
-@@ -4243,6 +4263,8 @@
+@@ -4141,6 +4161,8 @@
          if (
  #if defined(__FreeBSD__)
              pid != 0 &&

--- a/packages/ruby/yjit-src-codegen.rs.patch
+++ b/packages/ruby/yjit-src-codegen.rs.patch
@@ -1,12 +1,16 @@
-diff -u -r ../ruby-3.4.1/yjit/src/codegen.rs ./yjit/src/codegen.rs
---- ../ruby-3.4.1/yjit/src/codegen.rs	2024-12-25 07:43:20.000000000 +0000
-+++ ./yjit/src/codegen.rs	2025-02-04 22:59:32.167032348 +0000
-@@ -437,7 +437,7 @@
-     /// Flush addresses and symbols to /tmp/perf-{pid}.map
+diff -u -r ../ruby-4.0.3/yjit/src/codegen.rs ./yjit/src/codegen.rs
+--- ../ruby-4.0.3/yjit/src/codegen.rs	2024-12-25 07:43:20.000000000 +0000
++++ ./yjit/src/codegen.rs	2025-02-04 23:00:22.000000000 +0000
+@@ -451,10 +451,10 @@
+     }
+ 
+-    /// Flush addresses and symbols to /tmp/perf-{pid}.map
++    /// Flush addresses and symbols to @TERMUX_PREFIX@/tmp/perf-{pid}.map
      fn flush_perf_symbols(&self, cb: &CodeBlock) {
          assert_eq!(0, self.perf_stack.len());
 -        let path = format!("/tmp/perf-{}.map", std::process::id());
 +        let path = format!("@TERMUX_PREFIX@/tmp/perf-{}.map", std::process::id());
-         let mut f = std::fs::File::options().create(true).append(true).open(path).unwrap();
+-        let mut f = std::io::BufWriter::new(std::fs::File::options().create(true).append(true).open(path).unwrap());
++        let mut f = std::io::BufWriter::new(std::fs::File::options().create(true).append(true).open(path).unwrap());
          for sym in self.perf_map.borrow().iter() {
              if let (start, Some(end), name) = sym {

--- a/packages/ruby/yjit-src-options.rs.patch
+++ b/packages/ruby/yjit-src-options.rs.patch
@@ -1,0 +1,21 @@
+diff -uNr ruby-4.0.3/yjit/src/options.rs ruby-4.0.3.mod/yjit/src/options.rs
+--- ruby-4.0.3/yjit/src/options.rs	2024-12-25 07:43:20.000000000 +0000
++++ ruby-4.0.3.mod/yjit/src/options.rs	2025-02-04 23:00:22.000000000 +0000
+@@ -83,7 +83,7 @@
+     /// Run code GC when exec_mem_size is reached.
+     pub code_gc: bool,
+ 
+-    /// Enable writing /tmp/perf-{pid}.map for Linux perf
++    /// Enable writing @TERMUX_PREFIX@/tmp/perf-{pid}.map for Linux perf
+     pub perf_map: Option<PerfMap>,
+ 
+     // Where to store the log. `None` disables the log.
+@@ -155,7 +155,7 @@
+     File(std::os::unix::io::RawFd),
+ }
+ 
+-/// Type of symbols to dump into /tmp/perf-{pid}.map
++/// Type of symbols to dump into @TERMUX_PREFIX@/tmp/perf-{pid}.map
+ #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+ pub enum PerfMap {
+     // Dump ISEQ symbols

--- a/packages/ruby/yjit-src-yjit.rs.patch
+++ b/packages/ruby/yjit-src-yjit.rs.patch
@@ -1,7 +1,7 @@
-diff -u -r ../ruby-3.4.1/yjit/src/yjit.rs ./yjit/src/yjit.rs
---- ../ruby-3.4.1/yjit/src/yjit.rs	2024-12-25 07:43:20.000000000 +0000
-+++ ./yjit/src/yjit.rs	2025-02-04 23:00:22.788803376 +0000
-@@ -76,7 +76,7 @@
+diff -u -r ../ruby-4.0.3/yjit/src/yjit.rs ./yjit/src/yjit.rs
+--- ../ruby-4.0.3/yjit/src/yjit.rs	2024-12-25 07:43:20.000000000 +0000
++++ ./yjit/src/yjit.rs	2025-02-04 23:00:22.000000000 +0000
+@@ -82,7 +82,7 @@
  
      // Make sure --yjit-perf doesn't append symbols to an old file
      if get_option!(perf_map).is_some() {


### PR DESCRIPTION
## bump(main/ruby): 4.0.3, enable YJIT and ZJIT

Updates Ruby from **3.4.1** to **4.0.3** and enables the **YJIT** and **ZJIT** JIT compilers for `aarch64-linux-android`.

### What changed

**`build.sh`**
- Version bump to 4.0.3 (SHA256 updated).
- Added `--enable-yjit --enable-zjit` to configure args.
- Added `termux_setup_rust` call to provide a Rust toolchain with `aarch64-linux-android` std (uses the standard Termux helper, no hand-rolled Cargo setup).
- Passes `JIT_RUST_TARGET=$CARGO_TARGET_NAME` through to configure so rustc cross-compiles the JIT crates for the target, not the host.

**New patches**
| Patch | Purpose |
|---|---|
| `configure.ac.patch` | Adds `AC_ARG_VAR(JIT_RUST_TARGET)` to inject `--target` into `RUSTC`, and allows `JIT_TARGET_OK=yes` for Android when cross-compiling with a Rust target set. |
| `yjit-src-options.rs.patch` | Replaces hardcoded `/tmp/perf-{pid}.map` paths with `@TERMUX_PREFIX@/tmp/` in YJIT options. |

**Updated patches** (line-number / context updates for 4.0.3, no logic changes):
- `Makefile.in.patch`
- `fix-paths.patch`
- `libandroid-execinfo.patch`
- `process.c.patch`
- `yjit-src-codegen.rs.patch`
- `yjit-src-yjit.rs.patch`

### How the cross-compilation works

Upstream Ruby's `configure.ac` blocks YJIT/ZJIT when `cross_compiling=yes` or when the target is `*android*`. The `configure.ac.patch` adds a `JIT_RUST_TARGET` variable that, when set:
1. Rewrites `RUSTC` to `"$RUSTC --target=$JIT_RUST_TARGET"` so `libyjit.a` / `libzjit.a` / `libruby.a` are built for `aarch64-linux-android` instead of the host.
2. Allows the `JIT_TARGET_OK=yes` path for Android cross-builds.

The Termux toolchain setup already exports `CARGO_TARGET_NAME` and `CARGO_TARGET_<TARGET>_LINKER`, so `termux_setup_rust` + `JIT_RUST_TARGET` is all that's needed.

### Build verification

Successfully cross-compiled from x86_64 → aarch64 with:
```
./build-package.sh -a aarch64 -s ruby
```
Produced `ruby_4.0.3_aarch64.deb` (10 MB) and `ruby-ri_4.0.3_all.deb` (1.7 MB).

### Notes
- Upstream Ruby considers Android unsupported for YJIT/ZJIT; this is a Termux-specific enablement.
- On-device runtime validation of YJIT/ZJIT is a separate follow-up step.
