### PR TITLE
bump(main/rtorrent): 0.16.15

### DIFF
--- a/packages/rtorrent/build.sh
+++ b/packages/rtorrent/build.sh
@@ -2,11 +2,15 @@ TERMUX_PKG_HOMEPAGE=https://rakshasa.github.io/rtorrent/
 TERMUX_PKG_DESCRIPTION="Ncurses BitTorrent client based on libTorrent"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.16.14"
+TERMUX_PKG_VERSION="0.16.15"
 TERMUX_PKG_SRCURL=https://github.com/rakshasa/rtorrent/releases/download/v${TERMUX_PKG_VERSION}/rtorrent-$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_SHA256=d149fd4840065cc69da03caf051119593f10aa8d5b533811bc3bedc3da4a3c00
+TERMUX_PKG_SHA256=202b56b75916cae86b4db4208cc42279f12d07a06e2ffba8ac8361bcb6dac18d
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_DEPENDS="libc++, libcurl, libtorrent, libxmlrpc, ncurses"
+TERMUX_PKG_DEPENDS="libandroid-spawn, libc++, libcurl, libtorrent, libxmlrpc, ncurses"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --with-xmlrpc-c
 "
+
+termux_step_pre_configure() {
+	LDFLAGS+=" -landroid-spawn"
+}


### PR DESCRIPTION
Add libandroid-spawn library to fix the following error.
exec_file.cc:6:10: fatal error: 'spawn.h' file not found

* Fixes #30288 