### PR TITLE
enhance(main/ffmpeg): enable `xcbgrab` (AKA `x11grab`)

### DIFF
--- a/packages/ffmpeg/build.sh
+++ b/packages/ffmpeg/build.sh
@@ -4,14 +4,19 @@ TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # Please align version with `ffplay` package.
 TERMUX_PKG_VERSION="8.1.2"
-TERMUX_PKG_REVISION=4
+TERMUX_PKG_REVISION=5
 TERMUX_PKG_SRCURL="https://www.ffmpeg.org/releases/ffmpeg-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=464beb5e7bf0c311e68b45ae2f04e9cc2af88851abb4082231742a74d97b524c
-TERMUX_PKG_DEPENDS="fontconfig, freetype, fribidi, game-music-emu, glslang, harfbuzz, libaom, libandroid-glob, libandroid-stub, libass, libbluray, libbs2b, libbz2, libdav1d, libdvdnav, libdvdread, libiconv, libjxl, liblzma, libmysofa, libmp3lame, libopencore-amr, libopenmpt, libopus, libplacebo, librav1e, libsoxr, libsrt, libssh, libtheora, libv4l, libvidstab, libvmaf, libvo-amrwbenc, libvorbis, libvpx, libwebp, libx264, libx265, libxml2, libzimg, libzmq, littlecms, ocl-icd, openssl, rubberband, svt-av1, vulkan-icd, xvidcore, zlib"
+TERMUX_PKG_DEPENDS="fontconfig, freetype, fribidi, game-music-emu, glslang, harfbuzz, libaom, libandroid-glob, libandroid-shmem, libandroid-stub, libass, libbluray, libbs2b, libbz2, libdav1d, libdvdnav, libdvdread, libiconv, libjxl, liblzma, libmysofa, libmp3lame, libopencore-amr, libopenmpt, libopus, libplacebo, librav1e, libsoxr, libsrt, libssh, libtheora, libv4l, libvidstab, libvmaf, libvo-amrwbenc, libvorbis, libvpx, libwebp, libx264, libx265, libxcb, libxml2, libzimg, libzmq, littlecms, ocl-icd, openssl, rubberband, svt-av1, vulkan-icd, xvidcore, zlib"
 TERMUX_PKG_BUILD_DEPENDS="opencl-headers, vulkan-headers"
 TERMUX_PKG_CONFLICTS="libav"
 TERMUX_PKG_BREAKS="ffmpeg-dev"
 TERMUX_PKG_REPLACES="ffmpeg-dev"
+TERMUX_PKG_RM_AFTER_INSTALL="
+bin/ffplay
+share/doc/ffmpeg/ffplay*
+share/man/man1/ffplay*
+"
 
 termux_step_pre_configure() {
 	# Do not forget to bump revision of reverse dependencies and rebuild them
@@ -78,6 +83,7 @@ termux_step_configure() {
 		--disable-indevs \
 		--disable-outdevs \
 		--enable-indev=lavfi \
+		--enable-indev=xcbgrab \
 		--disable-static \
 		--disable-symver \
 		--enable-cross-compile \
@@ -122,6 +128,10 @@ termux_step_configure() {
 		--enable-libwebp \
 		--enable-libx264 \
 		--enable-libx265 \
+		--enable-libxcb \
+		--enable-libxcb-shm \
+		--enable-libxcb-xfixes \
+		--enable-libxcb-shape \
 		--enable-libxml2 \
 		--enable-libxvid \
 		--enable-libzimg \
@@ -132,7 +142,7 @@ termux_step_configure() {
 		--enable-shared \
 		--prefix="$TERMUX_PREFIX" \
 		--target-os=android \
-		--extra-libs="-landroid-glob" \
+		--extra-libs="-landroid-glob -landroid-shmem" \
 		--enable-vulkan \
 		$_EXTRA_CONFIGURE_FLAGS \
 		--disable-libfdk-aac


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/30985

- Depends on `libxcb` and `libandroid-shmem`

- Makes `ffplay` get built, so remove `ffplay` to not conflict with `ffplay` package

- Makes this command work in Termux: `ffmpeg -video_size 1024x768 -framerate 25 -f x11grab -i :0.0+100,200 output.mp4`