### PR TITLE
bump(x11/librewolf): 150.0.1-1

### DIFF
--- a/x11-packages/librewolf/1003-no-frozen.patch
+++ b/x11-packages/librewolf/1003-no-frozen.patch
@@ -1,0 +1,36 @@
+Prevents:
+error: cannot update the lock file /home/builder/.termux-build/librewolf/src/Cargo.lock
+because --frozen was passed to prevent this
+
+--- a/python/mozbuild/mozbuild/vendor/vendor_rust.py
++++ b/python/mozbuild/mozbuild/vendor/vendor_rust.py
+@@ -734,7 +734,6 @@ license file's hash.
+         flags = ["--output-format=json"]
+         if "MOZ_AUTOMATION" in os.environ:
+             flags.append("--locked")
+-            flags.append("--frozen")
+         res = cargo_vet(
+             self,
+             flags,
+--- a/config/makefiles/rust.mk
++++ b/config/makefiles/rust.mk
+@@ -24,7 +24,6 @@ endif
+ # within a tree, the Rust dependencies have been vendored in so Cargo won't
+ # touch the lock file.
+ ifndef JS_STANDALONE
+-cargo_build_flags += --frozen
+ endif
+ 
+ cargo_build_flags += --manifest-path $(CARGO_FILE)
+ 
+--- a/build/RunCbindgen.py
++++ b/build/RunCbindgen.py
+@@ -55,7 +55,7 @@ def generate_metadata(output, cargo_config):
+     # within a tree, the Rust dependencies have been vendored in so Cargo won't
+     # touch the lock file.
+     if not buildconfig.substs.get("JS_STANDALONE"):
+-        args.append("--frozen")
++        pass
+ 
+     stdout, returncode = _run_process(args)
+ 

--- a/x11-packages/librewolf/build.sh
+++ b/x11-packages/librewolf/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://librewolf.net/
 TERMUX_PKG_DESCRIPTION="A custom version of Firefox, focused on privacy, security and freedom."
 TERMUX_PKG_LICENSE="MPL-2.0"
 TERMUX_PKG_MAINTAINER="@3ls-it"
-TERMUX_PKG_VERSION="150.0-1"
+TERMUX_PKG_VERSION="150.0.1-1"
 TERMUX_PKG_SRCURL="https://codeberg.org/api/packages/librewolf/generic/librewolf-source/${TERMUX_PKG_VERSION}/librewolf-${TERMUX_PKG_VERSION}.source.tar.gz"
-TERMUX_PKG_SHA256=e93d39180d74ea9e07d9a7cae7a441cc6e790f64e053f2b7e168cc490b043034
+TERMUX_PKG_SHA256=d6470f5d93b531b9a20f750f2a2903ce20f5186e5bc4e87e28bbb6f4409fe4fa
 # ffmpeg and pulseaudio are dependencies through dlopen(3):
 TERMUX_PKG_DEPENDS="ffmpeg, fontconfig, freetype, gdk-pixbuf, glib, gtk3, libandroid-shmem, libandroid-spawn, libc++, libcairo, libevent, libffi, libice, libicu, libjpeg-turbo, libnspr, libnss, libpixman, libsm, libvpx, libwebp, libx11, libxcb, libxcomposite, libxdamage, libxext, libxfixes, libxrandr, libxtst, pango, pulseaudio, zlib"
 TERMUX_PKG_BUILD_DEPENDS="libcpufeatures, libice, libsm"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/29589

- Add `no-frozen.patch` to prevent `error: cannot update the lock file /home/builder/.termux-build/librewolf/src/Cargo.lock`