### PR TITLE
fix(main/python-msgpack): fix repeated builds

### DIFF
--- a/packages/python-msgpack/build.sh
+++ b/packages/python-msgpack/build.sh
@@ -3,9 +3,9 @@ TERMUX_PKG_DESCRIPTION="MessagePack serializer implementation for Python"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.2.1"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 # _cmsgpack.c is absent in https://github.com/msgpack/msgpack-python/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SRCURL=https://pypi.org/packages/source/m/msgpack/msgpack-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SRCURL="https://pypi.org/packages/source/m/msgpack/msgpack-${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libc++, python"
@@ -18,5 +18,5 @@ termux_step_make() {
 termux_step_make_install() {
 	local _pyver="${TERMUX_PYTHON_VERSION//./}"
 	local _wheel="msgpack-${TERMUX_PKG_VERSION}-cp${_pyver}-cp${_pyver}-android_${TERMUX_ARCH}.whl"
-	pip install --no-deps --prefix="$TERMUX_PREFIX" "$TERMUX_PKG_SRCDIR/dist/${_wheel}"
+	pip install --force-reinstall --no-deps --prefix="$TERMUX_PREFIX" "$TERMUX_PKG_SRCDIR/dist/${_wheel}"
 }


### PR DESCRIPTION
- Fixes this error:

```
msgpack is already installed with the same version as the provided wheel. Use --force-reinstall to force an installation of the wheel.
ERROR: No files in package.
```

In this series of commands:

```bash
scripts/run-docker.sh ./build-package.sh -I -f python-msgpack
scripts/run-docker.sh ./build-package.sh -I -f python-msgpack
```