### PR TITLE
bump(main/proton-bridge): 3.25.0

### DIFF
--- a/packages/proton-bridge/build.sh
+++ b/packages/proton-bridge/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/ProtonMail/proton-bridge
 TERMUX_PKG_DESCRIPTION="ProtonMail Bridge application"
 TERMUX_PKG_LICENSE="GPL-3.0"
-TERMUX_PKG_VERSION="3.24.2"
+TERMUX_PKG_VERSION="3.25.0"
 TERMUX_PKG_SRCURL=git+https://github.com/ProtonMail/proton-bridge
 TERMUX_PKG_GIT_BRANCH="v${TERMUX_PKG_VERSION}"
 TERMUX_PKG_MAINTAINER="@termux"

--- a/packages/proton-bridge/disable-updater.patch
+++ b/packages/proton-bridge/disable-updater.patch
@@ -12,7 +12,7 @@
  import (
 --- /dev/null
 +++ b/internal/updater/updater_android.go
-@@ -0,0 +1,86 @@
+@@ -0,0 +1,78 @@
 +// Copyright (c) 2023 Proton AG
 +//
 +// This file is part of Proton Mail Bridge.
@@ -59,7 +59,7 @@
 +
 +type Installer interface {
 +	IsAlreadyInstalled(*semver.Version) bool
-+	InstallUpdate(*semver.Version, io.Reader) error
++	InstallUpdate(*semver.Version, io.Reader, bool) error
 +}
 +
 +type Updater struct {
@@ -80,19 +80,11 @@
 +	}
 +}
 +
-+func (u *Updater) GetVersionInfoLegacy(ctx context.Context, downloader Downloader, channel Channel) (VersionInfoLegacy, error) {
-+	return VersionInfoLegacy{}, errors.New("no updates available for this channel")
-+}
-+
 +func (u *Updater) GetVersionInfo(ctx context.Context, downloader Downloader) (VersionInfo, error) {
 +	return VersionInfo{}, errors.New("no updates available for this channel")
 +}
 +
-+func (u *Updater) InstallUpdateLegacy(ctx context.Context, downloader Downloader, update VersionInfoLegacy) error {
-+	return nil
-+}
-+
-+func (u *Updater) InstallUpdate(ctx context.Context, downloader Downloader, release Release) error {
++func (u *Updater) InstallUpdate(ctx context.Context, downloader Downloader, release Release, removeTemporaryFolderDisabled bool) error {
 +	return nil
 +}
 +


### PR DESCRIPTION
Remove legacy updater functions same as upstream.
https://github.com/ProtonMail/proton-bridge/commit/0851c50dacd7d6169aa61d83cf3f1a339e2fda01
* Fixes #30104 