### PR TITLE
bump(main/git): 2.55.0

### DIFF
--- a/packages/git/build.sh
+++ b/packages/git/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://git-scm.com/
 TERMUX_PKG_DESCRIPTION="Fast, scalable, distributed revision control system"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
-TERMUX_PKG_VERSION="2.54.0"
-TERMUX_PKG_SRCURL=https://mirrors.kernel.org/pub/software/scm/git/git-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=f689162364c10de79ef89aa8dbf48731eb057e34edbbd20aca510ce0154681a3
+TERMUX_PKG_VERSION="2.55.0"
+TERMUX_PKG_SRCURL="https://mirrors.kernel.org/pub/software/scm/git/git-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256=457fdb04dc8728e007d4688695e6912e6f680727920f2a40bf11eacc17505357
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libcurl, libexpat, libiconv, less, openssl, pcre2, zlib"
 TERMUX_PKG_RECOMMENDS="openssh"
@@ -53,6 +53,17 @@ termux_step_pre_configure() {
 
 	# Fixes build if utfcpp is installed:
 	CPPFLAGS="-I$TERMUX_PKG_SRCDIR $CPPFLAGS"
+}
+
+termux_step_configure() {
+	# Rust is enabled by default starting in 2.55.0
+	# https://github.com/git/git/commit/32d5b905909e781786c4735e6bd71503b23e4fb1
+	termux_setup_rust
+	TERMUX_PKG_EXTRA_MAKE_ARGS+="
+		RUST_TARGET_DIR=target/$CARGO_TARGET_NAME/debug
+		CARGO_ARGS=--target=$CARGO_TARGET_NAME
+	"
+	termux_step_configure_autotools
 }
 
 termux_step_post_make_install() {


### PR DESCRIPTION
This took more doing than I expected.
Took me about 2 hours to get Git 2.55.0 building ***with*** Rust support.
The cross compilation support for that part seems to be a bit janky still.

I managed to get it building, but I'm not sure I'm happy with the way I had to get it working.
The upstream Makefile would suggest if we don't define `DEBUG` it should do a `--release` build.
https://github.com/git/git/blob/v2.55.0/Makefile#L942-L946
https://github.com/git/git/blob/v2.55.0/Makefile#L982-L984

The file it's looking for ends up in `target/$CARGO_TARGET_NAME/debug` regardless.
I'm not sure if that's a problem in Git's Makefile, or Cargo, or related to cross compilation, or what.
I was able to adapt something analogous from `firefoxpwa`.
https://github.com/termux/termux-packages/blob/e02260d2f71c8506a81cd981a4d86ae94634556a/x11-packages/firefoxpwa/build.sh#L31-L34

Except since we ***always*** seem to end up in the `DEBUG` codepath I just hardcoded that.
If someone's able to get to the bottom of that I'd be very thankful cause I was just about to give up and build with `NO_RUST` until I noticed that it seems to always end up in `debug/libgitcore.a`.

These two `make` args need to be set up in `termux_step_configure` because:
- A.) `$CARGO_TARGET_NAME` is populated by `termux_setup_rust`
<sup>and</sup>
- 2.) We need that value in a build continuation (`-c`) scenario as well, so it can't go in `pre_`/`post_configure`.

Package has not been tested for on-device functionality yet.
Not even sure how I'd test the Rust part(s).

<h1><em></em></h1> <!-- thin separator --> 

On a fun procedural note, I made use of the newly introduced `git history fixup` command as part of this PR.
`git history` itself was introduced with 2.54.0, but it gained a new `fixup` subcommand in this release.
https://man.archlinux.org/man/extra/git/git-history.1.en#COMMANDS