### PR TITLE
addpkg(x11/eden): 0.2.1 #tur:2498

### DIFF
--- a/x11-packages/eden/build.sh
+++ b/x11-packages/eden/build.sh
@@ -1,0 +1,38 @@
+TERMUX_PKG_HOMEPAGE=https://eden-emu.dev/
+TERMUX_PKG_DESCRIPTION="An open-source Nintendo Switch emulator"
+TERMUX_PKG_LICENSE="GPL-3.0-or-later"
+TERMUX_PKG_MAINTAINER="@IntinteDAO"
+TERMUX_PKG_VERSION="0.2.1"
+TERMUX_PKG_SRCURL=https://git.eden-emu.dev/eden-emu/eden/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=a43ea2886b75204438f691a4ddfad99e88b508e30431978dd13fba1c22440d19
+TERMUX_PKG_DEPENDS="boost, dbus, ffmpeg, fmt, libandroid-shmem, libandroid-spawn, libenet, liblz4, libusb, libva, libzip, nlohmann-json, openssl, qt6-qtbase, qt6-qtcharts, qt6-qtmultimedia, qt6-qtsvg, qt6-qttools, qt6-qtwebengine, sdl2, shaderc, vulkan-headers, vulkan-loader, zlib, zstd"
+TERMUX_PKG_BUILD_DEPENDS="catch2, extra-cmake-modules, glslang, pkg-config, qt6-qtbase-cross-tools, qt6-qttools-cross-tools"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DCPM_USE_LOCAL_PACKAGES=ON
+-DENABLE_QT_TRANSLATION=ON
+-Dhttplib_FORCE_BUNDLED=ON
+-DVulkanHeaders_FORCE_BUNDLED=ON
+-DVulkanUtilityLibraries_FORCE_BUNDLED=ON
+-DUSE_AAUDIO=OFF
+-DENABLE_AAUDIO=OFF
+-DUSE_DISCORD_PRESENCE=OFF
+-DYUZU_CHECK_SUBMODULES=OFF
+-DYUZU_TESTS=OFF
+-DDYNARMIC_TESTS=OFF
+-DBUILD_TESTING=OFF
+-DYUZU_USE_BUNDLED_FFMPEG=OFF
+-DYUZU_USE_BUNDLED_QT=OFF
+-DYUZU_USE_BUNDLED_SDL2=OFF
+-DYUZU_USE_EXTERNAL_SDL2=OFF
+-DYUZU_USE_QT_MULTIMEDIA=ON
+-DYUZU_USE_QT_WEB_ENGINE=ON
+"
+
+termux_step_pre_configure() {
+	CFLAGS+=" -flto=thin"
+	CXXFLAGS+=" -flto=thin"
+	LDFLAGS+=" -flto=thin -landroid-shmem -landroid-spawn"
+}

--- a/x11-packages/eden/fix-device-power-state.patch
+++ b/x11-packages/eden/fix-device-power-state.patch
@@ -1,0 +1,15 @@
+--- a/src/common/device_power_state.cpp
++++ b/src/common/device_power_state.cpp
+@@ -8,9 +8,9 @@
+ 
+ #elif defined(__ANDROID__)
+ #include <atomic>
+-extern std::atomic<int> g_battery_percentage;
+-extern std::atomic<bool> g_is_charging;
+-extern std::atomic<bool> g_has_battery;
++std::atomic<int> g_battery_percentage{100};
++std::atomic<bool> g_is_charging{true};
++std::atomic<bool> g_has_battery{false};
+ 
+ #elif defined(__APPLE__)
+ #include <TargetConditionals.h>

