### PR TITLE
nodejs: use --use-prefix-to-find-headers so node-gyp uses patched local headers

### DIFF
--- a/packages/nodejs-lts/build.sh
+++ b/packages/nodejs-lts/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Yaksh Bariya <thunder-coding@termux.dev>"
 # Also update version in termux_setup_nodejs.sh when updating this package
 TERMUX_PKG_VERSION=24.18.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=e94afde24db08e0c564ee7110a2d5aab51ee0059382c9fd8233c54eec47b28f9
 # thunder-coding: don't try to autoupdate nodejs, that thing takes 2 whole hours to build for a single arch, and requires a lot of patch updates everytime. Also I run tests everytime I update it to ensure least bugs
@@ -159,6 +160,12 @@ termux_step_configure() {
 	fi
 	# See note above TERMUX_PKG_DEPENDS why we do not use a shared libuv.
 	# When building with ninja, build.ninja is generated for both Debug and Release builds.
+	# Make node-gyp use the headers installed with this package
+	# ($TERMUX_PREFIX/include/node) instead of downloading the official ones
+	# from nodejs.org. The installed headers are patched by common.gypi.patch;
+	# without this flag node-gyp pulls the upstream common.gypi whose android
+	# branch references an undefined android_ndk_path variable and breaks
+	# every native module build ("gyp: Undefined variable android_ndk_path").
 	./configure \
 		--prefix=$TERMUX_PREFIX \
 		--dest-cpu=$DEST_CPU \
@@ -170,6 +177,7 @@ termux_step_configure() {
 		--shared-zlib \
 		--with-intl=system-icu \
 		--cross-compiling \
+		--use-prefix-to-find-headers \
 		--ninja \
 		"${_DEBUG[@]}"
 

--- a/packages/nodejs/build.sh
+++ b/packages/nodejs/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Open Source, cross-platform JavaScript runtime environme
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Yaksh Bariya <thunder-coding@termux.dev>"
 TERMUX_PKG_VERSION=26.4.0
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=9eceb3621024069d91035b5471d2ebe86aa04d22dbeba72a782eaf36ff9183ac
 # thunder-coding: don't try to autoupdate nodejs, that thing takes 2 whole hours to build for a single arch, and requires a lot of patch updates everytime. Also I run tests everytime I update it to ensure least bugs
@@ -168,6 +169,12 @@ termux_step_configure() {
 	fi
 	# See note above TERMUX_PKG_DEPENDS why we do not use a shared libuv.
 	# When building with ninja, build.ninja is generated for both Debug and Release builds.
+	# Make node-gyp use the headers installed with this package
+	# ($TERMUX_PREFIX/include/node) instead of downloading the official ones
+	# from nodejs.org. The installed headers are patched by common.gypi.patch;
+	# without this flag node-gyp pulls the upstream common.gypi whose android
+	# branch references an undefined android_ndk_path variable and breaks
+	# every native module build ("gyp: Undefined variable android_ndk_path").
 	./configure \
 		--prefix=$TERMUX_PREFIX \
 		--dest-cpu=$DEST_CPU \
@@ -180,6 +187,7 @@ termux_step_configure() {
 		--shared-zlib \
 		--with-intl=system-icu \
 		--cross-compiling \
+		--use-prefix-to-find-headers \
 		--ninja \
 		"${_DEBUG[@]}"
 


### PR DESCRIPTION
Add `--use-prefix-to-find-headers` to the configure invocation in `packages/nodejs/build.sh` and `packages/nodejs-lts/build.sh`.

When Termux users build native npm modules, node-gyp downloads the official headers tarball (URL built in `deps/npm/node_modules/node-gyp/lib/process-release.js`) and compiles against the `common.gypi` inside it, unless `use_prefix_to_find_headers` is set (see `deps/npm/node_modules/node-gyp/lib/configure.js`, `getNodeDir()`). The upstream `common.gypi` android branch references `android_ndk_path`, which doesn't exist on Termux (no NDK), so every native module build fails with:

```
gyp: Undefined variable android_ndk_path in binding.gyp while trying to load binding.gyp
```

The headers shipped with both packages are already patched (`common.gypi.patch`) so the android branch doesn't use NDK variables — node-gyp just never sees them because the flag is off. This PR turns it on for both.

Verified on aarch64 with Node v26.4.0 from this package: node-gyp fails with the error above against the downloaded official headers (URL built in `deps/npm/node_modules/node-gyp/lib/process-release.js`), and the same module builds successfully against the local patched headers at `$PREFIX/include/node`.

English is not my first language — I used an AI assistant for the wording, but the investigation and the testing above are mine.

Closes #30975