### PR TITLE
addpkg(x11/tiemu): 3.03

### DIFF
--- a/packages/libticables2/0001-disable-build-tests.patch
+++ b/packages/libticables2/0001-disable-build-tests.patch
@@ -1,0 +1,21 @@
+--- a/Makefile.am	2013-04-13 09:26:51.000000000 -0400
++++ b/Makefile.am	2026-07-29 23:07:46.599235725 -0400
+@@ -3,7 +3,7 @@
+ ACLOCAL_AMFLAGS=-I m4
+ 
+ # Subdirectories to scan
+-SUBDIRS = build/mingw po src tests
++SUBDIRS = build/mingw po src
+ 
+ if USE_DOCGEN
+   SUBDIRS += docs
+--- a/configure.ac	2016-03-23 07:38:40.000000000 -0400
++++ b/configure.ac	2026-07-29 23:08:40.951235725 -0400
+@@ -38,7 +38,6 @@
+   src/Makefile
+   src/win32/dha/Makefile
+   src/win64/rwp/Makefile
+-  tests/Makefile
+   ticables2.pc
+ ])
+ 

--- a/packages/libticables2/build.sh
+++ b/packages/libticables2/build.sh
@@ -1,0 +1,30 @@
+TERMUX_PKG_HOMEPAGE="http://lpg.ticalc.org/prj_tilp/"
+TERMUX_PKG_DESCRIPTION="Provides libticables2 library and headers for TiEmu and TiLP"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="3ls-it <3ls-it@pm.me>"
+TERMUX_PKG_VERSION=1.3.5
+# No version number in the master tarball; this is the cannonical source
+# and contains the source tarballs for all libti*
+TERMUX_PKG_SRCURL="https://www.ticalc.org/pub/unix/tilibs.tar.gz"
+TERMUX_PKG_SHA256=af7b61b5115e5cdae6dc9396004de8828ce00d64d4428e5077a4bf1629e78e1d
+# This codebase dates from 2013 and will not likely change soon
+# If it does, the maintainer will manually update
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="glib, libandroid-shmem, libusb"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--enable-libusb10
+"
+
+termux_step_get_source() {
+		mkdir -p "$TERMUX_PKG_SRCDIR"
+		# Download and extract libticables2 source
+		termux_download "${TERMUX_PKG_SRCURL}" "${TERMUX_PKG_CACHEDIR}/tilibs.tar.gz"
+		tar xf "$TERMUX_PKG_CACHEDIR"/"tilibs.tar.gz"
+		tar xf "$TERMUX_PKG_CACHEDIR"/"tilibs2/libticables2-${TERMUX_PKG_VERSION}.tar.bz2" \
+				-C "$TERMUX_PKG_SRCDIR" --strip-components=1
+}
+
+termux_step_pre_configure() {
+		autoreconf -fi
+		LDFLAGS+=" -landroid-shmem"
+}

--- a/packages/libticalcs2/0001-disable-build-tests.patch
+++ b/packages/libticalcs2/0001-disable-build-tests.patch
@@ -1,0 +1,21 @@
+--- a/Makefile.am	2013-04-13 09:26:52.000000000 -0400
++++ b/Makefile.am	2026-07-29 23:12:17.215235725 -0400
+@@ -3,7 +3,7 @@
+ ACLOCAL_AMFLAGS=-I m4
+ 
+ # Subdirectories to scan
+-SUBDIRS = build/mingw po src tests
++SUBDIRS = build/mingw po src
+ 
+ if USE_DOCGEN
+   SUBDIRS += docs
+--- a/configure.ac	2016-04-04 01:59:39.000000000 -0400
++++ b/configure.ac	2026-07-29 23:12:55.891235725 -0400
+@@ -42,7 +42,6 @@
+   src/romdump_9x/Makefile
+   src/romdump_89t_usb/Makefile
+   src/romdump_834pce_usb/Makefile
+-  tests/Makefile
+   ticalcs2.pc
+ ])
+ 

--- a/packages/libticalcs2/build.sh
+++ b/packages/libticalcs2/build.sh
@@ -1,0 +1,26 @@
+TERMUX_PKG_HOMEPAGE="http://lpg.ticalc.org/prj_tilp/"
+TERMUX_PKG_DESCRIPTION="Provides libticalcs2 library and headers for TiEmu and TiLP"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="3ls-it <3ls-it@pm.me>"
+TERMUX_PKG_VERSION=1.1.9
+# No version number in the master tarball; this is the cannonical source
+# and contains the source tarballs for all libti*
+TERMUX_PKG_SRCURL="https://www.ticalc.org/pub/unix/tilibs.tar.gz"
+TERMUX_PKG_SHA256=af7b61b5115e5cdae6dc9396004de8828ce00d64d4428e5077a4bf1629e78e1d
+# This codebase dates from 2013 and will not likely change soon
+# If it does, the maintainer will manually update
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="glib, libticonv, libticables2, libtifiles2"
+
+termux_step_get_source() {
+		mkdir -p "$TERMUX_PKG_SRCDIR"
+		# Download and extract libticalcs2 source
+		termux_download "${TERMUX_PKG_SRCURL}" "${TERMUX_PKG_CACHEDIR}/tilibs.tar.gz"
+		tar xf "$TERMUX_PKG_CACHEDIR"/"tilibs.tar.gz"
+		tar xf "$TERMUX_PKG_CACHEDIR"/"tilibs2/libticalcs2-${TERMUX_PKG_VERSION}.tar.bz2" \
+				-C "$TERMUX_PKG_SRCDIR" --strip-components=1
+}
+
+termux_step_pre_configure() {
+		autoreconf -fi
+}

--- a/packages/libticonv/0001-disable-build-tests.patch
+++ b/packages/libticonv/0001-disable-build-tests.patch
@@ -1,0 +1,21 @@
+--- a/configure.ac	2016-03-23 07:38:40.000000000 -0400
++++ b/configure.ac	2026-07-29 21:57:56.223235725 -0400
+@@ -35,7 +35,6 @@
+   build/mingw/Makefile
+   docs/Makefile
+   src/Makefile
+-  tests/Makefile
+   ticonv.pc
+ ])
+ 
+--- a/Makefile.am	2013-04-13 09:26:51.000000000 -0400
++++ b/Makefile.am	2026-07-29 22:06:10.503235725 -0400
+@@ -3,7 +3,7 @@
+ ACLOCAL_AMFLAGS=-I m4
+ 
+ # Subdirectories to scan
+-SUBDIRS = build/mingw src tests
++SUBDIRS = build/mingw src
+ 
+ if USE_DOCGEN
+   SUBDIRS += docs

