### PR TITLE
fix(main/foundry): fix runtime errors

### DIFF
--- a/packages/foundry/build.sh
+++ b/packages/foundry/build.sh
@@ -4,7 +4,8 @@ TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="LICENSE-MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.7.1"
-TERMUX_PKG_SRCURL="https://github.com/foundry-rs/foundry/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://github.com/foundry-rs/foundry/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=e8c3a5470233992dda512f93d768940249f20ff20be27b430664dcdcf5df1a16
 TERMUX_PKG_DEPENDS="libiconv, ca-certificates, zlib, openssl, libssh2, pcre2, libgit2"
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -17,18 +18,36 @@ termux_step_pre_configure() {
 		-mindepth 1 -maxdepth 1 -type d \
 		! -wholename ./vendor/cc \
 		! -wholename ./vendor/aws-lc-sys \
+		! -wholename ./vendor/foundry-compilers \
+		! -wholename ./vendor/rustls-platform-verifier \
 		-exec rm -rf '{}' \;
 
 	local cc_patch="$TERMUX_PKG_BUILDER_DIR/rust-cc-do-not-concatenate-all-the-CFLAGS.diff"
-	patch -p1 -d vendor/cc <"$cc_patch"
+	patch -p1 -d vendor/cc < "$cc_patch"
 
 	# Fix getentropy not being available on Android API < 28 (affects 32-bit ARM)
 	# patch cc_builder.rs to avoid adding HOST_LDFLAGS
 	local aws_patch="$TERMUX_PKG_BUILDER_DIR/aws-lc-sys.diff"
-	patch -p1 -d vendor/aws-lc-sys <"$aws_patch"
+	patch -p1 -d vendor/aws-lc-sys < "$aws_patch"
+
+	local solc_compiler_patch="$TERMUX_PKG_BUILDER_DIR/solc_compiler_fix.diff"
+	patch -p1 -d vendor/foundry-compilers < "$solc_compiler_patch"
+
+	sed -i \
+		-e "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" \
+		./vendor/foundry-compilers/src/compilers/solc/compiler.rs
+
+	find vendor/rustls-platform-verifier -type f -print0 | \
+		xargs -0 sed -i \
+		-e 's|"android"|"disabling_this_because_it_is_for_building_an_apk"|g' \
+		-e "s|ANDROID|DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK|g" \
+		-e 's|"linux"|"android"|g'
+
 
 	sed -i '/\[patch.crates-io\]/a cc = { path = "./vendor/cc" }' Cargo.toml
 	sed -i '/\[patch.crates-io\]/a aws-lc-sys = { path = "./vendor/aws-lc-sys" }' Cargo.toml
+	sed -i '/\[patch.crates-io\]/a foundry-compilers = { path = "./vendor/foundry-compilers" }' Cargo.toml
+	sed -i '/\[patch.crates-io\]/a rustls-platform-verifier = { path = "./vendor/rustls-platform-verifier" }' Cargo.toml
 }
 
 termux_step_make() {

--- a/packages/foundry/fs_read_write_lock.patch
+++ b/packages/foundry/fs_read_write_lock.patch
@@ -1,0 +1,92 @@
+--- a/crates/common/src/fs.rs	2026-05-16 17:48:14.147489070 +0600
++++ b/crates/common/src/fs.rs	2026-05-17 16:55:54.076779778 +0600
+@@ -9,6 +9,31 @@
+     path::{Component, Path, PathBuf},
+ };
+ 
++// ──────────────── Termux compatibility ───────────────────
++// Android's /data filesystem does not support flock(LOCK_SH) or flock(LOCK_EX)
++// — both return EOPNOTSUPP.  We work around this as follows:
++//
++//   Reads  — safe to perform concurrently without any lock; no replacement
++//            needed.
++//
++//   Writes — replaced with a process-local Mutex so that parallel forge test
++//            threads cannot interleave writes to the same output files.
++//            A single global Mutex is sufficient: write durations are tiny and
++//            forge never intentionally writes the same file from two tests at
++//            once.
++#[cfg(target_os = "android")]
++static PROCESS_WRITE_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
++
++#[cfg(target_os = "android")]
++#[inline]
++fn process_write_guard() -> std::sync::MutexGuard<'static, ()> {
++    PROCESS_WRITE_LOCK
++        .get_or_init(|| std::sync::Mutex::new(()))
++        .lock()
++        .expect("foundry fs write lock poisoned")
++}
++// ──────────────────────── End ───────────────────────────────
++
+ /// The [`fs`](self) result type.
+ pub type Result<T> = std::result::Result<T, FsPathError>;
+ 
+@@ -71,9 +96,17 @@
+     let path = path.as_ref();
+     let mut file =
+         fs::OpenOptions::new().read(true).open(path).map_err(|err| FsPathError::open(err, path))?;
++
++    // Android/Termux: flock(LOCK_SH) is not supported on the /data filesystem.
++    // Concurrent reads cannot corrupt file contents so no fallback is needed.
++    #[cfg(not(target_os = "android"))]
+     file.lock_shared().map_err(|err| FsPathError::lock(err, path))?;
++
+     let contents = read_inner(path, &mut file)?;
++
++    #[cfg(not(target_os = "android"))]
+     file.unlock().map_err(|err| FsPathError::unlock(err, path))?;
++
+     Ok(contents)
+ }
+ 
+@@ -130,9 +163,18 @@
+         .truncate(true)
+         .open(path)
+         .map_err(|err| FsPathError::open(err, path))?;
++
++    // Android/Termux: replace OS lock with a process-local Mutex.
++    #[cfg(target_os = "android")]
++    let _guard = process_write_guard();
++    #[cfg(not(target_os = "android"))]
+     file.lock().map_err(|err| FsPathError::lock(err, path))?;
++
+     file.write_all(contents.as_ref()).map_err(|err| FsPathError::write(err, path))?;
+-    file.unlock().map_err(|err| FsPathError::unlock(err, path))
++    #[cfg(not(target_os = "android"))]
++    file.unlock().map_err(|err| FsPathError::unlock(err, path))?;
++
++    Ok(())
+ }
+ 
+ /// Writes a line in an exclusive locked file.
+@@ -148,9 +190,18 @@
+         .open(path)
+         .map_err(|err| FsPathError::open(err, path))?;
+ 
++    // Android/Termux: replace OS lock with a process-local Mutex.
++    #[cfg(target_os = "android")]
++    let _guard = process_write_guard();
++    #[cfg(not(target_os = "android"))]
+     file.lock().map_err(|err| FsPathError::lock(err, path))?;
++
+     writeln!(file, "{line}").map_err(|err| FsPathError::write(err, path))?;
+-    file.unlock().map_err(|err| FsPathError::unlock(err, path))
++
++    #[cfg(not(target_os = "android"))]
++    file.unlock().map_err(|err| FsPathError::unlock(err, path))?;
++
++    Ok(())
+ }
+ 
+ // Locking fails on Windows if the file is opened in append mode.

