### PR TITLE
chore(scripts/big-pkgs): mark dotnet10.0 as a big package

### DIFF
--- a/scripts/big-pkgs.list
+++ b/scripts/big-pkgs.list
@@ -12,6 +12,7 @@ dart
 deno
 dotnet8.0
 dotnet9.0
+dotnet10.0
 electron-for-code-oss
 electron-host-tools-for-code-oss
 emscripten


### PR DESCRIPTION
- We never marked `dotnet10.0` as a big package when it was added in #28486.
This PR just adds it to the list.