### PR TITLE
addpkg(x11/grafx2): 2.9-20260424

### DIFF
--- a/x11-packages/grafx2/build.sh
+++ b/x11-packages/grafx2/build.sh
@@ -1,0 +1,64 @@
+TERMUX_PKG_HOMEPAGE=https://gitlab.com/GrafX2/grafX2
+TERMUX_PKG_DESCRIPTION="The Ultimate 256-color bitmap paint program"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+_COMMIT=e6ee44e579defed0ad8a005bed475fd8ea433788
+_COMMIT_DATE=20260424
+TERMUX_PKG_VERSION="2.9-p${_COMMIT_DATE}"
+TERMUX_PKG_SRCURL=git+https://gitlab.com/GrafX2/grafX2.git
+TERMUX_PKG_GIT_BRANCH=master
+TERMUX_PKG_SHA256=12b4688adef4a048da0cecc16809b8b2d7e4b771a065a030f053cb4e2b4d88b9
+TERMUX_PKG_DEPENDS="freetype, lua51, sdl2 | sdl2-compat, sdl2-image, sdl2-ttf, libiconv"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_HOSTBUILD=true
+
+termux_step_host_build() {
+	make -C "$TERMUX_PKG_SRCDIR/tools/8x8fonts" -j "$TERMUX_PKG_MAKE_PROCESSES"
+	cp "$TERMUX_PKG_SRCDIR/bin/generate_png_fonts" .
+}
+
+termux_step_post_get_source() {
+	git fetch --unshallow
+	git checkout "$_COMMIT"
+
+	local pdate="p$(git log -1 --format=%cs | sed 's/-//g')"
+	if [[ "$TERMUX_PKG_VERSION" != *"${pdate}" ]]; then
+		echo -n "ERROR: The version string \"$TERMUX_PKG_VERSION\" is"
+		echo -n " different from what is expected to be; should end"
+		echo " with \"${pdate}\"."
+		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files. Expected: ${s}"
+	fi
+}
+
+termux_step_pre_configure() {
+	# patch like sdl2
+	find "$TERMUX_PKG_SRCDIR"/src -type f | \
+		xargs -n 1 sed -i \
+		-e 's/\([^A-Za-z0-9_]__ANDROID\)\(__[^A-Za-z0-9_]\)/\1_NO_TERMUX\2/g' \
+		-e 's/\([^A-Za-z0-9_]__ANDROID\)__$/\1_NO_TERMUX__/g'
+
+	export API="sdl2"
+	export SDL2CONFIG="$TERMUX_PREFIX/bin/sdl2-config"
+
+	patch="$TERMUX_PKG_BUILDER_DIR/generate-png-fonts.diff"
+	echo "Applying patch: $(basename "$patch")"
+	sed 's|@GENERATE_PNG_FONTS@|'"${TERMUX_PKG_HOSTBUILD_DIR}/generate_png_fonts"'|g' \
+		"$patch" | patch -p1
+}
+
+termux_step_make() {
+	make -j "$TERMUX_PKG_MAKE_PROCESSES"
+}
+
+termux_step_make_install() {
+	make -C src/ install
+}
+
+termux_step_post_make_install() {
+	mv "$TERMUX_PREFIX"/bin/grafx2{-sdl2,}
+}

--- a/x11-packages/grafx2/generate-png-fonts.diff
+++ b/x11-packages/grafx2/generate-png-fonts.diff
@@ -1,0 +1,9 @@
+--- a/tools/8x8fonts/Makefile
++++ b/tools/8x8fonts/Makefile
+@@ -42,5 +42,5 @@ $(BIN):	generate_png_fonts.o
+ $(FONTPATHS):	.fonts.generated
+ 
+ .fonts.generated:	$(BIN)
+-	$(BIN) $(FONTDIR)
++	@GENERATE_PNG_FONTS@ $(FONTDIR)
+ 	touch $@

--- a/x11-packages/grafx2/makefile-force-non-gnu-libiconv-linking-codepath.patch
+++ b/x11-packages/grafx2/makefile-force-non-gnu-libiconv-linking-codepath.patch
@@ -1,0 +1,12 @@
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -710,7 +710,7 @@ endif
+         # enable UTF8 filename translation
+         # For Linux (GLibc), iconv is built into the C library so no LOPT needed.
+         COPT += -DENABLE_FILENAMES_ICONV
+-        ifneq ($(filter-out NetBSD Linux,$(PLATFORM)),)
++        ifneq ($(filter-out NetBSD,$(PLATFORM)),)
+           ifneq ($(DEB_HOST_ARCH_OS), kfreebsd)
+             LOPT += -liconv
+           endif
+

--- a/x11-packages/grafx2/sdl2-config.patch
+++ b/x11-packages/grafx2/sdl2-config.patch
@@ -1,0 +1,35 @@
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -715,10 +715,10 @@ endif
+         TESTSBIN = ../bin/tests-$(API)
+         COPT = -W -Wall -Wdeclaration-after-statement -std=c99 -g
+         ifeq ($(API),sdl)
+-          COPT += $(shell sdl-config --cflags)
++          COPT += $(shell ${SDL2CONFIG} --cflags)
+         endif
+         ifeq ($(API),sdl2)
+-          COPT += $(shell sdl2-config --cflags)
++          COPT += $(shell ${SDL2CONFIG} --cflags)
+         endif
+         COPT += $(TTFCOPT) $(LUACOPT) $(JOYCOPT) -O$(OPTIM)
+         COPT += $(shell $(PKG_CONFIG) --cflags libpng)
+@@ -740,7 +740,7 @@ endif
+           endif
+         endif
+         ifeq ($(API),sdl2)
+-          LOPT += $(shell sdl2-config --libs) -lSDL2_image
++          LOPT += $(shell ${SDL2CONFIG} --libs) -lSDL2_image
+           ifneq ($(NO_X11),1)
+             LOPT += $(shell $(PKG_CONFIG) --libs x11)
+             COPT += $(shell $(PKG_CONFIG) --cflags x11)
+--- a/tools/sdl_image_test/Makefile
++++ b/tools/sdl_image_test/Makefile
+@@ -2,7 +2,7 @@ CFLAGS = -Wall -O -g
+ 
+ ifeq ($(API),sdl2)
+ # SDL 2.x
+-SDLCONFIGNAME = sdl2-config
++SDLCONFIGNAME = ${SDL2CONFIG}
+ SDLIMAGE = SDL2_image
+ BIN = showimage-sdl2
+ CFLAGS += -DUSE_SDL2

--- a/x11-packages/grafx2/src-factory.c.patch
+++ b/x11-packages/grafx2/src-factory.c.patch
@@ -1,0 +1,10 @@
+--- a/src/factory.c
++++ b/src/factory.c
+@@ -49,6 +49,7 @@
+ #include "realpath.h"
+ #include "setup.h"
+ #include "tiles.h"
++#include "layers.h"
+ 
+ /// Lua scripts bound to shortcut keys.
+ char * Bound_script[10];


### PR DESCRIPTION
- It needs to be built using a recent commit of the git repository so that the submodules are fully working and there are no errors

- A user has requested this