### PR TITLE
ghc/packages: enable i686 build

### DIFF
--- a/packages/cabal-install/build.sh
+++ b/packages/cabal-install/build.sh
@@ -1,9 +1,9 @@
 TERMUX_PKG_HOMEPAGE="https://www.haskell.org/cabal/"
 TERMUX_PKG_DESCRIPTION="The command-line interface for Haskell-Cabal and Hackage"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
-TERMUX_PKG_MAINTAINER="Aditya Alok <alok@termux.org>"
+TERMUX_PKG_MAINTAINER="Aditya Alok <alok@termux.dev>"
 TERMUX_PKG_VERSION=3.14.1.1
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL="https://hackage.haskell.org/package/cabal-install-${TERMUX_PKG_VERSION}/cabal-install-${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=f11d364ab87fb46275a987e60453857732147780a8c592460eec8a16dbb6bace
 TERMUX_PKG_AUTO_UPDATE=false
@@ -12,15 +12,6 @@ TERMUX_PKG_SUGGESTS="ghc, dnsutils"
 TERMUX_PKG_DEPENDS="libffi, libiconv, libgmp, zlib, libandroid-posix-semaphore"
 TERMUX_PKG_BUILD_DEPENDS="aosp-libs"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-f-native-dns --ghc-options=-optl-landroid-posix-semaphore"
-
-# Iserv has some linking problem on i686.
-# ```
-# 	ghc-iserv: /home/builder/.termux-build/_cache/ghc-cross-9.12.1-i686-runtime/lib/ghc-9.12.1/lib/i386-linux-ghc-9.12.1-inplace/ghc-prim-0.13.0-inplace/libHSghc-prim-0.13.0-inplace.a: unhandled ELF relocation(Rel) type 10
-# 	ghc-iserv: Failed to lookup symbol: ghczmprim_GHCziTypes_ZMZN_closure
-# 	ghc-iserv: ^^ Could not load 'ghczmprim_GHCziCString_unpackCStringzh_closure', dependency unresolved. See top entry above.
-# ```
-# Disabling it for now. # TODO: Fix it.
-TERMUX_PKG_EXCLUDED_ARCHES="i686"
 
 termux_step_post_configure() {
 	cabal get splitmix-0.1.3.1

--- a/packages/shellcheck/build.sh
+++ b/packages/shellcheck/build.sh
@@ -3,15 +3,13 @@ TERMUX_PKG_DESCRIPTION="Shell script analysis tool"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
 TERMUX_PKG_VERSION=0.11.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://hackage.haskell.org/package/ShellCheck-${TERMUX_PKG_VERSION}/ShellCheck-${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=81a72e9c195788301f38e4b2e250ab916cf3778993d428786bfb2fac2a847400
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_DEPENDS="libffi, libgmp, libiconv"
 TERMUX_PKG_BUILD_DEPENDS="aosp-libs"
 TERMUX_PKG_AUTO_UPDATE=true
-# i686 is currently unsupported pending;
-# https://github.com/termux/ghc-cross-tools/pull/6
-TERMUX_PKG_EXCLUDED_ARCHES="i686"
 
 termux_step_pre_configure() {
 	chmod u+x ./striptests

--- a/scripts/build/setup/termux_setup_ghc.sh
+++ b/scripts/build/setup/termux_setup_ghc.sh
@@ -20,10 +20,10 @@ termux_setup_ghc() {
 		[[ -d "$TERMUX_GHC_RUNTIME_FOLDER" ]] && return
 
 		declare -A checksums=(
-			["aarch64"]="a9a70c178d3b7cd5733730d93c00975b9957e164f203d80ba04e53cd76c54183"
-			["arm"]="173c3b9bbc37afb47edb5f1f2f287064c37c7b4ef19ce787e6d82970e7c5f9cf"
-			["i686"]="77315c0eeae163d5a21077c86d1c2f6f0192fdc6cb6fe1e377fc1115cfb073d4"
-			["x86_64"]="07a289d912be3a9ae75aa5e2ae5f22d577fabd3a13331de3e6f318d7545fd38a"
+			["aarch64"]="efd05af38dbfd37706dcfe457aae99725c33b91223490582bdde172f6383668d"
+			["arm"]="6caa502e8694b1098fb93cdc291baf75cfd52e4851100a2d482e014b37e4db39"
+			["i686"]="5596d519c5353c7559e841660df4a80ad57decd49ffa66a6b7eaec12c2facb8c"
+			["x86_64"]="3700423505d40fb2563b0a417a5a3f60aed12c8655cde6b242a75175d0b51ea3"
 		)
 
 		local target="$TERMUX_HOST_PLATFORM"
@@ -49,6 +49,13 @@ termux_setup_ghc() {
 				--host="$target"
 			make install
 		) &>/dev/null
+
+		# Provide a common interface for downstream usecase:
+		for b in "$TERMUX_GHC_RUNTIME_FOLDER"/bin/"$target"-*; do
+			ln -sf "$b" "${b/$target-/}"
+		done
+		ln -sf "$TERMUX_GHC_RUNTIME_FOLDER"/lib/"$target"-ghc-"$TERMUX_GHC_VERSION"/bin/{"$target"-ghc-iserv,ghc-iserv}
+		ln -sf "$TERMUX_GHC_RUNTIME_FOLDER"/lib/"$target"-ghc-"$TERMUX_GHC_VERSION"/bin/{"$target"-ghc-iserv-dyn,ghc-iserv-dyn}
 
 		rm -rf "$TERMUX_GHC_TAR" "$TERMUX_GHC_TEMP_FOLDER"
 	else


### PR DESCRIPTION
- scripts(build/termux_setup_ghc): update sha256 checksum
- enhance(main/cabal-install): enable `i686`
- enhance(main/shellcheck): enable `i686`

See: <https://github.com/termux/ghc-cross-tools/pull/6>
