### PR TITLE
fix(build-package.sh): fix error in call depth logic

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -7,15 +7,15 @@ export TMPDIR
 # Set the build-package.sh call depth
 # If its the root call, then create a file to store the list of packages and their dependencies
 # that have been compiled at any instant by recursive calls to build-package.sh
-if (( ${TERMUX_BUILD_PACKAGE_CALL_DEPTH-0} )); then
-	export TERMUX_BUILD_PACKAGE_CALL_DEPTH=$((TERMUX_BUILD_PACKAGE_CALL_DEPTH+1))
-else
+if [[ ! "$TERMUX_BUILD_PACKAGE_CALL_DEPTH" =~ ^[0-9]+$ ]]; then
 	TERMUX_BUILD_PACKAGE_CALL_DEPTH=0
 	TERMUX_BUILD_PACKAGE_CALL_BUILT_PACKAGES_LIST_FILE_PATH="${TMPDIR}/build-package-call-built-packages-list-$(date +"%Y-%m-%d-%H.%M.%S.")$((RANDOM%1000))"
 	TERMUX_BUILD_PACKAGE_CALL_BUILDING_PACKAGES_LIST_FILE_PATH="${TMPDIR}/build-package-call-building-packages-list-$(date +"%Y-%m-%d-%H.%M.%S.")$((RANDOM%1000))"
 	export TERMUX_BUILD_PACKAGE_CALL_DEPTH TERMUX_BUILD_PACKAGE_CALL_BUILT_PACKAGES_LIST_FILE_PATH TERMUX_BUILD_PACKAGE_CALL_BUILDING_PACKAGES_LIST_FILE_PATH
 	echo -n " " > "$TERMUX_BUILD_PACKAGE_CALL_BUILT_PACKAGES_LIST_FILE_PATH"
 	touch "$TERMUX_BUILD_PACKAGE_CALL_BUILDING_PACKAGES_LIST_FILE_PATH"
+else
+	export TERMUX_BUILD_PACKAGE_CALL_DEPTH=$((TERMUX_BUILD_PACKAGE_CALL_DEPTH+1))
 fi
 
 set -euo pipefail


### PR DESCRIPTION
As pointed out to me by @Maxython, the call depth logic in `build-package.sh` has been silently broken for 8 months now.
The change I introduced to it in #27351 was not a semantically identical rewrite and the change in behavior broke the `-F` flag and cyclic dependency detection.

This reverts commit 9365de5aafa0dabc43fab27355d4c8486b6fa2f8.