### PR TITLE
chore(main/proot): include version information into build

### DIFF
--- a/packages/proot/build.sh
+++ b/packages/proot/build.sh
@@ -17,7 +17,7 @@ TERMUX_PKG_EXTRA_MAKE_ARGS="-C src PROOT_WITH_LIBANDROID_SHMEM=true"
 export PROOT_UNBUNDLE_LOADER=$TERMUX_PREFIX/libexec/proot
 
 termux_step_pre_configure() {
-	CPPFLAGS+=" -DARG_MAX=131072"
+	CPPFLAGS+=" -DARG_MAX=131072 -DVERSION=\\\"${TERMUX_PKG_VERSION}\\\""
 }
 
 termux_step_post_make_install() {


### PR DESCRIPTION
Now `proot --version` will show correct package version.
```
 _____ _____              ___
|  __ \  __ \_____  _____|   |_
|   __/     /  _  \/  _  \    _|
|__|  |__|__\_____/\_____/\____| v5.1.107.85

built-in accelerators: process_vm = yes, seccomp_filter = yes

Visit http://proot.me for help, bug reports, suggestions, patchs, ...
Copyright (C) 2015 STMicroelectronics, licensed under GPL v2 or later
```

This is only build.sh change. Package will be rebuilt after proot new tag release.