### PR TITLE
addpkg(main/wrangler): Cloudflare Workers CLI

### DIFF
--- a/packages/wrangler/build.sh
+++ b/packages/wrangler/build.sh
@@ -1,0 +1,276 @@
+TERMUX_PKG_HOMEPAGE=https://developers.cloudflare.com/workers/wrangler/
+TERMUX_PKG_DESCRIPTION="Cloudflare Workers command-line tooling with native Android workerd and esbuild"
+TERMUX_PKG_LICENSE="MIT, Apache-2.0"
+TERMUX_PKG_MAINTAINER="@adybag14-cyber"
+TERMUX_PKG_VERSION="4.123.0"
+_WORKERD_VERSION="1.20260811.1"
+_PNPM_VERSION="10.33.0"
+_BAZEL_VERSION="9.2.0"
+_ESBUILD_VERSIONS=(
+	0.18.20
+	0.23.1
+	0.24.2
+	0.27.3
+	0.28.1
+)
+TERMUX_PKG_LICENSE_FILE="LICENSE-MIT, workerd-${_WORKERD_VERSION}/LICENSE, esbuild-${_ESBUILD_VERSIONS[-1]}/LICENSE.md"
+TERMUX_PKG_SRCURL=(
+	"https://github.com/cloudflare/workers-sdk/archive/refs/tags/wrangler%40${TERMUX_PKG_VERSION}.tar.gz"
+	"https://github.com/cloudflare/workerd/archive/refs/tags/v${_WORKERD_VERSION}.tar.gz"
+	"https://github.com/evanw/esbuild/archive/refs/tags/v${_ESBUILD_VERSIONS[0]}.tar.gz"
+	"https://github.com/evanw/esbuild/archive/refs/tags/v${_ESBUILD_VERSIONS[1]}.tar.gz"
+	"https://github.com/evanw/esbuild/archive/refs/tags/v${_ESBUILD_VERSIONS[2]}.tar.gz"
+	"https://github.com/evanw/esbuild/archive/refs/tags/v${_ESBUILD_VERSIONS[3]}.tar.gz"
+	"https://github.com/evanw/esbuild/archive/refs/tags/v${_ESBUILD_VERSIONS[4]}.tar.gz"
+	"https://registry.npmjs.org/pnpm/-/pnpm-${_PNPM_VERSION}.tgz"
+)
+TERMUX_PKG_SHA256=(
+	7251a6784a8427e0b79fd849de0445af24bade1930a88afc172ac40abf37eaff
+	bad369875859db11ae72cf2ce8e221345072a1b580d58e6849fadd0ee6b66836
+	f4072282dd01d9343b03e6551f88599d9877b5e9f3a82e595e988e091249a86f
+	da504f77d1856e642de6d6e96bab7ddc1da9a73726c7a67467eb4c2b7c0fdaae
+	171e1b0cd4c64222a1953203f6b3dab3c7a3f95b8939a72b4ebbd024302513b4
+	05d56070104b46d24c8921bfc4c83209d71cf583eb0396c13d0f359705bb5b61
+	65c756fa87d43178ac4a5242454c2bd0fde325f8ecf77997f8fa4b88f94d5cd2
+	bfcc1bcbad279b13a516c446a75b3c58b6904b45d57a1951411015e50b751a80
+)
+TERMUX_PKG_DEPENDS="libc++, nodejs | nodejs-lts"
+# termux_setup_proot executes cross-built Android generator tools during the
+# workerd/V8 build and requires the package-builder's Bionic userspace.
+TERMUX_PKG_BUILD_DEPENDS="aosp-libs"
+TERMUX_PKG_BUILD_IN_SRC=true
+# workerd's Bazel zlib port explicitly supports only x86_64 and arm64, and
+# its pinned Rust toolchains likewise target 64-bit hosts. Support both Termux
+# 64-bit architectures while leaving the unsupported 32-bit targets excluded.
+TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"
+# workerd and esbuild versions are coupled to each Wrangler release. Keep
+# updates deliberate until an update hook can validate that tuple.
+TERMUX_PKG_AUTO_UPDATE=false
+
+_wrangler_set_arch() {
+	case "$TERMUX_ARCH" in
+		aarch64)
+			_WRANGLER_GOARCH=arm64
+			_WRANGLER_WORKERD_PLATFORM=android_arm64
+			_WRANGLER_V8_CPU=arm64
+			_WRANGLER_ELF_MACHINE=AArch64
+			;;
+		x86_64)
+			_WRANGLER_GOARCH=amd64
+			_WRANGLER_WORKERD_PLATFORM=android_x86_64
+			_WRANGLER_V8_CPU=x64
+			_WRANGLER_ELF_MACHINE='Advanced Micro Devices X86-64'
+			;;
+		*)
+			termux_error_exit "Unsupported Wrangler architecture: $TERMUX_ARCH"
+			;;
+	esac
+}
+
+termux_step_post_get_source() {
+	local expected_workerd
+	expected_workerd="$(sed -n 's/^  workerd: "\([^"]*\)"/\1/p' pnpm-workspace.yaml | head -n1)"
+	local expected_esbuild
+	expected_esbuild="$(sed -n 's/^  esbuild: "\([^"]*\)"/\1/p' pnpm-workspace.yaml | head -n1)"
+	local expected_pnpm
+	expected_pnpm="$(python3 -c 'import json; print(json.load(open("package.json"))["packageManager"].removeprefix("pnpm@"))')"
+
+	[[ "$expected_workerd" == "$_WORKERD_VERSION" ]] || \
+		termux_error_exit "Wrangler $TERMUX_PKG_VERSION expects workerd $expected_workerd, recipe pins $_WORKERD_VERSION"
+	[[ "$expected_esbuild" == "${_ESBUILD_VERSIONS[-1]}" ]] || \
+		termux_error_exit "Wrangler $TERMUX_PKG_VERSION expects esbuild $expected_esbuild, recipe pins ${_ESBUILD_VERSIONS[-1]}"
+	[[ "$expected_pnpm" == "$_PNPM_VERSION" ]] || \
+		termux_error_exit "Wrangler $TERMUX_PKG_VERSION expects pnpm $expected_pnpm, recipe pins $_PNPM_VERSION"
+
+	[[ -d "workerd-${_WORKERD_VERSION}" ]] || termux_error_exit "workerd source archive was not extracted"
+	for version in "${_ESBUILD_VERSIONS[@]}"; do
+		[[ -d "esbuild-$version" ]] || termux_error_exit "esbuild $version source archive was not extracted"
+	done
+
+	# The npm tarball has a generic top-level `package/` directory. Give it a
+	# stable package-local name and verify the exact version before use.
+	[[ -d package ]] || termux_error_exit "pnpm source archive was not extracted"
+	mv package "pnpm-${_PNPM_VERSION}"
+	local pnpm_archive_version
+	pnpm_archive_version="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "pnpm-${_PNPM_VERSION}/package.json")"
+	[[ "$pnpm_archive_version" == "$_PNPM_VERSION" ]] || termux_error_exit "Unexpected pnpm source version: $pnpm_archive_version"
+
+}
+
+termux_step_pre_configure() {
+	_wrangler_set_arch
+	termux_setup_nodejs
+	termux_setup_golang
+	termux_setup_proot
+
+	# workerd is a secondary source archive, so apply its Android/Bionic port
+	# explicitly. Keep the API level symbolic in the checked-in diff and bind
+	# it to the package build's selected Android API level here.
+	local workerd_tree="$TERMUX_PKG_SRCDIR/workerd-${_WORKERD_VERSION}"
+	local workerd_diff="$TERMUX_PKG_BUILDER_DIR/patches/workerd-android.diff"
+	echo "Applying patch: $(basename "$workerd_diff")"
+	sed "s|@TERMUX_PKG_API_LEVEL@|$TERMUX_PKG_API_LEVEL|g" "$workerd_diff" | \
+		patch --silent -d "$workerd_tree" -p1
+
+	mkdir -p "$TERMUX_PKG_TMPDIR/bin"
+	local pnpm_js="$TERMUX_PKG_SRCDIR/pnpm-${_PNPM_VERSION}/bin/pnpm.cjs"
+	[[ -f "$pnpm_js" ]] || termux_error_exit "Pinned pnpm entrypoint is missing"
+	cat > "$TERMUX_PKG_TMPDIR/bin/pnpm" <<-EOF
+		#!/bin/sh
+		exec node "$pnpm_js" "\$@"
+	EOF
+	chmod 0700 "$TERMUX_PKG_TMPDIR/bin/pnpm"
+	export PATH="$TERMUX_PKG_TMPDIR/bin:$PATH"
+	[[ "$(pnpm --version)" == "$_PNPM_VERSION" ]] || termux_error_exit "Unexpected pnpm version"
+
+	local workerd_bazel_version
+	workerd_bazel_version="$(tr -d '[:space:]' < "$workerd_tree/.bazelversion")"
+	[[ "$workerd_bazel_version" == "$_BAZEL_VERSION" ]] || \
+		termux_error_exit "workerd expects Bazel $workerd_bazel_version, recipe pins $_BAZEL_VERSION"
+	local bazel_bin="$TERMUX_PKG_TMPDIR/bin/bazel"
+	termux_download \
+		"https://github.com/bazelbuild/bazel/releases/download/${_BAZEL_VERSION}/bazel-${_BAZEL_VERSION}-linux-x86_64" \
+		"$bazel_bin" \
+		7668a95db1250f12c40407251e4e203b4ec8bf39bc495d2f485b2d8c99048694
+	chmod 0700 "$bazel_bin"
+	[[ "$($bazel_bin --version)" == "bazel $_BAZEL_VERSION" ]] || termux_error_exit "Unexpected Bazel version"
+
+	local proot_runner
+	proot_runner="$(command -v termux-proot-run)"
+	[[ -x "$proot_runner" ]] || termux_error_exit "termux-proot-run is unavailable after termux_setup_proot"
+
+	local target_runner="$TERMUX_PKG_TMPDIR/workerd-android-run-under"
+	cat > "$target_runner" <<-EOF
+		#!/bin/bash
+		# Bazel actions run with a hermetic PATH that excludes Termux's cached
+		# proot helper directory, so embed the resolved helper path here.
+		exec "$proot_runner" env LD_PRELOAD= LD_LIBRARY_PATH= "\$@"
+	EOF
+	chmod 0700 "$target_runner"
+
+	# Static Android source changes live in patches/workerd-android.diff. Only
+	# builder-local absolute paths belong here.
+	cat >> "$workerd_tree/.bazelrc" <<-EOF
+
+# Native Android configuration for the official Termux package build.
+build:android --config=unix
+build:android --@capnp-cpp//src/kj:libdl=False
+build:android --repo_env=CC=$TERMUX_HOST_LLVM_BASE_DIR/bin/clang
+build:android --repo_env=AR=$TERMUX_HOST_LLVM_BASE_DIR/bin/llvm-ar
+build:android --host_linkopt=--ld-path=$TERMUX_HOST_LLVM_BASE_DIR/bin/ld.lld
+build:android --host_linkopt=-latomic
+build:android --//build/config:target_run_under=$target_runner
+build:android --@v8//bazel/config:v8_target_cpu=$_WRANGLER_V8_CPU
+build:release_android --config=android
+build:release_android --config=release_unix
+build:release_android --@workerd//src/workerd/server:use_tcmalloc=False
+build:release_android --@workerd//src/workerd/util:use_perfetto=False
+	EOF
+
+	export ANDROID_NDK_HOME="$NDK"
+}
+
+_build_esbuild() {
+	local version="$1"
+	local goos="$2"
+	local goarch="$3"
+	local output="$4"
+	(
+		cd "$TERMUX_PKG_SRCDIR/esbuild-$version"
+		CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
+			go build -trimpath -o "$output" ./cmd/esbuild
+	)
+	chmod 0700 "$output"
+}
+
+termux_step_make() {
+	_wrangler_set_arch
+	export NODE_ENV=production
+	export CI_OS=Linux
+	export WRANGLER_SEND_METRICS=false
+	export PATH="$TERMUX_PKG_TMPDIR/bin:$PATH"
+
+	# Build every host esbuild version used by Wrangler's filtered dependency
+	# graph from source, then replace npm's platform payloads before any build
+	# script can execute them.
+	pnpm --filter="wrangler..." install --frozen-lockfile --ignore-scripts
+	for version in "${_ESBUILD_VERSIONS[@]}"; do
+		local host_binary="$TERMUX_PKG_TMPDIR/esbuild-host-$version"
+		_build_esbuild "$version" linux amd64 "$host_binary"
+		[[ "$($host_binary --version)" == "$version" ]] || termux_error_exit "Host esbuild $version verification failed"
+
+		mapfile -t targets < <(
+			find node_modules/.pnpm \
+				-path "*/@esbuild+linux-x64@$version/node_modules/@esbuild/linux-x64/bin/esbuild" \
+				-type f
+		)
+		((${#targets[@]} > 0)) || termux_error_exit "No installed @esbuild/linux-x64 payload for $version"
+		for target in "${targets[@]}"; do
+			install -m 0700 "$host_binary" "$target"
+		done
+	done
+
+	local target_esbuild="$TERMUX_PKG_TMPDIR/esbuild-android"
+	if [[ "$TERMUX_ARCH" == x86_64 ]]; then
+		# Go requires external linking for android/amd64. Use Termux's NDK
+		# target compiler; esbuild itself remains built entirely from source.
+		(
+			cd "$TERMUX_PKG_SRCDIR/esbuild-${_ESBUILD_VERSIONS[-1]}"
+			CGO_ENABLED=1 GOOS=android GOARCH="$_WRANGLER_GOARCH" CC="$CC" \
+				go build -trimpath -o "$target_esbuild" ./cmd/esbuild
+		)
+		chmod 0700 "$target_esbuild"
+	else
+		_build_esbuild "${_ESBUILD_VERSIONS[-1]}" android "$_WRANGLER_GOARCH" "$target_esbuild"
+	fi
+
+	pnpm --filter="wrangler..." build
+	local deploy="$TERMUX_PKG_TMPDIR/wrangler-deploy"
+	rm -rf "$deploy"
+	pnpm --filter=wrangler deploy "$deploy" --prod --legacy --no-optional --ignore-scripts
+
+	local workerd_tree="$TERMUX_PKG_SRCDIR/workerd-${_WORKERD_VERSION}"
+	(
+		cd "$workerd_tree"
+		ANDROID_NDK_HOME="$NDK" "$TERMUX_PKG_TMPDIR/bin/bazel" build \
+			//src/workerd/server:workerd \
+			--enable_platform_specific_config=false \
+			--config=release_android \
+			--platforms=//:$_WRANGLER_WORKERD_PLATFORM \
+			--jobs="$TERMUX_PKG_MAKE_PROCESSES" \
+			--verbose_failures
+	)
+
+	local workerd_binary="$workerd_tree/bazel-bin/src/workerd/server/workerd"
+	[[ -x "$workerd_binary" ]] || termux_error_exit "workerd Android binary was not produced"
+}
+
+termux_step_make_install() {
+	_wrangler_set_arch
+	local deploy="$TERMUX_PKG_TMPDIR/wrangler-deploy"
+	local target_esbuild="$TERMUX_PKG_TMPDIR/esbuild-android"
+	local workerd_binary="$TERMUX_PKG_SRCDIR/workerd-${_WORKERD_VERSION}/bazel-bin/src/workerd/server/workerd"
+
+	python3 "$TERMUX_PKG_BUILDER_DIR/prepare-wrangler-deploy.py" \
+		--deploy "$deploy" \
+		--prefix "$TERMUX_PREFIX" \
+		--workerd-binary "$workerd_binary" \
+		--esbuild-binary "$target_esbuild" \
+		--wrangler-version "$TERMUX_PKG_VERSION"
+}
+
+termux_step_post_make_install() {
+	_wrangler_set_arch
+	local workerd_binary="$TERMUX_PREFIX/lib/wrangler/native/workerd"
+	local esbuild_binary="$TERMUX_PREFIX/lib/wrangler/native/esbuild"
+	for binary in "$workerd_binary" "$esbuild_binary"; do
+		[[ -x "$binary" ]] || termux_error_exit "Missing native runtime: $binary"
+		readelf -h "$binary" | grep -Fq "$_WRANGLER_ELF_MACHINE" || \
+			termux_error_exit "Wrong-architecture native runtime for $TERMUX_ARCH: $binary"
+		readelf -l "$binary" | grep -Fq '/system/bin/linker64' || \
+			termux_error_exit "Non-Android ELF interpreter: $binary"
+		if readelf -d "$binary" 2>/dev/null | grep -Fq 'libc.so.6'; then
+			termux_error_exit "glibc dependency detected: $binary"
+		fi
+	done
+}

--- a/packages/wrangler/patches/workerd-android.diff
+++ b/packages/wrangler/patches/workerd-android.diff
@@ -1,0 +1,457 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 6acb6a7..1c8f15e 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -83,6 +83,24 @@ platform(
+     ],
+ )
+ 
++# Native Android/Termux 64-bit targets. These deliberately use the Android OS
++# constraint instead of pretending Bionic is glibc Linux.
++platform(
++    name = "android_arm64",
++    constraint_values = [
++        "@platforms//os:android",
++        "@platforms//cpu:aarch64",
++    ],
++)
++
++platform(
++    name = "android_x86_64",
++    constraint_values = [
++        "@platforms//os:android",
++        "@platforms//cpu:x86_64",
++    ],
++)
++
+ # Detect whether we use Linux/macOS/either, used to configure whether tcmalloc/perfetto should be
+ # used.
+ config_setting(
+@@ -97,11 +115,18 @@ config_setting(
+     visibility = ["//visibility:public"],
+ )
+ 
++config_setting(
++    name = "is_android",
++    constraint_values = ["@platforms//os:android"],
++    visibility = ["//visibility:public"],
++)
++
+ selects.config_setting_group(
+     name = "is_unix",
+     match_any = [
+         ":is_linux",
+         ":is_macos",
++        ":is_android",
+     ],
+     visibility = ["//visibility:public"],
+ )
+diff --git a/MODULE.bazel b/MODULE.bazel
+index f686065..b898bed 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -2,6 +2,17 @@
+ 
+ module(name = "workerd")
+ 
++# Native Android targets for the Termux package build. The NDK is
++# supplied by the Termux build environment through ANDROID_NDK_HOME.
++bazel_dep(name = "rules_android_ndk", version = "0.1.5")
++android_ndk_repository_extension = use_extension(
++    "@rules_android_ndk//:extension.bzl",
++    "android_ndk_repository_extension",
++)
++android_ndk_repository_extension.configure(api_level = @TERMUX_PKG_API_LEVEL@)
++use_repo(android_ndk_repository_extension, "androidndk")
++register_toolchains("@androidndk//:all")
++
+ # sqlite3 is downloaded from sqlite.org (not GitHub), so it remains manual.
+ # We have some patches that aren't included in BCR:
+ # https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/sqlite3/3.47.0/patches
+diff --git a/build/BUILD.zlib b/build/BUILD.zlib
+index 65b292e..dfe463f 100644
+--- a/build/BUILD.zlib
++++ b/build/BUILD.zlib
+@@ -20,6 +20,14 @@ selects.config_setting_group(
+     ],
+ )
+ 
++selects.config_setting_group(
++    name = "x86_android",
++    match_all = [
++        "@platforms//cpu:x86_64",
++        "@platforms//os:android",
++    ],
++)
++
+ selects.config_setting_group(
+     name = "x86_macos",
+     match_all = [
+@@ -44,6 +52,14 @@ selects.config_setting_group(
+     ],
+ )
+ 
++selects.config_setting_group(
++    name = "arm64_android",
++    match_all = [
++        "@platforms//cpu:aarch64",
++        "@platforms//os:android",
++    ],
++)
++
+ selects.config_setting_group(
+     name = "arm64_macos",
+     match_all = [
+@@ -94,6 +110,7 @@ cc_library(
+         "@platforms//cpu:aarch64": ["ADLER32_SIMD_NEON"],
+     }) + select({
+         ":x86_linux": ["X86_NOT_WINDOWS"],
++        ":x86_android": ["X86_NOT_WINDOWS"],
+         ":x86_macos": ["X86_NOT_WINDOWS"],
+         ":x86_windows": ["X86_WINDOWS"],
+         "//conditions:default": [],
+@@ -119,6 +136,7 @@ cc_library(
+         "ZLIB_IMPLEMENTATION",
+     ] + select({
+         "@platforms//os:linux": ["ARMV8_OS_LINUX"],
++        "@platforms//os:android": ["ARMV8_OS_LINUX"],
+         "@platforms//os:macos": ["ARMV8_OS_MACOS"],
+         "@platforms//os:windows": ["ARMV8_OS_WINDOWS"],
+     }),
+@@ -244,9 +262,11 @@ cc_library(
+         ],
+     }) + select({
+         ":x86_linux": ["X86_NOT_WINDOWS"],
++        ":x86_android": ["X86_NOT_WINDOWS"],
+         ":x86_macos": ["X86_NOT_WINDOWS"],
+         ":x86_windows": ["X86_WINDOWS"],
+         ":arm64_linux": ["ARMV8_OS_LINUX"],
++        ":arm64_android": ["ARMV8_OS_LINUX"],
+         "arm64_macos": ["ARMV8_OS_MACOS"],
+         "arm64_windows": ["ARMV8_OS_WINDOWS"],
+         "//conditions:default": [],
+diff --git a/build/deps/gen/deps.MODULE.bazel b/build/deps/gen/deps.MODULE.bazel
+index 0825f59..3380fbf 100644
+--- a/build/deps/gen/deps.MODULE.bazel
++++ b/build/deps/gen/deps.MODULE.bazel
+@@ -27,6 +27,8 @@ bazel_dep(name = "brotli", version = "1.2.0.bcr.1")
+ # capnp-cpp
+ http.archive(
+     name = "capnp-cpp",
++    patch_args = ["-p1"],
++    patches = ["//:patches/capnp/0001-android-bionic-port.patch"],
+     sha256 = "a080720b26dd2e47ebab47a3be4b681184f7136a923b2225a39b5b2603aad446",
+     strip_prefix = "capnproto-capnproto-86bb703/c++",
+     type = "tgz",
+diff --git a/build/deps/rust.MODULE.bazel b/build/deps/rust.MODULE.bazel
+index fcd261e..a8bbba0 100644
+--- a/build/deps/rust.MODULE.bazel
++++ b/build/deps/rust.MODULE.bazel
+@@ -5,8 +5,10 @@ RUST_NIGHTLY_VERSION = "nightly/2026-05-28"
+ RUST_TARGET_TRIPLES = [
+     "x86_64-apple-darwin",
+     "aarch64-unknown-linux-gnu",
++    "aarch64-linux-android",
+     "aarch64-apple-darwin",
+     "x86_64-unknown-linux-gnu",
++    "x86_64-linux-android",
+     "x86_64-pc-windows-msvc",
+ ]
+ 
+@@ -18,9 +20,11 @@ rust.toolchain(
+         # Enable ISA extensions matching the ones used for C++. The clmul feature is not included as
+         # it is still "unstable" as of 1.86.0.
+         "x86_64-unknown-linux-gnu": ["-Ctarget-feature=+sse4.2"],
++        "x86_64-linux-android": ["-Ctarget-feature=+sse4.2"],
+         "x86_64-apple-darwin": ["-Ctarget-feature=+sse4.2"],
+         "x86_64-pc-windows-msvc": ["-Ctarget-feature=+sse4.2"],
+         "aarch64-unknown-linux-gnu": ["-Ctarget-feature=+crc"],
++        "aarch64-linux-android": ["-Ctarget-feature=+crc"],
+         # No options needed for aarch64-apple-darwin: CRC feature is enabled by default.
+     },
+     extra_target_triples = RUST_TARGET_TRIPLES,
+diff --git a/build/deps/v8.MODULE.bazel b/build/deps/v8.MODULE.bazel
+index 18db5f3..4c57a22 100644
+--- a/build/deps/v8.MODULE.bazel
++++ b/build/deps/v8.MODULE.bazel
+@@ -61,6 +61,13 @@ PATCHES = [
+     "0036-Fix-ExtendedMap-layout-on-Windows.patch",
+     "0037-Fix-CFunction-MemorySpan-declarations-on-Windows.patch",
+     "0038-Properly-depend-on-llvm-libc.patch",
++    "0040-Fix-Android-stack-trace-project-include.patch",
++    "0041-Provide-atomic-ref-on-Android.patch",
++    "0042-Build-V8-generators-in-exec-configuration.patch",
++    "0043-Use-CXX23-for-Clang-Bazel-builds.patch",
++    "0044-Set-Android-mksnapshot-target-OS.patch",
++    "0045-Explicit-SIMD-shuffle-array-size.patch",
++    "0046-Remove-unused-object-literal-native-context.patch",
+ ]
+ 
+ http_archive(
+diff --git a/patches/capnp/0001-android-bionic-port.patch b/patches/capnp/0001-android-bionic-port.patch
+new file mode 100644
+index 0000000..0964041
+--- /dev/null
++++ b/patches/capnp/0001-android-bionic-port.patch
+@@ -0,0 +1,20 @@
++diff --git a/src/kj/filesystem.c++ b/src/kj/filesystem.c++
++--- a/src/kj/filesystem.c++
+++++ b/src/kj/filesystem.c++
++@@ -31 +31 @@
++-#if __linux__
+++#if __linux__ && !defined(__ANDROID__)
++@@ -1839 +1839 @@
++-#if __linux__
+++#if __linux__ && !defined(__ANDROID__)
++diff --git a/src/kj/filesystem.h b/src/kj/filesystem.h
++--- a/src/kj/filesystem.h
+++++ b/src/kj/filesystem.h
++@@ -939 +939 @@
++-#if __linux__
+++#if __linux__ && !defined(__ANDROID__)
++diff --git a/src/kj/BUILD.bazel b/src/kj/BUILD.bazel
++--- a/src/kj/BUILD.bazel
+++++ b/src/kj/BUILD.bazel
++@@ -84,0 +85 @@
+++        "@platforms//os:android": [],
+diff --git a/patches/v8/0040-Fix-Android-stack-trace-project-include.patch b/patches/v8/0040-Fix-Android-stack-trace-project-include.patch
+new file mode 100644
+index 0000000..dd0ed17
+--- /dev/null
++++ b/patches/v8/0040-Fix-Android-stack-trace-project-include.patch
+@@ -0,0 +1,6 @@
++diff --git a/src/base/debug/stack_trace_android.cc b/src/base/debug/stack_trace_android.cc
++--- a/src/base/debug/stack_trace_android.cc
+++++ b/src/base/debug/stack_trace_android.cc
++@@ -15 +15 @@
++-#include <src/base/platform/platform.h>
+++#include "src/base/platform/platform.h"
+diff --git a/patches/v8/0041-Provide-atomic-ref-on-Android.patch b/patches/v8/0041-Provide-atomic-ref-on-Android.patch
+new file mode 100644
+index 0000000..3879022
+--- /dev/null
++++ b/patches/v8/0041-Provide-atomic-ref-on-Android.patch
+@@ -0,0 +1,108 @@
++diff --git a/include/v8config.h b/include/v8config.h
++--- a/include/v8config.h
+++++ b/include/v8config.h
++@@ -21,7 +21,104 @@
++ #include "v8-gn.h"  // NOLINT(build/include_directory)
++ #endif
++
+++#include <atomic>
++ #include <memory>
+++
+++// Android NDK libc++ does not currently provide C++20 std::atomic_ref. V8
+++// relies on atomic_ref for atomically accessing existing storage, so provide
+++// the subset of the interface V8 uses via Clang's __atomic builtins.
+++#if defined(__ANDROID__) && !defined(__cpp_lib_atomic_ref)
+++namespace std {
+++namespace __v8_android_atomic_ref_compat {
+++constexpr int ToBuiltinOrder(memory_order order) noexcept {
+++  switch (order) {
+++    case memory_order_relaxed: return __ATOMIC_RELAXED;
+++    case memory_order_consume: return __ATOMIC_CONSUME;
+++    case memory_order_acquire: return __ATOMIC_ACQUIRE;
+++    case memory_order_release: return __ATOMIC_RELEASE;
+++    case memory_order_acq_rel: return __ATOMIC_ACQ_REL;
+++    case memory_order_seq_cst: return __ATOMIC_SEQ_CST;
+++  }
+++  __builtin_unreachable();
+++}
+++constexpr memory_order FailureOrder(memory_order order) noexcept {
+++  if (order == memory_order_release) return memory_order_relaxed;
+++  if (order == memory_order_acq_rel) return memory_order_acquire;
+++  return order;
+++}
+++}  // namespace __v8_android_atomic_ref_compat
+++
+++template <typename T>
+++class atomic_ref {
+++ public:
+++  using value_type = T;
+++  static constexpr size_t required_alignment = alignof(T);
+++  static constexpr bool is_always_lock_free =
+++      __atomic_always_lock_free(sizeof(T), nullptr);
+++
+++  explicit atomic_ref(T& object) noexcept : ptr_(&object) {}
+++  atomic_ref(const atomic_ref&) noexcept = default;
+++
+++  T load(memory_order order = memory_order_seq_cst) const noexcept {
+++    T value;
+++    __atomic_load(ptr_, &value,
+++                  __v8_android_atomic_ref_compat::ToBuiltinOrder(order));
+++    return value;
+++  }
+++
+++  void store(T desired,
+++             memory_order order = memory_order_seq_cst) const noexcept {
+++    __atomic_store(ptr_, &desired,
+++                   __v8_android_atomic_ref_compat::ToBuiltinOrder(order));
+++  }
+++
+++  T exchange(T desired,
+++             memory_order order = memory_order_seq_cst) const noexcept {
+++    T old;
+++    __atomic_exchange(ptr_, &desired, &old,
+++                      __v8_android_atomic_ref_compat::ToBuiltinOrder(order));
+++    return old;
+++  }
+++
+++  bool compare_exchange_strong(T& expected, T desired, memory_order success,
+++                               memory_order failure) const noexcept {
+++    return __atomic_compare_exchange(
+++        ptr_, &expected, &desired, false,
+++        __v8_android_atomic_ref_compat::ToBuiltinOrder(success),
+++        __v8_android_atomic_ref_compat::ToBuiltinOrder(failure));
+++  }
+++
+++  bool compare_exchange_strong(
+++      T& expected, T desired,
+++      memory_order order = memory_order_seq_cst) const noexcept {
+++    return compare_exchange_strong(
+++        expected, desired, order,
+++        __v8_android_atomic_ref_compat::FailureOrder(order));
+++  }
+++
+++  template <typename U = T>
+++  enable_if_t<is_integral_v<U>, U> fetch_or(
+++      U arg, memory_order order = memory_order_seq_cst) const noexcept {
+++    return __atomic_fetch_or(
+++        ptr_, arg, __v8_android_atomic_ref_compat::ToBuiltinOrder(order));
+++  }
+++
+++  template <typename U = T>
+++  enable_if_t<is_integral_v<U>, U> fetch_add(
+++      U arg, memory_order order = memory_order_seq_cst) const noexcept {
+++    return __atomic_fetch_add(
+++        ptr_, arg, __v8_android_atomic_ref_compat::ToBuiltinOrder(order));
+++  }
+++
+++  bool is_lock_free() const noexcept {
+++    return __atomic_is_lock_free(sizeof(T), ptr_);
+++  }
+++
+++ private:
+++  T* ptr_;
+++};
+++}  // namespace std
+++#endif  // defined(__ANDROID__) && !defined(__cpp_lib_atomic_ref)
++ // clang-format off
++
++ // Platform headers for feature detection below.
+diff --git a/patches/v8/0042-Build-V8-generators-in-exec-configuration.patch b/patches/v8/0042-Build-V8-generators-in-exec-configuration.patch
+new file mode 100644
+index 0000000..cc39a0a
+--- /dev/null
++++ b/patches/v8/0042-Build-V8-generators-in-exec-configuration.patch
+@@ -0,0 +1,6 @@
++diff --git a/bazel/defs.bzl b/bazel/defs.bzl
++--- a/bazel/defs.bzl
+++++ b/bazel/defs.bzl
++@@ -353 +353 @@ def get_cfg():
++-    return "target"
+++    return "exec"
+diff --git a/patches/v8/0043-Use-CXX23-for-Clang-Bazel-builds.patch b/patches/v8/0043-Use-CXX23-for-Clang-Bazel-builds.patch
+new file mode 100644
+index 0000000..ad1df5b
+--- /dev/null
++++ b/patches/v8/0043-Use-CXX23-for-Clang-Bazel-builds.patch
+@@ -0,0 +1,6 @@
++diff --git a/bazel/defs.bzl b/bazel/defs.bzl
++--- a/bazel/defs.bzl
+++++ b/bazel/defs.bzl
++@@ -152 +152 @@
++-                "-std=c++20",
+++                "-std=c++23",
+diff --git a/patches/v8/0044-Set-Android-mksnapshot-target-OS.patch b/patches/v8/0044-Set-Android-mksnapshot-target-OS.patch
+new file mode 100644
+index 0000000..c0c059b
+--- /dev/null
++++ b/patches/v8/0044-Set-Android-mksnapshot-target-OS.patch
+@@ -0,0 +1,17 @@
++diff --git a/bazel/defs.bzl b/bazel/defs.bzl
++--- a/bazel/defs.bzl
+++++ b/bazel/defs.bzl
++@@ -548,5 +548 @@ def v8_mksnapshot(name, args, suffix = ""):
++-        target_os = select({
++-            "@v8//bazel/config:is_macos": "mac",
++-            "@v8//bazel/config:is_windows": "win",
++-            "//conditions:default": "",
++-        }),
+++        target_os = "android",
++@@ -557,5 +553 @@ def v8_mksnapshot(name, args, suffix = ""):
++-        target_os = select({
++-            "@v8//bazel/config:is_macos": "mac",
++-            "@v8//bazel/config:is_windows": "win",
++-            "//conditions:default": "",
++-        }),
+++        target_os = "android",
+diff --git a/patches/v8/0045-Explicit-SIMD-shuffle-array-size.patch b/patches/v8/0045-Explicit-SIMD-shuffle-array-size.patch
+new file mode 100644
+index 0000000..442fc3d
+--- /dev/null
++++ b/patches/v8/0045-Explicit-SIMD-shuffle-array-size.patch
+@@ -0,0 +1,6 @@
++diff --git a/src/compiler/turboshaft/wasm-shuffle-reducer.cc b/src/compiler/turboshaft/wasm-shuffle-reducer.cc
++--- a/src/compiler/turboshaft/wasm-shuffle-reducer.cc
+++++ b/src/compiler/turboshaft/wasm-shuffle-reducer.cc
++@@ -522 +522 @@
++-    SimdShuffle::ShuffleArray shuffle_bytes;
+++    SimdShuffle::ShuffleArray<kSimd128Size> shuffle_bytes;
+diff --git a/patches/v8/0046-Remove-unused-object-literal-native-context.patch b/patches/v8/0046-Remove-unused-object-literal-native-context.patch
+new file mode 100644
+index 0000000..6459dc0
+--- /dev/null
++++ b/patches/v8/0046-Remove-unused-object-literal-native-context.patch
+@@ -0,0 +1,5 @@
++diff --git a/src/runtime/runtime-literals.cc b/src/runtime/runtime-literals.cc
++--- a/src/runtime/runtime-literals.cc
+++++ b/src/runtime/runtime-literals.cc
++@@ -519 +518,0 @@ Handle<JSObject> CreateObjectLiteral(
++-  DirectHandle<NativeContext> native_context = isolate->native_context();
+diff --git a/src/workerd/api/crypto/endianness.c++ b/src/workerd/api/crypto/endianness.c++
+index 8bef872..c36ed5b 100644
+--- a/src/workerd/api/crypto/endianness.c++
++++ b/src/workerd/api/crypto/endianness.c++
+@@ -10,7 +10,26 @@
+ 
+ #endif
+ 
+-#if defined(__linux__) || defined(__CYGWIN__)
++#if defined(__ANDROID__)
++
++#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
++#error Termux Android targets are expected to be little-endian
++#endif
++
++uint16_t htobe16(uint16_t x) { return __builtin_bswap16(x); }
++uint16_t htole16(uint16_t x) { return x; }
++uint16_t be16toh(uint16_t x) { return __builtin_bswap16(x); }
++uint16_t le16toh(uint16_t x) { return x; }
++uint32_t htobe32(uint32_t x) { return __builtin_bswap32(x); }
++uint32_t htole32(uint32_t x) { return x; }
++uint32_t be32toh(uint32_t x) { return __builtin_bswap32(x); }
++uint32_t le32toh(uint32_t x) { return x; }
++uint64_t htobe64(uint64_t x) { return __builtin_bswap64(x); }
++uint64_t htole64(uint64_t x) { return x; }
++uint64_t be64toh(uint64_t x) { return __builtin_bswap64(x); }
++uint64_t le64toh(uint64_t x) { return x; }
++
++#elif defined(__linux__) || defined(__CYGWIN__)
+ 
+ #include <endian.h>
+ 
+diff --git a/src/workerd/jsg/modules-new.c++ b/src/workerd/jsg/modules-new.c++
+index f810391..5fa0277 100644
+--- a/src/workerd/jsg/modules-new.c++
++++ b/src/workerd/jsg/modules-new.c++
+@@ -8,7 +8,7 @@
+ #include <workerd/jsg/jsg.h>
+ #include <workerd/jsg/util.h>
+ 
+-#include <simdutf.h>
++#include "simdutf.h"
+ 
+ #include <kj/encoding.h>
+ #include <kj/mutex.h>

--- a/packages/wrangler/prepare-wrangler-deploy.py
+++ b/packages/wrangler/prepare-wrangler-deploy.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Assemble a self-contained Wrangler package for native Termux."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+from pathlib import Path
+
+WORKERD_ANCHOR = "function generateBinPath() {\n  const { pkg, subpath } = pkgAndSubpathForCurrentPlatform();"
+WORKERD_ANDROID = """function generateBinPath() {
+  // Upstream workerd does not register Android in its npm
+  // platform table. The package launcher points this at the exact Android
+  // workerd binary built from source alongside Wrangler.
+  if (process.platform === "android" && process.env.WORKERD_BINARY_PATH) {
+    return { binPath: process.env.WORKERD_BINARY_PATH };
+  }
+  const { pkg, subpath } = pkgAndSubpathForCurrentPlatform();"""
+
+
+def executable_copy(source: Path, destination: Path) -> None:
+    source = source.resolve(strict=True)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+    destination.chmod(0o755)
+
+
+def normalize_wrangler_self_link(root: Path) -> None:
+    link = root / "node_modules" / ".pnpm" / "node_modules" / "wrangler"
+    if not link.is_symlink():
+        return
+    target = link.resolve(strict=True)
+    if target == root.resolve():
+        return
+    package_json = target / "package.json"
+    try:
+        package = json.loads(package_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Unexpected external Wrangler self-link target: {target}") from exc
+    if package.get("name") != "wrangler":
+        raise RuntimeError(f"Unexpected external Wrangler self-link target: {target}")
+    link.unlink()
+    # From node_modules/.pnpm/node_modules back to the deployment root.
+    os.symlink("../../..", link, target_is_directory=True)
+
+
+TERMUX_RUNTIME_PREFIX = Path("@TERMUX_PREFIX@")
+TERMUX_WRANGLER_HOME = TERMUX_RUNTIME_PREFIX / "lib" / "wrangler"
+FORBIDDEN_NATIVE_PACKAGE_PREFIXES = (
+    # The unscoped JS wrappers are portable; these scoped packages are the
+    # npm-distributed platform payloads that this project replaces from source.
+    "@cloudflare/workerd-",
+    "@esbuild/",
+    "@img/sharp-",
+)
+
+
+def deployment_root_variants(root: Path) -> set[str]:
+    resolved = str(root.resolve())
+    variants = {resolved, resolved.replace("\\", "/")}
+    match = re.match(r"^/mnt/([A-Za-z])/(.*)$", resolved)
+    if match:
+        drive, rest = match.groups()
+        windows = drive.upper() + ":\\" + rest.replace("/", "\\")
+        variants.update({windows, windows.replace("\\", "/")})
+    return {value for value in variants if value}
+
+
+def normalize_pnpm_bin_shims(root: Path) -> None:
+    """Remove Windows shims and rewrite pnpm's absolute deploy-root NODE_PATHs."""
+    replacements = deployment_root_variants(root)
+    destination = str(TERMUX_WRANGLER_HOME)
+    for bin_dir in root.rglob(".bin"):
+        if not bin_dir.is_dir():
+            continue
+        for shim in bin_dir.iterdir():
+            if shim.is_symlink() or not shim.is_file():
+                continue
+            if shim.suffix.lower() in {".cmd", ".ps1"}:
+                shim.unlink()
+                continue
+            try:
+                text = shim.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                continue
+            updated = text
+            for source in sorted(replacements, key=len, reverse=True):
+                updated = updated.replace(source, destination)
+            if any(source in updated for source in replacements):
+                raise RuntimeError(f"pnpm shim still contains its staging deployment path: {shim}")
+            if updated != text:
+                shim.write_text(updated, encoding="utf-8", newline="\n")
+
+
+def normalize_termux_shebangs(root: Path) -> None:
+    """Rewrite conventional Linux shebangs to paths that exist in Termux."""
+    replacements = {
+        b"#!/bin/sh": b"#!@TERMUX_PREFIX@/bin/sh",
+        b"#!/usr/bin/env sh": b"#!@TERMUX_PREFIX@/bin/sh",
+        b"#!/usr/bin/env node": b"#!@TERMUX_PREFIX@/bin/node",
+        b"#! /usr/bin/env node": b"#!@TERMUX_PREFIX@/bin/node",
+        b"#!/usr/bin/env bash": b"#!@TERMUX_PREFIX@/bin/bash",
+    }
+    for path in root.rglob("*"):
+        if path.is_symlink() or not path.is_file():
+            continue
+        try:
+            data = path.read_bytes()
+        except OSError:
+            continue
+        newline = data.find(b"\n")
+        if newline < 0:
+            continue
+        first_line = data[:newline].rstrip(b"\r")
+        replacement = replacements.get(first_line)
+        if replacement is not None:
+            path.write_bytes(replacement + b"\n" + data[newline + 1 :])
+
+
+def remove_foreign_native_payloads(root: Path) -> None:
+    """Drop foreign PE/Mach-O helpers and reject accidental host ELF payloads."""
+    macho_magics = {
+        b"\xfe\xed\xfa\xce",
+        b"\xce\xfa\xed\xfe",
+        b"\xfe\xed\xfa\xcf",
+        b"\xcf\xfa\xed\xfe",
+        b"\xca\xfe\xba\xbe",
+        b"\xbe\xba\xfe\xca",
+    }
+    for path in root.rglob("*"):
+        if path.is_symlink() or not path.is_file():
+            continue
+        try:
+            with path.open("rb") as handle:
+                magic = handle.read(4)
+        except OSError:
+            continue
+        if magic.startswith(b"MZ") or magic in macho_magics:
+            print(f"Removing foreign native payload: {path.relative_to(root)}")
+            path.unlink()
+            continue
+        if magic.startswith(b"\x7fELF"):
+            raise RuntimeError(f"Deployment contains an unexpected host ELF binary: {path}")
+
+
+def reject_platform_native_packages(root: Path) -> None:
+    """Reject npm-distributed native payload packages; native bits are source-built here."""
+    for path in root.rglob("package.json"):
+        try:
+            name = json.loads(path.read_text(encoding="utf-8")).get("name", "")
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if any(name.startswith(prefix) for prefix in FORBIDDEN_NATIVE_PACKAGE_PREFIXES):
+            raise RuntimeError(f"Platform-native dependency leaked into Wrangler deployment: {name}")
+
+
+def verify_self_contained(root: Path) -> None:
+    resolved_root = root.resolve()
+    for path in root.rglob("*"):
+        if not path.is_symlink():
+            continue
+        try:
+            target = path.resolve(strict=True)
+            target.relative_to(resolved_root)
+        except (FileNotFoundError, ValueError) as exc:
+            raise RuntimeError(f"Deployment contains an external or broken symlink: {path}") from exc
+
+        # pnpm uses relative symlinks on Linux, but a deployment produced on
+        # Windows may expose equivalent directory junctions as absolute links
+        # through WSL. They are self-contained before relocation but would point
+        # back to the original staging tree after copytree(..., symlinks=True).
+        # Canonicalize every validated internal link to a relative target first.
+        relative_target = os.path.relpath(target, start=path.parent)
+        raw_target = os.readlink(path)
+        if raw_target != relative_target:
+            target_is_directory = target.is_dir()
+            path.unlink()
+            os.symlink(relative_target, path, target_is_directory=target_is_directory)
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--deploy", required=True, type=Path)
+    parser.add_argument("--prefix", required=True, type=Path)
+    parser.add_argument("--workerd-binary", required=True, type=Path)
+    parser.add_argument("--esbuild-binary", required=True, type=Path)
+    parser.add_argument("--wrangler-version", required=True)
+    args = parser.parse_args()
+
+    deploy = args.deploy.resolve(strict=True)
+    normalize_wrangler_self_link(deploy)
+    normalize_pnpm_bin_shims(deploy)
+    normalize_termux_shebangs(deploy)
+    remove_foreign_native_payloads(deploy)
+    verify_self_contained(deploy)
+
+    package = json.loads((deploy / "package.json").read_text(encoding="utf-8"))
+    if package.get("name") != "wrangler" or package.get("version") != args.wrangler_version:
+        raise RuntimeError(
+            f"Unexpected deployment identity: {package.get('name')}@{package.get('version')}"
+        )
+    if not (deploy / "bin" / "wrangler.js").is_file():
+        raise RuntimeError("Wrangler deployment is missing bin/wrangler.js")
+    if not (deploy / "bin" / "cf-wrangler.js").is_file():
+        raise RuntimeError("Wrangler deployment is missing bin/cf-wrangler.js")
+    reject_platform_native_packages(deploy)
+
+    prefix_path = args.prefix
+    app = prefix_path / "lib" / "wrangler"
+    if app.exists() or app.is_symlink():
+        if app.is_symlink() or app.is_file():
+            app.unlink()
+        else:
+            shutil.rmtree(app)
+    app.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(deploy, app, symlinks=True)
+
+    workerd_main = (app / "node_modules" / "workerd" / "lib" / "main.js").resolve(strict=True)
+    try:
+        workerd_main.relative_to(app.resolve())
+    except ValueError as exc:
+        raise RuntimeError("workerd runtime resolved outside Wrangler deployment") from exc
+    workerd_text = workerd_main.read_text(encoding="utf-8")
+    if WORKERD_ANCHOR not in workerd_text:
+        raise RuntimeError("Unexpected workerd runtime layout; Android patch anchor missing")
+    workerd_main.write_text(
+        workerd_text.replace(WORKERD_ANCHOR, WORKERD_ANDROID, 1),
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    native = app / "native"
+    executable_copy(args.workerd_binary, native / "workerd")
+    executable_copy(args.esbuild_binary, native / "esbuild")
+
+    bin_dir = prefix_path / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+
+    def write_launcher(name: str, entrypoint: str) -> None:
+        if not (app / "bin" / entrypoint).is_file():
+            raise RuntimeError(f"Wrangler entrypoint missing: {entrypoint}")
+        launcher = bin_dir / name
+        lines = [
+            "#!@TERMUX_PREFIX@/bin/sh",
+            "set -eu",
+            "PREFIX=${PREFIX:-@TERMUX_PREFIX@}",
+            'export WRANGLER_HOME="$PREFIX/lib/wrangler"',
+            'export WORKERD_BINARY_PATH="$WRANGLER_HOME/native/workerd"',
+            'export MINIFLARE_WORKERD_PATH="$WORKERD_BINARY_PATH"',
+            'export ESBUILD_BINARY_PATH="$WRANGLER_HOME/native/esbuild"',
+            f'exec "$PREFIX/bin/node" "$WRANGLER_HOME/bin/{entrypoint}" "$@"',
+            "",
+        ]
+        launcher.write_text("\n".join(lines), encoding="utf-8", newline="\n")
+        launcher.chmod(0o755)
+
+    write_launcher("wrangler", "wrangler.js")
+    wrangler2 = bin_dir / "wrangler2"
+    if wrangler2.exists() or wrangler2.is_symlink():
+        wrangler2.unlink()
+    os.symlink("wrangler", wrangler2)
+    write_launcher("cf-wrangler", "cf-wrangler.js")
+
+    print(f"Installed Wrangler {args.wrangler_version} into {app}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/wrangler/tests/smoke.sh
+++ b/packages/wrangler/tests/smoke.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -eu
+
+pkg install -y wrangler curl
+
+wrangler --version
+wrangler2 --version
+"$PREFIX/lib/wrangler/native/esbuild" --version
+"$PREFIX/lib/wrangler/native/workerd" --version 2>&1 | grep -F workerd
+
+smoke="${TMPDIR:-$PREFIX/tmp}/wrangler-package-smoke-$$"
+rm -rf "$smoke"
+mkdir -p "$smoke"
+trap 'rm -rf "$smoke"' EXIT INT TERM
+cd "$smoke"
+
+cat > index.js <<'JS'
+export default { fetch() { return new Response("termux-wrangler-ok"); } };
+JS
+cat > wrangler.jsonc <<'JSON'
+{"name":"termux-wrangler-package-smoke","main":"index.js","compatibility_date":"2026-08-01"}
+JSON
+
+WRANGLER_SEND_METRICS=false wrangler deploy --dry-run --outdir "$smoke/dry-run"
+WRANGLER_SEND_METRICS=false wrangler dev --ip 127.0.0.1 --port 8791 >"$smoke/dev.log" 2>&1 &
+pid=$!
+cleanup() {
+	kill "$pid" 2>/dev/null || true
+	wait "$pid" 2>/dev/null || true
+	rm -rf "$smoke"
+}
+trap cleanup EXIT INT TERM
+
+body=""
+i=0
+while [ "$i" -lt 120 ]; do
+	if ! kill -0 "$pid" 2>/dev/null; then
+		cat "$smoke/dev.log"
+		exit 1
+	fi
+	if body="$(curl -fsS --max-time 3 http://127.0.0.1:8791/ 2>/dev/null)"; then
+		break
+	fi
+	i=$((i + 1))
+	sleep 1
+done
+
+[ "$body" = "termux-wrangler-ok" ] || {
+	cat "$smoke/dev.log"
+	exit 1
+}
+printf 'Wrangler local Worker smoke: %s\n' "$body"

--- a/scripts/big-pkgs.list
+++ b/scripts/big-pkgs.list
@@ -43,5 +43,6 @@ wasi-libc
 wasmer
 wezterm-nightly
 wine-stable
+wrangler
 zig
 zen-browser


### PR DESCRIPTION
Fixes #31027

## Summary

Add Cloudflare Wrangler 4.123.0 for native Termux on `aarch64` and `x86_64`, with matching Android/Bionic `workerd` 1.20260811.1 and `esbuild` 0.28.1 runtimes built from upstream source.

Stock npm Wrangler is currently unusable on native Termux/aarch64 because upstream workerd does not publish an Android/arm64 platform package. A native ARM64 baseline of `npm install -g wrangler@4.123.0` exits with `Error: Unsupported platform: android arm64 LE`.

`arm` and `i686` remain excluded. The pinned workerd source explicitly states that its Bazel zlib port does not support architectures other than x86_64 or arm64, and its pinned Rust target/toolchain list is likewise 64-bit-only. The recipe therefore supports every Termux architecture that the pinned workerd port can currently build and that has been validated here.

## Packaging approach

- pins workers-sdk/Wrangler, workerd, pnpm, Bazel, and all required esbuild source inputs;
- builds runtime-shipped native code from source;
- applies the Android/Bionic workerd port to the matching pinned workerd source;
- builds workerd with Termux's NDK, host LLVM, and `termux_setup_proot` target runner;
- supports `aarch64` and `x86_64` Android workerd/V8 targets;
- removes/rejects npm-distributed platform-native payloads before packaging;
- installs Wrangler under `$PREFIX/lib/wrangler` with `wrangler`, `wrangler2`, and `cf-wrangler` launchers;
- performs deployment/relocation work in `termux_step_make_install()`;
- keeps the manual runtime check at `packages/wrangler/tests/smoke.sh` (not wired into external Termux CI).

No contributor-built runtime binaries or third-party APT repository artifacts are package inputs. Runtime does not require proot.

### Why five esbuild source versions?

The filtered `wrangler...` pnpm install contains exactly these esbuild package instances:

- 0.18.20
- 0.23.1
- 0.24.2
- 0.27.3
- 0.28.1

It also contains exactly those five matching `@esbuild/linux-x64` executable payloads. Install scripts are disabled, so the recipe source-builds those exact host esbuild versions and replaces the npm platform executables before Wrangler's own build runs. Only target esbuild 0.28.1 is installed in the final Termux package.

### Android endian shim

The earlier big-endian branch was removed; the Android shim is now little-endian-only, matching supported Termux targets. Removing the Android definitions entirely was tested and causes workerd to reach final link but fail with undefined `htobe32`/`htobe64`, so the remaining shim is required for the Android port rather than speculative compatibility code.

## Why a Termux package instead of npm?

Native ARM baseline:

https://github.com/adybag14-cyber/termux-packages/actions/runs/31911938728

```text
Node: android:arm64
.../node_modules/workerd/install.js
Error: Unsupported platform: android arm64 LE
STOCK_NPM_RESULT=install_failed rc=1
```

This uses the packaging-policy exception for language-manager software that requires Termux-specific native work.

## Validation

The current review revision was built with the normal Termux package builder on a disposable Ubuntu 26.04 Termux build host.

### aarch64

```text
wrangler_4.123.0_aarch64.deb
46,499,908 bytes
SHA-256 dfaa4c605306fcea17863f174028779c6bddce4a5695c68b03eb62c0592e58dc
```

The forced review-revision build completed all 15,424 workerd/V8 Bazel actions and Termux's final undefined-symbol audit passed both native binaries. Runtime validation through the Termux AArch64 environment passed:

- Node: `android:arm64`
- Wrangler: `4.123.0`
- workerd: `workerd 2026-08-11`
- esbuild: `0.28.1`
- `wrangler deploy --dry-run`
- real `wrangler dev` response: `termux-wrangler-arm64-ok`

The earlier independent GitHub ARM64 validation is also available here:
https://github.com/adybag14-cyber/termux-packages/actions/runs/31947136548

### x86_64

```text
wrangler_4.123.0_x86_64.deb
50,012,248 bytes
SHA-256 4ff5bf43d8ab3087dc272a34de256f158bce8ac9a9506beb9b62f6e07adf7b94
```

The x86_64 build completed the real Android workerd/V8 graph and Termux's final undefined-symbol audit. Both native files are Android 24 x86-64 ELFs using `/system/bin/linker64`, with no glibc dependency. Runtime validation in a Termux x86_64 userspace passed:

- Node: `android:x64`
- Wrangler: `4.123.0`
- workerd: `workerd 2026-08-11`
- esbuild: `0.28.1`
- `wrangler deploy --dry-run`
- real `wrangler dev` response: `termux-wrangler-x86-ok`

The exact submitted tree also passes `scripts/lint-packages.sh`, Bash/Python syntax checks, metadata/source closure checks, and a clean-tag dry-run of `workerd-android.patch` against workerd `v1.20260811.1`.

## Development disclosure

LLM/AI assistance was used while implementing/debugging this package and drafting parts of the submission. The resulting changes have been checked against the pinned upstream source and validated with the source builds and runtime tests described above.

Package request: https://github.com/termux/termux-packages/issues/31027
