### PR TITLE
fix(main/ty): fix `ty --version`

### DIFF
--- a/packages/ty/build.sh
+++ b/packages/ty/build.sh
@@ -1,6 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/astral-sh/ty
 TERMUX_PKG_DESCRIPTION="An extremely fast Python type checker and language server, written in Rust"
 TERMUX_PKG_VERSION="0.0.37"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="LICENSE"
 TERMUX_PKG_MAINTAINER="@termux"
@@ -9,6 +10,14 @@ TERMUX_PKG_SHA256=1fc7e5b92c254888963bb8603ccfaa404fcdfb3202cd22af0d09822934bef1
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 
+# The original "termux_extract_src_archive" always strips the first components
+# but the source of ty is directly under the root directory of the tar file
+termux_extract_src_archive() {
+	local file="$TERMUX_PKG_CACHEDIR/$(basename "$TERMUX_PKG_SRCURL")"
+	mkdir -p "$TERMUX_PKG_SRCDIR"
+	tar -xf "$file" -C "$TERMUX_PKG_SRCDIR"
+}
+
 termux_step_pre_configure() {
 	# when rust projects include a .cargo folder with their source code,
 	# attempting to cross-compile that code for android usually results in
@@ -16,6 +25,9 @@ termux_step_pre_configure() {
 	# varying depending on what content exactly was in .cargo.
 	# deleting .cargo first before doing anything else usually seems to prevent that.
 	rm -rf .cargo
+	TERMUX_PKG_SRCDIR+="/ruff"
+	TERMUX_PKG_BUILDDIR="$TERMUX_PKG_SRCDIR"
+	cd "$TERMUX_PKG_SRCDIR"
 
 	termux_setup_rust
 


### PR DESCRIPTION
- Previously, `ty` source code was built from the main source folder being merged into the `ruff` subfolder, causing a side effect of `ty --verson` showing `ty unknown`, which will be fixed by this.