### PR TITLE
add package: yaolang (Chinese keywords programming language)

### DIFF
--- a/packages/yaolang/build.sh
+++ b/packages/yaolang/build.sh
@@ -1,0 +1,21 @@
+# License: MIT
+TERMUX_PKG_HOMEPAGE=https://yaolang.l.cd
+TERMUX_PKG_DESCRIPTION="YaoLang - A system programming language with 100% Chinese keywords"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="YaoLang Team"
+TERMUX_PKG_VERSION=0.1.0
+TERMUX_PKG_SRCURL=https://github.com/a737812/yaolang/archive/refs/tags/v${TERMUX_PKG_VERSION}-alpha.tar.gz
+TERMUX_PKG_SHA256=SKIP_CHECKSUM
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_DEPENDS="clang, make"
+TERMUX_PKG_HOSTBUILD=true
+
+termux_step_make() {
+    cc -O2 -o yaolang src/yaolang.c -lm
+}
+
+termux_step_make_install() {
+    install -Dm700 yaolang ${TERMUX_PREFIX}/bin/yaolang
+    install -Dm600 README.md ${TERMUX_PREFIX}/share/doc/yaolang/README.md
+    cp -r docs/ ${TERMUX_PREFIX}/share/doc/yaolang/
+}


### PR DESCRIPTION
## YaoLang - Chinese Keywords Programming Language

YaoLang is a compiled programming language with 100% Chinese keywords. It compiles source code to C, then to native machine code via the system C compiler.

### Features
- 100% Chinese keywords (函数, 变量, 若, 当, 对于, 匹配, 结构, 枚举)
- Compiles to native code via C (performance comparable to C)
- Static type system (整数, 浮点, 布尔, 文本, 字符)
- 40+ builtin functions (string, file I/O, math, GUI)
- Self-bootstrapping: lexer written in YaoLang can parse itself
- Single-file compiler (~3700 lines C)

### Homepage
https://yaolang.l.cd

### Source
https://github.com/a737812/yaolang

### License
MIT