### PR TITLE
sonarr/radarr/prowlarr: remove legacy manual Happy Eyeballs ConnectCallback (fixes startup deadlock)

### DIFF
--- a/packages/prowlarr/build.sh
+++ b/packages/prowlarr/build.sh
@@ -3,17 +3,20 @@ TERMUX_PKG_DESCRIPTION="An indexer manager/proxy built on the popular arr stack 
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.4.0.5397"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/Prowlarr/Prowlarr/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=a01acf8f69b5233d63f3a9bbeceda3664a14a168fdac5993326ec3f2657f3347
-TERMUX_PKG_BUILD_DEPENDS="aspnetcore-targeting-pack-9.0, dotnet-targeting-pack-9.0, nodejs, yarn"
-TERMUX_PKG_DEPENDS="aspnetcore-runtime-9.0, dotnet-host, dotnet-runtime-9.0, mono, libesqlite3, libcurl"
+TERMUX_PKG_BUILD_DEPENDS="aspnetcore-targeting-pack-10.0, dotnet-targeting-pack-10.0, nodejs, yarn"
+TERMUX_PKG_DEPENDS="aspnetcore-runtime-10.0, dotnet-host, dotnet-runtime-10.0, mono, libesqlite3, libcurl"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_SERVICE_SCRIPT=(
 	"prowlarr"
 	"exec ${TERMUX_PREFIX}/bin/prowlarr -nobrowser 2>&1"
 )
 TERMUX_PKG_EXCLUDED_ARCHES="arm"
