### PR TITLE
chore(main/imagemagick): Fix auto update to prevent false version downgrade

### DIFF
--- a/packages/imagemagick/build.sh
+++ b/packages/imagemagick/build.sh
@@ -7,6 +7,7 @@ TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/ImageMagick/ImageMagick/archive/refs/tags/${TERMUX_PKG_VERSION%.*}-${TERMUX_PKG_VERSION##*.}.tar.gz"
 TERMUX_PKG_SHA256=485dad5226fda2417ea65f3eb6e3f63e7d5dfacacdf6f57f9c39b6ef1e3cb667
 TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_VERSION_SED_REGEXP="s/-/./g"
 TERMUX_PKG_DEPENDS="djvulibre, fftw, fontconfig, freetype, gdk-pixbuf, ghostscript, glib, graphviz, harfbuzz, imath, jbig2dec, libandroid-support, libbz2, libc++, libcairo, libheif, libjpeg-turbo, libjxl, liblqr, libltdl, liblzma, libpng, libraqm, libraw, librsvg, libtiff, libwebp, libx11, libxext, libxml2, libzip, littlecms, openexr, openjpeg, pango, zlib"
 TERMUX_PKG_BREAKS="imagemagick-dev, imagemagick-x"
 TERMUX_PKG_REPLACES="imagemagick-dev, imagemagick-x"


### PR DESCRIPTION
Previously, the following message was shown in CI.
imagemagick 7.1.2.27 => 7.1.2-29 (Error? current version is larger than latest fetched version)

See this CI run for the error message https://github.com/termux/termux-packages/actions/runs/31889249543/job/95022956712