### PR TITLE
bump(main/yazi): v26.5.6

### DIFF
--- a/packages/yazi/build.sh
+++ b/packages/yazi/build.sh
@@ -2,14 +2,13 @@ TERMUX_PKG_HOMEPAGE=https://yazi-rs.github.io/
 TERMUX_PKG_DESCRIPTION="Blazing fast terminal file manager written in Rust, based on async I/O"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="26.1.22"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="26.5.6"
 TERMUX_PKG_SRCURL=https://github.com/sxyazi/yazi/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=83b8a1bf166bfcb54b44b966fa3f34afa7c55584bf81d29275a1cdd99d1c9c4c
+TERMUX_PKG_SHA256=a18445df86a20068f7b17609d12d6f635de488958579ae7a2b143a244ba7e63f
 TERMUX_PKG_BUILD_DEPENDS='aosp-libs, imagemagick'
 TERMUX_PKG_RECOMMENDS='7zip, chafa, fd, ffmpeg, fzf, imagemagick, jq, poppler, ripgrep, zoxide'
-TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
 
 termux_step_pre_configure() {
 	termux_setup_rust
@@ -21,6 +20,7 @@ termux_step_pre_configure() {
 	find ./vendor \
 		-mindepth 1 -maxdepth 1 -type d \
 		! -wholename ./vendor/trash \
+		! -wholename ./vendor/cc \
 		-exec rm -rf '{}' \;
 
 	find vendor/trash -type f -print0 | \
@@ -28,14 +28,24 @@ termux_step_pre_configure() {
 		-e 's|"android"|"disabling_this_because_it_is_for_building_an_apk"|g' \
 		-e "s|/tmp|$TERMUX_PREFIX/tmp|g"
 
+	# patch trash-rs
 	local patch="$TERMUX_PKG_BUILDER_DIR/trash-rs-implement-get_mount_points-android.diff"
 	local dir="vendor/trash"
 	echo "Applying patch: $patch"
 	patch -p1 -d "$dir" < "$patch"
 
-	echo "" >> Cargo.toml
-	echo '[patch.crates-io]' >> Cargo.toml
-	echo 'trash = { path = "./vendor/trash" }' >> Cargo.toml
+	# patch rust-cc
+	local patch="$TERMUX_PKG_BUILDER_DIR/rust-cc-do-not-concatenate-all-the-CFLAGS.diff"
+	local dir="vendor/cc"
+	echo "Applying patch: $patch"
+	patch -p1 -d "$dir" < "$patch"
+
+	cat >> Cargo.toml <<-EOF
+
+		[patch.crates-io]
+		trash = { path = "./vendor/trash" }
+		cc = { path = "./vendor/cc" }
+	EOF
 }
 
 termux_step_make() {

--- a/packages/yazi/force-enable-trash.patch
+++ b/packages/yazi/force-enable-trash.patch
@@ -1,15 +1,17 @@
 --- a/yazi-fs/Cargo.toml
 +++ b/yazi-fs/Cargo.toml
-@@ -45,5 +45,5 @@ windows-sys = { version = "0.61.2", features = [ "Win32_Storage_FileSystem" ] }
+@@ -48,5 +48,5 @@ windows-sys = { version = "0.61.2", features = [ "Win32_Storage_FileSystem" ] }
  core-foundation-sys = { workspace = true }
  objc2               = { workspace = true }
  
 -[target.'cfg(not(target_os = "android"))'.dependencies]
 +[target.'cfg(not(target_os = "disabling_this_because_it_is_for_building_an_apk"))'.dependencies]
- trash = "5.2.5"
+ trash = "5.2.6"
+diff --git a/yazi-fs/src/provider/local/local.rs b/yazi-fs/src/provider/local/local.rs
+index 6ec0557..b2b2baa 100644
 --- a/yazi-fs/src/provider/local/local.rs
 +++ b/yazi-fs/src/provider/local/local.rs
-@@ -189,7 +189,7 @@ impl<'a> Provider for Local<'a> {
+@@ -209,7 +209,7 @@ impl<'a> Provider for Local<'a> {
  	async fn trash(&self) -> io::Result<()> {
  		let path = self.path.to_owned();
  		tokio::task::spawn_blocking(move || {
@@ -18,7 +20,7 @@
  			{
  				Err(io::Error::new(io::ErrorKind::Unsupported, "Unsupported OS for trash operation"))
  			}
-@@ -200,7 +200,7 @@ impl<'a> Provider for Local<'a> {
+@@ -220,7 +220,7 @@ impl<'a> Provider for Local<'a> {
  				ctx.set_delete_method(DeleteMethod::NsFileManager);
  				ctx.delete(path).map_err(io::Error::other)
  			}

--- a/packages/yazi/rust-cc-do-not-concatenate-all-the-CFLAGS.diff
+++ b/packages/yazi/rust-cc-do-not-concatenate-all-the-CFLAGS.diff
@@ -1,0 +1,37 @@
+`rust-cc` changed how it collects `CFLAGS` from environment variables.
+It retrieves environment variables according to a specific set of rules,
+which are described in [1]. Previously, it used the first match [2,3],
+but now it concatenates all matches and passes them to `CC` [4,5]. This
+breaks Termux's build since Termux's `CFLAGS` include flags related to
+the Android target and unrelated to the target when compiling `glslopt`
+as a host tool, which is `x86_64-linux-gnu`.
+
+This patch will restore the old behaviour. For Termux we know how it is going.
+
+[1] https://docs.rs/cc/latest/cc/
+[2] https://github.com/rust-lang/cc-rs/blob/fcf940ef66f23f411aa50473baa14df9ed2f2cda/src/lib.rs#L1910
+[3] https://github.com/rust-lang/cc-rs/blob/fcf940ef66f23f411aa50473baa14df9ed2f2cda/src/lib.rs#L3669-3681
+[4] https://github.com/rust-lang/cc-rs/blob/cda8b386d419f3adb0c15b729af5504201689aa1/src/lib.rs#L1977
+[5] https://github.com/rust-lang/cc-rs/blob/cda8b386d419f3adb0c15b729af5504201689aa1/src/lib.rs#L3836-L3858
+
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -3973,14 +3973,13 @@ impl Build {
+ 
+     /// Get values from CFLAGS-style environment variable.
+     fn envflags(&self, env: &str) -> Result<Option<Vec<String>>, Error> {
+-        // Collect from all environment variables, in reverse order as in
+-        // `getenv_with_target_prefixes` precedence (so that `CFLAGS_$TARGET`
+-        // can override flags in `TARGET_CFLAGS`, which overrides those in
+-        // `CFLAGS`).
+         let mut any_set = false;
+         let mut res = vec![];
+-        for env in self.target_envs(env)?.iter().rev() {
++        for env in self.target_envs(env)?.iter() {
+             if let Some(var) = self.get_env(env) {
++                if any_set {
++                    continue;
++                }
+                 any_set = true;
+ 
+                 let var = var.to_string_lossy();


### PR DESCRIPTION
just regenerated the `force-enable-trash` patch

full changelog of yazi: https://github.com/sxyazi/yazi/blob/main/CHANGELOG.md#v2656

closes https://github.com/termux/termux-packages/issues/29679