### PR TITLE
fix(scripts/updates): respect explicit `$TERMUX_PKG_UPDATE_METHOD`

### DIFF
--- a/packages/ltrace/build.sh
+++ b/packages/ltrace/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="Tracks runtime library calls in dynamically linked progr
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1:0.8.1"
-TERMUX_PKG_SRCURL=https://github.com/dkogan/ltrace/archive/82c66409c7a93ca6ad2e4563ef030dfb7e6df4d4.tar.gz
-TERMUX_PKG_SHA256=4aecf69e4a33331aed1e50ce4907e73a98cbccc4835febc3473863474304d547
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://gitlab.com/cespedes/ltrace/-/archive/${TERMUX_PKG_VERSION:2}/ltrace-${TERMUX_PKG_VERSION:2}.tar.gz"
+TERMUX_PKG_SHA256=11c85a1353fcf2b5438b19d0ccc2d376c96656ce6f11cf9537e3a92b84392c58
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_UPDATE_METHOD=repology
 TERMUX_PKG_DEPENDS="libc++, libelf, libdw"
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
@@ -19,6 +19,8 @@ termux_step_pre_configure() {
 	if [ "$TERMUX_ARCH" == "arm" ]; then
 		CFLAGS+=" -DSHT_ARM_ATTRIBUTES=0x70000000+3"
 	fi
+
+	cp "${TERMUX_PKG_BUILDER_DIR}/reallocarray.c" "${TERMUX_PKG_SRCDIR}"
 
 	./autogen.sh
 }

--- a/packages/ltrace/define-reallocarray.patch
+++ b/packages/ltrace/define-reallocarray.patch
@@ -1,0 +1,36 @@
+diff --git a/libltrace.c b/libltrace.c
+index 97fcb2b..ecd501c 100644
+--- a/libltrace.c
++++ b/libltrace.c
+@@ -38,6 +38,7 @@
+ #include "prototype.h"
+ #include "read_config_file.h"
+ #include "summary.h"
++#include "reallocarray.c"
+ 
+ char *command = NULL;
+ 
+diff --git a/options.c b/options.c
+index 7f725a0..f769ec0 100644
+--- a/options.c
++++ b/options.c
+@@ -42,6 +42,7 @@
+ #include "filter.h"
+ #include "glob.h"
+ #include "demangle.h"
++#include "reallocarray.c"
+ 
+ struct options_t options = {
+ 	.align    = DEFAULT_ALIGN,    /* alignment column for results */
+diff --git a/output.c b/output.c
+index 9b20e09..85f4824 100644
+--- a/output.c
++++ b/output.c
+@@ -51,6 +51,7 @@
+ #include "value_dict.h"
+ #include "filter.h"
+ #include "debug.h"
++#include "reallocarray.c"
+ 
+ #if defined(HAVE_LIBDW)
+ #include "dwarf_prototypes.h"

--- a/packages/ltrace/ltrace-elf.c.patch
+++ b/packages/ltrace/ltrace-elf.c.patch
@@ -1,8 +1,8 @@
 diff --git a/ltrace-elf.c b/ltrace-elf.c
-index f439cb0..60f1941 100644
+index beaf69f..f91c2ef 100644
 --- a/ltrace-elf.c
 +++ b/ltrace-elf.c
-@@ -423,7 +423,9 @@ ltelf_destroy(struct ltelf *lte)
+@@ -443,7 +443,9 @@ ltelf_destroy(struct ltelf *lte)
  	debug(DEBUG_FUNCTION, "close_elf()");
  	elf_end(lte->elf);
  	close(lte->fd);
@@ -13,7 +13,18 @@ index f439cb0..60f1941 100644
  }
  
  static void
