### PR TITLE
chore(main/tar): apply `autoreconf -fi` after update to Ubuntu 26.04

### DIFF
--- a/packages/tar/build.sh
+++ b/packages/tar/build.sh
@@ -26,4 +26,6 @@ termux_step_pre_configure() {
 	if [ $TERMUX_ARCH_BITS = 32 ]; then
 		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --disable-year2038"
 	fi
+
+	autoreconf -fi
 }

--- a/packages/tar/selinux.patch
+++ b/packages/tar/selinux.patch
@@ -9,3 +9,15 @@
  do
    if test -z "$ac_lib"; then
      ac_res="none required"
+--- a/m4/selinux-selinux-h.m4
++++ b/m4/selinux-selinux-h.m4
+@@ -60,7 +60,7 @@ AC_DEFUN([gl_LIBSELINUX],
+   LIB_SELINUX=
+   if test "$with_selinux" != no; then
+     gl_save_LIBS=$LIBS
+-    AC_SEARCH_LIBS([setfilecon], [selinux],
++    AC_SEARCH_LIBS([setfilecon], [android-selinux],
+                    [test "$ac_cv_search_setfilecon" = "none required" ||
+                     LIB_SELINUX=$ac_cv_search_setfilecon])
+     LIBS=$gl_save_LIBS
+


### PR DESCRIPTION
- Fixes `aclocal-1.16: command not found`

- Keep `configure` patch in case `autoreconf -fi` needs to be removed again anytime in the future

%ci:no-build