### PR TITLE
bump(main/dash): 0.5.13.4

### DIFF
--- a/packages/dash/build.sh
+++ b/packages/dash/build.sh
@@ -2,12 +2,14 @@ TERMUX_PKG_HOMEPAGE=http://gondor.apana.org.au/~herbert/dash/
 TERMUX_PKG_DESCRIPTION="Small POSIX-compliant implementation of /bin/sh"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.5.12"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION="0.5.13.4"
 TERMUX_PKG_SRCURL="https://git.kernel.org/pub/scm/utils/dash/dash.git/snapshot/dash-${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256=0d632f6b945058d84809cac7805326775bd60cb4a316907d0bd4228ff7107154
+TERMUX_PKG_SHA256=652e95024b75758dcd141b64a0d3973a026cc6aaee1aec81ce03e76dc3e6a267
 TERMUX_PKG_ESSENTIAL=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-static"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+ac_cv_func_wait3=yes
+--disable-static
+"
 
 termux_step_pre_configure() {
 	autoreconf -fi
@@ -15,6 +17,6 @@ termux_step_pre_configure() {
 
 termux_step_post_make_install() {
 	# Symlink sh -> dash
-	ln -sfr $TERMUX_PREFIX/bin/{dash,sh}
-	ln -sfr $TERMUX_PREFIX/share/man/man1/{dash,sh}.1
+	ln -sfr "$TERMUX_PREFIX"/bin/{dash,sh}
+	ln -sfr "$TERMUX_PREFIX"/share/man/man1/{dash,sh}.1
 }


### PR DESCRIPTION
Had to add `ac_cv_func_wait3=yes` to get it to build now.
This seems to have been caused by [`da72f698`](https://git.kernel.org/pub/scm/utils/dash/dash.git/commit/?id=da72f6988ceb2e50dbdd894a45c40d02edca9293) which has been in `dash` since `0.5.13`.

Still needs validation testing on-device since this is an essential package ***and*** provides our `sh`.