### PR TITLE
revbump(x11/melonds): missing from repository

### DIFF
--- a/x11-packages/melonds/build.sh
+++ b/x11-packages/melonds/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A fast and accurate Nintendo DS emulator."
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/melonDS-emu/melonDS/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=61e339bcb18a68a17485973637d972ea628c5624d7e6b8adf6870f895d5e26fd
 TERMUX_PKG_DEPENDS="libcurl, libpcap, sdl2, libarchive, libenet, zstd, faad2, qt6-qtbase, qt6-qtmultimedia, qt6-qtsvg"


### PR DESCRIPTION
- A strange problem occurred during the first build, during the "gather build summary" step, that skipped building: https://github.com/termux/termux-packages/actions/runs/30523971822/job/90810526952