### PR TITLE
bump(main/kubo): 0.42.0

### DIFF
--- a/packages/kubo/build.sh
+++ b/packages/kubo/build.sh
@@ -3,9 +3,9 @@ TERMUX_PKG_DESCRIPTION="A peer-to-peer hypermedia distribution protocol"
 TERMUX_PKG_LICENSE="MIT, Apache-2.0"
 TERMUX_PKG_LICENSE_FILE="LICENSE, LICENSE-APACHE, LICENSE-MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.41.0"
+TERMUX_PKG_VERSION="0.42.0"
 TERMUX_PKG_SRCURL="https://github.com/ipfs/kubo/releases/download/v${TERMUX_PKG_VERSION}/kubo-source.tar.gz"
-TERMUX_PKG_SHA256=d20dce2c72f5ee99e2604fa1331ae493cec26c9a3a214de6ec236383dd26951b
+TERMUX_PKG_SHA256=1515f7f4f19a2d7aed802e5948177f8f9fbe6bbe4b223308f2a68de8b238dc68
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_SUGGESTS="termux-services"
 TERMUX_PKG_SERVICE_SCRIPT=("ipfs" "[ ! -d \"${TERMUX_ANDROID_HOME}/.ipfs\" ] && ipfs init --empty-repo 2>&1 && ipfs config --json Swarm.EnableRelayHop false 2>&1 && ipfs config --json Swarm.EnableAutoRelay true 2>&1; exec ipfs daemon --enable-namesys-pubsub 2>&1")
@@ -22,10 +22,6 @@ termux_step_make() {
 	cp -a "${TERMUX_PKG_SRCDIR}" "${GOPATH}/src/github.com/ipfs/kubo"
 	cd "${GOPATH}/src/github.com/ipfs/kubo"
 
-	# TODO: remove this once the upstream package is updated to suport go 1.26
-	go mod edit -replace github.com/cockroachdb/swiss=github.com/cockroachdb/swiss@b0f6560
-	go mod tidy
-	go mod vendor
 	make build
 
 	# Fix folders without write permissions preventing which fails repeating builds:

--- a/packages/kubo/cmd-ipfs-Rules.mk.patch
+++ b/packages/kubo/cmd-ipfs-Rules.mk.patch
@@ -1,14 +1,13 @@
 See https://github.com/wlynxg/anet?tab=readme-ov-file#how-to-build-with-go-1230-or-later
 
-diff -u -r ../kk/cmd/ipfs/Rules.mk ./cmd/ipfs/Rules.mk
---- ../kk/cmd/ipfs/Rules.mk	2024-10-16 18:28:08.000000000 +0000
-+++ ./cmd/ipfs/Rules.mk	2024-10-17 21:18:34.984576632 +0000
-@@ -12,7 +12,7 @@ PATH := $(realpath $(d)):$(PATH)
+--- a/cmd/ipfs/Rules.mk
++++ b/cmd/ipfs/Rules.mk
+@@ -12,7 +12,7 @@
  # DEPS_OO_$(d) += merkledag/pb/merkledag.pb.go namesys/pb/namesys.pb.go
  # DEPS_OO_$(d) += pin/internal/pb/header.pb.go unixfs/pb/unixfs.pb.go
  
--$(d)_flags =-ldflags="-X "github.com/ipfs/kubo".CurrentCommit=$(git-hash) -X "github.com/ipfs/kubo".taggedRelease=$(git-tag)"
-+$(d)_flags =-ldflags="-checklinkname=0 -X "github.com/ipfs/kubo".CurrentCommit=$(git-hash) -X "github.com/ipfs/kubo".taggedRelease=$(git-tag)"
+-$(d)_flags =-ldflags="-X "github.com/ipfs/kubo".CurrentCommit=$(git-hash) -X "github.com/ipfs/kubo".taggedRelease=$(git-tag) -X "github.com/ipfs/kubo".buildOrigin=$(git-origin)"
++$(d)_flags =-ldflags="-checklinkname=0 -X "github.com/ipfs/kubo".CurrentCommit=$(git-hash) -X "github.com/ipfs/kubo".taggedRelease=$(git-tag) -X "github.com/ipfs/kubo".buildOrigin=$(git-origin)"
  
  $(IPFS_BIN_$(d)): GOFLAGS += $(cmd/ipfs_flags)
  


### PR DESCRIPTION
Remove the workaround from 32ead5ba4c400a96d6174ffb4b99ee362d378e87 commit because upstream now supports go 1.26.

* Fixes #30077 