### PR TITLE
enhance(main/age): include age-inspect

### DIFF
--- a/packages/age/build.sh
+++ b/packages/age/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="A simple, modern and secure encryption tool with small e
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1:1.3.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/FiloSottile/age/archive/refs/tags/v${TERMUX_PKG_VERSION:2}.tar.gz
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_SHA256=396007bc0bc53de253391493bda1252757ba63af1a19db86cfb60a35cb9d290a
@@ -14,10 +15,12 @@ termux_step_make() {
 	cd $TERMUX_PKG_SRCDIR
 	go build ./cmd/age
 	go build ./cmd/age-keygen
+	go build ./cmd/age-inspect
 }
 
 termux_step_make_install() {
 	install -Dm755 -t "${TERMUX_PREFIX}"/bin \
 		"${TERMUX_PKG_SRCDIR}"/age \
-		"${TERMUX_PKG_SRCDIR}"/age-keygen
+		"${TERMUX_PKG_SRCDIR}"/age-keygen \
+		"${TERMUX_PKG_SRCDIR}"/age-inspect
 }


### PR DESCRIPTION
This PR adds the `age-inspect` command to the age package.
Currently the age package does not build and install `age-inspect`, but I think it's a useful feature as there is no other way to 'check' an encrypted age file.
