### PR TITLE
fix(main/awesome{,-luajit}): do not needlessly download duplicate copies of the `luajit` and `lua5.4` ubuntu packages

### DIFF
--- a/x11-packages/awesome-luajit/build.sh
+++ b/x11-packages/awesome-luajit/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 _COMMIT=fa805ab465821c54094126b71a92acf2eba17674
 TERMUX_PKG_VERSION="2026.03.31"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=git+https://github.com/awesomeWM/awesome
 TERMUX_PKG_SHA256=ed61955ed9bdf1d216b881543572c32c83a15f419d9410d5c6b4ed3df3392383
 TERMUX_PKG_GIT_BRANCH=master
@@ -72,8 +72,6 @@ termux_step_host_build() {
 		"libmagickwand-7.q16-10"
 		# gobject-introspection needed to build lua-lgi
 		"libgirepository-1.0-dev"
-		# lua $hostbuild_lua_version
-		"luajit"
 		"libluajit-$hostbuild_luajit_version-2"
 		"libluajit-$hostbuild_luajit_version-dev"
 		# gobject-introspect needed by lua-lgi
@@ -142,7 +140,7 @@ termux_step_host_build() {
 	find "${HOSTBUILD_ROOTFS}/usr/lib/x86_64-linux-gnu" -xtype l \
 		-exec sh -c "ln -snvf /usr/lib/x86_64-linux-gnu/\$(readlink \$1) \$1" sh {} \;
 	ln -sf convert-im7.q16 "${HOSTBUILD_ROOTFS}/usr/bin/convert"
-	ln -sf "${HOSTBUILD_ROOTFS}/usr/bin/luajit" "${HOSTBUILD_ROOTFS}/usr/bin/lua-any"
+	ln -sf $(command -v luajit) "${HOSTBUILD_ROOTFS}/usr/bin/lua-any"
 
 	_load_ubuntu_packages
 

--- a/x11-packages/awesome/build.sh
+++ b/x11-packages/awesome/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Latest release version 4.3 does not support Lua 5.4.
 _COMMIT=fa805ab465821c54094126b71a92acf2eba17674
 TERMUX_PKG_VERSION="2026.03.31"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=git+https://github.com/awesomeWM/awesome
 TERMUX_PKG_SHA256=ed61955ed9bdf1d216b881543572c32c83a15f419d9410d5c6b4ed3df3392383
 TERMUX_PKG_GIT_BRANCH=master
@@ -73,8 +73,6 @@ termux_step_host_build() {
 		"libmagickwand-7.q16-10"
 		# gobject-introspection needed to build lua-lgi
 		"libgirepository-1.0-dev"
-		# lua $hostbuild_lua_version
-		"lua$hostbuild_lua_version"
 		"liblua$hostbuild_lua_version-0"
 		"liblua$hostbuild_lua_version-dev"
 		# gobject-introspect needed by lua-lgi
@@ -142,7 +140,7 @@ termux_step_host_build() {
 	find "${HOSTBUILD_ROOTFS}/usr/lib/x86_64-linux-gnu" -xtype l \
 		-exec sh -c "ln -snvf /usr/lib/x86_64-linux-gnu/\$(readlink \$1) \$1" sh {} \;
 	ln -sf convert-im7.q16 "${HOSTBUILD_ROOTFS}/usr/bin/convert"
-	ln -sf "${HOSTBUILD_ROOTFS}/usr/bin/lua$hostbuild_lua_version" "${HOSTBUILD_ROOTFS}/usr/bin/lua-any"
+	ln -sf $(command -v "lua$hostbuild_lua_version") "${HOSTBUILD_ROOTFS}/usr/bin/lua-any"
 
 	_load_ubuntu_packages
 


### PR DESCRIPTION
- Partially reverts https://github.com/termux/termux-packages/commit/3ea7a454151029a96b15d66fd6e933a16fa15beb and https://github.com/termux/termux-packages/commit/8b3236f15fcd9ce72d043a62145778c030237170 and reverts https://github.com/termux/termux-packages/commit/0d40d6c6c0f15dc3f97de20668c95f507b4b465f, which are incorrect

- The calculation for the optimal contents of `ubuntu_packages` arrays is required dependencies plus transitive dependencies minus packages that are already installed either by upstream or during `scripts/setup-ubuntu.sh`, not required dependencies plus transitive dependencies.

> Also `command -v lua$hostbuild_lua_version` doesn't actually work

false. it does work. it's also more optimial for downloading time and storage space than what it was replaced with.