### PR TITLE
bump(main/xmlsec): 1.3.12

### DIFF
--- a/packages/xmlsec/build.sh
+++ b/packages/xmlsec/build.sh
@@ -3,17 +3,18 @@ TERMUX_PKG_DESCRIPTION="XML Security Library"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_LICENSE_FILE="Copyright"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.3.11"
+TERMUX_PKG_VERSION="1.3.12"
 TERMUX_PKG_SRCURL=https://github.com/lsh123/xmlsec/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_SHA256=bf499efd2f98a31244ad6855f327d7c3f06cc6c6447f0d2fbaea2b0103d47ecb
+TERMUX_PKG_SHA256=d6e6a758198fe91bcaab584443350df38b68230c93dbfd62843707d217ee114c
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libgcrypt, libxml2, libnspr, libnss, libxslt, openssl"
 TERMUX_PKG_BREAKS="xmlsec-dev"
 TERMUX_PKG_REPLACES="xmlsec-dev"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-crypto-dl
+--disable-werror
+--disable-pedantic
 --without-gnutls
---without-pedantic
 "
 
 termux_step_post_get_source() {

--- a/packages/xmlsec/src-nss-kdf.c.patch
+++ b/packages/xmlsec/src-nss-kdf.c.patch
@@ -1,9 +1,0 @@
---- a/src/nss/kdf.c
-+++ b/src/nss/kdf.c
-@@ -1194,4 +1194,4 @@
- 
- typedef int make_iso_compilers_happy;
- 
--#endif /* !defined(XMLSEC_NO_PBKDF2) || !defined(XMLSEC_NO_CONCATKDF) || !defined(XMLSEC_NO_HKDF) */
-\ No newline at end of file
-+#endif /* !defined(XMLSEC_NO_PBKDF2) || !defined(XMLSEC_NO_CONCATKDF) || !defined(XMLSEC_NO_HKDF) */


### PR DESCRIPTION
Add configure option to disable strict handling of warnings as error.
list_unit_tests.c:826:2: error: no newline at end of file [-Werror,-Wnewline-eof]
Also, remove the patch file which was added for same error as above.

* Fixes #30292 