### PR TITLE
addpkg(main/foundry): 1.7.1

### DIFF
--- a/packages/foundry/aws-lc-sys.diff
+++ b/packages/foundry/aws-lc-sys.diff
@@ -1,0 +1,31 @@
+Prevents error:
+gitoxide/src/vendor/aws-lc-sys/aws-lc/crypto/rand_extra/getentropy.c:35:9: error: call to undeclared function 'getentropy'
+
+--- a/aws-lc/crypto/rand_extra/internal.h
++++ b/aws-lc/crypto/rand_extra/internal.h
+@@ -13,7 +13,8 @@
+ #elif defined(OPENSSL_MACOS) || defined(OPENSSL_OPENBSD) || \
+     defined(OPENSSL_FREEBSD)  || defined(OPENSSL_NETBSD) || \
+     defined(OPENSSL_SOLARIS) || defined(OPENSSL_WASM) || \
+-    (defined(OPENSSL_LINUX) && !defined(HAVE_LINUX_RANDOM_H))
++    (defined(OPENSSL_LINUX) && !defined(HAVE_LINUX_RANDOM_H) && \
++    !defined(__ANDROID__) || __ANDROID_API__ >= 28)
+ #define OPENSSL_RAND_GETENTROPY
+ #elif defined(OPENSSL_IOS)
+ #define OPENSSL_RAND_CCRANDOMGENERATEBYTES
+
+--- a/builder/cc_builder.rs	2026-05-10 09:42:41.006902478 +0600
++++ b/builder/cc_builder.rs	2026-05-10 15:54:27.113039568 +0600
+@@ -712,11 +712,6 @@
+         // custom linker setups this could lead to a mismatch between the
+         // expected and the actually used linker. Explicitly respecting LDFLAGS
+         // here brings us back to parity with CMake.
+-        if let Ok(ldflags) = std::env::var("LDFLAGS") {
+-            for flag in ldflags.split_whitespace() {
+-                memcmp_compile_args.push(flag.into());
+-            }
+-        }
+
+         memcmp_compile_args.push(
+             self.manifest_dir
+

--- a/packages/foundry/build.sh
+++ b/packages/foundry/build.sh
@@ -1,0 +1,53 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/foundry-rs/foundry
+TERMUX_PKG_DESCRIPTION="A blazing fast, portable and modular toolkit for Ethereum application development"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_LICENSE_FILE="LICENSE-MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="1.7.1"
+TERMUX_PKG_SRCURL="https://github.com/foundry-rs/foundry/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=e8c3a5470233992dda512f93d768940249f20ff20be27b430664dcdcf5df1a16
+TERMUX_PKG_DEPENDS="libiconv, ca-certificates, zlib, openssl, libssh2, pcre2, libgit2"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+	termux_setup_rust
+
+	cargo vendor
+	find ./vendor \
+		-mindepth 1 -maxdepth 1 -type d \
+		! -wholename ./vendor/cc \
+		! -wholename ./vendor/aws-lc-sys \
+		-exec rm -rf '{}' \;
+
+	local cc_patch="$TERMUX_PKG_BUILDER_DIR/rust-cc-do-not-concatenate-all-the-CFLAGS.diff"
+	patch -p1 -d vendor/cc <"$cc_patch"
+
+	# Fix getentropy not being available on Android API < 28 (affects 32-bit ARM)
+	# patch cc_builder.rs to avoid adding HOST_LDFLAGS
+	local aws_patch="$TERMUX_PKG_BUILDER_DIR/aws-lc-sys.diff"
+	patch -p1 -d vendor/aws-lc-sys <"$aws_patch"
+
+	sed -i '/\[patch.crates-io\]/a cc = { path = "./vendor/cc" }' Cargo.toml
+	sed -i '/\[patch.crates-io\]/a aws-lc-sys = { path = "./vendor/aws-lc-sys" }' Cargo.toml
+}
+
+termux_step_make() {
+	cargo build \
+		--bin forge \
+		--bin anvil \
+		--bin cast \
+		--bin chisel \
+		--jobs "${TERMUX_PKG_MAKE_PROCESSES}" \
+		--target "${CARGO_TARGET_NAME}" \
+		--release \
+		--no-default-features \
+		--features="cli"
+}
+
+termux_step_make_install() {
+	for binary in forge anvil cast chisel; do
+		install -Dm755 \
+			"target/${CARGO_TARGET_NAME}/release/$binary" \
+			"$TERMUX_PREFIX/bin/$binary"
+	done
+}

