### PR TITLE
addpkg(main/ctranslate2): 4.8.1

### DIFF
--- a/packages/ctranslate2/build.sh
+++ b/packages/ctranslate2/build.sh
@@ -1,0 +1,34 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/OpenNMT/CTranslate2
+TERMUX_PKG_DESCRIPTION="A fast inference engine for Transformer models"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=4.8.1
+TERMUX_PKG_SRCURL=git+https://github.com/OpenNMT/CTranslate2
+TERMUX_PKG_GIT_BRANCH=v${TERMUX_PKG_VERSION}
+TERMUX_PKG_DEPENDS="libandroid-posix-semaphore, libopenblas, libc++, python"
+TERMUX_PKG_BUILD_DEPENDS="half"
+TERMUX_PKG_PYTHON_COMMON_BUILD_DEPS="build, 'pybind11==2.11.1'"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DWITH_MKL=OFF
+-DWITH_OPENBLAS=ON
+-DOPENBLAS_INCLUDE_DIR=${TERMUX_PREFIX}/include
+-DOPENMP_RUNTIME=NONE
+-DCMAKE_POLICY_VERSION_MINIMUM=3.5
+"
+
+termux_step_pre_configure() {
+	export CXXFLAGS+=" -I${TERMUX_PREFIX}/include/openblas -D_GNU_SOURCE"
+	export LDFLAGS+=" -lc++_shared -landroid-posix-semaphore"
+}
+
+termux_step_post_make_install() {
+	cd "$TERMUX_PKG_SRCDIR/python"
+	export CTRANSLATE2_ROOT="$TERMUX_PREFIX"
+	python -m build --wheel --no-isolation
+	pip install dist/*.whl --no-deps --force-reinstall --prefix="$TERMUX_PREFIX"
+	ln -sf "$TERMUX_PREFIX/lib/libctranslate2.so" \
+		"$TERMUX_PYTHON_HOME/site-packages/ctranslate2/libctranslate2.so"
+}

--- a/packages/ctranslate2/fix-android-thread-affinity.patch
+++ b/packages/ctranslate2/fix-android-thread-affinity.patch
@@ -1,0 +1,20 @@
+--- a/src/thread_pool.cc
++++ b/src/thread_pool.cc
+@@ -86,9 +86,17 @@
+     cpu_set_t cpuset;
+     CPU_ZERO(&cpuset);
+     CPU_SET(index, &cpuset);
++#if defined(__ANDROID__)
++    const int status = sched_setaffinity(pthread_gettid_np(pthread_self()), sizeof(cpu_set_t), &cpuset);
++#else
+     const int status = pthread_setaffinity_np(thread.native_handle(), sizeof (cpu_set_t), &cpuset);
++#endif
+     if (status != 0) {
++#if defined(__ANDROID__)
++      throw std::runtime_error("Error calling sched_setaffinity: "
++#else
+       throw std::runtime_error("Error calling pthread_setaffinity_np: "
++#endif
+                                + std::to_string(status));
+     }
+ #endif

--- a/packages/ctranslate2/python-ctranslate2.subpackage.sh
+++ b/packages/ctranslate2/python-ctranslate2.subpackage.sh
@@ -1,0 +1,8 @@
+TERMUX_SUBPKG_INCLUDE="
+bin/ct2-*-converter
+lib/python*/site-packages/ctranslate2/
+lib/python*/site-packages/ctranslate2-*.dist-info/
+"
+TERMUX_SUBPKG_DESCRIPTION="Python bindings for CTranslate2"
+TERMUX_SUBPKG_DEPENDS="python, python-numpy, python-pip"
+TERMUX_SUBPKG_PLATFORM_INDEPENDENT=true

--- a/packages/ctranslate2/use-system-half.patch
+++ b/packages/ctranslate2/use-system-half.patch
@@ -1,0 +1,11 @@
+--- a/include/ctranslate2/types.h
++++ b/include/ctranslate2/types.h
+@@ -3,7 +3,7 @@
+ #include <cstdint>
+ #include <string>
+ 
+-#include <half_float/half.hpp>
++#include <half/half.hpp>
+ 
+ #include "bfloat16.h"
+ #include "devices.h"


### PR DESCRIPTION
### Package name
ctranslate2

### Short description
A fast inference engine for Transformer models

### Home page
https://github.com/OpenNMT/CTranslate2

### License
MIT

### Dependencies
libopenblas

### Why is this package useful?
CTranslate2 is a highly optimized, lightweight inference engine for Transformer models. Adding it to Termux allows users to run local Large Language Models (LLMs) and AI workloads directly on their Android devices offline. It is specifically optimized for CPU inference using OpenBLAS, making it perfect for the Termux environment where GPU access is limited.