### PR TITLE
revbump(main/glslang): fix spirv-opt crashes

### DIFF
--- a/packages/glslang/build.sh
+++ b/packages/glslang/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="OpenGL and OpenGL ES shader front end and validator"
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="16.4.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/KhronosGroup/glslang/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=c634d6237eb0cc04d5ddf5dc9955daa175d82b0f8797acab45b49965e9f6df13
 TERMUX_PKG_DEPENDS="libc++"


### PR DESCRIPTION
compile glslang with `spirv-tools` 1.4.357.0 to fix shader compilation crashes https://github.com/KhronosGroup/SPIRV-Tools/issues/6712
https://github.com/KhronosGroup/SPIRV-Tools/pull/6725

should also fix
https://github.com/termux-user-repository/tur/issues/2694
https://github.com/termux-user-repository/tur/issues/2685