### PR TITLE
bump(main/vulkan-tools): 1.4.357

### DIFF
--- a/packages/vulkan-tools/0003-revert-vk-khr-display.patch
+++ b/packages/vulkan-tools/0003-revert-vk-khr-display.patch
@@ -11,11 +11,12 @@ WARNING: [Loader Message] Code 0 : ICD for selected physical device does not exp
 
 --- a/vulkaninfo/CMakeLists.txt
 +++ b/vulkaninfo/CMakeLists.txt
-@@ -93,7 +93,6 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux|BSD|GNU")
-         target_compile_definitions(vulkaninfo PRIVATE VK_USE_PLATFORM_DIRECTFB_EXT)
-         target_link_libraries(vulkaninfo PRIVATE PkgConfig::DirectFB)
-     endif()
--    target_compile_definitions(vulkaninfo PRIVATE VK_USE_PLATFORM_DISPLAY)
- endif()
+@@ -62,8 +62,6 @@ target_include_directories(vulkaninfo PRIVATE
  
- if(APPLE)
+ target_compile_definitions(vulkaninfo PRIVATE VK_ENABLE_BETA_EXTENSIONS VK_NO_PROTOTYPES)
+ 
+-target_compile_definitions(vulkaninfo PRIVATE VK_USE_PLATFORM_DISPLAY_KHR)
+-
+ if (CMAKE_SYSTEM_NAME MATCHES "Linux|BSD|GNU")
+     option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
+     option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)

--- a/packages/vulkan-tools/build.sh
+++ b/packages/vulkan-tools/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://github.com/KhronosGroup/Vulkan-Tools
 TERMUX_PKG_DESCRIPTION="Vulkan Tools and Utilities"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.4.354"
+TERMUX_PKG_VERSION="1.4.357"
 TERMUX_PKG_SRCURL=https://github.com/KhronosGroup/Vulkan-Tools/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=f10eb09b46c1bd35afd3c8b0c5946fa0d619534dde215389b036a84a95eee508
+TERMUX_PKG_SHA256=7dc4dba3b834e3f23ff34feeb10a8f71f7ee2bed467f208ec21f380e1696110b
 TERMUX_PKG_DEPENDS="libc++, libwayland, libx11, libxcb, vulkan-loader"
 TERMUX_PKG_BUILD_DEPENDS="libwayland-protocols, vulkan-headers (=${TERMUX_PKG_VERSION}), vulkan-volk"
 TERMUX_PKG_ANTI_BUILD_DEPENDS="vulkan-loader"


### PR DESCRIPTION
VK_USE_PLATFORM_DISPLAY was removed in the following commit.
https://github.com/KhronosGroup/Vulkan-Tools/commit/db008c1ac735713164b498f36b796bc7f00387f3

* Fixes #30383 