### PR TITLE
Add KDE Education applications

### DIFF
--- a/x11-packages/analitza/build.sh
+++ b/x11-packages/analitza/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/analitza"
+TERMUX_PKG_DESCRIPTION="A library to add mathematical features to your program"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/analitza-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="66e9bcdf400595a03dfadc59b45e380b1a6cbe6fbc3522af0d772edf5c35ed2a"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="libc++, qt6-qtbase, qt6-qtdeclarative, qt6-qtsvg"
+TERMUX_PKG_BUILD_DEPENDS="eigen, extra-cmake-modules, kf6-kdoctools, qt6-qttools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+} 

--- a/x11-packages/artikulate/build.sh
+++ b/x11-packages/artikulate/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/artikulate"
+TERMUX_PKG_DESCRIPTION="Improve your pronunciation by listening to native speakers"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/artikulate-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="bf134e1b2df358ba19120ae124da3763642f0007426ec3e7a97c81d2bcc694c5"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kirigami-addons, kf6-karchive, kf6-kconfig, kf6-kcoreaddons, kf6-kcrash, kf6-ki18n, kf6-kirigami, kf6-kitemmodels, kf6-knewstuff, libc++, libxml2, qt6-qtbase, qt6-qtdeclarative, qt6-qtmultimedia"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kdoctools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+} 

--- a/x11-packages/blinken/build.sh
+++ b/x11-packages/blinken/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/blinken"
+TERMUX_PKG_DESCRIPTION="Memory Enhancement Game"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/blinken-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="fe6182b27fa31e5b2cc257644f1ce40cbbaf500de161ab3498fe3ab18e05fffb"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kf6-kconfig, kf6-kcoreaddons, kf6-kcrash, kf6-kdbusaddons, kf6-kguiaddons, kf6-ki18n, kf6-kxmlgui, libc++, qt6-qtbase, qt6-qtmultimedia, qt6-qtsvg"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kdoctools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+} 

--- a/x11-packages/cantor/build.sh
+++ b/x11-packages/cantor/build.sh
@@ -1,0 +1,47 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/cantor"
+TERMUX_PKG_DESCRIPTION="KDE Frontend to Mathematical Software"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/cantor-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="a1224d780ac8657dfac0f53bfc645aad8bee7f0b2beb9e373212c91dd2f4dcf6"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_HOSTBUILD=true
+TERMUX_PKG_DEPENDS="analitza, kf6-karchive, kf6-kcolorscheme, kf6-kcompletion, kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-kcrash, kf6-ki18n, kf6-kiconthemes, kf6-kio, kf6-knewstuff, kf6-kparts, kf6-ktexteditor, kf6-ktextwidgets, kf6-kwidgetsaddons, kf6-kxmlgui, kf6-syntax-highlighting, libc++, libspectre, libxml2, libxslt, luajit, poppler-qt, python, qalculate-gtk, qt6-qtbase, qt6-qtsvg, qt6-qttools, qt6-qtwebengine"
+TERMUX_PKG_BUILD_DEPENDS="analitza, extra-cmake-modules, kf6-kdoctools, luajit, python"
+TERMUX_PKG_RECOMMENDS="maxima, octave-x"
+#qt6-qtwebengine is not supported for i686 architecture
+TERMUX_PKG_EXCLUDED_ARCHES="i686"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_host_build() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "true" ]]; then
+		return
+	fi
+
+	local discount_src="${TERMUX_PKG_SRCDIR}/thirdparty/discount-2.2.6-patched"
+
+	cd "${discount_src}"
+	sh configure.sh
+
+	gcc -I"${discount_src}" "${discount_src}/mktags.c" -o "${TERMUX_PKG_HOSTBUILD_DIR}/mktags"
+	"${TERMUX_PKG_HOSTBUILD_DIR}/mktags" > "${TERMUX_PKG_HOSTBUILD_DIR}/blocktags"
+}
+
+termux_step_pre_configure() {
+	rm -rf "$TERMUX_HOSTBUILD_MARKER"
+
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+
+		patch --silent -p1 -d "$TERMUX_PKG_SRCDIR" \
+			< "$TERMUX_PKG_BUILDER_DIR/discount-crossbuild.diff"
+
+		sed -i "s|SOURCE_SUBDIR cmake|SOURCE_SUBDIR cmake\n    PATCH_COMMAND \${CMAKE_COMMAND} -E copy_if_different $TERMUX_PKG_HOSTBUILD_DIR/blocktags <SOURCE_DIR>/blocktags|" \
+			"$TERMUX_PKG_SRCDIR/thirdparty/CMakeLists.txt"
+	fi
+}

