### PR TITLE
fix(build): avoid packaging DEBIAN folder in continued builds and fix run-docker.ps1

### DIFF
--- a/scripts/build/termux_create_debian_subpackages.sh
+++ b/scripts/build/termux_create_debian_subpackages.sh
@@ -85,6 +85,8 @@ termux_create_debian_subpackages() {
 		fi
 		local SUB_PKG_INSTALLSIZE
 		SUB_PKG_INSTALLSIZE=$(du -sk . | cut -f 1)
+		# Clean up DEBIAN metadata directory from previous runs to prevent bundling it in data.tar.xz on continued builds.
+		rm -rf DEBIAN
 		tar --sort=name \
 			--mtime="@${SOURCE_DATE_EPOCH}" \
 			--owner=0 --group=0 --numeric-owner \

--- a/scripts/build/termux_step_create_debian_package.sh
+++ b/scripts/build/termux_step_create_debian_package.sh
@@ -3,6 +3,8 @@ termux_step_create_debian_package() {
 		# Metapackage doesn't have data inside.
 		rm -rf data
 	fi
+	# Clean up DEBIAN metadata directory from previous runs to prevent bundling it in data.tar.xz on continued builds.
+	rm -rf DEBIAN
 	tar --sort=name \
 		--mtime="@${SOURCE_DATE_EPOCH}" \
 		--owner=0 --group=0 --numeric-owner \

--- a/scripts/run-docker.ps1
+++ b/scripts/run-docker.ps1
@@ -17,6 +17,9 @@ if (-Not $?) {
         --detach `
         --name $CONTAINER_NAME `
         --volume "${PWD}:/home/builder/termux-packages" `
+        --security-opt seccomp="${PWD}/scripts/profile.json" `
+        --cap-add CAP_SYS_ADMIN `
+        --device /dev/fuse `
         --tty `
         "$IMAGE_NAME"
 }


### PR DESCRIPTION
### Description

1. **DEBIAN folder packaging fix**: When a build is continued (using `-c` or `--continue`), the massage folder (`massagedir`) is not cleaned up. In previous/failed runs, the `DEBIAN` metadata directory was created in `massagedir` to write the control files. On a resumed run, the `ar` command that packs the `data.tar.xz` payload archive would run first and bundle the existing `DEBIAN` directory into the payload. When installing the built `.deb` package, `dpkg` would attempt to extract the `./DEBIAN` directory to the system root, failing with a Read-only file system error on Termux. This is resolved by removing any existing `DEBIAN` directory before packing `data.tar.xz` in both main package and `subpackage` builders.

2. **run-docker.ps1 parity**: Added `FUSE`, `seccomp`, and `CAP_SYS_ADMIN` options to 
`run-docker.ps1` to bring it in parity with `run-docker.sh` (which already has these parameters for Linux hosts).