### PR TITLE
fix(main/keychain): exclude betas from auto-updates

### DIFF
--- a/packages/keychain/build.sh
+++ b/packages/keychain/build.sh
@@ -1,13 +1,14 @@
-TERMUX_PKG_HOMEPAGE=https://www.funtoo.org/Keychain
-TERMUX_PKG_DESCRIPTION="keychain ssh-agent front-end"
-TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_HOMEPAGE=https://kernel-seeds.org/projects/keychain/
+TERMUX_PKG_DESCRIPTION="Keychain manager for ssh-agent and gpg-agent"
+TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.9.8"
-TERMUX_PKG_SRCURL=https://github.com/funtoo/keychain/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://github.com/danielrobbins/keychain/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=589cf55ae5c4b65af1d977d705beb319006efca5bcdda8352b8558d0dcff5a84
-TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+\.\d+"
 TERMUX_PKG_DEPENDS="dash, gnupg"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_VERSION_REGEXP='\d+\.\d+\.\d+(?!.beta)'
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 

--- a/scripts/updates/utils/termux_pkg_upgrade_version.sh
+++ b/scripts/updates/utils/termux_pkg_upgrade_version.sh
@@ -73,7 +73,7 @@ termux_pkg_upgrade_version() {
 	# Translate "-suffix" into "~suffix": "X.Y.Z-suffix" is considered later
 	# than X.Y.Z. for it to be considered earlier use "X.Y.Z~suffix".
 	for suffix in "rc" "alpha" "beta"; do
-		LATEST_VERSION="$(sed -E "s/[-.]?(${suffix}[0-9]*)/~\1/ig" <<< "$LATEST_VERSION")"
+		LATEST_VERSION="$(sed -E "s/[-._]?(${suffix}[0-9]*)/~\1/ig" <<< "$LATEST_VERSION")"
 	done
 
 	# If FD 3 is open, use it for reporting the fully parsed $LATEST_VERSION


### PR DESCRIPTION
- closes #30097

The `keychain` package has had several changes to its package metadata recently.
See: https://www.funtoo.org/Funtoo:Keychain

The relevant changes to us are:
- New official repo location
- New homepage
- Clarified license as GPL-3.0
- Project is currently releasing beta tags under `3.0.0_beta<n>`, which wasn't getting caught by the beta version fixer in `termux_pkg_upgrade_version`.
We *could* probably make it catch any 1 char before `alpha`/`beta`/`rc`, but I'm afraid we might end up with false positives that way, so I think adding chars to the group as we encounter them in beta prefixes is a good approach for the time being.

`keychain` should not be updated to beta releases since it is a `ssh-agent`/`gpg-agent` secrets manager, so it seems prudent to stick to stable release versions.