### PR TITLE
addpkg(x11/melonds): 1.1

### DIFF
--- a/x11-packages/melonds/build.sh
+++ b/x11-packages/melonds/build.sh
@@ -1,0 +1,15 @@
+TERMUX_PKG_HOMEPAGE=https://melonds.kuribo64.net/
+TERMUX_PKG_DESCRIPTION="A fast and accurate Nintendo DS emulator."
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="1.1"
+TERMUX_PKG_SRCURL="https://github.com/melonDS-emu/melonDS/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=61e339bcb18a68a17485973637d972ea628c5624d7e6b8adf6870f895d5e26fd
+TERMUX_PKG_DEPENDS="libcurl, libpcap, sdl2, libarchive, libenet, zstd, faad2, qt6-qtbase, qt6-qtmultimedia, qt6-qtsvg"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, qt6-qtbase-cross-tools, qt6-qtmultimedia-cross-tools, qt6-qtsvg-cross-tools"
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_INSTALL_PREFIX=${TERMUX__PREFIX}
+-DCMAKE_BUILD_TYPE=Debug
+-DCMAKE_SYSTEM_NAME=Linux
+"

--- a/x11-packages/melonds/fix-armjit.patch
+++ b/x11-packages/melonds/fix-armjit.patch
@@ -1,0 +1,13 @@
+diff --git a/src/ARMJIT_Memory.h b/src/ARMJIT_Memory.h
+index 0fbce17c..4bf660e1 100644
+--- a/src/ARMJIT_Memory.h
++++ b/src/ARMJIT_Memory.h
+@@ -190,7 +190,7 @@ private:
+     static void SigsegvHandler(int sig, siginfo_t* info, void* rawContext);
+     int MemoryFile = -1;
+ #endif
+-#ifdef ANDROID
++#if defined(__ANDROID__)
+     Platform::DynamicLibrary* Libandroid = nullptr;
+ #endif
+     u8 MappingStatus9[1 << (32-12)] {};


### PR DESCRIPTION
This PR will add the MelonDS (Nintendo DS) emulator to Termux X11 packages.

Build for all 4 architectures are successful.

NOTE: Build contains a patch file to fix an issue while compiling JIT for 64-bit (x86_64 and aarch64) architectures. Also, the build type is set to Debug.