--- a/packages/libticonv/build.sh
+++ b/packages/libticonv/build.sh
@@ -1,0 +1,26 @@
+TERMUX_PKG_HOMEPAGE="http://lpg.ticalc.org/prj_tilp/"
+TERMUX_PKG_DESCRIPTION="Provides libticonv libraries and headers for TiEmu and TiLP"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="3ls-it <3ls-it@pm.me>"
+TERMUX_PKG_VERSION=1.1.5
+# No version number in the master tarball; this is the cannonical source
+# and contains the source tarballs for all libti*
+TERMUX_PKG_SRCURL="https://www.ticalc.org/pub/unix/tilibs.tar.gz"
+TERMUX_PKG_SHA256=af7b61b5115e5cdae6dc9396004de8828ce00d64d4428e5077a4bf1629e78e1d
+# This codebase dates from 2013 and will not likely change soon
+# If it does, the maintainer will manually update
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="glib"
+
+termux_step_get_source() {
+		mkdir -p "$TERMUX_PKG_SRCDIR"
+		# Download and extract libticonv source
+		termux_download "${TERMUX_PKG_SRCURL}" "${TERMUX_PKG_CACHEDIR}/tilibs.tar.gz"
+		tar xf "$TERMUX_PKG_CACHEDIR"/"tilibs.tar.gz"
+		tar xf "$TERMUX_PKG_CACHEDIR"/"tilibs2/libticonv-${TERMUX_PKG_VERSION}.tar.bz2" \
+				-C "$TERMUX_PKG_SRCDIR" --strip-components=1
+}
+
+termux_step_pre_configure() {
+		autoreconf -fi
+}

--- a/packages/libtifiles2/0001-disable-build-tests.patch
+++ b/packages/libtifiles2/0001-disable-build-tests.patch
@@ -1,0 +1,21 @@
+--- a/Makefile.am	2013-04-13 09:26:53.000000000 -0400
++++ b/Makefile.am	2026-07-29 22:50:06.027235725 -0400
+@@ -3,7 +3,7 @@
+ ACLOCAL_AMFLAGS=-I m4
+ 
+ # Subdirectories to scan
+-SUBDIRS = build/mingw po src tests
++SUBDIRS = build/mingw po src
+ 
+ if USE_DOCGEN
+   SUBDIRS += docs
+--- a/configure.ac	2016-04-04 01:59:39.000000000 -0400
++++ b/configure.ac	2026-07-29 22:51:08.891235725 -0400
+@@ -36,7 +36,6 @@
+   docs/Makefile
+   po/Makefile.in
+   src/Makefile
+-  tests/Makefile
+   tifiles2.pc
+ ])
+ 

--- a/packages/libtifiles2/build.sh
+++ b/packages/libtifiles2/build.sh
@@ -1,0 +1,26 @@
+TERMUX_PKG_HOMEPAGE="http://lpg.ticalc.org/prj_tilp/"
+TERMUX_PKG_DESCRIPTION="Provides libtifiles2 library and headers for TiEmu and TiLP"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="3ls-it <3ls-it@pm.me>"
+TERMUX_PKG_VERSION=1.1.7
+# No version number in the master tarball; this is the cannonical source
+# and contains the source tarballs for all libti*
+TERMUX_PKG_SRCURL="https://www.ticalc.org/pub/unix/tilibs.tar.gz"
+TERMUX_PKG_SHA256=af7b61b5115e5cdae6dc9396004de8828ce00d64d4428e5077a4bf1629e78e1d
+# This codebase dates from 2013 and will not likely change soon
+# If it does, the maintainer will manually update
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="glib, libarchive, libticonv"
+
+termux_step_get_source() {
+		mkdir -p "$TERMUX_PKG_SRCDIR"
+		# Download and extract libtifiles source
+		termux_download "${TERMUX_PKG_SRCURL}" "${TERMUX_PKG_CACHEDIR}/tilibs.tar.gz"
+		tar xf "$TERMUX_PKG_CACHEDIR"/"tilibs.tar.gz"
+		tar xf "$TERMUX_PKG_CACHEDIR"/"tilibs2/libtifiles2-${TERMUX_PKG_VERSION}.tar.bz2" \
+				-C "$TERMUX_PKG_SRCDIR" --strip-components=1
+}
+
+termux_step_pre_configure() {
+		autoreconf -fi
+}

--- a/packages/pedrom/build.sh
+++ b/packages/pedrom/build.sh
@@ -1,0 +1,38 @@
+TERMUX_PKG_HOMEPAGE="https://t3.yaronet.com/?id=19"
+TERMUX_PKG_DESCRIPTION="PedroM is an open source Operating System for Ti-68k calculators."
+TERMUX_PKG_LICENSE="GPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="3ls-it <3ls-it@pm.me>"
+TERMUX_PKG_VERSION="0.83"
+TERMUX_PKG_SRCURL="https://ticalc.org/pub/89/os/pedrom.zip"
+TERMUX_PKG_SHA256=bee0400235ac7c29c890a55be79018f7e561688374a343c01a4fc1f478135cfc
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+
+termux_step_configure() {
+		:
+}
+
+termux_step_make() {
+		:
+}
+
+termux_step_make_install() {
+		local src="$TERMUX_PKG_SRCDIR"
+		local pedrom_dir="$TERMUX_PREFIX/share/pedrom"
+		local tiemu_dir="$TERMUX_PREFIX/share/tiemu/pedrom"
+
+		mkdir -p "$pedrom_dir" "$tiemu_dir"
+
+		# Install the complete PedroM distribution.
+		cp -a "$src"/. "$pedrom_dir"/
+
+		# Make working images available to TiEmu's startup scanner.
+		for image in \
+				PedroM-89.89u \
+				PedroM-89ti.89u \
+				PedroM-9x.9xu \
+				PedroM-v2.9xu
+		do
+				install -Dm644 "$src/$image" "$tiemu_dir/$image"
+		done
+}

--- a/x11-packages/libglade2/build.sh
+++ b/x11-packages/libglade2/build.sh
@@ -1,0 +1,16 @@
+TERMUX_PKG_HOMEPAGE="https://download.gnome.org/sources/libglade/"
+TERMUX_PKG_DESCRIPTION="Library to load .glade files at runtime"
+TERMUX_PKG_LICENSE="LGPL-2.1"
+TERMUX_PKG_MAINTAINER="3ls-it <3ls-it@pm.me>"
+TERMUX_PKG_VERSION="2.6.4"
+TERMUX_PKG_SRCURL="https://download.gnome.org/sources/libglade/${TERMUX_PKG_VERSION%.*}/libglade-${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=c41d189b68457976069073e48d6c14c183075d8b1d8077cb6dfb8b7c5097add3
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="atk, glib, gtk2, libxml2"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--disable-static
+"
+
+termux_step_pre_configure() {
+		LDFLAGS+=" -lgmodule-2.0"
+}

