### PR TITLE
bump(main/chicken): v6.0.0

### DIFF
--- a/packages/chicken/build.sh
+++ b/packages/chicken/build.sh
@@ -3,10 +3,9 @@ TERMUX_PKG_DESCRIPTION="A feature rich Scheme compiler and interpreter"
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_LICENSE_FILE="LICENSE"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="5.4.0"
-TERMUX_PKG_REVISION=2
-TERMUX_PKG_SRCURL=https://code.call-cc.org/releases/${TERMUX_PKG_VERSION}/chicken-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=3c5d4aa61c1167bf6d9bf9eaf891da7630ba9f5f3c15bf09515a7039bfcdec5f
+TERMUX_PKG_VERSION="6.0.0"
+TERMUX_PKG_SRCURL="https://code.call-cc.org/releases/${TERMUX_PKG_VERSION}/chicken-${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=92835552b1b687ad26737e429b5aba36510bf429f8816ec0f6d336c8cb41f443
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_MAKE_ARGS="
@@ -20,7 +19,12 @@ termux_step_pre_configure() {
 	if [[ "${TERMUX_ARCH}" == "i686" ]]; then
 		ARCH="x86"
 	fi
-	TERMUX_PKG_EXTRA_MAKE_ARGS+=" ARCH=${ARCH}"
+	TERMUX_PKG_EXTRA_MAKE_ARGS+=" ARCH=$ARCH LIBRARIAN=$AR"
 
 	export C_COMPILER="$CC"
 }
+
+# chicken's configuration is not autoconf.
+# It tries to test compiler by running a program which fails.
+# But we can bypass configure and pass relevant options directly to make.
+termux_step_configure() { :; }

--- a/packages/chicken/build.sh
+++ b/packages/chicken/build.sh
@@ -3,10 +3,9 @@ TERMUX_PKG_DESCRIPTION="A feature rich Scheme compiler and interpreter"
 TERMUX_PKG_LICENSE="BSD"
 TERMUX_PKG_LICENSE_FILE="LICENSE"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="5.4.0"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_VERSION="6.0.0"
 TERMUX_PKG_SRCURL=https://code.call-cc.org/releases/${TERMUX_PKG_VERSION}/chicken-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=3c5d4aa61c1167bf6d9bf9eaf891da7630ba9f5f3c15bf09515a7039bfcdec5f
+TERMUX_PKG_SHA256=92835552b1b687ad26737e429b5aba36510bf429f8816ec0f6d336c8cb41f443
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_EXTRA_MAKE_ARGS="
@@ -24,3 +23,6 @@ termux_step_pre_configure() {
 
 	export C_COMPILER="$CC"
 }
+
+#chicken's configuration is not autoconf
+termux_step_configure() { :; }

--- a/packages/chicken/runtime.c.patch
+++ b/packages/chicken/runtime.c.patch
@@ -1,17 +1,17 @@
---- ./runtime.c.orig	2022-05-29 09:26:50.789444359 +0000
-+++ ./runtime.c	2022-05-29 09:27:41.589413742 +0000
-@@ -37,10 +37,6 @@
+diff -uNr chicken-6.0.0/runtime.c chicken-6.0.0.mod/runtime.c
+--- chicken-6.0.0/runtime.c	2026-08-10 14:08:38.135000504 +0530
++++ chicken-6.0.0.mod/runtime.c	2026-08-12 12:45:37.986259134 +0530
+@@ -37,9 +37,6 @@
  # include <sysexits.h>
  #endif
 
 -#ifdef __ANDROID__
 -# include <android/log.h>
 -#endif
--
+
  #if !defined(PIC)
  # define NO_DLOAD2
- #endif
-@@ -606,14 +602,10 @@
+@@ -591,14 +588,10 @@
    va_list va;
 
    va_start(va, fstr);


### PR DESCRIPTION
- fixes https://github.com/termux/termux-packages/issues/30945

The `termux_step_configure() { :; }` is necessary otherwise it just prints the help screen instead of compiling.
Chicken dosen't have its own `termux_step_configure` and it falls back to the generic implimentation which assumes auto conf style which dosen't work because it uses a custom parser, it dosen't undrestand normal flags and prints the help screen and exits

The implimented fix is that we add a fake `termux_step_configure` which gives true no matter what happens so it skips the generic implimentaion and continues compilation

Works on all archs