### PR TITLE
fix(main/mise): fix build of version 2026.5.18 for 32-bit targets

### DIFF
--- a/packages/mise/build.sh
+++ b/packages/mise/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="dev tools, env vars, task runner"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2026.5.18"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/jdx/mise/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=f1a3b31060484207b1618746b526571c29ee7150e509c4229f33b1e512b2d667
 TERMUX_PKG_DEPENDS="bzip2, openssl"
@@ -22,6 +23,7 @@ termux_step_pre_configure() {
 	find ./vendor-termux \
 		-mindepth 1 -maxdepth 1 -type d \
 		! -wholename ./vendor-termux/rattler_pty \
+		! -wholename ./vendor-termux/cc \
 		-exec rm -rf '{}' \;
 
 	patch="$TERMUX_PKG_BUILDER_DIR/rattler_pty-android-target.diff"
@@ -29,10 +31,16 @@ termux_step_pre_configure() {
 	echo "Applying patch: $patch"
 	patch -p1 -d "$dir" < "$patch"
 
+	patch="$TERMUX_PKG_BUILDER_DIR/rust-cc-do-not-concatenate-all-the-CFLAGS.diff"
+	dir="vendor-termux/cc"
+	echo "Applying patch: $patch"
+	patch -p1 -d "$dir" < "$patch"
+
 	cat <<-EOL >> Cargo.toml
 
 		[patch.crates-io]
 		rattler_pty = { path = "./vendor-termux/rattler_pty" }
+		cc = { path = "./vendor-termux/cc" }
 	EOL
 
 	local -u env_host="${CARGO_TARGET_NAME//-/_}"

--- a/packages/mise/rust-cc-do-not-concatenate-all-the-CFLAGS.diff
+++ b/packages/mise/rust-cc-do-not-concatenate-all-the-CFLAGS.diff
@@ -1,0 +1,38 @@
+`rust-cc` changed how it collects `CFLAGS` from environment variables.
+It retrieves environment variables according to a specific set of rules,
+which are described in [1]. Previously, it used the first match [2,3],
+but now it concatenates all matches and passes them to `CC` [4,5]. This
+breaks Termux's build since Termux's `CFLAGS` include flags related to
+the Android target and unrelated to the target when compiling `glslopt`
+as a host tool, which is `x86_64-linux-gnu`.
+
+This patch will restore the old behaviour. For Termux we know how it is going.
+
+[1] https://docs.rs/cc/latest/cc/
+[2] https://github.com/rust-lang/cc-rs/blob/fcf940ef66f23f411aa50473baa14df9ed2f2cda/src/lib.rs#L1910
+[3] https://github.com/rust-lang/cc-rs/blob/fcf940ef66f23f411aa50473baa14df9ed2f2cda/src/lib.rs#L3669-3681
+[4] https://github.com/rust-lang/cc-rs/blob/cda8b386d419f3adb0c15b729af5504201689aa1/src/lib.rs#L1977
+[5] https://github.com/rust-lang/cc-rs/blob/cda8b386d419f3adb0c15b729af5504201689aa1/src/lib.rs#L3836-L3858
+
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -3924,14 +3924,13 @@ impl Build {
+
+     /// Get values from CFLAGS-style environment variable.
+     fn envflags(&self, env: &str) -> Result<Option<Vec<String>>, Error> {
+-        // Collect from all environment variables, in reverse order as in
+-        // `getenv_with_target_prefixes` precedence (so that `CFLAGS_$TARGET`
+-        // can override flags in `TARGET_CFLAGS`, which overrides those in
+-        // `CFLAGS`).
+         let mut any_set = false;
+         let mut res = vec![];
+-        for env in self.target_envs(env)?.iter().rev() {
++        for env in self.target_envs(env)?.iter() {
+             if let Some(var) = self.get_env(env) {
++                if any_set {
++                    continue;
++                }
+                 any_set = true;
+
+                 let var = var.to_string_lossy();
+


### PR DESCRIPTION
- Apply the `rust-cc-do-not-concatenate-all-the-CFLAGS.diff` that is already required for many other Rust packages