### PR TITLE
fix(main/lua{51,52,53,54,55}): remove unversioned `lua++.pc` symlink

### DIFF
--- a/packages/lua51/build.sh
+++ b/packages/lua51/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Lua scripting language 5.1.x"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=5.1.5
-TERMUX_PKG_REVISION=9
+TERMUX_PKG_REVISION=10
 TERMUX_PKG_SRCURL="https://www.lua.org/ftp/lua-$TERMUX_PKG_VERSION.tar.gz"
 TERMUX_PKG_SHA256=2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333
 TERMUX_PKG_BUILD_DEPENDS="readline"
@@ -90,7 +90,6 @@ termux_step_make_install() {
 
 	# Install and symlink liblua++ pkgconfig files.
 	install -vDm600 lua++.pc "$TERMUX_PREFIX/lib/pkgconfig/lua++${LUA_VERSION/.}.pc"
-	ln -vsf "lua++${LUA_VERSION/.}.pc" "$TERMUX_PREFIX/lib/pkgconfig/lua++.pc"
 	ln -vsf "lua++${LUA_VERSION/.}.pc" "$TERMUX_PREFIX/lib/pkgconfig/lua++${LUA_VERSION}.pc"
 	ln -vsf "lua++${LUA_VERSION/.}.pc" "$TERMUX_PREFIX/lib/pkgconfig/lua++-${LUA_VERSION}.pc"
 }

--- a/packages/lua52/build.sh
+++ b/packages/lua52/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Lua scripting language 5.2.x"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=5.2.4
-TERMUX_PKG_REVISION=17
+TERMUX_PKG_REVISION=18
 TERMUX_PKG_SRCURL="https://www.lua.org/ftp/lua-$TERMUX_PKG_VERSION.tar.gz"
 TERMUX_PKG_SHA256=b9e2e4aad6789b3b63a056d442f7b39f0ecfca3ae0f1fc0ae4e9614401b69f4b
 TERMUX_PKG_BREAKS="liblua52-dev, liblua52"
@@ -90,7 +90,6 @@ termux_step_make_install() {
 
 	# Install and symlink liblua++ pkgconfig files.
 	install -vDm600 lua++.pc "$TERMUX_PREFIX/lib/pkgconfig/lua++${LUA_VERSION/.}.pc"
-	ln -vsf "lua++${LUA_VERSION/.}.pc" "$TERMUX_PREFIX/lib/pkgconfig/lua++.pc"
 	ln -vsf "lua++${LUA_VERSION/.}.pc" "$TERMUX_PREFIX/lib/pkgconfig/lua++${LUA_VERSION}.pc"
 	ln -vsf "lua++${LUA_VERSION/.}.pc" "$TERMUX_PREFIX/lib/pkgconfig/lua++-${LUA_VERSION}.pc"
 }

--- a/packages/lua53/build.sh
+++ b/packages/lua53/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Lua scripting language 5.3.x"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=5.3.6
-TERMUX_PKG_REVISION=8
+TERMUX_PKG_REVISION=9
 TERMUX_PKG_SRCURL="https://www.lua.org/ftp/lua-${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=fc5fd69bb8736323f026672b1b7235da613d7177e72558893a0bdcd320466d60
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -90,7 +90,6 @@ termux_step_make_install() {
 
 	# Install and symlink liblua++ pkgconfig files.
 	install -vDm600 lua++.pc "$TERMUX_PREFIX/lib/pkgconfig/lua++${LUA_VERSION/.}.pc"
-	ln -vsf "lua++${LUA_VERSION/.}.pc" "$TERMUX_PREFIX/lib/pkgconfig/lua++.pc"
 	ln -vsf "lua++${LUA_VERSION/.}.pc" "$TERMUX_PREFIX/lib/pkgconfig/lua++${LUA_VERSION}.pc"
 	ln -vsf "lua++${LUA_VERSION/.}.pc" "$TERMUX_PREFIX/lib/pkgconfig/lua++-${LUA_VERSION}.pc"
 }

--- a/packages/lua54/build.sh
+++ b/packages/lua54/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Lua scripting language 5.4.x"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=5.4.8
-TERMUX_PKG_REVISION=8
+TERMUX_PKG_REVISION=9
 TERMUX_PKG_SRCURL="https://www.lua.org/ftp/lua-${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=4f18ddae154e793e46eeab727c59ef1c0c0c2b744e7b94219710d76f530629ae
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -90,7 +90,6 @@ termux_step_make_install() {
 
 	# Install and symlink liblua++ pkgconfig files.
 	install -vDm600 lua++.pc "$TERMUX_PREFIX/lib/pkgconfig/lua++${LUA_VERSION/.}.pc"
-	ln -vsf "lua++${LUA_VERSION/.}.pc" "$TERMUX_PREFIX/lib/pkgconfig/lua++.pc"
 	ln -vsf "lua++${LUA_VERSION/.}.pc" "$TERMUX_PREFIX/lib/pkgconfig/lua++${LUA_VERSION}.pc"
 	ln -vsf "lua++${LUA_VERSION/.}.pc" "$TERMUX_PREFIX/lib/pkgconfig/lua++-${LUA_VERSION}.pc"
 }

--- a/packages/lua55/build.sh
+++ b/packages/lua55/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Lua scripting language 5.5.x"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=5.5.1
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://www.lua.org/ftp/lua-${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=1c4b4068d67061f2a2231ad2b5422e77acea1487ea9890f6320af614f4373dce
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -89,7 +90,6 @@ termux_step_make_install() {
 
 	# Install and symlink liblua++ pkgconfig files.
 	install -vDm600 lua++.pc "$TERMUX_PREFIX/lib/pkgconfig/lua++${LUA_VERSION/.}.pc"
-	ln -vsf "lua++${LUA_VERSION/.}.pc" "$TERMUX_PREFIX/lib/pkgconfig/lua++.pc"
 	ln -vsf "lua++${LUA_VERSION/.}.pc" "$TERMUX_PREFIX/lib/pkgconfig/lua++${LUA_VERSION}.pc"
 	ln -vsf "lua++${LUA_VERSION/.}.pc" "$TERMUX_PREFIX/lib/pkgconfig/lua++-${LUA_VERSION}.pc"
 }


### PR DESCRIPTION
- fixes #30925
- fixes https://github.com/termux/termux-packages/pull/30857#discussion_r3748384227

Slipped through review because I only tested `lua55` on-device and verified the others by `data.tar.xz` layout only.
And I didn't notice the unversioned `lua++.pc` in each of them.