--- a/x11-packages/tiemu/0001-src-core-uae-use-hostcc-and-gnu89-for-generators.patch
+++ b/x11-packages/tiemu/0001-src-core-uae-use-hostcc-and-gnu89-for-generators.patch
@@ -1,0 +1,46 @@
+--- a/src/core/uae/Makefile	2006-01-06 18:30:04.000000000 -0500
++++ b/src/core/uae/Makefile	2026-07-30 14:58:01.182347313 -0400
+@@ -6,6 +6,8 @@
+ # trying to be portable... *TRYING*
+ #CFLAGS   = -mms-bitfields
+ CPUFLAGS = $(CFLAGS) -fomit-frame-pointer -Wno-unused -Wno-format -W -Wmissing-prototypes -Wstrict-prototypes -D__inline__=inline -DSTATFS_NO_ARGS=2 -DSTATBUF_BAVAIL=f_bavail #-Wall
++HOSTCC ?= gcc
++HOSTCFLAGS ?= -std=gnu89
+ 
+ gen: cpudefs.c cpustbl.c cputbl.h cpuemu.c
+ 
+@@ -14,26 +16,26 @@
+ 
+ # For cross-compiling (generators are run on host)
+ build68k_host.o: build68k.c
+-	C_INCLUDE_PATH="" LIBRARY_PATH="" gcc -c -o $@ $?
++	C_INCLUDE_PATH="" LIBRARY_PATH="" $(HOSTCC) $(HOSTCFLAGS) -c -o $@ $?
+ gencpu_host.o: gencpu.c
+-	C_INCLUDE_PATH="" LIBRARY_PATH="" gcc -c -o $@ $?
++	C_INCLUDE_PATH="" LIBRARY_PATH="" $(HOSTCC) $(HOSTCFLAGS) -c -o $@ $?
+ readcpu_host.o: readcpu.c
+-	C_INCLUDE_PATH="" LIBRARY_PATH="" gcc -c -o $@ $?
++	C_INCLUDE_PATH="" LIBRARY_PATH="" $(HOSTCC) $(HOSTCFLAGS) -c -o $@ $?
+ cpudefs_host.o: cpudefs.c
+-	C_INCLUDE_PATH="" LIBRARY_PATH="" gcc -c -o $@ $?
++	C_INCLUDE_PATH="" LIBRARY_PATH="" $(HOSTCC) $(HOSTCFLAGS) -c -o $@ $?
+ missing_host.o: missing.c
+-	C_INCLUDE_PATH="" LIBRARY_PATH="" gcc -c -o $@ $?
++	C_INCLUDE_PATH="" LIBRARY_PATH="" $(HOSTCC) $(HOSTCFLAGS) -c -o $@ $?
+ xmalloc_host.o: xmalloc.c
+-	C_INCLUDE_PATH="" LIBRARY_PATH="" gcc -c -o $@ $?
++	C_INCLUDE_PATH="" LIBRARY_PATH="" $(HOSTCC) $(HOSTCFLAGS) -c -o $@ $?
+ 
+ # Build generators and files to generate
+ build68k: build68k_host.o
+ 	@echo "-> Compiling 68k builder..."
+-	C_INCLUDE_PATH="" LIBRARY_PATH="" gcc $(LDFLAGS) -o $@ $?
++	C_INCLUDE_PATH="" LIBRARY_PATH="" $(HOSTCC) $(HOSTCFLAGS) -o $@ $?
+ 
+ gencpu: gencpu_host.o readcpu_host.o cpudefs_host.o missing_host.o xmalloc_host.o
+ 	@echo "-> Compiling CPU generator..."
+-	C_INCLUDE_PATH="" LIBRARY_PATH="" gcc $(LDFLAGS) -o $@ gencpu_host.o readcpu_host.o cpudefs_host.o missing_host.o xmalloc_host.o
++	C_INCLUDE_PATH="" LIBRARY_PATH="" $(HOSTCC) $(HOSTCFLAGS) -o $@ gencpu_host.o readcpu_host.o cpudefs_host.o missing_host.o xmalloc_host.o
+ 
+ cpudefs.c: build68k table68k
+ 	@echo "-> Building CPU definitions..."

--- a/x11-packages/tiemu/0002-src-core-uae-newcpu-include-romcalls-and-handles.patch
+++ b/x11-packages/tiemu/0002-src-core-uae-newcpu-include-romcalls-and-handles.patch
@@ -1,0 +1,11 @@
+--- a/src/core/uae/newcpu.c	2008-05-25 09:08:41.000000000 -0400
++++ b/src/core/uae/newcpu.c	2026-07-30 15:31:51.990347313 -0400
+@@ -30,6 +30,8 @@
+ extern const char *symfile;
+ #endif /* CYGNUS_SIM */
+ #define FLOATFORMAT_H /* don't include glib.h in romcalls.h */
++#include "romcalls.h"
++#include "handles.h"
+ // tiemu end
+ 
+ /* Opcode of faulting instruction */

--- a/x11-packages/tiemu/0003-src-core-uae-drop-abort-macro-override.patch
+++ b/x11-packages/tiemu/0003-src-core-uae-drop-abort-macro-override.patch
@@ -1,0 +1,19 @@
+--- a/src/core/uae/sysdeps.h	2007-06-24 01:05:05.000000000 -0400
++++ b/src/core/uae/sysdeps.h	2026-07-30 16:53:11.346347313 -0400
+@@ -137,12 +137,16 @@
+ #define ENUMDECL typedef enum
+ #define ENUMNAME(name) name
+ 
++/* Remove macro; collides with libc abort()*/
++#if 0
+ /* While we're here, make abort more useful.  */
+ #define abort() \
+   do { \
+     fprintf (stderr, "UAE: Internal error; file %s, line %d\n", __FILE__, __LINE__); \
+     (abort) (); \
+ } while (0)
++#endif
++
+ #else
+ #define ENUMDECL enum
+ #define ENUMNAME(name) ; typedef int name

--- a/x11-packages/tiemu/0004-gui-about-use-gtk-about-dialog-set-program-name.patch
+++ b/x11-packages/tiemu/0004-gui-about-use-gtk-about-dialog-set-program-name.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/about.c	2007-04-15 04:29:34.000000000 -0400
++++ b/src/gui/about.c	2026-07-30 17:31:17.522347313 -0400
+@@ -103,7 +103,7 @@
+ 	dlg = GTK_ABOUT_DIALOG(widget);
+ 	pix = create_pixbuf("logo.xpm");
+ 
+-	gtk_about_dialog_set_name(dlg, "TiEmu - Ti Emulator - ");
++	gtk_about_dialog_set_program_name(dlg, "TiEmu - Ti Emulator - ");
+ 	gtk_about_dialog_set_version(dlg, TIEMU_VERSION);
+ 	gtk_about_dialog_set_comments(dlg, version);
+ 	gtk_about_dialog_set_copyright(dlg, "Copyright (c) 1999-2007 The TiEmu Team");

