### PR TITLE
fix(main/libmysofa): fix unchanged package homepage from template

### DIFF
--- a/packages/libmysofa/build.sh
+++ b/packages/libmysofa/build.sh
@@ -1,8 +1,9 @@
-TERMUX_PKG_HOMEPAGE="https://libntl.org"
+TERMUX_PKG_HOMEPAGE="https://github.com/hoene/libmysofa"
 TERMUX_PKG_DESCRIPTION="Reader for AES SOFA files to get better HRTFs"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.3.4"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/hoene/libmysofa/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=64c661f75ef39edf68bfc3a28403d2b5a0bd251d0b9f5d021ed6f7917867fb37
 TERMUX_PKG_DEPENDS="zlib"


### PR DESCRIPTION
I never changed the TERMUX_PKG_HOMEPAGE for the `libmysofa` package from the package build I used as a base.
Best get that fixed right away.