### PR TITLE
mpv and mpv-x: add wayland and aaudio support

### DIFF
--- a/packages/mpv/build.sh
+++ b/packages/mpv/build.sh
@@ -37,7 +37,10 @@ termux_step_post_get_source() {
 	# Version guard
 	local ver_m ver_x
 	ver_m="${TERMUX_PKG_VERSION#*:}"
-	ver_x="$(. "$TERMUX_SCRIPTDIR/x11-packages/mpv-x/build.sh"; echo "${TERMUX_PKG_VERSION#*:}")"
+	ver_x="$(
+		. "$TERMUX_SCRIPTDIR/x11-packages/mpv-x/build.sh"
+		echo "${TERMUX_PKG_VERSION#*:}"
+	)"
 	if [[ "${ver_m}" != "${ver_x}" ]]; then
 		termux_error_exit "Version mismatch between mpv and mpv-x."
 	fi
@@ -45,6 +48,16 @@ termux_step_post_get_source() {
 
 # shellcheck disable=SC2031
 termux_step_pre_configure() {
+	# Adapted code from pulseaudio package
+	if [ $TERMUX_PKG_API_LEVEL -lt 26 ]; then
+		local _libdir="$TERMUX_PKG_TMPDIR/libaaudio"
+		rm -rf "${_libdir}"
+		mkdir -p "${_libdir}"
+		cp "$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib/$TERMUX_HOST_PLATFORM/26/libaaudio.so" \
+			"${_libdir}"
+		LDFLAGS+=" -L${_libdir}"
+		sed -i "s/aaudio_opt = get_option('aaudio').require(features\['android'\])/aaudio_opt = get_option('aaudio')/" "${TERMUX_PKG_SRCDIR}/meson.build"
+	fi
 	LDFLAGS+=" -landroid-glob"
 	sed -i "s/host_machine.system() == 'android'/false/" "${TERMUX_PKG_SRCDIR}/meson.build"
 }

--- a/x11-packages/mpv-x/build.sh
+++ b/x11-packages/mpv-x/build.sh
@@ -8,7 +8,7 @@ TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://github.com/mpv-player/mpv/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=ee21092a5ee427353392360929dc64645c54479aefdb5babc5cfbb5fad626209
 TERMUX_PKG_AUTO_UPDATE=false
-TERMUX_PKG_DEPENDS="alsa-lib, ffmpeg, jack, libandroid-glob, libandroid-shmem, libarchive, libass, libbluray, libcaca, libdrm, libdvdnav, libiconv, libjpeg-turbo, libplacebo, libsixel, libuchardet, libx11, libxext, libxinerama, libxpresent, libxrandr, libxss, libzimg, littlecms, luajit, openal-soft, opengl, pipewire, pulseaudio, rubberband, vulkan-icd, zlib"
+TERMUX_PKG_DEPENDS="alsa-lib, ffmpeg, jack, libandroid-glob, libandroid-shmem, libarchive, libass, libbluray, libcaca, libdrm, libdvdnav, libiconv, libjpeg-turbo, libplacebo, libsixel, libuchardet, libx11, libxext, libxinerama, libxpresent, libxrandr, libxkbcommon, libxss, libzimg, libwayland, libwayland-protocols, littlecms, luajit, openal-soft, opengl, pipewire, pulseaudio, rubberband, vulkan-icd, zlib"
 TERMUX_PKG_BUILD_DEPENDS="vulkan-headers, vulkan-loader-generic"
 TERMUX_PKG_CONFLICTS="mpv"
 TERMUX_PKG_REPLACES="mpv"
@@ -24,6 +24,11 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -Dvaapi=disabled
 -Dvulkan=enabled
 -Dxv=disabled
+-Degl-wayland=enabled
+-Degl-x11=enabled
+-Dwayland=enabled
+-Daaudio=enabled
+-Dpipewire=enabled
 -Dandroid-media-ndk=disabled
 "
 
@@ -31,7 +36,10 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 termux_step_post_get_source() {
 	# Version guard
 	local ver_m ver_x
-	ver_m="$(. "$TERMUX_SCRIPTDIR/packages/mpv/build.sh"; echo "${TERMUX_PKG_VERSION#*:}")"
+	ver_m="$(
+		. "$TERMUX_SCRIPTDIR/packages/mpv/build.sh"
+		echo "${TERMUX_PKG_VERSION#*:}"
+	)"
 	ver_x="${TERMUX_PKG_VERSION#*:}"
 	if [[ "${ver_m}" != "${ver_x}" ]]; then
 		termux_error_exit "Version mismatch between mpv and mpv-x."
@@ -40,6 +48,16 @@ termux_step_post_get_source() {
 
 # shellcheck disable=SC2031
 termux_step_pre_configure() {
+	# Adapted from pulseaudio package
+	if [ $TERMUX_PKG_API_LEVEL -lt 26 ]; then
+		local _libdir="$TERMUX_PKG_TMPDIR/libaaudio"
+		rm -rf "${_libdir}"
+		mkdir -p "${_libdir}"
+		cp "$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib/$TERMUX_HOST_PLATFORM/26/libaaudio.so" \
+			"${_libdir}"
+		LDFLAGS+=" -L${_libdir}"
+		sed -i "s/aaudio_opt = get_option('aaudio').require(features\['android'\])/aaudio_opt = get_option('aaudio')/" "${TERMUX_PKG_SRCDIR}/meson.build"
+	fi
 	LDFLAGS+=" -landroid-glob -landroid-shmem"
 	sed -i "s/host_machine.system() == 'android'/false/" "${TERMUX_PKG_SRCDIR}/meson.build"
 }


### PR DESCRIPTION
Added Wayland Dependencies and AAudio support with code from pulseaudio build script. Part of issue #30867 