### PR TITLE
fix(main/rsync): connection unexpectedly closed

### DIFF
--- a/packages/rsync/build.sh
+++ b/packages/rsync/build.sh
@@ -3,7 +3,8 @@ TERMUX_PKG_DESCRIPTION="Fast incremental file transfer utility"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
 TERMUX_PKG_VERSION="3.4.3"
-TERMUX_PKG_SRCURL=https://rsync.samba.org/ftp/rsync/src/rsync-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://rsync.samba.org/ftp/rsync/src/rsync-${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=c72e63ca3021cbc80ba86ec30102773f4c5631fbc492b52e773b3958f82a53d3
 TERMUX_PKG_DEPENDS="libiconv, liblz4, libpopt, openssh | dropbear, openssl, openssl-tool, xxhash, zlib, zstd"
 TERMUX_PKG_AUTO_UPDATE=true
@@ -15,7 +16,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --with-included-zlib=no
 --enable-ipv6=yes
 --disable-debug
---disable-simd
 --disable-xattr-support
 --enable-xxhash
 "

--- a/packages/rsync/syscall.c.patch
+++ b/packages/rsync/syscall.c.patch
@@ -1,0 +1,27 @@
+reverts the change in
+https://github.com/RsyncProject/rsync/commit/4fa7156ccdb2ad34b034d18fe2fd6cd79adef8a1
+that is causing https://github.com/RsyncProject/rsync/issues/904 and
+https://www.reddit.com/r/termux/comments/1tivbjl/rsync_errors_since_upgrade/
+
+diff --git a/syscall.c b/syscall.c
+index e317bcc..1e2897c 100644
+--- a/syscall.c
++++ b/syscall.c
+@@ -1691,7 +1691,7 @@ static int path_has_dotdot_component(const char *path)
+ 	return 0;
+ }
+ 
+-#ifdef __linux__
++#if 0
+ static int secure_relative_open_linux(const char *basedir, const char *relpath, int flags, mode_t mode)
+ {
+ 	struct open_how how;
+@@ -1791,7 +1791,7 @@ int secure_relative_open(const char *basedir, const char *relpath, int flags, mo
+ 		return -1;
+ 	}
+ 
+-#ifdef __linux__
++#if 0
+ 	{
+ 		int fd = secure_relative_open_linux(basedir, relpath, flags, mode);
+ 		/* ENOSYS = kernel < 5.6 doesn't have the syscall even though


### PR DESCRIPTION
rsync recetly introduced a regression in this commit https://github.com/RsyncProject/rsync/commit/4fa7156ccdb2ad34b034d18fe2fd6cd79adef8a1, this includes a minimal patch to fix it

<img width="1920" height="1080" alt="Screenshot_20260524_000224_niri" src="https://github.com/user-attachments/assets/eb9cbaa1-7c18-47e0-8429-1a827f15604f" />

also removed `--disable-simd` because of the following warning:
```
configure.sh: WARNING: unrecognized options: --disable-simd
```