--- a/x11-packages/cantor/disable-update-mimetypes.patch
+++ b/x11-packages/cantor/disable-update-mimetypes.patch
@@ -1,0 +1,12 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index e591492..c719caa 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -53,7 +53,6 @@ install( TARGETS cantor ${KDE_INSTALL_TARGETS_DEFAULT_ARGS} )
+ install( FILES org.kde.cantor.desktop  DESTINATION ${KDE_INSTALL_APPDIR} )
+ install( FILES cantor.knsrc cantor-documentation.knsrc DESTINATION ${KDE_INSTALL_KNSRCDIR} )
+ install( FILES cantor.xml DESTINATION ${KDE_INSTALL_MIMEDIR} )
+-update_xdg_mimetypes(${KDE_INSTALL_MIMEDIR})
+ 
+ #########################################################################
+ # KPART SECTION

--- a/x11-packages/cantor/discount-crossbuild.diff
+++ b/x11-packages/cantor/discount-crossbuild.diff
@@ -1,0 +1,22 @@
+diff --git a/thirdparty/discount-2.2.6-patched/cmake/CMakeLists.txt b/thirdparty/discount-2.2.6-patched/cmake/CMakeLists.txt
+index a29eb48..2764d79 100644
+--- a/thirdparty/discount-2.2.6-patched/cmake/CMakeLists.txt
++++ b/thirdparty/discount-2.2.6-patched/cmake/CMakeLists.txt
+@@ -113,12 +113,10 @@ configure_file("${_ROOT}/mkdio.h.in"
+ 
+ include_directories("${_ROOT}")
+ 
+-add_executable(mktags
+-    "${_ROOT}/mktags.c")
+-
+-add_custom_command(OUTPUT "${_ROOT}/blocktags"
+-    COMMAND mktags > blocktags
+-    WORKING_DIRECTORY "${_ROOT}")
++if(NOT EXISTS "${_ROOT}/blocktags")
++    message(FATAL_ERROR
++        "Pre-generated blocktags is required for cross-compiling")
++endif()
+ 
+ add_library(libmarkdown
+     "${_ROOT}/mkdio.c"
+

--- a/x11-packages/kalgebra/build.sh
+++ b/x11-packages/kalgebra/build.sh
@@ -1,0 +1,23 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/kalgebra"
+TERMUX_PKG_DESCRIPTION="Graph Calculator"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/kalgebra-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="7c33d1436f8eadec3dfd9a9f34ed665c1e298ab840b92823ba3ac01b59e03387"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="analitza, kirigami-addons, kf6-kcolorscheme, kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-ki18n, kf6-kio, kf6-kwidgetsaddons, kf6-kxmlgui, libc++, qt6-qtbase, qt6-qtdeclarative, qt6-qtwebengine"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kdoctools, libplasma"
+#qt6-qtwebengine is not supported for i686 architecture
+TERMUX_PKG_EXCLUDED_ARCHES="i686"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+} 

--- a/x11-packages/kalzium/build.sh
+++ b/x11-packages/kalzium/build.sh
@@ -1,0 +1,23 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/kalzium"
+TERMUX_PKG_DESCRIPTION="Periodic Table of Elements"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/kalzium-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="19deaf831a91168b9e6a20deae1d678c149a5312a9391d261af40ef2c1eba0a6"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kf6-kcompletion, kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-kcrash, kf6-ki18n, kf6-kio, kf6-kitemviews, kf6-knewstuff, kf6-kplotting, kf6-ktextwidgets, kf6-kunitconversion, kf6-kwidgetsaddons, kf6-kxmlgui, libc++, libxml2, openbabel, qt6-qt5compat, qt6-qtbase, qt6-qtdeclarative, qt6-qtscxml, qt6-qtsvg"
+TERMUX_PKG_BUILD_DEPENDS="eigen, extra-cmake-modules, kf6-kdoctools, openbabel-static"
+#avogadro, ocaml and facile can be added later if packaged in future
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	export LDFLAGS+=" -lxml2"
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+} 

