### PR TITLE
bump(main/dos2unix): 7.5.6

### DIFF
--- a/packages/dos2unix/build.sh
+++ b/packages/dos2unix/build.sh
@@ -1,11 +1,11 @@
-TERMUX_PKG_HOMEPAGE=https://waterlan.home.xs4all.nl/dos2unix.html
+TERMUX_PKG_HOMEPAGE=https://waterlander.net/dos2unix/
 TERMUX_PKG_DESCRIPTION="Converts between DOS and Unix text files"
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_LICENSE_FILE="COPYING.txt"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="7.5.5"
-TERMUX_PKG_SRCURL="https://waterlan.home.xs4all.nl/dos2unix/dos2unix-${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256=75f692b8484c8c24579a2ffd87df16b9c9428ed95497e3393a21d1ba0697ac33
+TERMUX_PKG_VERSION="7.5.6"
+TERMUX_PKG_SRCURL="https://waterlander.net/dos2unix/files/dos2unix-${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=63650acbd0c7fa8623429bcbf93a888e3351a1cad0f556cf41876f5673dd7d0b
 TERMUX_PKG_DEPENDS="libandroid-support"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true


### PR DESCRIPTION
- closes #29949

`dos2unix` has a new page and thus a new source URL.