### PR TITLE
addpkg(main/mdf2iso): Small utility that converts MDF images to ISO

### DIFF
--- a/packages/mdf2iso/build.sh
+++ b/packages/mdf2iso/build.sh
@@ -1,0 +1,8 @@
+TERMUX_PKG_HOMEPAGE=https://salsa.debian.org/debian/mdf2iso
+TERMUX_PKG_DESCRIPTION="Small utility that converts MDF images to ISO format"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.3.1"
+TERMUX_PKG_SRCURL="https://salsa.debian.org/debian/mdf2iso/-/archive/upstream/${TERMUX_PKG_VERSION}/mdf2iso-upstream-${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=821181f95dbc1646b63f5b1035249cce30a50137a46b4d7ab6b98e4266cec089
+TERMUX_PKG_BUILD_IN_SRC=true


### PR DESCRIPTION
### Why is it worth to add this package?

As the name suggests, mdf2iso is a small utility that converts MDF images to ISO format, we don't have that in Termux yet. The binary is very small (single C file) and relatively maintainable (doesn't need patches nor deps). It is also packaged by numerous distros.

### Home page URL

https://salsa.debian.org/debian/mdf2iso

### Source code URL

https://salsa.debian.org/debian/mdf2iso

### Packaging policy acknowledgement

- [ ] The project is actively developed.
  Though it has been a while since last commit, I would rather consider this project as "done" considering how narrow and simple this project is.
- [x] The project has [existing packages](https://repology.org/projects/mdf2iso) and is "well known".
- [x] Licensed under an [open source license](https://spdx.org/licenses/).
- [x] Not available through a language package manager: cargo, cpan, dotnet tool, gem, npm, pip, etc.

- [x] Not taking up too much disk space (< 100MiB per architecture, exceptions can be made)
- [x] Not duplicating the functionality of existing packages.
- [x] Not serving hacking, malware, phishing, spamming, spying, ddos functionality.
- [x] I certify that I have read [Termux Packaging Policy](https://github.com/termux/termux-packages/blob/master/CONTRIBUTING.md#packaging-policy) and understand that my request will be denied if it is found lacking.

### Additional information

None.