### PR TITLE
fix(x11/opencv-python): do not set `LD_LIBRARY_PATH`

### DIFF
--- a/x11-packages/opencv/build.sh
+++ b/x11-packages/opencv/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Open Source Computer Vision Library"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="4.13.0"
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_REVISION=4
 TERMUX_PKG_SRCURL=(
 	"https://github.com/opencv/opencv/archive/refs/tags/${TERMUX_PKG_VERSION}/opencv-${TERMUX_PKG_VERSION}.tar.gz"
 	"https://github.com/opencv/opencv_contrib/archive/refs/tags/${TERMUX_PKG_VERSION}/opencv_contrib-${TERMUX_PKG_VERSION}.tar.gz"

--- a/x11-packages/opencv/do-not-set-ld-library-path.patch
+++ b/x11-packages/opencv/do-not-set-ld-library-path.patch
@@ -1,0 +1,19 @@
+this was adding this to LD_LIBRARY_PATH,
+/data/data/com.termux/files/usr/lib/python3.13/site-packages/cv2/../../../../lib
+which resolves to /data/data/com.termux/files/usr/lib, which is already in run path
+globally set in termux_step_setup_toolchain_29, so it is not necessary,
+and should not be set in Termux because setting LD_LIBRARY_PATH breaks running
+ffmpeg
+
+--- a/modules/python/package/cv2/__init__.py
++++ b/modules/python/package/cv2/__init__.py
+@@ -143,8 +143,7 @@ def bootstrap():
+         os.environ['PATH'] = ';'.join(l_vars['BINARIES_PATHS']) + ';' + os.environ.get('PATH', '')
+         if DEBUG: print('OpenCV loader: PATH={}'.format(str(os.environ['PATH'])))
+     else:
+-        # amending of LD_LIBRARY_PATH works for sub-processes only
+-        os.environ['LD_LIBRARY_PATH'] = ':'.join(l_vars['BINARIES_PATHS']) + ':' + os.environ.get('LD_LIBRARY_PATH', '')
++        pass
+ 
+     if DEBUG: print("Relink everything from native cv2 module to cv2 package")
+ 


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-app/discussions/4378#discussioncomment-17490489

- Fixes the error `CANNOT LINK EXECUTABLE "ffmpeg": cannot locate symbol "eglDestroySyncKHR" referenced by "/system/lib64/libgui.so"...` in this command on Manamama's device:

```bash
python3 -c "import os, subprocess; import cv2; print('LD_LIBRARY_PATH at ffmpeg-spawn time:', repr(os.environ.get('LD_LIBRARY_PATH'))); subprocess.run(['ffmpeg', '-version'])"
```