### PR TITLE
bump(x11/atril): 1.28.4

### DIFF
--- a/x11-packages/atril/build.sh
+++ b/x11-packages/atril/build.sh
@@ -2,36 +2,29 @@ TERMUX_PKG_HOMEPAGE=https://mate-desktop.org
 TERMUX_PKG_DESCRIPTION="MATE document viewer"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.28.3"
+TERMUX_PKG_VERSION="1.28.4"
 # https://pub.mate-desktop.org/releases/${TERMUX_PKG_VERSION%.*}/atril-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SRCURL="https://github.com/mate-desktop/atril/releases/download/v${TERMUX_PKG_VERSION}/atril-${TERMUX_PKG_VERSION}.tar.xz"
-TERMUX_PKG_SHA256=1a89724cdfb8af83fa44f08d89d66049f9aac053b28be9cef13eb27148a970da
+TERMUX_PKG_SHA256=a6f5fbf0ab4305c1b8162c5d5a1146a669784b00dec69242e04f148de1b79653
 TERMUX_PKG_AUTO_UPDATE=true
 # links with poppler-glib, not poppler
-TERMUX_PKG_DEPENDS="atk, djvulibre, gdk-pixbuf, glib, gtk3, harfbuzz, libarchive, libc++, libcairo, libice, libsecret, libsm, libsoup3, libtiff, libxml2, mate-desktop, pango, poppler, texlive-bin, webkit2gtk-4.1, zlib"
+TERMUX_PKG_DEPENDS="atk, djvulibre, gdk-pixbuf, glib, gtk3, harfbuzz, libarchive, libc++, libcairo, libice, libsecret, libsm, libspectre, libsoup3, libtiff, libxml2, mate-desktop, pango, poppler, texlive-bin, webkit2gtk-4.1, zlib"
 TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, glib-cross"
 TERMUX_PKG_VERSIONED_GIR=false
 TERMUX_PKG_DISABLE_GIR=false
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
---disable-caja
---enable-djvu
---enable-dvi
---enable-epub
---enable-introspection
---enable-pixbuf
+-Dcaja=disabled
+-Ddjvu=enabled
+-Ddvi=enabled
+-Depub=enabled
+-Dintrospection=true
+-Dpixbuf=enabled
 "
 
 termux_step_pre_configure() {
+	# Workaround strict compiler error
+	CFLAGS+=" -Wno-format-security -Wno-format-nonliteral"
+
+	termux_setup_glib_cross_pkg_config_wrapper
 	termux_setup_gir
-
-	CPPFLAGS+=" -DHAVE_MEMCPY -Wno-deprecated-declarations"
-
-	# fix arm build and potentially other archs hidden bugs
-	# ERROR: ./lib/atril/3/backends/libpdfdocument.so contains undefined symbols:
-	# 162: 00000000     0 NOTYPE  GLOBAL DEFAULT   UND __aeabi_idivmod
-	# 163: 00000000     0 NOTYPE  GLOBAL DEFAULT   UND __aeabi_idiv
-	local _libgcc_file="$($CC -print-libgcc-file-name)"
-	local _libgcc_path="$(dirname $_libgcc_file)"
-	local _libgcc_name="$(basename $_libgcc_file)"
-	LDFLAGS+=" -L$_libgcc_path -l:$_libgcc_name"
 }

--- a/x11-packages/atril/install-scripts-meson.build.patch
+++ b/x11-packages/atril/install-scripts-meson.build.patch
@@ -1,0 +1,10 @@
+--- a/install-scripts/meson.build
++++ b/install-scripts/meson.build
+@@ -15,7 +15,6 @@
+ meson.add_install_script('meson_install_schemas.py')
+ 
+ # Update mime info
+-meson.add_install_script('meson_update_mime_database.py')
+ 
+ # Update the Gtk icon cache
+ meson.add_install_script('meson_update_icon_cache.py')


### PR DESCRIPTION
* Port build options to meson.
* Remove LDFLAGS workaround for autotools.
* Fixes #29800 