### PR TITLE
enhance(x11/gtk4): enable SO versioning and drop unused CMake setup

### DIFF
--- a/x11-packages/gtk4/build.sh
+++ b/x11-packages/gtk4/build.sh
@@ -3,7 +3,8 @@ TERMUX_PKG_DESCRIPTION="GObject-based multi-platform GUI toolkit"
 TERMUX_PKG_LICENSE="LGPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="4.22.4"
-TERMUX_PKG_SRCURL=https://download.gnome.org/sources/gtk/${TERMUX_PKG_VERSION%.*}/gtk-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://download.gnome.org/sources/gtk/${TERMUX_PKG_VERSION%.*}/gtk-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=51bd9f60c7d23a665a556c7364c21fb2e4e282566b3e7e092455e8f910330893
 TERMUX_PKG_DEPENDS="adwaita-icon-theme, fontconfig, fribidi, gdk-pixbuf, glib, graphene, gtk-update-icon-cache, harfbuzz, iso-codes, libcairo, libdrm, libepoxy, libjpeg-turbo, libpng, librsvg, libtiff, libwayland, libx11, libxcursor, libxdamage, libxext, libxfixes, libxi, libxinerama, libxkbcommon, libxrandr, pango, shared-mime-info"
 TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, glib-cross, libwayland-protocols, libwayland-cross-scanner, xorgproto"
@@ -27,8 +28,8 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 "
 
 termux_step_pre_configure() {
-	termux_setup_cmake
 	termux_setup_gir
 	termux_setup_ninja
 	termux_setup_pkg_config_wrapper "${TERMUX_PREFIX}/opt/glib/cross/lib/x86_64-linux-gnu/pkgconfig:${TERMUX_PREFIX}/opt/libwayland/cross/lib/x86_64-linux-gnu/pkgconfig"
+	export TERMUX_MESON_ENABLE_SOVERSION=1
 }


### PR DESCRIPTION
I noticed SO versioning is enabled for `gtk3` but not for `gtk4` while helping a user in the Discord with troubleshooting.
Some third party libraries, notably `puregotk` specifically look for `libgtk-4.so.1`.
https://codeberg.org/puregotk/puregotk
<sup>We don't package this, but making it work is trivial by providing the symlink.</sup>

I also double checked the build systems supported by GTK 4.
Neither GTK 3, nor 4 use CMake in any capacity (anymore?),
so I have dropped the CMake setup calls from their builds.
- The GTK3 one is in a separate PR (#30944) because it does not require a rebuild.