### PR TITLE
bump(packages/asymptote): 3.12

### DIFF
--- a/packages/asymptote/build.sh
+++ b/packages/asymptote/build.sh
@@ -2,16 +2,19 @@ TERMUX_PKG_HOMEPAGE=https://asymptote.sourceforge.io/
 TERMUX_PKG_DESCRIPTION="A powerful descriptive vector graphics language for technical drawing"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="3.11"
+TERMUX_PKG_VERSION="3.12"
 TERMUX_PKG_SRCURL="https://downloads.sourceforge.net/asymptote/asymptote-${TERMUX_PKG_VERSION}.src.tgz"
-TERMUX_PKG_SHA256=537e9f22621bf84f09ee0d44dc455c4ea91ba193830f1d7624a07d4710d7e7d1
+TERMUX_PKG_SHA256=eaec1e97463ef213a393c388d466a73478b0818f9403c962b91240659c9b8f1b
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="fftw, libc++, libcurl, libtirpc, zlib, ncurses, readline"
-TERMUX_PKG_BUILD_DEPENDS="glm"
+TERMUX_PKG_BUILD_DEPENDS="eigen, glm"
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-gc
+--disable-gl
 --disable-lsp
+--disable-vulkan
 "
 
 termux_step_pre_configure() {
@@ -19,6 +22,6 @@ termux_step_pre_configure() {
 }
 
 termux_step_make_install() {
-	install -Dm700 -t $TERMUX_PREFIX/bin asy
-	cp -rT base $TERMUX_PREFIX/share/asymptote
+	install -Dm700 -t "$TERMUX_PREFIX/bin" asy
+	cp -rT base "$TERMUX_PREFIX/share/asymptote"
 }

--- a/packages/asymptote/disable-x11.patch
+++ b/packages/asymptote/disable-x11.patch
@@ -1,14 +1,16 @@
 asymptote's GUI has dependency on PySide6, but this asymptote package is minimal
 and is not in the x11-packages folder.
 
+diff --git a/Makefile.in b/Makefile.in
+index 4537389e3..21d02b84a 100644
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -135,7 +135,7 @@
+@@ -158,7 +158,7 @@ endif
  
  export prefix docdir exampledir mandir infodir INSTALL MAKE DESTDIR TEXI2DVI
  
--asy: base/version.asy $(FILES:=.o) $(XNAME) revision.o $(GCLIB) \
-+asy: base/version.asy $(FILES:=.o) revision.o $(GCLIB) \
- 		@LSPLIB@ @GLEW@
- 	$(CXX) $(OPTS) -o $(NAME) $(FILES:=.o) revision.o $(LIBS)
- 
+-asy: base/version.asy $(FILES:=.o) $(XNAME) revision.o $(GCLIB) @LSPLIB@ $(SHIMLIBS)
++asy: base/version.asy $(FILES:=.o) revision.o $(GCLIB) @LSPLIB@ $(SHIMLIBS)
+ 	$(CXX) $(OPTS) -rdynamic -o $(NAME) $(FILES:=.o) revision.o $(LIBS)
+ ifeq ($(BUNDLE_VULKAN),yes)
+ 	@sh build-scripts/bundle-vulkan-macos.sh $(NAME) "$(CODESIGN_IDENTITY)"


### PR DESCRIPTION
- closes #30017

Had to explicitly disable `gl` and `vulkan`.
Also had to regenerate the patch again.
Noticed we weren't providing `eigen` as build dependency, support for it works without any issues so I added it to the build dependencies.
I have confirmed that it is a build only dependency using `patchelf --print-needed`