### PR TITLE
fix(main/libxmlrpc): set `TERMUX_PKG_MAKE_PROCESSES=1`

### DIFF
--- a/packages/libxmlrpc/build.sh
+++ b/packages/libxmlrpc/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_LICENSE_FILE="doc/COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.64.03"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://downloads.sourceforge.net/project/xmlrpc-c/Xmlrpc-c%20Super%20Stable/${TERMUX_PKG_VERSION}/xmlrpc-${TERMUX_PKG_VERSION}.tgz
 TERMUX_PKG_SHA256=74729d364edbedbe42e782822da1e076f3f45c65c4278a3cfba5f2342d7cedbe
 TERMUX_PKG_AUTO_UPDATE=true
@@ -18,6 +19,11 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-wininet-client
 --enable-cplusplus
 "
+# when building on PCs that have a large amount of CPU cores,
+# this error occurs consistently if this is not set,
+# and disappears consistently when it is set:
+# ln: failed to create symbolic link 'libxmlrpc_util.so.4': File exists
+TERMUX_PKG_MAKE_PROCESSES=1
 
 # separate host-build directory but build system does not support out-of-tree build
 termux_step_host_build() {


### PR DESCRIPTION
when building on PCs that have a large amount of CPU cores, this error occurs consistently if this is not set, and disappears consistently when it is set:

```
ln: failed to create symbolic link 'libxmlrpc_util.so.4': File exists
```