### PR TITLE
bump(main/pv): 1.11.0

### DIFF
--- a/packages/pv/build.sh
+++ b/packages/pv/build.sh
@@ -2,8 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://www.ivarch.com/programs/pv.shtml
 TERMUX_PKG_DESCRIPTION="Terminal-based tool for monitoring the progress of data through a pipeline"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.10.5"
+TERMUX_PKG_VERSION="1.11.0"
 TERMUX_PKG_SRCURL=https://www.ivarch.com/programs/sources/pv-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=ab21b4f8662280646b6a02e1b9f096790918f89c952bbe0d06fef75d3b52fb15
+TERMUX_PKG_SHA256=fc02c9fc2b82b20a92cc8d98f844be63f22abd98751a8e4abc875e1d803662eb
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-ipc"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--disable-copy-file-range
+--disable-ipc
+"


### PR DESCRIPTION
Disable copy_file_range function to fix the following compiler error.
transfer.c:743:13: error: call to undeclared function 'copy_file_range'

* Fixes #30147 