### PR TITLE
fix(pacman): Avoid freeing libalpm handle in forked child to prevent

### DIFF
--- a/packages/pacman/build.sh
+++ b/packages/pacman/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="A library-based package manager with dependency support"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@Maxython <mixython@gmail.com>"
 TERMUX_PKG_VERSION=7.1.0
-TERMUX_PKG_REVISION=6
+TERMUX_PKG_REVISION=7
 _PALT_VERSION=1.0.0
 TERMUX_PKG_SRCURL=(https://gitlab.archlinux.org/pacman/pacman/-/releases/v${TERMUX_PKG_VERSION}/downloads/pacman-${TERMUX_PKG_VERSION}.tar.xz
 		https://github.com/termux-pacman/pacman-alternatives/archive/refs/tags/v${_PALT_VERSION}.tar.gz)

--- a/packages/pacman/util.c.patch
+++ b/packages/pacman/util.c.patch
@@ -19,7 +19,21 @@
  		if(chdir("/") != 0) {
  			fprintf(stderr, _("could not change directory to %s (%s)\n"),
  					"/", strerror(errno));
-@@ -684,7 +681,7 @@
+@@ -676,7 +673,12 @@
+ 		unsetenv("BASH_ENV");
+ 		umask(0022);
+ 		_alpm_reset_signals();
+-		_alpm_handle_free(handle);
++		/*
++		 * Do not free the inherited libalpm handle in the forked child.
++		 * On Termux/Bionic this cleanup can block on inherited library
++		 * locks before execv() reaches ALPM hooks. The child is about to
++		 * replace its image; the parent remains responsible for cleanup.
++		 */
+ 		execv(cmd, argv);
+ 		/* execv only returns if there was an error */
+ 		fprintf(stderr, _("call to execv failed (%s)\n"), strerror(errno));
+@@ -684,7 +686,7 @@
  		/* this code runs for the parent only (wait on the child) */
  		int status;
  		char obuf[PIPE_BUF]; /* writes <= PIPE_BUF are guaranteed atomic */

--- a/packages/pacman/util.c.patch
+++ b/packages/pacman/util.c.patch
@@ -1,14 +1,14 @@
---- pacman-6.1.0/lib/libalpm/util.c	2024-03-04 06:07:58.000000000 +0300
-+++ pacman-6.1.0/lib/libalpm/util.c.patch	2024-03-28 23:01:55.557474407 +0300
-@@ -35,6 +35,7 @@
- #include <fnmatch.h>
+--- pacman-7.1.0/lib/libalpm/util.c	2025-11-01 14:05:29.000000000 +0300
++++ pacman-7.1.0/lib/libalpm/util.c.patch	2026-08-30 19:35:45.168630816 +0300
+@@ -38,6 +38,7 @@
  #include <poll.h>
+ #include <pwd.h>
  #include <signal.h>
 +#include <sys/syscall.h>
  
  /* libarchive */
  #include <archive.h>
-@@ -657,10 +658,6 @@
+@@ -676,10 +677,6 @@
  		/* use fprintf instead of _alpm_log to send output through the parent */
  		/* don't chroot() to "/": this allows running with less caps when the
  		 * caller puts us in the right root */
@@ -19,7 +19,15 @@
  		if(chdir("/") != 0) {
  			fprintf(stderr, _("could not change directory to %s (%s)\n"),
  					"/", strerror(errno));
-@@ -684,7 +681,7 @@
+@@ -694,7 +691,6 @@
+ 		unsetenv("BASH_ENV");
+ 		umask(0022);
+ 		_alpm_reset_signals();
+-		_alpm_handle_free(handle);
+ 		execv(cmd, argv);
+ 		/* execv only returns if there was an error */
+ 		fprintf(stderr, _("call to execv failed (%s)\n"), strerror(errno));
+@@ -703,7 +699,7 @@
  		/* this code runs for the parent only (wait on the child) */
  		int status;
  		char obuf[PIPE_BUF]; /* writes <= PIPE_BUF are guaranteed atomic */
@@ -28,7 +36,7 @@
  		ssize_t olen = 0, ilen = 0;
  		nfds_t nfds = 2;
  		struct pollfd fds[2], *child2parent = &(fds[0]), *parent2child = &(fds[1]);
-@@ -919,7 +916,7 @@
+@@ -938,7 +934,7 @@
  	if((tmpdir = getenv("TMPDIR")) && stat(tmpdir, &buf) && S_ISDIR(buf.st_mode)) {
  		/* TMPDIR was good, we can use it */
  	} else {
@@ -37,7 +45,7 @@
  	}
  	alpm_option_add_cachedir(handle, tmpdir);
  	cachedir = handle->cachedirs->prev->data;
-@@ -1375,11 +1372,11 @@
+@@ -1488,11 +1484,11 @@
  		CALLOC(check_path, len, sizeof(char), RET_ERR(handle, ALPM_ERR_MEMORY, -1));
  		snprintf(check_path, len, "%s%s", dir, file);
  


### PR DESCRIPTION
@robertkirkman this fixes pacman hook freeze on termux-docker-pacman, but I don't know if is something that is safe to implement for termux outside of that environment.

This patch stops libalpm from calling `_alpm_handle_free(handle)` in the forked hook child immediately before `execv()`.

The freeze was narrowed in `termux-docker` CI to the child process blocking inside `_alpm_handle_free(handle)` after `_alpm_reset_signals()` and before it could exec the ALPM hook script:

https://github.com/wallentx/termux-docker/actions/runs/28703857381

A follow-up run replacing only that child-side cleanup with a no-op allowed the `coreutils` reinstall to complete and the `pacman-alternatives` post-transaction hook to run successfully:

https://github.com/wallentx/termux-docker/actions/runs/28703957986

The same candidate passed again with the shorter/default probe settings:

https://github.com/wallentx/termux-docker/actions/runs/28704031573

This cleanup is unnecessary in the child because a successful `execv()` replaces the process image, and the parent still owns normal libalpm cleanup.
Avoiding broad handle cleanup after `fork()` also avoids inherited
Bionic/runtime lock state before hook execution.

- Fixes https://github.com/termux/termux-docker/issues/82