### PR TITLE
bump(main/bash-completion): 2.18.0

### DIFF
--- a/packages/bash-completion/build.sh
+++ b/packages/bash-completion/build.sh
@@ -2,15 +2,19 @@ TERMUX_PKG_HOMEPAGE=https://github.com/scop/bash-completion
 TERMUX_PKG_DESCRIPTION="Programmable completion for the bash shell"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
-TERMUX_PKG_VERSION="2.17.0"
-TERMUX_PKG_REVISION="2"
-TERMUX_PKG_SRCURL=https://github.com/scop/bash-completion/releases/download/${TERMUX_PKG_VERSION}/bash-completion-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=dd9d825e496435fb3beba3ae7bea9f77e821e894667d07431d1d4c8c570b9e58
+TERMUX_PKG_VERSION="2.18.0"
+TERMUX_PKG_SRCURL="https://github.com/scop/bash-completion/releases/download/${TERMUX_PKG_VERSION}/bash-completion-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256=88bcf85124f77f74f2f2f8bcd16ac4382d807a827ede742a64940c7116aea33f
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="bash"
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 # This package provides completions for many others, and there are a few conflicts.
-# patchutils - interdiff
+# In general, prefer a package's own completions if it ships them.
+# Conflicts (Package)
+#
+# interdiff (patchutils)
+# makepkg   (pacman)
+# tmux      (tmux)
 TERMUX_PKG_RM_AFTER_INSTALL="
 share/bash-completion/completions/interdiff
 share/bash-completion/completions/makepkg

--- a/packages/bash-completion/man.bash.patch
+++ b/packages/bash-completion/man.bash.patch
@@ -1,7 +1,7 @@
-diff --git a/completions/man b/completions/man
-index b405f084..eaa5b811 100644
---- a/completions/man
-+++ b/completions/man
+diff --git a/completions-core/man.bash b/completions-core/man.bash
+index 75887694..680f3655 100644
+--- a/completions-core/man.bash
++++ b/completions-core/man.bash
 @@ -56,18 +56,7 @@ _comp_cmd_man()
          return
      fi


### PR DESCRIPTION
- closes #30439

The completion for `man` got moved in this upstream commit.
https://github.com/scop/bash-completion/commit/7cccbd2c
- See relevant upstream discussion.
https://github.com/scop/bash-completion/discussions/1329#discussioncomment-12163012
