### PR TITLE
revbump(main/valkey): missing again from the apt repository, so attempt to re-add it

### DIFF
--- a/packages/valkey/build.sh
+++ b/packages/valkey/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="In-memory data structure store used as a database, cache
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="9.1.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/valkey-io/valkey/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=7d7232acd1b8a49b4e05d07a00b3ca8c801ae06ab633ca6a3423bc5f385ab7ee
 TERMUX_PKG_AUTO_UPDATE=true


### PR DESCRIPTION
- For some reason, `valkey` keeps disappearing from the apt repository. The reason is unknown, but it can be re-added by rebuilding and reuploading it each time. This has happened multiple times before. https://github.com/termux/termux-packages/issues/30723