### PR TITLE
enhance(main/aosp-libs): improve `/system/bin/su`, add `/system/bin/grep`, and connect DNS resolution to `resolv-conf`

### DIFF
--- a/packages/aosp-libs/aosp-utils.subpackage.sh
+++ b/packages/aosp-libs/aosp-utils.subpackage.sh
@@ -1,4 +1,4 @@
-TERMUX_SUBPKG_DESCRIPTION="AOSP-based mksh, toybox and iputils for termux-docker"
+TERMUX_SUBPKG_DESCRIPTION="AOSP-based mksh, toybox, grep and iputils for termux-docker"
 # It doesn't seem trivial to "wildcard" include most files in the bin folder
 # while excluding linker, debuggerd and crash_dump, which belong in the
 # main package.
@@ -158,4 +158,7 @@ opt/aosp/bin/xargs
 opt/aosp/bin/xxd
 opt/aosp/bin/yes
 opt/aosp/bin/zcat
+opt/aosp/bin/grep
+opt/aosp/bin/egrep
+opt/aosp/bin/fgrep
 "

--- a/packages/aosp-libs/bionic-force-reenable-resolv-conf.patch
+++ b/packages/aosp-libs/bionic-force-reenable-resolv-conf.patch
@@ -1,0 +1,98 @@
+This part of Android is a fork of part of NetBSD.
+This patch forcibly reenables the codepath of NetBSD that
+was designed to read resolv.conf configuration files, which
+was disabled by the Android developers because in
+vanilla Android netd replaces resolv.conf, but in termux-docker
+there is no netd, so DNS resolution in termux-docker was handled by
+dnsmasq or by static-dns-hosts,
+which was inconvenient, until this patch was invented.
+
+--- a/bionic/libc/dns/include/resolv_private.h
++++ b/bionic/libc/dns/include/resolv_private.h
+@@ -108,6 +108,10 @@ struct __res_state; /* forward */
+  * initial name server(s) to query and the domain search list.
+  */
+ 
++// for termux-docker; standard docker engine automatically creates an /etc/resolv.conf (nameservers dynamically detected)
++#define _PATH_RESCONF_DOCKER "/etc/resolv.conf"
++// for termux resolv-conf package; alternative for non-docker situations (hardcoded to 8.8.8.8; manually configurable)
++#define _PATH_RESCONF_TERMUX "@TERMUX_PREFIX@/etc/resolv.conf"
+ #ifndef _PATH_RESCONF
+ #ifdef ANDROID_CHANGES
+ #define _PATH_RESCONF        "/etc/ppp/resolv.conf"
+--- a/bionic/libc/dns/resolv/res_init.c
++++ b/bionic/libc/dns/resolv/res_init.c
+@@ -114,6 +114,7 @@ __RCSID("$NetBSD: res_init.c,v 1.8 2006/03/19 03:10:08 christos Exp $");
+ 
+ #include "res_private.h"
+ 
++#define RESOLVSORT
+ /* Options.  Should all be left alone. */
+ #ifndef DEBUG
+ #define DEBUG
+@@ -165,23 +165,23 @@ res_ninit(res_state statp) {
+ /* This function has to be reachable by res_data.c but not publicly. */
+ int
+ __res_vinit(res_state statp, int preinit) {
+-#if !defined(__BIONIC__)
++#if 1
+ 	register FILE *fp;
+ #endif
+ 	register char *cp, **pp;
+-#if !defined(__BIONIC__)
++#if 1
+ 	register int n;
+ #endif
+ 	char buf[BUFSIZ];
+ 	int nserv = 0;    /* number of nameserver records read from file */
+-#if !defined(__BIONIC__)
++#if 1
+ 	int haveenv = 0;
+ #endif
+ 	int havesearch = 0;
+ #ifdef RESOLVSORT
+ 	int nsort = 0;
+ #endif
+-#if !defined(__BIONIC__)
++#if 1
+ 	char *net;
+ #endif
+ 	int dots;
+@@ -284,14 +284,14 @@ __res_vinit(res_state statp, int preinit) {
+ 		statp->nscount = nserv;
+ #endif
+ 
+-#ifndef ANDROID_CHANGES /* !ANDROID_CHANGES - IGNORE resolv.conf in Android */
++#if 1
+ #define	MATCH(line, name) \
+ 	(!strncmp(line, name, sizeof(name) - 1) && \
+ 	(line[sizeof(name) - 1] == ' ' || \
+ 	 line[sizeof(name) - 1] == '\t'))
+ 
+ 	nserv = 0;
+-	if ((fp = fopen(_PATH_RESCONF, "re")) != NULL) {
++	if ((fp = fopen(_PATH_RESCONF_DOCKER, "re")) != NULL || (fp = fopen(_PATH_RESCONF_TERMUX, "re")) != NULL) {
+ 	    /* read the config file */
+ 	    while (fgets(buf, sizeof(buf), fp) != NULL) {
+ 		/* skip comments */
+@@ -368,12 +368,20 @@ __res_vinit(res_state statp, int preinit) {
+ 			hints.ai_flags = AI_NUMERICHOST;
+ 			sprintf(sbuf, "%u", NAMESERVER_PORT);
+ 			if (getaddrinfo(cp, sbuf, &hints, &ai) == 0 &&
++#ifdef __LP64__
+ 			    ai->ai_addrlen <= minsiz) {
++#else
++			    (unsigned int)ai->ai_addrlen <= minsiz) {
++#endif
+ 			    if (statp->_u._ext.ext != NULL) {
+ 				memcpy(&statp->_u._ext.ext->nsaddrs[nserv],
+ 				    ai->ai_addr, ai->ai_addrlen);
+ 			    }
++#ifdef __LP64__
+ 			    if (ai->ai_addrlen <=
++#else
++			    if ((unsigned int)ai->ai_addrlen <=
++#endif
+ 			        sizeof(statp->nsaddr_list[nserv])) {
+ 				memcpy(&statp->nsaddr_list[nserv],
+ 				    ai->ai_addr, ai->ai_addrlen);

--- a/packages/aosp-libs/build.sh
+++ b/packages/aosp-libs/build.sh
@@ -14,53 +14,68 @@ external/iputils/NOTICE
 "
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="9.0.0-r76"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
+TERMUX_PKG_SRCURL=https://android.googlesource.com/platform/manifest
+TERMUX_PKG_SHA256=SKIP_CHECKSUM
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_SKIP_SRC_EXTRACT=true
-# Should be handled by AOSP build system so I am disable it here.
+# Should be handled by AOSP build system, so it should be disabled here.
 TERMUX_PKG_UNDEF_SYMBOLS_FILES="all"
+TERMUX_PKG_DEPENDS="resolv-conf"
 TERMUX_PKG_BREAKS="bionic-host"
 TERMUX_PKG_REPLACES="bionic-host"
+# For safety to protect termux-docker users out of an abundance of caution,
+# because a failed or bugged build of this package may corrupt termux-docker more severely
+# than it may corrupt a standard Android ROM.
+TERMUX_PKG_ON_DEVICE_BUILD_NOT_SUPPORTED=true
 
 termux_step_get_source() {
-	if $TERMUX_ON_DEVICE_BUILD; then
-		termux_error_exit "Package '$TERMUX_PKG_NAME' is not safe for on-device builds."
+	local TMP_CHECKOUT="$TERMUX_PKG_CACHEDIR/tmp-checkout"
+	local TMP_CHECKOUT_VERSION="$TERMUX_PKG_CACHEDIR/tmp-checkout-version"
+
+	if [[ ! -f "$TMP_CHECKOUT_VERSION" || "$(cat $TMP_CHECKOUT_VERSION)" != "$TERMUX_PKG_VERSION" ]]; then
+		echo "Downloading AOSP source from '$TERMUX_PKG_SRCURL'"
+
+		rm -rf "$TMP_CHECKOUT"
+
+		export LD_LIBRARY_PATH="${TMP_CHECKOUT}/prefix/lib/x86_64-linux-gnu:${TMP_CHECKOUT}/prefix/usr/lib/x86_64-linux-gnu"
+		export PATH="${TMP_CHECKOUT}/prefix/usr/bin:${PATH//$HOME\/.cargo\/bin/}"
+
+		local -a ubuntu_packages=(
+			"libncurses5"
+			"libtinfo5"
+			"openssh-client"
+		)
+
+		DESTINATION="${TMP_CHECKOUT}/prefix" \
+		UBUNTU_RELEASE=jammy \
+		termux_download_ubuntu_packages "${ubuntu_packages[@]}"
+
+		termux_download https://storage.googleapis.com/git-repo-downloads/repo "${TERMUX_PKG_CACHEDIR}/repo" SKIP_CHECKSUM
+		chmod +x "${TERMUX_PKG_CACHEDIR}/repo"
+
+		pushd "$TMP_CHECKOUT"
+
+		# Repo requires us to have a Git user name and email set.
+		# The GitHub workflow does this, but the local build container doesn't
+		[[ "$(git config --get user.name)" != '' ]] || git config --global user.name "Termux Github Actions"
+		[[ "$(git config --get user.email)" != '' ]] || git config --global user.email "contact@termux.dev"
+		"${TERMUX_PKG_CACHEDIR}"/repo init \
+			-u "${TERMUX_PKG_SRCURL}" \
+			-b main -m "${TERMUX_PKG_BUILDER_DIR}/default.xml" <<< 'n'
+		"${TERMUX_PKG_CACHEDIR}"/repo sync -c -j32
+
+		popd
+
+		echo "$TERMUX_PKG_VERSION" > "$TMP_CHECKOUT_VERSION"
+	else
+		echo "Skipped downloading of AOSP source from '$TERMUX_PKG_SRCURL'"
 	fi
 
-	case "${TERMUX_ARCH}" in
-		i686) _ARCH=x86 ;;
-		aarch64) _ARCH=arm64 ;;
-		*) _ARCH=${TERMUX_ARCH} ;;
-	esac
-
-	export LD_LIBRARY_PATH="${TERMUX_PKG_SRCDIR}/prefix/lib/x86_64-linux-gnu:${TERMUX_PKG_SRCDIR}/prefix/usr/lib/x86_64-linux-gnu"
-	export PATH="${TERMUX_PKG_SRCDIR}/prefix/usr/bin:${PATH//$HOME\/.cargo\/bin/}"
-
-	local -a ubuntu_packages=(
-		"libncurses5"
-		"libtinfo5"
-		"openssh-client"
-	)
-
-	DESTINATION="${TERMUX_PKG_SRCDIR}/prefix" \
-	UBUNTU_RELEASE=jammy \
-	termux_download_ubuntu_packages "${ubuntu_packages[@]}"
-
-	termux_download https://storage.googleapis.com/git-repo-downloads/repo "${TERMUX_PKG_CACHEDIR}/repo" SKIP_CHECKSUM
-	chmod +x "${TERMUX_PKG_CACHEDIR}/repo"
-
-	cd "${TERMUX_PKG_SRCDIR}" || termux_error_exit "Couldn't enter source code directory: ${TERMUX_PKG_SRCDIR}"
-
-	# Repo requires us to have a Git user name and email set.
-	# The GitHub workflow does this, but the local build container doesn't
-	[[ "$(git config --get user.name)" != '' ]] || git config --global user.name "Termux Github Actions"
-	[[ "$(git config --get user.email)" != '' ]] || git config --global user.email "contact@termux.dev"
-	"${TERMUX_PKG_CACHEDIR}"/repo init \
-		-u https://android.googlesource.com/platform/manifest \
-		-b main -m "${TERMUX_PKG_BUILDER_DIR}/default.xml" <<< 'n'
-	"${TERMUX_PKG_CACHEDIR}"/repo sync -c -j32
+	rm -rf "$TERMUX_PKG_SRCDIR"
+	cp -Rf "$TMP_CHECKOUT" "$TERMUX_PKG_SRCDIR"
 }
 
 termux_step_host_build() {
@@ -87,8 +102,18 @@ termux_step_host_build() {
 }
 
 termux_step_configure() {
+	case "${TERMUX_ARCH}" in
+		i686)    _AOSP_ARCH=x86    ;;
+		x86_64)  _AOSP_ARCH=x86_64 ;;
+		arm)     _AOSP_ARCH=arm    ;;
+		aarch64) _AOSP_ARCH=arm64  ;;
+		*) termux_error_exit "Unsupported arch: $TERMUX_ARCH"
+	esac
+
 	# for adding python 2 to $PATH on subsequent builds when termux_step_host_build() has already run
 	export PATH="${TERMUX_PKG_HOSTBUILD_DIR}/python2/bin:${PATH}"
+
+	export LD_LIBRARY_PATH="${TERMUX_PKG_SRCDIR}/prefix/lib/x86_64-linux-gnu:${TERMUX_PKG_SRCDIR}/prefix/usr/lib/x86_64-linux-gnu"
 }
 
 termux_step_make() {
@@ -96,10 +121,10 @@ termux_step_make() {
 		set -e;
 		cd ${TERMUX_PKG_SRCDIR}
 		source build/envsetup.sh;
-		lunch aosp_${_ARCH}-eng;
+		lunch aosp_${_AOSP_ARCH}-eng;
 		export ALLOW_MISSING_DEPENDENCIES=true
 		make linker libc libm libdl libicuuc debuggerd crash_dump
-		make toybox sh mkshrc ping ping6 tracepath tracepath6 traceroute6 arping
+		make toybox grep sh mkshrc ping ping6 tracepath tracepath6 traceroute6 arping
 	"
 }
 

--- a/packages/aosp-libs/toybox-enable-su-disable-selinux.patch
+++ b/packages/aosp-libs/toybox-enable-su-disable-selinux.patch
@@ -185,6 +185,25 @@ https://github.com/landley/toybox/commit/20eb4585a140a4bcd7901d4892a3222ff9f0d12
  #define CFG_SULOGIN 0
  #define USE_SULOGIN(...)
  #define CFG_SWAPOFF 1
+--- a/external/toybox/generated/flags.h
++++ b/external/toybox/generated/flags.h
+@@ -5339,11 +5339,11 @@
+ #ifndef TT
+ #define TT this.su
+ #endif
+-#define FLAG_s (FORCED_FLAG<<0)
+-#define FLAG_c (FORCED_FLAG<<1)
+-#define FLAG_p (FORCED_FLAG<<2)
+-#define FLAG_m (FORCED_FLAG<<3)
+-#define FLAG_l (FORCED_FLAG<<4)
++#define FLAG_s (1<<0)
++#define FLAG_c (1<<1)
++#define FLAG_p (1<<2)
++#define FLAG_m (1<<3)
++#define FLAG_l (1<<4)
+ #endif
+ 
+ #ifdef FOR_sulogin
 --- a/external/toybox/toys/lsb/su.c
 +++ b/external/toybox/toys/lsb/su.c
 @@ -41,9 +41,8 @@ static char *snapshot_env(char *name)
@@ -225,3 +244,12 @@ https://github.com/landley/toybox/commit/20eb4585a140a4bcd7901d4892a3222ff9f0d12
    }
  
    up = xgetpwnam(name);
+@@ -86,7 +86,7 @@ void su_main()
+     *(argv++) = "-l";
+     xchdir(up->pw_dir);
+   } else unsetenv("IFS");
+-  setenv("PATH", "/sbin:/bin:/usr/sbin:/usr/bin", 1);
++  setenv("PATH", "/system/bin", 1);
+   if (!(toys.optflags & (FLAG_m|FLAG_p))) {
+     setenv("HOME", up->pw_dir, 1);
+     setenv("SHELL", up->pw_shell, 1);


### PR DESCRIPTION
- This changeset includes changes aimed towards building a partial or complete solution to:
  - https://github.com/termux/termux-docker/issues/50
  - https://github.com/termux/termux-docker/issues/62
  - https://github.com/termux/termux-docker/issues/64
  - https://github.com/termux/termux-docker/issues/69

because it will enable the DNS resolution of `aosp-libs`-based ROMs like termux-docker to function much more like that of the Docker images of Desktop Linux distros, reducing or eliminating the necessity for custom entrypoint scripts for running all DNS-interfacing commands. Not every detail of those issues is covered by this, but in testing I have observed a significant improvement in DNS resolution reliability, so it will open up the ability to test much more potential settings for termux-docker both locally and within GitHub Actions, including settings that have not previously been considered viable up to this point because of the DNS resolution issue.


#### New Features

- Enables DNS resolution code found within bionic libc that originates from NetBSD
  - connects it to `/etc/resolv.conf`, which is a hardcoded absolute path into which standard Docker Engine places the host system's automatically determined DNS addresses,
  - and also as a fallback, to the `resolv-conf` package's `/data/data/com.termux/files/usr/etc/resolv.conf`
  - Reason: In some configurations, it's inconvenient or difficult to have to start `dnsmasq` first in order to resolve domain names. Even today, for some people a problem still occurs sometimes if `dnsmasq` fails: https://github.com/termux/termux-docker/pull/72#pullrequestreview-4091713768 This solution fixes that.
  - Can eventually fix this command that previously often failed (GitHub Actions `container:` mode overrides entrypoints):
    - `docker run --rm --entrypoint=/data/data/com.termux/files/usr/bin/bash termux/termux-docker -c 'ping google.com'`

- Enable and include `/system/bin/grep` in `aosp-utils`
  - Android 9's `/system/bin/grep`, a fork of FreeBSD grep
  - Reason: I was using a minimal `PATH=/system/bin` shell for troubleshooting and I found it inconvenient that `/system/bin/grep` did not exist in `aosp-utils`.
  - Can eventually fix this command that previously often failed:
    - `docker run --rm termux/termux-docker bash -c '/system/bin/grep'`

#### Bug Fixes

- Set the default `PATH` of `/system/bin/su` to `/system/bin`
  - Reason: to match the behavior of most of the popular implementations of `su` for Android (except for other `/system` paths which are not present in this `aosp-utils`), and for convenience
  - Can eventually fix this command that previously often failed:
    - `docker run --rm --entrypoint=/system/bin/su termux/termux-docker -s ls`

- Fix all of the arguments of `su`, including both `-c` and `-l`, that did not previously work
  - This occurred because when I developed https://github.com/termux/termux-packages/pull/22906 in January 2025, I did not understand that editing `external/toybox/generated/config.h` to enable `su` would also require me to simultaneously enable the _arguments_ for `su` in `external/toybox/generated/flags.h`. Eventually, over the past 18 months, I debugged the root cause of the problem and I found that the `-c` and `-l` arguments to the `su` command are disabled/enabled in a different area of the codebase from the `su` command itself, and that when I enabled the `su` command itself, I had failed to read enough of the code at the time to discover that I needed to also, separately enable the `-c` and `-l` arguments. This change to `external/toybox/generated/flags.h` fixes my mistake and successfully fixes the `-c` and `-l` arguments to `su`
  - Reason: This can allow significant cleanup of some awkward code in the current `Dockerfile` of termux-docker, greatly increasing its readability, and fixes abnormal, unexpected behavior of `/system/bin/su` to be normal, allowing its manual use by users conveniently.
  - Can eventually fix this command that previously often failed:
    - `docker run --rm --entrypoint=/data/data/com.termux/files/usr/bin/bash termux/termux-docker -c '/system/bin/su -l -p system -s /data/data/com.termux/files/usr/bin/bash -c env'`