### PR TITLE
addpkg(main/hermes-agent): 2026.8.16

### DIFF
--- a/packages/hermes-agent/build.sh
+++ b/packages/hermes-agent/build.sh
@@ -1,0 +1,127 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/NousResearch/hermes-agent
+TERMUX_PKG_DESCRIPTION="Self-improving AI agent that creates and improves skills from experience"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_LICENSE_FILE="LICENSE"
+TERMUX_PKG_MAINTAINER="adybag14-cyber <252811164+adybag14-cyber@users.noreply.github.com>"
+TERMUX_PKG_VERSION="2026.8.16"
+TERMUX_PKG_SRCURL="https://github.com/NousResearch/hermes-agent/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=655639384767611feee5ef5d6871e1a1b2294f7b1fd80fb401e9b888a418f4f9
+# Upstream is transitioning release tags from CalVer to SemVer. Keep updates
+# manual until one stable tag scheme can be expressed without a second version
+# authority in this recipe.
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="bash, ca-certificates, curl, gh, git, nodejs | nodejs-lts, npm, python, python-cryptography, python-jiter, python-pillow, python-pip, python-psutil, python-pydantic-core, python-rpds-py, ripgrep, uv"
+TERMUX_PKG_SUGGESTS="ffmpeg"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_PYTHON_COMMON_BUILD_DEPS="setuptools"
+
+# Hermes itself is shipped as its official source tree because upstream blocks
+# wheels/sdists: those artifacts intentionally omit runtime assets. Termux's
+# standard Python debscript support installs the Python runtime dependencies.
+# Native cryptography/Pillow/psutil are provided by Termux packages above.
+TERMUX_PKG_PYTHON_RUNTIME_DEPS="'openai==2.24.0', 'certifi==2026.5.20', 'python-dotenv==1.2.2', 'fire==0.7.1', 'httpx[socks]==0.28.1', 'rich==14.3.3', 'tenacity==9.1.4', 'pyyaml==6.0.3', 'ruamel.yaml==0.18.17', 'requests==2.33.0', 'jinja2==3.1.6', 'pydantic==2.13.4', 'prompt_toolkit==3.0.52', 'croniter==6.0.0', 'packaging==26.0', 'Markdown==3.10.2', 'PyJWT[crypto]==2.13.0', 'urllib3>=2.7.0,<3', 'websockets==15.0.1', 'pathspec==1.1.1', 'fastapi>=0.104.0,<1', 'uvicorn>=0.24.0,<1', 'python-multipart>=0.0.9,<1', 'ptyprocess>=0.7.0,<1', 'python-telegram-bot[webhooks]==22.8', 'mcp==1.28.1', 'starlette==1.3.1', 'honcho-ai==2.2.0', 'agent-client-protocol==0.9.0'"
+
+termux_step_make() {
+	termux_setup_nodejs
+	local npm_cli="$TERMUX_PREFIX/lib/node_modules/npm/bin/npm-cli.js"
+	test -f "$npm_cli" || termux_error_exit "Termux npm CLI is unavailable"
+
+	# Build only the two JavaScript surfaces used at runtime. The upstream
+	# lockfile remains the dependency authority; install scripts are unnecessary
+	# for these pure frontend builds.
+	node "$npm_cli" ci --ignore-scripts --no-audit --no-fund --fetch-retries=5 \
+		--workspace web \
+		--workspace ui-tui \
+		--workspace ui-tui/packages/hermes-ink \
+		--workspace apps/shared \
+		--include-workspace-root=false
+	node "$npm_cli" run build --workspace web
+	node "$npm_cli" run build --workspace ui-tui
+
+	test -f hermes_cli/web_dist/index.html || \
+		termux_error_exit "Hermes web bundle was not produced"
+	test -f ui-tui/dist/entry.js || \
+		termux_error_exit "Hermes TUI bundle was not produced"
+}
+
+termux_step_make_install() {
+	local app="$TERMUX_PREFIX/share/hermes-agent"
+	local pyhome="$TERMUX_PREFIX/lib/python$TERMUX_PYTHON_VERSION/site-packages"
+
+	rm -rf "$app"
+	mkdir -p "$app" "$pyhome"
+
+	# Python/runtime source directories. Keep the source-checkout layout because
+	# Hermes resolves project assets relative to hermes_cli/config.py.
+	local dir
+	for dir in \
+		acp_adapter agent assets cron gateway hermes_cli locales native \
+		optional-mcps optional-skills plugins providers scripts skills tools \
+		tui_gateway; do
+		cp -a "$TERMUX_PKG_SRCDIR/$dir" "$app/"
+	done
+
+	# The TUI is prebuilt at package build time; its TypeScript sources and
+	# node_modules are not runtime payload.
+	mkdir -p "$app/ui-tui"
+	cp -a "$TERMUX_PKG_SRCDIR/ui-tui/dist" "$app/ui-tui/"
+
+	# Hermes also has top-level Python modules imported by the packaged source.
+	find "$TERMUX_PKG_SRCDIR" -maxdepth 1 -type f -name '*.py' \
+		-exec cp -a -t "$app" {} +
+	install -Dm600 "$TERMUX_PKG_SRCDIR/constraints-termux.txt" \
+		"$app/constraints-termux.txt"
+	install -Dm600 "$TERMUX_PKG_SRCDIR/pyproject.toml" "$app/pyproject.toml"
+	install -Dm600 "$TERMUX_PKG_SRCDIR/LICENSE" "$app/LICENSE"
+
+	# Preserve upstream Python distribution identity without installing a wheel.
+	# A few runtime integrations query importlib.metadata.version("hermes-agent")
+	# for their User-Agent strings. Upstream intentionally blocks wheel/sdist
+	# builds because those artifacts omit runtime assets, but its egg_info command
+	# is metadata-only and remains supported for source/editable layouts.
+	local egg_base="$TERMUX_PKG_TMPDIR/hermes-egg-info"
+	rm -rf "$egg_base"
+	mkdir -p "$egg_base"
+	(
+		cd "$TERMUX_PKG_SRCDIR"
+		build-python setup.py egg_info --egg-base "$egg_base"
+	)
+	test -f "$egg_base/hermes_agent.egg-info/PKG-INFO" || \
+		termux_error_exit "Hermes Python package metadata was not generated"
+	cp -a "$egg_base/hermes_agent.egg-info" "$pyhome/"
+
+	# Make the packaged source importable by the system Termux Python without a
+	# private interpreter or private site-packages tree.
+	printf '%s\n' "$app" > "$pyhome/hermes-agent.pth"
+	printf 'apt\n' > "$app/.install_method"
+
+	mkdir -p "$TERMUX_PREFIX/bin"
+	# Reusable Termux build prefixes may contain stale symlinks from an older
+	# Hermes package. Remove all launcher paths before redirection so writing one
+	# entry point can never follow a stale alias and overwrite another launcher.
+	rm -f "$TERMUX_PREFIX/bin/hermes" "$TERMUX_PREFIX/bin/hermes-agent" "$TERMUX_PREFIX/bin/hermes-acp"
+	cat > "$TERMUX_PREFIX/bin/hermes" <<-EOF
+	#!$TERMUX_PREFIX/bin/sh
+	export HERMES_TUI_DIR="$app/ui-tui/dist"
+	export HERMES_WEB_DIST="$app/hermes_cli/web_dist"
+	exec "$TERMUX_PREFIX/bin/python" -m hermes_cli.main "\$@"
+	EOF
+	chmod 0700 "$TERMUX_PREFIX/bin/hermes"
+
+	cat > "$TERMUX_PREFIX/bin/hermes-agent" <<-EOF
+	#!$TERMUX_PREFIX/bin/sh
+	export HERMES_TUI_DIR="$app/ui-tui/dist"
+	export HERMES_WEB_DIST="$app/hermes_cli/web_dist"
+	exec "$TERMUX_PREFIX/bin/python" -m run_agent "\$@"
+	EOF
+	chmod 0700 "$TERMUX_PREFIX/bin/hermes-agent"
+
+	cat > "$TERMUX_PREFIX/bin/hermes-acp" <<-EOF
+	#!$TERMUX_PREFIX/bin/sh
+	export HERMES_TUI_DIR="$app/ui-tui/dist"
+	export HERMES_WEB_DIST="$app/hermes_cli/web_dist"
+	exec "$TERMUX_PREFIX/bin/python" -m acp_adapter.entry "\$@"
+	EOF
+	chmod 0700 "$TERMUX_PREFIX/bin/hermes-acp"
+}

