### PR TITLE
addpkg(nerd-fonts): add 9 Nerd Fonts packages (v3.5.0)

### DIFF
--- a/packages/ttf-cascadia-code-nerd/build.sh
+++ b/packages/ttf-cascadia-code-nerd/build.sh
@@ -1,0 +1,31 @@
+TERMUX_PKG_HOMEPAGE=https://www.nerdfonts.com/
+TERMUX_PKG_DESCRIPTION="Cascadia Code patched with Nerd Fonts icons/glyphs (Font Awesome, Devicons, Octicons, Powerline, etc)"
+TERMUX_PKG_LICENSE="OFL-1.1"
+TERMUX_PKG_LICENSE_FILE="LICENSE"
+TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
+TERMUX_PKG_VERSION=3.5.0
+TERMUX_PKG_SRCURL=https://github.com/ryanoasis/nerd-fonts/releases/download/v${TERMUX_PKG_VERSION}/CascadiaCode.zip
+TERMUX_PKG_SHA256=34230d1534c70976bc508abfa9a3b0ec3faf12881e83b85eb5a0cbe225682256
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+# The release zip is a flat archive of *.ttf files (no subfolders), so the
+# default "termux_extract_src_archive" (which expects the upstream project
+# layout) is not needed here - a plain unzip is enough.
+termux_extract_src_archive() {
+	local file="$TERMUX_PKG_CACHEDIR/$(basename "$TERMUX_PKG_SRCURL")"
+	mkdir -p "$TERMUX_PKG_SRCDIR"
+	unzip -q "$file" -d "$TERMUX_PKG_SRCDIR"
+}
+
+termux_step_make_install() {
+	## Install fonts.
+	## NOTE: upstream file name is "Caskaydia Cove" (the Nerd Fonts fork name
+	## for Cascadia Code), only keep Regular/Bold/Italic/BoldItalic styles to
+	## keep the package size reasonable.
+	mkdir -p "$TERMUX_PREFIX/share/fonts/TTF"
+	cp CaskaydiaCoveNerdFont-Regular.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp CaskaydiaCoveNerdFont-Bold.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp CaskaydiaCoveNerdFont-Italic.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp CaskaydiaCoveNerdFont-BoldItalic.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+}

--- a/packages/ttf-hack-nerd/build.sh
+++ b/packages/ttf-hack-nerd/build.sh
@@ -1,0 +1,30 @@
+TERMUX_PKG_HOMEPAGE=https://www.nerdfonts.com/
+TERMUX_PKG_DESCRIPTION="Hack patched with Nerd Fonts icons/glyphs (Font Awesome, Devicons, Octicons, Powerline, etc)"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_LICENSE_FILE="LICENSE.md"
+TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
+TERMUX_PKG_VERSION=3.5.0
+TERMUX_PKG_SRCURL=https://github.com/ryanoasis/nerd-fonts/releases/download/v${TERMUX_PKG_VERSION}/Hack.zip
+TERMUX_PKG_SHA256=24a54aa41ff8ca5829409bfeb1bc2883b9fcafbf79f8d4b7674898550cb5e3b3
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+# The release zip is a flat archive of *.ttf files (no subfolders), so the
+# default "termux_extract_src_archive" (which expects the upstream project
+# layout) is not needed here - a plain unzip is enough.
+termux_extract_src_archive() {
+	local file="$TERMUX_PKG_CACHEDIR/$(basename "$TERMUX_PKG_SRCURL")"
+	mkdir -p "$TERMUX_PKG_SRCDIR"
+	unzip -q "$file" -d "$TERMUX_PKG_SRCDIR"
+}
+
+termux_step_make_install() {
+	## Install fonts.
+	## Only keep the plain (non-Mono, non-Propo) Regular/Bold/Italic/BoldItalic
+	## styles to keep the package size reasonable.
+	mkdir -p "$TERMUX_PREFIX/share/fonts/TTF"
+	cp HackNerdFont-Regular.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp HackNerdFont-Bold.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp HackNerdFont-Italic.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp HackNerdFont-BoldItalic.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+}

