### PR TITLE
new -j flag to prevent oom on device

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -524,6 +524,8 @@ _show_usage() {
 	echo "  -F Force build even if package and its dependencies have already been built."
 	[[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]] && echo "  -i Download and extract dependencies instead of building them."
 	echo "  -I Download and extract dependencies instead of building them, keep existing $TERMUX_BASE_DIR files."
+	echo "  -j <N> Number of threads. (default or 0, N = \`nproc\` = $(nproc))"
+	echo "         Can also be passed combined, e.g. '-j12'."
 	echo "  -L The package and its dependencies will be based on the same library."
 	echo "  -q Quiet build."
 	echo "  -Q Loud build -- set -x debug output and function tracing."
@@ -583,6 +585,21 @@ while (( $# )); do
 		-I)
 			export TERMUX_INSTALL_DEPS=true
 			export TERMUX_PKGS__BUILD__RM_ALL_PKGS_BUILT_MARKER_AND_INSTALL_FILES=false
+		;;
+		-j|-j[0-9]*)
+			# If we got the 2 arg form discard the "-j".
+			[[ "$1" == "-j" && "${2:-}" == [0-9]* ]] && shift 1
+			# Check that -j's argument exists and is numeric.
+			[[ -n "${1/-j}" && "${1/-j}" =~ ^[0-9]+$ ]] || termux_error_exit "./build-package.sh: option '-j' only takes integers"
+
+			# Assign the requested number of threads.
+			# If the result is 0 or negative then default to `nproc`
+			TERMUX_PKG_MAKE_PROCESSES="${1/-j}"
+			if (( TERMUX_PKG_MAKE_PROCESSES < 1 )); then
+				TERMUX_PKG_MAKE_PROCESSES="$(nproc)"
+			fi
+
+			export TERMUX_PKG_MAKE_PROCESSES
 		;;
 		-L) export TERMUX_GLOBAL_LIBRARY=true;;
 		-q) export TERMUX_QUIET_BUILD=true;;

--- a/build-package.sh
+++ b/build-package.sh
@@ -515,14 +515,14 @@ _show_usage() {
 	echo "Build a package by creating a .deb file in the output/ folder."
 	echo
 	echo "Available options:"
-	[[ "$TERMUX_ON_DEVICE_BUILD" = "false" ]] && echo "  -a The architecture to build for: aarch64(default), arm, i686, x86_64 or all."
+	[[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]] && echo "  -a The architecture to build for: aarch64(default), arm, i686, x86_64 or all."
 	echo "  -c Continue previous build."
 	echo "  -C Cleanup already built packages on low disk space."
 	echo "  -d Build with debug symbols."
 	echo "  -D Build a disabled package in disabled-packages/."
 	echo "  -f Force build even if package has already been built."
 	echo "  -F Force build even if package and its dependencies have already been built."
-	[[ "$TERMUX_ON_DEVICE_BUILD" = "false" ]] && echo "  -i Download and extract dependencies instead of building them."
+	[[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]] && echo "  -i Download and extract dependencies instead of building them."
 	echo "  -I Download and extract dependencies instead of building them, keep existing $TERMUX_BASE_DIR files."
 	echo "  -L The package and its dependencies will be based on the same library."
 	echo "  -q Quiet build."
@@ -632,7 +632,7 @@ if [[ -n "${TERMUX_PACKAGE_LIBRARY-}" ]]; then
 	esac
 fi
 
-if [[ "${TERMUX_INSTALL_DEPS-false}" = "true" || "${TERMUX_PACKAGE_LIBRARY-bionic}" = "glibc" ]]; then
+if [[ "${TERMUX_INSTALL_DEPS-false}" == "true" || "${TERMUX_PACKAGE_LIBRARY-bionic}" == "glibc" ]]; then
 	# Setup PGP keys for verifying integrity of dependencies.
 	# Keys are obtained from our keyring package.
 	gpg --list-keys 2C7F29AE97891F6419A9E2CDB0076E490B71616B > /dev/null 2>&1 || {
@@ -776,7 +776,7 @@ for (( i=0; i < ${#PACKAGE_LIST[@]}; i++ )); do
 		cd "$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX_CLASSICAL"
 		termux_step_post_massage
 		# At the final stage (when the package is archiving) it is better to use commands from the system
-		if [[ "$TERMUX_ON_DEVICE_BUILD" = "false" ]]; then
+		if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
 			export PATH="/usr/bin:$PATH"
 		fi
 		cd "$TERMUX_PKG_MASSAGEDIR"


### PR DESCRIPTION
new default on device is -j1

to prevent system stall the oom culprit has to be closed immediately

this is exactly contrary to how android works because child apps are not under direct control of lmk

it will first close a plethora of background apps before closing foreground app

after that it's up to the system to finally close the culprit which is an unmanaged  child of the foreground app or tmux server under init

this is slow enough that a system stall is possible

with bad luck : hard reset leave disk in inconsistent state . boot failure . system reset . dropped user partition . all files gone
