### PR TITLE
fix(packages/uftrace): fix trace indefinite hang

### DIFF
--- a/packages/uftrace/build.sh
+++ b/packages/uftrace/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Function (graph) tracer for user-space"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.19"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL="https://github.com/namhyung/uftrace/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=c35ef25f279684fc7d79dcc250fb29386890870fd2c9f812e587151419ca01af
 # Hardcoded libpython${TERMUX_PYTHON_VERSION}.so is dlopen(3)ed by uftrace.

--- a/packages/uftrace/libmcount-wrap.c.patch
+++ b/packages/uftrace/libmcount-wrap.c.patch
@@ -1,34 +1,37 @@
---- a/libmcount/wrap.c	2022-04-15 17:55:05.279817913 +0000
-+++ b/libmcount/wrap.c	2022-04-15 19:45:32.879129081 +0000
-@@ -273,7 +272,12 @@
+--- a/libmcount/wrap.c	2026-03-02 16:32:16.000000000 +1100
++++ b/libmcount/wrap.c	2026-07-17 11:00:15.291419756 +1000
+@@ -308,18 +308,29 @@
  
  void mcount_hook_functions(void)
  {
++	real_dlopen = dlsym(RTLD_NEXT, "dlopen");
 +#if !defined __ANDROID__ || __ANDROID_API__ >= 33
  	real_backtrace = dlsym(RTLD_NEXT, "backtrace");
 +#else
-+	void *libandroid_execinfo = dlopen("libandroid-execinfo.so", RTLD_NOW);
++	void *libandroid_execinfo = real_dlopen("libandroid-execinfo.so", RTLD_NOW);
 +	real_backtrace = dlsym(libandroid_execinfo, "backtrace");
 +#endif
  	real_cxa_throw = dlsym(RTLD_NEXT, "__cxa_throw");
  	real_cxa_rethrow = dlsym(RTLD_NEXT, "__cxa_rethrow");
  	real_cxa_begin_catch = dlsym(RTLD_NEXT, "__cxa_begin_catch");
-@@ -281,8 +285,14 @@
- 	real_dlopen = dlsym(RTLD_NEXT, "dlopen");
+ 	real_cxa_end_catch = dlsym(RTLD_NEXT, "__cxa_end_catch");
+ 	real_cxa_guard_abort = dlsym(RTLD_NEXT, "__cxa_guard_abort");
+-	real_dlopen = dlsym(RTLD_NEXT, "dlopen");
+ 	real_dlclose = dlsym(RTLD_NEXT, "dlclose");
  	real_pthread_exit = dlsym(RTLD_NEXT, "pthread_exit");
  	real_unwind_resume = dlsym(RTLD_NEXT, "_Unwind_Resume");
 +#if !defined __ANDROID__ || __ANDROID_API__ >= 28
  	real_posix_spawn = dlsym(RTLD_NEXT, "posix_spawn");
  	real_posix_spawnp = dlsym(RTLD_NEXT, "posix_spawnp");
 +#else
-+	void *libandroid_spawn = dlopen("libandroid-spawn.so", RTLD_NOW);
++	void *libandroid_spawn = real_dlopen("libandroid-spawn.so", RTLD_NOW);
 +	real_posix_spawn = dlsym(libandroid_spawn, "posix_spawn");
 +	real_posix_spawnp = dlsym(libandroid_spawn, "posix_spawnp");
 +#endif
  	real_execve = dlsym(RTLD_NEXT, "execve");
  	real_execvpe = dlsym(RTLD_NEXT, "execvpe");
  	real_fexecve = dlsym(RTLD_NEXT, "fexecve");
-@@ -338,7 +320,8 @@
+@@ -396,7 +407,8 @@
  	real_cxa_rethrow();
  }
  
@@ -38,7 +41,7 @@
  {
  	struct mcount_thread_data *mtdp;
  
-@@ -360,7 +343,7 @@
+@@ -417,7 +429,7 @@
  		mcount_rstack_restore(mtdp);
  	}
  
@@ -46,4 +49,4 @@
 +	__real__Unwind_Resume(exception);
  }
  
- __visible_default void * __cxa_begin_catch(void *exception)
+ __visible_default void *__cxa_begin_catch(void *exception)


### PR DESCRIPTION
fixes namhyung/uftrace#1993

uftrace also hooks `dlopen()` inside `mcount_hook_functions()`, but the original dlopen is called instead of the wrapper in `libmcount-wrap.c.patch`,  which causes indefinite hang when trying to record a trace when using uftrace.