### PR TITLE
fix(main/fdisk): append `block/` to `/dev/` strategically

### DIFF
--- a/packages/util-linux/build.sh
+++ b/packages/util-linux/build.sh
@@ -11,7 +11,7 @@ TERMUX_PKG_LICENSE_FILE="
 "
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.42.1"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL="https://www.kernel.org/pub/linux/utils/util-linux/v${TERMUX_PKG_VERSION:0:4}/util-linux-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=82e9158eb12a9b0b569d84e1687fed9dd18fe89ccd8ef5ac3427218a7c0d7f7f
 # <dependency>: <binaries linking to that dependency>

--- a/packages/util-linux/lib-sysfs.c.patch
+++ b/packages/util-linux/lib-sysfs.c.patch
@@ -1,0 +1,34 @@
+Fixes the command 'sudo fdisk -l'
+On device: Samsung Galaxy S8+ SM-G955F LineageOS 23.0
+
+--- a/lib/sysfs.c
++++ b/lib/sysfs.c
+@@ -887,7 +887,7 @@ int sysfs_devname_is_hidden(const char *prefix, const char *name)
+ 	int rc = 0, hidden = 0, len;
+ 	FILE *f;
+ 
+-	if (strncmp("/dev/", name, 5) == 0)
++	if (strncmp("/dev/block/", name, 11) == 0)
+ 		return 0;
+ 
+ 	if (!prefix)
+@@ -925,7 +925,7 @@ dev_t __sysfs_devname_to_devno(const char *prefix, const char *name, const char
+ 
+ 	assert(name);
+ 
+-	if (strncmp("/dev/", name, 5) == 0) {
++	if (strncmp("/dev/block/", name, 11) == 0) {
+ 		/*
+ 		 * Read from /dev
+ 		 */
+@@ -1024,8 +1024,8 @@ char *sysfs_blkdev_get_path(struct path_cxt *pc, char *buf, size_t bufsiz)
+ 		goto done;
+ 
+ 	/* create the final "/dev/<name>" string */
+-	memmove(buf + 5, name, sz + 1);
+-	memcpy(buf, "/dev/", 5);
++	memmove(buf + 11, name, sz + 1);
++	memcpy(buf, "/dev/block/", 11);
+ 
+ 	if (!stat(buf, &st) && S_ISBLK(st.st_mode) && st.st_rdev == sysfs_blkdev_get_devno(pc))
+ 		res = buf;


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/30300

- Android has storage devices under `/dev/block`, like `/dev/block/sda`. Android also has symlinks in `/dev/block/by-name` so that partitions can be accessed by their names regardless of device vendor. Linux has devices directly under `/dev`, like `/dev/sda`, the equivalent to by-name should be `/dev/disk/by-label` symlinks. https://android.googlesource.com/platform/system/core/+/8eec38f4e463d8cd980562ec49432c17972cc5cb