### PR TITLE
enhance(main/ghc): provide termux specific libraries as cabal `extra-libraries`

### DIFF
--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="The Glasgow Haskell Compiler"
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_MAINTAINER="Aditya Alok <alok@termux.dev>"
 TERMUX_PKG_VERSION=9.12.2
-TERMUX_PKG_REVISION=4
+TERMUX_PKG_REVISION=5
 TERMUX_PKG_SRCURL="https://downloads.haskell.org/~ghc/$TERMUX_PKG_VERSION/ghc-$TERMUX_PKG_VERSION-src.tar.xz"
 TERMUX_PKG_SHA256=0e49cd5dde43f348c5716e5de9a5d7a0f8d68d945dc41cf75dfdefe65084f933
 TERMUX_PKG_DEPENDS="libiconv, libffi, libgmp, libandroid-posix-semaphore, libandroid-utimes, ncurses"
@@ -92,10 +92,9 @@ termux_step_make() {
 			-j"$TERMUX_PKG_MAKE_PROCESSES" \
 			--flavour="release$no_profiled_libs" --docs=none \
 			"stage1.rts.ghc.link.opts += -optl-Wl,-z,global" \
-			"stage1.unix.ghc.link.opts += -optl-landroid-posix-semaphore" \
 			"stage1.unix.cabal.configure.opts += --configure-option=ac_cv_func_futimes=yes" \
 			"stage1.unix.cabal.configure.opts += --configure-option=ac_cv_func_lutimes=yes" \
-			"stage1.unix.ghc.link.opts += -optl-landroid-utimes"
+			"stage1.unix.cabal.configure.opts += -f+android-libs"
 	)
 }
 

--- a/packages/ghc/unix-extra-libraries.patch
+++ b/packages/ghc/unix-extra-libraries.patch
@@ -1,0 +1,22 @@
+--- ghc-9.12.2/libraries/unix/unix.cabal	2025-03-13 00:55:48.000000000 +0530
++++ ghc-9.12.2.mod/libraries/unix/unix.cabal	2026-08-05 14:27:08.866697701 +0530
+@@ -50,11 +50,19 @@
+   default: False
+   manual: False
+ 
++flag android-libs
++  description: Termux specific android-libs
++  default: False
++  manual: True
++
+ source-repository head
+     type:     git
+     location: https://github.com/haskell/unix.git
+ 
+ library
++    if flag(android-libs)
++      extra-libraries: android-posix-semaphore android-utimes
++
+     default-language: Haskell2010
+     other-extensions:
+         CApiFFI


### PR DESCRIPTION
- now it will not be required to manually link against them

Signed-off-by: Aditya Alok <alok@termux.dev>
