### PR TITLE
enhance(main/micro): add man

### DIFF
--- a/packages/micro/build.sh
+++ b/packages/micro/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Modern and intuitive terminal-based text editor"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.0.15"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="latest-release-tag"
 TERMUX_PKG_SRCURL=git+https://github.com/zyedidia/micro
@@ -26,4 +26,5 @@ termux_step_make_install() {
 	sed -zEi 's/VERSION = \$\(.+\\\n.+\)/VERSION = '"$TERMUX_PKG_VERSION"'/gm' Makefile
 	make build
 	mv micro "$TERMUX_PREFIX/bin/micro"
+	install -Dm644 -t $TERMUX_PREFIX/share/man/man1 assets/packaging/${TERMUX_PKG_NAME}.1
 }


### PR DESCRIPTION
With the new addition of alternatives on pacman, installing micro throw an error.

<img width="1080" height="763" alt="Screenshot_20260705-020443__01" src="https://github.com/user-attachments/assets/4f7b96d1-dc68-4c14-9f98-3306e0f1251a" />

So by also installing man, I think it fixed this problem.

```
❯ pacman -U output/micro-2.0.15-2-aarch64.pkg.tar.xz
loading packages...
resolving dependencies...
looking for conflicting packages...

Packages (1) micro-2.0.15-2

Total Installed Size:  13.25 MiB

:: Proceed with installation? [Y/n] y
(1/1) checking keys in keyring                     [########] 100%
(1/1) checking package integrity                   [########] 100%
(1/1) loading package files                        [########] 100%
(1/1) checking for file conflicts                  [########] 100%
(1/1) checking available disk space                [########] 100%
:: Processing package changes...
(1/1) installing micro                             [########] 100%
:: Running post-transaction hooks...
(1/2) Creating the whatis database...
(2/2) Automatically enabling alternatives...
==> Reading alternative files...
  -> reading alternative files
==> Checking alternatives status for enabling...
==> Checking alternatives status for selecting...
==> Checking alternatives for enabling...
  -> checking alternative data integrity
  -> checking root paths for existence
  -> checking link paths for validity
  -> checking link paths for permission
  -> checking root paths for duplicate
  -> checking link paths for conflicts
==> Checking alternatives for selecting...
  -> checking alternative data integrity
  -> checking root paths for existence
  -> checking link paths for validity
  -> checking link paths for permission
  -> checking enabled alternatives for conflicts
==> Enabling associations...
  -> enabling associations for editor:micro
==> Installing associations...
  -> installing associations for editor:micro
```

But it created `editor.1.gz` symlink on man1 folder. Idk much about alternatives behave with pacman. Is this intended?