-@@ -1149,9 +1151,11 @@ read_module(struct library *lib, struct process *proc,
+@@ -1015,8 +1017,9 @@ populate_this_symtab(struct process *proc, const char *filename,
+ 		arch_addr_t addr = (arch_addr_t)
+ 			(uintptr_t)(sym.st_value + lte->bias);
+ 		arch_addr_t naddr;
+-
++#ifdef PPC64_LOCAL_ENTRY_OFFSET
+ 		addr += PPC64_LOCAL_ENTRY_OFFSET(sym.st_other);
++#endif
+ 
+ 		/* On arches that support OPD, the value of typical
+ 		 * function symbol will be a pointer to .opd, but some
+@@ -1185,9 +1188,11 @@ read_module(struct library *lib, struct process *proc,
  	 * determine whether ABI is supported.  This is to get
  	 * reasonable error messages when trying to run 64-bit binary
  	 * with 32-bit ltrace.  It is desirable to preserve this.  */
@@ -28,3 +39,13 @@ index f439cb0..60f1941 100644
  
  	/* Find out the base address.  For PIE main binaries we look
  	 * into auxv, otherwise we scan phdrs.  */
+@@ -1255,7 +1260,8 @@ read_module(struct library *lib, struct process *proc,
+ 			goto fail;
+ 		library_set_soname(lib, soname, 1);
+ 	} else {
+-		const char *soname = rindex(lib->pathname, '/');
++		// Use strrchr() instead of the obsolete rindex()
++		const char *soname = strrchr(lib->pathname, '/');
+ 		if (soname != NULL)
+ 			soname += 1;
+ 		else

--- a/packages/ltrace/reallocarray.c
+++ b/packages/ltrace/reallocarray.c
@@ -1,0 +1,15 @@
+#if defined __ANDROID__ && __ANDROID_API__ < 29
+#include <stdlib.h>
+#include <errno.h>
+
+static void *
+reallocarray(void *ptr, size_t nmemb, size_t size)
+{
+    size_t res;
+    if (__builtin_mul_overflow(nmemb, size, &res)) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return realloc(ptr, nmemb * size);
+}
+#endif

--- a/scripts/bin/update-packages
+++ b/scripts/bin/update-packages
@@ -124,20 +124,6 @@ _update() {
 	. "${TERMUX_PKG_BUILDER_DIR}"/build.sh 2>/dev/null
 	set -e -u
 
-	# Attempt to determine the update method for logging purposes.
-	local _tag_type="${TERMUX_PKG_UPDATE_TAG_TYPE:-}" _update_method _codepath
-	_update_method="$(termux_pkg_get_update_method "$TERMUX_PKG_SRCURL")"
-
-	if [[ -z "${_tag_type}" ]]; then
-		if [[ "${TERMUX_PKG_SRCURL:0:4}" == "git+" ]]; then
-			_tag_type="newest-tag"
-		elif [[ -n "$TERMUX_PKG_UPDATE_VERSION_REGEXP" ]]; then
-			_tag_type="latest-regex"
-		else
-			_tag_type="latest-release-tag"
-		fi
-	fi
-
 	# Colorize the codepaths if not in CI for at a glance identification.
 	if [[ -z "${CI:-}" ]]; then
 		case "$_tag_type" in
@@ -153,8 +139,12 @@ _update() {
 		esac
 	fi
 
-	echo # Newline.
-	echo "INFO: Updating ${TERMUX_PKG_NAME} [Current version: ${TERMUX_PKG_VERSION}, ${_update_method}/${_tag_type}]"
+	# INFO: Updating <package name> [<current version>, <update api>(/<tag type>)?]
+	printf '\nINFO: Updating %s [%s, %s]\n' \
+		"${TERMUX_PKG_NAME}" \
+		"Current version: ${TERMUX_PKG_VERSION}" \
+		"${_update_method}${_tag_type:+/}${_tag_type}"
+
 	# Throw FD 3 into the FIFO for reporting
 	exec {IPC_FIFO_FD}<>"$IPC_FIFO"
 	termux_pkg_auto_update 3>& "${IPC_FIFO_FD}"
@@ -163,7 +153,8 @@ _update() {
 
 declare -A _LATEST_TAGS=()
 declare -A _FAILED_UPDATES=()
-declare -A _ALREADY_SEEN=() # Array of successful or packages and their old/new version.
+declare -A _ALREADY_SEEN=()   # Array of successful updates or packages and their old/new version.
+declare -A _UPDATE_METHODS=() # Codepath counts for the various codepath combinations for auto-updates.
 
 # _fetch_and_cache_tags fetches all possible tags using termux_pkg_auto_update, but using Ninja build system.
 # The key difference is that we make the process concurrent, allowing us to fetch tags simultaneously rather than one at a time.
@@ -400,8 +391,30 @@ _run_update() {
 	export TERMUX_PKG_NAME="${pkg_name}"
 
 	local output="" _CURRENT_VERSION _NEWEST_VERSION _ISSUE
+
 	# shellcheck disable=SC1091 # Ignore shellcheck's inability to follow the source
+	{
+	local _SRCURL _REGEXP _tag_type _update_method
 	_CURRENT_VERSION="$(set +eu; . "$(realpath "$pkg_dir")/build.sh"; echo "${TERMUX_PKG_VERSION#*:}")"
+	_SRCURL="$(set +eu; . "$(realpath "$pkg_dir")/build.sh"; echo "${TERMUX_PKG_SRCURL}")"
+	_REGEXP="$(set +eu; . "$(realpath "$pkg_dir")/build.sh"; echo "${TERMUX_PKG_UPDATE_VERSION_REGEXP:-}")"
+	_tag_type="$(set +eu; . "$(realpath "$pkg_dir")/build.sh"; echo "${TERMUX_PKG_UPDATE_TAG_TYPE:-}")"
+	_update_method="$(termux_pkg_get_update_method "$_SRCURL")"
+	} &> /dev/null
+
+	# Repology method only has a $_tag_type if set explicitly.
+	if [[ -z "${_tag_type}" && "${_update_method}" != 'repology' ]]; then
+		if [[ "${_SRCURL:0:4}" == "git+" ]]; then
+			_tag_type="newest-tag"
+		elif [[ -n "$_REGEXP" ]]; then
+			_tag_type="latest-regex"
+		else
+			_tag_type="latest-release-tag"
+		fi
+	fi
+
+	# Keep a running count for each of the methods
+	(( _UPDATE_METHODS["${_update_method}${_tag_type:+/}${_tag_type}"]++ ))
 
 	# Ensure the FIFO is empty at the start of each update.
 	# This clears stale data from dependency checks, to prevent
@@ -584,6 +597,13 @@ indirect="$(( total - direct ))"
 echo ""
 echo "SUMMARY: Checked ${total} packages - took $(ms_to_human_readable $(( $(date +%10s%3N) - _start_time ))) in total."
 echo "SUMMARY: ${direct} (Directly passed), ${indirect} (Dependencies)"
+echo "SUMMARY: Update methods and release types."
+for variant in "${!_UPDATE_METHODS[@]}"; do
+    printf '%-30s%s\n' "${variant}:" "${_UPDATE_METHODS[$variant]}"
+done | sort
+echo
+# This expands to e.g. +12 +34 +56 +78, which then sums up.
+echo "total: $(( ${_UPDATE_METHODS[@]/#/+} ))"
 echo ""
 echo "=================================================="
 echo ""
@@ -593,7 +613,7 @@ echo ""
 echo "SUMMARY: ${#_FAILED_UPDATES[*]} failed updates."
 echo "${!_FAILED_UPDATES[@]}"
 
-unset IPC_FIFO IPC_FIFO_FD _unix_millis _start_time _pkg total direct indirect
+unset IPC_FIFO IPC_FIFO_FD _unix_millis _start_time _pkg total direct indirect variant
 
 ################################################FAILURE HANDLING#################################################
 

--- a/scripts/bin/update-packages
+++ b/scripts/bin/update-packages
@@ -126,6 +126,7 @@ _update() {
 
 	# Colorize the codepaths if not in CI for at a glance identification.
 	if [[ -z "${CI:-}" ]]; then
+		[[ -n "${_is_dependency:-}" ]] && printf -v _is_dependency '(\e[1;95m%s\e[m)' "${_is_dependency:1:-1}"
 		case "$_tag_type" in
 			"newest-tag") printf -v _tag_type '\e[1;33m%s\e[m' "$_tag_type";;
 			"latest-regex") printf -v _tag_type '\e[1;34m%s\e[m' "$_tag_type";;
@@ -140,10 +141,11 @@ _update() {
 	fi
 
 	# INFO: Updating <package name> [<current version>, <update api>(/<tag type>)?]
-	printf '\nINFO: Updating %s [%s, %s]\n' \
+	printf '\nINFO: Updating %s [%s, %s%s]\n' \
 		"${TERMUX_PKG_NAME}" \
 		"Current version: ${TERMUX_PKG_VERSION}" \
-		"${_update_method}${_tag_type:+/}${_tag_type}"
+		"${_update_method}${_tag_type:+/}${_tag_type}" \
+		"${_is_dependency:-}"
 
 	# Throw FD 3 into the FIFO for reporting
 	exec {IPC_FIFO_FD}<>"$IPC_FIFO"
@@ -153,8 +155,8 @@ _update() {
 
 declare -A _LATEST_TAGS=()
 declare -A _FAILED_UPDATES=()
-declare -A _ALREADY_SEEN=()   # Array of successful updates or packages and their old/new version.
-declare -A _UPDATE_METHODS=() # Codepath counts for the various codepath combinations for auto-updates.
+declare -A _ALREADY_SEEN=() # Array of successful updates or packages and their old/new version.
+declare -A _SUMMARY=()      # Updater codepath, package and dependency counts for the summary.
 
 # _fetch_and_cache_tags fetches all possible tags using termux_pkg_auto_update, but using Ninja build system.
 # The key difference is that we make the process concurrent, allowing us to fetch tags simultaneously rather than one at a time.
@@ -325,15 +327,16 @@ _fetch_and_cache_tags() {
 			;;
 		esac
 		_LATEST_TAGS["${pkg_name:-_}"]="$pkg_version"
+		(( _SUMMARY["total"]++ ))
 	done
 
 	echo "${CI:+::endgroup::}"
 
 	# Sum up results
-	echo "INFO: Fetched ${#LATEST_TAGS[*]} tags."
+	echo "INFO: Fetched ${_SUMMARY[total]} tags."
 	echo "INFO: GitHub - ${#LATEST_TAGS_GITHUB[*]}"
-	echo "INFO: Other  - $(( ${#LATEST_TAGS[*]} - ${#LATEST_TAGS_GITHUB[*]} ))"
-	echo "INFO: Cached - ${#_ALREADY_SEEN[*]}"
+	echo "INFO: Other  - $(( _SUMMARY[total] - ${#LATEST_TAGS_GITHUB[*]} ))"
+	echo "INFO: Cached - $(( _SUMMARY[total] - ${#__UNCACHED_PACKAGES[@]} ))"
 	if (( ${#__UNCACHED_PACKAGES[@]} )); then
 	printf '%s\n' \
 		"${CI:+::group::}INFO: Uncached - ${#__UNCACHED_PACKAGES[*]}" \
@@ -394,7 +397,7 @@ _run_update() {
 
 	# shellcheck disable=SC1091 # Ignore shellcheck's inability to follow the source
 	{
-	local _SRCURL _REGEXP _tag_type _update_method
+	local _SRCURL _REGEXP _tag_type _update_method _is_dependency
 	_CURRENT_VERSION="$(set +eu; . "$(realpath "$pkg_dir")/build.sh"; echo "${TERMUX_PKG_VERSION#*:}")"
 	_SRCURL="$(set +eu; . "$(realpath "$pkg_dir")/build.sh"; echo "${TERMUX_PKG_SRCURL}")"
 	_REGEXP="$(set +eu; . "$(realpath "$pkg_dir")/build.sh"; echo "${TERMUX_PKG_UPDATE_VERSION_REGEXP:-}")"
@@ -414,7 +417,18 @@ _run_update() {
 	fi
 
 	# Keep a running count for each of the methods
-	(( _UPDATE_METHODS["${_update_method}${_tag_type:+/}${_tag_type}"]++ ))
+	(( _SUMMARY["${_update_method}${_tag_type:+/}${_tag_type}"]++ ))
+
+
+	# If this package hasn't been seen before update the total.
+	if [[ -z ${_LATEST_TAGS[${pkg_name}]:-} ]]; then
+		(( _SUMMARY["total"]++ ))
+		# Check if this is running though _update_dependencies()
+		if [[ "${FUNCNAME[1]}" == '_update_dependencies' ]]; then
+			_is_dependency='(dependency)'
+			(( _SUMMARY["dependencies"]++ ))
+		fi
+	fi
 
 	# Ensure the FIFO is empty at the start of each update.
 	# This clears stale data from dependency checks, to prevent
@@ -588,22 +602,27 @@ exec {IPC_FIFO_FD}<&- # close the FIFO
 # Clean up our FIFO and repology data file
 rm "$IPC_FIFO" "$TERMUX_REPOLOGY_DATA_FILE"
 
+############################################CALCULATE CODEPATH SUMMARY###########################################
+
+for update_codepath in "${!_SUMMARY[@]}"; do
+	case "${update_codepath}" in
+		'dependencies'|'total');;
+		*)
+			printf -v codepaths '%s%-30s%s\n' \
+				"${codepaths:-}" \
+				"${update_codepath}:" \
+				"${_SUMMARY[$update_codepath]}"
+		;;
+	esac
+done
+
 #################################################REPORT CHANGES##################################################
 
-total="${#_ALREADY_SEEN[*]}"
-direct="$#"
-indirect="$(( total - direct ))"
-
 echo ""
-echo "SUMMARY: Checked ${total} packages - took $(ms_to_human_readable $(( $(date +%10s%3N) - _start_time ))) in total."
-echo "SUMMARY: ${direct} (Directly passed), ${indirect} (Dependencies)"
+echo "SUMMARY: Checked ${_SUMMARY[total]} packages - took $(ms_to_human_readable $(( $(date +%10s%3N) - _start_time ))) in total."
+echo "SUMMARY: $# (Directly passed), ${_SUMMARY[dependencies]} (Dependencies)"
 echo "SUMMARY: Update methods and release types."
-for variant in "${!_UPDATE_METHODS[@]}"; do
-    printf '%-30s%s\n' "${variant}:" "${_UPDATE_METHODS[$variant]}"
-done | sort
-echo
-# This expands to e.g. +12 +34 +56 +78, which then sums up.
-echo "total: $(( ${_UPDATE_METHODS[@]/#/+} ))"
+sort <<< "${codepaths}"
 echo ""
 echo "=================================================="
 echo ""
@@ -613,7 +632,7 @@ echo ""
 echo "SUMMARY: ${#_FAILED_UPDATES[*]} failed updates."
 echo "${!_FAILED_UPDATES[@]}"
 
-unset IPC_FIFO IPC_FIFO_FD _unix_millis _start_time _pkg total direct indirect variant
+unset IPC_FIFO IPC_FIFO_FD _unix_millis _start_time _pkg update_codepath codepaths
 
 ################################################FAILURE HANDLING#################################################
 

--- a/scripts/updates/termux_pkg_auto_update.sh
+++ b/scripts/updates/termux_pkg_auto_update.sh
@@ -3,6 +3,10 @@
 termux_pkg_get_update_method() {
 	local source_url="$1"
 
+	# shellcheck source=/dev/null
+	# If the package has an explicit $TERMUX_PKG_UPDATE_METHOD make sure we know about it.
+	TERMUX_PKG_UPDATE_METHOD="$(set +e +u; . "${TERMUX_PKG_BUILDER_DIR}/build.sh" &> /dev/null ; echo "${TERMUX_PKG_UPDATE_METHOD:-}")"
+
 	# Example:
 	# https://github.com/vim/vim/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 	#            _="https:"
@@ -26,7 +30,7 @@ termux_pkg_get_update_method() {
 			TERMUX_PKG_UPDATE_METHOD="repology"
 		fi
 	fi
-	printf '%s' "$TERMUX_PKG_UPDATE_METHOD"
+	printf '%s' "${TERMUX_PKG_UPDATE_METHOD}"
 }
 
 termux_pkg_auto_update() {


### PR DESCRIPTION
- fixes #29822, fixes #29823, fixes #29824, fixes #29825, fixes #29826, fixes #29827, fixes #29828, fixes #29829, fixes #29830, fixes #29831, fixes #29832, fixes #29833, fixes #29834, fixes #29835, fixes #29836, fixes #29837, fixes #29838.

<h1><em></em></h1> <!-- thin separator -->

`$TERMUX_PKG_UPDATE_METHOD` wasn't guaranteed to be passed along to `termux_pkg_get_update_method` so set it within the function itself to ensure explcit values for it are respected.
On that same note, `$TERMUX_PKG_UPDATE_TAG_TYPE` has no effect for the `repology` update method so don't try to guess it for that.

Also move `$_tag_type` and `$_update_method` out of the subshell in `_update()` so we can pass their values to `_update()` via the environment and log them as a count for the summary.

<h1><em></em></h1> <!-- thin separator -->

Further update issues found in the course of making this PR:
- `ltrace` moved to Gitlab, so we haven't actually been building any new versions of it past 0.7.9 while still incrementing the version number.
I've fixed up the build.
- `librewolf` was throwing an error due to the unused `$api_url_r` copied over from `firefox`'s update function.
(#29839)
- `xcape` is gone. Just gone. Not archived, just gone.
<sup>https://repology.org/project/xcape/information</sup>
Haven't done anything about it yet, just wanna note it.