### PR TITLE
Source mirror support, 100% tested and working reliably and gracefully

### DIFF
--- a/.github/workflows/clean_source_mirror.yml
+++ b/.github/workflows/clean_source_mirror.yml
@@ -1,0 +1,26 @@
+name: Clean source mirror
+
+on:
+  schedule:
+    - cron: "0 6 * * 0"
+  workflow_dispatch:
+
+permissions: {} # none
+
+concurrency:
+  group: .github/workflows/packages.yml
+  cancel-in-progress: false
+
+jobs:
+  clean:
+    permissions:
+      contents: write
+    if: github.repository == 'termux/termux-packages'
+    runs-on: ubuntu-slim
+    steps:
+      - name: Git clone
+        uses: actions/checkout@v7
+      - name: Clean source mirror
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/bin/source-mirror clean

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -289,7 +289,8 @@ jobs:
         echo "packages: ${packages[*]}"
 
         if [[ "${#packages[@]}" -gt 0 ]]; then
-          ./scripts/run-docker.sh -d ./build-package.sh -I -C -a "${{ matrix.target_arch }}" "${packages[@]}"
+          ./scripts/run-docker.sh -d ./build-package.sh -I -C -a "${{ matrix.target_arch }}" \
+            ${{ case(matrix.target_arch == 'aarch64', '-m', '') }} "${packages[@]}"
         fi
 
     - name: Generate build artifacts
@@ -334,6 +335,13 @@ jobs:
       with:
         name: debs-${{ matrix.target_arch }}-${{ github.sha }}
         path: ./artifacts
+    - name: Store source files
+      if: ${{ matrix.target_arch == 'aarch64' }}
+      uses: actions/upload-artifact@v6
+      with:
+        name: source
+        path: ./output/source
+        if-no-files-found: ignore
     - name: AppArmor Logs
       if: always()
       run: |
@@ -500,3 +508,15 @@ jobs:
             fi
           fi
         done
+    - name: Upload source archives to source mirror
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        [ -d "source" ] || exit 0
+        cd "source"
+        for source_file in *; do
+          mirror_name="$(../scripts/build/get_source/termux_download_source_mirror.sh --mirror-name "${source_file}")"
+          echo "Uploading ${source_file} to ${mirror_name}"
+          gh release upload --clobber "${mirror_name}" "${source_file}"
+        done
+        cd ..

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -289,7 +289,8 @@ jobs:
         echo "packages: ${packages[*]}"
 
         if [[ "${#packages[@]}" -gt 0 ]]; then
-          ./scripts/run-docker.sh -d ./build-package.sh -I -C -a "${{ matrix.target_arch }}" "${packages[@]}"
+          ./scripts/run-docker.sh -d ./build-package.sh -I -C -a "${{ matrix.target_arch }}" \
+            ${{ case(matrix.target_arch == 'aarch64', '-m', '') }} "${packages[@]}"
         fi
 
     - name: Generate build artifacts
@@ -334,6 +335,13 @@ jobs:
       with:
         name: debs-${{ matrix.target_arch }}-${{ github.sha }}
         path: ./artifacts
+    - name: Store source files
+      if: ${{ matrix.target_arch == 'aarch64' }}
+      uses: actions/upload-artifact@v6
+      with:
+        name: source
+        path: ./output/source
+        if-no-files-found: ignore
     - name: AppArmor Logs
       if: always()
       run: |
@@ -500,3 +508,16 @@ jobs:
             fi
           fi
         done
+    - name: Upload source archives to source mirror
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        if [ -d "source" ]; then
+          cd "source"
+          for source_file in *; do
+            mirror_name="$(../scripts/build/get_source/termux_download_source_mirror.sh --mirror-name ${source_file})"
+            echo "Uploading ${source_file} to ${mirror_name}"
+            gh release upload --clobber "${mirror_name}" "${source_file}"
+          done
+          cd ..
+        fi

--- a/build-package.sh
+++ b/build-package.sh
@@ -257,6 +257,10 @@ source "$TERMUX_SCRIPTDIR/scripts/build/get_source/termux_step_get_source.sh"
 # shellcheck source=scripts/build/get_source/termux_step_get_source.sh
 source "$TERMUX_SCRIPTDIR/scripts/build/get_source/termux_git_clone_src.sh"
 
+# Download source archive from Termux source mirror, for both .tar archives and git repositories.
+# shellcheck source=scripts/build/get_source/termux_download_source_mirror.sh
+source "$TERMUX_SCRIPTDIR/scripts/build/get_source/termux_download_source_mirror.sh"
+
 # Run from termux_step_get_source if TERMUX_PKG_SRCURL does not begin with "git+".
 # shellcheck source=scripts/build/get_source/termux_download_src_archive.sh
 source "$TERMUX_SCRIPTDIR/scripts/build/get_source/termux_download_src_archive.sh"
@@ -527,6 +531,7 @@ _show_usage() {
 	echo "  -j <N> Number of threads. (default or 0, N = \`nproc\` = $(nproc))"
 	echo "         Can also be passed combined, e.g. '-j12'."
 	echo "  -L The package and its dependencies will be based on the same library."
+	echo "  -m Copy downloaded source archives to directory output/source/, if they are not present on the source mirror."
 	echo "  -q Quiet build."
 	echo "  -Q Loud build -- set -x debug output and function tracing."
 	echo "  -r Remove all package build dependent dirs that '-f/-F'"
@@ -602,6 +607,7 @@ while (( $# )); do
 			export TERMUX_PKG_MAKE_PROCESSES
 		;;
 		-L) export TERMUX_GLOBAL_LIBRARY=true;;
+		-m) export TERMUX_COPY_TO_SOURCE_MIRROR=true;;
 		-q) export TERMUX_QUIET_BUILD=true;;
 		-Q) export PS4='+$0 \[\e[32m\]${FUNCNAME[0]:-<global scope>}${FUNCNAME[*]:+()}:$LINENO\[\e[0m\] '; set -x;;
 		-r) export TERMUX_PKGS__BUILD__RM_ALL_PKG_BUILD_DEPENDENT_DIRS=true;;

