### PR TITLE
addpkg(main/harper-ls): lsp for grammar checking

### DIFF
--- a/packages/harper/build.sh
+++ b/packages/harper/build.sh
@@ -1,0 +1,36 @@
+TERMUX_PKG_HOMEPAGE=https://writewithharper.com/
+TERMUX_PKG_DESCRIPTION="Offline, privacy-first grammar checker. Fast, open-source, Rust-powered"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="2.6.0"
+TERMUX_PKG_SRCURL="https://github.com/Automattic/harper/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=9cd55f642eb17c2a1c7e8bfb9f958fe5ea165ec98264b7ce568bedbc32dc8b18
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+	termux_setup_rust
+
+	cargo vendor
+	find ./vendor \
+		-mindepth 1 -maxdepth 1 -type d \
+		! -wholename ./vendor/cc \
+		-exec rm -rf '{}' \;
+
+	local patch="$TERMUX_PKG_BUILDER_DIR/rust-cc-do-not-concatenate-all-the-CFLAGS.diff"
+	local dir="vendor/cc"
+	echo "Applying patch: $patch"
+	patch -p1 -d "$dir" <"$patch"
+
+	echo "" >>Cargo.toml
+	echo '[patch.crates-io]' >>Cargo.toml
+	echo "cc = { path = \"./vendor/cc\" }" >>Cargo.toml
+}
+
+termux_step_make() {
+	cargo build --release --manifest-path $TERMUX_PKG_BUILDDIR/harper-ls/Cargo.toml
+}
+
+termux_step_make_install() {
+	install -Dm700 target/release/harper-ls "${TERMUX_PREFIX}"/bin/harper-ls
+}

--- a/packages/harper/rust-cc-do-not-concatenate-all-the-CFLAGS.diff
+++ b/packages/harper/rust-cc-do-not-concatenate-all-the-CFLAGS.diff
@@ -1,0 +1,33 @@
+Source: https://github.com/termux/termux-packages/blob/f7a0e50247a8d1f203facd52392cbd735ff81385/packages/ty/rust-cc-do-not-concatenate-all-the-CFLAGS.diff
+
+`rust-cc` changed how it collects `CFLAGS` from environment variables.
+It retrieves environment variables according to a specific set of rules,
+which are described in [1]. Previously, it used the first match [2,3],
+but now it concatenates all matches and passes them to `CC` [4,5]. This
+breaks Termux's build since Termux's `CFLAGS` include flags related to
+the Android target and unrelated to the target when compiling `glslopt`
+as a host tool, which is `x86_64-linux-gnu`.
+
+This patch will restore the old behaviour. For Termux we know how it is going.
+
+[1] https://docs.rs/cc/latest/cc/
+[2] https://github.com/rust-lang/cc-rs/blob/fcf940ef66f23f411aa50473baa14df9ed2f2cda/src/lib.rs#L1910
+[3] https://github.com/rust-lang/cc-rs/blob/fcf940ef66f23f411aa50473baa14df9ed2f2cda/src/lib.rs#L3669-3681
+[4] https://github.com/rust-lang/cc-rs/blob/cda8b386d419f3adb0c15b729af5504201689aa1/src/lib.rs#L1977
+[5] https://github.com/rust-lang/cc-rs/blob/cda8b386d419f3adb0c15b729af5504201689aa1/src/lib.rs#L3836-L3858
+
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -3844,8 +3844,11 @@
+         // `CFLAGS`).
+         let mut any_set = false;
+         let mut res = vec![];
+-        for env in self.target_envs(env)?.iter().rev() {
++        for env in self.target_envs(env)?.iter() {
+             if let Some(var) = self.getenv(env) {
++                if any_set {
++                    continue;
++                }
+                 any_set = true;
+
+                 let var = var.to_string_lossy();


### PR DESCRIPTION
This pull request adds the harper-ls package.
This allows for grammar checking in lsp-compatible editors like neovim and helix.

Harper-ls is inside a subdirectory in the source, but uses other projects inside the source. I don't know if I handled that correctly, so correct me if it's incorrect.