--- a/packages/hermes-agent/hermes-termux.patch
+++ b/packages/hermes-agent/hermes-termux.patch
@@ -1,0 +1,197 @@
+diff --git a/hermes_cli/banner.py b/hermes_cli/banner.py
+index a1cd4748..259c454b 100644
+--- a/hermes_cli/banner.py
++++ b/hermes_cli/banner.py
+@@ -406,7 +406,7 @@ def check_for_updates() -> Optional[int]:
+     # (web_server.py); mirror that here so the banner/TUI surfaces agree.
+     try:
+         from hermes_cli.config import detect_install_method, get_project_root
+-        if detect_install_method(get_project_root()) == "docker":
++        if detect_install_method(get_project_root()) in {"docker", "apt"}:
+             return None
+     except Exception:
+         pass
+diff --git a/hermes_cli/config.py b/hermes_cli/config.py
+index cd226a92..b632cd5f 100644
+--- a/hermes_cli/config.py
++++ b/hermes_cli/config.py
+@@ -410,7 +410,7 @@ def _install_method_project_root(project_root: Optional[Path] = None) -> Path:
+ 
+ 
+ def detect_install_method(project_root: Optional[Path] = None) -> str:
+-    """Detect how Hermes was installed: 'docker', 'nix', 'nixos', 'git', or 'unknown'.
++    """Detect how Hermes was installed: 'apt', 'docker', 'nix', 'nixos', 'git', or 'unknown'.
+ 
+     Resolution order:
+     1. Code-scoped stamp ``<install tree>/.install_method`` (next to the
+@@ -454,7 +454,8 @@ def detect_install_method(project_root: Optional[Path] = None) -> str:
+     See issue #34397.
+     """
+     root = _install_method_project_root(project_root)
+-    supported_methods = {"docker", "nix", "nixos", "git", "unknown"}
++    # "apt" is the Termux APT distribution identifier.
++    supported_methods = {"apt", "docker", "nix", "nixos", "git", "unknown"}
+ 
+     # 1. Code-scoped stamp â€” authoritative, immune to shared $HERMES_HOME.
+     try:
+@@ -548,6 +549,8 @@ def recommended_update_command_for_method(method: str) -> str:
+         return _NIX_UPDATE_MSG
+     if method == "docker":
+         return "docker pull nousresearch/hermes-agent:latest"
++    if method == "apt":
++        return "pkg upgrade hermes-agent"
+     return "hermes update"
+ 
+ 
+diff --git a/hermes_cli/doctor.py b/hermes_cli/doctor.py
+index e16de606..cf3f2e25 100644
+--- a/hermes_cli/doctor.py
++++ b/hermes_cli/doctor.py
+@@ -91,6 +91,8 @@ def _sqlite_upgrade_hint(install_method: str | None = None) -> str:
+         action = f"run `{command}`, then recreate all Hermes containers"
+     elif method in {"nix", "nixos"}:
+         action = recommended_update_command_for_method(method)
++    elif method == "apt":
++        action = f"run `{recommended_update_command_for_method(method)}`"
+     else:
+         action = "run `hermes update`"
+     return (
+diff --git a/hermes_cli/main.py b/hermes_cli/main.py
+index ed9fe973..92977ba8 100644
+--- a/hermes_cli/main.py
++++ b/hermes_cli/main.py
+@@ -9822,7 +9822,7 @@ def cmd_update(args):
+         print(format_docker_update_message())
+         sys.exit(1)
+ 
+-    if install_method in {"nix", "nixos"}:
++    if install_method in {"nix", "nixos", "apt"}:
+         print(recommended_update_command_for_method(install_method))
+         sys.exit(1)
+ 
+diff --git a/hermes_cli/observability/schemas/hermes.shared_metrics.v2.schema.json b/hermes_cli/observability/schemas/hermes.shared_metrics.v2.schema.json
+index 5d0bea61..00525696 100644
+--- a/hermes_cli/observability/schemas/hermes.shared_metrics.v2.schema.json
++++ b/hermes_cli/observability/schemas/hermes.shared_metrics.v2.schema.json
+@@ -58,7 +58,7 @@
+         },
+         "install_method": {
+           "type": "string",
+-          "enum": ["docker", "git", "homebrew", "nixos", "pip", "unknown"]
++          "enum": ["apt", "docker", "git", "homebrew", "nixos", "pip", "unknown"]
+         },
+         "os_family": {
+           "type": "string",
+diff --git a/hermes_cli/observability/shared_metrics_contract.py b/hermes_cli/observability/shared_metrics_contract.py
+index b7637c93..6a1cec1c 100644
+--- a/hermes_cli/observability/shared_metrics_contract.py
++++ b/hermes_cli/observability/shared_metrics_contract.py
+@@ -194,6 +194,7 @@ CLIENT_ARCHITECTURES: frozenset[str] = frozenset({
+     "x86_64",
+ })
+ CLIENT_INSTALL_METHODS: frozenset[str] = frozenset({
++    "apt",
+     "docker",
+     "git",
+     "homebrew",
+diff --git a/hermes_cli/uninstall.py b/hermes_cli/uninstall.py
+index efc546d8..446f8c5b 100644
+--- a/hermes_cli/uninstall.py
++++ b/hermes_cli/uninstall.py
+@@ -592,6 +592,11 @@ def run_uninstall(args):
+     project_root = get_project_root()
+     hermes_home = get_hermes_home()
+ 
++    from hermes_cli.config import detect_install_method
++    if detect_install_method(project_root) == "apt":
++        print("Hermes is managed by Termux APT; run `pkg uninstall hermes-agent`.")
++        raise SystemExit(1)
++
+     if bool(getattr(args, "dry_run", False)):
+         _print_uninstall_dry_run(
+             project_root=project_root,
+diff --git a/hermes_cli/update_cmd.py b/hermes_cli/update_cmd.py
+index 57cff41f..051557c3 100644
+--- a/hermes_cli/update_cmd.py
++++ b/hermes_cli/update_cmd.py
+@@ -2491,7 +2491,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
+         print(format_docker_update_message())
+         sys.exit(1)
+ 
+-    if method in {"nix", "nixos"}:
++    if method in {"nix", "nixos", "apt"}:
+         print(recommended_update_command_for_method(method))
+         sys.exit(1)
+ 
+diff --git a/hermes_cli/web_server.py b/hermes_cli/web_server.py
+index 2cc53ece..41f08791 100644
+--- a/hermes_cli/web_server.py
++++ b/hermes_cli/web_server.py
+@@ -4474,14 +4474,16 @@ async def update_hermes():
+             "update_command": recommended_update_command_for_method(install_method),
+         }
+ 
+-    if install_method in {"nix", "nixos"}:
++    if install_method in {"nix", "nixos", "apt"}:
+         message = recommended_update_command_for_method(install_method)
+         _record_completed_action("hermes-update", message, exit_code=1)
+         return {
+             "ok": False,
+             "pid": None,
+             "name": "hermes-update",
+-            "error": "nix_update_unsupported",
++            "error": (
++                "apt_update_required" if install_method == "apt" else "nix_update_unsupported"
++            ),
+             "message": message,
+             "update_command": message,
+         }
+@@ -4580,7 +4582,7 @@ async def check_hermes_update(force: bool = False):
+     ``POST /api/hermes/update`` actually runs ``hermes update``.
+ 
+     Returns:
+-        install_method: 'git' | 'docker' | 'nix' | 'nixos' | 'unknown'
++        install_method: 'apt' | 'git' | 'docker' | 'nix' | 'nixos' | 'unknown'
+         current_version: installed Hermes version string
+         behind: commits behind upstream (>=1), 0 if up to date,
+                 -1 if behind by an unknown count, or null if the
+@@ -4627,6 +4629,9 @@ async def check_hermes_update(force: bool = False):
+     if install_method == "docker":
+         payload["message"] = format_docker_update_message()
+         return payload
++    if install_method == "apt":
++        payload["message"] = "Hermes is managed by Termux APT; run `pkg upgrade hermes-agent`."
++        return payload
+ 
+     # banner.check_for_updates() handles git / nix-revision paths and
+     # caches the result for 6h. ``force`` busts the cache so the "Check now"
+diff --git a/pyproject.toml b/pyproject.toml
+index 1191bd2c..2171037f 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -5,14 +5,8 @@ name = "hermes-agent"
+ version = "0.20.2"
+ description = "The self-improving AI agent â€” creates skills from experience, improves them during use, and runs anywhere"
+ readme = "README.md"
+-# Upper bound is load-bearing, not cosmetic. uv resolves the project's
+-# Python from `requires-python`, and an inherited `UV_PYTHON` env var (or a
+-# fresh distro whose newest interpreter uv auto-picks) will otherwise select
+-# 3.14, where Rust-backed transitives (e.g. pydantic-core) have no cp314
+-# wheel yet and fall back to a maturin source build that fails. Capping at
+-# <3.14 makes uv refuse 3.14 with a clear error instead of attempting that
+-# build. Raise the ceiling once our Rust transitives ship cp314 wheels.
+-requires-python = ">=3.11,<3.14"
++# Termux ships Python 3.14; its package manager supplies the native dependencies.
++requires-python = ">=3.11,<3.15"
+ authors = [{ name = "Nous Research" }]
+ license = "MIT"
+ license-files = ["LICENSE"]
+@@ -112,7 +106,7 @@ dependencies = [
+   # .gitignore-aware file matching for desktop build stamp.
+   "pathspec==1.1.1",
+   "fastapi>=0.104.0,<1",
+-  "uvicorn[standard]>=0.24.0,<1",
++  "uvicorn>=0.24.0,<1",
+   # Streaming multipart uploads for the dashboard file manager (NS-501).
+   # FastAPI's UploadFile/Form depend on python-multipart; it is NOT pulled in
+   # by fastapi itself, so the dashboard's multipart upload endpoint would 500

--- a/packages/hermes-agent/tests.sh
+++ b/packages/hermes-agent/tests.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+hermes --version | grep -F '0.20.2'
+python - <<'PY'
+import cryptography
+import importlib.metadata
+import hermes_cli
+import PIL
+import psutil
+import pydantic
+import yaml
+assert importlib.metadata.version("hermes-agent") == "0.20.2"
+print("Hermes Python imports OK")
+PY
+
+test -f "$PREFIX/share/hermes-agent/hermes_cli/web_dist/index.html"
+test -f "$PREFIX/share/hermes-agent/ui-tui/dist/entry.js"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+set +e
+output="$(HERMES_HOME="$tmp" timeout 30s hermes update --check 2>&1)"
+status=$?
+set -e
+[ "$status" -ne 0 ]
+printf '%s\n' "$output" | grep -F 'pkg upgrade hermes-agent'

--- a/packages/python-jiter/build.sh
+++ b/packages/python-jiter/build.sh
@@ -1,0 +1,46 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/pydantic/jiter
+TERMUX_PKG_DESCRIPTION="Fast iterable JSON parser"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_LICENSE_FILE="LICENSE"
+TERMUX_PKG_MAINTAINER="adybag14-cyber <252811164+adybag14-cyber@users.noreply.github.com>"
+TERMUX_PKG_VERSION="0.13.0"
+TERMUX_PKG_SRCURL="https://pypi.io/packages/source/j/jiter/jiter-${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4
+# Hermes Agent currently consumes this exact release from its lockfile.
+# Update it in lockstep with the dependent package.
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="python, python-pip"
+TERMUX_PKG_PYTHON_COMMON_BUILD_DEPS="maturin"
+TERMUX_PKG_PYTHON_RUNTIME_DEPS=false
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_configure() {
+	termux_setup_rust
+	export CARGO_BUILD_TARGET="${CARGO_TARGET_NAME}"
+	export PYO3_CROSS_LIB_DIR="${TERMUX_PREFIX}/lib"
+	export ANDROID_API_LEVEL="${TERMUX_PKG_API_LEVEL}"
+	export CFLAGS_${CARGO_TARGET_NAME//-/_}+=" -I$TERMUX_PREFIX/include/python$TERMUX_PYTHON_VERSION"
+}
+
+termux_step_make() {
+	:
+}
+
+termux_step_make_install() {
+	# Keep maturin in the build interpreter; installing it into cross-python
+	# makes pip try to execute a target Android binary on the build host.
+	export ANDROID_API_LEVEL="$TERMUX_PKG_API_LEVEL"
+	cross-pip install --no-build-isolation --no-deps . --prefix "$TERMUX_PREFIX"
+}
+
+termux_step_post_make_install() {
+	# PyO3 extension modules need an explicit libpython dependency on Android.
+	local so
+	so="$(find "$TERMUX_PREFIX/lib/python$TERMUX_PYTHON_VERSION/site-packages" \
+		-name 'jiter*.so' -print -quit)"
+	[[ -n "$so" ]] || termux_error_exit "jiter extension missing"
+	local libpython="libpython${TERMUX_PYTHON_VERSION}.so"
+	if ! patchelf --print-needed "$so" | grep -Fxq "$libpython"; then
+		patchelf --add-needed "$libpython" "$so"
+	fi
+}

--- a/packages/python-jiter/tests.sh
+++ b/packages/python-jiter/tests.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+python - <<'PY'
+import importlib.metadata
+import jiter
+print(importlib.metadata.version("jiter"))
+PY

--- a/packages/python-pydantic-core/build.sh
+++ b/packages/python-pydantic-core/build.sh
@@ -1,0 +1,50 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/pydantic/pydantic-core
+TERMUX_PKG_DESCRIPTION="Core validation logic for Pydantic written in Rust"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_LICENSE_FILE="LICENSE"
+TERMUX_PKG_MAINTAINER="adybag14-cyber <252811164+adybag14-cyber@users.noreply.github.com>"
+TERMUX_PKG_VERSION="2.46.4"
+TERMUX_PKG_SRCURL="https://pypi.io/packages/source/p/pydantic-core/pydantic_core-${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1
+# Pydantic pins pydantic-core exactly. Keep this release coordinated with
+# packages that consume it instead of independently auto-bumping the ABI.
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="python, python-pip"
+TERMUX_PKG_PYTHON_COMMON_BUILD_DEPS="maturin"
+# Keep the framework-generated Python dependency check pinned to the APT-owned
+# native package.  The upstream METADATA name uses an underscore, so without
+# this exact self-pin the generic debscript can treat it as upgradeable and
+# replace it with a newer PyPI sdist during pkg install.
+TERMUX_PKG_PYTHON_RUNTIME_DEPS="'pydantic-core==${TERMUX_PKG_VERSION}'"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_configure() {
+	termux_setup_rust
+	export CARGO_BUILD_TARGET="${CARGO_TARGET_NAME}"
+	export PYO3_CROSS_LIB_DIR="${TERMUX_PREFIX}/lib"
+	export ANDROID_API_LEVEL="${TERMUX_PKG_API_LEVEL}"
+	export CFLAGS_${CARGO_TARGET_NAME//-/_}+=" -I$TERMUX_PREFIX/include/python$TERMUX_PYTHON_VERSION"
+}
+
+termux_step_make() {
+	:
+}
+
+termux_step_make_install() {
+	# Keep maturin in the build interpreter; installing it into cross-python
+	# makes pip try to execute a target Android binary on the build host.
+	export ANDROID_API_LEVEL="$TERMUX_PKG_API_LEVEL"
+	cross-pip install --no-build-isolation --no-deps . --prefix "$TERMUX_PREFIX"
+}
+
+termux_step_post_make_install() {
+	# PyO3 extension modules need an explicit libpython dependency on Android.
+	local so
+	so="$(find "$TERMUX_PREFIX/lib/python$TERMUX_PYTHON_VERSION/site-packages" \
+		-name '_pydantic_core*.so' -print -quit)"
+	[[ -n "$so" ]] || termux_error_exit "pydantic-core extension missing"
+	local libpython="libpython${TERMUX_PYTHON_VERSION}.so"
+	if ! patchelf --print-needed "$so" | grep -Fxq "$libpython"; then
+		patchelf --add-needed "$libpython" "$so"
+	fi
+}

--- a/packages/python-pydantic-core/tests.sh
+++ b/packages/python-pydantic-core/tests.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+python - <<'PY'
+import importlib.metadata
+import pydantic_core
+print(importlib.metadata.version("pydantic-core"))
+PY

--- a/packages/python-rpds-py/build.sh
+++ b/packages/python-rpds-py/build.sh
@@ -1,0 +1,46 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/crate-py/rpds
+TERMUX_PKG_DESCRIPTION="Python bindings to persistent data structures in Rust"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_LICENSE_FILE="LICENSE"
+TERMUX_PKG_MAINTAINER="adybag14-cyber <252811164+adybag14-cyber@users.noreply.github.com>"
+TERMUX_PKG_VERSION="0.30.0"
+TERMUX_PKG_SRCURL="https://pypi.io/packages/source/r/rpds-py/rpds_py-${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84
+# Hermes Agent currently consumes this exact release from its lockfile.
+# Update it in lockstep with the dependent package.
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="python, python-pip"
+TERMUX_PKG_PYTHON_COMMON_BUILD_DEPS="maturin"
+TERMUX_PKG_PYTHON_RUNTIME_DEPS=false
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_configure() {
+	termux_setup_rust
+	export CARGO_BUILD_TARGET="${CARGO_TARGET_NAME}"
+	export PYO3_CROSS_LIB_DIR="${TERMUX_PREFIX}/lib"
+	export ANDROID_API_LEVEL="${TERMUX_PKG_API_LEVEL}"
+	export CFLAGS_${CARGO_TARGET_NAME//-/_}+=" -I$TERMUX_PREFIX/include/python$TERMUX_PYTHON_VERSION"
+}
+
+termux_step_make() {
+	:
+}
+
+termux_step_make_install() {
+	# Keep maturin in the build interpreter; installing it into cross-python
+	# makes pip try to execute a target Android binary on the build host.
+	export ANDROID_API_LEVEL="$TERMUX_PKG_API_LEVEL"
+	cross-pip install --no-build-isolation --no-deps . --prefix "$TERMUX_PREFIX"
+}
+
+termux_step_post_make_install() {
+	# PyO3 extension modules need an explicit libpython dependency on Android.
+	local so
+	so="$(find "$TERMUX_PREFIX/lib/python$TERMUX_PYTHON_VERSION/site-packages" \
+		-name 'rpds*.so' -print -quit)"
+	[[ -n "$so" ]] || termux_error_exit "rpds-py extension missing"
+	local libpython="libpython${TERMUX_PYTHON_VERSION}.so"
+	if ! patchelf --print-needed "$so" | grep -Fxq "$libpython"; then
+		patchelf --add-needed "$libpython" "$so"
+	fi
+}

--- a/packages/python-rpds-py/tests.sh
+++ b/packages/python-rpds-py/tests.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+python - <<'PY'
+import importlib.metadata
+import rpds
+print(importlib.metadata.version("rpds-py"))
+PY


### PR DESCRIPTION
Closes #31041

## Summary

Add `hermes-agent` from upstream release `v2026.8.16` using the normal Termux packaging model.

This PR has been rewritten from the earlier private-runtime implementation after review. The package now uses Termux system Python and system tools, installs the upstream Hermes source layout under `$PREFIX/share/hermes-agent`, and uses `TERMUX_PKG_PYTHON_RUNTIME_DEPS` for ordinary Python runtime dependencies.

Three Rust-backed Python extensions that cannot be built safely by pip/rustup during `pkg install` are packaged as normal Termux dependencies:

- `python-jiter` 0.13.0
- `python-pydantic-core` 2.46.4
- `python-rpds-py` 0.30.0

Existing Termux packages are reused for Python, pip, cryptography, Pillow, psutil, Node/npm, git, gh, ripgrep and uv. There is no private Python interpreter, private `site-packages`, downloaded npm runtime, secondary Python lock/distribution system, or custom package manager.

Hermes itself is installed from the official `v2026.8.16` source archive. Upstream's source layout is retained because upstream explicitly does not support ordinary wheel/sdist installation for the complete application assets. The dashboard and TUI are built during the package build and installed as package-owned files.

The package also preserves upstream Python distribution identity using metadata-only `setup.py egg_info`. This provides `hermes-agent` version/console-script metadata for integrations using `importlib.metadata` without installing a wheel or transferring ownership to pip.

The small downstream patch carries Termux/APT ownership behavior, permits the current Termux Python 3.14 runtime, avoids the unnecessary `uvicorn[standard]` optional native extras on Termux, and prevents `hermes uninstall` from deleting dpkg-owned files. `hermes update` and `hermes uninstall` instead direct users to `pkg upgrade hermes-agent` and `pkg uninstall hermes-agent`.

`TERMUX_PKG_AUTO_UPDATE=false` is intentional while upstream is transitioning its release/versioning scheme; the Termux package version follows the upstream release tag (`2026.8.16`) while Hermes reports its application version (`0.20.2`).

## Validation

All four recipes pass the current Termux package linter. Local Termux cross-build validation completed successfully for `aarch64`, `arm`, `i686`, and `x86_64`; on every architecture, the three native Python packages and `hermes-agent` build successfully and pass Termux's normal symbol checks.

The 12 native extension artifacts (3 packages × 4 architectures) were independently inspected. Each has the expected target architecture, targets Android API 24 with NDK r29, and has exactly one `libpython3.14.so` dependency.

A clean x86_64 installation was tested from the official Termux bootstrap rather than from the build prefix. The bootstrap first/second stages completed, APT resolved the package dependencies, and the resulting installation reports:

```text
hermes-agent             2026.8.16
python-jiter             0.13.0
python-pydantic-core     2.46.4
python-rpds-py           0.30.0
```

Runtime checks in that clean install verify:

- `hermes --version` -> `Hermes Agent v0.20.2 (2026.8.16)`
- `importlib.metadata.version("hermes-agent")` -> `0.20.2`
- QQBot and Codex version probes -> `0.20.2` rather than fallback `dev` / `0.0.0`
- upstream console-script metadata for `hermes`, `hermes-agent`, and `hermes-acp`
- `pip check` -> no broken requirements
- native imports for jiter, pydantic-core and rpds-py
- OpenAI, Pydantic, MCP, ACP and Honcho imports
- separate working `hermes`, `hermes-agent` and `hermes-acp` launchers
- packaged dashboard and TUI assets
- APT install-method detection and `$PREFIX/share/hermes-agent` project root
- `hermes update` -> `pkg upgrade hermes-agent`
- interactive `hermes uninstall` -> `pkg uninstall hermes-agent`
- all four submitted `tests.sh` files

Fresh exact-head fork CI completed successfully on commit `99eb0bae524931ef9eb0d1032e7e9ebd46e46f54`:

https://github.com/adybag14-cyber/termux-packages/actions/runs/32385013437

The repository's standard `Packages` workflow passed for `aarch64`, `arm`, `i686`, and `x86_64`, including package lint, randomized build-order testing, real package builds, symbol checks, and artifact/checksum generation. It explicitly built `hermes-agent python-jiter python-pydantic-core python-rpds-py`.

The exact-head `Package updates` workflow also passed:

https://github.com/adybag14-cyber/termux-packages/actions/runs/32385002646

## AI/LLM disclosure

AI/LLM assistance was used during development/debugging and in drafting parts of this PR text. The package behavior described above was verified with the concrete Termux builds, fresh-bootstrap APT installation, runtime tests, ELF inspection, metadata regression checks and package lint described above.
