### PR TITLE
feat(build): add sonarr, radarr, prowlarr,  and seerr

### DIFF
--- a/packages/prowlarr/build.sh
+++ b/packages/prowlarr/build.sh
@@ -1,0 +1,120 @@
+TERMUX_PKG_HOMEPAGE="https://prowlarr.com"
+TERMUX_PKG_DESCRIPTION="An indexer manager/proxy built on the popular arr stack (server)"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="2.4.0.5397"
+TERMUX_PKG_SRCURL="https://github.com/Prowlarr/Prowlarr/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=a01acf8f69b5233d63f3a9bbeceda3664a14a168fdac5993326ec3f2657f3347
+TERMUX_PKG_BUILD_DEPENDS="aspnetcore-targeting-pack-9.0, dotnet-targeting-pack-9.0, nodejs, yarn"
+TERMUX_PKG_DEPENDS="aspnetcore-runtime-9.0, dotnet-host, dotnet-runtime-9.0, mono, libesqlite3, libcurl"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_SERVICE_SCRIPT=(
+	"prowlarr"
+	"exec ${TERMUX_PREFIX}/bin/prowlarr -nobrowser 2>&1"
+)
+TERMUX_PKG_EXCLUDED_ARCHES="arm"
+TERMUX_DOTNET_VERSION=9.0
+
+termux_step_pre_configure() {
+	# Remove global.json to allow using system dotnet version
+	rm -f global.json
+
+	termux_setup_dotnet
+	termux_setup_nodejs
+
+	# Create a host wrapper for yarn since the one in $TERMUX_PREFIX/bin
+	# has a shebang pointing to the target node
+	local bin="$TERMUX_PKG_BUILDDIR/_bin"
+	mkdir -p "$bin"
+	local yarn="$bin/yarn"
+	cat > "$yarn" <<-EOF
+		#!/bin/sh
+		exec node $TERMUX_PREFIX/share/yarn/bin/yarn.js "\$@"
+	EOF
+	chmod 0755 "$yarn"
+	export PATH="$bin:$PATH"
+
+	# Patch Directory.Build.props to disable TreatWarningsAsErrors and ignore vulnerabilities
+	sed -i 's/<TreatWarningsAsErrors>true<\/TreatWarningsAsErrors>/<TreatWarningsAsErrors>false<\/TreatWarningsAsErrors>/g' src/Directory.Build.props
+	sed -i 's/<EnforceCodeStyleInBuild>true<\/EnforceCodeStyleInBuild>/<EnforceCodeStyleInBuild>false<\/EnforceCodeStyleInBuild>/g' src/Directory.Build.props
+	sed -i 's/<AnalysisLevel>.*<\/AnalysisLevel>/<AnalysisLevel>none<\/AnalysisLevel>/g' src/Directory.Build.props
+	sed -i 's/<GenerateDocumentationFile>true<\/GenerateDocumentationFile>/<GenerateDocumentationFile>false<\/GenerateDocumentationFile>/g' src/Directory.Build.props
+	sed -i '/<NoWarn>$(NoWarn);CS1591<\/NoWarn>/a \    <NoWarn>$(NoWarn);NU1901;NU1902;NU1903;NU1904;NU1605</NoWarn>' src/Directory.Build.props
+	sed -i '/<PropertyGroup>/a \    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>' src/Directory.Build.props
+
+	# Force all projects to target .NET 9.0
+	find src -name "*.csproj" -exec sed -i 's/<TargetFrameworks>.*<\/TargetFrameworks>/<TargetFrameworks>net9.0<\/TargetFrameworks>/g' {} +
+	find src -name "*.csproj" -exec sed -i 's/<TargetFramework>.*<\/TargetFramework>/<TargetFramework>net9.0<\/TargetFramework>/g' {} +
+
+	# Update Microsoft.Extensions and specific System packages to 9.0.0 for compatibility with .NET 9.0
+	find src -name "*.csproj" -exec sed -i 's/Include="Microsoft\.Extensions\.\([^"]*\)" Version="[0-9.]*"/Include="Microsoft.Extensions.\1" Version="9.0.0"/g' {} +
+	find src -name "*.csproj" -exec sed -i 's/Include="System\.ServiceProcess\.ServiceController" Version="[0-9.]*"/Include="System.ServiceProcess.ServiceController" Version="9.0.0"/g' {} +
+
+	# Remove obsolete System.* package references that are built into .NET 9.0
+	find src -name "*.csproj" -exec sed -i '/Include="System\.\(ValueTuple\|Memory\|Runtime\.Loader\|Threading\.Tasks\.Extensions\)"/d' {} +
+
+	# Fix ambiguous IPNetwork reference under .NET 9.0
+	if ! grep -q "using IPNetwork =" src/NzbDrone.Host/Startup.cs; then
+		sed -i 's/\bIPNetwork\b/Microsoft.AspNetCore.HttpOverrides.IPNetwork/g' src/NzbDrone.Host/Startup.cs
+	fi
+
+	# Build UI
+	export NODE_OPTIONS="--max-old-space-size=4096"
+	yarn install
+	yarn build --env production
+}
+
+termux_step_make() {
+	termux_setup_dotnet
+	local COMMON_ARGS=(
+		--framework "net${TERMUX_DOTNET_VERSION}"
+		--no-self-contained
+		--runtime "${DOTNET_TARGET_NAME}"
+		--configuration Release
+		--output build/
+		--verbosity minimal
+		-m:1
+		-nodeReuse:false
+		-p:UseSharedCompilation=false
+		-p:Platform=Posix
+		-p:DebugType=None
+		-p:PublishRepositoryUrl=false
+		-p:EmbedAllSources=false
+		-p:AssemblyVersion="${TERMUX_PKG_VERSION}"
+		-p:FileVersion="${TERMUX_PKG_VERSION}"
+		-p:InformationalVersion="${TERMUX_PKG_VERSION}"
+		-p:Version="${TERMUX_PKG_VERSION}"
+	)
+
+	dotnet publish src/NzbDrone.Console/Prowlarr.Console.csproj "${COMMON_ARGS[@]}"
+
+	# Prowlarr.Mono is dynamically loaded at runtime on Linux/macOS
+	dotnet publish src/NzbDrone.Mono/Prowlarr.Mono.csproj "${COMMON_ARGS[@]}"
+
+	# Lower required .NET version in runtimeconfig.json to allow running on older .NET 9.0.x runtimes
+	find build -name "*.runtimeconfig.json" -exec sed -i 's/"version": "9.0.[0-9]*"/"version": "9.0.0"/g' {} +
+
+	dotnet build-server shutdown
+}
+
+termux_step_make_install() {
+	# Remove bundled native libs that we want to use from system
+	rm -f build/{libe_sqlite3,libMonoPosixHelper}.so*
+
+	rm -rf "${TERMUX_PREFIX}/lib/prowlarr"
+	mkdir -p "${TERMUX_PREFIX}/lib/prowlarr"
+
+	# Copy build artifacts
+	cp -r build/* "${TERMUX_PREFIX}/lib/prowlarr/"
+
+	# Copy UI files
+	mkdir -p "${TERMUX_PREFIX}/lib/prowlarr/UI"
+	cp -r _output/UI/* "${TERMUX_PREFIX}/lib/prowlarr/UI/"
+
+	# Create launch script
+	cat > "${TERMUX_PREFIX}/bin/prowlarr" <<-HERE
+		#!${TERMUX_PREFIX}/bin/sh
+		exec dotnet "${TERMUX_PREFIX}/lib/prowlarr/Prowlarr.dll" "\$@"
+	HERE
+	chmod u+x "${TERMUX_PREFIX}/bin/prowlarr"
+}

--- a/packages/radarr/build.sh
+++ b/packages/radarr/build.sh
@@ -1,0 +1,124 @@
+TERMUX_PKG_HOMEPAGE="https://radarr.video"
+TERMUX_PKG_DESCRIPTION="A PVR for Usenet and BitTorrent users (server)"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="6.2.1.10461"
+TERMUX_PKG_SRCURL="https://github.com/Radarr/Radarr/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=2cb1eccec4cd420461206248f351f41162c099387cba95a1f694d0a73e1631cc
+TERMUX_PKG_BUILD_DEPENDS="aspnetcore-targeting-pack-9.0, dotnet-targeting-pack-9.0, nodejs, yarn"
+TERMUX_PKG_DEPENDS="aspnetcore-runtime-9.0, dotnet-host, dotnet-runtime-9.0, mono, libesqlite3, libcurl, ffmpeg"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_SERVICE_SCRIPT=(
+	"radarr"
+	"exec ${TERMUX_PREFIX}/bin/radarr -nobrowser 2>&1"
+)
+TERMUX_PKG_EXCLUDED_ARCHES="arm"
+TERMUX_DOTNET_VERSION=9.0
+
+termux_step_pre_configure() {
+	# Remove global.json to allow using system dotnet version
+	rm -f global.json
+
+	termux_setup_dotnet
+	termux_setup_nodejs
+
+	# Create a host wrapper for yarn since the one in $TERMUX_PREFIX/bin
+	# has a shebang pointing to the target node
+	local bin="$TERMUX_PKG_BUILDDIR/_bin"
+	mkdir -p "$bin"
+	local yarn="$bin/yarn"
+	cat > "$yarn" <<-EOF
+		#!/bin/sh
+		exec node $TERMUX_PREFIX/share/yarn/bin/yarn.js "\$@"
+	EOF
+	chmod 0755 "$yarn"
+	export PATH="$bin:$PATH"
+
+	# Patch Directory.Build.props to disable TreatWarningsAsErrors and ignore vulnerabilities
+	sed -i 's/<TreatWarningsAsErrors>true<\/TreatWarningsAsErrors>/<TreatWarningsAsErrors>false<\/TreatWarningsAsErrors>/g' src/Directory.Build.props
+	sed -i 's/<EnforceCodeStyleInBuild>true<\/EnforceCodeStyleInBuild>/<EnforceCodeStyleInBuild>false<\/EnforceCodeStyleInBuild>/g' src/Directory.Build.props
+	sed -i 's/<AnalysisLevel>.*<\/AnalysisLevel>/<AnalysisLevel>none<\/AnalysisLevel>/g' src/Directory.Build.props
+	sed -i 's/<GenerateDocumentationFile>true<\/GenerateDocumentationFile>/<GenerateDocumentationFile>false<\/GenerateDocumentationFile>/g' src/Directory.Build.props
+	sed -i '/<NoWarn>$(NoWarn);CS1591<\/NoWarn>/a \    <NoWarn>$(NoWarn);NU1901;NU1902;NU1903;NU1904;NU1605</NoWarn>' src/Directory.Build.props
+	sed -i '/<PropertyGroup>/a \    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>' src/Directory.Build.props
+
+	# Force all projects to target .NET 9.0
+	find src -name "*.csproj" -exec sed -i 's/<TargetFrameworks>.*<\/TargetFrameworks>/<TargetFrameworks>net9.0<\/TargetFrameworks>/g' {} +
+	find src -name "*.csproj" -exec sed -i 's/<TargetFramework>.*<\/TargetFramework>/<TargetFramework>net9.0<\/TargetFramework>/g' {} +
+
+	# Update Microsoft.Extensions and specific System packages to 9.0.0 for compatibility with .NET 9.0
+	find src -name "*.csproj" -exec sed -i 's/Include="Microsoft\.Extensions\.\([^"]*\)" Version="[0-9.]*"/Include="Microsoft.Extensions.\1" Version="9.0.0"/g' {} +
+	find src -name "*.csproj" -exec sed -i 's/Include="System\.ServiceProcess\.ServiceController" Version="[0-9.]*"/Include="System.ServiceProcess.ServiceController" Version="9.0.0"/g' {} +
+
+	# Remove obsolete System.* package references that are built into .NET 9.0
+	find src -name "*.csproj" -exec sed -i '/Include="System\.\(ValueTuple\|Memory\|Runtime\.Loader\|Threading\.Tasks\.Extensions\)"/d' {} +
+
+	# Fix ambiguous IPNetwork reference under .NET 9.0
+	if ! grep -q "using IPNetwork =" src/NzbDrone.Host/Startup.cs; then
+		sed -i 's/\bIPNetwork\b/Microsoft.AspNetCore.HttpOverrides.IPNetwork/g' src/NzbDrone.Host/Startup.cs
+	fi
+
+	# Build UI
+	export NODE_OPTIONS="--max-old-space-size=4096"
+	yarn install
+	yarn build --env production
+}
+
+termux_step_make() {
+	termux_setup_dotnet
+	local COMMON_ARGS=(
+		--framework "net${TERMUX_DOTNET_VERSION}"
+		--no-self-contained
+		--runtime "${DOTNET_TARGET_NAME}"
+		--configuration Release
+		--output build/
+		--verbosity minimal
+		-m:1
+		-nodeReuse:false
+		-p:UseSharedCompilation=false
+		-p:Platform=Posix
+		-p:DebugType=None
+		-p:PublishRepositoryUrl=false
+		-p:EmbedAllSources=false
+		-p:AssemblyVersion="${TERMUX_PKG_VERSION}"
+		-p:FileVersion="${TERMUX_PKG_VERSION}"
+		-p:InformationalVersion="${TERMUX_PKG_VERSION}"
+		-p:Version="${TERMUX_PKG_VERSION}"
+	)
+
+	dotnet publish src/NzbDrone.Console/Radarr.Console.csproj "${COMMON_ARGS[@]}"
+
+	# Radarr.Mono is dynamically loaded at runtime on Linux/macOS
+	dotnet publish src/NzbDrone.Mono/Radarr.Mono.csproj "${COMMON_ARGS[@]}"
+
+	# Lower required .NET version in runtimeconfig.json to allow running on older .NET 9.0.x runtimes
+	find build -name "*.runtimeconfig.json" -exec sed -i 's/"version": "9.0.[0-9]*"/"version": "9.0.0"/g' {} +
+
+	dotnet build-server shutdown
+}
+
+termux_step_make_install() {
+	# Remove bundled native libs that we want to use from system
+	rm -f build/{libe_sqlite3,libMonoPosixHelper}.so*
+
+	rm -rf "${TERMUX_PREFIX}/lib/radarr"
+	mkdir -p "${TERMUX_PREFIX}/lib/radarr"
+
+	# Copy build artifacts
+	cp -r build/* "${TERMUX_PREFIX}/lib/radarr/"
+
+	# Copy UI files
+	mkdir -p "${TERMUX_PREFIX}/lib/radarr/UI"
+	cp -r _output/UI/* "${TERMUX_PREFIX}/lib/radarr/UI/"
+
+	# Create symlinks for ffmpeg/ffprobe
+	ln -sf "${TERMUX_PREFIX}/bin/ffmpeg" "${TERMUX_PREFIX}/lib/radarr/ffmpeg"
+	ln -sf "${TERMUX_PREFIX}/bin/ffprobe" "${TERMUX_PREFIX}/lib/radarr/ffprobe"
+
+	# Create launch script
+	cat > "${TERMUX_PREFIX}/bin/radarr" <<-HERE
+		#!${TERMUX_PREFIX}/bin/sh
+		exec dotnet "${TERMUX_PREFIX}/lib/radarr/Radarr.dll" "\$@"
+	HERE
+	chmod u+x "${TERMUX_PREFIX}/bin/radarr"
+}

--- a/packages/seerr/build.sh
+++ b/packages/seerr/build.sh
@@ -1,0 +1,156 @@
+TERMUX_PKG_HOMEPAGE="https://github.com/seerr-team/seerr"
+TERMUX_PKG_DESCRIPTION="A fork of Overseerr with focus on adding support for Jellyfin/Emby"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="3.3.0"
+TERMUX_PKG_SRCURL="https://github.com/seerr-team/seerr/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256="3a6caf9266f7525c3ac2aecb666f5939034e383296761bdea14ad3105237721c"
+TERMUX_PKG_BUILD_DEPENDS="nodejs, libvips, pkg-config"
+TERMUX_PKG_DEPENDS="nodejs, libvips, termux-services"
+# Uncomment the line below to avoid file conflicts when building on-device
+# while other background services are actively writing logs (system-level bug #30401)
+# TERMUX_PKG_RM_AFTER_INSTALL="var/log"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_SERVICE_SCRIPT=(
+	"seerr"
+	"exec ${TERMUX_PREFIX}/bin/seerr 2>&1"
+)
+
+termux_step_pre_configure() {
+	termux_setup_nodejs
+
+	# Install pnpm locally in a clean prefix to avoid dependency resolution conflicts with package.json
+	local PNPM_DIR="$TERMUX_PKG_TMPDIR/pnpm"
+	mkdir -p "$PNPM_DIR"
+	npm install --prefix "$PNPM_DIR" pnpm
+	export PATH="$PNPM_DIR/node_modules/.bin:$PATH"
+
+	# Loosen node engine requirements in package.json
+	sed -i '/"engines": {/,/}/ s/"node": ".*"/"node": ">=20.0.0"/' package.json
+
+	# Setup cross-compilation environment for node-gyp (sqlite3, bcrypt, etc.)
+	export CC=$CC
+	export CXX=$CXX
+	export AR=$AR
+	export LINK=$CXX
+
+	local GYP_ARCH
+	case "$TERMUX_ARCH" in
+		aarch64) GYP_ARCH="arm64" ;;
+		arm) GYP_ARCH="arm" ;;
+		i686) GYP_ARCH="ia32" ;;
+		x86_64) GYP_ARCH="x64" ;;
+	esac
+	export npm_config_arch=$GYP_ARCH
+	export npm_config_platform=android
+
+	# Force sharp to compile against system libvips using pkg-config
+	export SHARP_FORCE_GLOBAL_LIBVIPS=1
+
+	# Cypress binary download is not needed for packaging
+	export CYPRESS_INSTALL_BINARY=0
+
+	# Install dependencies
+	pnpm install --frozen-lockfile=false --no-engine-strict
+
+	# Add SWC WASM loader node package matching the next.js version
+	local NEXT_VERSION=$(node -p "require('./package.json').dependencies.next")
+	pnpm add "@next/swc-wasm-nodejs@$NEXT_VERSION"
+
+	# Patch Next.js SWC loader for WASM fallback
+	local INDEX_JS="node_modules/next/dist/build/swc/index.js"
+	if [ -f "$INDEX_JS" ]; then
+		sed -i 's/const isWebContainer = .*;/const isWebContainer = true;/g' "$INDEX_JS"
+	fi
+
+	# Disable swcMinify in config file to prevent build issues
+	local CONFIG_FILE=""
+	if [ -f "next.config.ts" ]; then
+		CONFIG_FILE="next.config.ts"
+	elif [ -f "next.config.js" ]; then
+		CONFIG_FILE="next.config.js"
+	fi
+
+	if [ -n "$CONFIG_FILE" ]; then
+		if ! grep -q "swcMinify: false" "$CONFIG_FILE"; then
+			if grep -q "const nextConfig: NextConfig = {" "$CONFIG_FILE"; then
+				sed -i 's/const nextConfig: NextConfig = {/const nextConfig: NextConfig = {\n  swcMinify: false,/' "$CONFIG_FILE"
+			elif grep -q "module.exports = {" "$CONFIG_FILE"; then
+				sed -i 's/module.exports = {/module.exports = {\n  swcMinify: false,/' "$CONFIG_FILE"
+			fi
+		fi
+	fi
+
+	# Force Next.js to use Webpack instead of Turbopack (the default in Next.js 16).
+	# Turbopack's runtime dynamically generates relative symlinks in .next/node_modules/
+	# pointing back to the temporary build directory, which go dead once relocated to
+	# $TERMUX_PREFIX for packaging (upstream bug: vercel/next.js#89851).
+	sed -i 's/"build:next": "next build"/"build:next": "next build --webpack"/g' package.json
+}
+
+termux_step_make() {
+	termux_setup_nodejs
+	export PATH="$TERMUX_PKG_TMPDIR/pnpm/node_modules/.bin:$TERMUX_PKG_SRCDIR/node_modules/.bin:$PATH"
+	pnpm build
+}
+
+termux_step_make_install() {
+	termux_setup_nodejs
+	# Clean up devDependencies before packaging
+	export PATH="$TERMUX_PKG_TMPDIR/pnpm/node_modules/.bin:$TERMUX_PKG_SRCDIR/node_modules/.bin:$PATH"
+	pnpm prune --prod --ignore-scripts
+
+	rm -rf "${TERMUX_PREFIX}/lib/seerr"
+	mkdir -p "${TERMUX_PREFIX}/lib/seerr"
+
+	# Copy build artifacts, public assets, and runtime dependencies
+	cp -r dist "${TERMUX_PREFIX}/lib/seerr/"
+	cp -r public "${TERMUX_PREFIX}/lib/seerr/"
+	cp -r .next "${TERMUX_PREFIX}/lib/seerr/"
+	cp -r node_modules "${TERMUX_PREFIX}/lib/seerr/"
+	cp package.json seerr-api.yml "${TERMUX_PREFIX}/lib/seerr/"
+
+	# Remove Next.js build cache (only used at compilation time, not runtime)
+	rm -rf "${TERMUX_PREFIX}/lib/seerr/.next/cache"
+
+	# Remove useless dev/doc files from node_modules to reduce package size
+	find "${TERMUX_PREFIX}/lib/seerr/node_modules" -type f \( \
+		-name "*.md" -o \
+		-name "*.map" -o \
+		-name "*.ts" -o \
+		-name "*.tsx" -o \
+		-name "LICENSE" -o \
+		-name "license" -o \
+		-name "Makefile" \
+	\) -delete
+
+	find "${TERMUX_PREFIX}/lib/seerr/node_modules" -type d \( \
+		-name "test" -o \
+		-name "tests" -o \
+		-name "__tests__" -o \
+		-name "docs" -o \
+		-name "doc" -o \
+		-name "example" -o \
+		-name "examples" -o \
+		-name ".github" -o \
+		-name ".circleci" -o \
+		-name ".husky" \
+	\) -exec rm -rf {} +
+
+	# Strip native Node.js binaries, ignoring non-ELF formats like macOS Mach-O
+	find "${TERMUX_PREFIX}/lib/seerr/node_modules" -name "*.node" -exec sh -c '${STRIP} --strip-unneeded "$1" 2>/dev/null || true' _ {} \;
+
+	# Remove native build intermediate objects to save space
+	find "${TERMUX_PREFIX}/lib/seerr/node_modules" -type d -name "obj.target" -exec rm -rf {} +
+
+	# Create launch script
+	cat > "${TERMUX_PREFIX}/bin/seerr" <<-HERE
+		#!${TERMUX_PREFIX}/bin/sh
+		export CONFIG_DIRECTORY="\${CONFIG_DIRECTORY:-\$HOME/.config/seerr}"
+		export PORT="\${PORT:-5055}"
+		export NODE_ENV=production
+		cd "${TERMUX_PREFIX}/lib/seerr"
+		exec node dist/index.js "\$@"
+	HERE
+	chmod u+x "${TERMUX_PREFIX}/bin/seerr"
+}

--- a/packages/seerr/next-config-webpack-svg.patch
+++ b/packages/seerr/next-config-webpack-svg.patch
@@ -1,0 +1,18 @@
+--- a/next.config.ts
++++ b/next.config.ts
+@@ -21,6 +21,15 @@
+       },
+     },
+   },
++  webpack(config) {
++    config.module.rules.push({
++      test: /\.svg$/,
++      issuer: /\.(js|ts)x?$/,
++      use: ['@svgr/webpack'],
++    });
++
++    return config;
++  },
+   experimental: {
+     scrollRestoration: true,
+     largePageDataBytes: 512 * 1000,

--- a/packages/sonarr/build.sh
+++ b/packages/sonarr/build.sh
@@ -1,0 +1,124 @@
+TERMUX_PKG_HOMEPAGE="https://sonarr.tv"
+TERMUX_PKG_DESCRIPTION="A PVR for Usenet and BitTorrent users (server)"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="4.0.17.2952"
+TERMUX_PKG_SRCURL="https://github.com/Sonarr/Sonarr/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=9b986545f28308de5969bdd913ae3b3528f71a632b7dc097af72c63b16789d7b
+TERMUX_PKG_BUILD_DEPENDS="aspnetcore-targeting-pack-9.0, dotnet-targeting-pack-9.0, nodejs, yarn"
+TERMUX_PKG_DEPENDS="aspnetcore-runtime-9.0, dotnet-host, dotnet-runtime-9.0, mono, libesqlite3, libcurl, ffmpeg"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_SERVICE_SCRIPT=(
+	"sonarr"
+	"exec ${TERMUX_PREFIX}/bin/sonarr -nobrowser 2>&1"
+)
+TERMUX_PKG_EXCLUDED_ARCHES="arm"
+TERMUX_DOTNET_VERSION=9.0
+
+termux_step_pre_configure() {
+	# Remove global.json to allow using system dotnet version
+	rm -f global.json
+
+	termux_setup_dotnet
+	termux_setup_nodejs
+
+	# Create a host wrapper for yarn since the one in $TERMUX_PREFIX/bin
+	# has a shebang pointing to the target node
+	local bin="$TERMUX_PKG_BUILDDIR/_bin"
+	mkdir -p "$bin"
+	local yarn="$bin/yarn"
+	cat > "$yarn" <<-EOF
+		#!/bin/sh
+		exec node $TERMUX_PREFIX/share/yarn/bin/yarn.js "\$@"
+	EOF
+	chmod 0755 "$yarn"
+	export PATH="$bin:$PATH"
+
+	# Patch Directory.Build.props to disable TreatWarningsAsErrors and ignore vulnerabilities
+	sed -i 's/<TreatWarningsAsErrors>true<\/TreatWarningsAsErrors>/<TreatWarningsAsErrors>false<\/TreatWarningsAsErrors>/g' src/Directory.Build.props
+	sed -i 's/<EnforceCodeStyleInBuild>true<\/EnforceCodeStyleInBuild>/<EnforceCodeStyleInBuild>false<\/EnforceCodeStyleInBuild>/g' src/Directory.Build.props
+	sed -i 's/<AnalysisLevel>.*<\/AnalysisLevel>/<AnalysisLevel>none<\/AnalysisLevel>/g' src/Directory.Build.props
+	sed -i 's/<GenerateDocumentationFile>true<\/GenerateDocumentationFile>/<GenerateDocumentationFile>false<\/GenerateDocumentationFile>/g' src/Directory.Build.props
+	sed -i '/<NoWarn>$(NoWarn);CS1591<\/NoWarn>/a \    <NoWarn>$(NoWarn);NU1901;NU1902;NU1903;NU1904;NU1605</NoWarn>' src/Directory.Build.props
+	sed -i '/<PropertyGroup>/a \    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>' src/Directory.Build.props
+
+	# Force all projects to target .NET 9.0
+	find src -name "*.csproj" -exec sed -i 's/<TargetFrameworks>.*<\/TargetFrameworks>/<TargetFrameworks>net9.0<\/TargetFrameworks>/g' {} +
+	find src -name "*.csproj" -exec sed -i 's/<TargetFramework>.*<\/TargetFramework>/<TargetFramework>net9.0<\/TargetFramework>/g' {} +
+
+	# Update Microsoft.Extensions and specific System packages to 9.0.0 for compatibility with .NET 9.0
+	find src -name "*.csproj" -exec sed -i 's/Include="Microsoft\.Extensions\.\([^"]*\)" Version="[0-9.]*"/Include="Microsoft.Extensions.\1" Version="9.0.0"/g' {} +
+	find src -name "*.csproj" -exec sed -i 's/Include="System\.ServiceProcess\.ServiceController" Version="[0-9.]*"/Include="System.ServiceProcess.ServiceController" Version="9.0.0"/g' {} +
+
+	# Remove obsolete System.* package references that are built into .NET 9.0
+	find src -name "*.csproj" -exec sed -i '/Include="System\.\(ValueTuple\|Memory\|Runtime\.Loader\|Threading\.Tasks\.Extensions\)"/d' {} +
+
+	# Fix ambiguous IPNetwork reference under .NET 9.0
+	if ! grep -q "using IPNetwork =" src/NzbDrone.Host/Startup.cs; then
+		sed -i 's/\bIPNetwork\b/Microsoft.AspNetCore.HttpOverrides.IPNetwork/g' src/NzbDrone.Host/Startup.cs
+	fi
+
+	# Build UI
+	export NODE_OPTIONS="--max-old-space-size=4096"
+	yarn install
+	yarn build --env production
+}
+
+termux_step_make() {
+	termux_setup_dotnet
+	local COMMON_ARGS=(
+		--framework "net${TERMUX_DOTNET_VERSION}"
+		--no-self-contained
+		--runtime "${DOTNET_TARGET_NAME}"
+		--configuration Release
+		--output build/
+		--verbosity minimal
+		-m:1
+		-nodeReuse:false
+		-p:UseSharedCompilation=false
+		-p:Platform=Posix
+		-p:DebugType=None
+		-p:PublishRepositoryUrl=false
+		-p:EmbedAllSources=false
+		-p:AssemblyVersion="${TERMUX_PKG_VERSION}"
+		-p:FileVersion="${TERMUX_PKG_VERSION}"
+		-p:InformationalVersion="${TERMUX_PKG_VERSION}"
+		-p:Version="${TERMUX_PKG_VERSION}"
+	)
+
+	dotnet publish src/NzbDrone.Console/Sonarr.Console.csproj "${COMMON_ARGS[@]}"
+
+	# Sonarr.Mono is dynamically loaded at runtime on Linux/macOS
+	dotnet publish src/NzbDrone.Mono/Sonarr.Mono.csproj "${COMMON_ARGS[@]}"
+
+	# Lower required .NET version in runtimeconfig.json to allow running on older .NET 9.0.x runtimes
+	find build -name "*.runtimeconfig.json" -exec sed -i 's/"version": "9.0.[0-9]*"/"version": "9.0.0"/g' {} +
+
+	dotnet build-server shutdown
+}
+
+termux_step_make_install() {
+	# Remove bundled native libs that we want to use from system
+	rm -f build/{libe_sqlite3,libMonoPosixHelper}.so*
+
+	rm -rf "${TERMUX_PREFIX}/lib/sonarr"
+	mkdir -p "${TERMUX_PREFIX}/lib/sonarr"
+
+	# Copy build artifacts
+	cp -r build/* "${TERMUX_PREFIX}/lib/sonarr/"
+
+	# Copy UI files
+	mkdir -p "${TERMUX_PREFIX}/lib/sonarr/UI"
+	cp -r _output/UI/* "${TERMUX_PREFIX}/lib/sonarr/UI/"
+
+	# Create symlinks for ffmpeg/ffprobe
+	ln -sf "${TERMUX_PREFIX}/bin/ffmpeg" "${TERMUX_PREFIX}/lib/sonarr/ffmpeg"
+	ln -sf "${TERMUX_PREFIX}/bin/ffprobe" "${TERMUX_PREFIX}/lib/sonarr/ffprobe"
+
+	# Create launch script
+	cat > "${TERMUX_PREFIX}/bin/sonarr" <<-HERE
+		#!${TERMUX_PREFIX}/bin/sh
+		exec dotnet "${TERMUX_PREFIX}/lib/sonarr/Sonarr.dll" "\$@"
+	HERE
+	chmod u+x "${TERMUX_PREFIX}/bin/sonarr"
+}


### PR DESCRIPTION
### Description
This PR adds and updates media server packages for the Termux environment:
**New Packages**:
   - `sonarr` (v4.0.17.2952)
   - `radarr` (v6.2.1.10461)
   - `prowlarr` (v2.4.0.5397)
   - `seerr` (v3.3.0)

### Details
- **Dotnet 9 Compatibility**: For `sonarr`, `radarr`, and `prowlarr`, applied patches to resolve ambiguous `IPNetwork` references and configured the projects to build using system .NET 9.
- **Webpack SVG Support for Seerr**: Added Webpack configuration patch for `seerr` to enable SVG loading during the Next.js compilation phase.