### PR TITLE
bump(qemu): 11.0.3

### DIFF
--- a/packages/qemu-system-x86-64-headless/0001-fix-hardcoded-paths.patch
+++ b/packages/qemu-system-x86-64-headless/0001-fix-hardcoded-paths.patch
@@ -51,7 +51,7 @@ diff -uNr qemu-8.2.5/contrib/ivshmem-server/main.c qemu-8.2.5.mod/contrib/ivshme
 diff -uNr qemu-8.2.5/hw/hppa/machine.c qemu-8.2.5.mod/hw/hppa/machine.c
 --- qemu-8.2.5/hw/hppa/machine.c	2024-06-10 20:19:05.000000000 +0300
 +++ qemu-8.2.5.mod/hw/hppa/machine.c	2024-06-12 21:43:54.585416673 +0300
-@@ -207,37 +207,37 @@ static FWCfgState *create_fw_cfg(MachineState *ms, PCIBus *pci_bus,
+@@ -219,41 +219,41 @@ static FWCfgState *create_fw_cfg(MachineState *ms, PCIBus *pci_bus,
      fw_cfg_add_i64(fw_cfg, FW_CFG_RAM_SIZE, ms->ram_size);
  
      val = cpu_to_le64(MIN_SEABIOS_HPPA_VERSION);
@@ -73,6 +73,11 @@ diff -uNr qemu-8.2.5/hw/hppa/machine.c qemu-8.2.5.mod/hw/hppa/machine.c
 -    fw_cfg_add_file(fw_cfg, "/etc/hppa/machine",
 +    fw_cfg_add_file(fw_cfg, "@TERMUX_PREFIX@/etc/hppa/machine",
                      g_memdup2(mc->name, len), len);
+ 
+     val = cpu_to_le64(hpm->memsplit_addr);
+-    fw_cfg_add_file(fw_cfg, "/etc/hppa/memsplit-addr",
++    fw_cfg_add_file(fw_cfg, "@TERMUX_PREFIX@/etc/hppa/memsplit-addr",
+                     g_memdup2(&val, sizeof(val)), sizeof(val));
  
      val = cpu_to_le64(soft_power_reg);
 -    fw_cfg_add_file(fw_cfg, "/etc/hppa/power-button-addr",
@@ -133,10 +138,10 @@ diff -uNr qemu-8.2.5/linux-user/syscall.c qemu-8.2.5.mod/linux-user/syscall.c
              snprintf(filename, sizeof(filename), "%s/qemu-open.XXXXXX", tmpdir);
              fd = mkstemp(filename);
              if (fd < 0) {
-diff -uNr qemu-8.2.5/migration/migration.c qemu-8.2.5.mod/migration/migration.c
---- qemu-8.2.5/migration/migration.c	2024-06-10 20:19:05.000000000 +0300
-+++ qemu-8.2.5.mod/migration/migration.c	2024-06-12 21:43:13.393221456 +0300
-@@ -476,7 +476,7 @@
+diff -uNr qemu-8.2.5/migration/channel.c qemu-8.2.5.mod/migration/channel.c
+--- qemu-8.2.5/migration/channel.c	2024-06-10 20:19:05.000000000 +0300
++++ qemu-8.2.5.mod/migration/channel.c	2024-06-12 21:43:13.393221456 +0300
+@@ -364,7 +364,7 @@ bool migrate_uri_parse(const char *uri, MigrationChannel **channel,
          QAPI_LIST_APPEND(tail, g_strdup(exec_get_cmd_path()));
          QAPI_LIST_APPEND(tail, g_strdup("/c"));
  #else

--- a/packages/qemu-system-x86-64-headless/0010-add-missing-arch_prctl.patch
+++ b/packages/qemu-system-x86-64-headless/0010-add-missing-arch_prctl.patch
@@ -1,6 +1,6 @@
-diff -uNr qemu-8.2.5/tcg/i386/tcg-target.c.inc qemu-8.2.5.mod/tcg/i386/tcg-target.c.inc
---- qemu-8.2.5/tcg/i386/tcg-target.c.inc	2024-06-10 20:19:05.000000000 +0300
-+++ qemu-8.2.5.mod/tcg/i386/tcg-target.c.inc	2024-06-12 23:46:41.377731268 +0300
+diff -uNr qemu-8.2.5/tcg/x86_64/tcg-target.c.inc qemu-8.2.5.mod/tcg/x86_64/tcg-target.c.inc
+--- qemu-8.2.5/tcg/x86_64/tcg-target.c.inc	2024-06-10 20:19:05.000000000 +0300
++++ qemu-8.2.5.mod/tcg/x86_64/tcg-target.c.inc	2024-06-12 23:46:41.377731268 +0300
 @@ -1938,7 +1938,11 @@
  #if defined(__x86_64__) && defined(__linux__)
  # include <asm/prctl.h>

--- a/packages/qemu-system-x86-64-headless/0014-disable-signalfd.patch
+++ b/packages/qemu-system-x86-64-headless/0014-disable-signalfd.patch
@@ -1,13 +1,13 @@
 diff -uNr qemu-6.1.0/meson.build qemu-6.1.0.mod/meson.build
 --- qemu-6.1.0/meson.build	2021-08-25 21:20:39.873631512 +0300
 +++ qemu-6.1.0.mod/meson.build	2021-08-25 21:21:35.135670419 +0300
-@@ -2948,9 +2948,6 @@ config_host_data.set('CONFIG_PTHREAD_AFFINITY_NP', cc.links(osdep_prefix + '''
+@@ -2918,9 +2918,6 @@ config_host_data.set('CONFIG_PTHREAD_AFFINITY_NP', cc.links(osdep_prefix + '''
      CPU_FREE(cpuset);
      return 0;
    }''', dependencies: threads))
 -config_host_data.set('CONFIG_SIGNALFD', cc.links(osdep_prefix + '''
 -  #include <sys/signalfd.h>
 -  int main(void) { return signalfd(-1, NULL, SFD_CLOEXEC); }'''))
- config_host_data.set('CONFIG_SPLICE', cc.links(osdep_prefix + '''
-   int main(void)
-   {
+ 
+ config_host_data.set('HAVE_MLOCKALL', cc.links(osdep_prefix + '''
+   #include <sys/mman.h>

--- a/packages/qemu-system-x86-64-headless/0017-shm_open.patch
+++ b/packages/qemu-system-x86-64-headless/0017-shm_open.patch
@@ -66,6 +66,6 @@ https://github.com/termux/termux-packages/pull/17789
 +    return fd;
 +}
 +
- #define MAX_MEM_PREALLOC_THREAD_COUNT 16
+ #define MAX_MEM_PREALLOC_THREAD_COUNT 32
  
  struct MemsetThread;

--- a/packages/qemu-system-x86-64-headless/0018-libnfs-fix.patch
+++ b/packages/qemu-system-x86-64-headless/0018-libnfs-fix.patch
@@ -1,21 +1,18 @@
-diff -uNr qemu-8.2.6/block/nfs.c qemu-8.2.6.mod/block/nfs.c
---- qemu-8.2.6/block/nfs.c	2024-07-16 23:23:46.000000000 +0300
-+++ qemu-8.2.6.mod/block/nfs.c	2024-12-22 14:30:32.265373660 +0200
-@@ -270,11 +270,11 @@
-     NFSRPC task;
- 
-     nfs_co_init_task(bs, &task);
--    task.iov = iov;
- 
-     WITH_QEMU_LOCK_GUARD(&client->mutex) {
+--- a/block/nfs.c
++++ b/block/nfs.c
+@@ -293,9 +293,9 @@ static int coroutine_fn nfs_co_preadv(BlockDriverState *bs, int64_t offset,
+                             buf, bytes, offset,
+                             nfs_co_generic_cb, &task) != 0) {
+ #else
+-        task.iov = iov;
 -        if (nfs_pread_async(client->context, client->fh,
 -                            offset, bytes, nfs_co_generic_cb, &task) != 0) {
 +        if (nfs_pread_async(client->context, client->fh, iov->iov[0].iov_base,
 +                            bytes > iov->iov[0].iov_len ? iov->iov[0].iov_len : bytes,
 +                            offset, nfs_co_generic_cb, &task) != 0) {
-             return -ENOMEM;
-         }
- 
+ #endif
+             if (my_buffer) {
+                 g_free(buf);
 @@ -320,7 +320,7 @@
  
      WITH_QEMU_LOCK_GUARD(&client->mutex) {

--- a/packages/qemu-system-x86-64-headless/build.sh
+++ b/packages/qemu-system-x86-64-headless/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.qemu.org
 TERMUX_PKG_DESCRIPTION="A generic and open source machine emulator and virtualizer (headless)"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1:10.2.1"
+TERMUX_PKG_VERSION="1:11.0.3"
 TERMUX_PKG_SRCURL="https://download.qemu.org/qemu-${TERMUX_PKG_VERSION:2}.tar.xz"
-TERMUX_PKG_SHA256=a3717477d8e2c84d630bfffbc20f6cd3293eb45aa1e6dac6d0cc27689991c9e1
+TERMUX_PKG_SHA256=da5fcffc32762820568b828ed430a728864d34d50b6d2f30358597760cbb0523
 TERMUX_PKG_DEPENDS="alsa-lib, dtc, glib, jack2, libbz2, libcurl, libdw, libgmp, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libslirp, libspice-server, libssh, libusb, libusbredir, ncurses, pulseaudio, qemu-common, resolv-conf, zlib, zstd"
 
 # Required by configuration script, but I can't find any binary that uses it.
@@ -13,6 +13,7 @@ TERMUX_PKG_BUILD_DEPENDS="libtasn1"
 TERMUX_PKG_CONFLICTS="qemu-system-x86_64-headless"
 TERMUX_PKG_REPLACES="qemu-system-x86_64-headless"
 TERMUX_PKG_PROVIDES="qemu-system-x86_64-headless"
+TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_pre_configure() {
@@ -48,40 +49,26 @@ termux_step_configure() {
 	local QEMU_TARGETS=""
 
 	# System emulation.
-	if [[ "$TERMUX_ARCH_BITS" == "64" ]]; then
-		QEMU_TARGETS+="aarch64-softmmu,"
-	fi
+	QEMU_TARGETS+="aarch64-softmmu,"
 	QEMU_TARGETS+="arm-softmmu,"
 	QEMU_TARGETS+="i386-softmmu,"
 	QEMU_TARGETS+="m68k-softmmu,"
-	if [[ "$TERMUX_ARCH_BITS" == "64" ]]; then
-		QEMU_TARGETS+="ppc64-softmmu,"
-	fi
+	QEMU_TARGETS+="ppc64-softmmu,"
 	QEMU_TARGETS+="ppc-softmmu,"
 	QEMU_TARGETS+="riscv32-softmmu,"
-	if [[ "$TERMUX_ARCH_BITS" == "64" ]]; then
-		QEMU_TARGETS+="riscv64-softmmu,"
-		QEMU_TARGETS+="x86_64-softmmu,"
-	fi
+	QEMU_TARGETS+="riscv64-softmmu,"
+	QEMU_TARGETS+="x86_64-softmmu,"
 
 	# User mode emulation.
-	if [[ "$TERMUX_ARCH_BITS" == "64" ]]; then
-		QEMU_TARGETS+="aarch64-linux-user,"
-	fi
+	QEMU_TARGETS+="aarch64-linux-user,"
 	QEMU_TARGETS+="arm-linux-user,"
 	QEMU_TARGETS+="i386-linux-user,"
 	QEMU_TARGETS+="m68k-linux-user,"
-	if [[ "$TERMUX_ARCH_BITS" == "64" ]]; then
-		QEMU_TARGETS+="ppc64-linux-user,"
-	fi
+	QEMU_TARGETS+="ppc64-linux-user,"
 	QEMU_TARGETS+="ppc-linux-user,"
-	if [[ "$TERMUX_ARCH_BITS" == "64" ]]; then
-		QEMU_TARGETS+="riscv32-linux-user,"
-		QEMU_TARGETS+="riscv64-linux-user,"
-		QEMU_TARGETS+="x86_64-linux-user"
-	else
-		QEMU_TARGETS+="riscv32-linux-user"
-	fi
+	QEMU_TARGETS+="riscv32-linux-user,"
+	QEMU_TARGETS+="riscv64-linux-user,"
+	QEMU_TARGETS+="x86_64-linux-user"
 
 	CFLAGS+=" $CPPFLAGS"
 	CXXFLAGS+=" $CPPFLAGS"

--- a/packages/qemu-system-x86-64-headless/qemu-common.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-common.subpackage.sh
@@ -9,13 +9,11 @@ bin/qemu-pr-helper
 bin/qemu-storage-daemon
 include
 libexec/qemu-bridge-helper
-libexec/virtfs-proxy-helper
 share/applications
 share/doc
 share/icons
 share/man/man1/qemu-storage-daemon.1.gz
 share/man/man1/qemu.1.gz
-share/man/man1/virtfs-proxy-helper.1.gz
 share/man/man7
 share/man/man8
 share/qemu

--- a/packages/qemu-system-x86-64-headless/qemu-utils.subpackage.sh
+++ b/packages/qemu-system-x86-64-headless/qemu-utils.subpackage.sh
@@ -7,6 +7,7 @@ bin/elf2dmp
 bin/qemu-edid
 bin/qemu-img
 bin/qemu-io
+bin/qemu-keymap
 bin/qemu-nbd
 share/man/man1/qemu-img.1.gz
 share/man/man8/qemu-nbd.8.gz

--- a/x11-packages/qemu-system-x86-64/build.sh
+++ b/x11-packages/qemu-system-x86-64/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.qemu.org
 TERMUX_PKG_DESCRIPTION="A generic and open source machine emulator and virtualizer"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1:10.2.1"
+TERMUX_PKG_VERSION="1:11.0.3"
 TERMUX_PKG_SRCURL="https://download.qemu.org/qemu-${TERMUX_PKG_VERSION:2}.tar.xz"
-TERMUX_PKG_SHA256=a3717477d8e2c84d630bfffbc20f6cd3293eb45aa1e6dac6d0cc27689991c9e1
+TERMUX_PKG_SHA256=da5fcffc32762820568b828ed430a728864d34d50b6d2f30358597760cbb0523
 TERMUX_PKG_DEPENDS="alsa-lib, dtc, gdk-pixbuf, glib, jack2, gtk3, libbz2, libcairo, libcurl, libdw, libepoxy, libgmp, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libslirp, libspice-server, libssh, libusb, libusbredir, libx11, mesa, ncurses, pulseaudio, qemu-common, resolv-conf, sdl2 | sdl2-compat, sdl2-image, virglrenderer, zlib, zstd"
 # Required by configuration script, but I can't find any binary that uses it.
 TERMUX_PKG_BUILD_DEPENDS="libtasn1"
@@ -16,19 +16,18 @@ bin/qemu-edid
 bin/qemu-ga
 bin/qemu-img
 bin/qemu-io
+bin/qemu-keymap
 bin/qemu-nbd
 bin/qemu-pr-helper
 bin/qemu-storage-daemon
 include/*
 libexec/qemu-bridge-helper
-libexec/virtfs-proxy-helper
 share/applications
 share/doc
 share/icons
 share/man/man1/qemu-img.1*
 share/man/man1/qemu-storage-daemon.1*
 share/man/man1/qemu.1*
-share/man/man1/virtfs-proxy-helper.1*
 share/man/man7
 share/man/man8/qemu-ga.8*
 share/man/man8/qemu-nbd.8*
@@ -39,6 +38,7 @@ share/qemu
 TERMUX_PKG_CONFLICTS="qemu-system-x86_64, qemu-system-x86_64-headless, qemu-system-x86-64-headless"
 TERMUX_PKG_REPLACES="qemu-system-x86_64, qemu-system-x86_64-headless, qemu-system-x86-64-headless"
 TERMUX_PKG_PROVIDES="qemu-system-x86_64"
+TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_pre_configure() {
@@ -74,23 +74,15 @@ termux_step_configure() {
 	local QEMU_TARGETS=""
 
 	# System emulation.
-	if [[ "$TERMUX_ARCH_BITS" == "64" ]]; then
-		QEMU_TARGETS+="aarch64-softmmu,"
-	fi
+	QEMU_TARGETS+="aarch64-softmmu,"
 	QEMU_TARGETS+="arm-softmmu,"
 	QEMU_TARGETS+="i386-softmmu,"
 	QEMU_TARGETS+="m68k-softmmu,"
-	if [[ "$TERMUX_ARCH_BITS" == "64" ]]; then
-		QEMU_TARGETS+="ppc64-softmmu,"
-	fi
+	QEMU_TARGETS+="ppc64-softmmu,"
 	QEMU_TARGETS+="ppc-softmmu,"
-	if [[ "$TERMUX_ARCH_BITS" == "64" ]]; then
-		QEMU_TARGETS+="riscv32-softmmu,"
-		QEMU_TARGETS+="riscv64-softmmu,"
-		QEMU_TARGETS+="x86_64-softmmu"
-	else
-		QEMU_TARGETS+="riscv32-softmmu"
-	fi
+	QEMU_TARGETS+="riscv32-softmmu,"
+	QEMU_TARGETS+="riscv64-softmmu,"
+	QEMU_TARGETS+="x86_64-softmmu"
 
 	CFLAGS+=" $CPPFLAGS"
 	CXXFLAGS+=" $CPPFLAGS"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/30835

- Fixes https://github.com/termux/termux-packages/issues/30861

- After this commit and many surrounding commits, upstream no longer supports 32-bit hosts https://github.com/qemu/qemu/commit/25512d6865e24976a67f034a1a5be8da266bc58c

- QEMU 10 binaries for 32-bit guests on 32-bit hosts will be available in TUR