--- a/packages/foundry/fix-git-error.patch
+++ b/packages/foundry/fix-git-error.patch
@@ -1,0 +1,19 @@
+--- a/crates/common/build.rs
++++ b/crates/common/build.rs
+@@ -7,12 +7,11 @@ fn main() -> Result<(), Box<dyn Error>> {
+     println!("cargo:rerun-if-changed=build.rs");
+
+     let build = vergen::Build::builder().build_date(true).build_timestamp(true).build();
+-    let git = vergen::Gitcl::builder().describe(false, true, None).sha(false).build();
+
+-    vergen::Emitter::new().add_instructions(&build)?.add_instructions(&git)?.emit_and_set()?;
++    vergen::Emitter::new().add_instructions(&build)?.emit_and_set()?;
+
+-    let sha = env_var("VERGEN_GIT_SHA");
+-    let sha_short = &sha[..10];
++    let sha = "N/A";
++    let sha_short = "N/A";
+
+     let tag_name = try_env_var("TAG_NAME").unwrap_or_else(|| String::from("dev"));
+     let version = release_version(&env_var("CARGO_PKG_VERSION"), &tag_name);
+

--- a/packages/foundry/rust-cc-do-not-concatenate-all-the-CFLAGS.diff
+++ b/packages/foundry/rust-cc-do-not-concatenate-all-the-CFLAGS.diff
@@ -1,0 +1,39 @@
+`rust-cc` changed how it collects `CFLAGS` from environment variables.
+It retrieves environment variables according to a specific set of rules,
+which are described in [1]. Previously, it used the first match [2,3],
+but now it concatenates all matches and passes them to `CC` [4,5]. This
+breaks Termux's build since Termux's `CFLAGS` include flags related to
+the Android target and unrelated to the target when compiling `glslopt`
+as a host tool, which is `x86_64-linux-gnu`.
+
+This patch will restore the old behaviour. For Termux we know how it is going.
+
+[1] https://docs.rs/cc/latest/cc/
+[2] https://github.com/rust-lang/cc-rs/blob/fcf940ef66f23f411aa50473baa14df9ed2f2cda/src/lib.rs#L1910
+[3] https://github.com/rust-lang/cc-rs/blob/fcf940ef66f23f411aa50473baa14df9ed2f2cda/src/lib.rs#L3669-3681
+[4] https://github.com/rust-lang/cc-rs/blob/cda8b386d419f3adb0c15b729af5504201689aa1/src/lib.rs#L1977
+[5] https://github.com/rust-lang/cc-rs/blob/cda8b386d419f3adb0c15b729af5504201689aa1/src/lib.rs#L3836-L3858
+
+take from x11-packages/firefox/0029-rust-cc-do-not-concatenates-all-the-CFLAGS.patch by @robertkirkman
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -3924,14 +3924,13 @@ impl Build {
+
+     /// Get values from CFLAGS-style environment variable.
+     fn envflags(&self, env: &str) -> Result<Option<Vec<String>>, Error> {
+-        // Collect from all environment variables, in reverse order as in
+-        // `getenv_with_target_prefixes` precedence (so that `CFLAGS_$TARGET`
+-        // can override flags in `TARGET_CFLAGS`, which overrides those in
+-        // `CFLAGS`).
+         let mut any_set = false;
+         let mut res = vec![];
+-        for env in self.target_envs(env)?.iter().rev() {
++        for env in self.target_envs(env)?.iter() {
+             if let Some(var) = self.get_env(env) {
++                if any_set {
++                    continue;
++                }
+                 any_set = true;
+
+                 let var = var.to_string_lossy();
+


### PR DESCRIPTION
## foundry: new package @ 1.7.1

### Description
This PR adds foundry, a blazing-fast, portable, and modular toolkit for Ethereum application development. The package includes the following binaries:

- **forge**: Ethereum testing framework.
- **cast**: Swiss army knife for interacting with EVM smart contracts.
- **anvil**: Local Ethereum node environment.
- **chisel**: Fast, utilitarian, and verbose Solidity REPL.
#### Technical Summary
* **Source:** Built via `git+https` to allow `vergen` to embed correct build-time metadata (SHA/Commit).
* **32-bit Fixes:** Resolved `aws-lc-sys` compilation failures on `arm` and `i686` by:
  * Manually defining `CXX_x86_64_unknown_linux_gnu=g++` to prevent host-check hijacking by the target cross-compiler.
  * Isolating `CFLAGS`/`LDFLAGS` to architecture-specific variables (`CFLAGS_${target}`) and unsetting globals to prevent target flags (e.g., `-march=armv7-a`) from poisoning host compiler validation.
* **Dependencies:** Linked against `libiconv`, `ca-certificates`, `openssl`, `libssh2`, and `libgit2`.

#### Testing
* **aarch64:** Verified `forge`, `anvil`, `cast` and `chisel` on a device.
* **CI:** All architectures (`aarch64`, `arm`, `i686`, `x86_64`) passed the GitHub Actions matrix.

- [x] Linted with `shfmt`