--- a/packages/ttf-inconsolata-nerd/build.sh
+++ b/packages/ttf-inconsolata-nerd/build.sh
@@ -1,0 +1,28 @@
+TERMUX_PKG_HOMEPAGE=https://www.nerdfonts.com/
+TERMUX_PKG_DESCRIPTION="Inconsolata patched with Nerd Fonts icons/glyphs (Font Awesome, Devicons, Octicons, Powerline, etc)"
+TERMUX_PKG_LICENSE="OFL-1.1"
+TERMUX_PKG_LICENSE_FILE="OFL.txt"
+TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
+TERMUX_PKG_VERSION=3.5.0
+TERMUX_PKG_SRCURL=https://github.com/ryanoasis/nerd-fonts/releases/download/v${TERMUX_PKG_VERSION}/Inconsolata.zip
+TERMUX_PKG_SHA256=2b10ce776b163467d64b20fc64a2d5b83cd79d596c3acc0ab9cec7adea5c2e8f
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+# The release zip is a flat archive of *.ttf files (no subfolders), so the
+# default "termux_extract_src_archive" (which expects the upstream project
+# layout) is not needed here - a plain unzip is enough.
+termux_extract_src_archive() {
+	local file="$TERMUX_PKG_CACHEDIR/$(basename "$TERMUX_PKG_SRCURL")"
+	mkdir -p "$TERMUX_PKG_SRCDIR"
+	unzip -q "$file" -d "$TERMUX_PKG_SRCDIR"
+}
+
+termux_step_make_install() {
+	## Install fonts.
+	## NOTE: upstream Inconsolata Nerd Font only ships Regular and Bold -
+	## there is no Italic/BoldItalic .ttf in this release.
+	mkdir -p "$TERMUX_PREFIX/share/fonts/TTF"
+	cp InconsolataNerdFont-Regular.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp InconsolataNerdFont-Bold.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+}

--- a/packages/ttf-iosevka-nerd/build.sh
+++ b/packages/ttf-iosevka-nerd/build.sh
@@ -1,0 +1,30 @@
+TERMUX_PKG_HOMEPAGE=https://www.nerdfonts.com/
+TERMUX_PKG_DESCRIPTION="Iosevka patched with Nerd Fonts icons/glyphs (Font Awesome, Devicons, Octicons, Powerline, etc)"
+TERMUX_PKG_LICENSE="OFL-1.1"
+TERMUX_PKG_LICENSE_FILE="LICENSE.md"
+TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
+TERMUX_PKG_VERSION=3.5.0
+TERMUX_PKG_SRCURL=https://github.com/ryanoasis/nerd-fonts/releases/download/v${TERMUX_PKG_VERSION}/Iosevka.zip
+TERMUX_PKG_SHA256=a5a218f974c7d3264c0f330c514364aacabf839d8ee92abd05f5c2cd4ad514b5
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+# The release zip is a flat archive of *.ttf files (no subfolders), so the
+# default "termux_extract_src_archive" (which expects the upstream project
+# layout) is not needed here - a plain unzip is enough.
+termux_extract_src_archive() {
+	local file="$TERMUX_PKG_CACHEDIR/$(basename "$TERMUX_PKG_SRCURL")"
+	mkdir -p "$TERMUX_PKG_SRCDIR"
+	unzip -q "$file" -d "$TERMUX_PKG_SRCDIR"
+}
+
+termux_step_make_install() {
+	## Install fonts.
+	## Iosevka has a huge number of weights/widths upstream, only keep
+	## Regular/Bold/Italic/BoldItalic to keep the package size reasonable.
+	mkdir -p "$TERMUX_PREFIX/share/fonts/TTF"
+	cp IosevkaNerdFont-Regular.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp IosevkaNerdFont-Bold.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp IosevkaNerdFont-Italic.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp IosevkaNerdFont-BoldItalic.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+}

