### PR TITLE
bump(main/proot): version 5.1.107.78 (enable libandroid-shmem)

### DIFF
--- a/packages/proot/build.sh
+++ b/packages/proot/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_DESCRIPTION="Emulate chroot, bind mount and binfmt_misc for non-root 
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="Michal Bednarski @michalbednarski"
 TERMUX_PKG_VERSION="5.1.107.78"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/termux/proot/archive/v${TERMUX_PKG_VERSION}.zip
 TERMUX_PKG_SHA256=7babd3fde0875adfff33936418886620c429cdd077d42db3af605d6bbe686d22
 TERMUX_PKG_AUTO_UPDATE=true

--- a/packages/proot/build.sh
+++ b/packages/proot/build.sh
@@ -3,15 +3,15 @@ TERMUX_PKG_HOMEPAGE=https://proot-me.github.io/
 TERMUX_PKG_DESCRIPTION="Emulate chroot, bind mount and binfmt_misc for non-root users"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="Michal Bednarski @michalbednarski"
-TERMUX_PKG_VERSION="5.1.107.77"
+TERMUX_PKG_VERSION="5.1.107.78"
 TERMUX_PKG_SRCURL=https://github.com/termux/proot/archive/v${TERMUX_PKG_VERSION}.zip
-TERMUX_PKG_SHA256=f79a9f3615af92c27793746b19143214b8ffd036c7217ee06262988344bd1bdd
+TERMUX_PKG_SHA256=7babd3fde0875adfff33936418886620c429cdd077d42db3af605d6bbe686d22
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
-TERMUX_PKG_DEPENDS="libtalloc"
+TERMUX_PKG_DEPENDS="libandroid-shmem, libtalloc"
 TERMUX_PKG_SUGGESTS="proot-distro"
 TERMUX_PKG_BUILD_IN_SRC=true
-TERMUX_PKG_EXTRA_MAKE_ARGS="-C src"
+TERMUX_PKG_EXTRA_MAKE_ARGS="-C src PROOT_WITH_LIBANDROID_SHMEM=true"
 
 # Install loader in libexec instead of extracting it every time
 export PROOT_UNBUNDLE_LOADER=$TERMUX_PREFIX/libexec/proot


### PR DESCRIPTION
This enables libandroid-shmem backend for proot shared memory implementation.

Added revision just in case if auto-update will be triggered before this pull request get merged.