### PR TITLE
addpkg(x11/marknote): 1.6.0

### DIFF
--- a/packages/md4c/build.sh
+++ b/packages/md4c/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE="https://github.com/mity/md4c"
+TERMUX_PKG_DESCRIPTION="C Markdown parser"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.5.3"
+TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
+TERMUX_PKG_SRCURL="https://github.com/mity/md4c/archive/refs/tags/release-${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256="353c346f376b87c954a13f3415ede2d51264cc61dc5abcd38ff1d2aa0d059b9e"
+TERMUX_PKG_AUTO_UPDATE=true

--- a/x11-packages/kmime/build.sh
+++ b/x11-packages/kmime/build.sh
@@ -1,0 +1,15 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/pim/kmime"
+TERMUX_PKG_DESCRIPTION="Library for handling mail messages and newsgroup articles"
+TERMUX_PKG_LICENSE="LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/kmime-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="7473522f42d84684cd71fe7549cc668a1fcfd91716a72860dc9bcbaa8569ed6d"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kf6-kcodecs, libc++, qt6-qtbase"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, qt6-qttools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"

--- a/x11-packages/marknote/build.sh
+++ b/x11-packages/marknote/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/office/marknote"
+TERMUX_PKG_DESCRIPTION="A simple markdown note management app"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="1.6.0"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/marknote/marknote-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="d3bb39614e22fd1a8ddd74bcfb4c384cbffe25685ec01116f694e470816284a9"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kirigami-addons, kf6-breeze-icons, kf6-kcolorscheme, kf6-kconfig, kf6-kcoreaddons, kf6-ki18n, kf6-kirigami, kf6-knotifications, kf6-kwindowsystem, kf6-qqc2-desktop-style, kf6-syntax-highlighting, kmime, libc++, md4c, qt6-qtbase, qt6-qtdeclarative"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+} 


### PR DESCRIPTION
This PR adds Marknote to the repository.

## Description

Marknote lets you create rich text notes and easily organise them into notebooks.

## Included packages

- marknote 26.04.2
  - kmime 26.04.2
  - md4c 0.5.3

##
<img width="2400" height="1080" alt="marknote" src="https://github.com/user-attachments/assets/4f20610d-c165-4cdf-a5a1-7dfc981479a5" />
