### PR TITLE
fix(x11/kpat): do not update mime types during build

### DIFF
--- a/x11-packages/kpat/build.sh
+++ b/x11-packages/kpat/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="KPatience offers a selection of solitaire card games"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="3ls-it <3ls-it@pm.me>"
 TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/kpat-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=c0ae10f2c10e2413351ea79cbc83d9a56ec1c37c57065dc3d5e481d37c76afd7
 TERMUX_PKG_AUTO_UPDATE=true

--- a/x11-packages/kpat/do-not-update-mimetypes.patch
+++ b/x11-packages/kpat/do-not-update-mimetypes.patch
@@ -1,0 +1,7 @@
+--- a/mimetypes/CMakeLists.txt
++++ b/mimetypes/CMakeLists.txt
+@@ -1,4 +1,3 @@
+ find_package( SharedMimeInfo REQUIRED )
+ 
+ install( FILES kpatience.xml DESTINATION ${KDE_INSTALL_MIMEDIR} )
+-update_xdg_mimetypes( ${KDE_INSTALL_MIMEDIR} )


### PR DESCRIPTION
- Like analogous code in many preexisting termux packages

https://github.com/termux/termux-packages/blob/033fbddb2a0a1eeba730bc239caae2230047632f/x11-packages/calligraplan/disable-update-mime-types.patch#L7

- Fixes this error in termux-pacman:

```
error: failed to commit transaction (conflicting files)
kpat: /data/data/com.termux/files/usr/share/mime/XMLnamespaces exists in filesystem
```