### PR TITLE
addpkg(main/txr): add v302

### DIFF
--- a/packages/txr/build.sh
+++ b/packages/txr/build.sh
@@ -1,0 +1,24 @@
+TERMUX_PKG_HOMEPAGE=https://www.nongnu.org/txr/
+TERMUX_PKG_DESCRIPTION="Data munging language and pattern matching tool"
+TERMUX_PKG_LICENSE="BSD 2-Clause"
+TERMUX_PKG_MAINTAINER="Jules Amonith <examosa@fastmail.com>"
+TERMUX_PKG_VERSION="302"
+TERMUX_PKG_SRCURL="https://www.kylheku.com/cgit/txr/snapshot/txr-${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=94778081f698c2922117dc4bcbcc50f8c279c128660f4233221ce748d1369dc7
+TERMUX_PKG_DEPENDS="libffi, zlib"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_HOSTBUILD=true
+TERMUX_PKG_EXTRA_HOSTBUILD_CONFIGURE_ARGS="ccname=gcc"
+TERMUX_PKG_EXTRA_MAKE_ARGS="LN:=ln LN+=-rs"
+
+termux_step_pre_configure() {
+	cp --force --no-preserve=timestamps \
+		"${TERMUX_PKG_HOSTBUILD_DIR}/stdlib/"*.tlo \
+		"${TERMUX_PKG_SRCDIR}/stdlib/"
+}
+
+termux_step_configure() {
+	"${TERMUX_PKG_SRCDIR}/configure" \
+		prefix="${TERMUX__PREFIX}" \
+		do_nopie=
+}

--- a/packages/txr/configure.patch
+++ b/packages/txr/configure.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index c5e62d5..02250f4 100755
+--- a/configure
++++ b/configure
+@@ -1288,7 +1288,7 @@ if ! [ $darwin_target ] ; then
+   if [ "$($make conftest.android)" = "yes" ] ; then
+     printf "yes\n"
+     android_target=y
+-    lang_flags="$lang_flags --target=aarch64-unknown-linux-android26 -D_BSD_SOURCE"
++    lang_flags="$lang_flags -D_BSD_SOURCE"
+     printf "Regenerating config.make ... "
+     gen_config_make
+     printf "done\n"


### PR DESCRIPTION
Adds [`txr`](https://www.nongnu.org/txr/) v302.

- New package: `packages/txr`
- Uses upstream `configure` with `prefix=${TERMUX__PREFIX}`
- Uses `LN:=ln LN+=-rs` to avoid hardlink install failures
- Runtime deps: `libffi`, `zlib`
