### PR TITLE
chore(packages/proot-distro): disable autoupdates until 5.0 release

### DIFF
--- a/packages/proot-distro/build.sh
+++ b/packages/proot-distro/build.sh
@@ -9,8 +9,8 @@ TERMUX_PKG_DEPENDS="bash, bzip2, coreutils, curl, file, findutils, gzip, ncurses
 TERMUX_PKG_SUGGESTS="bash-completion, termux-api"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
-TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_UPDATE_TAG_TYPE="latest-release-tag"
 
 termux_step_make_install() {
 	env TERMUX_APP_PACKAGE="$TERMUX_APP_PACKAGE" \


### PR DESCRIPTION
I plan to have two release kinds at proot-distro repo:

* Normal releases which represent a new proot-distro version
* Pre-releases with rootfs automatically built by GitHub Actions

In order to prevent accidental pushing of unwanted package update to users during tests, I disable automatic upgrade of proot-distro package until stable v5.0 is published.