### PR TITLE
script(termux_setup_build_python): add support for glibc packages

### DIFF
--- a/scripts/build/setup/termux_setup_build_python.sh
+++ b/scripts/build/setup/termux_setup_build_python.sh
@@ -23,37 +23,42 @@ termux_setup_build_python() {
 			exit 1
 		fi
 	else
-		local _PYTHON_VERSION
 		local _PYTHON_SRCURL
 		local _PYTHON_SHA256
 		local _PYTHON_FOLDER
-		_PYTHON_VERSION="$(. "$TERMUX_SCRIPTDIR/packages/python/build.sh"; echo "$TERMUX_PKG_VERSION")"
-		_PYTHON_SRCURL="$(. "$TERMUX_SCRIPTDIR/packages/python/build.sh"; echo "$TERMUX_PKG_SRCURL")"
-		_PYTHON_SHA256="$(. "$TERMUX_SCRIPTDIR/packages/python/build.sh"; echo "$TERMUX_PKG_SHA256")"
+		if [[ "${TERMUX_PACKAGE_LIBRARY}" == "bionic" ]]; then
+			_PYTHON_SRCURL="$(. "$TERMUX_SCRIPTDIR/packages/python/build.sh"; echo "$TERMUX_PKG_SRCURL")"
+			_PYTHON_SHA256="$(. "$TERMUX_SCRIPTDIR/packages/python/build.sh"; echo "$TERMUX_PKG_SHA256")"
+		else # glibc
+			_PYTHON_SRCURL="$(. "$TERMUX_SCRIPTDIR/gpkg/python/build.sh"; echo "$TERMUX_PKG_SRCURL")"
+			_PYTHON_SHA256="$(. "$TERMUX_SCRIPTDIR/gpkg/python/build.sh"; echo "$TERMUX_PKG_SHA256")"
+		fi
 		if [[ "${TERMUX_PACKAGES_OFFLINE-false}" = "true" ]]; then
-			_PYTHON_FOLDER=${TERMUX_SCRIPTDIR}/build-tools/python-${_PYTHON_VERSION}
+			_PYTHON_FOLDER=${TERMUX_SCRIPTDIR}/build-tools/python-${TERMUX_PYTHON_VERSION}
 		else
-			_PYTHON_FOLDER=${TERMUX_COMMON_CACHEDIR}/python-${_PYTHON_VERSION}
+			_PYTHON_FOLDER=${TERMUX_COMMON_CACHEDIR}/python-${TERMUX_PYTHON_VERSION}
 		fi
 		export TERMUX_BUILD_PYTHON_DIR=$_PYTHON_FOLDER
 
 		if [[ ! -d "$_PYTHON_FOLDER" ]]; then
-			[[ "${CI-false}" == "true" ]] && echo "::group::INFO: [${FUNCNAME[0]}] Building minimal host Python $_PYTHON_VERSION" || :
+			[[ "${CI-false}" == "true" ]] && echo "::group::INFO: [${FUNCNAME[0]}] Building minimal host Python ${TERMUX_PYTHON_VERSION}" || :
 
 			termux_download \
-				"$_PYTHON_SRCURL" "python-$_PYTHON_VERSION.tar.xz" "$_PYTHON_SHA256"
+				"$_PYTHON_SRCURL" "python-${TERMUX_PYTHON_VERSION}.tar.xz" "$_PYTHON_SHA256"
 			mkdir "$_PYTHON_FOLDER"
 			tar \
 				--extract \
 				--strip-components=1 \
 				-C "$_PYTHON_FOLDER" \
-				-f "python-$_PYTHON_VERSION.tar.xz"
+				-f "python-${TERMUX_PYTHON_VERSION}.tar.xz"
 			cd "$_PYTHON_FOLDER"
 
-			for f in "$TERMUX_SCRIPTDIR"/packages/python/0008-fix-ctypes-util-find_library.patch; do
-				echo "[${FUNCNAME[0]}]: Applying $(basename "$f")"
-				cat "$f" | sed -e "s|@@TERMUX_PKG_API_LEVEL@@|${TERMUX_PKG_API_LEVEL}|g" | patch --silent -p1
-			done
+			if [[ "${TERMUX_PACKAGE_LIBRARY}" = "bionic" ]]; then
+				for f in "$TERMUX_SCRIPTDIR"/packages/python/0008-fix-ctypes-util-find_library.patch; do
+					echo "[${FUNCNAME[0]}]: Applying $(basename "$f")"
+					cat "$f" | sed -e "s|@@TERMUX_PKG_API_LEVEL@@|${TERMUX_PKG_API_LEVEL}|g" | patch --silent -p1
+				done
+			fi
 
 			# Perform a hostbuild of python. We are kind of doing a minimal build, which
 			# may break some stuff that rely on an extended python release.


### PR DESCRIPTION
+ use `TERMUX_PKG_VERSION` instead of `_PKG_VERSION`