### PR TITLE
addpkg(x11/kf6-ktexttemplate): 6.27.0

### DIFF
--- a/x11-packages/kf6-ktexttemplate/build.sh
+++ b/x11-packages/kf6-ktexttemplate/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE="https://invent.kde.org/frameworks/ktexttemplate"
+TERMUX_PKG_DESCRIPTION="Library to allow application developers to separate the structure of documents from the data they contain"
+TERMUX_PKG_LICENSE="LGPL-2.0-only, LGPL-3.0-only"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="6.27.0"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/frameworks/${TERMUX_PKG_VERSION%.*}/ktexttemplate-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256=18a92b802b1c3130ff22087f9e048807bdf39c4147835e9aaa1be18408b9361b
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="libc++, qt6-qtbase"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, qt6-qttools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+"
+
+termux_step_pre_configure() {
+	if [[ "$TERMUX_ON_DEVICE_BUILD" == "false" ]]; then
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/"
+	fi
+}


### PR DESCRIPTION
This PR adds the KDE Frameworks package KF6TextTemplate  
  
- Successfully builds in Termux Docker for all architectures