### PR TITLE
feat: add minigit package

### DIFF
--- a/packages/minigit/build.sh
+++ b/packages/minigit/build.sh
@@ -1,0 +1,22 @@
+TERMUX_PKG_HOMEPAGE="http://72.61.248.193:3800"
+TERMUX_PKG_DESCRIPTION="A Git-compatible version control CLI for Mini GitHub platform"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="rahipatel1285 <rahul834757@gmail.com>"
+TERMUX_PKG_VERSION="1.0.1"
+TERMUX_PKG_SRCURL="https://registry.npmjs.org/minigit-cli/-/minigit-cli-${TERMUX_PKG_VERSION}.tgz"
+TERMUX_PKG_SHA256="9e11c818f9ca2b9e5830a681f54e32a4cbfb6822a4e96e5335905e4783173131"
+TERMUX_PKG_DEPENDS="nodejs"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make_install() {
+    # Create required directories
+    mkdir -p $TERMUX_PREFIX/lib/node_modules/minigit-cli
+    mkdir -p $TERMUX_PREFIX/bin
+
+    # Copy files
+    cp -r * $TERMUX_PREFIX/lib/node_modules/minigit-cli/
+
+    # Create the executable symlink
+    ln -srf $TERMUX_PREFIX/lib/node_modules/minigit-cli/dist/index.js $TERMUX_PREFIX/bin/minigit
+    chmod +x $TERMUX_PREFIX/bin/minigit
+}


### PR DESCRIPTION
### Package description
MiniGit is a Git-compatible version control CLI designed for the Mini GitHub platform. It provides a familiar, lightweight Git-like experience (clone, push, pull, commit, log, status) for developers interacting with our platform directly from the terminal. 

Since it relies heavily on Node.js, we have built it purely on standard `nodejs` dependencies to ensure cross-platform compatibility, including native execution on Android devices via Termux.

**Package details:**
- **Name**: minigit
- **Version**: 1.0.1
- **Homepage**: http://72.61.248.193:3800
- **Source**: Published to npm registry (`minigit-cli`)

### Checks
- [x] The package compiles and works on my device.
- [x] I have tested the package on an Android device (or via an emulator/Termux environment).
- [x] I have read the [developer's guide](https://github.com/termux/termux-packages/wiki/Developer%27s-guide).
- [x] `termux-lint` has been run and it passes (no errors or warnings).

### Additional info
This is an independent open-source CLI client for our specific platform. We are packaging it directly via the published `.tgz` from npm to ensure deterministic builds. Node.js is explicitly declared as a dependency.
