### PR TITLE
fix(main/proton-pass-cli): disable keyring provider on Android

### DIFF
--- a/packages/proton-pass-cli/0001-fix-protoc-path.patch
+++ b/packages/proton-pass-cli/0001-fix-protoc-path.patch
@@ -1,0 +1,17 @@
+Use the system protoc installed by termux_setup_protobuf instead of the
+vendored protoc binary. protoc-bin-vendored only ships prebuilt binaries
+for common desktop targets (x86_64 Linux/macOS/Windows) and has no binary
+for aarch64-unknown-linux-android, so protoc_bin_path().unwrap() panics
+during the build on Android.
+
+--- a/pass-domain/build.rs
++++ b/pass-domain/build.rs
+@@ -63,7 +63,7 @@
+ 
+     protobuf_codegen::Codegen::new()
+         .protoc()
+-        .protoc_path(&protoc_bin_vendored::protoc_bin_path().unwrap())
++        .protoc_path(&PathBuf::from("protoc"))
+         .include(proto_dir)
+         .input(proto_path)
+         .out_dir(out_dir)

--- a/packages/proton-pass-cli/0002-disable-android-keyring.patch
+++ b/packages/proton-pass-cli/0002-disable-android-keyring.patch
@@ -1,0 +1,30 @@
+--- a/pass-cli/src/features/mod.rs
++++ b/pass-cli/src/features/mod.rs
+@@ -64,20 +64,21 @@
+     let provider_type = env::var("PROTON_PASS_KEY_PROVIDER").unwrap_or_default();
+ 
+     match provider_type.as_str() {
+-        "fs" => {
++        "fs" | "" => {
+             info!("Using filesystem-based local key provider");
+             Ok(Arc::new(FsLocalKeyProvider::new(base_dir)))
+         }
+-        "keyring" | "" => {
+-            info!("Using keyring-based local key provider");
+-            Ok(Arc::new(keyring::KeyringKeyProvider::new(base_dir)?))
+-        }
++        "keyring" => Err(anyhow::anyhow!(
++            "PROTON_PASS_KEY_PROVIDER=keyring is unsupported on Termux/Android: the kernel keyring \
++             service is not available. Use 'fs' (default) or 'env' instead."
++        )),
+         "env" => {
+             info!("Using environment variable-based local key provider");
+             Ok(Arc::new(env_key_provider::EnvLocalKeyProvider::new()?))
+         }
+         _ => Err(anyhow::anyhow!(
+-            "Invalid PROTON_PASS_KEY_PROVIDER value: '{}'. Valid values are 'fs', 'keyring', or 'env'",
++            "Invalid PROTON_PASS_KEY_PROVIDER value: '{}'. Valid values are 'fs', 'keyring' (disabled \
++             on Termux/Android), or 'env'",
+             provider_type
+         )),
+     }

--- a/packages/proton-pass-cli/build.sh
+++ b/packages/proton-pass-cli/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Proton Pass Command Line Interface (CLI)"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
 TERMUX_PKG_VERSION="2.3.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/protonpass/pass-cli/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=9b15641124c6a29eb7015f510cabc8f209fdef9274ace2821085eb02e37997ff
 TERMUX_PKG_DEPENDS="openssl, protobuf, sqlcipher, zlib"
@@ -12,12 +13,7 @@ termux_step_pre_configure() {
 	termux_setup_protobuf
 	termux_setup_rust
 	termux_setup_cmake
-	# protoc-bin-vendored only ships prebuilt protoc binaries for common
-	# desktop targets (x86_64 Linux/macOS/Windows) and has no binary for
-	# aarch64-unknown-linux-android, causing build.rs to panic on unwrap().
-	# Point it at the system protoc (installed via termux_setup_protobuf)
-	# instead of the vendored downloader.
-	sed -i 's/\&protoc_bin_vendored::protoc_bin_path().unwrap()/\&PathBuf::from("protoc")/g' pass-domain/build.rs
+
 	export OPENSSL_NO_VENDOR=1
 	export LIBSQLITE3_SYS_USE_PKG_CONFIG=1
 	export LIBZ_SYS_TEXT_LINK=1


### PR DESCRIPTION

## Problem

`pass-cli login` fails on Termux with:

```
Error: Error creating client features
Caused by:
    0: Failed to get encryption key for database
    1: Could not get local key from keyring
    2: Error accessing credential [...]: NoDefaultStore
```

This is reported in #30987 (comment) by @EvanTechDev.

## Root cause

proton-pass-cli's default key storage (`PROTON_PASS_KEY_PROVIDER=keyring`)
uses the Linux **kernel keyring** (kernel key retention service via the
`linux_keyutils` crate), not D-Bus/Secret Service. Android's kernel does
not support this the way a standard Linux kernel does, so the backend
fails to initialize.

Having `gnome-keyring` installed does not help, since pass-cli only
talks to a Secret Service provider (e.g. GNOME Keyring) when
`PROTON_PASS_LINUX_KEYRING=dbus` is explicitly set — it does not fall
back automatically. Reference: https://protonpass.github.io/pass-cli/get-started/configuration/
