### PR TITLE
fix(main/step-cli): rename binary from `step` to `step-cli` to match Arch Linux

### DIFF
--- a/packages/step-cli/build.sh
+++ b/packages/step-cli/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="An easy-to-use CLI tool for building, operating, and aut
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.30.6"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/smallstep/cli/releases/download/v${TERMUX_PKG_VERSION}/step_${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=cea2360b959320cbc81a21b0497bc40811ceb4e822ea77cb21f69507d5e5df08
 TERMUX_PKG_AUTO_UPDATE=true
@@ -26,13 +27,19 @@ termux_step_post_get_source() {
 termux_step_make() {
 	termux_setup_golang
 
+	# rename to step-cli like arch linux does to not conflict with KDE step
+	# https://gitlab.archlinux.org/archlinux/packaging/packages/step-cli/-/blob/7271a552567d98b0ab3532ba22dc0a2aaeec4e2a/PKGBUILD#L19
+	# https://github.com/termux/termux-packages/issues/30285
+	sed -i "s/step/${TERMUX_PKG_NAME}/g" autocomplete/zsh_autocomplete
+	sed -i "s/step/${TERMUX_PKG_NAME}/g" autocomplete/bash_autocomplete
+
 	local _DATE=$(date -u '+%Y-%m-%d %H:%M UTC')
 	go build -v -ldflags "-X \"main.Version=$TERMUX_PKG_VERSION\" -X \"main.BuildTime=$_DATE\"" \
 		./cmd/step
 }
 
 termux_step_make_install() {
-	install -Dm700 -t $TERMUX_PREFIX/bin step
+	install -Dm700 step "$TERMUX_PREFIX/bin/${TERMUX_PKG_NAME}"
 }
 
 
@@ -45,16 +52,16 @@ termux_step_post_massage() {
 termux_step_create_debscripts() {
 	cat <<-EOF > ./postinst
 		#!${TERMUX_PREFIX}/bin/sh
-		${TERMUX_PREFIX}/bin/step completion bash > ${TERMUX_PREFIX}/share/bash-completion/completions/step
-		${TERMUX_PREFIX}/bin/step completion zsh > ${TERMUX_PREFIX}/share/zsh/site-functions/_step
-		${TERMUX_PREFIX}/bin/step completion fish > ${TERMUX_PREFIX}/share/fish/vendor_completions.d/step.fish
+		${TERMUX_PREFIX}/bin/${TERMUX_PKG_NAME} completion bash > ${TERMUX_PREFIX}/share/bash-completion/completions/${TERMUX_PKG_NAME}
+		${TERMUX_PREFIX}/bin/${TERMUX_PKG_NAME} completion zsh > ${TERMUX_PREFIX}/share/zsh/site-functions/_${TERMUX_PKG_NAME}
+		${TERMUX_PREFIX}/bin/${TERMUX_PKG_NAME} completion fish | sed -e "s/-c step/-c ${TERMUX_PKG_NAME}/g" > ${TERMUX_PREFIX}/share/fish/vendor_completions.d/${TERMUX_PKG_NAME}.fish
 		exit 0
 	EOF
 	cat <<-EOF > ./prerm
 		#!${TERMUX_PREFIX}/bin/sh
-		rm -f ${TERMUX_PREFIX}/share/bash-completion/completions/step
-		rm -f ${TERMUX_PREFIX}/share/zsh/site-functions/_step
-		rm -f ${TERMUX_PREFIX}/share/fish/vendor_completions.d/step.fish
+		rm -f ${TERMUX_PREFIX}/share/bash-completion/completions/${TERMUX_PKG_NAME}
+		rm -f ${TERMUX_PREFIX}/share/zsh/site-functions/_${TERMUX_PKG_NAME}
+		rm -f ${TERMUX_PREFIX}/share/fish/vendor_completions.d/${TERMUX_PKG_NAME}.fish
 		exit 0
 	EOF
 }


### PR DESCRIPTION
- The reason why Arch Linux is unaffected by https://github.com/termux/termux-packages/issues/30285 is because they have never used the name `step` for `step-cli` and have always installed it as `step-cli`, so directly copy and paste the naming patches of Arch Linux into Termux for this package. https://gitlab.archlinux.org/archlinux/packaging/packages/step-cli/-/blob/7271a552567d98b0ab3532ba22dc0a2aaeec4e2a/PKGBUILD

- Fixes https://github.com/termux/termux-packages/issues/30285