### PR TITLE
fix(scripts/build-bootstraps.sh): replace bzip2 with libbz2

### DIFF
--- a/scripts/build-bootstraps.sh
+++ b/scripts/build-bootstraps.sh
@@ -429,7 +429,7 @@ main() {
 
 		# Core utilities.
 		PACKAGES+=("bash") # Used by `termux-bootstrap-second-stage.sh`
-		PACKAGES+=("bzip2")
+		PACKAGES+=("libbz2")  # produces bzip2 subpackage
 		if ! ${BOOTSTRAP_ANDROID10_COMPATIBLE}; then
 			PACKAGES+=("command-not-found")
 		else


### PR DESCRIPTION
## Description

  `build-bootstraps.sh` references `bzip2` in the bootstrap `PACKAGES` array,
  but `bzip2` is not a standalone package — it is a subpackage of `libbz2`
  (see `packages/libbz2/bzip2.subpackage.sh`).

  Building `libbz2` automatically produces both `libbz2*.deb` and `bzip2*.deb`,
  so the bootstrap script should depend on `libbz2` instead.

  ## Steps to Reproduce

  1. Run `./scripts/build-bootstraps.sh --architectures aarch64`
  2. Observe: `ERROR: No package bzip2 found in any of the enabled repositories.`

  ## Fix

  - Change `PACKAGES+=("bzip2")` → `PACKAGES+=("libbz2")` with a comment

  Fixes #27093 
  Related: #24647