### PR TITLE
newpkg(main/chez-scheme): 10.4.1

### DIFF
--- a/packages/chez-scheme/build.sh
+++ b/packages/chez-scheme/build.sh
@@ -1,0 +1,52 @@
+TERMUX_PKG_HOMEPAGE=https://cisco.github.io/ChezScheme
+TERMUX_PKG_DESCRIPTION="Chez Scheme is both a programming language, an implementation, and a superset of R6RS"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=10.4.1
+TERMUX_PKG_SRCURL="https://github.com/cisco/ChezScheme/releases/download/v${TERMUX_PKG_VERSION}/csv${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=2e74952db7bc177f0c3602e2217a341ba677d733eec4cd7726418c3a4e1ef308
+TERMUX_PKG_DEPENDS="libiconv, liblz4, ncurses, zlib"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_HOSTBUILD=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_post_get_source() {
+	# Target names copied from Alpine's chez-scheme APKBUILD
+	case "${TERMUX_ARCH}" in
+		aarch64) CHEZ_HOST=tarm64le ;;
+		arm) CHEZ_HOST=tarm32le ;;
+		i686) CHEZ_HOST=ti3le ;;
+		x86_64) CHEZ_HOST=ta6le ;;
+	esac
+	export CHEZ_HOST
+}
+
+termux_step_host_build() {
+	local configure_args=()
+	if [[ "${TERMUX_ON_DEVICE_BUILD}" == true ]]; then
+		configure_args+=(LIBS=-liconv)
+	fi
+
+	"${TERMUX_PKG_SRCDIR}/configure" "${configure_args[@]}"
+	make -j "${TERMUX_PKG_MAKE_PROCESSES}" bootquick XM="${CHEZ_HOST}"
+}
+
+termux_step_pre_configure() {
+	cp -a "${TERMUX_PKG_HOSTBUILD_DIR}/boot/${CHEZ_HOST}" "${TERMUX_PKG_SRCDIR}/boot/"
+}
+
+# Chez Scheme uses a non-Autotools configure script, which does not accept
+# the extra options passed by Termux's standard configure step.
+termux_step_configure() {
+	# X11 is used only for optional clipboard support in the expression editor.
+	# Keep this package in the main repository without an X11 dependency.
+	./configure --cross --force \
+		--prefix="${TERMUX_PREFIX}" \
+		--installman="${TERMUX_PREFIX}/share/man" \
+		--nogzip-man-pages \
+		--machine="${CHEZ_HOST}" \
+		--installschemename=chez \
+		--installpetitename=chez-petite \
+		--disable-x11 \
+		ZLIB="-lz" LZ4="-llz4" LIBS="-liconv"
+}

--- a/packages/chez-scheme/makefiles-install.zuo.patch
+++ b/packages/chez-scheme/makefiles-install.zuo.patch
@@ -1,0 +1,19 @@
+--- a/makefiles/install.zuo	2026-05-11 19:29:03.000000000 +0200
++++ b/makefiles/install.zuo	2026-08-12 23:12:47.317436574 +0200
+@@ -179,12 +179,11 @@
+     (shell/wait* "rm" "-f" f))
+   (define (rm-rf d)
+     (shell/wait* "rm" "-rf" d))
+-  (define haiku? (glob-match? "*hk" m))
+   (define (ln-f from to)
+-    (if haiku?
+-        ;; no hard links on BeFS
+-        (shell/wait* "ln" "-s" from to)
+-        (shell/wait* "ln" "-f" from to)))
++    ;; Android does not permit hard links to app executables. Use relative
++    ;; symbolic links for all aliases installed by Chez Scheme.
++    (define to-dir (car (split-path to)))
++    (shell/wait* "ln" "-sf" (find-relative-path to-dir from) to))
+   (define (ln-s from to)
+     (shell/wait* "ln" "-s" from to))
+ 


### PR DESCRIPTION
Closes #4304.

This supersedes #22423 and builds on the packaging work by @asumbek. The original commit authorship has been preserved.

Compared with #22423, this updates Chez Scheme from 10.1.0 to 10.4.1 and adjusts the recipe for the current Chez and Termux build systems:

- uses Chez's `bootquick` target without a redundant full host build
- keeps generated target boot files in `TERMUX_PKG_HOSTBUILD_DIR`, so repeated and forced builds work
- exports the Chez machine type from `termux_step_post_get_source`
- uses Termux's zlib, lz4, iconv and ncurses libraries
- disables X11
- replaces Android-incompatible boot-file hardlinks with relative symlinks
- allows `libkernel.a` to be placed in the automatically generated `chez-scheme-static` subpackage
- retains the upstream `scheme-script` command name, which is required for Chez to recognize script mode correctly

Validation performed:

- package linter passes
- clean Docker build for `aarch64` passes
- repeated forced Docker build passes
- installed and tested on a physical AArch64 device:
  - Termux 0.118.3
  - Android 16
  - Samsung SM-A175F
- `chez`, `chez-petite`, and `scheme-script` execute successfully
- `(machine-type)` reports `tarm64le`
- runtime links against Termux's libiconv, ncurses, zlib and liblz4
- boot-file symlinks resolve correctly
- `dpkg -V` passes for both packages
- `chez-scheme-static` was tested by compiling `examples/crepl.c` against `libkernel.a`; the resulting embedded Chez executable ran successfully
