### PR TITLE
fix(main/prowlarr): patch AngleSharp to fix JIT virtual stub dispatch crash on ARM64

### DIFF
--- a/packages/prowlarr/anglesharp-jit-fix.diff
+++ b/packages/prowlarr/anglesharp-jit-fix.diff
@@ -1,0 +1,76 @@
+diff --git a/src/AngleSharp/Css/Dom/Internal/ClassSelector.cs b/src/AngleSharp/Css/Dom/Internal/ClassSelector.cs
+index d485698..387f981 100644
+--- a/src/AngleSharp/Css/Dom/Internal/ClassSelector.cs
++++ b/src/AngleSharp/Css/Dom/Internal/ClassSelector.cs
+@@ -18,6 +18,14 @@ public ClassSelector(String cls)
+ 
+         public void Accept(ISelectorVisitor visitor) => visitor.Class(_cls);
+ 
+-        public Boolean Match(IElement element, IElement? scope) => element.ClassList.Contains(_cls);
++        public Boolean Match(IElement element, IElement? scope)
++        {
++            var list = element.ClassList;
++            if (list is TokenList concreteList)
++            {
++                return concreteList.Contains(_cls);
++            }
++            return list.Contains(_cls);
++        }
+     }
+ }
+diff --git a/src/AngleSharp/Dom/Internal/Element.cs b/src/AngleSharp/Dom/Internal/Element.cs
+index d39a3bc..c6b47da 100644
+--- a/src/AngleSharp/Dom/Internal/Element.cs
++++ b/src/AngleSharp/Dom/Internal/Element.cs
+@@ -5,6 +5,7 @@ namespace AngleSharp.Dom
+     using AngleSharp.Text;
+     using System;
+     using System.Linq;
++    using System.Threading;
+     using Common;
+     using Html.Construction;
+     using Html.Parser;
+@@ -108,13 +109,15 @@ public ITokenList ClassList
+         {
+             get
+             {
+-                if (_classList is null)
++                var classList = Volatile.Read(ref _classList);
++                if (classList is null)
+                 {
+-                    _classList = new TokenList(this.GetOwnAttribute(AttributeNames.Class));
+-                    _classList.Changed += value => UpdateAttribute(AttributeNames.Class, value);
++                    var list = new TokenList(this.GetOwnAttribute(AttributeNames.Class));
++                    list.Changed += value => UpdateAttribute(AttributeNames.Class, value);
++                    var current = Interlocked.CompareExchange(ref _classList, list, null);
++                    classList = current ?? list;
+                 }
+-
+-                return _classList;
++                return classList;
+             }
+         }
+ 
+diff --git a/src/AngleSharp/Dom/QueryExtensions.cs b/src/AngleSharp/Dom/QueryExtensions.cs
+index 8612884..f1e5ce4 100644
+--- a/src/AngleSharp/Dom/QueryExtensions.cs
++++ b/src/AngleSharp/Dom/QueryExtensions.cs
+@@ -316,6 +316,18 @@ public static void QuerySelectorAll<T>(this T elements, ISelector selector, List
+         /// <returns>True if the string contained all tokens, otherwise false.</returns>
+         public static Boolean Contains<T>(this T list, String[] tokens) where T : class, ITokenList
+         {
++            if (list is TokenList concreteList)
++            {
++                for (var i = 0; i < tokens.Length; i++)
++                {
++                    if (!concreteList.Contains(tokens[i]))
++                    {
++                        return false;
++                    }
++                }
++                return true;
++            }
++
+             for (var i = 0; i < tokens.Length; i++)
+             {
+                 if (!list.Contains(tokens[i]))

--- a/packages/prowlarr/build.sh
+++ b/packages/prowlarr/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="An indexer manager/proxy built on the popular arr stack 
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2.4.0.5397"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL="https://github.com/Prowlarr/Prowlarr/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=a01acf8f69b5233d63f3a9bbeceda3664a14a168fdac5993326ec3f2657f3347
 TERMUX_PKG_BUILD_DEPENDS="aspnetcore-targeting-pack-10.0, dotnet-targeting-pack-10.0, nodejs, yarn"
@@ -24,6 +24,15 @@ termux_step_pre_configure() {
 
 	termux_setup_dotnet
 	termux_setup_nodejs
+
+	# Clone, patch, and build custom AngleSharp to avoid JIT optimization bug on ARM64
+	local anglesharp_dir="$TERMUX_PKG_BUILDDIR/AngleSharp-src"
+	rm -rf "$anglesharp_dir"
+	git clone --depth 1 --branch v1.4.0 https://github.com/AngleSharp/AngleSharp.git "$anglesharp_dir"
+	cd "$anglesharp_dir"
+	patch -p1 < "$TERMUX_PKG_BUILDER_DIR/anglesharp-jit-fix.diff"
+	dotnet build -c Release -f net10.0 src/AngleSharp/AngleSharp.Core.csproj
+	cd "$TERMUX_PKG_SRCDIR"
 
 	# Create a host wrapper for yarn since the one in $TERMUX_PREFIX/bin
 	# has a shebang pointing to the target node
@@ -93,6 +102,9 @@ termux_step_make() {
 
 	# Prowlarr.Mono is dynamically loaded at runtime on Linux/macOS
 	dotnet publish src/NzbDrone.Mono/Prowlarr.Mono.csproj "${COMMON_ARGS[@]}"
+
+	# Overwrite NuGet downloaded AngleSharp.dll with our JIT-patch-compiled one
+	cp -f "$TERMUX_PKG_BUILDDIR/AngleSharp-src/src/AngleSharp/bin/Release/net10.0/AngleSharp.dll" build/
 
 	# Lower required .NET version in runtimeconfig.json to allow running on older .NET 10.0.x runtimes
 	find build -name "*.runtimeconfig.json" -exec sed -i 's/"version": "10.0.[0-9]*"/"version": "10.0.0"/g' {} +


### PR DESCRIPTION
This solves the private indexers breaking on https://github.com/prowlarr/prowlarr in **Termux** issue. 

Should also fix the same issue in https://github.com/Jackett/Jackett/issues/16452 with same patch should this patch get submitted.

Here are basic details regarding https://github.com/termux/termux-packages/issues/30480#issuecomment-5013159450 -

### Technical Diagnosis & Root Cause

1. **The Virtual Stub Dispatch (VSD) Interface JIT Bug:** During `.NET 10` Release builds on ARM64, the JIT compiler miscompiles interface virtual method dispatches (VSD) when calling `ITokenList.Contains(string)` on lazy-initialized structures. Instead of calling `Contains`, it incorrectly jumps to the next slot, calling `ITokenList.Add(params string[])` instead. Because a single `string` reference pointer is passed into a method expecting an array reference (`string[]`), the internal CLR array element checks throw `ArrayTypeMismatchException` inside `List<T>.AddWithResize.`
2. **Weak Memory Model Race Condition:** On ARM64 (which has a weak memory ordering model), `Element.ClassList` was lazy-initialized using `_classList is null` checks without proper memory barriers. Concurrent access by Prowlarr/CSS matching threads would occasionally see a partially-constructed `TokenList` before its internal fields were published, causing internal array access crashes.
  ──────
### Solution Implementation

Updated the AngleSharp patchfile (anglesharp-jit-fix.patchfile) to apply the following during the build:

1. **Direct Call Interface Bypass** (in `ClassSelector.cs` and `QueryExtensions.cs`): Instead of invoking `.Contains` via the `ITokenList` interface, the code now checks if the instance is the concrete `TokenList` class and performs a direct non-virtual call, completely avoiding VSD interface stub table lookups:
```c#
if (list is TokenList concreteList)
{
    return concreteList.Contains(_cls);
}
return list.Contains(_cls);
```
2. **Thread-Safe & Memory-Barrier-Safe Lazy Initialization** (in `Element.cs`): Utilized `Volatile.Read` and atomic `Interlocked.CompareExchange` to guarantee proper memory fence publishing, ensuring no other thread can ever access a partially-constructed `TokenList` instance on ARM64.


