### PR TITLE
bump(main/geth): 1.17.4

### DIFF
--- a/packages/geth/build.sh
+++ b/packages/geth/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://geth.ethereum.org/
 TERMUX_PKG_DESCRIPTION="Go implementation of the Ethereum protocol"
 TERMUX_PKG_LICENSE="LGPL-3.0, GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.17.3"
+TERMUX_PKG_VERSION="1.17.4"
 TERMUX_PKG_SRCURL=https://github.com/ethereum/go-ethereum/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=fe1fb68c8d3230570fcd20950d29c93768bd4a240070fee84274ce92a759d9a9
+TERMUX_PKG_SHA256=80b4dee3b89ea40bedc808132befd605208089fdb8fde7981fc3c530596d3a9e
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_SUGGESTS="geth-utils"
 
@@ -16,14 +16,14 @@ termux_step_make() {
 	ln -sf "$TERMUX_PKG_SRCDIR" "$GOPATH"/src/github.com/ethereum/go-ethereum
 
 	cd "$GOPATH"/src/github.com/ethereum/go-ethereum
-	for applet in abidump abigen blsync clef devp2p era ethkey evm geth rlpdump; do
-		go -C ./cmd/"$applet" build -v
+	for applet in abidump abigen blsync devp2p era ethkey evm geth rlpdump; do
+		go -C ./cmd/"$applet" build -ldflags=-checklinkname=0 -v
 	done
 	unset applet
 }
 
 termux_step_make_install() {
-	for applet in abidump abigen blsync clef devp2p era ethkey evm geth rlpdump; do
+	for applet in abidump abigen blsync devp2p era ethkey evm geth rlpdump; do
 		install -Dm700 \
 			"$TERMUX_PKG_SRCDIR/cmd/$applet/$applet" \
 			"$TERMUX_PREFIX"/bin/

--- a/packages/geth/geth-utils.subpackage.sh
+++ b/packages/geth/geth-utils.subpackage.sh
@@ -3,7 +3,6 @@ TERMUX_SUBPKG_INCLUDE="
 bin/abidump
 bin/abigen
 bin/blsync
-bin/clef
 bin/devp2p
 bin/era
 bin/ethkey


### PR DESCRIPTION
Add go linker flag to fix the following error.
link: github.com/wlynxg/anet: invalid reference to net.zoneCache

Also, clef program was removed in this release. see
https://github.com/ethereum/go-ethereum/releases/tag/v1.17.4

* Fixes #30284 