### PR TITLE
fix(x11/librewolf): fix auto update

### DIFF
--- a/x11-packages/librewolf/build.sh
+++ b/x11-packages/librewolf/build.sh
@@ -10,6 +10,7 @@ TERMUX_PKG_DEPENDS="ffmpeg, fontconfig, freetype, gdk-pixbuf, glib, gtk3, liband
 TERMUX_PKG_BUILD_DEPENDS="libcpufeatures, libice, libsm"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_VERSION_SED_REGEXP="s/_/-/g"
 
 termux_step_post_get_source() {
 	local f="media/ffvpx/config_unix_aarch64.h"


### PR DESCRIPTION
- For some reason, the repology auto update of `librewolf` by default shows "Package will be updated to [same real version with all `-` or `_` symbols replaced with `.`]". This will attempt to fix that.

%ci:no-build