### PR TITLE
fix(main/mise): fix build of version 2026.8.9 for 32-bit targets

### DIFF
--- a/packages/mise/build.sh
+++ b/packages/mise/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="dev tools, env vars, task runner"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="2026.8.9"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/jdx/mise/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=404defbcf11ddfe14133bbd7700f84a7c0658b90fcc0b2bce943ada5c496c38d
 TERMUX_PKG_DEPENDS="bzip2, openssl"

--- a/packages/mise/stat-mode-32-bit-android.patch
+++ b/packages/mise/stat-mode-32-bit-android.patch
@@ -68,3 +68,23 @@ index eba9609..72fb85f 100644
          nix::sys::stat::fchmod(&destination, mode)?;
      }
      Ok(())
+--- a/src/system/managed_files.rs
++++ b/src/system/managed_files.rs
+@@ -1599,9 +1599,15 @@ fn open_or_create_directory_tree_inner(
+             Ok(directory) => directory,
+             Err(open_error) => {
+                 let metadata = fstatat(&directory, name.as_os_str(), AtFlags::AT_SYMLINK_NOFOLLOW);
+-                if metadata.is_ok_and(|metadata| {
++                #[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
++                let metadataIsOk = metadata.is_ok_and(|metadata| {
+                     SFlag::from_bits_truncate(metadata.st_mode).contains(SFlag::S_IFLNK)
+-                }) {
++                });
++                #[cfg(all(target_os = "android", target_pointer_width = "32"))]
++                let metadataIsOk = metadata.is_ok_and(|metadata| {
++                    SFlag::from_bits_truncate(metadata.st_mode as u16).contains(SFlag::S_IFLNK)
++                });
++                if metadataIsOk {
+                     let parent = fstat(&directory)?;
+                     if parent.st_uid != 0 || parent.st_mode & 0o022 != 0 {
+                         bail!(


### PR DESCRIPTION
- Just like https://github.com/termux/termux-packages/pull/31119

- They added another use of `stat.st_mode`