--- a/x11-packages/kanagram/build.sh
+++ b/x11-packages/kanagram/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/kanagram"
+TERMUX_PKG_DESCRIPTION="Letter Order Game"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/kanagram-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="73a1d5056fd00f137bac234cb618d24a8f3e4bda31d03fec0089bb93de069ab9"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-kcrash, kf6-ki18n, kf6-knewstuff, kf6-kwidgetsaddons, kf6-kxmlgui, kf6-sonnet, libc++, libkeduvocdocument, qt6-qtbase, qt6-qtdeclarative, qt6-qtmultimedia, qt6-qtspeech"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kdoctools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}

--- a/x11-packages/kbruch/build.sh
+++ b/x11-packages/kbruch/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/kbruch"
+TERMUX_PKG_DESCRIPTION="Exercise Fractions"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/kbruch-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="af81430b703edc70091a507f911ce66377bc720eed3e88e781a4ce8b9d1db343"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-kcrash, kf6-ki18n, kf6-kwidgetsaddons, kf6-kxmlgui, libc++, qt6-qtbase"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kdoctools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}

--- a/x11-packages/kdeedu-data/build.sh
+++ b/x11-packages/kdeedu-data/build.sh
@@ -1,0 +1,15 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/kdeedu-data"
+TERMUX_PKG_DESCRIPTION="Common data for KDE Edu applications"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/kdeedu-data-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="be7e26a14ec91053f407709ab48edffe9c437d374bebf0cadc10d9fd31b29722"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="hicolor-icon-theme"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, qt6-qtbase"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"

--- a/x11-packages/kf6-ktexttemplate/build.sh
+++ b/x11-packages/kf6-ktexttemplate/build.sh
@@ -1,0 +1,15 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/frameworks/ktexttemplate"
+TERMUX_PKG_DESCRIPTION="Library to allow application developers to separate the structure of documents from the data they contain"
+TERMUX_PKG_LICENSE="LGPL-2.1-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="6.27.0"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/frameworks/${TERMUX_PKG_VERSION%.*}/ktexttemplate-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="18a92b802b1c3130ff22087f9e048807bdf39c4147835e9aaa1be18408b9361b"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="libc++, qt6-qtbase, qt6-qtdeclarative"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, qt6-qttools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"

--- a/x11-packages/kgeography/build.sh
+++ b/x11-packages/kgeography/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/kgeography"
+TERMUX_PKG_DESCRIPTION="Geography Trainer"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/kgeography-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="3bd27fe577ece70dc63c942c5635c035c00d7743236c259e4abc92e3c29a8e8c"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-kcrash, kf6-ki18n, kf6-kitemviews, kf6-kwidgetsaddons, kf6-kxmlgui, libc++, qt6-qtbase"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kdoctools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}

--- a/x11-packages/khangman/build.sh
+++ b/x11-packages/khangman/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/khangman"
+TERMUX_PKG_DESCRIPTION="Hangman Game"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/khangman-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="92df44a17f4cb0cd62af9ecc16f61669b83f1c259f70992d31fc3c76739d078c"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kirigami-addons, kf6-kconfig, kf6-kcoreaddons, kf6-kcrash, kf6-ki18n, kf6-kirigami, kf6-knewstuff, libc++, libkeduvocdocument, qt6-qtbase, qt6-qtdeclarative, qt6-qtmultimedia"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kconfigwidgets, kf6-kdoctools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}

