### PR TITLE
bump(x11/quickshell): 0.3.0

### DIFF
--- a/x11-packages/quickshell/build.sh
+++ b/x11-packages/quickshell/build.sh
@@ -2,17 +2,18 @@ TERMUX_PKG_HOMEPAGE="https://git.outfoxxed.me/quickshell/quickshell"
 TERMUX_PKG_DESCRIPTION="Flexible toolkit for making desktop shells with QtQuick"
 TERMUX_PKG_LICENSE="LGPL-3.0-only"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.2.1"
+TERMUX_PKG_VERSION="0.3.0"
 TERMUX_PKG_SRCURL="https://github.com/quickshell-mirror/quickshell/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256="337bab5d4badb92e51d01ac1cfbeaeb784478bad82f3c8297fd7be42a6995af2"
+TERMUX_PKG_SHA256="5229069b0f1d375f34b0a04a4e6a69156e2f010995d9ec5a943793424e589b5d"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="hicolor-icon-theme, libc++, libdrm, libglvnd, libwayland, libxcb, mesa, pipewire, qt6-qtbase, qt6-qtdeclarative, qt6-qtsvg, qt6-qtwayland"
 TERMUX_PKG_BUILD_DEPENDS="cli11, libwayland-protocols, qt6-shadertools, spirv-tools"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DCMAKE_SYSTEM_NAME=Linux
--DCRASH_REPORTER=OFF
+-DCRASH_HANDLER=OFF
 -DUSE_JEMALLOC=OFF
 -DSERVICE_PAM=OFF
+-DSERVICE_POLKIT=OFF
 -DINSTALL_QML_PREFIX=lib/qt6/qml
 "
 

--- a/x11-packages/quickshell/use-qstandardpaths-for-runtime-dir.patch
+++ b/x11-packages/quickshell/use-qstandardpaths-for-runtime-dir.patch
@@ -2,16 +2,16 @@ diff --git a/src/core/paths.cpp b/src/core/paths.cpp
 index e17c3bc..2bc6c2b 100644
 --- a/src/core/paths.cpp
 +++ b/src/core/paths.cpp
-@@ -57,7 +57,12 @@ QDir* QsPaths::baseRunDir() {
+@@ -64,7 +64,12 @@ QDir* QsPaths::baseRunDir() {
  	if (this->baseRunState == DirState::Unknown) {
  		auto runtimeDir = qEnvironmentVariable("XDG_RUNTIME_DIR");
  		if (runtimeDir.isEmpty()) {
-+                #ifdef __TERMUX__
-+                        runtimeDir = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
-+                        QDir().mkpath(runtimeDir);
-+                #else
- 			runtimeDir = QString("/run/user/$1").arg(getuid());
-+                #endif
++#ifdef __TERMUX__
++			runtimeDir = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
++			QDir().mkpath(runtimeDir);
++#else
+ 			runtimeDir = QString("/run/user/%1").arg(getuid());
++#endif
  			qCInfo(logPaths) << "XDG_RUNTIME_DIR was not set, defaulting to" << runtimeDir;
  		}
  


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/29654

- `CRASH_REPORTER` is now named `CRASH_HANDLER`

- `SERVICE_POLKIT` is now enabled by default and needs to be disabled