### PR TITLE
bump(main/exfatprogs): 1.4.0

### DIFF
--- a/packages/exfatprogs/build.sh
+++ b/packages/exfatprogs/build.sh
@@ -2,12 +2,15 @@ TERMUX_PKG_HOMEPAGE="https://github.com/exfatprogs/exfatprogs"
 TERMUX_PKG_DESCRIPTION="exFAT filesystem userspace utilities"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.3.2"
-TERMUX_PKG_SRCURL="https://github.com/exfatprogs/exfatprogs/releases/download/${TERMUX_PKG_VERSION}/exfatprogs-${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256=0c5d445947df781f90ba6bfddbd323bd6324c78a51fe75380a6ce2238c3cbcce
+TERMUX_PKG_VERSION="1.4.0"
+TERMUX_PKG_SRCURL="https://github.com/exfatprogs/exfatprogs/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=3340a80cede17a7f94497fdc54c69c0e6ea3625e314d960551967b046eed981c
 TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="libblkid"
 
 termux_step_pre_configure() {
+	autoreconf -fiv
+
 	CFLAGS+=" -D_FILE_OFFSET_BITS=64"
 	CPPFLAGS+=" -D_FILE_OFFSET_BITS=64"
 }


### PR DESCRIPTION
Switch to GitHub generated tarball because the release artifacts do not contain all the required source files.
* Fixes #29928 