--- a/x11-packages/tiemu/0005-gui-calc-use-gsourcefunc-for-timeout-callback.patch
+++ b/x11-packages/tiemu/0005-gui-calc-use-gsourcefunc-for-timeout-callback.patch
@@ -1,0 +1,29 @@
+--- a/src/gui/calc/calc.c	2007-12-16 10:29:16.000000000 -0500
++++ b/src/gui/calc/calc.c	2026-07-30 17:57:39.190347313 -0400
+@@ -313,7 +313,7 @@
+ {
+     gdk_draw_pixmap(
+         widget->window,
+-		widget->style->fg_gc[GTK_WIDGET_STATE (widget)],
++		widget->style->fg_gc[gtk_widget_get_state(widget)],
+ 		pixmap,
+ 		event->area.x, event->area.y,
+ 		event->area.x, event->area.y,
+@@ -586,7 +586,7 @@
+ 
+     // Install LCD refresh: 100 FPS (10 ms)
+     tid = g_timeout_add((params.lcd_rate == -1) ? 50 : params.lcd_rate, 
+-		(GtkFunction)hid_refresh, NULL);
++		(GSourceFunc)hid_refresh, NULL);
+ 
+ 	explicit_destroy = 0;
+ 	gtk_widget_show(main_wnd);	// show wnd here
+@@ -640,7 +640,7 @@
+ 	g_source_remove(tid);
+ 
+ 	tid = g_timeout_add((params.lcd_rate == -1) ? 50 : params.lcd_rate, 
+-		(GtkFunction)hid_refresh, NULL);
++		(GSourceFunc)hid_refresh, NULL);
+ }
+ 
+ int hid_switch_with_skin(void)

--- a/x11-packages/tiemu/0006-gui-screen-use-gtk_widget_get_state.patch
+++ b/x11-packages/tiemu/0006-gui-screen-use-gtk_widget_get_state.patch
@@ -1,0 +1,38 @@
+--- a/src/gui/calc/screen.c	2006-11-06 12:18:51.000000000 -0500
++++ b/src/gui/calc/screen.c	2026-07-30 18:08:42.554347313 -0400
+@@ -187,7 +187,7 @@
+ 	skin_infos.image = gdk_pixbuf_scale_simple(skin_infos.raw, wr.wr.w, wr.wr.h, GDK_INTERP_NEAREST);
+ 
+ 	// and draw image into pixmap (next, into window on expose event)
+-    gdk_draw_pixbuf(pixmap, main_wnd->style->fg_gc[GTK_WIDGET_STATE(main_wnd)],
++    gdk_draw_pixbuf(pixmap, main_wnd->style->fg_gc[gtk_widget_get_state(main_wnd)],
+ 		  skin_infos.image, 0, 0, 0, 0, -1, -1, GDK_RGB_DITHER_NONE, 0, 0);
+ 	gdk_window_invalidate_rect(main_wnd->window, &wr.gr, FALSE);
+ }
+@@ -204,7 +204,7 @@
+ 		gdk_pixbuf_scale_simple(skin_infos.raw, sr.w, sr.h, GDK_INTERP_NEAREST);
+ 
+ 	// and draw
+-	gdk_draw_pixbuf(pixmap, main_wnd->style->fg_gc[GTK_WIDGET_STATE(main_wnd)],
++	gdk_draw_pixbuf(pixmap, main_wnd->style->fg_gc[gtk_widget_get_state(main_wnd)],
+ 		  skin_infos.image, ls.x, ls.y, lr.x, lr.y, lr.w, lr.h, GDK_RGB_DITHER_NONE, 0, 0);
+ 	gtk_widget_queue_draw_area(area, lr.x, lr.y, lr.w, lr.h);
+ }
+@@ -324,7 +324,7 @@
+ 			skin_infos.image = gdk_pixbuf_scale_simple(lcd, lr.w, lr.h, GDK_INTERP_NEAREST);
+ 
+ 			// and draw image into pixmap (next, into window on expose event)
+-			gdk_draw_pixbuf(pixmap, main_wnd->style->fg_gc[GTK_WIDGET_STATE(main_wnd)],
++			gdk_draw_pixbuf(pixmap, main_wnd->style->fg_gc[gtk_widget_get_state(main_wnd)],
+ 			 skin_infos.image, src.x, src.y, lr.x, lr.y, src.w, src.h,
+ 			  GDK_RGB_DITHER_NONE, 0, 0);
+ 			gtk_widget_queue_draw_area(area, lr.x, lr.y, src.w, src.h);
+@@ -332,7 +332,7 @@
+ 		else
+ 		{
+ 			// and draw image into pixmap (next, into window on expose event)
+-			gdk_draw_pixbuf(pixmap, main_wnd->style->fg_gc[GTK_WIDGET_STATE(main_wnd)],
++			gdk_draw_pixbuf(pixmap, main_wnd->style->fg_gc[gtk_widget_get_state(main_wnd)],
+ 			  lcd_mem, src.x, src.y, lr.x, lr.y, src.w, src.h,
+ 			  GDK_RGB_DITHER_NONE, 0, 0);
+ 			gtk_widget_queue_draw_area(area, lr.x, lr.y, src.w, src.h);

--- a/x11-packages/tiemu/0007-gui-debugger-gtk_widget_get_visible.patch
+++ b/x11-packages/tiemu/0007-gui-debugger-gtk_widget_get_visible.patch
@@ -1,0 +1,50 @@
+--- a/src/gui/debugger/dbg_all.c	2009-05-08 06:56:40.000000000 -0400
++++ b/src/gui/debugger/dbg_all.c	2026-07-30 18:33:31.750347313 -0400
+@@ -90,21 +90,21 @@
+ {	
+ 	WND_TMR_START();
+ 
+-	if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.regs))
++	if(options3.dbg_dock || gtk_widget_get_visible(dbgw.regs))
+ 		dbgregs_refresh_window();
+-	if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.mem))
++	if(options3.dbg_dock || gtk_widget_get_visible(dbgw.mem))
+ 		dbgmem_refresh_window();
+-	if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.bkpts))
++	if(options3.dbg_dock || gtk_widget_get_visible(dbgw.bkpts))
+ 		dbgbkpts_refresh_window();
+-	if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.pclog))
++	if(options3.dbg_dock || gtk_widget_get_visible(dbgw.pclog))
+ 		dbgpclog_refresh_window();
+-	if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.code))
++	if(options3.dbg_dock || gtk_widget_get_visible(dbgw.code))
+ 		dbgcode_refresh_window();
+-    if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.stack))
++    if(options3.dbg_dock || gtk_widget_get_visible(dbgw.stack))
+ 		dbgstack_refresh_window();
+-	if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.heap))
++	if(options3.dbg_dock || gtk_widget_get_visible(dbgw.heap))
+ 		dbgheap_refresh_window();
+-	if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.iop))
++	if(options3.dbg_dock || gtk_widget_get_visible(dbgw.iop))
+ 		dbgiop_refresh_window();
+ 
+ 	WND_TMR_STOP("Debugger Refresh Time");
+@@ -163,7 +163,7 @@
+ 	gtk_debugger_refresh();
+ 
+ 	// enable the debugger if GDB disabled it
+-	if (!options3.dbg_dock && !GTK_WIDGET_SENSITIVE(dbgw.regs))
++	if (!options3.dbg_dock && !gtk_widget_get_sensitive(dbgw.regs))
+ 		gtk_debugger_enable();
+ 
+ 	// handle automatic debugging requests
+@@ -180,7 +180,7 @@
+ 
+ 			ti68k_bkpt_get_pgmentry_offset(id, &handle, &offset);
+ 			ti68k_bkpt_del_pgmentry(handle);
+-			if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.bkpts))
++			if(options3.dbg_dock || gtk_widget_get_visible(dbgw.bkpts))
+ 				dbgbkpts_refresh_window();
+ 
+ 			delete_command(NULL, 0);

