### PR TITLE
fix(main/rqbit): crash on torrent add due to rust-tls issue

### DIFF
--- a/packages/rqbit/build.sh
+++ b/packages/rqbit/build.sh
@@ -4,6 +4,7 @@ TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_LICENSE_FILE="LICENSE"
 TERMUX_PKG_MAINTAINER="DevGitPit <106362593+DevGitPit@users.noreply.github.com>"
 TERMUX_PKG_VERSION="9.0.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="latest-release-tag"
 TERMUX_PKG_SRCURL="https://github.com/ikatson/rqbit/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
@@ -17,6 +18,22 @@ termux_step_pre_configure() {
 
 	termux_setup_rust
 	termux_setup_nodejs
+
+	cargo vendor
+	find ./vendor \
+		-mindepth 1 -maxdepth 1 -type d \
+		! -wholename ./vendor/rustls-platform-verifier \
+		-exec rm -rf '{}' \;
+
+	find vendor/rustls-platform-verifier -type f -print0 | \
+		xargs -0 sed -i \
+		-e 's|"android"|"disabling_this_because_it_is_for_building_an_apk"|g' \
+		-e "s|ANDROID|DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK|g" \
+		-e 's|"linux"|"android"|g'
+
+	echo "" >> Cargo.toml
+	echo '[patch.crates-io]' >> Cargo.toml
+	echo 'rustls-platform-verifier = { path = "./vendor/rustls-platform-verifier" }' >> Cargo.toml
 }
 
 termux_step_make_install() {


### PR DESCRIPTION
- Resolves - https://github.com/termux/termux-packages/pull/30840#issuecomment-5306284556
---
I packaged `v9.0.0` over the same script that packaged `v9.0.0-beta.2` of `rqbit`. Meanwhile, `reqwest` got bumped from 0.12 to 0.13 upstream. 

That now sets default tls as `rusttls` using `rusttls-platform-verifier` instead of native-tls. 

Fixed now to vendor and patch `rustls-platform-verifier` to use its Linux verifier implementation (verifying against Termux's `ca-certificates` store) instead of the Android JNI verifier. 