--- a/scripts/bin/source-mirror
+++ b/scripts/bin/source-mirror
@@ -1,0 +1,233 @@
+#!/bin/bash
+
+export TERMUX_SCRIPTDIR
+TERMUX_SCRIPTDIR=$(realpath "$(dirname "$0")/../..") # Root of repository."
+DOWNLOAD_DIR="${TERMUX_SCRIPTDIR}/source-mirror"
+
+if [[ $# != 1 ]]; then
+  echo "Usage:"
+  echo "$0 download      Download all source archives to directory ${DOWNLOAD_DIR}"
+  echo "$0 upload        Upload source archives to Github releases from directory ${DOWNLOAD_DIR}"
+  echo "$0 clean         Remove all obsolete source archives from Github releases"
+  exit 0
+fi
+
+COMMAND="$1"
+if [ "$COMMAND" != "download" ] && [ "$COMMAND" != "upload" ] && [ "$COMMAND" != "clean" ]; then
+  echo "Invalid command"
+  exit 1
+fi
+
+cd "${TERMUX_SCRIPTDIR}" || exit 1
+
+TERMUX_PKG_TMPDIR=${TERMUX_SCRIPTDIR}/tmp
+PARALLEL_DOWNLOADS=10
+
+rm -rf ${TERMUX_PKG_TMPDIR}
+mkdir -p ${TERMUX_PKG_TMPDIR}
+
+# Utility function to download a resource with an expected checksum.
+# shellcheck source=scripts/build/termux_download.sh
+source "${TERMUX_SCRIPTDIR}/scripts/build/termux_download.sh"
+
+source "${TERMUX_SCRIPTDIR}/scripts/build/get_source/termux_download_source_mirror.sh"
+
+# Some package scripts require these extra variables
+TERMUX_ARCH=aarch64
+TERMUX_PREFIX=/data/data/com.termux/files
+
+mkdir -p ${DOWNLOAD_DIR}
+if [ "$COMMAND" = "download" ]; then
+  rm -f ${DOWNLOAD_DIR}/download-failed.txt
+elif [ "$COMMAND" = "upload" ] || [ "$COMMAND" = "clean" ]; then
+  rm -f ${DOWNLOAD_DIR}/list-*.txt ${DOWNLOAD_DIR}/list-*.sha256 ${DOWNLOAD_DIR}/upload-failed.txt
+fi
+
+total_packages=$(find packages x11-packages root-packages -mindepth 1 -maxdepth 1 -type d | sort)
+no_of_total_packages=$(echo "${total_packages}" | wc -l)
+count=0
+
+command_download() {
+  if [ -f "${DOWNLOAD_DIR}/${mirror_name}/${source_file}" ]; then
+    echo "${count}/${no_of_total_packages}: Archive already downloaded: ${url}"
+    return 0
+  fi
+
+  if [[ "${url}" =~ ^git[+]https://.* ]]; then
+    rm -rf "${TERMUX_PKG_TMPDIR}/${TERMUX_PKG_NAME}"
+    mkdir -p "${TERMUX_PKG_TMPDIR}/${TERMUX_PKG_NAME}"
+    git clone \
+        --depth 1 \
+        --branch "${TERMUX_PKG_GIT_BRANCH:-v${TERMUX_PKG_VERSION#*:}}" \
+        "${url:4}" \
+        "${TERMUX_PKG_TMPDIR}/${TERMUX_PKG_NAME}/src" \
+      && git \
+        -C "${TERMUX_PKG_TMPDIR}/${TERMUX_PKG_NAME}/src" \
+        submodule update --init --recursive --depth=1 \
+      && tar --xz \
+        -f "${TERMUX_PKG_TMPDIR}/${source_file}" \
+        -C "${TERMUX_PKG_TMPDIR}/${TERMUX_PKG_NAME}/src" \
+        -c . \
+      && mv -f "${TERMUX_PKG_TMPDIR}/${source_file}" \
+        "${DOWNLOAD_DIR}/${mirror_name}/${source_file}" \
+      && rm -rf "${TERMUX_PKG_TMPDIR}/${TERMUX_PKG_NAME}" \
+      || echo "${source_file} git clone --depth=1 --branch ${TERMUX_PKG_GIT_BRANCH:-v${TERMUX_PKG_VERSION#*:}} ${url:4} src && git -C src submodule update --init --recursive --depth=1 && tar -c --xz -C src -f ${source_file} ." \
+        >> "${DOWNLOAD_DIR}/download-failed.txt" &
+  elif [ -n "${url}" ]; then
+    echo "${count}/${no_of_total_packages}: Downloading ${url}"
+    mkdir -p ${DOWNLOAD_DIR}/${mirror_name}
+    termux_download_source_mirror \
+        "${TERMUX_PKG_NAME}" \
+        "${url}" \
+        "${DOWNLOAD_DIR}/${mirror_name}/${source_file}" \
+        "${sha256}" \
+      || termux_download \
+        "${url}" \
+        "${DOWNLOAD_DIR}/${mirror_name}/${source_file}" \
+        "${sha256}" \
+      || echo "${source_file} ${url}" \
+        >> "${DOWNLOAD_DIR}/download-failed.txt" &
+  fi
+}
+
+command_upload() {
+  if [ ! -f "${DOWNLOAD_DIR}/${mirror_name}/${source_file}" ]; then
+    echo "${source_file} is not downloaded, skipping" | tee -a "${DOWNLOAD_DIR}/upload-failed.txt"
+    return
+  fi
+
+  echo "${count}/${no_of_total_packages}: ${source_file}"
+  if [ ! -e "${DOWNLOAD_DIR}/list-${mirror_name}.txt" ]; then
+    gh release view --json assets --jq '.assets[].name' ${mirror_name} > "${DOWNLOAD_DIR}/list-${mirror_name}.txt" || exit 1
+    gh release view --json assets ${mirror_name} | jq -r '.assets[] | "\(.digest)  \(.name)"' \
+      | sed 's/^sha256://g' > "${DOWNLOAD_DIR}/list-${mirror_name}.sha256" || exit 1
+  fi
+
+  # TODO: check uploaded file checksum and re-upload if it does not match
+  ACTUAL_CHECKSUM=$(sha256sum "${DOWNLOAD_DIR}/${mirror_name}/${source_file}" | cut -d' ' -f1)
+  UPLOAD_CHECKSUM=$(grep -F " ${source_file}" "${DOWNLOAD_DIR}/list-${mirror_name}.sha256" | cut -d' ' -f1)
+  if [ "$sha256" = "SKIP_CHECKSUM" ] || [[ "${url}" =~ ^git[+]https://.* ]]; then
+    echo "Checksum check skipped"
+    if [ -n "$UPLOAD_CHECKSUM" ]; then
+      echo "File is already uploaded, skipping"
+      return
+    fi
+  elif [ "$sha256" != "$ACTUAL_CHECKSUM" ]; then
+    echo "${source_file} checksum is wrong for the local file, skipping" | tee -a "${DOWNLOAD_DIR}/upload-failed.txt"
+    return
+  elif [ "$sha256" = "$UPLOAD_CHECKSUM" ]; then
+    echo "File is already uploaded and the checksum matches, skipping"
+    return
+  elif [ -n "$UPLOAD_CHECKSUM" ]; then
+    echo "${source_file} uploaded file checksum is wrong, uploading the file again"
+  fi
+
+  pushd "${DOWNLOAD_DIR}/${mirror_name}" >/dev/null
+  gh release upload --clobber "${mirror_name}" "${source_file}" \
+    || echo "${source_file} upload failed" | tee -a "${DOWNLOAD_DIR}/upload-failed.txt"
+  popd >/dev/null
+}
+
+command_clean() {
+  echo "${count}/${no_of_total_packages}: ${source_file}"
+  if [ ! -e "${DOWNLOAD_DIR}/list-${mirror_name}.txt" ]; then
+    gh release view --json assets --jq '.assets[].name' ${mirror_name} > "${DOWNLOAD_DIR}/list-${mirror_name}.txt" || exit 1
+  fi
+  grep -Fxv "${source_file}" "${DOWNLOAD_DIR}/list-${mirror_name}.txt" > "${DOWNLOAD_DIR}/list-${mirror_name}.txt.new"
+  mv -f "${DOWNLOAD_DIR}/list-${mirror_name}.txt.new" "${DOWNLOAD_DIR}/list-${mirror_name}.txt"
+}
+
+for pkg in ${total_packages}; do
+  while [ $(jobs -rp | wc -l) -ge ${PARALLEL_DOWNLOADS} ]; do
+    sleep 1
+  done
+
+  count=$(expr ${count} + 1)
+
+  unset TERMUX_PKG_SRCURL
+  unset TERMUX_PKG_GIT_BRANCH
+  unset TERMUX_PKG_VERSION
+  unset TERMUX_PKG_SHA256
+
+  source "${pkg}/build.sh"
+
+  TERMUX_PKG_NAME="$(basename ${pkg})"
+  mirror_name="$(termux_get_source_mirror_name ${TERMUX_PKG_NAME})"
+
+  if [ "${TERMUX_PKG_NAME}" = "aapt" ]; then
+    echo "aapt git archive is bigger than 2 gigabytes and cannot be uploaded to Github source mirror"
+    continue
+  elif [ "${TERMUX_PKG_NAME}" = "angle-android" ]; then
+    echo "angle-android package points to the invalid git branch and instead clones the whole repo in the custom build step"
+    continue
+  fi
+
+  # TERMUX_PKG_SRCURL is actually an archive, loop through it
+  PKG_SRCURL=(${TERMUX_PKG_SRCURL[@]})
+  PKG_SHA256=(${TERMUX_PKG_SHA256[@]})
+
+  for i in $(seq 0 $(( ${#PKG_SRCURL[@]}-1 ))); do
+    sha256="${PKG_SHA256[$i]:-SKIP_CHECKSUM}"
+    url="${PKG_SRCURL[$i]}"
+    source_file="${TERMUX_PKG_NAME}_$(basename ${url})"
+    if [[ "${url}" =~ ^git[+]https://.* ]]; then
+      source_file="${TERMUX_PKG_NAME}_${TERMUX_PKG_GIT_BRANCH:-v${TERMUX_PKG_VERSION#*:}}.tar.xz"
+    fi
+
+    if [ "$COMMAND" = "download" ]; then
+      command_download
+    elif [ "$COMMAND" = "upload" ]; then
+      command_upload
+    elif [ "$COMMAND" = "clean" ]; then
+      command_clean
+    fi
+  done
+done
+
+wait
+
+if [ "$COMMAND" = "download" ]; then
+  if [ -f "${DOWNLOAD_DIR}/download-failed.txt" ]; then
+    echo "====="
+    echo "Download failed for following packages:"
+    echo "====="
+    cat "${DOWNLOAD_DIR}/download-failed.txt"
+    echo "====="
+    echo "Please download these source archives manually using a web browser,"
+    echo "rename downloaded file as specified here, and upload to source mirror."
+    echo "====="
+  else
+    echo "====="
+    echo "All source archives are downloaded to disk"
+    echo "====="
+  fi
+elif [ "$COMMAND" = "upload" ]; then
+  if [ -f "${DOWNLOAD_DIR}/upload-failed.txt" ]; then
+    echo "====="
+    echo "Upload failed for following packages:"
+    echo "====="
+    cat "${DOWNLOAD_DIR}/upload-failed.txt"
+    echo "====="
+  else
+    echo "====="
+    echo "All source archives are uploaded to source mirror"
+    echo "====="
+  fi
+  rm -f ${DOWNLOAD_DIR}/list-*.txt ${DOWNLOAD_DIR}/list-*.sha256 ${DOWNLOAD_DIR}/upload-failed.txt
+elif [ "$COMMAND" = "clean" ]; then
+  for list_file in ${DOWNLOAD_DIR}/list-*.txt; do
+    mirror_name="$(basename ${list_file} | sed -E 's/list-(.*)[.]txt/\1/')"
+    echo "====="
+    echo "Removing outdated source archives from source mirror ${mirror_name}:"
+    cat "${list_file}" | while read source_file; do
+      echo "${source_file}"
+      gh release delete-asset -y "${mirror_name}" "${source_file}"
+    done
+  done
+  echo "====="
+  echo "Done"
+  echo "====="
+  rm -f ${DOWNLOAD_DIR}/list-*.txt ${DOWNLOAD_DIR}/list-*.sha256
+fi
+
+rm -rf ${TERMUX_PKG_TMPDIR}

--- a/scripts/bin/source-mirror
+++ b/scripts/bin/source-mirror
@@ -1,0 +1,241 @@
+#!/bin/bash
+
+export TERMUX_SCRIPTDIR
+TERMUX_SCRIPTDIR=$(realpath "$(dirname "$0")/../..") # Root of repository."
+DOWNLOAD_DIR="${TERMUX_SCRIPTDIR}/source-mirror"
+
+if [[ $# != 1 ]]; then
+  echo "Usage:"
+  echo "$0 download      Download all source archives to directory ${DOWNLOAD_DIR}"
+  echo "$0 upload        Upload source archives to Github releases from directory ${DOWNLOAD_DIR}"
+  echo "$0 clean         Remove all obsolete source archives from Github releases"
+  exit 0
+fi
+
+COMMAND="$1"
+if [[ "$COMMAND" != "download" && "$COMMAND" != "upload" && "$COMMAND" != "clean" ]]; then
+  echo "Invalid command"
+  exit 1
+fi
+
+cd "${TERMUX_SCRIPTDIR}" || exit 1
+
+TERMUX_PKG_TMPDIR=${TERMUX_SCRIPTDIR}/tmp
+PARALLEL_DOWNLOADS=10
+
+rm -rf ${TERMUX_PKG_TMPDIR}
+mkdir -p ${TERMUX_PKG_TMPDIR}
+
+# Utility function to download a resource with an expected checksum.
+# shellcheck source=scripts/build/termux_download.sh
+source "${TERMUX_SCRIPTDIR}/scripts/build/termux_download.sh"
+
+source "${TERMUX_SCRIPTDIR}/scripts/build/get_source/termux_download_source_mirror.sh"
+
+# Some package scripts require these extra variables
+TERMUX_ARCH=aarch64
+TERMUX_PREFIX=/data/data/com.termux/files
+
+mkdir -p ${DOWNLOAD_DIR}
+if [[ "$COMMAND" == "download" ]]; then
+  rm -f ${DOWNLOAD_DIR}/download-failed.txt
+elif [[ "$COMMAND" == "upload" || "$COMMAND" == "clean" ]]; then
+  rm -f ${DOWNLOAD_DIR}/list-*.txt ${DOWNLOAD_DIR}/list-*.sha256 ${DOWNLOAD_DIR}/upload-failed.txt
+fi
+
+total_packages=$(find packages x11-packages root-packages -mindepth 1 -maxdepth 1 -type d | sort)
+no_of_total_packages=$(echo "${total_packages}" | wc -l)
+count=0
+
+command_download() {
+  if [[ -f "${DOWNLOAD_DIR}/${mirror_name}/${source_file}" ]]; then
+    echo "${count}/${no_of_total_packages}: Archive already downloaded: ${url}"
+    return 0
+  fi
+
+  if [[ "${url}" =~ ^git[+]https://.* ]]; then
+    rm -rf "${TERMUX_PKG_TMPDIR}/${TERMUX_PKG_NAME}"
+    mkdir -p "${TERMUX_PKG_TMPDIR}/${TERMUX_PKG_NAME}"
+    git clone \
+        --depth 1 \
+        --branch "${TERMUX_PKG_GIT_BRANCH:-v${TERMUX_PKG_VERSION#*:}}" \
+        "${url:4}" \
+        "${TERMUX_PKG_TMPDIR}/${TERMUX_PKG_NAME}/src" \
+      && git \
+        -C "${TERMUX_PKG_TMPDIR}/${TERMUX_PKG_NAME}/src" \
+        submodule update --init --recursive --depth=1 \
+      && tar --xz \
+        -f "${TERMUX_PKG_TMPDIR}/${source_file}" \
+        -C "${TERMUX_PKG_TMPDIR}/${TERMUX_PKG_NAME}/src" \
+        -c . \
+      && mv -f "${TERMUX_PKG_TMPDIR}/${source_file}" \
+        "${DOWNLOAD_DIR}/${mirror_name}/${source_file}" \
+      && rm -rf "${TERMUX_PKG_TMPDIR}/${TERMUX_PKG_NAME}" \
+      || echo "${source_file} git clone --depth=1 --branch ${TERMUX_PKG_GIT_BRANCH:-v${TERMUX_PKG_VERSION#*:}} ${url:4} src && git -C src submodule update --init --recursive --depth=1 && tar -c --xz -C src -f ${source_file} ." \
+        >> "${DOWNLOAD_DIR}/download-failed.txt" &
+  elif [[ -n "${url}" ]]; then
+    echo "${count}/${no_of_total_packages}: Downloading ${url}"
+    mkdir -p ${DOWNLOAD_DIR}/${mirror_name}
+    termux_download_source_mirror \
+        "${TERMUX_PKG_NAME}" \
+        "${url}" \
+        "${DOWNLOAD_DIR}/${mirror_name}/${source_file}" \
+        "${sha256}" \
+      || termux_download \
+        "${url}" \
+        "${DOWNLOAD_DIR}/${mirror_name}/${source_file}" \
+        "${sha256}" \
+      || echo "${source_file} ${url}" \
+        >> "${DOWNLOAD_DIR}/download-failed.txt" &
+  fi
+}
+
+command_upload() {
+  if [[ ! -f "${DOWNLOAD_DIR}/${mirror_name}/${source_file}" ]]; then
+    echo "${source_file} is not downloaded, skipping" | tee -a "${DOWNLOAD_DIR}/upload-failed.txt"
+    return
+  fi
+
+  echo "${count}/${no_of_total_packages}: ${source_file}"
+  if [[ ! -e "${DOWNLOAD_DIR}/list-${mirror_name}.txt" ]]; then
+    gh release view --json assets --jq '.assets[].name' ${mirror_name} > "${DOWNLOAD_DIR}/list-${mirror_name}.txt" || exit 1
+    gh release view --json assets ${mirror_name} | jq -r '.assets[] | "\(.digest)  \(.name)"' \
+      | sed 's/^sha256://g' > "${DOWNLOAD_DIR}/list-${mirror_name}.sha256" || exit 1
+  fi
+
+  # TODO: check uploaded file checksum and re-upload if it does not match
+  ACTUAL_CHECKSUM=$(sha256sum "${DOWNLOAD_DIR}/${mirror_name}/${source_file}" | cut -d' ' -f1)
+  UPLOAD_CHECKSUM=$(grep -F " ${source_file}" "${DOWNLOAD_DIR}/list-${mirror_name}.sha256" | cut -d' ' -f1)
+  if [[ "$sha256" == "SKIP_CHECKSUM" || "${url}" =~ ^git[+]https://.* ]]; then
+    echo "Checksum check skipped"
+    if [[ -n "$UPLOAD_CHECKSUM" ]]; then
+      echo "File is already uploaded, skipping"
+      return
+    fi
+  elif [[ "$sha256" != "$ACTUAL_CHECKSUM" ]]; then
+    echo "${source_file} checksum is wrong for the local file, skipping" | tee -a "${DOWNLOAD_DIR}/upload-failed.txt"
+    return
+  elif [[ "$sha256" == "$UPLOAD_CHECKSUM" ]]; then
+    echo "File is already uploaded and the checksum matches, skipping"
+    return
+  elif [[ -n "$UPLOAD_CHECKSUM" ]]; then
+    echo "${source_file} uploaded file checksum is wrong, uploading the file again"
+  fi
+
+  pushd "${DOWNLOAD_DIR}/${mirror_name}" >/dev/null
+  gh release upload --clobber "${mirror_name}" "${source_file}" \
+    || echo "${source_file} upload failed" | tee -a "${DOWNLOAD_DIR}/upload-failed.txt"
+  popd >/dev/null
+}
+
+command_clean() {
+  echo "${count}/${no_of_total_packages}: ${source_file}"
+  if [[ ! -e "${DOWNLOAD_DIR}/list-${mirror_name}.txt" ]]; then
+    gh release view --json assets --jq '.assets[].name' ${mirror_name} > "${DOWNLOAD_DIR}/list-${mirror_name}.txt" || exit 1
+  fi
+  grep -Fxv "${source_file}" "${DOWNLOAD_DIR}/list-${mirror_name}.txt" > "${DOWNLOAD_DIR}/list-${mirror_name}.txt.new"
+  mv -f "${DOWNLOAD_DIR}/list-${mirror_name}.txt.new" "${DOWNLOAD_DIR}/list-${mirror_name}.txt"
+}
+
+for pkg in ${total_packages}; do
+  while [[ $(jobs -rp | wc -l) -ge ${PARALLEL_DOWNLOADS} ]]; do
+    sleep 1
+  done
+
+  count=$((count += 1))
+
+  unset TERMUX_PKG_SRCURL
+  unset TERMUX_PKG_GIT_BRANCH
+  unset TERMUX_PKG_VERSION
+  unset TERMUX_PKG_SHA256
+
+  source "${pkg}/build.sh"
+
+  TERMUX_PKG_NAME="$(basename ${pkg})"
+  mirror_name="$(termux_get_source_mirror_name ${TERMUX_PKG_NAME})"
+
+  if [[ "${TERMUX_PKG_NAME}" == "aapt" ]]; then
+    echo "aapt git archive is bigger than 2 gigabytes and cannot be uploaded to Github source mirror"
+    continue
+  elif [[ "${TERMUX_PKG_NAME}" == "angle-android" ]]; then
+    echo "angle-android package points to the invalid git branch and instead clones the whole repo in the custom build step"
+    continue
+  fi
+
+  # TERMUX_PKG_SRCURL is actually an archive, loop through it
+  PKG_SRCURL=("${TERMUX_PKG_SRCURL[@]}")
+  PKG_SHA256=("${TERMUX_PKG_SHA256[@]}")
+
+  for i in $(seq 0 $(( ${#PKG_SRCURL[@]}-1 ))); do
+    sha256="${PKG_SHA256[$i]:-SKIP_CHECKSUM}"
+    url="${PKG_SRCURL[$i]}"
+    source_file="${TERMUX_PKG_NAME}_$(basename ${url})"
+    if [[ "${url}" =~ ^git[+]https://.* ]]; then
+      source_file="${TERMUX_PKG_NAME}_${TERMUX_PKG_GIT_BRANCH:-v${TERMUX_PKG_VERSION#*:}}.tar.xz"
+    fi
+
+    case "$COMMAND" in
+      "download")
+        command_download
+        ;;
+      "upload")
+        command_upload
+        ;;
+      "clean")
+        command_clean
+        ;;
+    esac
+  done
+done
+
+wait
+
+case "$COMMAND" in
+  "download")
+    if [[ -f "${DOWNLOAD_DIR}/download-failed.txt" ]]; then
+      echo "====="
+      echo "Download failed for following packages:"
+      echo "====="
+      cat "${DOWNLOAD_DIR}/download-failed.txt"
+      echo "====="
+      echo "Please download these source archives manually using a web browser,"
+      echo "rename downloaded file as specified here, and upload to source mirror."
+      echo "====="
+    else
+      echo "====="
+      echo "All source archives are downloaded to disk"
+      echo "====="
+    fi
+  ;;
+  "upload")
+    if [[ -f "${DOWNLOAD_DIR}/upload-failed.txt" ]]; then
+      echo "====="
+      echo "Upload failed for following packages:"
+      echo "====="
+      cat "${DOWNLOAD_DIR}/upload-failed.txt"
+      echo "====="
+    else
+      echo "====="
+      echo "All source archives are uploaded to source mirror"
+      echo "====="
+    fi
+    rm -f ${DOWNLOAD_DIR}/list-*.txt ${DOWNLOAD_DIR}/list-*.sha256 ${DOWNLOAD_DIR}/upload-failed.txt
+  ;;
+  "clean")
+    for list_file in ${DOWNLOAD_DIR}/list-*.txt; do
+      mirror_name="$(basename ${list_file} | sed -E 's/list-(.*)[.]txt/\1/')"
+      echo "====="
+      echo "Removing outdated source archives from source mirror ${mirror_name}:"
+      cat "${list_file}" | while read source_file; do
+        echo "${source_file}"
+        gh release delete-asset -y "${mirror_name}" "${source_file}"
+      done
+    done
+    echo "====="
+    echo "Done"
+    echo "====="
+    rm -f ${DOWNLOAD_DIR}/list-*.txt ${DOWNLOAD_DIR}/list-*.sha256
+  ;;
+esac
+
+rm -rf ${TERMUX_PKG_TMPDIR}

--- a/scripts/build/get_source/termux_download_source_mirror.sh
+++ b/scripts/build/get_source/termux_download_source_mirror.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/bash
+
+# Use Github releases as source file mirrors.
+# Github limits the amount of files in a single release to 1000, so we need several mirrors.
+# The repository should have releases and git tags with following names:
+# source-mirror-lib
+# source-mirror-0-9-a-d
+# source-mirror-e-j
+# source-mirror-k-m
+# source-mirror-n-p
+# source-mirror-q-s
+# source-mirror-t-z
+# Packages are sorted into the mirror by the first letter of the package name,
+# with 'lib' a separate category.
+# Source files are named as <package_name>-<last_element_of_download_url>,
+# so it's easy to sort by name and remove outdated source files,
+# and the download URL generally contains package version
+# and the archive file extension (.tar.gz or .tar.xz or .zip).
+# When downloading from the mirror, the file checksum is verified as with regular download.
+# Git repositories (with URL git+https://) are archived into .tar.xz file,
+# Git commit hash is not checked - some packages implement such checks
+# inside termux_step_post_get_source() in ad-hoc and unreliable way.
+# Termux packages count divided by the name as of 2026-07-22:
+# lib: 550
+# 0-9,a-d: 448
+# e-j: 473
+# k-m: 496
+# n-p: 353
+# q-s: 334
+# t-z: 463
+
+termux_get_source_mirror_name() {
+	if [[ $# != 1 ]]; then
+		echo "termux_get_source_mirror_name(): Invalid arguments - expected <PACKAGE>" 1>&2
+		return 1
+	fi
+	if [[ "$1" =~ ^lib.* ]]; then
+		echo "source-mirror-lib"
+	elif [[ "$1" =~ ^[0-9a-d].* ]]; then
+		echo "source-mirror-0-9-a-d"
+	elif [[ "$1" =~ ^[e-j].* ]]; then
+		echo "source-mirror-e-j"
+	elif [[ "$1" =~ ^[k-m].* ]]; then
+		echo "source-mirror-k-m"
+	elif [[ "$1" =~ ^[n-p].* ]]; then
+		echo "source-mirror-n-p"
+	elif [[ "$1" =~ ^[q-s].* ]]; then
+		echo "source-mirror-q-s"
+	elif [[ "$1" =~ ^[t-z].* ]]; then
+		echo "source-mirror-t-z"
+	else
+		echo "termux_get_source_mirror_name(): Invalid package name $1" 1>&2
+		return 1
+	fi
+}
+
+termux_download_source_mirror() {
+	local SOURCE_MIRROR_BASE_URL="https://github.com/termux/termux-packages/releases/download"
+
+	if [[ $# != 3 ]] && [[ $# != 4 ]]; then
+		echo "termux_download_source_mirror(): Invalid arguments - expected <PACKAGE> <URL> <DESTINATION> [<CHECKSUM>]" 1>&2
+		return 1
+	fi
+	local PKG="$1"
+	local PKG_URL="$2"
+	local DESTINATION="$3"
+	local CHECKSUM="${4:-SKIP_CHECKSUM}"
+	local SOURCE_MIRROR_NAME="$(termux_get_source_mirror_name ${PKG})"
+	local SOURCE_MIRROR_URL="${SOURCE_MIRROR_BASE_URL}/${SOURCE_MIRROR_NAME}/${PKG}_$(basename ${PKG_URL})"
+
+	# Same as termux_download but without retries, and with partial download enabled
+	if [ -f "$DESTINATION" ] && [ "$CHECKSUM" != "SKIP_CHECKSUM" ]; then
+		# Keep existing file if checksum matches.
+		local EXISTING_CHECKSUM
+		EXISTING_CHECKSUM=$(sha256sum "$DESTINATION" | cut -d' ' -f1)
+		[[ "$EXISTING_CHECKSUM" == "$CHECKSUM" ]] && return
+	fi
+
+	local TMPFILE
+	local -a CURL_OPTIONS=(
+		--fail               # Consider 4xx and 5xx responses as failures
+		--retry 5            # Retry up to 5 times on transient failures
+		--retry-connrefused  # Also retry on refused connections
+		--retry-delay 5      # Wait 5 seconds between retries
+		--connect-timeout 30 # Wait at most 30 seconds for a connection to be established
+		--retry-max-time 120 # Stop retrying if it's still failing after 120 seconds
+		--speed-limit 1000   # Expect at least 1000 Bytes per second
+		--speed-time 60      # Fail if the minimum speed isn't met for at least 60 seconds
+		--location           # Follow redirects
+		--continue-at -      # Resume interrupted download from the middle
+	)
+	TMPFILE=$(mktemp "$TERMUX_PKG_TMPDIR/download.${TERMUX_PKG_NAME-unnamed}.XXXXXXXXX")
+	if [[ "${TERMUX_QUIET_BUILD-}" == "true" ]]; then
+		CURL_OPTIONS+=(--no-progress-meter) # Don't print out transfer statistics
+	fi
+
+	echo "Downloading ${SOURCE_MIRROR_URL}"
+	if ! curl "${CURL_OPTIONS[@]}" --output "${TMPFILE}" "${SOURCE_MIRROR_URL}"; then
+		echo "Failed to download ${SOURCE_MIRROR_URL}" 1>&2
+		return 1
+	fi
+
+	local ACTUAL_CHECKSUM
+	ACTUAL_CHECKSUM=$(sha256sum "$TMPFILE" | cut -d' ' -f1)
+	if [[ -z "$CHECKSUM" ]]; then
+		printf "WARNING: No checksum check for %s:\nActual: %s\n" \
+			"$SOURCE_MIRROR_URL" "$ACTUAL_CHECKSUM"
+	elif [[ "$CHECKSUM" == "SKIP_CHECKSUM" ]]; then
+		:
+	elif [[ "$CHECKSUM" != "$ACTUAL_CHECKSUM" ]]; then
+		printf "Wrong checksum for %s\nExpected: %s\nActual:   %s\n" \
+			"$SOURCE_MIRROR_URL" "$CHECKSUM" "$ACTUAL_CHECKSUM" 1>&2
+		return 1
+	fi
+	mv "$TMPFILE" "$DESTINATION"
+	return 0
+}
+
+# Make script standalone executable as well as sourceable
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	if [ "$1" = "--mirror-name" ]; then
+		termux_get_source_mirror_name "$2"
+	else
+		termux_download_source_mirror "$@"
+	fi
+fi

--- a/scripts/build/get_source/termux_download_src_archive.sh
+++ b/scripts/build/get_source/termux_download_src_archive.sh
@@ -7,10 +7,14 @@ termux_download_src_archive() {
 
 	for i in $(seq 0 $(( ${#PKG_SRCURL[@]}-1 ))); do
 		local file="$TERMUX_PKG_CACHEDIR/$(basename "${PKG_SRCURL[$i]}")"
-		if [ "${PKG_SHA256[$i]:-}" == "" ]; then
-			termux_download "${PKG_SRCURL[$i]}" "$file"
-		else
-			termux_download "${PKG_SRCURL[$i]}" "$file" "${PKG_SHA256[$i]}"
+		if termux_download_source_mirror "${TERMUX_PKG_NAME}" \
+				"${PKG_SRCURL[$i]}" "$file" "${PKG_SHA256[$i]:-SKIP_CHECKSUM}"; then
+			true
+		elif termux_download "${PKG_SRCURL[$i]}" "$file" "${PKG_SHA256[$i]:-SKIP_CHECKSUM}"; then
+			if [ "$TERMUX_COPY_TO_SOURCE_MIRROR" = "true" ]; then
+				mkdir -p "${TERMUX_OUTPUT_DIR}/source"
+				cp -f "$file" "${TERMUX_OUTPUT_DIR}/source/${TERMUX_PKG_NAME}_$(basename ${PKG_SRCURL[$i]})"
+			fi
 		fi
 	done
 }

--- a/scripts/build/get_source/termux_git_clone_src.sh
+++ b/scripts/build/get_source/termux_git_clone_src.sh
@@ -43,33 +43,51 @@ termux_git_clone_src() {
 		echo "Downloading git source ${termux_pkg_branch_flags[1]:+"with branch '${termux_pkg_branch_flags[1]}' "}from '$termux_pkg_srcurl'"
 
 		rm -rf "$TMP_CHECKOUT"
-		git clone \
-			--depth 1 \
-			"${termux_pkg_branch_flags[@]}" \
-			"$termux_pkg_srcurl" \
-			"$TMP_CHECKOUT"
 
-		# Workaround some bad server behaviour
-		# error: Server does not allow request for unadvertised object commit_no
-		# fatal: Fetched in submodule 'submodule_path', but it did not contain commit_no. Direct fetching of that commit failed.
-		if ! git -C "$TMP_CHECKOUT" submodule update --init --recursive --depth=1; then
-			local depth=10
-			local maxdepth=100
-			sleep 1
-			while :; do
-				echo "WARN: Retrying with max depth $depth"
-				if git -C "$TMP_CHECKOUT" \
-					-c 'url.https://github.com/.insteadOf=git@github.com:' \
-					submodule update --init --recursive \
-					--depth="$depth"; then
-					break
-				fi
-				if (( depth > maxdepth )); then
-					termux_error_exit "Failed to clone submodule"
-				fi
-				(( depth += 10 ))
+		local git_archive="$(basename ${termux_pkg_srcurl})_${termux_pkg_branch_flags[1]}.tar.xz"
+		if termux_download_source_mirror "${TERMUX_PKG_NAME}" \
+				"${termux_pkg_branch_flags[1]}.tar.xz" \
+				"$TERMUX_PKG_CACHEDIR/$git_archive"; then
+			mkdir -p "$TMP_CHECKOUT"
+			tar -x --xz -C "$TMP_CHECKOUT" -f "$TERMUX_PKG_CACHEDIR/$git_archive" || return 1
+		else
+			git clone \
+				--depth 1 \
+				"${termux_pkg_branch_flags[@]}" \
+				"$termux_pkg_srcurl" \
+				"$TMP_CHECKOUT"
+
+			# Workaround some bad server behaviour
+			# error: Server does not allow request for unadvertised object commit_no
+			# fatal: Fetched in submodule 'submodule_path', but it did not contain commit_no. Direct fetching of that commit failed.
+			if ! git -C "$TMP_CHECKOUT" submodule update --init --recursive --depth=1; then
+				local depth=10
+				local maxdepth=100
 				sleep 1
-			done
+				while :; do
+					echo "WARN: Retrying with max depth $depth"
+					if git -C "$TMP_CHECKOUT" \
+						-c 'url.https://github.com/.insteadOf=git@github.com:' \
+						submodule update --init --recursive \
+						--depth="$depth"; then
+						break
+					fi
+					if (( depth > maxdepth )); then
+						termux_error_exit "Failed to clone submodule"
+					fi
+					(( depth += 10 ))
+				sleep 1
+				done
+			fi
+
+			if [ "$TERMUX_COPY_TO_SOURCE_MIRROR" = "true" ]; then
+				if [ "${TERMUX_PKG_NAME}" = "aapt" ]; then
+					echo "aapt git archive is bigger than 2 gigabytes and cannot be uploaded to Github source mirror"
+				else
+					mkdir -p "$TERMUX_OUTPUT_DIR/source"
+					tar -c -C "$TMP_CHECKOUT" . | xz -T0 > "${TERMUX_OUTPUT_DIR}/source/$git_archive" || exit 1
+				fi
+			fi
 		fi
 
 		echo "$TERMUX_PKG_VERSION" > "$TMP_CHECKOUT_VERSION"

--- a/scripts/build/get_source/termux_git_clone_src.sh
+++ b/scripts/build/get_source/termux_git_clone_src.sh
@@ -39,38 +39,54 @@ termux_git_clone_src() {
 		fi
 
 		echo "Downloading git source $([[ "$termux_pkg_branch_flags" != "" ]] && echo "with branch '${termux_pkg_branch_flags:9}' ")from '$termux_pkg_srcurl'"
-
 		rm -rf "$TMP_CHECKOUT"
-		git clone \
-			--depth 1 \
-			$termux_pkg_branch_flags \
-			"$termux_pkg_srcurl" \
-			"$TMP_CHECKOUT"
 
-		pushd "$TMP_CHECKOUT"
+		local git_archive="$(basename ${termux_pkg_srcurl})_${TERMUX_PKG_GIT_BRANCH:-v${TERMUX_PKG_VERSION#*:}}.tar.xz"
+		if termux_download_source_mirror "${TERMUX_PKG_NAME}" \
+				"${TERMUX_PKG_GIT_BRANCH:-v${TERMUX_PKG_VERSION#*:}}.tar.xz" \
+				"$TERMUX_PKG_CACHEDIR/$git_archive"; then
+			mkdir -p "$TMP_CHECKOUT"
+			tar -x --xz -C "$TMP_CHECKOUT" -f "$TERMUX_PKG_CACHEDIR/$git_archive" || return 1
+		else
+			git clone \
+				--depth 1 \
+				$termux_pkg_branch_flags \
+				"$termux_pkg_srcurl" \
+				"$TMP_CHECKOUT"
 
-		# Workaround some bad server behaviour
-		# error: Server does not allow request for unadvertised object commit_no
-		# fatal: Fetched in submodule 'submodule_path', but it did not contain commit_no. Direct fetching of that commit failed.
-		if ! git submodule update --init --recursive --depth=1; then
-			local depth=10
-			local maxdepth=100
-			sleep 1
-			while :; do
-				echo "WARN: Retrying with max depth $depth"
-				if git submodule update --init --recursive --depth=$depth; then
-					break
-				fi
-				if [[ "$depth" -gt "$maxdepth" ]]; then
-					termux_error_exit "Failed to clone submodule"
-				fi
-				depth=$((depth+10))
+			pushd "$TMP_CHECKOUT"
+
+			# Workaround some bad server behaviour
+			# error: Server does not allow request for unadvertised object commit_no
+			# fatal: Fetched in submodule 'submodule_path', but it did not contain commit_no. Direct fetching of that commit failed.
+			if ! git submodule update --init --recursive --depth=1; then
+				local depth=10
+				local maxdepth=100
 				sleep 1
-			done
+				while :; do
+					echo "WARN: Retrying with max depth $depth"
+					if git submodule update --init --recursive --depth=$depth; then
+						break
+					fi
+					if [[ "$depth" -gt "$maxdepth" ]]; then
+						termux_error_exit "Failed to clone submodule"
+					fi
+					depth=$((depth+10))
+					sleep 1
+				done
+			fi
+
+			popd
+
+			if [ "$TERMUX_COPY_TO_SOURCE_MIRROR" = "true" ]; then
+				if [ "${TERMUX_PKG_NAME}" = "aapt" ]; then
+					echo "aapt git archive is bigger than 2 gigabytes and cannot be uploaded to Github source mirror"
+				else
+					mkdir -p "$TERMUX_OUTPUT_DIR/source"
+					tar -c -C "$TMP_CHECKOUT" . | xz -T0 > "${TERMUX_OUTPUT_DIR}/source/$git_archive" || exit 1
+				fi
+			fi
 		fi
-
-		popd
-
 		echo "$TERMUX_PKG_VERSION" > "$TMP_CHECKOUT_VERSION"
 	else
 		echo "Skipped downloading of git source from '$termux_pkg_srcurl'"

--- a/scripts/build/termux_step_setup_variables.sh
+++ b/scripts/build/termux_step_setup_variables.sh
@@ -14,6 +14,7 @@ termux_step_setup_variables() {
 	: "${TERMUX_WITHOUT_DEPVERSION_BINDING:="false"}"
 	: "${TERMUX_SKIP_DEPCHECK:="false"}"
 	: "${TERMUX_GLOBAL_LIBRARY:="false"}"
+	: "${TERMUX_COPY_TO_SOURCE_MIRROR:="false"}"
 	: "${TERMUX_TOPDIR:="$HOME/.termux-build"}"
 	: "${TERMUX_PACMAN_PACKAGE_COMPRESSION:="xz"}"
 


### PR DESCRIPTION
Each package built in termux-packages repository using packages.yml workflow will have it's source archive copied to source mirror.

When recompiling the same package, the source archive will be fetched from the source mirror first, and the original source URL will only be accessed if the mirror does not contain the source archive. This will solve a problem when source websites go offline, remove old source archives, or implement anti-AI measures which cause web download in build scripts to fail.

Source archive is implemented by creating specially named Github releases inside termux/termux-packages repository:

source-mirror-0-9-a-d
source-mirror-e-j
source-mirror-k-m
source-mirror-lib
source-mirror-n-p
source-mirror-q-s
source-mirror-t-z

You will have to create Git tags with these names manually, and then create releases from these Git tags on Github webpage, this has to be done only once.

Forks of termux/termux-packages repo will use source mirror from termux/termux-packages.

Run script source-mirror on your PC to download every source archive from the web:

scripts/bin/source-mirror download

The script will print all inaccessible URLs or URLs where checksums does not match with checksums in build.sh, so these packages will either need to be updated, or you need to find the original source archive with matching checksum and upload it to the appropriate Github release manually.

After downloading source archives, run the script to upload them from your PC to Github releases:

scripts/bin/source-mirror upload

A new Github workflow will clean source mirror from the old versions of source archives once per week, but you can do the same from your PC:

scripts/bin/source-mirror clean

Source mirror is split into seven Github releases because Github limits each release to 1000 files. All packages are sorted into groups based on the first letter of the package name, with 'lib' as a separate category. Groups were selected to contain 500 packages or less. As of 2026-07-22, the package count for each group is:

source-mirror-0-9-a-d: 448
source-mirror-e-j: 473
source-mirror-k-m: 496
source-mirror-lib: 550
source-mirror-n-p: 353
source-mirror-q-s: 334
source-mirror-t-z: 463

My fork contains updates to all packages that point to dead websites, deleted source archives,
or archives with changed checksums, there is 31 such package:
https://github.com/pelya/termux-packages
