### PR TITLE
Make auto-updates of unconventionally versioned packages more robust.

### DIFF
--- a/packages/discordo/build.sh
+++ b/packages/discordo/build.sh
@@ -1,14 +1,10 @@
-TERMUX_PKG_HOMEPAGE=https://github.com/ayntgl/discordo
+TERMUX_PKG_HOMEPAGE=https://github.com/ayn2op/discordo
 TERMUX_PKG_DESCRIPTION="A lightweight, secure, and feature-rich Discord terminal client"
-TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-_COMMIT=cdd97ff900a099ca520e5a720c547780dd6de162
-TERMUX_PKG_VERSION=2025.08.06
-TERMUX_PKG_SRCURL=git+https://github.com/ayntgl/discordo
-TERMUX_PKG_GIT_BRANCH=main
-TERMUX_PKG_SHA256=030bfd86b518586ca520891c0af5b1b32c0285260d825a0ddccdd7eec5d920ae
-TERMUX_PKG_AUTO_UPDATE=false
-TERMUX_PKG_BUILD_DEPENDS="libx11"
+TERMUX_PKG_VERSION="2026.07.16+g2e051919"
+TERMUX_PKG_SRCURL="https://github.com/ayn2op/discordo/archive/${TERMUX_PKG_VERSION##*+g}.tar.gz"
+TERMUX_PKG_SHA256=853e69f8d0463b525c436b1f0fadf8b45cd3e131a762d3836a86eb73e150a92e
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 
@@ -77,13 +73,14 @@ termux_pkg_auto_update() {
 	termux_pkg_upgrade_version "${latest_commit_date}+g${latest_commit_sha::8}"
 }
 
