### PR TITLE
fix(main/nushell): fix compilation on i686 target

### DIFF
--- a/packages/nushell/0001-remove-sysinfo-Users.patch
+++ b/packages/nushell/0001-remove-sysinfo-Users.patch
@@ -1,7 +1,7 @@
-From 737061c8c3b6ba2d0cf81e280659ea8a1a6c34a3 Mon Sep 17 00:00:00 2001
+From 0b9d14795eaa2ee74be41d4b2ee8ff296ba46fa4 Mon Sep 17 00:00:00 2001
 From: Termux <contact@termux.dev>
 Date: Fri, 14 Nov 2025 12:06:03 +0600
-Subject: [PATCH 1/2] remove `sysinfo::Users`
+Subject: [PATCH 1/3] remove `sysinfo::Users`
 
 Starting from version 0.36, the `user` feature of `sysinfo` crate uses `getpwent`, etc.
 These were added to Android in API 26, but termux currently targets API 24.
@@ -10,7 +10,7 @@ These were added to Android in API 26, but termux currently targets API 24.
  1 file changed, 1 insertion(+), 33 deletions(-)
 
 diff --git a/crates/nu-command/src/system/sys/users.rs b/crates/nu-command/src/system/sys/users.rs
-index 55cedb5..e96d7d7 100644
+index 55cedb57..e96d7d72 100644
 --- a/crates/nu-command/src/system/sys/users.rs
 +++ b/crates/nu-command/src/system/sys/users.rs
 @@ -1,6 +1,4 @@
@@ -58,5 +58,5 @@ index 55cedb5..e96d7d7 100644
 +    Value::list(Vec::new(), span)
  }
 -- 
-2.53.0
+2.55.0
 

--- a/packages/nushell/0002-replace-osc-52-paste-with-termux-clipboard-get.patch
+++ b/packages/nushell/0002-replace-osc-52-paste-with-termux-clipboard-get.patch
@@ -1,17 +1,17 @@
-From 56b1b3dd22cf67472f9959cab5eca603eff6e079 Mon Sep 17 00:00:00 2001
+From 91b446d5218b3c9a3161b86aeb48e28fe058e22c Mon Sep 17 00:00:00 2001
 From: Termux <contact@termux.dev>
 Date: Mon, 8 Sep 2025 02:07:14 +0600
-Subject: [PATCH 2/2] replace osc 52 paste with termux-clipboard-get
+Subject: [PATCH 2/3] replace osc 52 paste with termux-clipboard-get
 
 ---
  crates/nu-std/std/clip/mod.nu | 9 +++------
  1 file changed, 3 insertions(+), 6 deletions(-)
 
 diff --git a/crates/nu-std/std/clip/mod.nu b/crates/nu-std/std/clip/mod.nu
-index d559fab..fb08e3a 100644
+index 94528e4d..8638dbb4 100644
 --- a/crates/nu-std/std/clip/mod.nu
 +++ b/crates/nu-std/std/clip/mod.nu
-@@ -52,16 +52,13 @@ export def paste []: [nothing -> string] {
+@@ -30,16 +30,13 @@ export def copy52 [
  } --result "Hello"
  export def paste52 []: [nothing -> string] {
    try {
@@ -30,7 +30,7 @@ index d559fab..fb08e3a 100644
 -  | decode
  }
  
- # After deprecated commands are removed, prefix will need to be changed to use clip copy or clip copy52.
+ # Add a prefix to each line of the content to be copied
 -- 
-2.53.0
+2.55.0
 

--- a/packages/nushell/0003-bump-fff-search-dependency-to-0.10.0.patch
+++ b/packages/nushell/0003-bump-fff-search-dependency-to-0.10.0.patch
@@ -1,0 +1,26 @@
+From 8a6c9a0f1f8c8b2b047a4aebc37eb1ffb7120c27 Mon Sep 17 00:00:00 2001
+From: Juhan280 <azurarobo280@gmail.com>
+Date: Tue, 7 Jul 2026 20:35:19 +0600
+Subject: [PATCH 3/3] bump fff-search dependency to =0.10.0
+
+fff-search 0.9.1+ had code that doesn't compile for i686 architecture
+---
+ Cargo.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Cargo.toml b/Cargo.toml
+index 228547c3..f9fd9431 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -161,7 +161,7 @@ encoding_rs = "0.8"
+ fancy-regex = "0.18"
+ filesize = "0.2"
+ filetime = "0.2.27"
+-fff-search = { version = "=0.9.6", default-features = false }
++fff-search = { version = "=0.10.0", default-features = false, features = ["ripgrep"] }
+ fluent = "0.17.0"
+ gatekeeper = "3.0.0"
+ heck = "0.5.0"
+-- 
+2.55.0
+

--- a/packages/nushell/build.sh
+++ b/packages/nushell/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A new type of shell operating on structured data"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.114.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/nushell/nushell/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=48ef2fb6bb3ec2b1dcff87a792aeebdfab10b29f3119a62291075b17e4ad25d5
 TERMUX_PKG_DEPENDS="openssl"


### PR DESCRIPTION
Currently the i686 build of nushell is failing which is preventing all other builds from being published.

- https://github.com/termux/termux-packages/issues/25481