--- a/x11-packages/eden/fix-strerror_r.patch
+++ b/x11-packages/eden/fix-strerror_r.patch
@@ -1,0 +1,11 @@
+--- a/src/common/error.cpp
++++ b/src/common/error.cpp
+@@ -30,7 +30,7 @@
+     return ret;
+ #else
+     char err_str[255];
+-#if defined(ANDROID) ||                                                                            \
++#if defined(ANDROID) || defined(__ANDROID__) ||                                                   \
+     (defined(__GLIBC__) && (_GNU_SOURCE || (_POSIX_C_SOURCE < 200112L && _XOPEN_SOURCE < 600)))
+     // Thread safe (GNU-specific)
+     const char* str = strerror_r(e, err_str, sizeof(err_str));

--- a/x11-packages/eden/fix-vulkan-surface-termux.patch
+++ b/x11-packages/eden/fix-vulkan-surface-termux.patch
@@ -1,0 +1,36 @@
+diff -ur a/src/video_core/vulkan_common/vulkan.h b/src/video_core/vulkan_common/vulkan.h
+--- a/src/video_core/vulkan_common/vulkan.h	2026-07-28 17:58:42.332191520 +0200
++++ b/src/video_core/vulkan_common/vulkan.h	2026-07-29 12:26:43.449613143 +0200
+@@ -11,7 +11,7 @@
+ #define VK_USE_PLATFORM_WIN32_KHR
+ #elif defined(__APPLE__)
+ #define VK_USE_PLATFORM_METAL_EXT
+-#elif defined(__ANDROID__)
++#elif 0
+ #define VK_USE_PLATFORM_ANDROID_KHR
+ #elif defined(__HAIKU__)
+ #define VK_USE_PLATFORM_XCB_KHR
+diff -ur a/src/video_core/vulkan_common/vulkan_instance.cpp b/src/video_core/vulkan_common/vulkan_instance.cpp
+--- a/src/video_core/vulkan_common/vulkan_instance.cpp	2026-07-28 17:58:42.332191520 +0200
++++ b/src/video_core/vulkan_common/vulkan_instance.cpp	2026-07-29 13:42:38.249896694 +0200
+@@ -51,7 +51,7 @@
+     case Core::Frontend::WindowSystemType::Cocoa:
+         extensions.push_back(VK_EXT_METAL_SURFACE_EXTENSION_NAME);
+         break;
+-#elif defined(__ANDROID__)
++#elif 0
+     case Core::Frontend::WindowSystemType::Android:
+         extensions.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
+         break;
+diff -ur a/src/video_core/vulkan_common/vulkan_surface.cpp b/src/video_core/vulkan_common/vulkan_surface.cpp
+--- a/src/video_core/vulkan_common/vulkan_surface.cpp	2026-07-28 17:58:42.332191520 +0200
++++ b/src/video_core/vulkan_common/vulkan_surface.cpp	2026-07-29 13:43:04.719612159 +0200
+@@ -45,7 +45,7 @@
+             throw vk::Exception(VK_ERROR_INITIALIZATION_FAILED);
+         }
+     }
+-#elif defined(__ANDROID__)
++#elif 0
+     if (window_info.type == Core::Frontend::WindowSystemType::Android) {
+         const VkAndroidSurfaceCreateInfoKHR android_ci{
+             VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR, nullptr, 0,


### PR DESCRIPTION
### Why is it worth to add this package?

The Linux version has more features than the Android version

### Home page URL

[Home Page](https://eden-emu.dev/)

### Source code URL

https://git.eden-emu.dev/eden-emu/eden

### Packaging policy acknowledgement

- [x] The project is actively developed.
- [x] The project has [existing packages](https://repology.org/projects/) and is "well known".
- [x] Licensed under an [open source license](https://spdx.org/licenses/).
- [x] Not available through a language package manager: cargo, cpan, dotnet tool, gem, npm, pip, etc.
- [x] Not taking up too much disk space (< 100MiB per architecture, exceptions can be made)
- [x] Not duplicating the functionality of existing packages.
- [x] Not serving hacking, malware, phishing, spamming, spying, ddos functionality.
- [x] I certify that I have read [Termux Packaging Policy](https://github.com/termux/termux-packages/blob/master/CONTRIBUTING.md#packaging-policy) and understand that my request will be denied if it is found lacking.