### PR TITLE
addpkg(main/glibc-solo): boot strap stand alone glibc root

### DIFF
--- a/packages/glibc-solo/build.sh
+++ b/packages/glibc-solo/build.sh
@@ -1,0 +1,22 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/termux/glibc-packages
+# TERMUX_PKG_DESCRIPTION="A package repository containing glibc-based programs and libraries"
+TERMUX_PKG_DESCRIPTION="glibc boot strap that replace glibc-repo"
+TERMUX_PKG_LICENSE="WTFPL"
+TERMUX_PKG_MAINTAINER="@termux-pacman"
+TERMUX_PKG_VERSION=0
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_SKIP_SRC_EXTRACT=true
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+
+termux_step_post_massage() {
+	local target=etc/apt
+	local source=$TERMUX_PKG_BUILDER_DIR
+	mkdir -p $target
+	cp $source/glibc.* $target/
+	sed -i "s,@TERMUX_PREFIX@,$TERMUX_PREFIX," $target/*
+}
+
+termux_step_create_debscripts() {
+	[ "$TERMUX_PACKAGE_FORMAT" = "pacman" ] && return 0
+	cp -f "${TERMUX_PKG_BUILDER_DIR}/postinst" .
+}

--- a/packages/glibc-solo/glibc.conf
+++ b/packages/glibc-solo/glibc.conf
@@ -1,0 +1,14 @@
+// vim:ft=aptconf
+APT::Install-Recommends "0";
+APT::Clean-Installed "0";
+Dir::Cache "@TERMUX_PREFIX@/glibc/var/cache/apt";
+Dir::Etc::sourcelist "@TERMUX_PREFIX@/etc/apt/glibc.sources";
+Dir::Etc::sourceparts "";
+Dir::State "@TERMUX_PREFIX@/glibc/var/lib/apt";
+Dir::State::status "@TERMUX_PREFIX@/glibc/var/lib/dpkg/status";
+DPkg::options {
+"--admindir";
+"@TERMUX_PREFIX@/glibc/var/lib/dpkg";
+;
+}
+

--- a/packages/glibc-solo/glibc.sources
+++ b/packages/glibc-solo/glibc.sources
@@ -1,0 +1,9 @@
+## See the sources.list(5) manual page for further settings.
+Types: deb
+URIs: https://packages-cf.termux.dev/apt/termux-glibc
+# URIs: https://packages.termux.dev/apt/termux-glibc
+Suites: glibc
+Components: stable
+Signed-By: @TERMUX_PREFIX@/etc/apt/trusted.gpg.d/termux-autobuilds.gpg
+
+

--- a/packages/glibc-solo/postinst
+++ b/packages/glibc-solo/postinst
@@ -1,0 +1,15 @@
+#!/bin/env bash
+echo '
+run this to boot strap glibc root
+apt -c $PREFIX/etc/apt/glibc.conf update
+apt -c $PREFIX/etc/apt/glibc.conf install apt-glibc bash-glibc
+
+open glibc shell
+unset LD_PRELOAD
+$PREFIX/glibc/bin/bash
+
+confirm you only see glibc packets
+export PATH=$PREFIX/glibc/bin:$PATH
+which apt
+apt list
+'


### PR DESCRIPTION

this packet   will boot strap  stand alone glibc root separate from bionic

apt-glibc has to be merged  before this works 

https://github.com/termux-pacman/glibc-packages/pull/361


# replace glibc-repo

this packet should replace glibc-repo


# remove -glibc suffix from packet names

when the old glibc-repo packet is replaced the -glibc suffix for packet names is no longer needed and can be removed 


#  move glibc root out from bionic root . files/usr/glibc -> glibc

and nesting glibc inside bionic is no longer necessary . it can be moved to /data/data/com.termux/glibc

files/usr/glibc can be replaced with a symlink


