### PR TITLE
fix(main/dnsutils): dig/host/nslookup hang after printing output

### DIFF
--- a/packages/dnsutils/build.sh
+++ b/packages/dnsutils/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Clients provided with BIND"
 TERMUX_PKG_LICENSE="MPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="9.20.27"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://downloads.isc.org/isc/bind9/${TERMUX_PKG_VERSION}/bind-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=145ab7a50b33a06d9d488b5e668c887e754f42acf8954e2b5dc7e238b080e4a0
 TERMUX_PKG_DEPENDS="cmocka, json-c, krb5, libandroid-execinfo, libandroid-glob, libcap, libnghttp2, liburcu, libuv, libxml2, openssl, readline, resolv-conf, zlib"

--- a/packages/dnsutils/workthread-qsbr-shutdown-deadlock.patch
+++ b/packages/dnsutils/workthread-qsbr-shutdown-deadlock.patch
@@ -1,0 +1,12 @@
+dig/host/nslookup hang after printing output when built with the qsbr liburcu flavor: a shutting-down worker reaches the stopping barrier while still RCU-online, so a sibling's synchronize_rcu() never returns and the barrier deadlocks. Go RCU-offline before the barrier, like the other blocking paths already do.
+
+--- a/lib/isc/work.c
++++ b/lib/isc/work.c
+@@ -276,6 +276,7 @@ workthread_thread(void *arg) {
+ 		work_run(work);
+ 	}
+
++	rcu_thread_offline();
+ 	isc__loopmgr_stopping(thread->loop);
+
+ 	return NULL;


### PR DESCRIPTION
Fixes #31302

The qsbr build parks a worker on the stopping barrier while still RCU-online, so a sibling's synchronize_rcu() never returns and the tools hang at shutdown. More in the commit message.
