### PR TITLE
bump(main/cabal-install): 3.16.1.0

### DIFF
--- a/packages/cabal-install/build.sh
+++ b/packages/cabal-install/build.sh
@@ -10,7 +10,7 @@ TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_SUGGESTS="ghc, dnsutils"
 TERMUX_PKG_DEPENDS="libffi, libiconv, libgmp, zlib, libandroid-posix-semaphore, libandroid-utimes"
 TERMUX_PKG_BUILD_DEPENDS="aosp-libs"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-f-native-dns --ghc-options=-optl-landroid-posix-semaphore"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-f-native-dns"
 TERMUX_PKG_PROVIDES="cabal"
 
 termux_step_post_configure() {

--- a/packages/cabal-install/build.sh
+++ b/packages/cabal-install/build.sh
@@ -2,14 +2,13 @@ TERMUX_PKG_HOMEPAGE="https://www.haskell.org/cabal/"
 TERMUX_PKG_DESCRIPTION="The command-line interface for Haskell-Cabal and Hackage"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="Aditya Alok <alok@termux.dev>"
-TERMUX_PKG_VERSION=3.14.1.1
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION=3.16.1.0
 TERMUX_PKG_SRCURL="https://hackage.haskell.org/package/cabal-install-${TERMUX_PKG_VERSION}/cabal-install-${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256=f11d364ab87fb46275a987e60453857732147780a8c592460eec8a16dbb6bace
+TERMUX_PKG_SHA256=9d27bc22989f3933486a7bba6ac0a2d8fef16891bf46a973f4d80f429ae95120
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_SUGGESTS="ghc, dnsutils"
-TERMUX_PKG_DEPENDS="libffi, libiconv, libgmp, zlib, libandroid-posix-semaphore"
+TERMUX_PKG_DEPENDS="libffi, libiconv, libgmp, zlib, libandroid-posix-semaphore, libandroid-utimes"
 TERMUX_PKG_BUILD_DEPENDS="aosp-libs"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-f-native-dns --ghc-options=-optl-landroid-posix-semaphore"
 
@@ -18,7 +17,7 @@ termux_step_post_configure() {
 	mv splitmix{-*,}
 
 	for f in "$TERMUX_PKG_BUILDER_DIR"/splitmix-patches/*.patch; do
-		patch --silent -p1 -d splitmix < "$f"
+		patch --silent -p1 -d splitmix <"$f"
 	done
 
 	cat <<-EOF >>cabal.project.local

--- a/packages/cabal-install/build.sh
+++ b/packages/cabal-install/build.sh
@@ -11,6 +11,7 @@ TERMUX_PKG_SUGGESTS="ghc, dnsutils"
 TERMUX_PKG_DEPENDS="libffi, libiconv, libgmp, zlib, libandroid-posix-semaphore, libandroid-utimes"
 TERMUX_PKG_BUILD_DEPENDS="aosp-libs"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-f-native-dns --ghc-options=-optl-landroid-posix-semaphore"
+TERMUX_PKG_PROVIDES="cabal"
 
 termux_step_post_configure() {
 	cabal get splitmix-0.1.3.1

--- a/scripts/build/setup/termux_setup_cabal.sh
+++ b/scripts/build/setup/termux_setup_cabal.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 termux_setup_cabal() {
 	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "false" ]]; then
-		local TERMUX_CABAL_VERSION=3.14.1.1
+		local TERMUX_CABAL_VERSION=3.16.1.0
 		local TERMUX_CABAL_TAR="${TERMUX_COMMON_CACHEDIR}/cabal-${TERMUX_CABAL_VERSION}.tar.xz"
 
 		local TERMUX_CABAL_RUNTIME_FOLDER
@@ -17,9 +17,9 @@ termux_setup_cabal() {
 
 		[[ -d "${TERMUX_CABAL_RUNTIME_FOLDER}" ]] && return
 
-		termux_download "https://downloads.haskell.org/~cabal/cabal-install-${TERMUX_CABAL_VERSION}/cabal-install-${TERMUX_CABAL_VERSION}-x86_64-linux-ubuntu22_04.tar.xz" \
+		termux_download "https://downloads.haskell.org/~cabal/cabal-install-${TERMUX_CABAL_VERSION}/cabal-install-${TERMUX_CABAL_VERSION}-x86_64-linux-ubuntu24_04.tar.xz" \
 			"${TERMUX_CABAL_TAR}" \
-			773633b5fff7f26abd6d9388b4ab7ef35b0cd544612ec34ab91ef9bc24438619
+			f7284888f523ff0bb3d8bfc9e7b8c89ab3b95fe87792aefc06019801b9f6ef74
 
 		mkdir -p "${TERMUX_CABAL_RUNTIME_FOLDER}"
 		tar xf "${TERMUX_CABAL_TAR}" -C "${TERMUX_CABAL_RUNTIME_FOLDER}"

--- a/scripts/build/setup/termux_setup_ghc.sh
+++ b/scripts/build/setup/termux_setup_ghc.sh
@@ -21,7 +21,7 @@ termux_setup_ghc() {
 
 		declare -A checksums=(
 			["aarch64"]="941c2d8d8da87bba8e71d562bd6e42205cea87012cfd47cb6de939a465faa04e"
-			["arm"]="941c2d8d8da87bba8e71d562bd6e42205cea87012cfd47cb6de939a465faa04e"
+			["arm"]="451cd4f6c32a31ae650683e4b24487fbfd5cd5a8b7220acdc948cff42c166cd0"
 			["i686"]="c6ac25a9a8ac1578378d2c002deed122d251bc63b40bc564c173d6ca3c60476d"
 			["x86_64"]="c494ac4f4c9eb68cea4e6a474e8416da423f7cc6107f31eb8324a5652953734d"
 		)


### PR DESCRIPTION
- **bump(main/cabal-install): 3.16.1.0**
- **enhance(main/cabal-install): provide `cabal`**
