### PR TITLE
bump(main/kew): 4.2.2

### DIFF
--- a/packages/kew/build.sh
+++ b/packages/kew/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://kewplayer.com
 TERMUX_PKG_DESCRIPTION="Music for the Shell"
 TERMUX_PKG_LICENSE="GPL-2.0-only"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="4.1.8"
+TERMUX_PKG_VERSION="4.2.2"
 TERMUX_PKG_SRCURL="https://codeberg.org/ravachol/kew/archive/v$TERMUX_PKG_VERSION.tar.gz"
-TERMUX_PKG_SHA256=418507821b1d2c9a36e9c2871b873be4431cbabcd90a623031cc65c7535e55d9
+TERMUX_PKG_SHA256=fad0c1e3ac955deeaebcd731f07dee28f580404e592e52a7c42a7b98858a0bd1
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_DEPENDS="chafa, faad2, fftw, glib, libogg, libvorbis, libopus, opusfile, taglib"
@@ -15,8 +15,8 @@ termux_step_post_get_source() {
 	local original_prefix_component_one="/data/data/com."
 	local original_prefix_component_two="termux/files/usr"
 	local original_prefix="${original_prefix_component_one}${original_prefix_component_two}"
-	find "$TERMUX_PKG_SRCDIR" -type f | \
-		xargs -n 1 sed -i -e "s%${original_prefix}%\@HARDCODED_TERMUX_PREFIX\@%g"
+	find "$TERMUX_PKG_SRCDIR" -type f -print0 | \
+		xargs -0 sed -i -e "s%${original_prefix}%\@HARDCODED_TERMUX_PREFIX\@%g"
 }
 
 termux_step_pre_configure() {


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/30558

- Use `-print0` with `find` and `-0` with `xargs` for compatibility with files with spaces in their filenames being in the `$TERMUX_PKG_SRCDIR`