### PR TITLE
bump(main/just): 1.56.0

### DIFF
--- a/packages/just/build.sh
+++ b/packages/just/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://just.systems
 TERMUX_PKG_DESCRIPTION="A handy way to save and run project-specific commands"
 TERMUX_PKG_LICENSE="CC0-1.0"
 TERMUX_PKG_MAINTAINER="@flipee"
-TERMUX_PKG_VERSION="1.55.1"
-TERMUX_PKG_SRCURL=https://github.com/casey/just/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=40a2d3725480523ffebb762669cafe2b0135a00383946eec3d47adf5e9be6345
+TERMUX_PKG_VERSION="1.56.0"
+TERMUX_PKG_SRCURL="https://github.com/casey/just/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=145cb76ccd858da30ee56de884dad9241b2706140bcf9ae189dfda5e5a62ed52
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
 

--- a/packages/just/termux_shebang.patch
+++ b/packages/just/termux_shebang.patch
@@ -1,12 +1,15 @@
-diff -uNr a/src/recipe.rs b/src/recipe.rs
+diff --git a/src/recipe.rs b/src/recipe.rs
+index bfa8b4b5..0d631cdd 100644
 --- a/src/recipe.rs
 +++ b/src/recipe.rs
-@@ -502,6 +502,8 @@
+@@ -489,6 +489,10 @@ impl<'src> Recipe<'src> {
            .unwrap_or_else(|| Interpreter::default_script_interpreter().clone()),
        )
      } else if self.body.first().is_some_and(Line::is_shebang) {
-+      evaluated_lines[0] = format!("#!@TERMUX_PREFIX@{}", evaluated_lines[0][2..].to_string());
-+      evaluated_lines[0] = evaluated_lines[0].replace("/usr/usr", "/usr");
-       let line = evaluated_lines
-         .first()
-         .ok_or_else(|| Error::internal("evaluated_lines was empty"))?;
++      evaluated_lines[0] = format!(
++        "#!@TERMUX_PREFIX@{}",
++        evaluated_lines[0][2..].to_string()
++      ).replace("/usr/usr", "/usr");
+       let shebang = &evaluated_lines[0];
+       Executor::Shebang(Shebang::new(shebang).ok_or_else(|| Error::InvalidShebang {
+         recipe: self.name,


### PR DESCRIPTION
- closes #30500
- Shebang handling got changed in this upstream PR (casey/just#3545).
Just had to slot in our patch in the new location.
Cut it down to one assignment while we're here anyway.