### PR TITLE
fix(termux_step_install_license): Use ',' delimiter only

### DIFF
--- a/scripts/build/termux_step_install_license.sh
+++ b/scripts/build/termux_step_install_license.sh
@@ -2,6 +2,8 @@
 termux_step_install_license() {
 	[[ "$TERMUX_PKG_METAPACKAGE" == 'true' ]] && return
 
+	echo "Installing licenses ($TERMUX_PKG_LICENSE) for package '$TERMUX_PKG_NAME'"
+
 	mkdir -p "$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME"
 	local LICENSE COUNTER=0
 	local -a LICENSES
@@ -35,7 +37,7 @@ termux_step_install_license() {
 				# shellcheck disable=SC2190 # this is a valid way to assign key value pairs
 				INSTALLED_LICENSES+=("${LICENSE_FILEPATH}" 'already installed')
 			fi
-			cp -f "${TERMUX_PKG_SRCDIR}/${LICENSE_FILE}" "$TARGET"
+			cp -vf "${TERMUX_PKG_SRCDIR}/${LICENSE_FILE}" "$TARGET"
 		done  <<< "${TERMUX_PKG_LICENSE_FILE//,/$'\n'}"
 	else # If a license file wasn't specified, find the one we need
 		local TO_LICENSE             # link target for generic licenses
@@ -79,9 +81,9 @@ termux_step_install_license() {
 						for FILE in "${COMMON_LICENSE_FILES[@]}"; do
 							[[ -f "$TERMUX_PKG_SRCDIR/$FILE" ]] && {
 								if (( COUNTER )); then
-									cp -f "${TERMUX_PKG_SRCDIR}/$FILE" "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}/copyright.${COUNTER}"
+									cp -vf "${TERMUX_PKG_SRCDIR}/$FILE" "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}/copyright.${COUNTER}"
 								else
-									cp -f "${TERMUX_PKG_SRCDIR}/$FILE" "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}/copyright"
+									cp -vf "${TERMUX_PKG_SRCDIR}/$FILE" "${TERMUX_PREFIX}/share/doc/${TERMUX_PKG_NAME}/copyright"
 								fi
 								(( ++COUNTER, ++FROM_SOURCES ))
 							}
@@ -104,9 +106,9 @@ termux_step_install_license() {
 						*)        termux_error_exit "'$TERMUX_PACKAGE_LIBRARY' is not a supported libc";;
 					esac
 					if (( COUNTER )); then
-						ln -sf "$TO_LICENSE" "$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/copyright.${COUNTER}"
+						ln -vsf "$TO_LICENSE" "$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/copyright.${COUNTER}"
 					else
-						ln -sf "$TO_LICENSE" "$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/copyright"
+						ln -vsf "$TO_LICENSE" "$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME/copyright"
 					fi
 					(( ++COUNTER ))
 				;;

--- a/scripts/build/termux_step_install_license.sh
+++ b/scripts/build/termux_step_install_license.sh
@@ -6,23 +6,27 @@ termux_step_install_license() {
 	local LICENSE COUNTER=0
 	local -a LICENSES
 	# Parse the license(s)
-	IFS+="," read -r -a LICENSES <<< "${TERMUX_PKG_LICENSE}"
+	IFS="," read -r -a LICENSES <<< "${TERMUX_PKG_LICENSE}"
+	shopt -s extglob
+	LICENSES=("${LICENSES[@]##+([[:space:]])}")
+	LICENSES=("${LICENSES[@]%%+([[:space:]])}")
+	shopt -u extglob
 
 	# Was a license file specified?
 	if [[ -n "${TERMUX_PKG_LICENSE_FILE}" ]]; then
 		COUNTER=1
-		local LICENSE_FILEPATH
+		local LICENSE_FILE LICENSE_FILEPATH
 		local -A INSTALLED_LICENSES=()
-		for LICENSE in "${LICENSES[@]}"; do
+		while read -r LICENSE_FILE; do
 			# Skip empty lines
-			[[ -z "${LICENSE}" ]] && continue
+			[[ -z "${LICENSE_FILE}" ]] && continue
 
 			# Check that the license file exists in the source files
-			[[ -f "$TERMUX_PKG_SRCDIR/$LICENSE" ]] || {
-				termux_error_exit "$TERMUX_PKG_SRCDIR/$LICENSE does not exist"
+			[[ -f "$TERMUX_PKG_SRCDIR/$LICENSE_FILE" ]] || {
+				termux_error_exit "$TERMUX_PKG_SRCDIR/$LICENSE_FILE does not exist"
 			}
 
-			LICENSE_FILEPATH="$(basename "$LICENSE")"
+			LICENSE_FILEPATH="$(basename "$LICENSE_FILE")"
 			if [[ -n ${INSTALLED_LICENSES[${LICENSE_FILEPATH}]:-} ]]; then
 				# We have already installed a license file named $(basename $LICENSE) so add a suffix to it
 				TARGET="$TERMUX_PREFIX/share/doc/${TERMUX_PKG_NAME}/${LICENSE_FILEPATH}.$((COUNTER++))"
@@ -31,16 +35,16 @@ termux_step_install_license() {
 				# shellcheck disable=SC2190 # this is a valid way to assign key value pairs
 				INSTALLED_LICENSES+=("${LICENSE_FILEPATH}" 'already installed')
 			fi
-			cp -f "${TERMUX_PKG_SRCDIR}/${LICENSE}" "$TARGET"
-		done
+			cp -f "${TERMUX_PKG_SRCDIR}/${LICENSE_FILE}" "$TARGET"
+		done  <<< "${TERMUX_PKG_LICENSE_FILE//,/$'\n'}"
 	else # If a license file wasn't specified, find the one we need
 		local TO_LICENSE             # link target for generic licenses
 		local FROM_SOURCES=0         # flag to check if we've included licenses from the source files yet
 		local -a COMMON_LICENSE_FILES=( # search list for licenses with copyright information
-		'copying'
-		'copyright'
-		'licence' # spelled with 'C'
-		'license' # spelled with 'S'
+			'copying'
+			'copyright'
+			'licence' # spelled with 'C'
+			'license' # spelled with 'S'
 		)
 
 		local license_name


### PR DESCRIPTION
Using IFS+=',' splits on ' \t\n,'
Strip leading and trailing whitespace via parameter expansion.

That's what I get for merging stuff before going to bed.
I really should have caught this.
And doing it via `extglob` is a less janky solution.

Eventually I'd like to replace ***all*** comma separated build variables with arrays so this sort of problem just disappears, but that's a project for another time.