--- a/x11-packages/kiten/build.sh
+++ b/x11-packages/kiten/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/kiten"
+TERMUX_PKG_DESCRIPTION="Japanese Reference/Study Tool"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/kiten-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="a04e6ab99cc78e59b38f082d4f4411eae3cd10395a79a2bd122805f8fd83afa0"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kf6-karchive, kf6-kcolorscheme, kf6-kcompletion, kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-kcrash, kf6-ki18n, kf6-kio, kf6-kwidgetsaddons, kf6-kxmlgui, libc++, qt6-qtbase"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kdoctools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}

--- a/x11-packages/klettres/build.sh
+++ b/x11-packages/klettres/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/klettres"
+TERMUX_PKG_DESCRIPTION="Learn The Alphabet"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/klettres-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="4f6b6758119c2869949d1288c9b344bc97f27dfa74179c5a7167860962b3ac02"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-kcrash, kf6-ki18n, kf6-knewstuff, kf6-kwidgetsaddons, kf6-kxmlgui, libc++, qt6-qtbase, qt6-qtmultimedia, qt6-qtsvg"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kdoctools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}

--- a/x11-packages/kmplot/build.sh
+++ b/x11-packages/kmplot/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/kmplot"
+TERMUX_PKG_DESCRIPTION="Mathematical Function Plotter"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/kmplot-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="a09faca5c4285228bf36394691fcb054221a3776c29b81115014f0f34acd271b"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kf6-kcompletion, kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-kcrash, kf6-kdbusaddons, kf6-ki18n, kf6-kio, kf6-kjobwidgets, kf6-kparts, kf6-ktextwidgets, kf6-kwidgetsaddons, kf6-kxmlgui, libc++, qt6-qtbase, qt6-qtsvg"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kdoctools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}

--- a/x11-packages/kqtquickcharts/build.sh
+++ b/x11-packages/kqtquickcharts/build.sh
@@ -1,0 +1,15 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/libraries/kqtquickcharts"
+TERMUX_PKG_DESCRIPTION="A QtQuick plugin to render beautiful and interactive charts"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/kqtquickcharts-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="c29190416c3215e212d939e7bd559b3cb2fe3170edcf374bd1baa1bddffa705f"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="libc++, qt6-qtbase, qt6-qtdeclarative"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"

--- a/x11-packages/ktouch/build.sh
+++ b/x11-packages/ktouch/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/ktouch"
+TERMUX_PKG_DESCRIPTION="Touch Typing Tutor"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/ktouch-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="fde4463b9623ff11b4926ce31d42717ba997d14c0b902ae65060a63d62c2b3ab"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kf6-kcmutils, kf6-kcolorscheme, kf6-kcompletion, kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-ki18n, kf6-kirigami, kf6-kitemviews, kf6-ktextwidgets, kf6-kwidgetsaddons, kf6-kxmlgui, kqtquickcharts, libc++, libx11, libxcb, libxml2, qt6-qt5compat, qt6-qtbase, qt6-qtdeclarative"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kdoctools, libxkbfile"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}

--- a/x11-packages/kturtle/build.sh
+++ b/x11-packages/kturtle/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/kturtle"
+TERMUX_PKG_DESCRIPTION="Educational Programming Environment"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/kturtle-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="42e306962f4795dba8932e00c5dfc70dc7892b6779ad97e1ac950816c44c0233"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-kcrash, kf6-ki18n, kf6-kio, kf6-knewstuff, kf6-ktextwidgets, kf6-kwidgetsaddons, kf6-kxmlgui, libc++, qt6-qtbase, qt6-qtsvg"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kdoctools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}

