### PR TITLE
fix(main/libvmaf): re-enable assembly in 32-bit x86 target

### DIFF
--- a/packages/libvmaf/build.sh
+++ b/packages/libvmaf/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="../LICENSE"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.2.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/Netflix/vmaf/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=a28f93f3b4fa65601be324587072e32a6a704a304ba7b1aec9b70b3f709bc1dc
 TERMUX_PKG_AUTO_UPDATE=true
@@ -11,8 +12,4 @@ TERMUX_PKG_DEPENDS="libc++"
 
 termux_step_pre_configure() {
 	TERMUX_PKG_SRCDIR="$TERMUX_PKG_SRCDIR/libvmaf"
-	# https://github.com/Netflix/vmaf/issues/1481
-	if [[ "$TERMUX_ARCH" == "i686" ]]; then
-		TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-Denable_asm=false"
-	fi
 }


### PR DESCRIPTION
- Upstream issue is now fixed https://github.com/Netflix/vmaf/issues/1481

- Reverts https://github.com/termux/termux-packages/commit/32c3ad09da6ce865df086a45bf1e82066a418248