### PR TITLE
addpkg(main/ty): 0.0.34

### DIFF
--- a/packages/ty/build.sh
+++ b/packages/ty/build.sh
@@ -1,0 +1,50 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/astral-sh/ty
+TERMUX_PKG_DESCRIPTION="An extremely fast Python type checker and language server, written in Rust"
+TERMUX_PKG_VERSION=0.0.34
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_LICENSE_FILE="LICENSE"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_SRCURL="https://github.com/astral-sh/ty/releases/download/$TERMUX_PKG_VERSION/source.tar.gz"
+TERMUX_PKG_SHA256=54d5e78609cc83389ef41aa5a1c5773273cfe1a894d00ce25d10987d6dd749c9
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+
+termux_step_pre_configure() {
+	# when rust projects include a .cargo folder with their source code,
+	# attempting to cross-compile that code for android usually results in
+	# frustrating errors lke 'error: Missing manifest in toolchain '1.95-x86_64-unknown-linux-gnu',
+	# varying depending on what content exactly was in .cargo.
+	# deleting .cargo first before doing anything else usually seems to prevent that.
+	rm -rf .cargo
+
+	termux_setup_rust
+
+	cargo vendor
+	find ./vendor \
+		-mindepth 1 -maxdepth 1 -type d \
+		! -wholename ./vendor/cc \
+		-exec rm -rf '{}' \;
+
+	local patch="$TERMUX_PKG_BUILDER_DIR/rust-cc-do-not-concatenate-all-the-CFLAGS.diff"
+	local dir="vendor/cc"
+	echo "Applying patch: $patch"
+	patch -p1 -d "$dir" < "$patch"
+
+	echo "" >> Cargo.toml
+	echo '[patch.crates-io]' >> Cargo.toml
+	echo "cc = { path = \"./vendor/cc\" }" >> Cargo.toml
+}
+
+termux_step_make() {
+	cargo build \
+		--bin ty \
+		--jobs "${TERMUX_PKG_MAKE_PROCESSES}" \
+		--target "${CARGO_TARGET_NAME}" \
+		--release
+}
+
+termux_step_make_install() {
+	install -Dm755 \
+		target/"${CARGO_TARGET_NAME}"/release/ty \
+		"$TERMUX_PREFIX"/bin/ty
+}

--- a/packages/ty/rust-cc-do-not-concatenate-all-the-CFLAGS.diff
+++ b/packages/ty/rust-cc-do-not-concatenate-all-the-CFLAGS.diff
@@ -1,0 +1,37 @@
+`rust-cc` changed how it collects `CFLAGS` from environment variables.
+It retrieves environment variables according to a specific set of rules,
+which are described in [1]. Previously, it used the first match [2,3],
+but now it concatenates all matches and passes them to `CC` [4,5]. This
+breaks Termux's build since Termux's `CFLAGS` include flags related to
+the Android target and unrelated to the target when compiling `glslopt`
+as a host tool, which is `x86_64-linux-gnu`.
+
+This patch will restore the old behaviour. For Termux we know how it is going.
+
+[1] https://docs.rs/cc/latest/cc/
+[2] https://github.com/rust-lang/cc-rs/blob/fcf940ef66f23f411aa50473baa14df9ed2f2cda/src/lib.rs#L1910
+[3] https://github.com/rust-lang/cc-rs/blob/fcf940ef66f23f411aa50473baa14df9ed2f2cda/src/lib.rs#L3669-3681
+[4] https://github.com/rust-lang/cc-rs/blob/cda8b386d419f3adb0c15b729af5504201689aa1/src/lib.rs#L1977
+[5] https://github.com/rust-lang/cc-rs/blob/cda8b386d419f3adb0c15b729af5504201689aa1/src/lib.rs#L3836-L3858
+
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -3824,14 +3824,13 @@ impl Build {
+
+     /// Get values from CFLAGS-style environment variable.
+     fn envflags(&self, env: &str) -> Result<Option<Vec<String>>, Error> {
+-        // Collect from all environment variables, in reverse order as in
+-        // `getenv_with_target_prefixes` precedence (so that `CFLAGS_$TARGET`
+-        // can override flags in `TARGET_CFLAGS`, which overrides those in
+-        // `CFLAGS`).
+         let mut any_set = false;
+         let mut res = vec![];
+-        for env in self.target_envs(env)?.iter().rev() {
++        for env in self.target_envs(env)?.iter() {
+             if let Some(var) = self.getenv(env) {
++                if any_set {
++                    continue;
++                }
+                 any_set = true;
+
+                 let var = var.to_string_lossy();


### PR DESCRIPTION
### Description
This PR introduces `ty`, an extremely fast Python type checker and language server written in Rust (built on top of `ruff`). 

### Checklist
- [x] Lifecycle / License matches requirements (MIT).
- [x] Package compiles successfully on all architectures (`aarch64`, `arm`, `i686`, `x86_64`) via GitHub Actions.
- [x] Submitting a clean, single-commit history.

### Testing Verification
- Successfully cross-compiled locally for `aarch64`.
- Installed the resulting `.deb` package inside a native Termux environment on an Android device.
- Tested directly with Neovim's built-in LSP client; the language server detects Python files, attaches correctly, and provides fast, real-time type checking diagnostics without issues.