### PR TITLE
fix(main/fish): add manpages and documentation when installing

### DIFF
--- a/packages/fish/build.sh
+++ b/packages/fish/build.sh
@@ -3,21 +3,42 @@ TERMUX_PKG_DESCRIPTION="The user-friendly command line shell"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="4.7.1"
-TERMUX_PKG_SRCURL=https://github.com/fish-shell/fish-shell/releases/download/$TERMUX_PKG_VERSION/fish-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://github.com/fish-shell/fish-shell/releases/download/$TERMUX_PKG_VERSION/fish-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=6f4d5b438a6338e3f5dcda19a28261e2ece7a9b7ff97686685e6abdc31dbb7df
 # fish calls 'tput' from ncurses-utils, at least when cancelling (Ctrl+C) a command line.
 # man is needed since fish calls apropos during command completion.
 TERMUX_PKG_DEPENDS="bc, libandroid-support, libc++, mandoc, ncurses, ncurses-utils, pcre2"
+TERMUX_PKG_BUILD_DEPENDS="python"
+TERMUX_PKG_PYTHON_COMMON_BUILD_DEPS="sphinx"
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
--DWITH_DOCS=OFF
 -DFISH_USE_SYSTEM_PCRE2=ON
 -DMAC_CODESIGN_ID=OFF
 -DWITH_MESSAGE_LOCALIZATION=OFF
 "
 TERMUX_PKG_AUTO_UPDATE=true
 
+termux_step_host_build() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "true" ]]; then
+		return
+	fi
+
+	termux_setup_cmake
+	termux_setup_ninja
+	termux_setup_rust
+
+	mkdir "$TERMUX_PKG_SRCDIR/build"
+	pushd "$TERMUX_PKG_SRCDIR/build"
+	cmake .. -GNinja -DWITH_DOCS=ON -DCMAKE_INSTALL_PREFIX="$TERMUX_PREFIX"
+	ninja -j "$TERMUX_PKG_MAKE_PROCESSES" install
+	popd
+}
+
 termux_step_pre_configure() {
+	rm -rf "$TERMUX_HOSTBUILD_MARKER"
+
 	termux_setup_cmake
 	termux_setup_ninja
 	termux_setup_rust
@@ -34,8 +55,16 @@ termux_step_pre_configure() {
 	# cmake invokes rustc directly leaving CARGO_TARGET_*_RUSTFLAGS unused
 	local -u env_host="${CARGO_TARGET_NAME//-/_}"
 	export RUSTFLAGS=$(env | grep CARGO_TARGET_${env_host}_RUSTFLAGS | cut -d'=' -f2-)
-	RUSTFLAGS+=" -C link-arg=-landroid-spawn"
+	# enable if libandroid-spawn is tested with fish in the future
+	# and confirmed to start working again
+	#RUSTFLAGS+=" -C link-arg=-landroid-spawn"
 	RUSTFLAGS+=" -L${TERMUX_PKG_BUILDDIR} -C link-arg=-l:libctermid.a"
+
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "true" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DWITH_DOCS=ON"
+	else
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DWITH_DOCS=OFF"
+	fi
 }
 
 termux_step_post_make_install() {


### PR DESCRIPTION
the fish package lacks manpages, this pr adds them back

[this commit](https://github.com/termux/termux-packages/commit/89b32a4bda37bd1ca713a5080c4b5f68746de34c) turned them off but i couldnt find a reason for it

adds python package `sphinx` that is used to generate the docs

<img width="1080" height="947" alt="Screenshot_20260422_183829_Termux" src="https://github.com/user-attachments/assets/44815bd1-a23d-4e05-8011-9951fed06f3e" />
