### PR TITLE
fix(scripts/update-packages): work around uutils `date` bug

### DIFF
--- a/scripts/bin/update-packages
+++ b/scripts/bin/update-packages
@@ -85,9 +85,17 @@ TERMUX_PACKAGES_DIRECTORIES=$(jq --raw-output 'del(.pkg_format) | keys | .[]' "$
 
 # Converts milliseconds to human-readable format.
 # Example: `ms_to_human_readable 123456789` => 34h 17m 36s 789ms
+#
+# We need to manually clamp the inputs to 13 digits since uutils `date`
+# does not handle widths for the '%N' specifier correctly as of version 0.8.0
+# which is what currently ships with Ubuntu 26.04.
+# This commit can be reverted once Ubuntu ships uutils >= 0.9.0 or backports the fix.
 ms_to_human_readable() {
-	local t="$1" hrs=0 mins=0 secs=0 ms=0
-	(( ms = t%1000, t /= 1000, secs = t%60, t /= 60, mins = t%60, hrs = t/60 ))
+    local now start
+    printf -v now '%13d' "$1"
+    printf -v start '%13d' "$2"
+    local span="$(( now - start ))" hrs=0 mins=0 secs=0 ms=0
+	(( ms = span%1000, span /= 1000, secs = span%60, span /= 60, mins = span%60, hrs = span/60 ))
 	echo "${hrs}h ${mins}m ${secs}s ${ms}ms" | sed 's/0h //;s/0m //;s/0s //'
 }
 
@@ -538,7 +546,7 @@ if [[ -n "$GITHUB_TOKEN" ]] && command -v gh &> /dev/null; then
 	)
 	printf "Cached %s existing issues - took %s\n" \
 		"${#_CACHED_ISSUES[*]}" \
-		"$(ms_to_human_readable $(( $(date +%10s%3N) - _start_time )))"
+		"$(ms_to_human_readable "$(date +%10s%3N)" "$_start_time")"
 fi
 _start_time="$(date +%10s%3N)"
 
@@ -598,7 +606,7 @@ for pkg_dir in "${PACKAGE_DIRS_LIST[@]}"; do
 	_should_update "${pkg_dir}" || continue
 	_update_dependencies "${pkg_dir}"
 	_run_update "${pkg_dir}"
-	echo "termux - took $(ms_to_human_readable $(( $(date +%10s%3N) - _unix_millis )))"
+	echo "termux - took $(ms_to_human_readable "$(date +%10s%3N)" "$_unix_millis")"
 done
 
 exec {IPC_FIFO_FD}<&- # close the FIFO
@@ -622,7 +630,7 @@ done
 #################################################REPORT CHANGES##################################################
 
 echo ""
-echo "SUMMARY: Checked ${_SUMMARY[total]} packages - took $(ms_to_human_readable $(( $(date +%10s%3N) - _start_time ))) in total."
+echo "SUMMARY: Checked ${_SUMMARY[total]} packages - took $(ms_to_human_readable "$(date +%10s%3N)" "$_start_time") in total."
 echo "SUMMARY: $# (Directly passed), ${_SUMMARY[dependencies]} (Dependencies)"
 echo "SUMMARY: Update methods and release types."
 sort <<< "${codepaths:-}"

--- a/scripts/bin/validation
+++ b/scripts/bin/validation
@@ -176,8 +176,17 @@ fi
 
 # Converts milliseconds to human-readable format.
 # Example: `ms_to_human_readable 123456789` => 34h 17m 36s 789ms
+#
+# Clamp timestamps to 13 digits to work around uutils `date` bug.
+# See scripts/bin/update-packages ms_to_human_readable()
+# for detailed explanation.
 ms_to_human_readable() {
-	echo "$(($1/3600000))h $(($1%3600000/60000))m $(($1%60000/1000))s $(($1%1000))ms" | sed 's/0h //;s/0m //;s/0s //'
+    local now start
+    printf -v now '%13d' "$1"
+    printf -v start '%13d' "$2"
+    local span="$(( now - start ))" hrs=0 mins=0 secs=0 ms=0
+	(( ms = span%1000, span /= 1000, secs = span%60, span /= 60, mins = span%60, hrs = span/60 ))
+	echo "${hrs}h ${mins}m ${secs}s ${ms}ms" | sed 's/0h //;s/0m //;s/0s //'
 }
 
 maybe_cleanup() {
@@ -218,12 +227,12 @@ for package in "${PACKAGES[@]}"; do
 		./scripts/run-docker.sh ./build-package.sh -I -f -a "${ARCH}" "${package}"
 		status="${PIPESTATUS[0]}"
 		echo # newline
-		echo "INFO: Building ${package} for ${ARCH} took $(ms_to_human_readable $(( $(date +%10s%3N) - start )))"
+		echo "INFO: Building ${package} for ${ARCH} took $(ms_to_human_readable "$(date +%10s%3N)" "$start")"
 		echo # newline
 		exit "$status"
 	)" || failed["${package} ${ARCH}"]="${output}"
 done
-echo "INFO: Building all packages for ${ARCH} took $(ms_to_human_readable $(( $(date +%10s%3N) - start_building_arch )))" | tee -a "${GITHUB_STEP_SUMMARY}"
+echo "INFO: Building all packages for ${ARCH} took $(ms_to_human_readable "$(date +%10s%3N)" "$start_building_arch")" | tee -a "${GITHUB_STEP_SUMMARY}"
 echo # newline
 
 if (( ${#failed[@]} > 0 )); then

--- a/scripts/lint-packages.sh
+++ b/scripts/lint-packages.sh
@@ -800,10 +800,15 @@ linter_main() {
 	return
 }
 
+# Clamp timestamps to 13 digits (+ decimal point) to work around uutils `date` bug.
+# See scripts/bin/update-packages ms_to_human_readable()
+# for detailed explanation.
 time_elapsed() {
-	local start="$1" end="$(date +%10s.%3N)"
-	local elapsed="$(( ${end/.} - ${start/.} ))"
-	echo "[INFO]: Finished linting build scripts ($(date -d "@$end" --utc '+%Y-%m-%dT%H:%M:%SZ' 2>&1))"
+	local now start
+	printf -v now '%14s' "$(date +%10s.%3N)"
+	printf -v start '%14s' "$1"
+	local elapsed="$(( ${now/.} - ${start/.} ))"
+	echo "[INFO]: Finished linting build scripts ($(date -d "@$now" --utc '+%Y-%m-%dT%H:%M:%SZ' 2>&1))"
 	printf '[INFO]: Time elapsed: %s\n' \
 		"$(sed 's/0m //;s/0s //' <<< "$(( elapsed % 3600000 / 60000 ))m$(( elapsed % 60000 / 1000 ))s$(( elapsed % 1000 ))ms")"
 }


### PR DESCRIPTION
- Decided to take a closer look at the bug that's been effecting `ms_to_human_readable` in our auto-update script for a while now.
Tracked it back to this upstream issue
uutils/coreutils#12001
It's fixed in uutils 0.9.0, but Ubuntu 26.04 still ships 0.8.0 and doesn't appear to have backported a fix.
So let's just clamp the timestamp values to the expected 13 digits manually inside the function for the time being.

The reason it breaks at full precision is because 19 digits collides with the 64bit integer limit.