### PR TITLE
fix(x11/flameshot): force-reenable X11 support in version 14

### DIFF
--- a/x11-packages/flameshot/build.sh
+++ b/x11-packages/flameshot/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Powerful yet simple to use screenshot software"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="14.0.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/flameshot-org/flameshot/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=810c399f3b9fbfd72e24e61417ede24243925f9c0d03040a8aba0d4866676d93
 TERMUX_PKG_AUTO_UPDATE=true

--- a/x11-packages/flameshot/force-reenable-x11.patch
+++ b/x11-packages/flameshot/force-reenable-x11.patch
@@ -1,0 +1,11 @@
+--- a/src/utils/confighandler.cpp
++++ b/src/utils/confighandler.cpp
+@@ -149,7 +149,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
+ #if defined(Q_OS_LINUX)
+     // Bypass freedesktop portal and use Qt's native X11
+     // screenshot method. Intended for WMs without xdg-desktop-portal.
+-    OPTION("useX11LegacyScreenshot"      ,Bool               ( false         )),
++    OPTION("useX11LegacyScreenshot"      ,Bool               ( true         )),
+ #endif
+ };
+ 


### PR DESCRIPTION
- After https://github.com/termux/termux-packages/pull/30159

- I wrote more details from the perspective of a user of other distro Gentoo here: https://github.com/flameshot-org/flameshot/issues/4693