### PR TITLE
fix(main/sqlcipher): apply `CPPFLAGS` to match exactly with build settings of `libsqlite`

### DIFF
--- a/packages/sqlcipher/build.sh
+++ b/packages/sqlcipher/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="SQLCipher is an SQLite extension that provides 256 bit A
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="4.15.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/sqlcipher/sqlcipher/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz"
 TERMUX_PKG_SHA256=21f5dfb2558a2a87740bb060ba75aadfec2e6119e08a87c3546c54751395a28d
 TERMUX_PKG_DEPENDS="libedit, openssl"
@@ -29,11 +30,23 @@ TCLLIBDIR=${TERMUX__PREFIX__LIB_DIR}/tcl8.6/sqlite
 
 termux_step_pre_configure() {
 	# CPPFLAGS and LDFLAGS as directed by README.md
+	# and also by the termux-packages libsqlite package so that sqlcipher
+	# can be built after libsqlite but before packages that depend on libsqlite
+	# and provide the exact same symbols as libsqlite
+	# in a single docker container building many packages
 	CPPFLAGS+=" -DSQLCIPHER_OMIT_LOG_DEVICE"
 	CPPFLAGS+=" -DSQLITE_HAS_CODEC"
 	CPPFLAGS+=" -DSQLITE_EXTRA_INIT=sqlcipher_extra_init"
 	CPPFLAGS+=" -DSQLITE_EXTRA_SHUTDOWN=sqlcipher_extra_shutdown"
+	CPPFLAGS+=" -DSQLITE_ENABLE_DBSTAT_VTAB=1"
+	CPPFLAGS+=" -DSQLITE_ENABLE_COLUMN_METADATA=1"
+	CPPFLAGS+=" -DSQLITE_ENABLE_UPDATE_DELETE_LIMIT=1"
+	CPPFLAGS+=" -DSQLITE_ENABLE_UNLOCK_NOTIFY=1"
+	CPPFLAGS+=" -DSQLITE_ENABLE_FTS3_PARENTHESIS"
+	CPPFLAGS+=" -DSQLITE_ENABLE_RBU"
+	CPPFLAGS+=" -DSQLITE_ENABLE_GEOPOLY"
 	LDFLAGS+=" -lcrypto"
+	LDFLAGS+=" -lm"
 }
 
 # See: https://github.com/termux/termux-packages/issues/23268#issuecomment-2685308408


### PR DESCRIPTION
- Since packages depending on `libsqlite` may in some situations be exposed to a `sqlcipher` when they attempt to link to `libsqlite` (this is sort of intended behavior), that case needs to be handled to avoid errors like `ld.lld: error: undefined symbol: sqlite3_column_table_name16` when using the `sqlcipher` as a linking stub in place of `libsqlite` during commands like `scripts/run-docker.sh ./build-package.sh -I -f libsqlite sqlcipher qt6-qtbase`

https://github.com/termux/termux-packages/blob/fc0fbead79b9b514d396a992a2a8e68dd1d6b536/packages/libsqlite/build.sh#L27-L33