### PR TITLE
enhance(scripts/updates): log tag parsing failures

### DIFF
--- a/scripts/updates/api/termux_github_api_get_tag.sh
+++ b/scripts/updates/api/termux_github_api_get_tag.sh
@@ -103,10 +103,10 @@ termux_github_api_get_tag() {
 	# echo interpolates control characters, which jq does not like.
 	response="$(printf "%s\n" "${response%|*}")"
 
-	local tag_name=""
+	local tag_name="" err=0
 	case "${http_code}" in
 		200)
-			tag_name="$(jq --exit-status --raw-output "${jq_filter}" <<< "${response}")"
+			tag_name="$(jq --exit-status --raw-output "${jq_filter}" <<< "${response}")" || err=1
 		;;
 		404)
 			termux_error_exit <<-EndOfError
@@ -134,8 +134,25 @@ termux_github_api_get_tag() {
 						fi
 					)'.
 				EndOfError
+			else
+				err=1
 			fi
 		;;
 	esac
+
+	# If the input failed to parse log it for the issue.
+	if (( err )); then
+		termux_error_exit <<-EndOfError
+			${CI:+::group::}ERROR: Response seems to be invalid JSON.
+			Codepath: ${FUNCNAME[0]}
+			API url : ${api_url}
+			API path: ${api_path}
+			\`\`\`json
+			${response}
+			\`\`\`
+			${CI:+::endgroup::}
+		EndOfError
+	fi
+
 	echo "${tag_name}"
 }

--- a/scripts/updates/api/termux_gitlab_api_get_tag.sh
+++ b/scripts/updates/api/termux_gitlab_api_get_tag.sh
@@ -69,10 +69,10 @@ termux_gitlab_api_get_tag() {
 	# echo interpolates control characters, which jq does not like.
 	response="$(printf "%s\n" "${response%|*}")"
 
-	local tag_name=""
+	local tag_name="" err=0
 	case "${http_code}" in
 		200)
-			tag_name="$(jq --exit-status --raw-output "${jq_filter}" <<< "${response}")"
+			tag_name="$(jq --exit-status --raw-output "${jq_filter}" <<< "${response}")" || err=1
 		;;
 		404)
 			termux_error_exit <<-EndOfError
@@ -100,8 +100,25 @@ termux_gitlab_api_get_tag() {
 						fi
 					)'.
 				EndOfError
+			else
+				err=1
 			fi
 		;;
 	esac
+
+	# If the input failed to parse log it for the issue.
+	if (( err )); then
+		termux_error_exit <<-EndOfError
+			${CI:+::group::}ERROR: Response seems to be invalid JSON.
+			Codepath: ${FUNCNAME[0]}
+			API url : ${api_url}
+			API path: ${api_path}
+			\`\`\`json
+			${response}
+			\`\`\`
+			${CI:+::endgroup::}
+		EndOfError
+	fi
+
 	echo "${tag_name}"
 }

--- a/scripts/updates/api/termux_repology_api_get_latest_version.sh
+++ b/scripts/updates/api/termux_repology_api_get_latest_version.sh
@@ -11,10 +11,28 @@
 # But hopefully, all this can be avoided if TERMUX_PKG_UPDATE_VERSION_REGEXP is set.
 #
 termux_repology_api_get_latest_version() {
+	# shellcheck source=scripts/build/termux_error_exit.sh
+	declare -f termux_error_exit >/dev/null ||
+		. "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../../build/termux_error_exit.sh" # realpath is used to resolve symlinks.
+
 	if [[ -z "$1" ]]; then
 		termux_error_exit "Usage: ${FUNCNAME[0]} PKG_NAME"
 	fi
 
-	# Why `--arg`? See: https://stackoverflow.com/a/54674832/15086226; `sub` strips the leading 'v'
-	jq -r --arg pkg "$1" '.[$pkg] // "null" | sub("^v";"")' "$TERMUX_REPOLOGY_DATA_FILE"
+	local tag_name
+	# We are performing a key match for `$pkg` (function `$1`) in the repology data file and return its value.
+	if ! tag_name="$(jq --exit-status --raw-output --arg pkg "$1" '.[$pkg] // "null"' "$TERMUX_REPOLOGY_DATA_FILE")"; then
+		# If the input failed to parse log it for the issue.
+		termux_error_exit <<-EndOfError
+			${CI:+::group::}ERROR: Response seems to be invalid JSON.
+			Codepath: ${FUNCNAME[0]}
+			\`\`\`json
+			$(<"$TERMUX_REPOLOGY_DATA_FILE")
+			\`\`\`
+			${CI:+::endgroup::}
+		EndOfError
+
+	fi
+
+	echo "${tag_name}"
 }


### PR DESCRIPTION
- closes #29980

That should at least give us some more insight.
Throwing in the entire `$TERMUX_REPOLOGY_DATA_FILE` on a repology parse failure might be overkill, but we can filter that down once we know what the failure mode for that looks like.