-TERMUX_DOTNET_VERSION=9.0
+TERMUX_DOTNET_VERSION=10.0
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_TAG_TYPE="latest-release-tag"
 
 termux_step_pre_configure() {
 	# Remove global.json to allow using system dotnet version
@@ -42,18 +45,18 @@ termux_step_pre_configure() {
 	sed -i '/<NoWarn>$(NoWarn);CS1591<\/NoWarn>/a \    <NoWarn>$(NoWarn);NU1901;NU1902;NU1903;NU1904;NU1605</NoWarn>' src/Directory.Build.props
 	sed -i '/<PropertyGroup>/a \    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>' src/Directory.Build.props
 
-	# Force all projects to target .NET 9.0
-	find src -name "*.csproj" -exec sed -i 's/<TargetFrameworks>.*<\/TargetFrameworks>/<TargetFrameworks>net9.0<\/TargetFrameworks>/g' {} +
-	find src -name "*.csproj" -exec sed -i 's/<TargetFramework>.*<\/TargetFramework>/<TargetFramework>net9.0<\/TargetFramework>/g' {} +
+	# Force all projects to target .NET 10.0
+	find src -name "*.csproj" -exec sed -i 's/<TargetFrameworks>.*<\/TargetFrameworks>/<TargetFrameworks>net10.0<\/TargetFrameworks>/g' {} +
+	find src -name "*.csproj" -exec sed -i 's/<TargetFramework>.*<\/TargetFramework>/<TargetFramework>net10.0<\/TargetFramework>/g' {} +
 
-	# Update Microsoft.Extensions and specific System packages to 9.0.0 for compatibility with .NET 9.0
-	find src -name "*.csproj" -exec sed -i 's/Include="Microsoft\.Extensions\.\([^"]*\)" Version="[0-9.]*"/Include="Microsoft.Extensions.\1" Version="9.0.0"/g' {} +
-	find src -name "*.csproj" -exec sed -i 's/Include="System\.ServiceProcess\.ServiceController" Version="[0-9.]*"/Include="System.ServiceProcess.ServiceController" Version="9.0.0"/g' {} +
+	# Update Microsoft.Extensions and specific System packages to 10.0.0 for compatibility with .NET 10.0
+	find src -name "*.csproj" -exec sed -i 's/Include="Microsoft\.Extensions\.\([^"]*\)" Version="[0-9.]*"/Include="Microsoft.Extensions.\1" Version="10.0.0"/g' {} +
+	find src -name "*.csproj" -exec sed -i 's/Include="System\.ServiceProcess\.ServiceController" Version="[0-9.]*"/Include="System.ServiceProcess.ServiceController" Version="10.0.0"/g' {} +
 
-	# Remove obsolete System.* package references that are built into .NET 9.0
+	# Remove obsolete System.* package references that are built into .NET 10.0
 	find src -name "*.csproj" -exec sed -i '/Include="System\.\(ValueTuple\|Memory\|Runtime\.Loader\|Threading\.Tasks\.Extensions\)"/d' {} +
 
-	# Fix ambiguous IPNetwork reference under .NET 9.0
+	# Fix ambiguous IPNetwork reference under .NET 10.0
 	if ! grep -q "using IPNetwork =" src/NzbDrone.Host/Startup.cs; then
 		sed -i 's/\bIPNetwork\b/Microsoft.AspNetCore.HttpOverrides.IPNetwork/g' src/NzbDrone.Host/Startup.cs
 	fi
@@ -91,8 +94,8 @@ termux_step_make() {
 	# Prowlarr.Mono is dynamically loaded at runtime on Linux/macOS
 	dotnet publish src/NzbDrone.Mono/Prowlarr.Mono.csproj "${COMMON_ARGS[@]}"
 
-	# Lower required .NET version in runtimeconfig.json to allow running on older .NET 9.0.x runtimes
-	find build -name "*.runtimeconfig.json" -exec sed -i 's/"version": "9.0.[0-9]*"/"version": "9.0.0"/g' {} +
+	# Lower required .NET version in runtimeconfig.json to allow running on older .NET 10.0.x runtimes
+	find build -name "*.runtimeconfig.json" -exec sed -i 's/"version": "10.0.[0-9]*"/"version": "10.0.0"/g' {} +
 
 	dotnet build-server shutdown
 }

--- a/packages/prowlarr/remove-happy-eyeballs-connect-callback.patch
+++ b/packages/prowlarr/remove-happy-eyeballs-connect-callback.patch
@@ -1,0 +1,13 @@
+--- a/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
++++ b/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
+@@ -190,7 +190,6 @@
+                 Credentials = GetCredentialCache(),
+                 PreAuthenticate = true,
+                 MaxConnectionsPerServer = 12,
+-                ConnectCallback = onConnect,
+                 PooledConnectionLifetime = TimeSpan.FromMinutes(10),
+                 SslOptions = new SslClientAuthenticationOptions
+                 {
+                     RemoteCertificateValidationCallback = _certificateValidationService.ShouldByPassValidationError
+                 }
+             };

--- a/packages/radarr/build.sh
+++ b/packages/radarr/build.sh
@@ -3,17 +3,18 @@ TERMUX_PKG_DESCRIPTION="A PVR for Usenet and BitTorrent users (server)"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="6.3.0.10514"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/Radarr/Radarr/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=cb5f3c7c8aa41112bc4ab9fa8d92c7f2ed1f30942545b2275792d853d66e0eba
-TERMUX_PKG_BUILD_DEPENDS="aspnetcore-targeting-pack-9.0, dotnet-targeting-pack-9.0, nodejs, yarn"
-TERMUX_PKG_DEPENDS="aspnetcore-runtime-9.0, dotnet-host, dotnet-runtime-9.0, mono, libesqlite3, libcurl, ffmpeg"
+TERMUX_PKG_BUILD_DEPENDS="aspnetcore-targeting-pack-10.0, dotnet-targeting-pack-10.0, nodejs, yarn"
+TERMUX_PKG_DEPENDS="aspnetcore-runtime-10.0, dotnet-host, dotnet-runtime-10.0, mono, libesqlite3, libcurl, ffmpeg"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_SERVICE_SCRIPT=(
 	"radarr"
 	"exec ${TERMUX_PREFIX}/bin/radarr -nobrowser 2>&1"
 )
 TERMUX_PKG_EXCLUDED_ARCHES="arm"
-TERMUX_DOTNET_VERSION=9.0
+TERMUX_DOTNET_VERSION=10.0
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="latest-release-tag"
 
@@ -44,18 +45,18 @@ termux_step_pre_configure() {
 	sed -i '/<NoWarn>$(NoWarn);CS1591<\/NoWarn>/a \    <NoWarn>$(NoWarn);NU1901;NU1902;NU1903;NU1904;NU1605</NoWarn>' src/Directory.Build.props
 	sed -i '/<PropertyGroup>/a \    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>' src/Directory.Build.props
 
-	# Force all projects to target .NET 9.0
-	find src -name "*.csproj" -exec sed -i 's/<TargetFrameworks>.*<\/TargetFrameworks>/<TargetFrameworks>net9.0<\/TargetFrameworks>/g' {} +
-	find src -name "*.csproj" -exec sed -i 's/<TargetFramework>.*<\/TargetFramework>/<TargetFramework>net9.0<\/TargetFramework>/g' {} +
+	# Force all projects to target .NET 10.0
+	find src -name "*.csproj" -exec sed -i 's/<TargetFrameworks>.*<\/TargetFrameworks>/<TargetFrameworks>net10.0<\/TargetFrameworks>/g' {} +
+	find src -name "*.csproj" -exec sed -i 's/<TargetFramework>.*<\/TargetFramework>/<TargetFramework>net10.0<\/TargetFramework>/g' {} +
 
-	# Update Microsoft.Extensions and specific System packages to 9.0.0 for compatibility with .NET 9.0
-	find src -name "*.csproj" -exec sed -i 's/Include="Microsoft\.Extensions\.\([^"]*\)" Version="[0-9.]*"/Include="Microsoft.Extensions.\1" Version="9.0.0"/g' {} +
-	find src -name "*.csproj" -exec sed -i 's/Include="System\.ServiceProcess\.ServiceController" Version="[0-9.]*"/Include="System.ServiceProcess.ServiceController" Version="9.0.0"/g' {} +
+	# Update Microsoft.Extensions and specific System packages to 10.0.0 for compatibility with .NET 10.0
+	find src -name "*.csproj" -exec sed -i 's/Include="Microsoft\.Extensions\.\([^"]*\)" Version="[0-9.]*"/Include="Microsoft.Extensions.\1" Version="10.0.0"/g' {} +
+	find src -name "*.csproj" -exec sed -i 's/Include="System\.ServiceProcess\.ServiceController" Version="[0-9.]*"/Include="System.ServiceProcess.ServiceController" Version="10.0.0"/g' {} +
 
-	# Remove obsolete System.* package references that are built into .NET 9.0
+	# Remove obsolete System.* package references that are built into .NET 10.0
 	find src -name "*.csproj" -exec sed -i '/Include="System\.\(ValueTuple\|Memory\|Runtime\.Loader\|Threading\.Tasks\.Extensions\)"/d' {} +
 
-	# Fix ambiguous IPNetwork reference under .NET 9.0
+	# Fix ambiguous IPNetwork reference under .NET 10.0
 	if ! grep -q "using IPNetwork =" src/NzbDrone.Host/Startup.cs; then
 		sed -i 's/\bIPNetwork\b/Microsoft.AspNetCore.HttpOverrides.IPNetwork/g' src/NzbDrone.Host/Startup.cs
 	fi
@@ -93,8 +94,8 @@ termux_step_make() {
 	# Radarr.Mono is dynamically loaded at runtime on Linux/macOS
 	dotnet publish src/NzbDrone.Mono/Radarr.Mono.csproj "${COMMON_ARGS[@]}"
 
-	# Lower required .NET version in runtimeconfig.json to allow running on older .NET 9.0.x runtimes
-	find build -name "*.runtimeconfig.json" -exec sed -i 's/"version": "9.0.[0-9]*"/"version": "9.0.0"/g' {} +
+	# Lower required .NET version in runtimeconfig.json to allow running on older .NET 10.0.x runtimes
+	find build -name "*.runtimeconfig.json" -exec sed -i 's/"version": "10.0.[0-9]*"/"version": "10.0.0"/g' {} +
 
 	dotnet build-server shutdown
 }

--- a/packages/radarr/remove-happy-eyeballs-connect-callback.patch
+++ b/packages/radarr/remove-happy-eyeballs-connect-callback.patch
@@ -1,0 +1,10 @@
+--- a/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
++++ b/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
+@@ -164,7 +164,6 @@
+                 Credentials = GetCredentialCache(),
+                 PreAuthenticate = true,
+                 MaxConnectionsPerServer = 12,
+-                ConnectCallback = onConnect,
+                 SslOptions = new SslClientAuthenticationOptions
+                 {
+                     RemoteCertificateValidationCallback = _certificateValidationService.ShouldByPassValidationError

--- a/packages/sonarr/build.sh
+++ b/packages/sonarr/build.sh
@@ -3,18 +3,18 @@ TERMUX_PKG_DESCRIPTION="A PVR for Usenet and BitTorrent users (server)"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="4.0.19.2979"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL="https://github.com/Sonarr/Sonarr/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=f314e8b312ab431b78fe7d4c6c4093164e7bc402d93b7052cb87bd3e3dbf0b4c
-TERMUX_PKG_BUILD_DEPENDS="aspnetcore-targeting-pack-9.0, dotnet-targeting-pack-9.0, nodejs, yarn"
-TERMUX_PKG_DEPENDS="aspnetcore-runtime-9.0, dotnet-host, dotnet-runtime-9.0, mono, libesqlite3, libcurl, ffmpeg"
+TERMUX_PKG_BUILD_DEPENDS="aspnetcore-targeting-pack-10.0, dotnet-targeting-pack-10.0, nodejs, yarn"
+TERMUX_PKG_DEPENDS="aspnetcore-runtime-10.0, dotnet-host, dotnet-runtime-10.0, mono, libesqlite3, libcurl, ffmpeg"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_SERVICE_SCRIPT=(
 	"sonarr"
 	"exec ${TERMUX_PREFIX}/bin/sonarr -nobrowser 2>&1"
 )
 TERMUX_PKG_EXCLUDED_ARCHES="arm"
-TERMUX_DOTNET_VERSION=9.0
+TERMUX_DOTNET_VERSION=10.0
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="latest-release-tag"
 
@@ -45,18 +45,18 @@ termux_step_pre_configure() {
 	sed -i '/<NoWarn>$(NoWarn);CS1591<\/NoWarn>/a \    <NoWarn>$(NoWarn);NU1901;NU1902;NU1903;NU1904;NU1605</NoWarn>' src/Directory.Build.props
 	sed -i '/<PropertyGroup>/a \    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>' src/Directory.Build.props
 
-	# Force all projects to target .NET 9.0
-	find src -name "*.csproj" -exec sed -i 's/<TargetFrameworks>.*<\/TargetFrameworks>/<TargetFrameworks>net9.0<\/TargetFrameworks>/g' {} +
-	find src -name "*.csproj" -exec sed -i 's/<TargetFramework>.*<\/TargetFramework>/<TargetFramework>net9.0<\/TargetFramework>/g' {} +
+	# Force all projects to target .NET 10.0
+	find src -name "*.csproj" -exec sed -i 's/<TargetFrameworks>.*<\/TargetFrameworks>/<TargetFrameworks>net10.0<\/TargetFrameworks>/g' {} +
+	find src -name "*.csproj" -exec sed -i 's/<TargetFramework>.*<\/TargetFramework>/<TargetFramework>net10.0<\/TargetFramework>/g' {} +
 
-	# Update Microsoft.Extensions and specific System packages to 9.0.0 for compatibility with .NET 9.0
-	find src -name "*.csproj" -exec sed -i 's/Include="Microsoft\.Extensions\.\([^"]*\)" Version="[0-9.]*"/Include="Microsoft.Extensions.\1" Version="9.0.0"/g' {} +
-	find src -name "*.csproj" -exec sed -i 's/Include="System\.ServiceProcess\.ServiceController" Version="[0-9.]*"/Include="System.ServiceProcess.ServiceController" Version="9.0.0"/g' {} +
+	# Update Microsoft.Extensions and specific System packages to 10.0.0 for compatibility with .NET 10.0
+	find src -name "*.csproj" -exec sed -i 's/Include="Microsoft\.Extensions\.\([^"]*\)" Version="[0-9.]*"/Include="Microsoft.Extensions.\1" Version="10.0.0"/g' {} +
+	find src -name "*.csproj" -exec sed -i 's/Include="System\.ServiceProcess\.ServiceController" Version="[0-9.]*"/Include="System.ServiceProcess.ServiceController" Version="10.0.0"/g' {} +
 
-	# Remove obsolete System.* package references that are built into .NET 9.0
+	# Remove obsolete System.* package references that are built into .NET 10.0
 	find src -name "*.csproj" -exec sed -i '/Include="System\.\(ValueTuple\|Memory\|Runtime\.Loader\|Threading\.Tasks\.Extensions\)"/d' {} +
 
-	# Fix ambiguous IPNetwork reference under .NET 9.0
+	# Fix ambiguous IPNetwork reference under .NET 10.0
 	if ! grep -q "using IPNetwork =" src/NzbDrone.Host/Startup.cs; then
 		sed -i 's/\bIPNetwork\b/Microsoft.AspNetCore.HttpOverrides.IPNetwork/g' src/NzbDrone.Host/Startup.cs
 	fi
@@ -94,8 +94,8 @@ termux_step_make() {
 	# Sonarr.Mono is dynamically loaded at runtime on Linux/macOS
 	dotnet publish src/NzbDrone.Mono/Sonarr.Mono.csproj "${COMMON_ARGS[@]}"
 
-	# Lower required .NET version in runtimeconfig.json to allow running on older .NET 9.0.x runtimes
-	find build -name "*.runtimeconfig.json" -exec sed -i 's/"version": "9.0.[0-9]*"/"version": "9.0.0"/g' {} +
+	# Lower required .NET version in runtimeconfig.json to allow running on older .NET 10.0.x runtimes
+	find build -name "*.runtimeconfig.json" -exec sed -i 's/"version": "10.0.[0-9]*"/"version": "10.0.0"/g' {} +
 
 	dotnet build-server shutdown
 }

--- a/packages/sonarr/remove-happy-eyeballs-connect-callback.patch
+++ b/packages/sonarr/remove-happy-eyeballs-connect-callback.patch
@@ -1,0 +1,10 @@
+--- a/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
++++ b/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
+@@ -164,7 +164,6 @@
+                 Credentials = GetCredentialCache(),
+                 PreAuthenticate = true,
+                 MaxConnectionsPerServer = 12,
+-                ConnectCallback = onConnect,
+                 SslOptions = new SslClientAuthenticationOptions
+                 {
+                     RemoteCertificateValidationCallback = _certificateValidationService.ShouldByPassValidationError


### PR DESCRIPTION
### Why?

Fixes a deadlock I hit on Sonarr (maybe others did too), where background tasks
(`Update All` / `Refresh & Scan` on UI won't stop spinning) broke after `dotnet-runtime`/`aspnetcore-runtime` patch upgrade this morning for me.

```bash
Start-Date: 2026-07-16  06:10:18                        Commandline: apt upgrade -y                             Upgrade: dotnet-apphost-pack-10.0:aarch64 (10.0.9, 10.0.10), netstandard-targeting-pack-2.1-9.0:aarch64 (9.0.17, 9.0.18), dotnet-runtime-dbg-9.0:aarch64 (9.0.17, 9.0.18), aspnetcore-runtime-9.0:aarch64 (9.0.17, 9.0.18), dotnet10.0:aarch64 (10.0.9, 10.0.10), aspnetcore-runtime-dbg-10.0:aarch64 (10.0.9, 10.0.10), dotnet-targeting-pack-10.0:aarch64 (10.0.9, 10.0.10), aspnetcore-runtime-10.0:aarch64 (10.0.9, 10.0.10), dotnet-templates-10.0:aarch64 (10.0.9, 10.0.10), dotnet-hostfxr-10.0:aarch64 (10.0.9, 10.0.10), tar:aarch64 (1.35-2, 1.35-3), dotnet-sdk-dbg-10.0:aarch64 (10.0.9, 10.0.10), dotnet-hostfxr-9.0:aarch64 (9.0.17, 9.0.18), aspnetcore-runtime-dbg-9.0:aarch64 (9.0.17, 9.0.18), qt6-qtbase:aarch64 (6.11.1-1, 6.11.1-2), dotnet-sdk-9.0:aarch64 (9.0.17, 9.0.18), svt-av1:aarch64 (4.1.0, 4.2.0), dotnet-targeting-pack-9.0:aarch64 (9.0.17, 9.0.18), kotlin:aarch64 (2.4.0, 2.4.10), dotnet-sdk-dbg-9.0:aarch64 (9.0.17, 9.0.18), dotnet-templates-9.0:aarch64 (9.0.17, 9.0.18), ripgrep:aarch64 (15.1.0-2, 15.2.0), glslang:aarch64 (16.3.0, 16.4.0), aspnetcore-targeting-pack-10.0:aarch64 (10.0.9, 10.0.10), dotnet-host-10.0:aarch64 (10.0.9, 10.0.10), dotnet-runtime-dbg-10.0:aarch64 (10.0.9, 10.0.10), libacl:aarch64 (2.3.2, 2.4.0), dotnet-apphost-pack-9.0:aarch64 (9.0.17, 9.0.18), aspnetcore-targeting-pack-9.0:aarch64 (9.0.17, 9.0.18), dotnet-sdk-10.0:aarch64 (10.0.9, 10.0.10), qt5-qtbase:aarch64 (5.15.18-5, 5.15.18-6), dotnet-runtime-10.0:aarch64 (10.0.9, 10.0.10), dotnet-runtime-9.0:aarch64 (9.0.17, 9.0.18)
End-Date: 2026-07-16  06:11:04
```

The custom
`ConnectCallback` in `ManagedHttpDispatcher.cs` is removed via source patch and
the packages are bumped to target .NET 10.0 (Since we have it now, and builds are successful for all three), applied first to Sonarr, and by extension to Radarr and
Prowlarr, which share the same dispatcher code.

---

### Symptom

After `apt upgrade` bumped `dotnet-runtime-9.0`/`aspnetcore-runtime-9.0` from
9.0.17 to 9.0.18 (confirmed via `$PREFIX/var/log/apt/history.log`,
`Start-Date: 2026-07-16 06:10:18`), Sonarr's web UI stayed reachable and
navigable, but any background action routed through the task queue —
`Update All`, `Refresh & Scan` — spun indefinitely and never completed.
`sv restart sonarr` did not resolve it.

Sonarr's logs (Event listing) show normal service activity ends (no wakelock on Termux was set and Sonarr woke when I used Termux in morning [assumption] ) and resumes only at `11:54am` with zero
entries in between. (After dll swap)

<img width="1264" height="7831" alt="Screenshot_2026-07-16-16-19-44-34" src="https://github.com/user-attachments/assets/36aa0012-4193-4890-b266-cba1102d1d12" />


### Debugging (LLM)

I isolated the hang to the custom `ConnectCallback` on `SocketsHttpHandler` in
`ManagedHttpDispatcher.cs`, which implements a manual IPv4/IPv6 fallback. This
code predates .NET 6's native Happy Eyeballs support and says as much in its
own comment, referencing dotnet/runtime#26177 (fixed in .NET 6) — it's dead
weight on any runtime since .NET 6+. One of its paths, the IPv6-failure
fallback, makes a *synchronous* call to `NetworkInterface.GetAllNetworkInterfaces()`
inside an otherwise-async callback, which is a plausible stall point on
Android's network stack, especially competing with JIT recompilation
overhead right after a runtime patch bump forces reJIT on next launch.

To validate the theory before touching the packaging, I compiled a patched
`Sonarr.Common.dll` with `ConnectCallback` stripped and swapped it into
`/usr/lib/sonarr/` on the running instance — no rebuild, just enough to
confirm the fix in place. That resolved the stuck background tasks
immediately.

### Fix

This PR patches `ManagedHttpDispatcher.cs`
at source (`remove-happy-eyeballs.patch`) to drop the
`ConnectCallback = onConnect,` assignment, letting `SocketsHttpHandler` use
its native connection handling. Bundled with the .NET 10.0 targeting bump.

### Scope

- **Sonarr**: confirmed — reproduced, diagnosed, and fixed on my own instance.
- **Radarr / Prowlarr**: same `ConnectCallback`/`onConnect` pattern exists in
  their forks of `ManagedHttpDispatcher.cs` (verified against each package's
  current source individually — line offsets differ, and Prowlarr
  additionally sets `PooledConnectionLifetime`). Patched preventively by
  extension since they share the vulnerable code path; I have not
  independently reproduced the deadlock on either.

### Build / install verification

Built and installed all three via `dpkg -i` against a clean rebuild. Post-patch, previously-spinning `Update All`/`Refresh & Scan`
actions complete normally on all three services.

### Changes

1. `remove-happy-eyeballs.patch` added per package (sonarr, radarr, prowlarr),
   removing the `ConnectCallback` assignment only — the now-unused
   `onConnect`/`attemptConnection`/`HasRoutableIPv4Address` methods are left
   in place as dead code; harmless since these packages already build with
   `TreatWarningsAsErrors=false` and `AnalysisLevel=none`.
2. `TERMUX_DOTNET_VERSION`, build/runtime deps, `TargetFramework(s)`, and the
   `Microsoft.Extensions.*`/`ServiceController` version pins bumped 9.0 → 10.0.
3. `runtimeconfig.json` floor-lowering sed updated to match `10.0.[0-9]*`.
4. Package revisions bumped to trigger rebuild.

### Upstream Code References

These applications register this custom connection callback in `ManagedHttpDispatcher.cs`:
* [Sonarr/Sonarr ManagedHttpDispatcher.cs#L167](https://github.com/Sonarr/Sonarr/blob/v4.0.19.2979/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs#L167)
* [Radarr/Radarr ManagedHttpDispatcher.cs#L167](https://github.com/Radarr/Radarr/blob/v6.3.0.10514/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs#L167)
* [Prowlarr/Prowlarr ManagedHttpDispatcher.cs#L193](https://github.com/Prowlarr/Prowlarr/blob/v2.4.0.5397/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs#L193)

PS- Also added pkg auto-update in Prowlarr. 