### PR TITLE
fix({main/emacs,x11/emacs-x}): ensure `subdirs.el` is always installed

### DIFF
--- a/packages/emacs/Makefile.patch
+++ b/packages/emacs/Makefile.patch
@@ -18,3 +18,12 @@
  	  -e '/^#define PATH_[^ ]*SEARCH /s/\([":]\):*/\1/g'				\
  	  -e '/^#define PATH_[^ ]*SEARCH /s/:"/"/'					\
  	  -e 's;\(#define.*PATH_EXEC\).*$$;\1 "${archlibdir}";'				\
+@@ -610,7 +610,7 @@ install: actual-all install-arch-indep install-etcdoc install-arch-dep install-$
+ ## world-readable.
+ ## TODO it might be good to warn about non-standard permissions of
+ ## pre-existing directories, but that does not seem easy.
+-write_subdir=if [ -f "$${subdir}/subdirs.el" ]; \
++write_subdir=if false; \
+ 	then true; \
+ 	else \
+ 	  umask 022; \

--- a/packages/emacs/build.sh
+++ b/packages/emacs/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # Update both emacs and emacs-x to the same version in one PR.
 TERMUX_PKG_VERSION="30.2"
-TERMUX_PKG_REVISION=5
+TERMUX_PKG_REVISION=6
 TERMUX_PKG_SRCURL="https://mirrors.kernel.org/gnu/emacs/emacs-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9
 TERMUX_PKG_DEPENDS="libacl, libgmp, libgnutls, libsqlite, libxml2, ncurses, tree-sitter, zlib"

--- a/x11-packages/emacs-exwm/build.sh
+++ b/x11-packages/emacs-exwm/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="Emacs X Window Manager"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.34"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL="https://github.com/emacs-exwm/exwm/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz"
 TERMUX_PKG_SHA256=ebe730bbda5bce75baf4532173171a9283a58684e7ec84192ba03c3d8328cf0a
 TERMUX_PKG_DEPENDS="emacs-x, emacs-xelb"
@@ -47,19 +47,15 @@ termux_step_pre_configure() {
 }
 
 termux_step_make() {
-	local emacs_version
-	emacs_version=$(. "$TERMUX_SCRIPTDIR/x11-packages/emacs-x/build.sh"; echo "$TERMUX_PKG_VERSION")
 	emacs -Q -batch \
-		-L . -L "$TERMUX_PREFIX/share/emacs/$emacs_version/site-lisp/xelb" \
+		-L . -L "$TERMUX_PREFIX/share/emacs/site-lisp/xelb" \
 		-f batch-byte-compile *.el
 }
 
 termux_step_make_install() {
 	local file
-	local emacs_version
-	emacs_version=$(. "$TERMUX_SCRIPTDIR/x11-packages/emacs-x/build.sh"; echo "$TERMUX_PKG_VERSION")
 	for file in *.el; do
-		install -Dm644 "$file" "$TERMUX_PREFIX/share/emacs/$emacs_version/site-lisp/exwm/$file"
+		install -Dm644 "$file" "$TERMUX_PREFIX/share/emacs/site-lisp/exwm/$file"
 	done
 }
 

--- a/x11-packages/emacs-x/build.sh
+++ b/x11-packages/emacs-x/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 # Update both emacs and emacs-x to the same version in one PR.
 TERMUX_PKG_VERSION="30.2"
-TERMUX_PKG_REVISION=7
+TERMUX_PKG_REVISION=8
 TERMUX_PKG_SRCURL="https://ftpmirror.gnu.org/gnu/emacs/emacs-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9
 TERMUX_PKG_DEPENDS="dbus, fontconfig, freetype, gdk-pixbuf, giflib, glib, harfbuzz, libacl, libgmp, libgnutls, libice, libjpeg-turbo, libpng, librsvg, libsm, libsqlite, libtiff, libwebp, libx11, libxaw, libxcb, libxext, libxfixes, libxft, libxinerama, libxml2, libxmu, libxpm, libxrandr, libxrender, libxt, littlecms, ncurses, tree-sitter, zlib"

--- a/x11-packages/emacs-xelb/build.sh
+++ b/x11-packages/emacs-xelb/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="X protocol Emacs Lisp Binding"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="0.19"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL="https://github.com/emacs-exwm/xelb/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz"
 TERMUX_PKG_SHA256=b518d4b74f41eaa104d389f77d9fe90eb1b99031d6afd7ba5a9dfd5dd49af112
 TERMUX_PKG_DEPENDS="emacs-x"
@@ -54,9 +54,7 @@ termux_step_make() {
 
 termux_step_make_install() {
 	local file
-	local emacs_version
-	emacs_version=$(. "$TERMUX_SCRIPTDIR/x11-packages/emacs-x/build.sh"; echo "$TERMUX_PKG_VERSION")
 	for file in *.el; do
-		install -Dm644 "$file" "$TERMUX_PREFIX/share/emacs/$emacs_version/site-lisp/xelb/$file"
+		install -Dm644 "$file" "$TERMUX_PREFIX/share/emacs/site-lisp/xelb/$file"
 	done
 }


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/31296
- Reverts https://github.com/termux/termux-packages/pull/31259