--- a/x11-packages/tiemu/0008-gui-debugger-dbg_wnds-gtk_widget_get_visible.patch
+++ b/x11-packages/tiemu/0008-gui-debugger-dbg_wnds-gtk_widget_get_visible.patch
@@ -1,0 +1,185 @@
+--- a/src/gui/debugger/dbg_wnds.c	2009-05-07 03:18:02.000000000 -0400
++++ b/src/gui/debugger/dbg_wnds.c	2026-07-30 18:58:11.478347313 -0400
+@@ -74,21 +74,21 @@
+ 	if(options3.dbg_dock)
+ 		return;
+ 
+-    if(GTK_WIDGET_VISIBLE(dbgw.regs))
++    if(gtk_widget_get_visible(dbgw.regs))
+         gtk_window_iconify(GTK_WINDOW(dbgw.regs));
+-    if(GTK_WIDGET_VISIBLE(dbgw.bkpts))
++    if(gtk_widget_get_visible(dbgw.bkpts))
+         gtk_window_iconify(GTK_WINDOW(dbgw.bkpts));
+-    if(GTK_WIDGET_VISIBLE(dbgw.mem))
++    if(gtk_widget_get_visible(dbgw.mem))
+         gtk_window_iconify(GTK_WINDOW(dbgw.mem));
+-    if(GTK_WIDGET_VISIBLE(dbgw.pclog))
++    if(gtk_widget_get_visible(dbgw.pclog))
+         gtk_window_iconify(GTK_WINDOW(dbgw.pclog));
+-    if(GTK_WIDGET_VISIBLE(dbgw.code) & all)
++    if(gtk_widget_get_visible(dbgw.code) & all)
+         gtk_window_iconify(GTK_WINDOW(dbgw.code));
+-    if(GTK_WIDGET_VISIBLE(dbgw.stack))
++    if(gtk_widget_get_visible(dbgw.stack))
+         gtk_window_iconify(GTK_WINDOW(dbgw.stack));
+-	if(GTK_WIDGET_VISIBLE(dbgw.heap))
++	if(gtk_widget_get_visible(dbgw.heap))
+         gtk_window_iconify(GTK_WINDOW(dbgw.heap));
+-	if(GTK_WIDGET_VISIBLE(dbgw.iop))
++	if(gtk_widget_get_visible(dbgw.iop))
+         gtk_window_iconify(GTK_WINDOW(dbgw.iop));
+ }
+ 
+@@ -98,21 +98,21 @@
+ 	if(options3.dbg_dock)
+ 		return;
+ 
+-    if(GTK_WIDGET_VISIBLE(dbgw.regs))
++    if(gtk_widget_get_visible(dbgw.regs))
+         gtk_window_deiconify(GTK_WINDOW(dbgw.regs));
+-    if(GTK_WIDGET_VISIBLE(dbgw.bkpts))
++    if(gtk_widget_get_visible(dbgw.bkpts))
+         gtk_window_deiconify(GTK_WINDOW(dbgw.bkpts));
+-    if(GTK_WIDGET_VISIBLE(dbgw.mem))
++    if(gtk_widget_get_visible(dbgw.mem))
+         gtk_window_deiconify(GTK_WINDOW(dbgw.mem));
+-    if(GTK_WIDGET_VISIBLE(dbgw.pclog))
++    if(gtk_widget_get_visible(dbgw.pclog))
+         gtk_window_deiconify(GTK_WINDOW(dbgw.pclog));
+-    if(GTK_WIDGET_VISIBLE(dbgw.code) & all)
++    if(gtk_widget_get_visible(dbgw.code) & all)
+         gtk_window_deiconify(GTK_WINDOW(dbgw.code));
+-    if(GTK_WIDGET_VISIBLE(dbgw.stack))
++    if(gtk_widget_get_visible(dbgw.stack))
+         gtk_window_deiconify(GTK_WINDOW(dbgw.stack));
+-	if(GTK_WIDGET_VISIBLE(dbgw.heap))
++	if(gtk_widget_get_visible(dbgw.heap))
+         gtk_window_deiconify(GTK_WINDOW(dbgw.heap));
+-	if(GTK_WIDGET_VISIBLE(dbgw.iop))
++	if(gtk_widget_get_visible(dbgw.iop))
+         gtk_window_deiconify(GTK_WINDOW(dbgw.iop));
+ }
+ 
+@@ -122,21 +122,21 @@
+     if(options3.dbg_dock)
+ 		return;
+ 
+-    if(!GTK_WIDGET_VISIBLE(dbgw.regs))
++    if(!gtk_widget_get_visible(dbgw.regs))
+         gtk_widget_show(dbgw.regs);
+-    if(!GTK_WIDGET_VISIBLE(dbgw.bkpts))
++    if(!gtk_widget_get_visible(dbgw.bkpts))
+         gtk_widget_show(dbgw.bkpts);
+-    if(!GTK_WIDGET_VISIBLE(dbgw.mem))
++    if(!gtk_widget_get_visible(dbgw.mem))
+         gtk_widget_show(dbgw.mem);
+-    if(!GTK_WIDGET_VISIBLE(dbgw.pclog))
++    if(!gtk_widget_get_visible(dbgw.pclog))
+         gtk_widget_show(dbgw.pclog);
+-    if(!GTK_WIDGET_VISIBLE(dbgw.code) && all)
++    if(!gtk_widget_get_visible(dbgw.code) && all)
+         gtk_widget_show(dbgw.code);
+-    if(!GTK_WIDGET_VISIBLE(dbgw.stack))
++    if(!gtk_widget_get_visible(dbgw.stack))
+         gtk_widget_show(dbgw.stack);
+-	if(!GTK_WIDGET_VISIBLE(dbgw.heap))
++	if(!gtk_widget_get_visible(dbgw.heap))
+         gtk_widget_show(dbgw.heap);
+-	if(!GTK_WIDGET_VISIBLE(dbgw.iop))
++	if(!gtk_widget_get_visible(dbgw.iop))
+         gtk_widget_show(dbgw.iop);
+ }
+ 
+@@ -146,21 +146,21 @@
+     if(options3.dbg_dock)
+ 		return;
+ 
+-    if(GTK_WIDGET_VISIBLE(dbgw.regs))
++    if(gtk_widget_get_visible(dbgw.regs))
+         gtk_widget_hide(dbgw.regs);
+-    if(GTK_WIDGET_VISIBLE(dbgw.bkpts))
++    if(gtk_widget_get_visible(dbgw.bkpts))
+         gtk_widget_hide(dbgw.bkpts);
+-    if(GTK_WIDGET_VISIBLE(dbgw.mem))
++    if(gtk_widget_get_visible(dbgw.mem))
+         gtk_widget_hide(dbgw.mem);
+-    if(GTK_WIDGET_VISIBLE(dbgw.pclog))
++    if(gtk_widget_get_visible(dbgw.pclog))
+         gtk_widget_hide(dbgw.pclog);
+-    if(GTK_WIDGET_VISIBLE(dbgw.code) && all)
++    if(gtk_widget_get_visible(dbgw.code) && all)
+         gtk_widget_hide(dbgw.code);
+-    if(GTK_WIDGET_VISIBLE(dbgw.stack))
++    if(gtk_widget_get_visible(dbgw.stack))
+         gtk_widget_hide(dbgw.stack);
+-	if(GTK_WIDGET_VISIBLE(dbgw.heap))
++	if(gtk_widget_get_visible(dbgw.heap))
+         gtk_widget_hide(dbgw.heap);
+-	if(GTK_WIDGET_VISIBLE(dbgw.iop))
++	if(gtk_widget_get_visible(dbgw.iop))
+         gtk_widget_hide(dbgw.iop);
+ }
+ 
+@@ -338,7 +338,7 @@
+ 	if(!options3.dbg_dock)
+ 	{
+ 		g_signal_handlers_block_by_func(GTK_OBJECT(item), on_registers1_activate, NULL);
+-		gtk_check_menu_item_set_active(item, GTK_WIDGET_VISIBLE(dbgw.regs));
++		gtk_check_menu_item_set_active(item, gtk_widget_get_visible(dbgw.regs));
+ 		g_signal_handlers_unblock_by_func(GTK_OBJECT(item), on_registers1_activate, NULL);
+ 	}
+ 	else
+@@ -350,7 +350,7 @@
+ 	if(!options3.dbg_dock)
+ 	{
+ 		g_signal_handlers_block_by_func(GTK_OBJECT(item), on_breakpoints1_activate, NULL);
+-		gtk_check_menu_item_set_active(item, GTK_WIDGET_VISIBLE(dbgw.bkpts));
++		gtk_check_menu_item_set_active(item, gtk_widget_get_visible(dbgw.bkpts));
+ 		g_signal_handlers_unblock_by_func(GTK_OBJECT(item), on_breakpoints1_activate, NULL);
+ 	}
+ 	else
+@@ -362,7 +362,7 @@
+ 	if(!options3.dbg_dock)
+ 	{
+ 		g_signal_handlers_block_by_func(GTK_OBJECT(item), on_memory1_activate, NULL);
+-		gtk_check_menu_item_set_active(item, GTK_WIDGET_VISIBLE(dbgw.mem));
++		gtk_check_menu_item_set_active(item, gtk_widget_get_visible(dbgw.mem));
+ 		g_signal_handlers_unblock_by_func(GTK_OBJECT(item), on_memory1_activate, NULL);
+ 	}
+ 	else
+@@ -372,7 +372,7 @@
+     elt = g_list_nth(list, 3);
+     item = GTK_CHECK_MENU_ITEM(elt->data);
+     g_signal_handlers_block_by_func(GTK_OBJECT(item), on_pc_log1_activate, NULL);
+-    gtk_check_menu_item_set_active(item, GTK_WIDGET_VISIBLE(dbgw.pclog));
++    gtk_check_menu_item_set_active(item, gtk_widget_get_visible(dbgw.pclog));
+     g_signal_handlers_unblock_by_func(GTK_OBJECT(item), on_pc_log1_activate, NULL);
+ 
+     // stack
+@@ -381,7 +381,7 @@
+ 	if(!options3.dbg_dock)
+ 	{
+ 		g_signal_handlers_block_by_func(GTK_OBJECT(item), on_stack_frame1_activate, NULL);
+-		gtk_check_menu_item_set_active(item, GTK_WIDGET_VISIBLE(dbgw.stack));
++		gtk_check_menu_item_set_active(item, gtk_widget_get_visible(dbgw.stack));
+ 		g_signal_handlers_unblock_by_func(GTK_OBJECT(item), on_stack_frame1_activate, NULL);
+ 	}
+ 	else
+@@ -393,7 +393,7 @@
+ 	if(!options3.dbg_dock)
+ 	{
+ 		g_signal_handlers_block_by_func(GTK_OBJECT(item), on_heap_frame1_activate, NULL);
+-		gtk_check_menu_item_set_active(item, GTK_WIDGET_VISIBLE(dbgw.heap));
++		gtk_check_menu_item_set_active(item, gtk_widget_get_visible(dbgw.heap));
+ 		g_signal_handlers_unblock_by_func(GTK_OBJECT(item), on_heap_frame1_activate, NULL);
+ 	}
+ 	else
+@@ -403,7 +403,7 @@
+ 	elt = g_list_nth(list, 6);
+     item = GTK_CHECK_MENU_ITEM(elt->data);
+     g_signal_handlers_block_by_func(GTK_OBJECT(item), on_ioports_frame1_activate, NULL);
+-    gtk_check_menu_item_set_active(item, GTK_WIDGET_VISIBLE(dbgw.iop));
++    gtk_check_menu_item_set_active(item, gtk_widget_get_visible(dbgw.iop));
+     g_signal_handlers_unblock_by_func(GTK_OBJECT(item), on_ioports_frame1_activate, NULL);
+ 
+ 	// dock/multi mode

