### PR TITLE
fix(x11/freerdp): prevent `SIGABRT` due to failed assert at start up

### DIFF
--- a/x11-packages/freerdp/0008-fallback-to-simpler-int-cast-assertion.patch
+++ b/x11-packages/freerdp/0008-fallback-to-simpler-int-cast-assertion.patch
@@ -1,0 +1,13 @@
+diff --git a/winpr/include/winpr/cast.h b/winpr/include/winpr/cast.h
+index 804ea0f66..a139021d4 100644
+--- a/winpr/include/winpr/cast.h
++++ b/winpr/include/winpr/cast.h
+@@ -96,7 +96,7 @@
+ #define WINPR_FUNC_PTR_CAST(ptr, dstType) (dstType)(uintptr_t) ptr
+ #endif
+ 
+-#if defined(__GNUC__) || defined(__clang__)
++#if ! defined(__ANDROID__) && ( defined(__GNUC__) || defined(__clang__) )
+ 
+ /**
+  * @brief A macro to do checked integer casts.

--- a/x11-packages/freerdp/build.sh
+++ b/x11-packages/freerdp/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A free remote desktop protocol library and clients"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.30.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/FreeRDP/FreeRDP/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=21b3f72bd688fcd1dbbef37b7129bfc9701906705572fce2a5a80b1e85ecc0ee
 TERMUX_PKG_AUTO_UPDATE=true


### PR DESCRIPTION
`freerdp` 3.30.0 currently crashes at start up with a SIGABRT error due to a failed assertion.
- I've tracked this down to this upstream commit/PR (https://github.com/FreeRDP/FreeRDP/commit/295e57bff28d46a82180633c061f4e49c3014239 / https://github.com/FreeRDP/FreeRDP/pull/13047)

It is possible this issue was also present in the 3.29.0 version of the package.
However the report I received from discord user `@spiral09` was for 3.30.0

I haven't been able to root-cause the issue so far.
The failed assertion is in the `TlsAlloc` function.
https://github.com/FreeRDP/FreeRDP/blob/3.30.0/winpr/libwinpr/thread/tls.c#L37-L46

I have solved the problem for the time being by forcing use of the simpler fallback implementation of the `WINPR_ASSERTING_INT_CAST` macro.
https://github.com/FreeRDP/FreeRDP/blob/3.30.0/winpr/include/winpr/cast.h#L99-L123
This macro is used widely across the freerdp codebase, so I suspect the issue is specific to `TlsAlloc`.