### PR TITLE
fix(main/maintainerr): build better-sqlite3 native addon from source

### DIFF
--- a/packages/maintainerr/build.sh
+++ b/packages/maintainerr/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="An automation rule engine for your media server"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.24.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/maintainerr/Maintainerr/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=546faf51aa75387895ca3d5210ed667ded6e801bfb94f57b2f382fd09af9d1ec
 TERMUX_PKG_BUILD_DEPENDS="nodejs, libvips, libcairo, pango, librsvg, giflib, libpixman, libjpeg-turbo, pkg-config, python"
@@ -60,6 +61,12 @@ termux_step_pre_configure() {
 
 	# Install dependencies
 	yarn install --network-timeout 99999999
+
+	# Explicitly compile better-sqlite3 native addon for target architecture
+	(
+		cd node_modules/better-sqlite3
+		npm_config_arch=$GYP_ARCH npm_config_platform=android "${TERMUX_PKG_SRCDIR}/node_modules/.bin/node-gyp" rebuild --release --force_build=1
+	)
 }
 
 termux_step_make() {
@@ -101,6 +108,11 @@ termux_step_make_install() {
 	if [ -d packages/contracts/node_modules ]; then
 		cp -r packages/contracts/node_modules "${TERMUX_PREFIX}/lib/maintainerr/packages/contracts/"
 	fi
+
+	# Remove incompatible host prebuilds bundled in better-sqlite3 and @img
+	rm -rf "${TERMUX_PREFIX}/lib/maintainerr/node_modules/better-sqlite3/prebuilds"
+	rm -rf "${TERMUX_PREFIX}/lib/maintainerr/node_modules/@img/sharp-libvips-"*
+	rm -rf "${TERMUX_PREFIX}/lib/maintainerr/node_modules/@img/sharp-"*
 
 	# Remove useless dev/doc files from node_modules to reduce package size
 	find "${TERMUX_PREFIX}/lib/maintainerr" -type f \( \


### PR DESCRIPTION
Fixes- 

```bash
[maintainerr] | 24/08/2026 09:19:16  [WARN] [Sharp] Image processing is unavailable: the native "sharp" module could not be loaded. Its prebuilt Linux x64 binaries require a CPU with the x86-64-v2 microarchitecture. If you run Maintainerr in a VM, set the CPU type to "host", "x86-64-v2", or newer. Overlay rendering and collection poster generation stay disabled until this is resolved.
[maintainerr] | 24/08/2026 09:19:17  [INFO] [JellyfinAdapterService] Jellyfin connection established: GT 6T (12.0.0)
[maintainerr] | 24/08/2026 09:19:17  [INFO] [TasksService] Task Overlay Handler created successfully
[maintainerr] | 24/08/2026 09:19:17  [INFO] [TasksService] Task Collection Handler created successfully
[maintainerr] | 24/08/2026 09:19:17  [INFO] [TasksService] Task Collection Log Cleaner created successfully
[maintainerr] | 24/08/2026 09:19:17  [INFO] [TasksService] Task Rule Maintenance created successfully
[maintainerr] | 24/08/2026 09:19:17  [INFO] [TasksService] Task Notification Timer created successfully
[maintainerr] | 24/08/2026 09:19:17  [INFO] [TasksService] Task Version Notification created successfully
[maintainerr] | 24/08/2026 09:19:17  [INFO] [NestFactory] Starting Nest application...
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] TypeOrmModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] ExternalApiModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] GracefulShutdownModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] DiscoveryModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] ServeStaticModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] EventEmitterModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] ScheduleModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [ERROR] [TypeOrmModule] Unable to connect to the database. Retrying (1)...
Error: Cannot find module '/data/data/com.termux/files/usr/lib/maintainerr/node_modules/better-sqlite3/build/Release/better_sqlite3.node'
Require stack:
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/better-sqlite3/lib/binding.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/better-sqlite3/lib/index.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/typeorm/platform/PlatformTools.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/typeorm/globals.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/typeorm/index.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/@nestjs/typeorm/dist/common/typeorm.utils.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/@nestjs/typeorm/dist/common/typeorm.decorators.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/@nestjs/typeorm/dist/common/index.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/@nestjs/typeorm/dist/index.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/@nestjs/typeorm/index.js
- /data/data/com.termux/files/usr/lib/maintainerr/apps/server/dist/app/app.module.js
- /data/data/com.termux/files/usr/lib/maintainerr/apps/server/dist/main.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1517:15)
    at wrapResolveFilename (node:internal/modules/cjs/loader:1071:27)
    at defaultResolveImplForCJSLoading (node:internal/modules/cjs/loader:1095:10)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1122:12)
    at Module._load (node:internal/modules/cjs/loader:1294:5)
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    at Module.require (node:internal/modules/cjs/loader:1617:12)
    at require (node:internal/modules/helpers:153:16)
    at getBinding (/data/data/com.termux/files/usr/lib/maintainerr/node_modules/better-sqlite3/lib/binding.js:38:25)
    at new Database (/data/data/com.termux/files/usr/lib/maintainerr/node_modules/better-sqlite3/lib/database.js:46:17)
[maintainerr] | 24/08/2026 09:19:17  [ERROR] [TypeOrmModule] Unable to connect to the database. Retrying (2)...
Error: Cannot find module '/data/data/com.termux/files/usr/lib/maintainerr/node_modules/better-sqlite3/build/Release/better_sqlite3.node'
Require stack:
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/better-sqlite3/lib/binding.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/better-sqlite3/lib/index.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/typeorm/platform/PlatformTools.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/typeorm/globals.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/typeorm/index.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/@nestjs/typeorm/dist/common/typeorm.utils.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/@nestjs/typeorm/dist/common/typeorm.decorators.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/@nestjs/typeorm/dist/common/index.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/@nestjs/typeorm/dist/index.js
- /data/data/com.termux/files/usr/lib/maintainerr/node_modules/@nestjs/typeorm/index.js
- /data/data/com.termux/files/usr/lib/maintainerr/apps/server/dist/app/app.module.js
- /data/data/com.termux/files/usr/lib/maintainerr/apps/server/dist/main.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1517:15)
    at wrapResolveFilename (node:internal/modules/cjs/loader:1071:27)
    at defaultResolveImplForCJSLoading (node:internal/modules/cjs/loader:1095:10)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1122:12)
    at Module._load (node:internal/modules/cjs/loader:1294:5)
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    at Module.require (node:internal/modules/cjs/loader:1617:12)
    at require (node:internal/modules/helpers:153:16)
    at getBinding (/data/data/com.termux/files/usr/lib/maintainerr/node_modules/better-sqlite3/lib/binding.js:38:25)
    at new Database (/data/data/com.termux/files/usr/lib/maintainerr/node_modules/better-sqlite3/lib/database.js:46:17)
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] TypeOrmCoreModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] TypeOrmModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] TypeOrmModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] TypeOrmModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] TypeOrmModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] TypeOrmModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] TypeOrmModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] TypeOrmModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] TypeOrmModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] EventsModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] GitHubApiModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] VersionModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] PlexApiModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] JellyfinModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] EmbyModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] TmdbApiModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] TvdbApiModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] TasksModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] DownloadClientApiModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] LogsModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] TautulliApiModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] InternalApiModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] StreamystatsApiModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] OverlayProviderModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] TracearrApiModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] ServarrApiModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] SeerrApiModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] ActionsModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] StorageMetricsModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] MetadataModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] SettingsModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] AppModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] NotificationsModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] MediaServerModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] OverlaysModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] CollectionsModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [InstanceLoader] RulesModule dependencies initialized
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RoutesResolver] AppController {/api/app}:
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/app/status, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/app/timezone, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/app/releases, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RoutesResolver] HealthController {/api/health}:
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/health/live, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/health/ready, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/health, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RoutesResolver] LogsController {/api/logs}:
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/logs/stream, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/logs/files, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/logs/files/:file, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/logs/settings, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/logs/settings, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/logs/client-error, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RoutesResolver] SettingsController {/api/settings}:
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/radarr, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/sonarr, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/sportarr, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/version, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/database/download, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/api/generate, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/plex/auth, DELETE} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings, PATCH} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/plex/token, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/test/setup, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/test/radarr, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/radarr, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/radarr/:id, PUT} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/radarr/:id, DELETE} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/test/sonarr, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/sonarr, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/sonarr/:id, PUT} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/test/sportarr, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/sportarr, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/sportarr/:id, PUT} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/tautulli, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/tautulli, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/tautulli, DELETE} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/test/tautulli, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/streamystats, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/streamystats, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/streamystats, DELETE} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/test/streamystats, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/tracearr, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/tracearr, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/tracearr, DELETE} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/tracearr/servers, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/test/tracearr, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/download-client, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/download-client, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/download-client, DELETE} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/test/download-client, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/tmdb, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/tmdb, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/tmdb, DELETE} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/test/tmdb, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/tvdb, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/tvdb, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/tvdb, DELETE} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/test/tvdb, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/metadata-provider, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/metadata-provider, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/metadata/refresh/:provider, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/seerr, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/overseerr, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/jellyseerr, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/seerr, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/overseerr, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/jellyseerr, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/seerr, DELETE} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/overseerr, DELETE} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/jellyseerr, DELETE} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/test/seerr, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/test/overseerr, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/test/jellyseerr, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/jellyfin, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/jellyfin/test, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/jellyfin, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/jellyfin, DELETE} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/emby, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/emby/test, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/emby, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/emby, DELETE} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/emby/login, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/sonarr/:id, DELETE} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/sportarr/:id, DELETE} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/test/plex, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/test/plex/auth, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/plex/devices/servers, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/cron/validate, POST} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings/media-server/switch/preview/:targetServerType, GET} route
[maintainerr] | 24/08/2026 09:19:17  [INFO] [RouterExplorer] Mapped {/api/settings
```