### PR TITLE
fix(main/mosh): change hard dependency on `openssh` to dependency on either `openssh` or `dropbear`

### DIFF
--- a/packages/mosh/build.sh
+++ b/packages/mosh/build.sh
@@ -2,13 +2,13 @@ TERMUX_PKG_HOMEPAGE=https://mosh.org
 TERMUX_PKG_DESCRIPTION="Mobile shell that supports roaming and intelligent local echo"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=1.4.0
-TERMUX_PKG_REVISION=16
-TERMUX_PKG_SRCURL=https://github.com/mobile-shell/mosh/releases/download/mosh-${TERMUX_PKG_VERSION}/mosh-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_VERSION="1.4.0"
+TERMUX_PKG_REVISION=17
+TERMUX_PKG_SRCURL="https://github.com/mobile-shell/mosh/releases/download/mosh-${TERMUX_PKG_VERSION}/mosh-${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=872e4b134e5df29c8933dff12350785054d2fd2839b5ae6b5587b14db1465ddd
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+\.\d+"
-TERMUX_PKG_DEPENDS="abseil-cpp, libandroid-support, libc++, libprotobuf, ncurses, openssl, openssh"
+TERMUX_PKG_DEPENDS="abseil-cpp, libandroid-support, libc++, libprotobuf, ncurses, openssl, openssh | dropbear"
 TERMUX_PKG_SUGGESTS="mosh-perl"
 
 termux_step_pre_configure() {


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/30090

- Like these preexisting packages in Termux, `mosh` depends only on the `ssh` command, whish can be provided by either `openssh` or `dropbear`.

https://github.com/termux/termux-packages/blob/5f8be09f4130a7a21059a5ced04fc4d9e44593f3/root-packages/sshfs/build.sh#L9

https://github.com/termux/termux-packages/blob/5f8be09f4130a7a21059a5ced04fc4d9e44593f3/packages/rsync/build.sh#L8

https://github.com/termux/termux-packages/blob/5f8be09f4130a7a21059a5ced04fc4d9e44593f3/packages/autossh/build.sh#L10