### PR TITLE
revbump(x11/librewolf): 151.0.3-1, 1

### DIFF
--- a/x11-packages/librewolf/0032-fontconfig-family_name-maybe-nullptr.patch
+++ b/x11-packages/librewolf/0032-fontconfig-family_name-maybe-nullptr.patch
@@ -1,1 +1,0 @@
-../firefox/0032-fontconfig-family_name-maybe-nullptr.patch

--- a/x11-packages/librewolf/1033-fix-webrender-cbindgen.patch
+++ b/x11-packages/librewolf/1033-fix-webrender-cbindgen.patch
@@ -1,0 +1,20 @@
+--- a/gfx/wr/webrender/src/texture_cache.rs	2026-06-08 15:13:30.000000000 -0400
++++ b/gfx/wr/webrender/src/texture_cache.rs	2026-06-11 16:15:09.138861529 -0400
+@@ -275,7 +275,7 @@
+ impl BudgetType {
+     pub const COUNT: usize = 7;
+ 
+-    pub const VALUES: [BudgetType; BudgetType::COUNT] = [
++    pub const VALUES: [BudgetType; 7] = [
+         BudgetType::SharedColor8Linear,
+         BudgetType::SharedColor8Nearest,
+         BudgetType::SharedColor8Glyphs,
+@@ -285,7 +285,7 @@
+         BudgetType::Standalone,
+     ];
+ 
+-    pub const PRESSURE_COUNTERS: [usize; BudgetType::COUNT] = [
++    pub const PRESSURE_COUNTERS: [usize; 7] = [
+         profiler::ATLAS_COLOR8_LINEAR_PRESSURE,
+         profiler::ATLAS_COLOR8_NEAREST_PRESSURE,
+         profiler::ATLAS_COLOR8_GLYPHS_PRESSURE,

--- a/x11-packages/librewolf/build.sh
+++ b/x11-packages/librewolf/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A custom version of Firefox, focused on privacy, securit
 TERMUX_PKG_LICENSE="MPL-2.0"
 TERMUX_PKG_MAINTAINER="@3ls-it"
 TERMUX_PKG_VERSION="151.0.3-1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://codeberg.org/api/packages/librewolf/generic/librewolf-source/${TERMUX_PKG_VERSION}/librewolf-${TERMUX_PKG_VERSION}.source.tar.gz"
 TERMUX_PKG_SHA256=a06d854cff9131120ba81bb31aaf05b41623c82806ea8842e0ef73d75f103aa3
 # ffmpeg and pulseaudio are dependencies through dlopen(3):


### PR DESCRIPTION
This PR revbumps Librewolf 151.0.3-1 to fix:
https://github.com/termux/termux-packages/issues/30093

This will add the patch provided by @sabamdarif with line numbers adjusted to match Librewolf source. It also removes the dangling symlink that used to point to
`x11-packages/firefox/0032-fontconfig-family_name-maybe-nullptr.patch`  
  
- Doing a revbump only and keeping version `151.0.3-1` to make sure auto update is successful.