-termux_step_pre_configure() {
+termux_step_post_get_source() {
+	# Vendor and sanitize go modules ahead of patching step.
 	termux_setup_golang
+	go mod tidy
+	go mod vendor
 
-	go mod init || :
-	go mod download
-
-	# golang's "mobile" package contains both code related to SurfaceFlinger(ANativeWindow[For Building an APK]),
+	# golang's "mobile" module contains both code
+	# related to SurfaceFlinger(ANativeWindow[For Building an APK]),
 	# and also X11-related code that upstream connects to "linux && !android".
 	# apply the pattern "treat Android as linux" here,
 	# to force the disabling of the SurfaceFlinger-dependent
@@ -92,16 +89,14 @@ termux_step_pre_configure() {
 	# android.c:171:52: error: incompatible pointer to integer conversion
 	# passing 'ANativeWindow *' (aka 'struct ANativeWindow *') to parameter
 	# of type 'EGLNativeWindowType' (aka 'unsigned long') [-Wint-conversion]
-	for go_module in golang.org/x/mobile golang.design/x/clipboard; do
-		cp --no-preserve=mode,ownership -rf "${GOPATH}"/pkg/mod/"${go_module}"\@* ./"${go_module##*/}"
-		find ./"${go_module##*/}" -type f | \
-			xargs -n 1 sed -i \
-			-e 's|build android|build disabling_this_because_it_is_for_building_an_apk|g' \
-			-e 's|linux && !android|linux|g' \
-			-e 's|linux,!android|linux|g'
-		local go_module_version=$(grep "${go_module}" go.mod | awk '{print $2}')
-		go mod edit -replace "${go_module}@${go_module_version}=./${go_module##*/}"
-	done
+	find \
+		vendor/golang.org/x/mobile \
+		-type f -print0 | \
+		xargs -0 -n 1 sed -i \
+		-e 's|build android|build disabling_this_because_it_is_for_building_an_apk|g' \
+		-e 's|linux && !android|linux|g' \
+		-e 's|linux,!android|linux|g'
+
 }
 
 termux_step_make() {

--- a/packages/discordo/build.sh
+++ b/packages/discordo/build.sh
@@ -10,22 +10,71 @@ TERMUX_PKG_SHA256=030bfd86b518586ca520891c0af5b1b32c0285260d825a0ddccdd7eec5d920
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_BUILD_DEPENDS="libx11"
 TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
 
-termux_step_post_get_source() {
-	git fetch --unshallow
-	git checkout "$_COMMIT"
+# This auto update function is based on x11/wezterm-nightly
+termux_pkg_auto_update() {
+	local origin_url last_autoupdate
+	# Throttle auto updates to once every two weeks
+	local update_interval="$((2 * 7 * 86400))"
 
-	local version="$(git log -1 --format=%cs | sed 's/-/./g')"
-	if [[ "$version" != "$TERMUX_PKG_VERSION" ]]; then
-		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
-		echo " is different from what is expected to be: \"$version\""
-		return 1
+	# Get the git history
+	if origin_url="$(git config --get remote.origin.url)"; then
+		git fetch --quiet "${origin_url}" || {
+			echo "WARN: Unable to fetch '${origin_url}'"
+			echo "WARN: Skipping auto update for '$TERMUX_PKG_NAME'"
+			return
+		}
 	fi
 
-	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
-	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
-		termux_error_exit "Checksum mismatch for source files."
+	# When was the last autoupdate to this package? (Unix epoch timestamp)
+	last_autoupdate="$(
+		git log \
+		--author="Termux Github Actions <contact@termux.dev>" \
+		-n1 \
+		--pretty=format:%at \
+		-- "$TERMUX_PKG_BUILDER_DIR/build.sh"
+	)"
+
+	# If we're still in the $update_interval skip the actual checking.
+	if (( last_autoupdate + update_interval > EPOCHSECONDS )); then
+		local t days hrs mins secs
+		(( t = EPOCHSECONDS - last_autoupdate, days = t/86400, t %= 86400, secs = t%60, t /= 60, mins = t%60, hrs = t/60 ))
+
+		printf 'INFO: Last updated %dd%dh%02dm%02ds ago.\n' "$days" "$hrs" "$mins" "$secs"
+		printf 'INFO: Which is less than the desired %sd minimum update interval.\n' "$(( update_interval / 86400 ))"
+		return
 	fi
+
+	# Get the latest commit's date and SHA.
+	local response latest_commit_date latest_commit_sha
+	response="$(curl -sL \
+		-H "X-GitHub-Api-Version: 2026-03-10" \
+		-H "Accept: application/vnd.github+json" \
+		"https://api.github.com/repos/ayn2op/discordo/commits/HEAD"
+	)"
+
+
+	read -rd' ' latest_commit_date latest_commit_sha < <(
+		jq -r '.commit.author.date, .sha' <<< "$response"
+	)
+
+	# Are they valid?
+	if ! date -d "${latest_commit_date:=null}" > /dev/null || [[ ! "${latest_commit_sha:=null}" =~ [0-9a-f]* ]]; then
+		{
+			echo "Unable to get commit date and SHA from ${TERMUX_PKG_SRCURL}."
+			echo "Date: $latest_commit_date"
+			echo "SHA:  $latest_commit_sha"
+			jq . <<< "$response"
+			return
+		} | tee "${GITHUB_STEP_SUMMARY:-/dev/null}" >&2
+	fi
+
+	# Massage the date into shape.
+	latest_commit_date="${latest_commit_date//-/.}" # 2026-07-16T03:01:40Z -> 2026.07.16T03:01:40Z
+	latest_commit_date="${latest_commit_date%T*}"   # 2026.07.16T03:01:40Z -> 2026.07.16
+
+	termux_pkg_upgrade_version "${latest_commit_date}+g${latest_commit_sha::8}"
 }
 
 termux_step_pre_configure() {

--- a/packages/discordo/x11-clipboard.patch
+++ b/packages/discordo/x11-clipboard.patch
@@ -1,0 +1,63 @@
+--- a/vendor/golang.design/x/clipboard/clipboard_android.c
++++ b/vendor/golang.design/x/clipboard/clipboard_android.c
+@@ -4,7 +4,7 @@
+ //
+ // Written by Changkun Ou <changkun.de>
+ 
+-//go:build android
++//go:build disabling_this_because_it_is_for_building_an_apk
+ 
+ #include <android/log.h>
+ #include <jni.h>
+--- a/vendor/golang.design/x/clipboard/clipboard_android.go
++++ b/vendor/golang.design/x/clipboard/clipboard_android.go
+@@ -4,7 +4,7 @@
+ //
+ // Written by Changkun Ou <changkun.de>
+ 
+-//go:build android
++//go:build disabling_this_because_it_is_for_building_an_apk
+ 
+ package clipboard
+ 
+--- a/vendor/golang.design/x/clipboard/clipboard_linux.go
++++ b/vendor/golang.design/x/clipboard/clipboard_linux.go
+@@ -4,7 +4,7 @@
+ //
+ // Written by Changkun Ou <changkun.de>
+ 
+-//go:build linux && !android
++//go:build android
+ 
+ package clipboard
+ 
+--- a/vendor/golang.design/x/clipboard/clipboard_nocgo.go
++++ b/vendor/golang.design/x/clipboard/clipboard_nocgo.go
+@@ -1,4 +1,4 @@
+-//go:build !darwin && !windows && !linux && !freebsd && !openbsd && !netbsd && !cgo
++//go:build !darwin && !windows && !freebsd && !openbsd && !netbsd && !cgo
+ 
+ package clipboard
+ 
+--- a/vendor/golang.design/x/clipboard/clipboard_wayland_linux.go
++++ b/vendor/golang.design/x/clipboard/clipboard_wayland_linux.go
+@@ -4,7 +4,7 @@
+ //
+ // Written by Changkun Ou <changkun.de>
+ 
+-//go:build linux && !android
++//go:build android
+ 
+ package clipboard
+ 
+--- a/vendor/golang.design/x/clipboard/clipboard_x11.go
++++ b/vendor/golang.design/x/clipboard/clipboard_x11.go
+@@ -4,7 +4,7 @@
+ //
+ // Written by Changkun Ou <changkun.de>
+ 
+-//go:build (linux || freebsd || openbsd || netbsd) && !android
++//go:build (android || freebsd || openbsd || netbsd)
+ 
+ package clipboard
+ 

--- a/packages/neovim-nightly/build.sh
+++ b/packages/neovim-nightly/build.sh
@@ -3,9 +3,9 @@ TERMUX_PKG_DESCRIPTION="Ambitious Vim-fork focused on extensibility and agility 
 TERMUX_PKG_LICENSE="Apache-2.0, VIM License"
 TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
 TERMUX_PKG_MAINTAINER="Joshua Kahn <tom@termux.dev>"
-TERMUX_PKG_VERSION="0.13.0~dev-980+g3a7989f4f4"
+TERMUX_PKG_VERSION="0.13.0~dev-1095+g53cbf66bd2"
 TERMUX_PKG_SRCURL="https://github.com/neovim/neovim/archive/${TERMUX_PKG_VERSION##*+g}.tar.gz"
-TERMUX_PKG_SHA256=77805a473ac69ba1fe79174b9abb92877eb99d19582b1843c04041e354114df3
+TERMUX_PKG_SHA256=ce4a02c1b079b0ec28241fc5500a9032b33e216a26289a8799ba9351e309ec79
 TERMUX_PKG_REPOLOGY_METADATA_VERSION="${TERMUX_PKG_VERSION%%~*}"
 TERMUX_PKG_DEPENDS="libandroid-support, libiconv, libmsgpack, libunibilium, libuv, libvterm (>= 1:0.3-0), lua51-lpeg, luajit, luv, tree-sitter, tree-sitter-parsers, utf8proc"
 TERMUX_PKG_BREAKS="neovim"
@@ -13,9 +13,7 @@ TERMUX_PKG_CONFLICTS="neovim"
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_CONFFILES="share/nvim/sysinit.vim"
 TERMUX_PKG_AUTO_UPDATE=true
-TERMUX_PKG_UPDATE_VERSION_REGEXP="v.*-dev.*\+g[0-9a-f]*"
-TERMUX_PKG_UPDATE_VERSION_SED_REGEXP="s/-/~/"
-
+TERMUX_PKG_UPDATE_VERSION_REGEXP="v[\d.]+~dev-\d+\+g[0-9a-f]*"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DLUAJIT_INCLUDE_DIR=$TERMUX_PREFIX/include/luajit-2.1
 -DLPEG_LIBRARY=$TERMUX_PREFIX/lib/liblpeg-5.1.so
@@ -25,43 +23,40 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 "
 
 termux_pkg_auto_update() {
-	local response commit latest_nightly
-	response="$(curl -sL \
-		-H "Accept: application/vnd.github+json" \
-		-H "X-GitHub-Api-Version: 2022-11-28" \
-		https://api.github.com/repos/neovim/neovim/releases/tags/nightly
-	)"
+	local nightly_sha
+	read -r nightly_sha _ < <(
+		git ls-remote --tags "https://github.com/neovim/neovim" "nightly"
+	)
 
-	commit="$(jq -r '.target_commitish' <<< "$response")"
-	if [[ -z "${commit:-}" ]]; then
+	if [[ -z "${nightly_sha:-}" ]]; then
 		{
-			echo "WARN: Couldn't fetch latest nightly tag from "
-			echo "https://api.github.com/repos/neovim/neovim/releases/tags/nightly"
-			echo "curl response:"
-			jq '.' <<< "$response"
+			echo "INFO: failed to obtain hash of 'nightly' tag from 'https://github.com/neovim/neovim'."
+			echo "This is probably a temporary issue, skipping update this run."
+			return
 		} | tee "${GITHUB_STEP_SUMMARY:-/dev/null}" >&2
-		return
-	elif [[ "${commit::10}" == "${TERMUX_PKG_VERSION##*+g}" ]]; then
+	fi
+
+	if [[ "${nightly_sha::10}" == "${TERMUX_PKG_VERSION##*+g}" ]]; then
 		echo "INFO: No update needed. Already at version '${TERMUX_PKG_VERSION}'."
 		return
 	fi
 
-	latest_nightly="$(grep --max-count=1 -oP "$TERMUX_PKG_UPDATE_VERSION_REGEXP" < <(jq -r '.body' <<< "$response"))"
+	local latest_nightly repo_dir="${TMPDIR:-/tmp}/neovim-nightly-auto-update"
 
-	if ! sed -E "${TERMUX_PKG_UPDATE_VERSION_SED_REGEXP}" <<< "${latest_nightly}"; then
-		{
-			echo "Failed to apply sed substution '${TERMUX_PKG_UPDATE_VERSION_SED_REGEXP}' to received version."
-			echo ""
-			echo "Current version: $TERMUX_PKG_VERSION"
-			echo "Fetched version: ${latest_nightly#v}"
-			echo ""
-			echo "curl response:"
-			jq '.target_commitish, .body' <<< "$response"
-		} | tee "${GITHUB_STEP_SUMMARY:-/dev/null}" >&2
-	fi
+	[[ -e "$repo_dir" ]] && rm -rf "$repo_dir"
+	{
+		git clone --filter=tree:0 --sparse "https://github.com/neovim/neovim" "$repo_dir"
+		latest_nightly="$(git -C "$repo_dir" describe --first-parent --abbrev=10 "nightly")"
+	} &> /dev/null
+	rm -rf "$repo_dir"
 
-	# We already filtered the version, so unset the regex to avoid reapplying it.
-	unset TERMUX_PKG_UPDATE_VERSION_REGEXP
+	# We need to transform the `git describe` output to match the `nvim --version`
+	# output used by Neovim's release workflow to determine the nightly version.
+	# See: https://github.com/neovim/neovim/blob/v0.12.4/cmake/GenerateVersion.cmake
+	local major minor patch
+	IFS='.' read -rd$'\n' major minor patch <<< "${latest_nightly%-*}" # 'v0' '12' '0'
+	latest_nightly="$major.$(( minor + 1 )).$patch+g${latest_nightly#*-g}" # v0.13.0-1084+ga277c08d98
+	latest_nightly="${latest_nightly/-/~dev-}" # v0.13.0~dev-1084+ga277c08d98
 
 	termux_pkg_upgrade_version "${latest_nightly}"
 }

--- a/x11-packages/wezterm-nightly/build.sh
+++ b/x11-packages/wezterm-nightly/build.sh
@@ -15,8 +15,8 @@ TERMUX_PKG_REPOLOGY_METADATA_VERSION="${TERMUX_PKG_VERSION:0:4}.${TERMUX_PKG_VER
 
 termux_pkg_auto_update() {
 	local origin_url last_autoupdate
-	# Throttle auto updates to once every three weeks
-	local update_interval="$((3 * 7 * 86400))"
+	# Throttle auto updates to once every two weeks
+	local update_interval="$((2 * 7 * 86400))"
 
 	# Get the git history
 	if origin_url="$(git config --get remote.origin.url)"; then
@@ -27,7 +27,7 @@ termux_pkg_auto_update() {
 		}
 	fi
 
-	# When was `wezterm` last autoupdated? (Unix epoch timestamp)
+	# When was the last autoupdate to this package? (Unix epoch timestamp)
 	last_autoupdate="$(
 		git log \
 		--author="Termux Github Actions <contact@termux.dev>" \
@@ -36,25 +36,45 @@ termux_pkg_auto_update() {
 		-- "$TERMUX_PKG_BUILDER_DIR/build.sh"
 	)"
 
-
-	if (( last_autoupdate > EPOCHSECONDS - update_interval )); then
+	# If we're still in the $update_interval skip the actual checking.
+	if (( last_autoupdate + update_interval > EPOCHSECONDS )); then
 		local t days hrs mins secs
-		(( t = EPOCHSECONDS - last_autoupdate, days = t/86400, t %= 86400, secs= t%60, t /= 60, mins = t%60, hrs = t/60 ))
+		(( t = EPOCHSECONDS - last_autoupdate, days = t/86400, t %= 86400, secs = t%60, t /= 60, mins = t%60, hrs = t/60 ))
 
 		printf 'INFO: Last updated %dd%dh%02dm%02ds ago.\n' "$days" "$hrs" "$mins" "$secs"
 		printf 'INFO: Which is less than the desired %sd minimum update interval.\n' "$(( update_interval / 86400 ))"
 		return
 	fi
 
-	local latest_commit_date
-	latest_commit_date="$(
-		curl -s https://api.github.com/repos/wezterm/wezterm/commits | jq -r '.[0] | .commit.author.date' | sed -e 's/-//g' | cut -c1-8
+	# Get the latest commit's date and SHA.
+	local response latest_commit_date latest_commit_sha
+	response="$(curl -sL \
+		-H "X-GitHub-Api-Version: 2026-03-10" \
+		-H "Accept: application/vnd.github+json" \
+		"https://api.github.com/repos/wezterm/wezterm/commits/HEAD"
 	)"
 
-	if [[ -z "${latest_commit_date}" ]]; then
-		termux_error_exit "Unable to get latest commit date from ${TERMUX_PKG_SRCURL}"
+
+	read -rd' ' latest_commit_date latest_commit_sha < <(
+		jq -r '.commit.author.date, .sha' <<< "$response"
+	)
+
+	# Are they valid?
+	if ! date -d "${latest_commit_date:=null}" > /dev/null || [[ ! "${latest_commit_sha:=null}" =~ [0-9a-f]* ]]; then
+		{
+			echo "Unable to get commit date and SHA from ${TERMUX_PKG_SRCURL}."
+			echo "Date: $latest_commit_date"
+			echo "SHA:  $latest_commit_sha"
+			jq . <<< "$response"
+			return
+		} | tee "${GITHUB_STEP_SUMMARY:-/dev/null}" >&2
 	fi
-	termux_pkg_upgrade_version "${latest_commit_date}"
+
+	# Massage the date into shape.
+	latest_commit_date="${latest_commit_date//-/}" # 2026-07-16T03:01:40Z -> 20260716T03:01:40Z
+	latest_commit_date="${latest_commit_date%T*}"  # 20260716T03:01:40Z -> 20260716
+
+	termux_pkg_upgrade_version "${latest_commit_date}+g${latest_commit_sha::8}"
 }
 
 termux_step_post_get_source() {

--- a/x11-packages/wezterm-nightly/build.sh
+++ b/x11-packages/wezterm-nightly/build.sh
@@ -2,8 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://wezterm.org/
 TERMUX_PKG_DESCRIPTION="GPU-accelerated cross-platform terminal emulator and multiplexer (development branch)"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="20260716"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="20260716+g76b606ec"
 TERMUX_PKG_SRCURL=git+https://github.com/wezterm/wezterm
 TERMUX_PKG_GIT_BRANCH=main
 TERMUX_PKG_DEPENDS="fontconfig, freetype, glib, harfbuzz, hicolor-icon-theme, libpng, libssh2, libx11, libxcb, libxkbcommon, openssl, ttf-jetbrains-mono, xdg-utils, xcb-util, xcb-util-image, zlib, zstd"
@@ -12,6 +11,7 @@ TERMUX_PKG_BREAKS="wezterm"
 TERMUX_PKG_CONFLICTS="wezterm"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_REPOLOGY_METADATA_VERSION="${TERMUX_PKG_VERSION:0:4}.${TERMUX_PKG_VERSION:4:2}.${TERMUX_PKG_VERSION:6:2}"
 
 termux_pkg_auto_update() {
 	local origin_url last_autoupdate
@@ -55,6 +55,15 @@ termux_pkg_auto_update() {
 		termux_error_exit "Unable to get latest commit date from ${TERMUX_PKG_SRCURL}"
 	fi
 	termux_pkg_upgrade_version "${latest_commit_date}"
+}
+
+termux_step_post_get_source() {
+	local commit="${TERMUX_PKG_VERSION##*+g}"
+	local commit_date="$TERMUX_PKG_REPOLOGY_METADATA_VERSION"
+
+	# Remember to pull in the necessary amount of git history
+	git fetch --shallow-since="$commit_date"
+	git checkout "$commit"
 }
 
 termux_step_pre_configure() {

--- a/x11-packages/wezterm-nightly/build.sh
+++ b/x11-packages/wezterm-nightly/build.sh
@@ -1,11 +1,12 @@
-TERMUX_PKG_HOMEPAGE=https://github.com/wez/wezterm
+TERMUX_PKG_HOMEPAGE=https://wezterm.org/
 TERMUX_PKG_DESCRIPTION="GPU-accelerated cross-platform terminal emulator and multiplexer (development branch)"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="20260716"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/wezterm/wezterm
 TERMUX_PKG_GIT_BRANCH=main
-TERMUX_PKG_DEPENDS="fontconfig, freetype, glib, harfbuzz, hicolor-icon-theme, libpng, libssh2, libx11, libxcb, libxkbcommon, openssl, ttf-jetbrains-mono, xdg-utils, xcb-util, xcb-util-image, zlib"
+TERMUX_PKG_DEPENDS="fontconfig, freetype, glib, harfbuzz, hicolor-icon-theme, libpng, libssh2, libx11, libxcb, libxkbcommon, openssl, ttf-jetbrains-mono, xdg-utils, xcb-util, xcb-util-image, zlib, zstd"
 TERMUX_PKG_RECOMMENDS="ncurses, ttf-nerd-fonts-symbols"
 TERMUX_PKG_BREAKS="wezterm"
 TERMUX_PKG_CONFLICTS="wezterm"
@@ -65,6 +66,7 @@ termux_step_pre_configure() {
 	PKG_CONFIG_PATH_x86_64_unknown_linux_gnu="$(grep 'DefaultSearchPaths:' "/usr/share/pkgconfig/personality.d/${HOST_TRIPLET}.personality" | cut -d ' ' -f 2)"
 	export PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
 	export LIBSSH2_SYS_USE_PKG_CONFIG=1
+	export ZSTD_SYS_USE_PKG_CONFIG=1
 
 	cargo vendor
 	find ./vendor \

--- a/x11-packages/wezterm/build.sh
+++ b/x11-packages/wezterm/build.sh
@@ -1,11 +1,12 @@
-TERMUX_PKG_HOMEPAGE=https://github.com/wez/wezterm
+TERMUX_PKG_HOMEPAGE=https://wezterm.org/
 TERMUX_PKG_DESCRIPTION="GPU-accelerated cross-platform terminal emulator and multiplexer"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="20240203-110809-5046fc22"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/wezterm/wezterm/releases/download/$TERMUX_PKG_VERSION/wezterm-$TERMUX_PKG_VERSION-src.tar.gz"
 TERMUX_PKG_SHA256=df60b1081d402b5a9239cc4cef16fc699eab68bbbeac9c669cb5d991a6010b2c
-TERMUX_PKG_DEPENDS="fontconfig, freetype, glib, harfbuzz, hicolor-icon-theme, libpng, libssh2, libx11, libxcb, libxkbcommon, openssl, ttf-jetbrains-mono, xdg-utils, xcb-util, xcb-util-image, zlib"
+TERMUX_PKG_DEPENDS="fontconfig, freetype, glib, harfbuzz, hicolor-icon-theme, libpng, libssh2, libx11, libxcb, libxkbcommon, openssl, ttf-jetbrains-mono, xdg-utils, xcb-util, xcb-util-image, zlib, zstd"
 TERMUX_PKG_RECOMMENDS="ncurses, ttf-nerd-fonts-symbols"
 TERMUX_PKG_BREAKS="wezterm-nightly"
 TERMUX_PKG_CONFLICTS="wezterm-nightly"
@@ -18,6 +19,7 @@ termux_step_pre_configure() {
 	sed -i 's/"vendored-fonts", //' wezterm-gui/Cargo.toml
 
 	export LIBSSH2_SYS_USE_PKG_CONFIG=1
+	export ZSTD_SYS_USE_PKG_CONFIG=1
 
 	cargo vendor
 	find ./vendor \


### PR DESCRIPTION
While updating the `discordo` package I noticed that it shares a surprising amount of quirks with the `wezterm-nightly` package.
I ported over the auto-update function and made it more robust with some inspiration from `luajit` and `neovim-nightly` (though both of those are significantly simpler cases).

The upshot of all this is that a simple "update this package" PR turned into:
- Update `discordo`
  - Enable auto-updates for it
- Backport auto-update improvements back to `wezterm-nightly`
  - Pin `wezterm-nightly` to a specific commit instead of whatever happens to be the HEAD commit at the time of the (re)build.
  - Make both `wezterm` and `wezterm-nightly` build from system `zstd` (taken from a recent Arch change).
  <sup>https://gitlab.archlinux.org/archlinux/packaging/packages/wezterm/-/commit/4c9d214d7677e817323c1cd7faa6226c88642832</sup>
  
<h1><em></em></h1> <!-- thin separator --> 

On a related note, it seems that a couple distros have started updating their `wezterm` (stable) package to newer versions.
Arch - 20260716 (https://github.com/wezterm/wezterm/commit/76b606ec597a3c0263fa60321548637451c0a547, latest nightly as of time of writing)
Gentoo - 20260616 (https://github.com/wezterm/wezterm/commit/40daec89346f44ca733dbcfa74e144a609d9acba)
Guix/NetBSD - 20260117 (https://github.com/wezterm/wezterm/commit/05343b387085842b434d267f91b6b0ec157e4331)
FreeBSD - 20250730 (https://github.com/wezterm/wezterm/commit/6a493f88fab06a792308e0c704790390fd3c6232)

It isn't entirely clear to me if these distros are simply choosing to pick a new "stable" point in lieu of a new tagged upstream release, to bring in the 17-29 months of interceding development progress since the last tagged release, or if they are treating their respective `wezterm` as a nightly build.
We may wanna consider updating `wezterm` (stable) to a newer commit for parity with these distros.