### PR TITLE
fix(x11/librewolf): fix api_url variable name

### DIFF
--- a/x11-packages/librewolf/build.sh
+++ b/x11-packages/librewolf/build.sh
@@ -35,7 +35,7 @@ termux_pkg_auto_update() {
 	if [[ "${e}" != 0 ]]; then
 		cat <<- EOL >&2
 		WARN: Auto update failure!
-		api_url_r=${api_url_r}
+		api_url=${api_url}
 		latest_version=${latest_version}
 		uptime_now=${uptime_now}
 		uptime_s=${uptime_s}


### PR DESCRIPTION
`api_url_r` was copied over from the `firefox` auto-update function but is never initialized by `librewolf` so it causes an error during auto-updates.