### PR TITLE
bump(x11/ruffle): 0.2.0 - switch to regular release tags

### DIFF
--- a/x11-packages/ruffle/0003-fontconfig-no-dlopen.patch
+++ b/x11-packages/ruffle/0003-fontconfig-no-dlopen.patch
@@ -4,15 +4,16 @@ ERROR ruffle_core::html::layout: Fallback font not found (Sans)
 for: CopprplGoth Bd BT, text will be missing
 
 https://github.com/termux/termux-packages/issues/29244
-
+diff --git a/desktop/Cargo.toml b/desktop/Cargo.toml
+index 6ddeaa1a6..38b99d4c4 100644
 --- a/desktop/Cargo.toml
 +++ b/desktop/Cargo.toml
 @@ -51,7 +51,7 @@ rand = "0.9.1"
  thiserror.workspace = true
  async-channel.workspace = true
  unicode-bidi = "0.3.18"
--fontconfig = { version = "0.10.0", optional = true, features = ["dlopen"]}
-+fontconfig = { version = "0.10.0", optional = true, features = []}
+-fontconfig = { version = "0.10.2", optional = true, features = ["dlopen"]}
++fontconfig = { version = "0.10.2", optional = true, features = []}
  memmap2.workspace = true
  walkdir.workspace = true
  async-task = "4.7.1"

--- a/x11-packages/ruffle/build.sh
+++ b/x11-packages/ruffle/build.sh
@@ -3,62 +3,12 @@ TERMUX_PKG_DESCRIPTION="A Flash Player emulator written in Rust"
 TERMUX_PKG_LICENSE="MIT, Apache-2.0"
 TERMUX_PKG_LICENSE_FILE="LICENSE.md"
 TERMUX_PKG_MAINTAINER="@termux"
-_COMMIT_DATE=2026-05-01
-TERMUX_PKG_VERSION="0.0.1-nightly-2026-05-01"
-TERMUX_PKG_SRCURL=https://github.com/ruffle-rs/ruffle/archive/refs/tags/nightly-${_COMMIT_DATE}.tar.gz
-TERMUX_PKG_SHA256=7b2015b51a714670197d18f16feef2b48d8da257a36458335aa9752eda64039c
+TERMUX_PKG_VERSION="0.2.0"
+TERMUX_PKG_SRCURL="https://github.com/ruffle-rs/ruffle/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=f14fa41476fcf509712a547f150f269caf1f410c11ce6a8d72641e233fd78f4c
 TERMUX_PKG_DEPENDS="alsa-lib, alsa-plugins, fontconfig, gtk3, openh264"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
-
-termux_pkg_auto_update() {
-	local latest_tags
-	latest_tags="$(termux_github_api_get_tag)"
-
-	local latest_commit_date=$(echo "${latest_tags}" | sed -e "s/nightly-//")
-	local latest_version="0.0.1-nightly-$latest_commit_date"
-
-	local current_date_epoch=$(date "+%s")
-	local _COMMIT_DATE_epoch=$(date -d "${_COMMIT_DATE}" "+%s")
-	local current_date_diff=$(((current_date_epoch-_COMMIT_DATE_epoch)/(60*60*24)))
-	local cooldown_days=14
-	if [[ "${current_date_diff}" -lt "${cooldown_days}" ]]; then
-		cat <<- EOL
-		INFO: Queuing updates since last push
-		Cooldown (days) = ${cooldown_days}
-		Days since	  = ${current_date_diff}
-		EOL
-		return
-	fi
-
-	if ! dpkg --compare-versions "${latest_version}" gt "${TERMUX_PKG_VERSION}"; then
-		termux_error_exit "
-		ERROR: Resulting latest version is not counted as an update!
-		Latest version  = ${latest_version}
-		Current version = ${TERMUX_PKG_VERSION}
-		"
-	fi
-
-	# unlikely to happen
-	if [[ "${latest_commit_date}" -lt "${_COMMIT_DATE}" ]]; then
-		cat <<- EOL
-		INFO: Upstream is older than current package version
-		EOL
-		return
-	fi
-
-	if [[ "${BUILD_PACKAGES}" == "false" ]]; then
-		echo "INFO: package needs to be updated to ${latest_version}."
-		return
-	fi
-
-	sed \
-		-e "s|^_COMMIT_DATE=.*|_COMMIT_DATE=${latest_commit_date}|" \
-		-i "${TERMUX_PKG_BUILDER_DIR}/build.sh"
-
-	termux_pkg_upgrade_version "${latest_version}" --skip-version-check
-}
 
 termux_step_pre_configure() {
 	termux_setup_rust


### PR DESCRIPTION
- closes #29809

Ruffle is now doing regular release tags do we can treat it as a normal package for auto-updates going forward.