### PR TITLE
new package: termux-share

### DIFF
--- a/packages/termux-share/build.sh
+++ b/packages/termux-share/build.sh
@@ -1,0 +1,13 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/BullLazy/termux-share
+TERMUX_PKG_DESCRIPTION="Share text, URLs, clipboard, and piped data from the terminal via Android's share menu"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@BullLazy"
+TERMUX_PKG_VERSION="2.1"
+TERMUX_PKG_SRCURL=$TERMUX_PKG_HOMEPAGE/archive/v$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=SKIP
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+
+termux_step_make_install() {
+    install -Dm700 termux-share "$TERMUX_PREFIX/bin/termux-share"
+}


### PR DESCRIPTION
## Description

`termux-share` is a lightweight Bash script that bridges the gap between the
Termux terminal and Android's native share system.

## Features

- Share text via `--content`
- Share URLs via `--url`
- Share clipboard content via `--clipboard`
- Share piped command output via `--pipe`
- Share file content as text via `--file-content`
- Quick one-liner notes via `--quick`
- Interactive menu via `--interactive`

## Homepage

https://github.com/BullLazy/termux-share

## Checklist

- [x] Package builds correctly
- [x] LICENSE file included (MIT)
- [x] README with usage examples