### PR TITLE
new package: ssh-android-agent

### DIFF
--- a/packages/ssh-android-agent/build.sh
+++ b/packages/ssh-android-agent/build.sh
@@ -1,0 +1,34 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/haraldh/ssh-android-agent
+TERMUX_PKG_DESCRIPTION="ssh-agent whose key lives in the Android hardware Keystore (via Termux:API)"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="Harald Hoyer <harald@hoyer.xyz>"
+TERMUX_PKG_VERSION=0.1.2
+TERMUX_PKG_SRCURL="https://github.com/haraldh/ssh-android-agent/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=e0df13346210c95a91534948fe2f1a0c6efe26b38a40ba413a2ed6ca6f5a4f0d
+TERMUX_PKG_DEPENDS="termux-api"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+	termux_setup_rust
+}
+
+termux_step_make() {
+	local -a BUILD_ARGS=("--release")
+	if [[ "$TERMUX_DEBUG_BUILD" == "true" ]]; then
+		BUILD_ARGS=()
+	fi
+
+	TERMUX_APP__PACKAGE_NAME="$TERMUX_APP__PACKAGE_NAME" \
+		cargo build --jobs "$TERMUX_PKG_MAKE_PROCESSES" \
+		--target "$CARGO_TARGET_NAME" "${BUILD_ARGS[@]}"
+}
+
+termux_step_make_install() {
+	local BUILD_TYPE="release"
+	if [[ "$TERMUX_DEBUG_BUILD" == "true" ]]; then
+		BUILD_TYPE="debug"
+	fi
+	install -Dm700 -t "$TERMUX_PREFIX/bin" \
+		"target/${CARGO_TARGET_NAME}/${BUILD_TYPE}/ssh-android-agent"
+}


### PR DESCRIPTION
Adds **ssh-android-agent** (https://github.com/haraldh/ssh-android-agent, MIT), a minimal ssh-agent whose single ECDSA P-256 identity lives in the Android hardware Keystore, reached through Termux:API's `termux-keystore`. The private key is generated inside the Keystore with signing-only purposes and never leaves it; the agent process only sees the public key and finished signatures.

Compared to the existing `tergent` (PKCS#11 provider), this is a standalone agent speaking the ssh-agent protocol on `SSH_AUTH_SOCK`, which makes `ssh -A` agent forwarding work without combining `ssh-agent` + `ssh-add -s`. It additionally offers an optional per-signature fingerprint prompt via `termux-fingerprint` (on by default, `--no-fingerprint` for devices without a sensor) on top of the Keystore's TEE-enforced unlock-validity window.

- Depends on `termux-api` (CLI) and requires the Termux:API app at runtime.
- Rust, builds with `termux_setup_rust`; recipe modeled on `packages/tergent/build.sh`.
- Upstream has a test suite that runs the agent against a fake `termux-keystore` (openssl-backed) and verifies signatures independently, so no device is needed for upstream CI.
- Tested on-device (aarch64): key generation, `ssh-add -L`/`-T`, and interactive `ssh -A` sessions work.

I'm the upstream author and will maintain the package (@haraldh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)