### PR TITLE
bump(x11/trenchbroom): 2026.2

### DIFF
--- a/packages/ctre/build.sh
+++ b/packages/ctre/build.sh
@@ -1,0 +1,8 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/hanickadot/compile-time-regular-expressions
+TERMUX_PKG_DESCRIPTION="Compile Time Regular Expression in C++"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="3.11.0"
+TERMUX_PKG_SRCURL="https://github.com/hanickadot/compile-time-regular-expressions/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=7d4b30d0bdd8864a47cceb2ab8e7c4d1846f0ec62383f8c45122435d32f19530
+TERMUX_PKG_AUTO_UPDATE=true

--- a/x11-packages/trenchbroom/build.sh
+++ b/x11-packages/trenchbroom/build.sh
@@ -2,15 +2,14 @@ TERMUX_PKG_HOMEPAGE=https://trenchbroom.github.io/
 TERMUX_PKG_DESCRIPTION="Level editor for Quake-engine based games"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="2026.1"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="2026.2"
 TERMUX_PKG_SRCURL="https://github.com/TrenchBroom/TrenchBroom/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz"
-TERMUX_PKG_SHA256=abb7d8a241362cea5bccbf2d6c0fc7406943ab126a2b5e8ab235b41c8d77b36c
+TERMUX_PKG_SHA256=3989d4adc45bda543b42c0f3eacea5e75de90b1fd22704ab4f37466b728f3ab7
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="assimp, cpptrace, freeimage, libtinyxml2, opengl, qt6-qtbase, qt6-qtsvg"
-# stduuid header-only library
+# stduuid and ctre header-only libraries
 # miniz and fmt needed during build, but not showing in ldd command on final binary
-TERMUX_PKG_BUILD_DEPENDS="stduuid, miniz, fmt"
+TERMUX_PKG_BUILD_DEPENDS="ctre, stduuid, miniz, fmt"
 # upstream does not develop builds for 32-bit targets
 # https://github.com/TrenchBroom/TrenchBroom/issues/3651
 # MiniGl.h:50:7: error: typedef redefinition with different types

--- a/x11-packages/trenchbroom/disable-tests.patch
+++ b/x11-packages/trenchbroom/disable-tests.patch
@@ -1,13 +1,13 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -98,7 +98,6 @@ find_package(assimp CONFIG REQUIRED)
+@@ -107,7 +107,6 @@ find_package(assimp CONFIG REQUIRED)
  find_package(cpptrace CONFIG REQUIRED)
  find_package(freeimage CONFIG REQUIRED)
  find_package(freetype CONFIG REQUIRED)
 -find_package(Catch2 CONFIG REQUIRED)
+ find_package(ctre CONFIG REQUIRED)
  find_package(fmt CONFIG REQUIRED)
  find_package(miniz CONFIG REQUIRED)
- find_package(tinyxml2 CONFIG REQUIRED)
 --- a/lib/KdLib/CMakeLists.txt
 +++ b/lib/KdLib/CMakeLists.txt
 @@ -39,4 +39,3 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")

--- a/x11-packages/trenchbroom/set-version.diff
+++ b/x11-packages/trenchbroom/set-version.diff
@@ -24,8 +24,8 @@
  set(APP_BUILD_TYPE "${CMAKE_BUILD_TYPE}")
  
  # Some global variables used in several targets
---- a/lib/TbUiLib/cmake/GenerateVersion.cmake
-+++ b/lib/TbUiLib/cmake/GenerateVersion.cmake
+--- a/lib/TbVersionLib/cmake/GenerateVersion.cmake
++++ b/lib/TbVersionLib/cmake/GenerateVersion.cmake
 @@ -1,9 +1,7 @@
  include("${UTILS}")
  


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/31212

- Now has build-time dependency on `ctre`