--- a/x11-packages/tiemu/0009-gui-debugger-dbg_dock-gtk_widget_get_visible.patch
+++ b/x11-packages/tiemu/0009-gui-debugger-dbg_dock-gtk_widget_get_visible.patch
@@ -1,0 +1,31 @@
+--- a/src/gui/debugger/dbg_dock.c	2008-05-26 12:48:30.000000000 -0400
++++ b/src/gui/debugger/dbg_dock.c	2026-07-30 19:37:28.894347313 -0400
+@@ -151,22 +151,22 @@
+ 
+ void dbgdock_show_all(int all)
+ {
+-	if(!GTK_WIDGET_VISIBLE(dbgw.dock) && all)
++	if(!gtk_widget_get_visible(dbgw.dock) && all)
+         gtk_widget_show(dbgw.dock);
+ 
+-	if(GTK_WIDGET_VISIBLE(dbgw.iop))
++	if(gtk_widget_get_visible(dbgw.iop))
+         gtk_window_iconify(GTK_WINDOW(dbgw.iop));
+-	if(GTK_WIDGET_VISIBLE(dbgw.pclog))
++	if(gtk_widget_get_visible(dbgw.pclog))
+         gtk_window_iconify(GTK_WINDOW(dbgw.pclog));
+ }
+ 
+ void dbgdock_hide_all(int all)
+ {
+-	if(GTK_WIDGET_VISIBLE(dbgw.dock) && all)
++	if(gtk_widget_get_visible(dbgw.dock) && all)
+         gtk_widget_hide(dbgw.dock);
+ 
+-    if(GTK_WIDGET_VISIBLE(dbgw.pclog))
++    if(gtk_widget_get_visible(dbgw.pclog))
+         gtk_widget_hide(dbgw.pclog);
+-	if(GTK_WIDGET_VISIBLE(dbgw.iop))
++	if(gtk_widget_get_visible(dbgw.iop))
+         gtk_widget_hide(dbgw.iop);
+ }

