### PR TITLE
Update CGCT toolchain pins

### DIFF
--- a/scripts/setup-cgct.sh
+++ b/scripts/setup-cgct.sh
@@ -16,10 +16,10 @@ if [ "$ARCH" != "$(uname -m)" ]; then
 fi
 
 declare -A CGCT=(
-	["cbt"]="2.45.1-0" # Cross Binutils for Termux
-	["cgt"]="15.2.0-0" # Cross GCCs for Termux
-	["glibc-cgct"]="2.42-0" # Glibc for CGCT
- 	["cgct-headers"]="6.18.6-0" # Headers for CGCT
+	["cbt"]="2.46.1-0" # Cross Binutils for Termux
+	["cgt"]="16.1.0-0" # Cross GCCs for Termux
+	["glibc-cgct"]="2.43-0" # Glibc for CGCT
+ 	["cgct-headers"]="7.1-0" # Headers for CGCT
 )
 
 : "${TERMUX_PKG_TMPDIR:="/tmp"}"


### PR DESCRIPTION
## Summary
- update CGCT component pins to match the current package index
- fixes the Docker image workflow failure caused by stale CGCT versions

## Details
The live CGCT index now provides:
- cbt 2.46.1-0
- cgt 16.1.0-0
- glibc-cgct 2.43-0
- cgct-headers 7.1-0

The previous pins caused the CGCT Docker image build to fail with:
versions do not match: requested - '6.18.6-0'; actual - '7.1-0'

## Testing
- verified pins against live cgct.json
- built local package-builder base image from this branch
- built package-builder-cgct image from the patched base image
- built zlib-glibc and zlib-glibc-static for x86_64 using the CGCT image
- installed zlib-glibc packages on an Android 36 x86_64 Termux emulator
- verified zlib headers/library files and libz.so NEEDED libc.so.6
- ran a zlib compress/uncompress smoke test on the emulator