--- a/packages/foundry/solc_compiler_fix.diff
+++ b/packages/foundry/solc_compiler_fix.diff
@@ -1,0 +1,127 @@
+--- a/src/compilers/solc/compiler.rs	2026-05-17 14:57:47.955143666 +0600
++++ b/src/compilers/solc/compiler.rs	2026-05-17 19:30:50.792780332 +0600
+@@ -17,6 +17,71 @@
+
+ /// Extensions acceptable by solc compiler.
+ pub const SOLC_EXTENSIONS: &[&str] = &["sol", "yul"];
++// ────────────────── Termux compatibility layer ────────────────────
++// Prebuilt solc binaries from binaries.soliditylang.org are x86_64/aarch64
++// glibc ELFs — they won't execute on Termux (Android / Bionic).
++// Instead we require the user to have installed solc via:
++//   pkg install solidity
++//
++// All functions that would normally download a binary are intercepted here
++// and replaced with a clear, actionable error message.
++
++// Returns the path to termux-packaged `solc` binary or `None` if it is
++// not installed
++const TERMUX_PREFIX: &str = "@TERMUX_PREFIX@";
++
++fn termux_solc_path() -> Option<PathBuf> {
++    let path = PathBuf::from(TERMUX_PREFIX).join("bin").join("solc");
++    if path.is_file() { Some(path) } else { None }
++}
++
++// The error message shown to Termux User when solc cannot be found.
++fn termux_solc_not_found_error() -> SolcError {
++    SolcError::msg(
++        "solc not found.\n\
++        Prebuilt solc binaries do not work on Termux.\n\
++        Install solc with Termux's package manager:\n\
++        \n\
++        \x20   pkg install solidity\n\
++        \n\
++        Then re-run your forge command.",
++    )
++}
++/// Used by `blocking_install` and `install` on Termux.
++///
++/// Instead of downloading a prebuilt binary (which won't run on Android/Bionic),
++/// we return the system-installed solc from the Termux prefix.
++/// If the installed version doesn't match what was requested, we warn and
++/// proceed — solc itself will surface any real incompatibility as a compile
++/// error.
++fn termux_use_system_solc(requested: &Version) -> std::result::Result<Solc, svm::SvmError> {
++    let path = termux_solc_path().ok_or_else(|| {
++        svm::SvmError::IoError(std::io::Error::new(
++            std::io::ErrorKind::NotFound,
++            termux_solc_not_found_error().to_string(),
++        ))
++    })?;
++
++    let installed = Solc::version(&path).map_err(|e| {
++        svm::SvmError::IoError(std::io::Error::new(
++            std::io::ErrorKind::Other,
++            e.to_string(),
++        ))
++    })?;
++
++    if &installed != requested {
++        eprintln!(
++            "\n\x1b[33m[Termux] Warning:\x1b[0m foundry.toml requests solc {requested}, \
++             but Termux has {installed} installed.\n\
++             Prebuilt solc binaries cannot run on Termux — \
++             compiling with {installed} instead.\n\
++             \x20 • To silence this: remove `solc` from foundry.toml\n\
++             \x20 • Or upgrade:       pkg upgrade solidity\n"
++        );
++    }
++
++    Ok(Solc::new_with_version(path, installed))
++}
+
+ /// take the lock in tests, we use this to enforce that
+ /// a test does not run while a compiler version is being installed
+@@ -160,6 +225,21 @@
+     /// If the required compiler version is not installed, it also proceeds to install it.
+     #[cfg(feature = "svm-solc")]
+     pub fn ensure_installed(sol_version: &VersionReq) -> Result<Version> {
++        // ── Termux: never download prebuilt binaries ────
++        let path = termux_solc_path().ok_or_else(termux_solc_not_found_error)?;
++        let version = Self::version(&path)?;
++        return if sol_version.matches(&version) {
++            Ok(version)
++        } else {
++            Err(SolcError::msg(format!(
++                        "Termux solc {version} does not satisfy the pragma requirement \
++                        `{sol_version}`.\n\
++                        The Termux `solidity` package provides a single version.\n\
++                        You can:\n\
++                        \x20 • Upgrade it with:  pkg upgrade solidity\n\
++                        \x20 • Or relax the pragma in your contract to accept {version}",
++            )))
++        };
+         #[cfg(test)]
+         take_solc_installer_lock!(_lock);
+
+@@ -276,6 +356,8 @@
+     #[cfg(feature = "svm-solc")]
+     #[instrument(name = "Solc::install", skip_all)]
+     pub async fn install(version: &Version) -> std::result::Result<Self, svm::SvmError> {
++        // Safety net: when version mismatches this function is called
++        return termux_use_system_solc(version);
+         trace!("installing solc version \"{}\"", version);
+         crate::report::solc_installation_start(version);
+         match svm::install(version).await {
+@@ -294,6 +376,8 @@
+     #[cfg(feature = "svm-solc")]
+     #[instrument(name = "Solc::blocking_install", skip_all)]
+     pub fn blocking_install(version: &Version) -> std::result::Result<Self, svm::SvmError> {
++        // Same as `install()` logic for Safety
++        return termux_use_system_solc(version);
+         use foundry_compilers_core::utils::RuntimeOrHandle;
+
+         #[cfg(test)]
+@@ -530,6 +614,12 @@
+     /// Either finds an installed Solc version or installs it if it's not found.
+     #[cfg(feature = "svm-solc")]
+     pub fn find_or_install(version: &Version) -> Result<Self> {
++        // ───────── Termux: use system solc, never download ──────────
++        let path = termux_solc_path().ok_or_else(termux_solc_not_found_error)?;
++        // Use the system version; forge will have already validated the
++        // version requirement in ensure_installed() above.
++        let sys_version = Self::version(&path)?;
++        return Ok(Self::new_with_version(path, sys_version));
+         let solc = if let Some(solc) = Self::find_svm_installed_version(version)? {
+             solc
+         } else {


### PR DESCRIPTION
## foundry-compiler patch

- [x] always uses termux installed `solc` 
- [x] skip prebuilt binaries installation 
- [x] warns users on version mismatch or if solc is not installed 
- [x] replaced `shared_lock()` and `lock()` with `Mutex` since syscalls are restricted which leads to error. 