--- a/x11-packages/tiemu/0010-gui-debugger-dbg_pkpts-gtk_widget_get_visible.patch
+++ b/x11-packages/tiemu/0010-gui-debugger-dbg_pkpts-gtk_widget_get_visible.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/debugger/dbg_bkpts.c	2009-05-06 15:48:47.000000000 -0400
++++ b/src/gui/debugger/dbg_bkpts.c	2026-07-30 19:49:50.462347313 -0400
+@@ -388,7 +388,7 @@
+ 		gtk_window_iconify(GTK_WINDOW(wnd));
+ #endif
+ 
+-	if(!GTK_WIDGET_VISIBLE(dbgw.bkpts) && !options3.bkpts.closed)
++	if(!gtk_widget_get_visible(dbgw.bkpts) && !options3.bkpts.closed)
+ 		gtk_widget_show(wnd);
+ 
+ 	return wnd;

--- a/x11-packages/tiemu/0011-gui-debugger-dbg_pclog-gtk_widget_get_visible.patch
+++ b/x11-packages/tiemu/0011-gui-debugger-dbg_pclog-gtk_widget_get_visible.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/debugger/dbg_pclog.c	2009-05-02 15:46:04.000000000 -0400
++++ /bsrc/gui/debugger/dbg_pclog.c	2026-07-30 20:46:46.690347313 -0400
+@@ -163,7 +163,7 @@
+ 		gtk_window_iconify(GTK_WINDOW(dbgw.pclog));
+ #endif
+ 
+-	if(!GTK_WIDGET_VISIBLE(dbgw.pclog) && !options3.pclog.closed)
++	if(!gtk_widget_get_visible(dbgw.pclog) && !options3.pclog.closed)
+ 		gtk_widget_show(dbgw.pclog);
+ 
+ 	return dbgw.pclog;

--- a/x11-packages/tiemu/0012-gui-debugger-dbg_stack-gtk_widget_get_visible.patch
+++ b/x11-packages/tiemu/0012-gui-debugger-dbg_stack-gtk_widget_get_visible.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/debugger/dbg_stack.c	2009-05-06 15:48:47.000000000 -0400
++++ b/src/gui/debugger/dbg_stack.c	2026-07-30 20:50:27.506347313 -0400
+@@ -197,7 +197,7 @@
+ 		gtk_window_iconify(GTK_WINDOW(dbgw.stack));
+ #endif
+ 
+-	if(!GTK_WIDGET_VISIBLE(dbgw.stack) && !options3.stack.closed)
++	if(!gtk_widget_get_visible(dbgw.stack) && !options3.stack.closed)
+ 		gtk_widget_show(dbgw.stack);
+ 
+ 	return dbgw.stack;

--- a/x11-packages/tiemu/0013-gui-debugger-dbg_heap-gtk_widget_get_visible.patch
+++ b/x11-packages/tiemu/0013-gui-debugger-dbg_heap-gtk_widget_get_visible.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/debugger/dbg_heap.c	2009-05-06 15:48:47.000000000 -0400
++++ b/src/gui/debugger/dbg_heap.c	2026-07-30 20:54:07.998347313 -0400
+@@ -171,7 +171,7 @@
+ 		gtk_window_iconify(GTK_WINDOW(dbgw.heap));
+ #endif
+ 
+-	if(!GTK_WIDGET_VISIBLE(dbgw.heap) && !options3.heap.closed)
++	if(!gtk_widget_get_visible(dbgw.heap) && !options3.heap.closed)
+ 		gtk_widget_show(dbgw.heap);
+ 
+ 	return dbgw.heap;

--- a/x11-packages/tiemu/0014-gui-debugger-dbg_code-gtk_widget_get_sensitive.patch
+++ b/x11-packages/tiemu/0014-gui-debugger-dbg_code-gtk_widget_get_sensitive.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/debugger/dbg_code.c	2009-05-06 15:48:47.000000000 -0400
++++ b/src/gui/debugger/dbg_code.c	2026-07-30 21:03:13.278347313 -0400
+@@ -1117,7 +1117,7 @@
+ 
+ int dbgcode_quit_enabled(void)
+ {
+-	return GTK_WIDGET_SENSITIVE(mi.m8);
++	return gtk_widget_get_sensitive(mi.m8);
+ }
+ 
+ static int close_debugger_wrapper(gpointer data)

--- a/x11-packages/tiemu/0015-gui-debugger-dbg_iop-gtk_widget_get_visible.patch
+++ b/x11-packages/tiemu/0015-gui-debugger-dbg_iop-gtk_widget_get_visible.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/debugger/dbg_iop.c	2009-05-02 15:46:04.000000000 -0400
++++ b/src/gui/debugger/dbg_iop.c	2026-07-30 21:06:46.902347313 -0400
+@@ -455,7 +455,7 @@
+ 		gtk_window_iconify(GTK_WINDOW(dbgw.iop));
+ #endif
+     
+-	if(!GTK_WIDGET_VISIBLE(dbgw.iop) && !options3.iop.closed)
++	if(!gtk_widget_get_visible(dbgw.iop) && !options3.iop.closed)
+ 		gtk_widget_show(dbgw.iop);
+ 
+ 	return dbgw.iop;

--- a/x11-packages/tiemu/0016-gui-debugger-dbg_regs-gtk_widget_get_visible.patch
+++ b/x11-packages/tiemu/0016-gui-debugger-dbg_regs-gtk_widget_get_visible.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/debugger/dbg_regs.c	2009-05-06 15:48:47.000000000 -0400
++++ b/src/gui/debugger/dbg_regs.c	2026-07-30 21:10:58.518347313 -0400
+@@ -302,7 +302,7 @@
+ 		gtk_window_iconify(GTK_WINDOW(dbgw.regs));
+ #endif
+ 
+-	if(!GTK_WIDGET_VISIBLE(dbgw.regs) && !options3.regs.closed)
++	if(!gtk_widget_get_visible(dbgw.regs) && !options3.regs.closed)
+ 		gtk_widget_show(dbgw.regs);
+ 
+ 	return dbgw.regs;