--- a/packages/ttf-jetbrains-mono-nerd/build.sh
+++ b/packages/ttf-jetbrains-mono-nerd/build.sh
@@ -1,0 +1,30 @@
+TERMUX_PKG_HOMEPAGE=https://www.nerdfonts.com/
+TERMUX_PKG_DESCRIPTION="JetBrains Mono patched with Nerd Fonts icons/glyphs (Font Awesome, Devicons, Octicons, Powerline, etc)"
+TERMUX_PKG_LICENSE="OFL-1.1"
+TERMUX_PKG_LICENSE_FILE="OFL.txt"
+TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
+TERMUX_PKG_VERSION=3.5.0
+TERMUX_PKG_SRCURL=https://github.com/ryanoasis/nerd-fonts/releases/download/v${TERMUX_PKG_VERSION}/JetBrainsMono.zip
+TERMUX_PKG_SHA256=9577de1ae84ec523df16fc69bac5338b89497a5b4fb91489e2dcb79dc06ac2b5
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+# The release zip is a flat archive of *.ttf files (no subfolders), so the
+# default "termux_extract_src_archive" (which expects the upstream project
+# layout) is not needed here - a plain unzip is enough.
+termux_extract_src_archive() {
+	local file="$TERMUX_PKG_CACHEDIR/$(basename "$TERMUX_PKG_SRCURL")"
+	mkdir -p "$TERMUX_PKG_SRCDIR"
+	unzip -q "$file" -d "$TERMUX_PKG_SRCDIR"
+}
+
+termux_step_make_install() {
+	## Install fonts.
+	## Only keep the plain (non-Mono, non-Propo) Regular/Bold/Italic/BoldItalic
+	## styles to keep the package size reasonable.
+	mkdir -p "$TERMUX_PREFIX/share/fonts/TTF"
+	cp JetBrainsMonoNerdFont-Regular.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp JetBrainsMonoNerdFont-Bold.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp JetBrainsMonoNerdFont-Italic.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp JetBrainsMonoNerdFont-BoldItalic.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+}

--- a/packages/ttf-meslo-nerd/build.sh
+++ b/packages/ttf-meslo-nerd/build.sh
@@ -1,0 +1,31 @@
+TERMUX_PKG_HOMEPAGE=https://www.nerdfonts.com/
+TERMUX_PKG_DESCRIPTION="Meslo (MesloLGS) patched with Nerd Fonts icons/glyphs (Font Awesome, Devicons, Octicons, Powerline, etc), commonly used with Powerlevel10k"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
+TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
+TERMUX_PKG_VERSION=3.5.0
+TERMUX_PKG_SRCURL=https://github.com/ryanoasis/nerd-fonts/releases/download/v${TERMUX_PKG_VERSION}/Meslo.zip
+TERMUX_PKG_SHA256=6ef538a04f30af9cbe4d95fbd1ae31205a04c48a2c09714f6145ac9cbb6d1b64
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+# The release zip is a flat archive of *.ttf files (no subfolders), so the
+# default "termux_extract_src_archive" (which expects the upstream project
+# layout) is not needed here - a plain unzip is enough.
+termux_extract_src_archive() {
+	local file="$TERMUX_PKG_CACHEDIR/$(basename "$TERMUX_PKG_SRCURL")"
+	mkdir -p "$TERMUX_PKG_SRCDIR"
+	unzip -q "$file" -d "$TERMUX_PKG_SRCDIR"
+}
+
+termux_step_make_install() {
+	## Install fonts.
+	## Upstream Meslo ships several sizes (LGS/LGM/LGL, plus "DZ" dotted-zero
+	## variants); we only ship the most popular MesloLGS Regular/Bold/Italic/
+	## BoldItalic set (as used by Powerlevel10k) to keep the package small.
+	mkdir -p "$TERMUX_PREFIX/share/fonts/TTF"
+	cp MesloLGSNerdFont-Regular.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp MesloLGSNerdFont-Bold.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp MesloLGSNerdFont-Italic.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp MesloLGSNerdFont-BoldItalic.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+}

