### PR TITLE
Create mtd/build.sh

### DIFF
--- a/packages/mtd/build.sh
+++ b/packages/mtd/build.sh
@@ -1,0 +1,16 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/project-mtd/mtd
+TERMUX_PKG_DESCRIPTION="A native utility to move and merge directories without overwriting"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="Nasa <hastagaming@github.com>"
+TERMUX_PKG_VERSION=1.0.0
+# URL source code dari GitHub Release atau commit
+TERMUX_PKG_SRCURL=https://github.com/project-mtd/mtd/archive/v${TERMUX_PKG_VERSION}.tar.gz
+# Hash SHA256 dari file tar.gz tersebut (bisa didapat dengan sha256sum)
+TERMUX_PKG_SHA256=6644dcfd6195c197e61e13a0c929e152d35e3fd253f60d43d1e1125ec1e79049  mtd-v1.0.0.tar.gz
+TERMUX_PKG_AUTO_UPDATE=true
+
+termux_step_pre_configure() {
+    # Karena kita pakai Makefile.in & configure.ac, 
+    # kita perlu generate script configure sebelum build dimulai
+    autoreconf -fi
+}

--- a/packages/mvtd/build.sh
+++ b/packages/mvtd/build.sh
@@ -6,11 +6,13 @@ TERMUX_PKG_VERSION=1.0.0
 # URL source code dari GitHub Release atau commit
 TERMUX_PKG_SRCURL=https://github.com/project-mtd/mtd/archive/v${TERMUX_PKG_VERSION}.tar.gz
 # Hash SHA256 dari file tar.gz tersebut (bisa didapat dengan sha256sum)
-TERMUX_PKG_SHA256=6644dcfd6195c197e61e13a0c929e152d35e3fd253f60d43d1e1125ec1e79049  mtd-v1.0.0.tar.gz
+TERMUX_PKG_SHA256="864f5641e0242781089b330ac756cc06be6386f720b0d878ea3a3b0625867f2f"
 TERMUX_PKG_AUTO_UPDATE=true
 
 termux_step_pre_configure() {
-    # Karena kita pakai Makefile.in & configure.ac, 
+    # Karena kita pakai Makefile.in & configure.ac,
     # kita perlu generate script configure sebelum build dimulai
     autoreconf -fi
 }
+#.
+


### PR DESCRIPTION
mtd (Move to Directory) is a native C utility designed to move and merge directories while strictly preventing file overwrites. Unlike the standard mv command, mtd recursively merges source contents into the destination, only moving files that do not already exist at the target path.