### PR TITLE
fix(main/mise): fix `stat.st_mode` to be cast as `u16` instead of `mode_t` on 32-bit Android

### DIFF
--- a/packages/mise/build.sh
+++ b/packages/mise/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="dev tools, env vars, task runner"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2026.8.8"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/jdx/mise/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=f4053c5f98801ea6e35fc0050033ecbeb1c5d6c2142b61e07abbc262f8cccbaa
 TERMUX_PKG_DEPENDS="bzip2, openssl"

--- a/packages/mise/stat-mode-32-bit-android.patch
+++ b/packages/mise/stat-mode-32-bit-android.patch
@@ -1,0 +1,70 @@
+diff --git a/src/system/packages/brew/cask.rs b/src/system/packages/brew/cask.rs
+index eba9609..72fb85f 100644
+--- a/src/system/packages/brew/cask.rs
++++ b/src/system/packages/brew/cask.rs
+@@ -1926,9 +1926,14 @@ fn copy_cask_artifact_at<Fd: std::os::fd::AsFd>(
+     use std::os::unix::fs::PermissionsExt;
+ 
+     let metadata = from.symlink_metadata()?;
++    #[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
+     let mode = nix::sys::stat::Mode::from_bits_truncate(
+         metadata.permissions().mode() as nix::libc::mode_t
+     );
++    #[cfg(all(target_os = "android", target_pointer_width = "32"))]
++    let mode = nix::sys::stat::Mode::from_bits_truncate(
++        metadata.permissions().mode() as u16
++    );
+     if metadata.file_type().is_symlink() {
+         nix::unistd::symlinkat(&std::fs::read_link(from)?, parent, name)?;
+     } else if metadata.is_dir() {
+@@ -2004,7 +2009,10 @@ fn remove_all_at<Fd: std::os::fd::AsFd>(parent: Fd, name: &std::ffi::OsStr) -> R
+             Err(nix::errno::Errno::ENOENT) => return Ok(()),
+             Err(err) => return Err(err.into()),
+         };
++    #[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
+     let kind = nix::sys::stat::SFlag::from_bits_truncate(stat.st_mode);
++    #[cfg(all(target_os = "android", target_pointer_width = "32"))]
++    let kind = nix::sys::stat::SFlag::from_bits_truncate(stat.st_mode as u16);
+     if kind.contains(nix::sys::stat::SFlag::S_IFDIR) {
+         let fd = nix::fcntl::openat(
+             &parent,
+@@ -2207,6 +2215,7 @@ fn open_trusted_directory(
+             || current_groups.contains(&stat.st_gid);
+         let writable_by_untrusted = stat.st_mode & 0o002 != 0
+             || (stat.st_mode & 0o020 != 0 && (!allow_current_user || !trusted_group));
++        #[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
+         if !SFlag::from_bits_truncate(stat.st_mode).contains(SFlag::S_IFDIR)
+             || !trusted_owner
+             || writable_by_untrusted
+@@ -2216,6 +2225,16 @@ fn open_trusted_directory(
+                 directory.display()
+             );
+         }
++        #[cfg(all(target_os = "android", target_pointer_width = "32"))]
++        if !SFlag::from_bits_truncate(stat.st_mode as u16).contains(SFlag::S_IFDIR)
++            || !trusted_owner
++            || writable_by_untrusted
++        {
++            bail!(
++                "brew-cask: refusing operation through untrusted directory {}",
++                directory.display()
++            );
++        }
+         Ok(())
+     };
+     let mut directory = resolved_root.to_path_buf();
+@@ -2611,9 +2630,14 @@ fn ditto_into<Fd: std::os::fd::AsFd>(from: &Path, dir: Fd, name: &std::ffi::OsSt
+     // Restore the bundle's own permissions, which the private staging mode hid.
+     if let Ok(metadata) = from.symlink_metadata() {
+         use std::os::unix::fs::PermissionsExt;
++        #[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
+         let mode = nix::sys::stat::Mode::from_bits_truncate(
+             metadata.permissions().mode() as nix::libc::mode_t
+         );
++        #[cfg(all(target_os = "android", target_pointer_width = "32"))]
++        let mode = nix::sys::stat::Mode::from_bits_truncate(
++            metadata.permissions().mode() as u16
++        );
+         nix::sys::stat::fchmod(&destination, mode)?;
+     }
+     Ok(())


### PR DESCRIPTION
- Fixes build of version 2026.8.8, which introduced many instances of `stat.st_mode`, on 32-bit targets

- Like all the other Rust programs with the same type of patch