### PR TITLE
addpkg(x11/pardus-pen): 4.2.1

### DIFF
--- a/x11-packages/pardus-pen/build.sh
+++ b/x11-packages/pardus-pen/build.sh
@@ -1,0 +1,22 @@
+TERMUX_PKG_HOMEPAGE=https://pardus.org.tr/en/projects/pardus-applications
+TERMUX_PKG_DESCRIPTION="Screen Drawing Tool"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="4.2.1"
+TERMUX_PKG_SRCURL="https://github.com/pardus/pardus-pen/archive/refs/tags/debian/${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=ad6dd725bb6672bfd6bc90c90e2d82e59282905e240035a1f19e8657d629662e
+TERMUX_PKG_DEPENDS="qt6-qtbase, qt6-qtsvg, poppler-qt, libarchive"
+TERMUX_PKG_BUILD_DEPENDS="qt6-qtbase-cross-tools"
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--prefix=${TERMUX__PREFIX}
+-Dbackgrounds=${TERMUX__PREFIX__SHARE_DIR}/pardus/pardus-pen/backgrounds
+"
+
+termux_step_pre_configure() {
+	if [[ "${TERMUX_ON_DEVICE_BUILD}" == true ]]; then
+		export PATH="${TERMUX__PREFIX__BASE_LIB_DIR}/qt6:${PATH}"
+	else
+		export PATH="${TERMUX__PREFIX__OPT_DIR}/qt6/cross/lib/qt6:${PATH}"
+	fi
+}

--- a/x11-packages/pardus-pen/fix-32bit-build.patch
+++ b/x11-packages/pardus-pen/fix-32bit-build.patch
@@ -1,0 +1,32 @@
+diff --git a/include/widgets/DrawingWidget.h b/include/widgets/DrawingWidget.h
+index e3a3a67..b813711 100644
+--- a/include/widgets/DrawingWidget.h
++++ b/include/widgets/DrawingWidget.h
+@@ -22,7 +22,11 @@
+ #else
+ #include <cstdio>
+ #include "../utils/misc.h"
++#ifdef __LP64__
+ #define debug printf("[%s:%ld]:", __func__, get_epoch() - _cur_time); _cur_time = get_epoch(); printf
++#else
++#define debug printf("[%s:%d]:", __func__, get_epoch() - _cur_time); _cur_time = get_epoch(); printf
++#endif
+ #endif
+ 
+ #define PADDING 8*scale
+diff --git a/src/utils/Archive.cpp b/src/utils/Archive.cpp
+index d31d850..d17cd34 100644
+--- a/src/utils/Archive.cpp
++++ b/src/utils/Archive.cpp
+@@ -135,7 +135,11 @@ class ArchiveStorage {
+                 while (1) {
+                     char buf[4096];
+                     long int r = archive_read_data(ar, buf, sizeof(buf));
++#ifdef __LP64__
+                     debug("%ld %ld %s\n", r, size, entryName);
++#else
++                    debug("%ld %lld %s\n", r, size, entryName);
++#endif
+                     if (r > 0){ // continue read
+                         input.append(buf, r);
+                     } else if (r == 0) { // done

--- a/x11-packages/pardus-pen/fix-paths.patch
+++ b/x11-packages/pardus-pen/fix-paths.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index d63db0a..647f42c 100644
+--- a/meson.build
++++ b/meson.build
+@@ -33,7 +33,7 @@ subdir('debian')
+ 
+ if get_option('resources')
+     # Build qrc
+-    run_command(['/bin/sh', './data/genresource.sh'], check:true)
++    run_command(['@TERMUX_PREFIX@/bin/sh', './data/genresource.sh'], check:true)
+     rcc_args = ['rcc', './data/resources.qrc', '-o', meson.current_build_dir()/'resources.cpp']
+     if not get_option('etap19')
+         rcc_args += ['-threshold=0' ,'--compress=9', '--compress-algo=zlib']


### PR DESCRIPTION
This PR will add `pardus-pen` to Termux X11 (`x11-repo`) packages list. 

Pardus Pen is used to draw over the screen, or on a background, developed by Pardus developers and TÜBİTAK (The Scientific and Technological Research Council of Turkey) ([source code here](https://github.com/pardus/pardus-pen)). I compiled it myself, and it works fine. However, there is only one issue I have found so far; the transparent background does not work in KDE Plasma.