### PR TITLE
Fix/opensles linker namespace

### DIFF
--- a/packages/libandroid-stub/build.sh
+++ b/packages/libandroid-stub/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Version should be equal to TERMUX_NDK_{VERSION_NUM,REVISION} in
 # scripts/properties.sh
 TERMUX_PKG_VERSION=29
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_CONFLICTS="libandroid"
 TERMUX_PKG_REPLACES="libandroid"
@@ -14,14 +14,27 @@ TERMUX_PKG_SKIP_SRC_EXTRACT=true
 TERMUX_PKG_API_LEVEL=28
 
 termux_step_make() {
+	local common_flags=(
+		$CFLAGS $LDFLAGS
+		-Wno-deprecated-declarations
+		-Wl,--no-use-android-relr-tags
+		-Wl,--pack-dyn-relocs=android
+	)
+
+	# The wrappers share a single namespace, so that a process is never left
+	# with two copies of libbinder.so and thus two ProcessState singletons.
+	"${CC}" -shared -fPIC \
+		-o "${TERMUX_PREFIX}/lib/libtermux-platform-ns.so" \
+		"${TERMUX_PKG_BUILDER_DIR}/platform-ns.c" \
+		"${common_flags[@]}"
+
 	local stub
 	for stub in android mediandk OpenSLES; do
 		"${CC}" -shared -fPIC \
 			-o "${TERMUX_PREFIX}/lib/lib${stub}.so" \
 			"${TERMUX_PKG_BUILDER_DIR}/lib${stub}-wrapper.c" \
-			$CFLAGS $LDFLAGS \
-			-Wno-deprecated-declarations \
-			-Wl,--no-use-android-relr-tags \
-			-Wl,--pack-dyn-relocs=android
+			-I"${TERMUX_PKG_BUILDER_DIR}" \
+			"${common_flags[@]}" \
+			-ltermux-platform-ns
 	done
 }

--- a/packages/libandroid-stub/libOpenSLES-wrapper.c
+++ b/packages/libandroid-stub/libOpenSLES-wrapper.c
@@ -1,3 +1,5 @@
+#include "platform-ns.h"
+
 #include <dlfcn.h>
 #include <stdio.h>
 
