### PR TITLE
addpkg(main/luau): 0.734

### DIFF
--- a/packages/luau/build.sh
+++ b/packages/luau/build.sh
@@ -1,0 +1,19 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/luau-lang/luau
+TERMUX_PKG_DESCRIPTION="A small, fast, and embeddable programming language based on Lua with a gradual type system."
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_LICENSE_FILE="
+LICENSE.txt
+extern/isocline/LICENSE
+"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.734"
+TERMUX_PKG_SRCURL="https://github.com/luau-lang/luau/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=cb55a891226d8c70284e22eb9281cc2b4496c709a4050f52aaa18a355fe7b1a3
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DLUAU_BUILD_TESTS=OFF
+"
+
+termux_step_make_install() {
+	install -Dm755 -t "$TERMUX_PREFIX/bin" luau luau-*
+}

--- a/packages/luau/fix-path-for-cli.patch
+++ b/packages/luau/fix-path-for-cli.patch
@@ -1,0 +1,13 @@
+diff --git a/CLI/src/Repl.cpp b/CLI/src/Repl.cpp
+index 520e38fa..afc7ec52 100644
+--- a/CLI/src/Repl.cpp
++++ b/CLI/src/Repl.cpp
+@@ -809,7 +809,7 @@ int replMain(int argc, char** argv)
+     {
+ #if __linux__
+         char path[128];
+-        snprintf(path, sizeof(path), "/tmp/perf-%d.map", getpid());
++        snprintf(path, sizeof(path), "@TERMUX_PREFIX@/tmp/perf-%d.map", getpid());
+ 
+         // note, there's no need to close the log explicitly as it will be closed when the process exits
+         FILE* codegenPerfLog = fopen(path, "w");


### PR DESCRIPTION
- Fixes #30283

This PR will add the Luau programming language to Termux main packages list.

Build for all architectures are successful ([results](https://github.com/TheMightyArie/termux-packages/actions/runs/31900322565)).