### PR TITLE
fix(main/zsh): do not load completions in etc/zshrc, causes delay

### DIFF
--- a/packages/zsh/build.sh
+++ b/packages/zsh/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="LICENCE"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
 TERMUX_PKG_VERSION=5.9.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://www.zsh.org/pub/zsh-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=5d20bec03f981dc4e9a09ec245e7415388ff641f79c5c5c416b5042e58d8280d
 TERMUX_PKG_DEPENDS="libandroid-support, libcap, ncurses, termux-tools, pcre2"

--- a/packages/zsh/etc-zshrc
+++ b/packages/zsh/etc-zshrc
@@ -12,8 +12,4 @@ if [ -x "@TERMUX_PREFIX@/libexec/termux/command-not-found" ]; then
 	}
 fi
 
-# Load and initialize the completions system.
-autoload -U compinit
-compinit
-
 # vim: set noet ft=zsh tw=4 sw=4 ff=unix


### PR DESCRIPTION
- fixes #30052

Loading `compinit` in the etc/zshrc leads to a ~80% startup performance
regression for Zsh sessions since it ends up having to evaluate all the
completions before `$fpath` is fully populated, causing it to have to be
evaluated early which is very slow.