### PR TITLE
addpkg(x11/xscreensaver): 6.15

### DIFF
--- a/x11-packages/xscreensaver/build.sh
+++ b/x11-packages/xscreensaver/build.sh
@@ -1,0 +1,31 @@
+TERMUX_PKG_HOMEPAGE=https://www.jwz.org/xscreensaver
+TERMUX_PKG_DESCRIPTION="Screen saver and OpenGL demos for the X Window System"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_LICENSE_FILE="debian/copyright"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="6.15"
+TERMUX_PKG_SRCURL="https://www.jwz.org/xscreensaver/xscreensaver-$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=d2e687e56263fbfd8fca1fb9cc7c9331fd4f096ab57d3f7482565fe012c362d3
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="at-spi2-core, gdk-pixbuf, glib, glu, gtk3, opengl, libandroid-shmem, libjpeg-turbo, libx11, libxext, libxft, libxi, libxml2, libxmu, libxrandr, libxt, libxxf86vm, xdg-utils"
+TERMUX_PKG_BUILD_DEPENDS="glib-cross"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--sysconfdir=$TERMUX_PREFIX/etc
+--localstatedir=$TERMUX_PREFIX/var
+--with-app-defaults=$TERMUX_PREFIX/etc/X11/app-defaults
+--with-gl
+--with-gtk
+--with-jpeg
+--with-pixbuf
+--without-gle
+--without-login-manager
+--without-pam
+--without-systemd
+--disable-locking
+"
+
+termux_step_pre_configure() {
+	termux_setup_glib_cross_pkg_config_wrapper
+
+	LDFLAGS+=" -landroid-shmem"
+}

--- a/x11-packages/xscreensaver/force-allow-autoconf-unrecognized-opts.patch
+++ b/x11-packages/xscreensaver/force-allow-autoconf-unrecognized-opts.patch
@@ -1,0 +1,15 @@
+--- a/configure
++++ b/configure
+@@ -2824,8 +2824,10 @@ echo "current directory: `pwd`"
+ echo "command line was: $0 $@"
+ 
+ if ! test -z "$ac_unrecognized_opts" ; then
+-  echo "" >&2
+-  exit 2
++  echo "the xscreensaver developer doesn't like autoconf unrecognized opts," >&2
++  echo "but termux likes them and heavily propagates them," >&2
++  echo "so unrecognized opts are being enabled now in order to" >&2
++  echo "faciliate the cross-compilation of xscreensaver for termux" >&2
+ fi
+ 
+ ###############################################################################

--- a/x11-packages/xscreensaver/force-disable-pam.patch
+++ b/x11-packages/xscreensaver/force-disable-pam.patch
@@ -1,0 +1,10 @@
+--- a/configure
++++ b/configure
+@@ -22419,7 +22419,6 @@ elif test "$have_pam" = no -a "$enable_locking" = yes ; then
+   if test -d /etc/pam.d -o -f /etc/pam.conf ; then
+     warn  "Your system seems to have PAM, but PAM is not being used."
+     warn2 "That is probably not going to work out well."
+-    CONF_STATUS=1
+   fi
+ fi
+ 


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/30483

- How to run the screensaver OpenGL programs as standalone demos:

```
export PATH=$PREFIX/libexec/xscreensaver:$PATH
geodesicgears
```