### PR TITLE
bump(main/rizin): 0.9.0

### DIFF
--- a/packages/rizin/build.sh
+++ b/packages/rizin/build.sh
@@ -2,13 +2,12 @@ TERMUX_PKG_HOMEPAGE=https://rizin.re
 TERMUX_PKG_DESCRIPTION="UNIX-like reverse engineering framework and command-line toolset."
 TERMUX_PKG_LICENSE="GPL-3.0, LGPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.8.2"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="0.9.0"
 # Use source tarball from release assets to get all bundled projects
 TERMUX_PKG_SRCURL=https://github.com/rizinorg/rizin/releases/download/v${TERMUX_PKG_VERSION}/rizin-src-v${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_DEPENDS="capstone, file, libandroid-execinfo, liblz4, liblzma, libzip, openssl, tree-sitter, xxhash, zlib, zstd"
 TERMUX_PKG_SUGGESTS="python, apk-tools, apktool, apksigner"
-TERMUX_PKG_SHA256=1630ca52bae86f2ff37eb220699fc82f951b5b18080edfa3f50dd36a526c2d95
+TERMUX_PKG_SHA256=0cb929b92b45f5cfa344ea8ea990ab5d9e8193f9bf0ef948c52f67150cbb9af7
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Denable_tests=false
@@ -31,5 +30,5 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 
 termux_step_pre_configure() {
 	# for backtrace and backtrace_symbols_fd
-	LDFLAGS+=" -landroid-execinfo"
+	LDFLAGS+=" -lm -landroid-execinfo"
 }


### PR DESCRIPTION
Link with math library explicitly to fix the following error.
ld.lld: error: undefined symbol: ldexpf

* Fixes #30280 