### PR TITLE
fix({main/emacs,x11/emacs-x}): mark as depending on `libacl`

### DIFF
--- a/packages/emacs/build.sh
+++ b/packages/emacs/build.sh
@@ -3,11 +3,11 @@ TERMUX_PKG_DESCRIPTION="Extensible, customizable text editor-and more"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # Update both emacs and emacs-x to the same version in one PR.
-TERMUX_PKG_VERSION=30.2
-TERMUX_PKG_REVISION=2
-TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/emacs/emacs-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_VERSION="30.2"
+TERMUX_PKG_REVISION=3
+TERMUX_PKG_SRCURL="https://mirrors.kernel.org/gnu/emacs/emacs-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9
-TERMUX_PKG_DEPENDS="libgmp, libgnutls, libsqlite, libxml2, ncurses, tree-sitter, zlib"
+TERMUX_PKG_DEPENDS="libacl, libgmp, libgnutls, libsqlite, libxml2, ncurses, tree-sitter, zlib"
 TERMUX_PKG_BREAKS="emacs-dev"
 TERMUX_PKG_REPLACES="emacs-dev"
 TERMUX_PKG_SERVICE_SCRIPT=("emacsd" 'exec emacs --fg-daemon 2>&1')

--- a/x11-packages/emacs-x/build.sh
+++ b/x11-packages/emacs-x/build.sh
@@ -4,10 +4,10 @@ TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # Update both emacs and emacs-x to the same version in one PR.
 TERMUX_PKG_VERSION="30.2"
-TERMUX_PKG_REVISION=4
+TERMUX_PKG_REVISION=5
 TERMUX_PKG_SRCURL="https://ftpmirror.gnu.org/gnu/emacs/emacs-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9
-TERMUX_PKG_DEPENDS="dbus, fontconfig, freetype, gdk-pixbuf, giflib, glib, harfbuzz, libgmp, libgnutls, libice, libjpeg-turbo, libpng, librsvg, libsm, libsqlite, libtiff, libwebp, libx11, libxaw, libxcb, libxext, libxfixes, libxft, libxinerama, libxml2, libxmu, libxpm, libxrandr, libxrender, libxt, littlecms, ncurses, tree-sitter, zlib"
+TERMUX_PKG_DEPENDS="dbus, fontconfig, freetype, gdk-pixbuf, giflib, glib, harfbuzz, libacl, libgmp, libgnutls, libice, libjpeg-turbo, libpng, librsvg, libsm, libsqlite, libtiff, libwebp, libx11, libxaw, libxcb, libxext, libxfixes, libxft, libxinerama, libxml2, libxmu, libxpm, libxrandr, libxrender, libxt, littlecms, ncurses, tree-sitter, zlib"
 TERMUX_PKG_CONFLICTS="emacs"
 TERMUX_PKG_REPLACES="emacs"
 TERMUX_PKG_PROVIDES="emacs"


### PR DESCRIPTION
- If `libacl` is present during the building of `emacs` or `emacs-x`, the `emacs` binary becomes linked to it and requires it at runtime, so `emacs` and `emacs-x` should be built with and marked as depending on `libacl`.

```
Does Emacs use access control lists?                    yes -lacl -lattr
```