### PR TITLE
chore(scripts/build/configure/termux_step_configure_meson): switch from `minsize` to `release` build type

### DIFF
--- a/scripts/build/configure/termux_step_configure_meson.sh
+++ b/scripts/build/configure/termux_step_configure_meson.sh
@@ -1,7 +1,7 @@
 termux_step_configure_meson() {
 	termux_setup_meson
 
-	local _meson_buildtype="minsize"
+	local _meson_buildtype="release"
 	local _meson_stripflag="--strip"
 	if [ "$TERMUX_DEBUG_BUILD" = "true" ]; then
 		_meson_buildtype="debug"


### PR DESCRIPTION
- https://github.com/termux/termux-packages/commit/5887bad0da9e8fb187d94fc12225cfea5f51dc7e but for Meson as well as CMake

- Makes `get_option('debug')` return `False` in `meson.build` files instead of `True` when `-d` is not passed to `./build-package.sh`

