### PR TITLE
bump(main/proot): include latest fixes

### DIFF
--- a/packages/proot/build.sh
+++ b/packages/proot/build.sh
@@ -4,11 +4,10 @@ TERMUX_PKG_DESCRIPTION="Emulate chroot, bind mount and binfmt_misc for non-root 
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="Michal Bednarski @michalbednarski"
 # Just bump commit and version when needed:
-_COMMIT=4dba3afbf3a63af89b4d9c1a59bf2bda10f4d10f
+_COMMIT=ee10b279a38d34b6704345bc448d18f019ca1b49
 TERMUX_PKG_VERSION=5.1.107
-TERMUX_PKG_REVISION=70
 TERMUX_PKG_SRCURL=https://github.com/termux/proot/archive/${_COMMIT}.zip
-TERMUX_PKG_SHA256=a72668607184f981e44181bfa47f86ef52d52bb237b4012ee94f0dc89cb39211
+TERMUX_PKG_SHA256=9f2cc32e60be6c2a09bade03f98e22bb27ccecda926c8a74979df03ae755b1dd
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_DEPENDS="libtalloc"
 TERMUX_PKG_SUGGESTS="proot-distro"


### PR DESCRIPTION
1. Expose correct executable path via AT_EXECFN mechanism: fixes uutils variant of coreutils in latest Ubuntu distribution versions.
2. Fix setresgid calls and related when running under proot -0
3. Fix permission denials when proot'ed program attempts to open /dev/stderr or /dev/stdout