--- a/packages/ttf-roboto-mono-nerd/build.sh
+++ b/packages/ttf-roboto-mono-nerd/build.sh
@@ -1,0 +1,30 @@
+TERMUX_PKG_HOMEPAGE=https://www.nerdfonts.com/
+TERMUX_PKG_DESCRIPTION="Roboto Mono patched with Nerd Fonts icons/glyphs (Font Awesome, Devicons, Octicons, Powerline, etc)"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
+TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
+TERMUX_PKG_VERSION=3.5.0
+TERMUX_PKG_SRCURL=https://github.com/ryanoasis/nerd-fonts/releases/download/v${TERMUX_PKG_VERSION}/RobotoMono.zip
+TERMUX_PKG_SHA256=31672eccf247e70e220466e65ee9dd9ff78bf1af264fdb9631d5702ea60b44fa
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+# The release zip is a flat archive of *.ttf files (no subfolders), so the
+# default "termux_extract_src_archive" (which expects the upstream project
+# layout) is not needed here - a plain unzip is enough.
+termux_extract_src_archive() {
+	local file="$TERMUX_PKG_CACHEDIR/$(basename "$TERMUX_PKG_SRCURL")"
+	mkdir -p "$TERMUX_PKG_SRCDIR"
+	unzip -q "$file" -d "$TERMUX_PKG_SRCDIR"
+}
+
+termux_step_make_install() {
+	## Install fonts.
+	## Only keep the plain (non-Mono, non-Propo) Regular/Bold/Italic/BoldItalic
+	## styles to keep the package size reasonable.
+	mkdir -p "$TERMUX_PREFIX/share/fonts/TTF"
+	cp RobotoMonoNerdFont-Regular.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp RobotoMonoNerdFont-Bold.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp RobotoMonoNerdFont-Italic.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp RobotoMonoNerdFont-BoldItalic.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+}

--- a/packages/ttf-sourcecodepro-nerd/build.sh
+++ b/packages/ttf-sourcecodepro-nerd/build.sh
@@ -1,0 +1,31 @@
+TERMUX_PKG_HOMEPAGE=https://www.nerdfonts.com/
+TERMUX_PKG_DESCRIPTION="Source Code Pro patched with Nerd Fonts icons/glyphs (Font Awesome, Devicons, Octicons, Powerline, etc)"
+TERMUX_PKG_LICENSE="OFL-1.1"
+TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
+TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
+TERMUX_PKG_VERSION=3.5.0
+TERMUX_PKG_SRCURL=https://github.com/ryanoasis/nerd-fonts/releases/download/v${TERMUX_PKG_VERSION}/SourceCodePro.zip
+TERMUX_PKG_SHA256=e8d18dae2086b5f45dc6e20c10c9b35c52d1bfeaf50426cfb54002fb744f0fa0
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+# The release zip is a flat archive of *.ttf files (no subfolders), so the
+# default "termux_extract_src_archive" (which expects the upstream project
+# layout) is not needed here - a plain unzip is enough.
+termux_extract_src_archive() {
+	local file="$TERMUX_PKG_CACHEDIR/$(basename "$TERMUX_PKG_SRCURL")"
+	mkdir -p "$TERMUX_PKG_SRCDIR"
+	unzip -q "$file" -d "$TERMUX_PKG_SRCDIR"
+}
+
+termux_step_make_install() {
+	## Install fonts.
+	## NOTE: upstream file name is "Sauce Code Pro" (the Nerd Fonts fork name
+	## for Source Code Pro), only keep Regular/Bold/Italic/BoldItalic styles
+	## to keep the package size reasonable.
+	mkdir -p "$TERMUX_PREFIX/share/fonts/TTF"
+	cp SauceCodeProNerdFont-Regular.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp SauceCodeProNerdFont-Bold.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp SauceCodeProNerdFont-Italic.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp SauceCodeProNerdFont-BoldItalic.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+}

