### PR TITLE
fix(scripts/profile.json): allow `fchmodat2` syscall

### DIFF
--- a/scripts/profile.json
+++ b/scripts/profile.json
@@ -110,6 +110,7 @@
                 "fchdir",
                 "fchmod",
                 "fchmodat",
+                "fchmodat2",
                 "fchown",
                 "fchown32",
                 "fchownat",
@@ -627,8 +628,7 @@
                     "s390x"
                 ]
             },
-            "excludes": {
-            }
+            "excludes": {}
         },
         {
             "names": [
@@ -636,8 +636,7 @@
             ],
             "action": "SCMP_ACT_ERRNO",
             "errnoRet": 38,
-            "excludes": {
-            }
+            "excludes": {}
         },
         {
             "names": [


### PR DESCRIPTION
- required to change mode in newer glibc versions

  <https://linux.die.net/man/2/fchmodat>
  <https://sourceware.org/pipermail/libc-alpha/2023-October/151853.html>

Signed-off-by: Aditya Alok <alok@termux.dev>