@@ -87,8 +89,8 @@ static struct {
 
 __attribute__((constructor)) static void init() {
     // simulate LD_PRELOAD=/system/lib64/libskcodec.so
-    void *skcodec_handle = dlopen(SKCODEC, RTLD_GLOBAL); // ignore errors, we only need to upload it to global namespace
-    void* handle = dlopen(LIB, RTLD_LOCAL);
+    void *skcodec_handle = platform_dlopen(SKCODEC, RTLD_GLOBAL); // ignore errors, we only need to upload it to global namespace
+    void* handle = platform_dlopen(LIB, RTLD_LOCAL);
     if (skcodec_handle)
         dlclose(skcodec_handle); // if the library is needed by any of libOpenSLES dependencies it will not be unloaded
 

--- a/packages/libandroid-stub/libOpenSLES-wrapper.c
+++ b/packages/libandroid-stub/libOpenSLES-wrapper.c
@@ -1,6 +1,7 @@
 #include "platform-ns.h"
 
 #include <dlfcn.h>
+#include <stdatomic.h>
 #include <stdio.h>
 
 // const attribute will not let us modify our variables
@@ -87,7 +88,11 @@ static struct {
 } stubs;
 #undef STUB
 
-__attribute__((constructor)) static void init() {
+static void ensure_loaded() {
+    static atomic_flag tried = ATOMIC_FLAG_INIT;
+    if (atomic_flag_test_and_set(&tried))
+        return;
+
     // simulate LD_PRELOAD=/system/lib64/libskcodec.so
     void *skcodec_handle = platform_dlopen(SKCODEC, RTLD_GLOBAL); // ignore errors, we only need to upload it to global namespace
     void* handle = platform_dlopen(LIB, RTLD_LOCAL);
@@ -105,7 +110,7 @@ __attribute__((constructor)) static void init() {
     #undef LOAD
 }
 
-#define CALL(f, def, ...) if (!stubs.f) return def; else return (stubs.f)(__VA_ARGS__)
+#define CALL(f, def, ...) ensure_loaded(); if (!stubs.f) return def; else return (stubs.f)(__VA_ARGS__)
 
 SL_API SLresult SLAPIENTRY slCreateEngine(SLObjectItf *pEngine, SLuint32 numOptions, const SLEngineOption *pEngineOptions, SLuint32 numInterfaces, const SLInterfaceID *pInterfaceIds, const SLboolean* pInterfaceRequired) {
     CALL(slCreateEngine, SL_RESULT_FEATURE_UNSUPPORTED, pEngine, numOptions, pEngineOptions, numInterfaces, pInterfaceIds, pInterfaceRequired);

--- a/packages/libandroid-stub/libandroid-wrapper.c
+++ b/packages/libandroid-stub/libandroid-wrapper.c
@@ -1,4 +1,6 @@
 #include <dlfcn.h>
+
+#include "platform-ns.h"
 #include <android/asset_manager.h>
 #include <android/asset_manager_jni.h>
 #include <android/choreographer.h>
@@ -325,7 +327,7 @@ static struct {
 #undef STUB
 
 __attribute__((constructor)) static void init() {
-    void* handle = dlopen(LIB, RTLD_LOCAL);
+    void* handle = platform_dlopen(LIB, RTLD_LOCAL);
     // Nothing bad happened, normal case for termux-docker.
     if (!handle)
         return;

--- a/packages/libandroid-stub/libandroid-wrapper.c
+++ b/packages/libandroid-stub/libandroid-wrapper.c
@@ -1,4 +1,5 @@
 #include <dlfcn.h>
+#include <stdatomic.h>
 
 #include "platform-ns.h"
 #include <android/asset_manager.h>
@@ -326,7 +327,11 @@ static struct {
 } stubs;
 #undef STUB
 
-__attribute__((constructor)) static void init() {
+static void ensure_loaded() {
+    static atomic_flag tried = ATOMIC_FLAG_INIT;
+    if (atomic_flag_test_and_set(&tried))
+        return;
+
     void* handle = platform_dlopen(LIB, RTLD_LOCAL);
     // Nothing bad happened, normal case for termux-docker.
     if (!handle)
@@ -336,7 +341,7 @@ __attribute__((constructor)) static void init() {
 #undef LOAD
 }
 
-#define CALL(f, def, ...) if (!stubs.f) return def; else return (stubs.f)(__VA_ARGS__)
+#define CALL(f, def, ...) ensure_loaded(); if (!stubs.f) return def; else return (stubs.f)(__VA_ARGS__)
 
 AAssetDir* AAssetManager_openDir(AAssetManager* mgr, const char* dirName) {
     CALL(AAssetManager_openDir, NULL, mgr, dirName);

--- a/packages/libandroid-stub/libmediandk-wrapper.c
+++ b/packages/libandroid-stub/libmediandk-wrapper.c
@@ -1,4 +1,6 @@
 #include <dlfcn.h>
+
+#include "platform-ns.h"
 #include <media/NdkImage.h>
 #include <media/NdkImageReader.h>
 #include <media/NdkMediaCodec.h>
@@ -227,7 +229,7 @@ static struct {
 #undef STUB
 
 __attribute__((constructor)) static void init() {
-    void* handle = dlopen(LIB, RTLD_LOCAL);
+    void* handle = platform_dlopen(LIB, RTLD_LOCAL);
     // Nothing bad happened, normal case for termux-docker.
     if (!handle)
         return;

--- a/packages/libandroid-stub/libmediandk-wrapper.c
+++ b/packages/libandroid-stub/libmediandk-wrapper.c
@@ -1,4 +1,5 @@
 #include <dlfcn.h>
+#include <stdatomic.h>
 
 #include "platform-ns.h"
 #include <media/NdkImage.h>
@@ -228,7 +229,11 @@ static struct {
 } stubs;
 #undef STUB
 
-__attribute__((constructor)) static void init() {
+static void ensure_loaded() {
+    static atomic_flag tried = ATOMIC_FLAG_INIT;
+    if (atomic_flag_test_and_set(&tried))
+        return;
+
     void* handle = platform_dlopen(LIB, RTLD_LOCAL);
     // Nothing bad happened, normal case for termux-docker.
     if (!handle)
@@ -238,7 +243,7 @@ __attribute__((constructor)) static void init() {
 #undef LOAD
 }
 
-#define CALL(f, def, ...) if (!stubs.f) return def; else return (stubs.f)(__VA_ARGS__)
+#define CALL(f, def, ...) ensure_loaded(); if (!stubs.f) return def; else return (stubs.f)(__VA_ARGS__)
 
 void AImage_delete(AImage* image) {
     CALL(AImage_delete,, image);

--- a/packages/libandroid-stub/platform-ns.c
+++ b/packages/libandroid-stub/platform-ns.c
@@ -1,0 +1,179 @@
+#include "platform-ns.h"
+
+#include <android/dlext.h>
+#include <dlfcn.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/* The same directories ld.config.txt gives the default namespace of a binary
+ * below /data; everything else comes in over a namespace link. */
+#ifdef __LP64__
+#define LIBRARY_PATH "/system/lib64:/system/system_ext/lib64"
+#else
+#define LIBRARY_PATH "/system/lib:/system/system_ext/lib"
+#endif
+
+/* A second copy of these in the process would be fatal, so they are imported
+ * from the namespace we are running in rather than loaded again. */
+#define IMPORTED_LIBRARIES "libc.so:libm.so:libdl.so:liblog.so"
+
+/* As defined in bionic's <android/dlext_namespaces.h>, which the NDK does not
+ * ship. Only the regular type is used here: unlike an isolated namespace it
+ * does not restrict loading to its search paths, which keeps us out of trouble
+ * on devices that keep platform libraries in less common places. */
+enum {
+    ANDROID_NAMESPACE_TYPE_REGULAR = 0,
+    ANDROID_NAMESPACE_TYPE_ISOLATED = 1,
+    ANDROID_NAMESPACE_TYPE_SHARED = 2,
+};
+
+/* Platform namespaces are named in the linker configuration; which of them
+ * exist differs between Android versions, and vendors add their own. */
+static const char *const linker_configs[] = {
+    "/linkerconfig/ld.config.txt", /* generated at boot since Android 11 */
+    "/system/etc/ld.config.txt",
+};
+
+/* The namespace API lives in the linker and is not part of the NDK, so it has
+ * to be looked up at runtime. The __loader_ entry points take the caller
+ * address that the libdl wrappers (gone since Android 11) passed on
+ * implicitly. */
+static struct android_namespace_t *(*create_namespace)(
+        const char *name, const char *ld_library_path, const char *default_library_path,
+        uint64_t type, const char *permitted_when_isolated_path,
+        struct android_namespace_t *parent, const void *caller_addr);
+
+static bool (*link_namespaces)(struct android_namespace_t *from,
+        struct android_namespace_t *to, const char *shared_libs_sonames);
+
+static bool (*link_all_libs)(struct android_namespace_t *from, struct android_namespace_t *to);
+
+static struct android_namespace_t *(*get_exported_namespace)(const char *name);
+
+/* Links every platform namespace the linker exposes to this process. The names
+ * are read off the device rather than hardcoded, and the linker itself then
+ * drops the ones that were not created for this process, so there is no need
+ * to work out which section of the configuration applies to us. This is how a
+ * library such as libandroidicu.so is reached at all: it lives in an APEX and
+ * no search path leads to it. */
+static void link_platform_namespaces(struct android_namespace_t *ns) {
+    struct android_namespace_t *seen[64];
+    unsigned n_seen = 0, i;
+    char line[512];
+    FILE *f = NULL;
+
+    for (i = 0; !f && i < sizeof(linker_configs) / sizeof(*linker_configs); i++)
+        f = fopen(linker_configs[i], "r");
+
+    if (!f)
+        return;
+
+    /* Whatever it is called, never link the namespace we came from: it is the
+     * one holding the Termux libraries this whole exercise is about. */
+    if ((seen[0] = get_exported_namespace("default")))
+        n_seen = 1;
+
+    while (fgets(line, sizeof(line), f)) {
+        struct android_namespace_t *platform;
+        char name[128];
+        const char *end;
+        size_t length;
+
+        /* There is one such line per namespace, and being visible is what
+         * allows android_get_exported_namespace() to hand it out at all. */
+        if (strncmp(line, "namespace.", 10) != 0)
+            continue;
+        if (!(end = strchr(line + 10, '.')))
+            continue;
+        if (strncmp(end, ".visible = true", 15) != 0)
+            continue;
+
+        length = end - line - 10;
+        if (length >= sizeof(name))
+            continue;
+
+        memcpy(name, line + 10, length);
+        name[length] = '\0';
+
+        if (!(platform = get_exported_namespace(name)))
+            continue;
+
+        for (i = 0; i < n_seen; i++)
+            if (seen[i] == platform)
+                platform = NULL;
+
+        if (platform && n_seen < sizeof(seen) / sizeof(*seen)) {
+            seen[n_seen++] = platform;
+            link_all_libs(ns, platform);
+        }
+    }
+
+    fclose(f);
+}
+
+/* Returns the namespace the platform libraries are loaded into, or NULL if the
+ * linker does not let us have one. Created on first use and shared from then
+ * on, so that a process gets a single one no matter how many wrappers ask. */
+static struct android_namespace_t *platform_namespace(void) {
+    static struct android_namespace_t *ns;
+    static bool created;
+
+    void *linker;
+
+    if (created)
+        return ns;
+
+    created = true;
+
+    if (!(linker = dlopen("libdl.so", RTLD_NOW)))
+        return NULL;
+
+    create_namespace = (__typeof__(create_namespace)) dlsym(linker, "__loader_android_create_namespace");
+    link_namespaces = (__typeof__(link_namespaces)) dlsym(linker, "__loader_android_link_namespaces");
+    link_all_libs = (__typeof__(link_all_libs)) dlsym(linker, "__loader_android_link_namespaces_all_libs");
+    get_exported_namespace = (__typeof__(get_exported_namespace)) dlsym(linker, "__loader_android_get_exported_namespace");
+
+    /* These entry points are implemented in the linker itself, which is never
+     * unloaded, so the handle is of no further use. */
+    dlclose(linker);
+
+    if (!create_namespace || !link_namespaces || !link_all_libs || !get_exported_namespace)
+        return NULL;
+
+    ns = create_namespace("termux-platform", LIBRARY_PATH, LIBRARY_PATH,
+                          ANDROID_NAMESPACE_TYPE_REGULAR, NULL, NULL,
+                          (const void *) &platform_namespace);
+    if (!ns)
+        return NULL;
+
+    /* A NULL target namespace means the default one, i.e. ours. Without the
+     * bionic core imported the namespace would load a second libc. */
+    if (!link_namespaces(ns, NULL, IMPORTED_LIBRARIES)) {
+        ns = NULL;
+        return NULL;
+    }
+
+    link_platform_namespaces(ns);
+
+    return ns;
+}
+
+void *platform_dlopen(const char *path, int flags) {
+    struct android_namespace_t *ns = platform_namespace();
+    void *handle = NULL;
+
+    if (ns) {
+        android_dlextinfo info = { .flags = ANDROID_DLEXT_USE_NAMESPACE, .library_namespace = ns };
+
+        handle = android_dlopen_ext(path, flags, &info);
+    }
+
+    /* Whatever went wrong, without a namespace of our own the behaviour is
+     * still the one the wrappers had before. */
+    if (!handle)
+        handle = dlopen(path, flags);
+
+    return handle;
+}

--- a/packages/libandroid-stub/platform-ns.h
+++ b/packages/libandroid-stub/platform-ns.h
@@ -1,0 +1,25 @@
+#ifndef PLATFORM_NS_H
+#define PLATFORM_NS_H
+
+/* dlopen(3) for an Android platform library.
+ *
+ * Termux installs libraries whose sonames collide with the platform ones
+ * (liblzma.so, libz.so, ...), so loading a platform library the ordinary way
+ * resolves its dependencies against $PREFIX/lib and fails. This loads it into
+ * a linker namespace of its own instead: one that only searches the platform
+ * directories and reaches the APEX libraries the way the platform does.
+ *
+ * The namespace is created once per process and shared by every caller, so
+ * that a process never ends up with two copies of libbinder.so and thus two
+ * ProcessState singletons. Where the linker does not let us have a namespace
+ * this falls back to plain dlopen(3), i.e. to the behaviour of the wrappers
+ * before namespaces were used at all.
+ *
+ * RTLD_GLOBAL keeps working: it applies within the namespace, which is what
+ * makes it usable for simulating LD_PRELOAD of a platform library.
+ *
+ * https://source.android.com/docs/core/architecture/vndk/linker-namespace */
+
+void *platform_dlopen(const char *path, int flags);
+
+#endif

--- a/packages/pulseaudio/build.sh
+++ b/packages/pulseaudio/build.sh
@@ -4,8 +4,8 @@ TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_SRCURL=git+https://github.com/pulseaudio/pulseaudio
 TERMUX_PKG_VERSION="17.0"
-TERMUX_PKG_REVISION=3
-TERMUX_PKG_DEPENDS="dbus, libandroid-execinfo, libandroid-glob, libc++, libltdl, libsndfile, libsoxr, libwebrtc-audio-processing, speexdsp"
+TERMUX_PKG_REVISION=4
+TERMUX_PKG_DEPENDS="dbus, libandroid-stub, libandroid-execinfo, libandroid-glob, libc++, libltdl, libsndfile, libsoxr, libwebrtc-audio-processing, speexdsp"
 TERMUX_PKG_BREAKS="libpulseaudio-dev, libpulseaudio"
 TERMUX_PKG_REPLACES="libpulseaudio-dev, libpulseaudio"
 # glib is only a runtime dependency of pulseaudio-glib subpackage
@@ -44,10 +44,6 @@ termux_step_pre_configure() {
 	# https://github.com/termux/termux-packages/issues/18977
 	# https://github.com/termux/termux-packages/issues/18810
 	export LDFLAGS+=" -Wl,--undefined-version"
-
-	# https://github.com/termux/termux-packages/issues/27978
-	# https://github.com/termux/termux-packages/pull/23185
-	export LDFLAGS+=" -Wl,--no-as-needed,-lOpenSLES,--as-needed"
 }
 
 termux_step_post_make_install() {

--- a/packages/pulseaudio/rlimit-nofile.patch
+++ b/packages/pulseaudio/rlimit-nofile.patch
@@ -1,0 +1,21 @@
+The linker holds an open file descriptor for every library of a load group,
+and libOpenSLES.so pulls in a couple of hundred of them. Past the built-in
+limit of 256 that surfaces as dlopen(3) reporting that a library which does
+exist cannot be found.
+
+Patched here rather than in daemon.conf, which is a conffile: dpkg keeps a
+daemon.conf the user has edited, so the fix would silently not reach the very
+people who tend to edit it. The value stays overridable there as usual.
+
+diff --git a/src/daemon/daemon-conf.c b/src/daemon/daemon-conf.c
+--- a/src/daemon/daemon-conf.c
++++ b/src/daemon/daemon-conf.c
+@@ -119,7 +119,7 @@ static const pa_daemon_conf default_conf = {
+    ,.rlimit_nproc = { .value = 0, .is_set = false }
+ #endif
+ #ifdef RLIMIT_NOFILE
+-   ,.rlimit_nofile = { .value = 256, .is_set = true }
++   ,.rlimit_nofile = { .value = 4096, .is_set = true }
+ #endif
+ #ifdef RLIMIT_MEMLOCK
+    ,.rlimit_memlock = { .value = 0, .is_set = false }


### PR DESCRIPTION
`libandroid-stub`'s wrappers `dlopen(3)` the platform library they forward to,
which resolves its dependencies against `$PREFIX/lib`. Termux ships libraries
whose sonames collide with the platform ones, so the load fails. Load them into
a linker namespace of their own instead, searching only the platform
directories and linked to the namespaces named in the linker configuration
(`libandroidicu.so` and friends live in an APEX and are reachable over a
namespace link only). Falls back to plain `dlopen(3)` where the linker hands
out no namespace.

`pulseaudio` then drops `--no-as-needed,-lOpenSLES` — which had pulled the
whole platform dependency chain into the daemon's `DT_NEEDED` — and depends on
`libandroid-stub` instead. Its `rlimit-nofile` is raised as well: the linker
keeps an fd open per library of a load group, and `libOpenSLES.so` pulls in a
couple of hundred, so past pulseaudio's default of 256 `dlopen(3)` reports a
library that does exist as not found.

## Related issues

Not using `Fixes`, since most of these are already closed and the one that is
open is a different package.

**Should be fixed by this PR**

- #27978 — the reported `Failed to initialize OpenSL ES: error 12` is exactly
  `SL_RESULT_FEATURE_UNSUPPORTED`, which is the value the `libandroid-stub`
  wrapper returns when its `dlopen()` of the real `libOpenSLES.so` failed. So
  that report is most likely this bug, seen through the wrapper's silent
  failure rather than through a linker error.
- #27367 — `LD_PRELOAD=/system/lib64/libOpenSLES.so` making the sles module
  work is a textbook symptom: preloading gets the platform library in before
  anything can shadow its dependencies.
- #19623, #13965 — same shape, both sinks silently falling back to
  `auto_null`.

**Same root cause, other packages — not addressed here**

- #30264 — identical symbol, `vulkan-loader-android` instead. The
  reporter suggests exactly the `libandroid-stub` wrapper pattern;
  `platform_dlopen()` from the new `libtermux-platform-ns.so` is reusable
  as-is, so that one could be a small follow-up.
- #14881, #23697, #23031 — `unar`, `ffmpeg`, `cv2`, all
  `Xzs_Construct` / `XzUnpacker_Construct` against `libunwindstack.so`.

**Prior art**

- #2416, #4126, #5056, PR #3747 — the same collision going back to 2019, worked
  around per package each time.
- #3078 — the "rename our libs to avoid collisions" proposal; a namespace does
  the same thing without touching sonames.