### PR TITLE
feat: add minigit package

### DIFF
--- a/packages/minigit/build.sh
+++ b/packages/minigit/build.sh
@@ -1,0 +1,22 @@
+TERMUX_PKG_HOMEPAGE="http://72.61.248.193:3800"
+TERMUX_PKG_DESCRIPTION="A Git-compatible version control CLI for Mini GitHub platform"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="rahipatel1285 <rahul834757@gmail.com>"
+TERMUX_PKG_VERSION="1.0.0"
+TERMUX_PKG_SRCURL="https://registry.npmjs.org/minigithub-cli/-/minigithub-cli-${TERMUX_PKG_VERSION}.tgz"
+TERMUX_PKG_SHA256="687d9eb0fc897c3a2474dd280d866bd663a3303019f9594c9ea0ef777caaa7da"
+TERMUX_PKG_DEPENDS="nodejs"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make_install() {
+    # Create required directories
+    mkdir -p $TERMUX_PREFIX/lib/node_modules/minigithub-cli
+    mkdir -p $TERMUX_PREFIX/bin
+
+    # Copy files
+    cp -r * $TERMUX_PREFIX/lib/node_modules/minigithub-cli/
+
+    # Create the executable symlink
+    ln -srf $TERMUX_PREFIX/lib/node_modules/minigithub-cli/dist/index.js $TERMUX_PREFIX/bin/minigit
+    chmod +x $TERMUX_PREFIX/bin/minigit
+}


### PR DESCRIPTION
### Package description
MiniGit is a full-featured Git-compatible CLI client built for the Mini GitHub platform. It is designed to run natively across all environments including Android (via Termux). 

The package is published as `minigithub-cli` on npm and we are packaging it for Termux users to have a native binary experience without needing to manage global npm scopes. 

- **Name**: minigit
- **Version**: 1.0.0
- **Homepage**: http://72.61.248.193:3800
- **NPM Package**: https://www.npmjs.com/package/minigithub-cli

### Checks
- [x] The package compiles and works on my device.
- [x] I have tested the package on an Android device (or via an emulator/Termux environment).
- [x] I have read the [developer's guide](https://github.com/termux/termux-packages/wiki/Developer%27s-guide).
- [x] `termux-lint` has been run and it passes (no errors or warnings).

### Additional info
This is NOT a wrapper around someone else's package. I am the owner of the `minigithub-cli` package on npm and this CLI is a core component of the Mini GitHub ecosystem.