--- a/x11-packages/kwordquiz/build.sh
+++ b/x11-packages/kwordquiz/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/kwordquiz"
+TERMUX_PKG_DESCRIPTION="Flash Card Trainer"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/kwordquiz-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="4bd9ea9e05f00ac2b276457335aee5d48c32b77558e4f802c6433056047f55dd"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kirigami-addons, kf6-kconfig, kf6-kcoreaddons, kf6-kcrash, kf6-kdbusaddons, kf6-ki18n, kf6-kirigami, kf6-knewstuff, kf6-qqc2-desktop-style, libc++, libkeduvocdocument, qt6-qtbase, qt6-qtdeclarative, qt6-qtmultimedia"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kdoctools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}

--- a/x11-packages/libkeduvocdocument/build.sh
+++ b/x11-packages/libkeduvocdocument/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/libkeduvocdocument"
+TERMUX_PKG_DESCRIPTION="Common libraries for KDE Edu applications"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/libkeduvocdocument-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="da1fa33f918a177e60bf51fa589748d8ff42fc230a7ab0d555d0eb8a01c09ff7"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kdeedu-data, kf6-karchive, kf6-kcoreaddons, kf6-ki18n, kf6-kio, libc++, qt6-qtbase"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kdoctools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}

--- a/x11-packages/marble/build.sh
+++ b/x11-packages/marble/build.sh
@@ -1,0 +1,26 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/marble"
+TERMUX_PKG_DESCRIPTION="Desktop Globe"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/marble-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="8b1f4b1fba722c42852150427803bb28f800e5c217d9a2a8549b122646ef2d44"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="abseil-cpp, kf6-kcmutils, kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-kcrash, kf6-ki18n, kf6-kparts, kf6-kwidgetsaddons, kf6-kxmlgui, kirigami-addons, libc++, libplasma, phonon-qt6, protobuf, qt6-qt5compat, qt6-qtbase, qt6-qtdeclarative, qt6-qtpositioning, qt6-qtsvg, qt6-qtwebchannel, qt6-qtwebengine, zlib"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kdoctools, kf6-knewstuff, kf6-krunner, qt6-qttools, qt6-qttools-cross-tools"
+#qt6-qtwebengine is not supported for i686 architecture
+TERMUX_PKG_EXCLUDED_ARCHES="i686"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		termux_setup_protobuf
+
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DQt6LinguistTools_DIR=$TERMUX_PREFIX/opt/qt6/cross/lib/cmake/Qt6LinguistTools"
+	fi
+}

--- a/x11-packages/marble/disable-update-xdg-mimetypes.patch
+++ b/x11-packages/marble/disable-update-xdg-mimetypes.patch
@@ -1,0 +1,10 @@
+diff --git a/data/CMakeLists.txt b/data/CMakeLists.txt
+index 789b1c7..384eabd 100644
+--- a/data/CMakeLists.txt
++++ b/data/CMakeLists.txt
+@@ -291,5 +291,4 @@ set(SHARED_MIME_INFO_MINIMUM_VERSION "1.8")
+ find_package( SharedMimeInfo QUIET)
+ if(SharedMimeInfo_FOUND)
+     install(FILES mimetypes/geo.xml  DESTINATION ${KDE_INSTALL_MIMEDIR})
+-    update_xdg_mimetypes( ${KDE_INSTALL_MIMEDIR})
+ endif()

--- a/x11-packages/minuet/build.sh
+++ b/x11-packages/minuet/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/minuet"
+TERMUX_PKG_DESCRIPTION="A KDE Software for Music Education"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/minuet-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="d870e4a36d748d603268d6aab90f2e0005beb743b8d3cfd7a93ccd65e2682dee"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="fluidsynth, kf6-kcoreaddons, kf6-kcrash, kf6-ki18n, kf6-kirigami, libc++, qt6-qtbase, qt6-qtdeclarative, qt6-qtsvg"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kdoctools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}

