### PR TITLE
bump(x11/firefox): 154.0

### DIFF
--- a/x11-packages/firefox/0008-fix-macros.patch
+++ b/x11-packages/firefox/0008-fix-macros.patch
@@ -9,17 +9,6 @@
  int VideoEngine::SetAndroidObjects() {
    LOG(("%s", __PRETTY_FUNCTION__));
  
---- a/security/sandbox/chromium/base/synchronization/lock_impl_posix.cc
-+++ b/security/sandbox/chromium/base/synchronization/lock_impl_posix.cc
-@@ -59,7 +59,7 @@ void dcheck_unlock_result(int rv) {
- // Lock::PriorityInheritanceAvailable still must be checked as the code may
- // compile but the underlying platform still may not correctly support priority
- // inheritance locks.
--#if BUILDFLAG(IS_NACL) || BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_FUCHSIA)
-+#if BUILDFLAG(IS_NACL) || BUILDFLAG(IS_ANDROID) || defined(__TERMUX__) || BUILDFLAG(IS_FUCHSIA)
- #define PRIORITY_INHERITANCE_LOCKS_POSSIBLE() 0
- #else
- #define PRIORITY_INHERITANCE_LOCKS_POSSIBLE() 1
 --- a/third_party/zucchini/chromium/base/synchronization/lock_impl_posix.cc
 +++ b/third_party/zucchini/chromium/base/synchronization/lock_impl_posix.cc
 @@ -59,7 +59,7 @@ void dcheck_unlock_result(int rv) {

--- a/x11-packages/firefox/build.sh
+++ b/x11-packages/firefox/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.mozilla.org/firefox
 TERMUX_PKG_DESCRIPTION="Mozilla Firefox web browser"
 TERMUX_PKG_LICENSE="MPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="153.0.4"
+TERMUX_PKG_VERSION="154.0"
 TERMUX_PKG_SRCURL="https://archive.mozilla.org/pub/firefox/releases/${TERMUX_PKG_VERSION#*really}/source/firefox-${TERMUX_PKG_VERSION#*really}.source.tar.xz"
-TERMUX_PKG_SHA256=f7aa83924c66bb3b04cf139b3b00612d388a9f024c92fe7834161553a6028a48
+TERMUX_PKG_SHA256=36cec5b3688a60f78a6d20dcaee15b598f84e03c66f6587056aead6cb498b99a
 # ffmpeg and pulseaudio are dependencies through dlopen(3):
 TERMUX_PKG_DEPENDS="ffmpeg, fontconfig, freetype, gdk-pixbuf, glib, gtk3, libandroid-shmem, libandroid-spawn, libc++, libcairo, libevent, libffi, libice, libicu, libjpeg-turbo, libnspr, libnss, libpixman, libsm, libvpx, libwebp, libx11, libxcb, libxcomposite, libxdamage, libxext, libxfixes, libxrandr, libxtst, pango, pulseaudio, zlib"
 TERMUX_PKG_BUILD_DEPENDS="libcpufeatures, libice, libsm"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/31126

- `fix-marcos.patch` -> `fix-macros.patch`

- The `PRIORITY_INHERITANCE_LOCKS_POSSIBLE()` is enabled for Android in this update in `security/sandbox/chromium/base/synchronization/lock_impl_posix.cc`, but not in `third_party/zucchini/chromium/base/synchronization/lock_impl_posix.cc`, which is kept the same. I assume that Termux follows Android in these files so the `PRIORITY_INHERITANCE_LOCKS_POSSIBLE()` should be enabled in `security/sandbox/chromium/base/synchronization/lock_impl_posix.cc` but not in `third_party/zucchini/chromium/base/synchronization/lock_impl_posix.cc`, following Android, but it is not really clear, and multiple options might have to be attempted.