### PR TITLE
enhance(main/zsh): vendor PCRE2 patch and build script cleanup

### DIFF
--- a/packages/zsh/backport-pcre2-support.patch
+++ b/packages/zsh/backport-pcre2-support.patch
@@ -1,0 +1,709 @@
+From 65a07a2df5c09da7b00bb76888ded40e916eb25b Mon Sep 17 00:00:00 2001
+From: Jun-ichi Takimoto <takimoto-j@kba.biglobe.ne.jp>
+Date: Mon, 26 Sep 2022 10:52:50 +0900
+Subject: [PATCH 1/3] 50658 + test: Enable to switch between C/UTF-8 locales in
+ PCRE
+
+(cherry picked from commit 1b421e4978440234fb73117c8505dad1ccc68d46)
+---
+ Src/Modules/pcre.c | 10 ++--------
+ Test/V07pcre.ztst  | 11 +++++++++++
+ 2 files changed, 13 insertions(+), 8 deletions(-)
+
+diff --git a/Src/Modules/pcre.c b/Src/Modules/pcre.c
+index 6289e003e..46875a59b 100644
+--- a/Src/Modules/pcre.c
++++ b/Src/Modules/pcre.c
+@@ -47,8 +47,6 @@ zpcre_utf8_enabled(void)
+ #if defined(MULTIBYTE_SUPPORT) && defined(HAVE_NL_LANGINFO) && defined(CODESET)
+     static int have_utf8_pcre = -1;
+ 
+-    /* value can toggle based on MULTIBYTE, so don't
+-     * be too eager with caching */
+     if (have_utf8_pcre < -1)
+ 	return 0;
+ 
+@@ -56,15 +54,11 @@ zpcre_utf8_enabled(void)
+ 	return 0;
+ 
+     if ((have_utf8_pcre == -1) &&
+-        (!strcmp(nl_langinfo(CODESET), "UTF-8"))) {
+-
+-	if (pcre_config(PCRE_CONFIG_UTF8, &have_utf8_pcre))
++	(pcre_config(PCRE_CONFIG_UTF8, &have_utf8_pcre))) {
+ 	    have_utf8_pcre = -2; /* erk, failed to ask */
+     }
+ 
+-    if (have_utf8_pcre < 0)
+-	return 0;
+-    return have_utf8_pcre;
++    return (have_utf8_pcre == 1) && (!strcmp(nl_langinfo(CODESET), "UTF-8"));
+ 
+ #else
+     return 0;
+diff --git a/Test/V07pcre.ztst b/Test/V07pcre.ztst
+index c9c844d2a..ca35d43f0 100644
+--- a/Test/V07pcre.ztst
++++ b/Test/V07pcre.ztst
+@@ -174,3 +174,14 @@
+     echo $match[2] )
+ 0:regression for segmentation fault, workers/38307
+ >test
++
++  LANG_SAVE=$LANG
++  [[ é =~ '^.\z' ]]; echo $?
++  LANG=C
++  [[ é =~ '^..\z' ]]; echo $?
++  LANG=$LANG_SAVE
++  [[ é =~ '^.\z' ]]; echo $?
++0:swich between C/UTF-8 locales
++>0
++>0
++>0
+-- 
+2.44.0
+
+
+From 0b65930705edd7507f7f6ad100bf29745796a7cf Mon Sep 17 00:00:00 2001
+From: Oliver Kiddle <opk@zsh.org>
+Date: Sat, 13 May 2023 00:53:32 +0200
+Subject: [PATCH 2/3] 51723: migrate pcre module to pcre2
+
+(cherry picked from commit b62e911341c8ec7446378b477c47da4256053dc0)
+---
+ Src/Modules/pcre.c | 223 ++++++++++++++++++---------------------------
+ Test/V07pcre.ztst  |  13 ++-
+ configure.ac       |  20 ++--
+ 3 files changed, 107 insertions(+), 149 deletions(-)
+
+diff --git a/Src/Modules/pcre.c b/Src/Modules/pcre.c
+index 46875a59b..079ecc2c5 100644
+--- a/Src/Modules/pcre.c
++++ b/Src/Modules/pcre.c
+@@ -34,11 +34,11 @@
+ #define CPCRE_PLAIN 0
+ 
+ /**/
+-#if defined(HAVE_PCRE_COMPILE) && defined(HAVE_PCRE_EXEC)
+-#include <pcre.h>
++#if defined(HAVE_PCRE2_COMPILE_8) && defined(HAVE_PCRE2_H)
++#define PCRE2_CODE_UNIT_WIDTH 8
++#include <pcre2.h>
+ 
+-static pcre *pcre_pattern;
+-static pcre_extra *pcre_hints;
++static pcre2_code *pcre_pattern;
+ 
+ /**/
+ static int
+@@ -54,8 +54,8 @@ zpcre_utf8_enabled(void)
+ 	return 0;
+ 
+     if ((have_utf8_pcre == -1) &&
+-	(pcre_config(PCRE_CONFIG_UTF8, &have_utf8_pcre))) {
+-	    have_utf8_pcre = -2; /* erk, failed to ask */
++       (pcre2_config(PCRE2_CONFIG_UNICODE, &have_utf8_pcre))) {
++           have_utf8_pcre = -2; /* erk, failed to ask */
+     }
+ 
+     return (have_utf8_pcre == 1) && (!strcmp(nl_langinfo(CODESET), "UTF-8"));
+@@ -69,115 +69,87 @@ zpcre_utf8_enabled(void)
+ static int
+ bin_pcre_compile(char *nam, char **args, Options ops, UNUSED(int func))
+ {
+-    int pcre_opts = 0, pcre_errptr, target_len;
+-    const char *pcre_error;
++    uint32_t pcre_opts = 0;
++    int target_len;
++    int pcre_error;
++    PCRE2_SIZE pcre_offset;
+     char *target;
+     
+-    if(OPT_ISSET(ops,'a')) pcre_opts |= PCRE_ANCHORED;
+-    if(OPT_ISSET(ops,'i')) pcre_opts |= PCRE_CASELESS;
+-    if(OPT_ISSET(ops,'m')) pcre_opts |= PCRE_MULTILINE;
+-    if(OPT_ISSET(ops,'x')) pcre_opts |= PCRE_EXTENDED;
+-    if(OPT_ISSET(ops,'s')) pcre_opts |= PCRE_DOTALL;
++    if (OPT_ISSET(ops, 'a')) pcre_opts |= PCRE2_ANCHORED;
++    if (OPT_ISSET(ops, 'i')) pcre_opts |= PCRE2_CASELESS;
++    if (OPT_ISSET(ops, 'm')) pcre_opts |= PCRE2_MULTILINE;
++    if (OPT_ISSET(ops, 'x')) pcre_opts |= PCRE2_EXTENDED;
++    if (OPT_ISSET(ops, 's')) pcre_opts |= PCRE2_DOTALL;
+     
+     if (zpcre_utf8_enabled())
+-	pcre_opts |= PCRE_UTF8;
+-
+-#ifdef HAVE_PCRE_STUDY
+-    if (pcre_hints)
+-#ifdef PCRE_CONFIG_JIT
+-	pcre_free_study(pcre_hints);
+-#else
+-	pcre_free(pcre_hints);
+-#endif
+-    pcre_hints = NULL;
+-#endif
++	pcre_opts |= PCRE2_UTF;
+ 
+     if (pcre_pattern)
+-	pcre_free(pcre_pattern);
++	pcre2_code_free(pcre_pattern);
+     pcre_pattern = NULL;
+ 
+     target = ztrdup(*args);
+     unmetafy(target, &target_len);
+ 
+-    if ((int)strlen(target) != target_len) {
+-	zwarnnam(nam, "embedded NULs in PCRE pattern terminate pattern");
+-    }
+-
+-    pcre_pattern = pcre_compile(target, pcre_opts, &pcre_error, &pcre_errptr, NULL);
++    pcre_pattern = pcre2_compile((PCRE2_SPTR) target, (PCRE2_SIZE) target_len,
++	    pcre_opts, &pcre_error, &pcre_offset, NULL);
+ 
+     free(target);
+ 
+     if (pcre_pattern == NULL)
+     {
+-	zwarnnam(nam, "error in regex: %s", pcre_error);
++	PCRE2_UCHAR buffer[256];
++	pcre2_get_error_message(pcre_error, buffer, sizeof(buffer));
++	zwarnnam(nam, "error in regex: %s", buffer);
+ 	return 1;
+     }
+     
+     return 0;
+ }
+ 
+-/**/
+-#ifdef HAVE_PCRE_STUDY
+-
+ /**/
+ static int
+ bin_pcre_study(char *nam, UNUSED(char **args), UNUSED(Options ops), UNUSED(int func))
+ {
+-    const char *pcre_error;
+-
+     if (pcre_pattern == NULL)
+     {
+ 	zwarnnam(nam, "no pattern has been compiled for study");
+ 	return 1;
+     }
+-    
+-    if (pcre_hints)
+-#ifdef PCRE_CONFIG_JIT
+-	pcre_free_study(pcre_hints);
+-#else
+-	pcre_free(pcre_hints);
+-#endif
+-    pcre_hints = NULL;
+ 
+-    pcre_hints = pcre_study(pcre_pattern, 0, &pcre_error);
+-    if (pcre_error != NULL)
+-    {
+-	zwarnnam(nam, "error while studying regex: %s", pcre_error);
+-	return 1;
++    int jit = 0;
++    if (!pcre2_config(PCRE2_CONFIG_JIT, &jit) && jit) {
++	if (pcre2_jit_compile(pcre_pattern, PCRE2_JIT_COMPLETE) < 0) {
++	    zwarnnam(nam, "error while studying regex");
++	    return 1;
++	}
+     }
+     
+     return 0;
+ }
+ 
+-/**/
+-#else /* !HAVE_PCRE_STUDY */
+-
+-# define bin_pcre_study bin_notavail
+-
+-/**/
+-#endif /* !HAVE_PCRE_STUDY */
+-
+-/**/
+ static int
+-zpcre_get_substrings(char *arg, int *ovec, int captured_count, char *matchvar,
+-		     char *substravar, int want_offset_pair, int matchedinarr,
+-		     int want_begin_end)
++zpcre_get_substrings(char *arg, pcre2_match_data *mdata, int captured_count,
++	char *matchvar, char *substravar, int want_offset_pair,
++	int matchedinarr, int want_begin_end)
+ {
+-    char **captures, *match_all, **matches;
++    PCRE2_SIZE *ovec;
++    char *match_all, **matches;
+     char offset_all[50];
+     int capture_start = 1;
+ 
+     if (matchedinarr) {
+-	/* bash-style captures[0] entire-matched string in the array */
++	/* bash-style ovec[0] entire-matched string in the array */
+ 	capture_start = 0;
+     }
+ 
+-    /* captures[0] will be entire matched string, [1] first substring */
+-    if (!pcre_get_substring_list(arg, ovec, captured_count, (const char ***)&captures)) {
+-	int nelem = arrlen(captures)-1;
++    /* ovec[0] will be entire matched string, [1] first substring */
++    ovec = pcre2_get_ovector_pointer(mdata);
++    if (ovec) {
++	int nelem = captured_count - 1;
+ 	/* Set to the offsets of the complete match */
+ 	if (want_offset_pair) {
+-	    sprintf(offset_all, "%d %d", ovec[0], ovec[1]);
++	    sprintf(offset_all, "%ld %ld", ovec[0], ovec[1]);
+ 	    setsparam("ZPCRE_OP", ztrdup(offset_all));
+ 	}
+ 	/*
+@@ -186,7 +158,7 @@ zpcre_get_substrings(char *arg, int *ovec, int captured_count, char *matchvar,
+ 	 * ovec is length 2*(1+capture_list_length)
+ 	 */
+ 	if (matchvar) {
+-	    match_all = metafy(captures[0], ovec[1] - ovec[0], META_DUP);
++	    match_all = metafy(arg + ovec[0], ovec[1] - ovec[0], META_DUP);
+ 	    setsparam(matchvar, match_all);
+ 	}
+ 	/*
+@@ -201,16 +173,12 @@ zpcre_get_substrings(char *arg, int *ovec, int captured_count, char *matchvar,
+ 	 */
+ 	if (substravar &&
+ 	    (!want_begin_end || nelem)) {
+-	    char **x, **y;
++	    char **x;
+ 	    int vec_off, i;
+-	    y = &captures[capture_start];
+ 	    matches = x = (char **) zalloc(sizeof(char *) * (captured_count+1-capture_start));
+-	    for (i = capture_start; i < captured_count; i++, y++) {
++	    for (i = capture_start; i < captured_count; i++) {
+ 		vec_off = 2*i;
+-		if (*y)
+-		    *x++ = metafy(*y, ovec[vec_off+1]-ovec[vec_off], META_DUP);
+-		else
+-		    *x++ = NULL;
++		*x++ = metafy(arg + ovec[vec_off], ovec[vec_off+1]-ovec[vec_off], META_DUP);
+ 	    }
+ 	    *x = NULL;
+ 	    setaparam(substravar, matches);
+@@ -247,7 +215,8 @@ zpcre_get_substrings(char *arg, int *ovec, int captured_count, char *matchvar,
+ 	    setiparam("MEND", offs + !isset(KSHARRAYS) - 1);
+ 	    if (nelem) {
+ 		char **mbegin, **mend, **bptr, **eptr;
+-		int i, *ipair;
++		int i;
++		size_t *ipair;
+ 
+ 		bptr = mbegin = zalloc(sizeof(char*)*(nelem+1));
+ 		eptr = mend = zalloc(sizeof(char*)*(nelem+1));
+@@ -287,8 +256,6 @@ zpcre_get_substrings(char *arg, int *ovec, int captured_count, char *matchvar,
+ 		setaparam("mend", mend);
+ 	    }
+ 	}
+-
+-	pcre_free_substring_list((const char **)captures);
+     }
+ 
+     return 0;
+@@ -314,7 +281,8 @@ getposint(char *instr, char *nam)
+ static int
+ bin_pcre_match(char *nam, char **args, Options ops, UNUSED(int func))
+ {
+-    int ret, capcount, *ovec, ovecsize, c;
++    int ret, c;
++    pcre2_match_data *pcre_mdata = NULL;
+     char *matched_portion = NULL;
+     char *plaintext = NULL;
+     char *receptacle = NULL;
+@@ -344,36 +312,30 @@ bin_pcre_match(char *nam, char **args, Options ops, UNUSED(int func))
+     /* For the entire match, 'Return' the offset byte positions instead of the matched string */
+     if(OPT_ISSET(ops,'b')) want_offset_pair = 1;
+ 
+-    if ((ret = pcre_fullinfo(pcre_pattern, pcre_hints, PCRE_INFO_CAPTURECOUNT, &capcount)))
+-    {
+-	zwarnnam(nam, "error %d in fullinfo", ret);
+-	return 1;
+-    }
+-
+-    ovecsize = (capcount+1)*3;
+-    ovec = zalloc(ovecsize*sizeof(int));
+-
+     plaintext = ztrdup(*args);
+     unmetafy(plaintext, &subject_len);
+ 
+     if (offset_start > 0 && offset_start >= subject_len)
+-	ret = PCRE_ERROR_NOMATCH;
+-    else
+-	ret = pcre_exec(pcre_pattern, pcre_hints, plaintext, subject_len, offset_start, 0, ovec, ovecsize);
++	ret = PCRE2_ERROR_NOMATCH;
++    else {
++	pcre_mdata = pcre2_match_data_create_from_pattern(pcre_pattern, NULL);
++	ret = pcre2_match(pcre_pattern, (PCRE2_SPTR) plaintext, subject_len,
++		offset_start, 0, pcre_mdata, NULL);
++    }
+ 
+     if (ret==0) return_value = 0;
+-    else if (ret==PCRE_ERROR_NOMATCH) /* no match */;
++    else if (ret == PCRE2_ERROR_NOMATCH) /* no match */;
+     else if (ret>0) {
+-	zpcre_get_substrings(plaintext, ovec, ret, matched_portion, receptacle,
++	zpcre_get_substrings(plaintext, pcre_mdata, ret, matched_portion, receptacle,
+ 			     want_offset_pair, 0, 0);
+ 	return_value = 0;
+     }
+     else {
+-	zwarnnam(nam, "error in pcre_exec [%d]", ret);
++	zwarnnam(nam, "error in pcre2_match [%d]", ret);
+     }
+     
+-    if (ovec)
+-	zfree(ovec, ovecsize*sizeof(int));
++    if (pcre_mdata)
++	pcre2_match_data_free(pcre_mdata);
+     zsfree(plaintext);
+ 
+     return return_value;
+@@ -383,17 +345,19 @@ bin_pcre_match(char *nam, char **args, Options ops, UNUSED(int func))
+ static int
+ cond_pcre_match(char **a, int id)
+ {
+-    pcre *pcre_pat;
+-    const char *pcre_err;
++    pcre2_code *pcre_pat = NULL;
++    int pcre_err;
++    PCRE2_SIZE pcre_erroff;
+     char *lhstr, *rhre, *lhstr_plain, *rhre_plain, *avar, *svar;
+-    int r = 0, pcre_opts = 0, pcre_errptr, capcnt, *ov, ovsize;
++    int r = 0, pcre_opts = 0;
++    pcre2_match_data *pcre_mdata = NULL;
+     int lhstr_plain_len, rhre_plain_len;
+     int return_value = 0;
+ 
+     if (zpcre_utf8_enabled())
+-	pcre_opts |= PCRE_UTF8;
++	pcre_opts |= PCRE2_UTF;
+     if (isset(REMATCHPCRE) && !isset(CASEMATCH))
+-	pcre_opts |= PCRE_CASELESS;
++	pcre_opts |= PCRE2_CASELESS;
+ 
+     lhstr = cond_str(a,0,0);
+     rhre = cond_str(a,1,0);
+@@ -401,9 +365,6 @@ cond_pcre_match(char **a, int id)
+     rhre_plain = ztrdup(rhre);
+     unmetafy(lhstr_plain, &lhstr_plain_len);
+     unmetafy(rhre_plain, &rhre_plain_len);
+-    pcre_pat = NULL;
+-    ov = NULL;
+-    ovsize = 0;
+ 
+     if (isset(BASHREMATCH)) {
+ 	svar = NULL;
+@@ -415,27 +376,27 @@ cond_pcre_match(char **a, int id)
+ 
+     switch(id) {
+ 	 case CPCRE_PLAIN:
+-		if ((int)strlen(rhre_plain) != rhre_plain_len) {
+-		    zwarn("embedded NULs in PCRE pattern terminate pattern");
+-		}
+-		pcre_pat = pcre_compile(rhre_plain, pcre_opts, &pcre_err, &pcre_errptr, NULL);
+-		if (pcre_pat == NULL) {
+-		    zwarn("failed to compile regexp /%s/: %s", rhre, pcre_err);
++		if (!(pcre_pat = pcre2_compile((PCRE2_SPTR) rhre_plain,
++			(PCRE2_SIZE) rhre_plain_len, pcre_opts,
++			&pcre_err, &pcre_erroff, NULL)))
++		{
++		    PCRE2_UCHAR buffer[256];
++		    pcre2_get_error_message(pcre_err, buffer, sizeof(buffer));
++		    zwarn("failed to compile regexp /%s/: %s", rhre, buffer);
+ 		    break;
+ 		}
+-                pcre_fullinfo(pcre_pat, NULL, PCRE_INFO_CAPTURECOUNT, &capcnt);
+-    		ovsize = (capcnt+1)*3;
+-		ov = zalloc(ovsize*sizeof(int));
+-    		r = pcre_exec(pcre_pat, NULL, lhstr_plain, lhstr_plain_len, 0, 0, ov, ovsize);
+-		/* r < 0 => error; r==0 match but not enough size in ov
++		pcre_mdata = pcre2_match_data_create_from_pattern(pcre_pat, NULL);
++		r = pcre2_match(pcre_pat, (PCRE2_SPTR8) lhstr_plain, lhstr_plain_len,
++			0, 0, pcre_mdata, NULL);
++		/* r < 0 => error; r==0 match but not enough size in match data
+ 		 * r > 0 => (r-1) substrings found; r==1 => no substrings
+ 		 */
+     		if (r==0) {
+-		    zwarn("reportable zsh problem: pcre_exec() returned 0");
++		    zwarn("reportable zsh problem: pcre2_match() returned 0");
+ 		    return_value = 1;
+ 		    break;
+ 		}
+-	        else if (r==PCRE_ERROR_NOMATCH) {
++		else if (r == PCRE2_ERROR_NOMATCH) {
+ 		    return_value = 0; /* no match */
+ 		    break;
+ 		}
+@@ -444,7 +405,7 @@ cond_pcre_match(char **a, int id)
+ 		    break;
+ 		}
+                 else if (r>0) {
+-		    zpcre_get_substrings(lhstr_plain, ov, r, svar, avar, 0,
++		    zpcre_get_substrings(lhstr_plain, pcre_mdata, r, svar, avar, 0,
+ 					 isset(BASHREMATCH),
+ 					 !isset(BASHREMATCH));
+ 		    return_value = 1;
+@@ -457,10 +418,10 @@ cond_pcre_match(char **a, int id)
+ 	free(lhstr_plain);
+     if(rhre_plain)
+ 	free(rhre_plain);
++    if (pcre_mdata)
++	pcre2_match_data_free(pcre_mdata);
+     if (pcre_pat)
+-	pcre_free(pcre_pat);
+-    if (ov)
+-	zfree(ov, ovsize*sizeof(int));
++	pcre2_code_free(pcre_pat);
+ 
+     return return_value;
+ }
+@@ -489,11 +450,11 @@ static struct builtin bintab[] = {
+ 
+ static struct features module_features = {
+     bintab, sizeof(bintab)/sizeof(*bintab),
+-#if defined(HAVE_PCRE_COMPILE) && defined(HAVE_PCRE_EXEC)
++#if defined(HAVE_PCRE2_COMPILE_8) && defined(HAVE_PCRE2_H)
+     cotab, sizeof(cotab)/sizeof(*cotab),
+-#else /* !(HAVE_PCRE_COMPILE && HAVE_PCRE_EXEC) */
++#else /* !(HAVE_PCRE2_COMPILE_8 && HAVE_PCRE2_H) */
+     NULL, 0,
+-#endif /* !(HAVE_PCRE_COMPILE && HAVE_PCRE_EXEC) */
++#endif /* !(HAVE_PCRE2_COMPILE_8 && HAVE_PCRE2_H) */
+     NULL, 0,
+     NULL, 0,
+     0
+@@ -540,19 +501,9 @@ cleanup_(Module m)
+ int
+ finish_(UNUSED(Module m))
+ {
+-#if defined(HAVE_PCRE_COMPILE) && defined(HAVE_PCRE_EXEC)
+-#ifdef HAVE_PCRE_STUDY
+-    if (pcre_hints)
+-#ifdef PCRE_CONFIG_JIT
+-	pcre_free_study(pcre_hints);
+-#else
+-	pcre_free(pcre_hints);
+-#endif
+-    pcre_hints = NULL;
+-#endif
+-
++#if defined(HAVE_PCRE2_COMPILE_8) && defined(HAVE_PCRE2_H)
+     if (pcre_pattern)
+-	pcre_free(pcre_pattern);
++	pcre2_code_free(pcre_pattern);
+     pcre_pattern = NULL;
+ #endif
+ 
+diff --git a/Test/V07pcre.ztst b/Test/V07pcre.ztst
+index ca35d43f0..0129ddc94 100644
+--- a/Test/V07pcre.ztst
++++ b/Test/V07pcre.ztst
+@@ -129,12 +129,17 @@
+ >78884; ZPCRE_OP: 25 30
+ >90210; ZPCRE_OP: 31 36
+ 
+-# Embedded NULs allowed in plaintext, but not in RE (although \0 as two-chars allowed)
++# Embedded NULs allowed in plaintext, in RE, pcre supports \0 as two-chars
+   [[ $'a\0bc\0d' =~ '^(a\0.)(.+)$' ]]
+   print "${#MATCH}; ${#match[1]}; ${#match[2]}"
+ 0:ensure ASCII NUL passes in and out of matched plaintext
+ >6; 3; 3
+ 
++# PCRE2 supports NULs also in the RE
++  [[ $'a\0b\0c' =~ $'^(.\0)+' ]] && print "${#MATCH}; ${#match[1]}"
++0:ensure ASCII NUL works also in the regex
++>4; 2
++
+ # Ensure the long-form infix operator works
+   [[ foo -pcre-match ^f..$ ]]
+   print $?
+@@ -181,7 +186,11 @@
+   [[ é =~ '^..\z' ]]; echo $?
+   LANG=$LANG_SAVE
+   [[ é =~ '^.\z' ]]; echo $?
+-0:swich between C/UTF-8 locales
++0:switch between C/UTF-8 locales
+ >0
+ >0
+ >0
++
++  [[ abc =~ 'a(d*)bc' ]] && print "$#MATCH; $#match; ${#match[1]}"
++0:empty capture
++>3; 1; 0
+diff --git a/configure.ac b/configure.ac
+index c72148d06..7238639f1 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -438,7 +438,7 @@ fi],
+ 
+ dnl Do you want to look for pcre support?
+ AC_ARG_ENABLE(pcre,
+-AS_HELP_STRING([--enable-pcre],[enable the search for the pcre library (may create run-time library dependencies)]))
++AS_HELP_STRING([--enable-pcre],[enable the search for the pcre2 library (may create run-time library dependencies)]))
+ 
+ dnl Do you want to look for capability support?
+ AC_ARG_ENABLE(cap,
+@@ -662,13 +662,12 @@ AC_HEADER_SYS_WAIT
+ 
+ oldcflags="$CFLAGS"
+ if test x$enable_pcre = xyes; then
+-AC_CHECK_PROG([PCRECONF], pcre-config, pcre-config)
+-dnl Typically (meaning on this single RedHat 9 box in front of me)
+-dnl pcre-config --cflags produces a -I output which needs to go into
++AC_CHECK_PROG([PCRECONF], pcre2-config, pcre2-config)
++dnl pcre2-config --cflags may produce a -I output which needs to go into
+ dnl CPPFLAGS else configure's preprocessor tests don't pick it up,
+ dnl producing a warning.
+-if test "x$ac_cv_prog_PCRECONF" = xpcre-config; then
+-  CPPFLAGS="$CPPFLAGS `pcre-config --cflags`"
++if test "x$ac_cv_prog_PCRECONF" = xpcre2-config; then
++  CPPFLAGS="$CPPFLAGS `pcre2-config --cflags`"
+ fi
+ fi
+ 
+@@ -678,9 +677,10 @@ AC_CHECK_HEADERS(sys/time.h sys/times.h sys/select.h termcap.h termio.h \
+ 		 locale.h errno.h stdio.h stdarg.h varargs.h stdlib.h \
+ 		 unistd.h sys/capability.h \
+ 		 utmp.h utmpx.h sys/types.h pwd.h grp.h poll.h sys/mman.h \
+-		 netinet/in_systm.h pcre.h langinfo.h wchar.h stddef.h \
++		 netinet/in_systm.h langinfo.h wchar.h stddef.h \
+ 		 sys/stropts.h iconv.h ncurses.h ncursesw/ncurses.h \
+ 		 ncurses/ncurses.h)
++AC_CHECK_HEADERS([pcre2.h],,,[#define PCRE2_CODE_UNIT_WIDTH 8])
+ if test x$dynamic = xyes; then
+   AC_CHECK_HEADERS(dlfcn.h)
+   AC_CHECK_HEADERS(dl.h)
+@@ -958,9 +958,7 @@ if test "x$ac_found_iconv" = "xyes"; then
+ fi
+ 
+ if test x$enable_pcre = xyes; then
+-dnl pcre-config should probably be employed here
+-dnl AC_SEARCH_LIBS(pcre_compile, pcre)
+-  LIBS="`$ac_cv_prog_PCRECONF --libs` $LIBS"
++  LIBS="`$ac_cv_prog_PCRECONF --libs8` $LIBS"
+ fi
+ 
+ dnl ---------------------
+@@ -1323,7 +1321,7 @@ AC_CHECK_FUNCS(strftime strptime mktime timelocal \
+ 	       pathconf sysconf \
+ 	       tgetent tigetflag tigetnum tigetstr setupterm initscr resize_term \
+ 	       getcchar setcchar waddwstr wget_wch win_wch use_default_colors \
+-	       pcre_compile pcre_study pcre_exec \
++	       pcre2_compile_8 \
+ 	       nl_langinfo \
+ 	       erand48 open_memstream \
+ 	       posix_openpt \
+-- 
+2.44.0
+
+
+From 7365877763708ed1d7337fdd61695c501b5fc155 Mon Sep 17 00:00:00 2001
+From: Jun-ichi Takimoto <takimoto-j@kba.biglobe.ne.jp>
+Date: Tue, 20 Jun 2023 18:14:27 +0900
+Subject: [PATCH 3/3] 51877: do not build pcre module if pcre2-config is not
+ found
+
+(cherry picked from commit 10bdbd8b5b0b43445aff23dcd412f25cf6aa328a)
+---
+ Src/Modules/pcre.mdd |  2 +-
+ configure.ac         | 31 +++++++++++++++++++------------
+ 2 files changed, 20 insertions(+), 13 deletions(-)
+
+diff --git a/Src/Modules/pcre.mdd b/Src/Modules/pcre.mdd
+index 6eb3c691b..3e1579117 100644
+--- a/Src/Modules/pcre.mdd
++++ b/Src/Modules/pcre.mdd
+@@ -1,5 +1,5 @@
+ name=zsh/pcre
+-link=`if test x$enable_pcre = xyes && (pcre-config --version >/dev/null 2>/dev/null); then echo dynamic; else echo no; fi`
++link=`if test x$enable_pcre = xyes; then echo dynamic; else echo no; fi`
+ load=no
+ 
+ autofeatures="b:pcre_compile b:pcre_study b:pcre_match"
+diff --git a/configure.ac b/configure.ac
+index 7238639f1..067053e8c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -440,6 +440,17 @@ dnl Do you want to look for pcre support?
+ AC_ARG_ENABLE(pcre,
+ AS_HELP_STRING([--enable-pcre],[enable the search for the pcre2 library (may create run-time library dependencies)]))
+ 
++AC_ARG_VAR(PCRE_CONFIG, [pathname of pcre2-config if it is not in PATH])
++if test "x$enable_pcre" = xyes; then
++  AC_CHECK_PROG([PCRE_CONFIG], pcre2-config, pcre2-config)
++  if test "x$PCRE_CONFIG" = x; then
++    enable_pcre=no
++    AC_MSG_WARN([pcre2-config not found: pcre module is disabled.])
++    AC_MSG_NOTICE(
++      [Set PCRE_CONFIG to pathname of pcre2-config if it is not in PATH.])
++  fi
++fi
++
+ dnl Do you want to look for capability support?
+ AC_ARG_ENABLE(cap,
+ AS_HELP_STRING([--enable-cap],[enable the search for POSIX capabilities (may require additional headers to be added by hand)]))
+@@ -660,15 +671,12 @@ AC_HEADER_DIRENT
+ AC_HEADER_STAT
+ AC_HEADER_SYS_WAIT
+ 
+-oldcflags="$CFLAGS"
+-if test x$enable_pcre = xyes; then
+-AC_CHECK_PROG([PCRECONF], pcre2-config, pcre2-config)
+ dnl pcre2-config --cflags may produce a -I output which needs to go into
+ dnl CPPFLAGS else configure's preprocessor tests don't pick it up,
+ dnl producing a warning.
+-if test "x$ac_cv_prog_PCRECONF" = xpcre2-config; then
+-  CPPFLAGS="$CPPFLAGS `pcre2-config --cflags`"
+-fi
++if test "x$enable_pcre" = xyes; then
++  CPPFLAGS="`$PCRE_CONFIG --cflags` $CPPFLAGS"
++  AC_CHECK_HEADERS([pcre2.h],,,[#define PCRE2_CODE_UNIT_WIDTH 8])
+ fi
+ 
+ AC_CHECK_HEADERS(sys/time.h sys/times.h sys/select.h termcap.h termio.h \
+@@ -680,7 +688,6 @@ AC_CHECK_HEADERS(sys/time.h sys/times.h sys/select.h termcap.h termio.h \
+ 		 netinet/in_systm.h langinfo.h wchar.h stddef.h \
+ 		 sys/stropts.h iconv.h ncurses.h ncursesw/ncurses.h \
+ 		 ncurses/ncurses.h)
+-AC_CHECK_HEADERS([pcre2.h],,,[#define PCRE2_CODE_UNIT_WIDTH 8])
+ if test x$dynamic = xyes; then
+   AC_CHECK_HEADERS(dlfcn.h)
+   AC_CHECK_HEADERS(dl.h)
+@@ -957,10 +964,6 @@ if test "x$ac_found_iconv" = "xyes"; then
+     [Define as const if the declaration of iconv() needs const.])
+ fi
+ 
+-if test x$enable_pcre = xyes; then
+-  LIBS="`$ac_cv_prog_PCRECONF --libs8` $LIBS"
+-fi
+-
+ dnl ---------------------
+ dnl CHECK TERMCAP LIBRARY
+ dnl ---------------------
+@@ -1321,7 +1324,6 @@ AC_CHECK_FUNCS(strftime strptime mktime timelocal \
+ 	       pathconf sysconf \
+ 	       tgetent tigetflag tigetnum tigetstr setupterm initscr resize_term \
+ 	       getcchar setcchar waddwstr wget_wch win_wch use_default_colors \
+-	       pcre2_compile_8 \
+ 	       nl_langinfo \
+ 	       erand48 open_memstream \
+ 	       posix_openpt \
+@@ -1376,6 +1378,11 @@ if test x$zsh_cv_func_realpath_accepts_null = xyes; then
+   AC_DEFINE(REALPATH_ACCEPTS_NULL)
+ fi
+ 
++if test x$enable_pcre = xyes; then
++  LIBS="`$PCRE_CONFIG --libs8` $LIBS"
++  AC_CHECK_FUNCS(pcre2_compile_8)
++fi
++
+ if test x$enable_cap = xyes; then
+   AC_CHECK_FUNCS(cap_get_proc)
+ fi
+-- 
+2.44.0
+

--- a/packages/zsh/build.sh
+++ b/packages/zsh/build.sh
@@ -4,75 +4,45 @@ TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="LICENCE"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
 TERMUX_PKG_VERSION=5.9
-TERMUX_PKG_REVISION=9
-TERMUX_PKG_SRCURL=https://www.zsh.org/pub/zsh-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_REVISION=10
+TERMUX_PKG_SRCURL="https://www.zsh.org/pub/zsh-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=9b8d1ecedd5b5e81fbf1918e876752a7dd948e05c1a0dba10ab863842d45acd5
-TERMUX_PKG_BUILD_DEPENDS="pcre2"
 TERMUX_PKG_DEPENDS="libandroid-support, libcap, ncurses, termux-tools, pcre2"
 TERMUX_PKG_RECOMMENDS="command-not-found, zsh-completions"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-gdbm
---enable-pcre
 --enable-cap
 --enable-etcdir=$TERMUX_PREFIX/etc
+--enable-pcre
+--enable-site-fndir=no
 zsh_cv_path_wtmp=no
 ac_cv_header_utmp_h=no
 ac_cv_func_getpwuid=yes
 ac_cv_func_setresgid=no
 ac_cv_func_setresuid=no
 "
+# FIXME: "largefile" for arithmetic larger than sint32
+# Zsh force disables the detection of these flags in its ./configure when running in a cross-build environment
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+="
+zsh_cv_printf_has_lld=yes
+zsh_cv_rlim_t_is_longer=no
+zsh_cv_type_rlim_t_is_unsigned=yes
+"
+
 TERMUX_PKG_CONFFILES="etc/zshrc"
 TERMUX_PKG_BUILD_IN_SRC=true
-
 # Remove hard link to bin/zsh as Android does not support hard links.
 # We replace this with a symlink to offer the same functionality:
 TERMUX_PKG_RM_AFTER_INSTALL="bin/zsh-${TERMUX_PKG_VERSION}"
-# Remove compdef for Solaris `pkg` command:
-TERMUX_PKG_RM_AFTER_INSTALL+="share/zsh/${TERMUX_PKG_VERSION}/functions/_pkg5"
-
-termux_step_post_get_source() {
-	# Fetch the Arch Linux cherry-picks for updating the zsh/pcre module to PCRE2.
-	termux_download \
-		'https://gitlab.archlinux.org/archlinux/packaging/packages/zsh/-/raw/main/0004-pcre2.patch' \
-		"${TERMUX_SCRIPTDIR}/packages/zsh/pcre2.patch" \
-		'ea68214d5be0514aa1b19e93fc9f44de878b9428e920227230a8fa3a75b0bd18'
-}
 
 termux_step_pre_configure() {
-
 	autoreconf -fi
-	## fix "largefile" for arithmetic larger than sint32
-	## as zsh force disable the detection of these flags in its ./configure when running in a cross-build environment
-	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+="
-	zsh_cv_printf_has_lld=yes
-	zsh_cv_rlim_t_is_longer=no
-	zsh_cv_type_rlim_t_is_unsigned=yes
-	"
-	if [[ "$TERMUX_ARCH" = arm || "$TERMUX_ARCH" = i686 ]] ; then
-		## this essentially attempts to add zsh_cv_64_bit_type="long long" in EXTRA_CONFIGURE_ARGS.
-		## the space in argument to this flag make build script of termux
-		## wrongly splitted the flag as separated flags
-		## the reason is termux build script does not use ${TERMUX_PKG_EXTRA_CONFIGURE_ARGS[@]}
-		## (which is required to keep space in each flags by using an array) during shell expansion
-		perl -0pe 's#zsh_cv_64_bit_type=no#zsh_cv_64_bit_type="long long"#ms' < configure > configure.newf
-		cat configure.newf > configure
-		rm configure.newf
-
-		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+="
-		zsh_cv_off_t_is_64_bit=yes
-		"
-	else
-		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+="
-		zsh_cv_64_bit_type=long
-		"
-	fi
-
 }
 
 termux_step_post_configure() {
 	# Certain packages are not safe to build on device because their
 	# build.sh script deletes specific files in $TERMUX_PREFIX.
-	if $TERMUX_ON_DEVICE_BUILD; then
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "true" ]]; then
 		termux_error_exit "Package '$TERMUX_PKG_NAME' is not safe for on-device builds."
 	fi
 
@@ -81,35 +51,55 @@ termux_step_post_configure() {
 	# and you will need to edit config.modules to make any other modules available."
 	# Since we build zsh non-dynamically (since dynamic loading doesn't work on Android when enabled),
 	# we need to explicitly enable the additional modules we want.
-	local modules=(
-	'cap'           # - The cap module was requested in https://github.com/termux/termux-packages/issues/3102.
-	'curses'        # - The curses module was requested by BrainDamage on IRC (#termux).
-	'deltochar'     # - The deltochar module is used by grml-zshrc https://github.com/termux/termux-packages/issues/494.
-	'files'         # - The files module is needed by `compinstall` https://github.com/termux/termux-packages/issues/61.
-	'mapfile'       # - The mapfile module was requested in https://github.com/termux/termux-packages/issues/3116.
-	'mathfunc'      # - The mathfunc module is used by grml-zshrc https://github.com/termux/termux-packages/issues/494.
-	'newuser'       # - The newuser module was requested in https://github.com/termux/termux-packages/discussions/20603.
-	'param_private' # - The param_private module was requested in https://github.com/termux/termux-packages/issues/7391.
-	'pcre'          # - The pcre module expands on the regex modules capabilities and is used by several extensions.
-	'regex'         # - The regex module seems to be used by several extensions.
-	'socket'        # - The socket module was requested by BrainDamage on IRC (#termux).
-	'stat'          # - The stat module is needed by zui https://github.com/termux/termux-packages/issues/2829.
-	'system'        # - The system module is needed by zplug https://github.com/termux/termux-packages/issues/659.
-	'zprof'         # - The zprof module was requested by BrainDamage on IRC (#termux).
-	'zpty'          # - The zpty module is needed by zsh-async https://github.com/termux/termux-packages/issues/672.
-	'zselect'       # - The zselect module is used by multiple plugins https://github.com/termux/termux-packages/issues/4939
+	local module
+	local -a modules=(
+		'cap'           # - The cap module was requested in https://github.com/termux/termux-packages/issues/3102.
+		'curses'        # - The curses module was requested by BrainDamage on IRC (#termux).
+		'deltochar'     # - The deltochar module is used by grml-zshrc https://github.com/termux/termux-packages/issues/494.
+		'files'         # - The files module is needed by `compinstall` https://github.com/termux/termux-packages/issues/61.
+		'mapfile'       # - The mapfile module was requested in https://github.com/termux/termux-packages/issues/3116.
+		'mathfunc'      # - The mathfunc module is used by grml-zshrc https://github.com/termux/termux-packages/issues/494.
+		'newuser'       # - The newuser module was requested in https://github.com/termux/termux-packages/discussions/20603.
+		'param_private' # - The param_private module was requested in https://github.com/termux/termux-packages/issues/7391.
+		'pcre'          # - The pcre module expands on the regex modules capabilities and is used by several extensions.
+		'regex'         # - The regex module seems to be used by several extensions.
+		'socket'        # - The socket module was requested by BrainDamage on IRC (#termux).
+		'stat'          # - The stat module is needed by zui https://github.com/termux/termux-packages/issues/2829.
+		'system'        # - The system module is needed by zplug https://github.com/termux/termux-packages/issues/659.
+		'zprof'         # - The zprof module was requested by BrainDamage on IRC (#termux).
+		'zpty'          # - The zpty module is needed by zsh-async https://github.com/termux/termux-packages/issues/672.
+		'zselect'       # - The zselect module is used by multiple plugins https://github.com/termux/termux-packages/issues/4939
 	)
 	for module in "${modules[@]}"; do
-		perl -p -i -e "s|${module}.mdd link=no|${module}.mdd link=static|" "$TERMUX_PKG_BUILDDIR/config.modules"
+		sed -i "s|${module}.mdd link=no|${module}.mdd link=static|" "$TERMUX_PKG_BUILDDIR/config.modules"
+	done
+
+	# Save a couple completion definitions for distro specific commands
+	# that are available on Termux by moving them to the generic Unix/ directory.
+	local compdef
+	local -a used_on_termux=(
+		'Debian/Command/_apt'                 # packages/apt
+		'Debian/Command/_apt-file'            # packages/apt-file
+		'Debian/Command/_apt-show-versions'   # packages/apt-show-versions
+		'Debian/Command/_dpkg'                # packages/dpkg
+		'Debian/Command/_update-alternatives' # packages/dpkg
+		'Redhat/Command/_rpm'                 # packages/rpm
+	)
+	for compdef in "${used_on_termux[@]}"; do
+		mv -v "$TERMUX_PKG_BUILDDIR/Completion/$compdef" "$TERMUX_PKG_BUILDDIR/Completion/Unix/Command/"
+	done
+
+	# Adapted from Arch Linux's build.
+	# Remove unneeded and conflicting completion scripts
+	for compdir in AIX BSD Cygwin Darwin Debian Mandriva openSUSE Redhat Solaris; do
+		rm -rf Completion/$compdir
+		sed "s#\s*Completion/$compdir/\*/\*##g" -i "$TERMUX_PKG_BUILDDIR/Src/Zle/complete.mdd"
 	done
 }
 
 termux_step_post_make_install() {
 	# /etc/zshrc - Run for interactive shells (http://zsh.sourceforge.net/Guide/zshguide02.html):
 	sed "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|" "$TERMUX_PKG_BUILDER_DIR/etc-zshrc" > "$TERMUX_PREFIX/etc/zshrc"
-
-	# Remove upstream PCRE2 patch
-	rm -f "${TERMUX_SCRIPTDIR}/packages/zsh/pcre2.patch"
 
 	# Remove zsh.new/zsh.old/zsh-$version if any exists:
 	rm -f "$TERMUX_PREFIX"/{zsh-*,zsh.*}

--- a/packages/zsh/configure.ac.patch
+++ b/packages/zsh/configure.ac.patch
@@ -1,5 +1,10 @@
+Since $TERMUX_PKG_EXTRA_CONFIGURE_ARGS isn't an array
+we can't prevent zsh_cv_64_bit_type=long long 
+from being split into two flags by termux_step_configure,
+if we added it directly to TERMUX_PKG_EXTRA_CONFIGURE_ARGS.
+To work around this, patch the configure file to set it to "long long".
 diff --git a/configure.ac b/configure.ac
-index c72148d06..1cecd2faa 100644
+index c72148d..eff505b 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -318,7 +318,7 @@ dnl Add /usr/local/share/zsh/site-functions if not yet present
@@ -11,3 +16,12 @@ index c72148d06..1cecd2faa 100644
  then fixed_sitefndir=''
  elif test X$prefix != X/usr/local; then
    if test X$prefix = XNONE && test X$ac_default_prefix = X/usr/local; then
+@@ -1080,7 +1080,7 @@ main() { return sizeof(ino_t) < 8; }
+        zsh_64_BIT_TYPE(off_t, zsh_cv_64_bit_type)
+      fi])
+     if test "$zsh_cv_64_bit_type" != no; then
+-      AC_DEFINE_UNQUOTED(ZSH_64_BIT_TYPE, $zsh_cv_64_bit_type)
++      AC_DEFINE(ZSH_64_BIT_TYPE, "long long")
+ 
+       dnl Handle cases where unsigned type cannot be simply
+       dnl `unsigned ZSH_64_BIT_TYPE'.  More tests may be required.


### PR DESCRIPTION
- Part of #29907

<h1><em></em></h1> <!-- thin separator --> 

This is a fairly large rewrite of the `zsh` build script.
The five main things done by this PR are:
- Vendor Arch's PCRE2 patch instead of doing an ad-hoc download of it at build time.
<sup>This could lead to the patch file being left as a loose file in the package directory if the build is interruped.</sup>
- Get rid of the janky Perl substitution to set `zsh_cv_64_bit_type="long long"` by just adding it to the configure.ac.patch file.
- Use `--enable-site-fndir=no` to replace the original hunk of configure.ac.patch (`test X$sitefndir = Xno || true`) with its configure flag equivalent.
- Sort configure flags.
- Adopt and adapt Arch's method of dropping non-applicable completion definitions from the build.