--- a/x11-packages/parley/build.sh
+++ b/x11-packages/parley/build.sh
@@ -1,0 +1,23 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/parley"
+TERMUX_PKG_DESCRIPTION="Vocabulary Trainer"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/parley-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="1207690ca4aaf5cc7fe299b12173a3d2eeeb558826b81544da5280472fdd00fc"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kf6-kcolorscheme, kf6-kcompletion, kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-kcrash, kf6-ki18n, kf6-kio, kf6-knewstuff, kf6-knotifications, kf6-ktextwidgets, kf6-kwidgetsaddons, kf6-kxmlgui, kf6-sonnet, libc++, libkeduvocdocument, qt6-qtbase, qt6-qtmultimedia, qt6-qtsvg, qt6-qtwebengine, translate-shell"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, kf6-kdoctools"
+#qt6-qtwebengine is not supported for i686 architecture
+TERMUX_PKG_EXCLUDED_ARCHES="i686"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}

--- a/x11-packages/rocs/build.sh
+++ b/x11-packages/rocs/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/rocs"
+TERMUX_PKG_DESCRIPTION="Graph Theory IDE"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/rocs-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="dee5f9fb0e7d782e5d336174dadc43088f6235839ec5baa9e352c2e82eabd13d"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="kf6-karchive, kf6-kcompletion, kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-kcrash, kf6-ki18n, kf6-kitemviews, kf6-kparts, kf6-ktexteditor, kf6-ktexttemplate, kf6-ktextwidgets, kf6-kwidgetsaddons, kf6-kxmlgui, libc++, qt6-qtbase, qt6-qtdeclarative"
+TERMUX_PKG_BUILD_DEPENDS="boost, extra-cmake-modules, kf6-kdoctools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}

--- a/x11-packages/step/build.sh
+++ b/x11-packages/step/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/education/step"
+TERMUX_PKG_DESCRIPTION="Interactive Physical Simulator"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later, LGPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="26.04.2"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/step-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256="4eb2130f6f5316df1b25d44c58787a527b24a57b2b0f5dcb577e456f45b8393f"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="gsl, kf6-kcompletion, kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-kcrash, kf6-ki18n, kf6-kiconthemes, kf6-kio, kf6-knewstuff, kf6-kplotting, kf6-ktextwidgets, kf6-kwidgetsaddons, kf6-kxmlgui, libc++, qalculate-gtk, qt6-qtbase"
+TERMUX_PKG_BUILD_DEPENDS="eigen, extra-cmake-modules, kf6-kdoctools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}

--- a/x11-packages/step/disable-update-xdg-mimetypes.patch
+++ b/x11-packages/step/disable-update-xdg-mimetypes.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 641369c..3b23b52 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -99,6 +99,5 @@ install(FILES org.kde.step.appdata.xml DESTINATION ${KDE_INSTALL_METAINFODIR})
+ 
+ find_package(SharedMimeInfo REQUIRED)
+ install(FILES org.kde.step.xml DESTINATION ${KDE_INSTALL_MIMEDIR})
+-update_xdg_mimetypes(${KDE_INSTALL_MIMEDIR})
+ 
+ feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
+


### PR DESCRIPTION
##
PR Description:
**KDE Education stack for Termux**

This pull request introduces the KDE Education 26.04.2 stack for Termux.
##
**KDE Gear / Education 26.04.2**

- analitza ✓
- artikulate ✓
- blinken ✓
- cantor ✓
- kalgebra ✓
- kalzium ✓
- kdeedu-data ✓
- libkeduvocdocument ✓
- kanagram ✓
- kbruch ✓
- kgeography ✓
- khangman ✓
- kiten ✓
- klettres ✓
- kmplot ✓
- ktouch ✓
    - kqtquickcharts ✓ [new dep]
- kturtle ✓
- kwordquiz ✓
- marble ✓
- minuet ✓
- parley ✓
- rocs ✓
- step ✓
##

New Frameworks Dep [6.27.0]
- kf6-ktexttemplate ✓
##

* Fixes #30152 
##
<img width="2400" height="1080" alt="KDE_EDU_1" src="https://github.com/user-attachments/assets/1244d0f9-a15f-4340-b2f1-cb1ee52846fc" />
<img width="2400" height="1080" alt="KDE_EDU_2" src="https://github.com/user-attachments/assets/705092b9-9b74-4c5a-84e7-49e267920f70" />