--- a/x11-packages/tiemu/0017-gui-debugger-dbg_mem-gtk_widget_get_visible.patch
+++ b/x11-packages/tiemu/0017-gui-debugger-dbg_mem-gtk_widget_get_visible.patch
@@ -1,0 +1,38 @@
+--- a/src/gui/debugger/dbg_mem.c	2009-05-06 15:48:47.000000000 -0400
++++ b/src/gui/debugger/dbg_mem.c	2026-07-30 21:47:45.010347313 -0400
+@@ -435,7 +435,7 @@
+ 		gtk_window_iconify(GTK_WINDOW(dbgw.mem));
+ #endif
+ 
+-	if(!GTK_WIDGET_VISIBLE(dbgw.mem) && !options3.mem.closed)
++	if(!gtk_widget_get_visible(dbgw.mem) && !options3.mem.closed)
+ 		gtk_widget_show(dbgw.mem);
+ 
+     return dbgw.mem;
+@@ -551,7 +551,7 @@
+ 
+ 	menu = gtk_menu_new();
+ 	g_object_set_data_full(G_OBJECT(menu), "memmap_menu",
+-			       gtk_widget_ref(menu),
++			       g_object_ref(menu),
+ 			       (GDestroyNotify)g_object_unref);
+ 
+ 	// (re)load mem map
+@@ -574,7 +574,7 @@
+ 
+ 		item = gtk_menu_item_new_with_label(label);
+ 		g_object_set_data_full(G_OBJECT(menu), "c_drive",
+-					   gtk_widget_ref(item),
++					   g_object_ref(item),
+ 					   (GDestroyNotify)g_object_unref);
+ 		gtk_widget_show(item);
+ 
+@@ -605,7 +605,7 @@
+ 
+ GLADE_CB void
+ on_notebook1_switch_page               (GtkNotebook     *notebook,
+-                                        GtkNotebookPage *page,
++                                        GtkNotebookTab  *page,
+                                         guint            page_num,
+                                         gpointer         user_data)
+ {

--- a/x11-packages/tiemu/0018-gui-debugger-dbg_romcall-GTK_COMBO_BOX.patch
+++ b/x11-packages/tiemu/0018-gui-debugger-dbg_romcall-GTK_COMBO_BOX.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/debugger/dbg_romcall.c	2007-07-05 07:36:10.000000000 -0400
++++ b/src/gui/debugger/dbg_romcall.c	2026-07-30 22:04:53.458347313 -0400
+@@ -163,7 +163,7 @@
+ 
+ 	// and set storage
+ 	gtk_combo_box_set_model(combo, model);
+-	gtk_combo_box_entry_set_text_column(GTK_COMBO_BOX_ENTRY(combo), COL_FULL);
++	gtk_combo_box_set_entry_text_column(GTK_COMBO_BOX(combo), COL_FULL);
+ 
+ 	/* --- */
+ 

--- a/x11-packages/tiemu/0019-gui-logger-fix-implicit-int-for-logger-enabled.patch
+++ b/x11-packages/tiemu/0019-gui-logger-fix-implicit-int-for-logger-enabled.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/logger/log_link.c	2009-05-02 15:46:04.000000000 -0400
++++ b/src/gui/logger/log_link.c	2026-07-30 22:09:59.246347313 -0400
+@@ -36,7 +36,7 @@
+ #include "filesel.h"
+ 
+ static GtkTextBuffer *txtbuf;
+-static logger_enabled = 0;
++static int logger_enabled = 0;
+ 
+ 
+ 

--- a/x11-packages/tiemu/0020-dont-install-bundled-pedrom-tib-images.patch
+++ b/x11-packages/tiemu/0020-dont-install-bundled-pedrom-tib-images.patch
@@ -1,0 +1,31 @@
+--- a/pedrom/Makefile.in	2009-04-30 16:45:57.000000000 -0400
++++ b/pedrom/Makefile.in	2026-08-01 13:14:45.594347313 -0400
+@@ -292,7 +292,7 @@
+ x_includes = @x_includes@
+ x_libraries = @x_libraries@
+ pedromdir = $(pkgdatadir)/pedrom
+-dist_pedrom_DATA = pedrom*.tib pedrom.txt
++dist_pedrom_DATA =
+ EXTRA_DIST = pedrom-src.tar.bz2
+ all: all-am
+ 
+@@ -482,7 +482,7 @@
+ 
+ 
+ uninstall:
+-	rm -f $(pkgdatadir)/pedrom/*.tib
++
+ # Tell versions [3.59,3.63) of GNU make to not export all variables.
+ # Otherwise a system limit (for SysV at least) may be exceeded.
+ .NOEXPORT:
+--- a/pedrom/Makefile.am	2007-12-08 05:26:22.000000000 -0500
++++ b/pedrom/Makefile.am	2026-08-01 13:15:49.014347313 -0400
+@@ -1,7 +1,6 @@
+ pedromdir = $(pkgdatadir)/pedrom
+-dist_pedrom_DATA = pedrom*.tib pedrom.txt
++dist_pedrom_DATA = 
+ 
+ EXTRA_DIST = pedrom-src.tar.bz2
+ 
+ uninstall:
+-	rm -f $(pkgdatadir)/pedrom/*.tib

--- a/x11-packages/tiemu/build.sh
+++ b/x11-packages/tiemu/build.sh
@@ -1,0 +1,33 @@
+TERMUX_PKG_HOMEPAGE="http://lpg.ticalc.org/prj_tiemu/"
+TERMUX_PKG_DESCRIPTION="TiEmu is an emulator for TI89/TI89-Titanium/TI92/TI92+/V200PLT calculators. (no GDB)"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="3ls-it <3ls-it@pm.me>"
+TERMUX_PKG_VERSION=3.03
+TERMUX_PKG_SRCURL="https://master.dl.sourceforge.net/project/gtktiemu/tiemu-linux/TIEmu%20${TERMUX_PKG_VERSION}/tiemu-${TERMUX_PKG_VERSION}-nogdb.tar.gz"
+TERMUX_PKG_SHA256=92d2830842278a8df29ab0717f5b89e06b34e88a50c073fe10ff9e6855b8a592
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_DEPENDS="glib, gtk2, libticables2, libticalcs2, libtifiles2, libglade2, pedrom"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--disable-sound
+--without-kde
+--disable-gdb
+"
+
+termux_step_create_debscripts() {
+		cat <<-EOF > ./postinst
+				#!$TERMUX_PREFIX/bin/sh
+				echo
+				echo "********"
+				echo "TiEmu is installed!"
+				echo
+				echo "By default it uses the open source PedroM OS for m68k-based TI calculators."
+				echo "You may also use a ROM dump of your own calculator, or a downloaded"
+				echo "upgrade ROM image from Texas Instruments."
+				echo
+				echo "It is unlawful to share or distribute your ROM image or an official image from"
+				echo "Texas Instruments as they are the property of Texas Instruments Inc."
+				echo "********"
+				echo
+		EOF
+}


### PR DESCRIPTION
#### This PR adds TiEmu v3.03 and dependencies.

addpkg(x11/tiemu): 3.03
addpkg(x11/libglade2): 2.6.4
addpkg(main/libticables2): 1.3.5
addpkg(main/libticalcs2): 1.1.9
addpkg(main/libticonv): 1.1.5
addpkg(main/libtifiles2): 1.1.7
addpkg(main/pedrom): 0.83

----

- Compiles in Termux Docker for all architectures
- Installs on-device and runs as expected
----

##### Note:  
- The upstream TiEmu 3.03 distribution includes legacy PedroM 0.81 `.tib` images, which are not accepted by the current TiEmu import path. The current PedroM 0.83 distribution provides valid `.89u`/`.9xu` FLASH images; these were tested successfully and are installed in TiEmu’s existing PedRom search directory.

----

TI-89 Titanium emulation with TI AMS OS v3.10:  
  
<img width="439" height="981" alt="tiemu_ti89t_TiAMS" src="https://github.com/user-attachments/assets/9e1b939f-9a56-4761-8c68-e288ae052d5d" />  
   
  
TI-Voyage200 emulation with PedroM OS v0.83:  
  
<img width="1028" height="691" alt="tiemu_v200_PedroM83" src="https://github.com/user-attachments/assets/21ebde1e-9236-4e29-82ce-d4110c31fd16" />  
  
