### PR TITLE
revbump(main/maintainerr): build sharp against system libvips in cross-compilation

### DIFF
--- a/packages/maintainerr/build.sh
+++ b/packages/maintainerr/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="An automation rule engine for your media server"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.24.0"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL="https://github.com/maintainerr/Maintainerr/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=546faf51aa75387895ca3d5210ed667ded6e801bfb94f57b2f382fd09af9d1ec
 TERMUX_PKG_BUILD_DEPENDS="nodejs, libvips, libcairo, pango, librsvg, giflib, libpixman, libjpeg-turbo, pkg-config, python"
@@ -61,12 +61,6 @@ termux_step_pre_configure() {
 
 	# Install dependencies
 	yarn install --network-timeout 99999999
-
-	# Explicitly compile better-sqlite3 native addon for target architecture
-	(
-		cd node_modules/better-sqlite3
-		npm_config_arch=$GYP_ARCH npm_config_platform=android "${TERMUX_PKG_SRCDIR}/node_modules/.bin/node-gyp" rebuild --release --force_build=1
-	)
 }
 
 termux_step_make() {
@@ -83,6 +77,33 @@ termux_step_make_install() {
 
 	# Clean up devDependencies before packaging
 	yarn workspaces focus --all --production
+
+	# Setup cross-compilation environment variables
+	local GYP_ARCH
+	case "$TERMUX_ARCH" in
+	aarch64) GYP_ARCH="arm64" ;;
+	arm) GYP_ARCH="arm" ;;
+	i686) GYP_ARCH="ia32" ;;
+	x86_64) GYP_ARCH="x64" ;;
+	esac
+
+	# Compile better-sqlite3 for target architecture in production node_modules
+	(
+		cd node_modules/better-sqlite3
+		npm_config_arch=$GYP_ARCH npm_config_platform=android "${TERMUX_PKG_SRCDIR}/node_modules/.bin/node-gyp" rebuild --release --force_build=1
+	)
+
+	# Patch sharp libvips.cjs to strictly use Termux PKG_CONFIG_PATH instead of host /usr paths
+	sed -i 's/getBrewPkgConfigPath(),//g' node_modules/sharp/dist/libvips.cjs
+	sed -i 's/getPkgConfigPath(),//g' node_modules/sharp/dist/libvips.cjs
+
+	# Compile sharp native addon against system libvips
+	(
+		cd node_modules/sharp
+		PATH="${TERMUX_PKG_SRCDIR}/node_modules/.bin:$PATH" \
+		npm_config_arch=$GYP_ARCH npm_config_platform=android \
+		node install/build.js
+	)
 
 	rm -rf "${TERMUX_PREFIX}/lib/maintainerr"
 	mkdir -p "${TERMUX_PREFIX}/lib/maintainerr"


### PR DESCRIPTION

> Root cause of the `/usr/include` leak - 
> 
> Inside `node_modules/sharp/dist/libvips.cjs`, `pkgConfigPath()` runs `pkg-config --variable pc_path pkg-config` (`getPkgConfigPath()`), which on the host Ubuntu builder evaluates to:
> `/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig:/usr/lib/pkgconfig`
> 
> It was prepending that host path *before* `process.env.PKG_CONFIG_PATH`. As a result, `sharp`'s `binding.gyp` called `pkg-config` against the host's `/usr/lib/.../libvips.pc` and added `-I/usr/include/x86_64-linux-gnu` compiler flags.
> 
> By patching `dist/libvips.cjs` to remove `getPkgConfigPath()` and `getBrewPkgConfigPath()`, `pkgConfigPath()` strictly adheres to `$PKG_CONFIG_PATH` (`$TERMUX_PREFIX/lib/pkgconfig`). This ensures `sharp` only compiles against Termux's system `libvips` headers without touching `/usr/include`.

