### PR TITLE
Gtk2 and 3 cleanup

### DIFF
--- a/x11-packages/gtk2/build.sh
+++ b/x11-packages/gtk2/build.sh
@@ -2,10 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.gtk.org/
 TERMUX_PKG_DESCRIPTION="GObject-based multi-platform GUI toolkit (legacy)"
 TERMUX_PKG_LICENSE="LGPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-_MAJOR_VERSION=2.24
-TERMUX_PKG_VERSION=${_MAJOR_VERSION}.33
+TERMUX_PKG_VERSION=2.24.33
 TERMUX_PKG_REVISION=8
-TERMUX_PKG_SRCURL=https://download.gnome.org/sources/gtk+/${_MAJOR_VERSION}/gtk+-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SRCURL="https://download.gnome.org/sources/gtk+/${TERMUX_PKG_VERSION%.*}/gtk+-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=ac2ac757f5942d318a311a54b0c80b5ef295f299c2a73c632f6bfb1ff49cc6da
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_DEPENDS="adwaita-icon-theme, atk, coreutils, desktop-file-utils, fontconfig, freetype, glib, gtk-update-icon-cache, harfbuzz, libandroid-shmem, libcairo, librsvg, libx11, libxcomposite, libxcursor, libxdamage, libxext, libxfixes, libxi, libxinerama, libxrandr, libxrender, pango, shared-mime-info, ttf-dejavu"
@@ -50,8 +49,8 @@ termux_step_create_debscripts() {
 	for i in $(test "$TERMUX_PACKAGE_FORMAT" != "pacman" && echo postinst) prerm triggers; do
 		sed \
 			"s|@TERMUX_PREFIX@|${TERMUX_PREFIX}|g" \
-			"${TERMUX_PKG_BUILDER_DIR}/hooks/${i}.in" > ./${i}
-		chmod 755 ./${i}
+			"${TERMUX_PKG_BUILDER_DIR}/hooks/${i}.in" > ./"${i}"
+		chmod 755 ./"${i}"
 	done
 	unset i
 	chmod 644 ./triggers

--- a/x11-packages/gtk3/build.sh
+++ b/x11-packages/gtk3/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="GObject-based multi-platform GUI toolkit"
 TERMUX_PKG_LICENSE="LGPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.24.52"
-TERMUX_PKG_SRCURL=https://gitlab.gnome.org/GNOME/gtk/-/archive/$TERMUX_PKG_VERSION/gtk-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SRCURL="https://gitlab.gnome.org/GNOME/gtk/-/archive/$TERMUX_PKG_VERSION/gtk-$TERMUX_PKG_VERSION.tar.gz"
 TERMUX_PKG_SHA256=e62514019679f831fcb37f3d294a761c3a6c14f1d346745ad11d70c2be17146e
 TERMUX_PKG_DEPENDS="adwaita-icon-theme, at-spi2-core, coreutils, desktop-file-utils, fontconfig, fribidi, gdk-pixbuf, glib, gtk-update-icon-cache, harfbuzz, libcairo, libepoxy, libwayland, libxcomposite, libxcursor, libxdamage, libxfixes, libxi, libxinerama, libxkbcommon, libxrandr, pango, shared-mime-info, ttf-dejavu"
 TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, glib-cross, libwayland-protocols, libwayland-cross-scanner, xorgproto"
@@ -26,7 +26,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 "
 
 termux_step_pre_configure() {
-	termux_setup_cmake
 	termux_setup_gir
 	termux_setup_ninja
 	termux_setup_pkg_config_wrapper "${TERMUX_PREFIX}/opt/glib/cross/lib/x86_64-linux-gnu/pkgconfig:${TERMUX_PREFIX}/opt/libwayland/cross/lib/x86_64-linux-gnu/pkgconfig"


### PR DESCRIPTION
- Part of #30943

Cleanup for `gtk2` and `gtk3` not requiring rebuilds.