--- a/packages/ttf-victor-mono-nerd/build.sh
+++ b/packages/ttf-victor-mono-nerd/build.sh
@@ -1,0 +1,30 @@
+TERMUX_PKG_HOMEPAGE=https://www.nerdfonts.com/
+TERMUX_PKG_DESCRIPTION="Victor Mono patched with Nerd Fonts icons/glyphs (Font Awesome, Devicons, Octicons, Powerline, etc)"
+TERMUX_PKG_LICENSE="OFL-1.1"
+TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
+TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
+TERMUX_PKG_VERSION=3.5.0
+TERMUX_PKG_SRCURL=https://github.com/ryanoasis/nerd-fonts/releases/download/v${TERMUX_PKG_VERSION}/VictorMono.zip
+TERMUX_PKG_SHA256=6f81fe83b7d4fcb27941d13e860c43e36621e124a330f5aeff2adcd8dede57b4
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+# The release zip is a flat archive of *.ttf files (no subfolders), so the
+# default "termux_extract_src_archive" (which expects the upstream project
+# layout) is not needed here - a plain unzip is enough.
+termux_extract_src_archive() {
+	local file="$TERMUX_PKG_CACHEDIR/$(basename "$TERMUX_PKG_SRCURL")"
+	mkdir -p "$TERMUX_PKG_SRCDIR"
+	unzip -q "$file" -d "$TERMUX_PKG_SRCDIR"
+}
+
+termux_step_make_install() {
+	## Install fonts.
+	## Only keep the plain (non-Mono, non-Propo) Regular/Bold/Italic/BoldItalic
+	## styles to keep the package size reasonable.
+	mkdir -p "$TERMUX_PREFIX/share/fonts/TTF"
+	cp VictorMonoNerdFont-Regular.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp VictorMonoNerdFont-Bold.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp VictorMonoNerdFont-Italic.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+	cp VictorMonoNerdFont-BoldItalic.ttf "$TERMUX_PREFIX/share/fonts/TTF/"
+}


### PR DESCRIPTION
## Description

Adds 9 new Nerd Fonts patched font packages, all sourced from the official
[ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) `v3.5.0`
release, following the same pattern as the existing `ttf-jetbrains-mono`
package.

Each package only ships the plain (non-Mono, non-Propo) Regular / Bold /
Italic / BoldItalic styles to keep package size reasonable.

| Package | Upstream font | Styles shipped | License |
|---|---|---|---|
| `ttf-jetbrains-mono-nerd-font` | JetBrains Mono | Regular, Bold, Italic, BoldItalic | OFL-1.1 |
| `ttf-hack-nerd-font` | Hack | Regular, Bold, Italic, BoldItalic | MIT |
| `ttf-cascadia-code-nerd-font` | Cascadia Code (Caskaydia Cove) | Regular, Bold, Italic, BoldItalic | OFL-1.1 |
| `ttf-meslo-nerd-font` | Meslo (MesloLGS, used by Powerlevel10k) | Regular, Bold, Italic, BoldItalic | Apache-2.0 |
| `ttf-source-code-pro-nerd-font` | Source Code Pro (Sauce Code Pro) | Regular, Bold, Italic, BoldItalic | OFL-1.1 |
| `ttf-iosevka-nerd-font` | Iosevka | Regular, Bold, Italic, BoldItalic | OFL-1.1 |
| `ttf-inconsolata-nerd-font` | Inconsolata | Regular, Bold *(no Italic upstream)* | OFL-1.1 |
| `ttf-roboto-mono-nerd-font` | Roboto Mono | Regular, Bold, Italic, BoldItalic | Apache-2.0 |
| `ttf-victor-mono-nerd-font` | Victor Mono | Regular, Bold, Italic, BoldItalic | OFL-1.1 |
