### PR TITLE
addpkg(x11/prismlauncher,main/tomlplusplus): 11.0.3

### DIFF
--- a/packages/tomlplusplus/build.sh
+++ b/packages/tomlplusplus/build.sh
@@ -1,0 +1,11 @@
+TERMUX_PKG_HOMEPAGE=https://marzer.github.io/tomlplusplus/
+TERMUX_PKG_DESCRIPTION="Header-only TOML config file parser and serializer for C++ 17"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="3.4.0"
+TERMUX_PKG_SRCURL="https://github.com/marzer/tomlplusplus/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=8517f65938a4faae9ccf8ebb36631a38c1cadfb5efa85d9a72e15b9e97d25155
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+"

--- a/x11-packages/lwjgl3/build.sh
+++ b/x11-packages/lwjgl3/build.sh
@@ -1,0 +1,35 @@
+TERMUX_PKG_HOMEPAGE=https://www.lwjgl.org/
+TERMUX_PKG_DESCRIPTION="Lightweight Java Game Library version 3"
+TERMUX_PKG_LICENSE="BSD 3-Clause"
+TERMUX_PKG_LICENSE_FILE="LICENSE.md"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="3.4.1"
+TERMUX_PKG_SRCURL="https://github.com/LWJGL/lwjgl3/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=86f22fa70bdb8dbf9ea205daa0e9d88dd80fa7cecbd60025f687b7400edb11fd
+TERMUX_PKG_DEPENDS="openjdk-25, openjdk-25-x"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_HOSTBUILD=true
+
+termux_step_host_build() {
+	if [[ ! -v ANT_HOME ]]; then
+		if [[ ${TERMUX_ON_DEVICE_BUILD} = false ]]; then
+			termux_download_ubuntu_packages ant
+		fi
+	fi
+}
+
+termux_step_pre_configure() {
+	if [[ ${TERMUX_ON_DEVICE_BUILD} = true ]]; then
+		export JAVA_HOME=${TERMUX__PREFIX__LIB_DIR}/jvm/java-25-openjdk
+	fi
+}
+
+termux_step_make() {
+	export PATH="$TERMUX_PKG_HOSTBUILD_DIR/ubuntu_packages/usr/bin:$PATH"
+	ant
+}
+
+termux_step_make_install() {
+	cp -r $TERMUX_PKG_SRCDIR/bin/libs/native/linux/arm64/org/lwjgl $TERMUX__PREFIX__LIB_DIR/lwjgl3
+}

--- a/x11-packages/lwjgl3/fix-for-termux.patch
+++ b/x11-packages/lwjgl3/fix-for-termux.patch
@@ -1,0 +1,297 @@
+diff --git a/config/linux/build.xml b/config/linux/build.xml
+index 7fb5a3aae..52e354219 100644
+--- a/config/linux/build.xml
++++ b/config/linux/build.xml
+@@ -43,7 +43,7 @@
+                 <arg line="-mcpu=powerpc64le" if:set="build.arch.ppc64le"/>
+                 <arg line="-march=rv64g" if:set="build.arch.riscv64"/>
+                 <arg line="-O3 -flto=auto -fPIC @{flags} -pthread -DNDEBUG -DLWJGL_LINUX -DLWJGL_${build.arch}"/>
+-                <arg line="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -D_GNU_SOURCE"/>
++                <arg line="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0"/>
+                 <arg line="-D_FILE_OFFSET_BITS=64"/>
+ 
+                 <arg value="-I${jni.headers}"/>
+@@ -162,7 +162,7 @@
+             <echo message="GCC executable: ${gcc.prefix}gcc${gcc.suffix}"/>
+             <exec executable="bash" logError="true" failonerror="false" taskname="Compiler">
+                 <arg line="-o pipefail -c"/>
+-                <arg value="${gcc.prefix}gcc${gcc.suffix} --version | grep ^.*gcc"/>
++                <arg value="${gcc.prefix}gcc${gcc.suffix} --version | head -1"/>
+             </exec>
+         </sequential>
+ 
+@@ -196,15 +196,8 @@
+                     <include name="${module.lwjgl}/jawt/src/generated/c/*.c" if:true="${binding.jawt}"/>
+                 </fileset>
+             </source>
+-            <beforeLink>
+-                <parallel threadsPerProcessor="2" failonany="true" unless:set="lib-dependencies-uptodate">
+-                    <update-dependency module="core" artifact="core/libffi.a"/>
+-                </parallel>
+-            </beforeLink>
+             <link>
+-                <fileset dir="${lib.native}/org/lwjgl">
+-                    <include name="libffi.a"/>
+-                </fileset>
++		<arg value="-lffi"/>
+                 <arg value="-ldl"/>
+             </link>
+         </build>
+@@ -273,15 +266,7 @@
+         <build module="nfd" simple="true" linker="g++" if:true="${binding.nfd}">
+             <beforeCompile>
+                 <compile lang="c++">
+-                    <arg value="-I/usr/include/gtk-3.0"/>
+-                    <arg value="-I/usr/include/glib-2.0"/>
+-                    <arg value="-I/usr/include/pango-1.0"/>
+-                    <arg value="-I/usr/include/harfbuzz"/>
+-                    <arg value="-I/usr/include/cairo"/>
+-                    <arg value="-I/usr/include/gdk-pixbuf-2.0"/>
+-                    <arg value="-I/usr/include/atk-1.0"/>
+-                    <arg value="-I/usr/lib64/glib-2.0/include"/>
+-                    <arg value="-I/usr/lib/${linux.triplet}/glib-2.0/include"/>
++		    <arg line="-I@TERMUX_PREFIX@/include/gtk-3.0 -I@TERMUX_PREFIX@/include/glib-2.0 -I@TERMUX_PREFIX@/lib/glib-2.0/include -I@TERMUX_PREFIX@/include/pango-1.0 -I@TERMUX_PREFIX@/include/harfbuzz -I@TERMUX_PREFIX@/include/cairo -I@TERMUX_PREFIX@/include/gdk-pixbuf-2.0 -I@TERMUX_PREFIX@/include/atk-1.0"/>
+                     <arg value="-I${src.main.rel}/include"/>
+                     <fileset dir="." includes="${src.main}/nfd_gtk.cpp"/>
+                 </compile>
+@@ -299,7 +284,7 @@
+         <build module="nfd" suffix="_portal" simple="true" linker="g++" if:true="${binding.nfd}">
+             <beforeCompile>
+                 <compile lang="c++">
+-                    <arg line="-I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include -I/usr/lib/${linux.triplet}/dbus-1.0/include"/>
++                    <arg line="-I@TERMUX_PREFIX@/include/dbus-1.0 -I@TERMUX_PREFIX@/lib/dbus-1.0/include"/>
+                     <arg value="-I${src.main.rel}/include"/>
+                     <fileset dir="." includes="${src.main}/nfd_portal.cpp"/>
+                 </compile>
+@@ -347,6 +332,7 @@
+             <link>
+                 <arg value="-ldl"/>
+                 <arg value="-lm"/>
++		<arg value="-lGLX"/>
+                 <arg value="-l:libGL.so.1" unless:set="gcc.libpath.opengl"/>
+                 <arg line="-L ${gcc.libpath.opengl} -l:libGL.so.1" if:set="gcc.libpath.opengl"/>
+             </link>
+@@ -405,6 +391,7 @@
+         <!-- Vulkan Memory Allocator -->
+         <build module="vma" lang="c++" if:true="${binding.vma}">
+             <source>
++		<arg value="-Wno-nullability-completeness"/>
+                 <arg value="-I${src.main.rel}"/>
+                 <arg value="-I${module.lwjgl.rel}/vulkan/src/main/c"/>
+                 <fileset dir="." includes="${src.generated}/*.cpp"/>
+@@ -482,4 +469,4 @@
+             <touch file="${lib.native}/touch.txt" verbose="false"/>
+         </sequential>
+     </target>
+-</project>
+\ No newline at end of file
++</project>
+diff --git a/modules/lwjgl/core/src/main/c/linux/liburing/include/liburing.h b/modules/lwjgl/core/src/main/c/linux/liburing/include/liburing.h
+index 0188937b0..c22493987 100644
+--- a/modules/lwjgl/core/src/main/c/linux/liburing/include/liburing.h
++++ b/modules/lwjgl/core/src/main/c/linux/liburing/include/liburing.h
+@@ -323,11 +323,11 @@ int io_uring_register_restrictions(struct io_uring *ring,
+ 				   unsigned int nr_res) LIBURING_NOEXCEPT;
+ int io_uring_enable_rings(struct io_uring *ring) LIBURING_NOEXCEPT;
+ int __io_uring_sqring_wait(struct io_uring *ring) LIBURING_NOEXCEPT;
+-#ifdef _GNU_SOURCE
++#if defined(_GNU_SOURCE) && !defined(__ANDROID__)
+ int io_uring_register_iowq_aff(struct io_uring *ring, size_t cpusz,
+ 				const cpu_set_t *mask) LIBURING_NOEXCEPT;
+-#endif
+ int io_uring_unregister_iowq_aff(struct io_uring *ring) LIBURING_NOEXCEPT;
++#endif
+ int io_uring_register_iowq_max_workers(struct io_uring *ring,
+ 				       unsigned int *values) LIBURING_NOEXCEPT;
+ int io_uring_register_ring_fd(struct io_uring *ring) LIBURING_NOEXCEPT;
+@@ -1666,7 +1666,7 @@ IOURINGINLINE void io_uring_prep_fixed_fd_install(struct io_uring_sqe *sqe,
+ 	sqe->install_fd_flags = flags;
+ }
+ 
+-#ifdef _GNU_SOURCE
++#if defined(_GNU_SOURCE) && !defined(__ANDROID__)
+ IOURINGINLINE void io_uring_prep_ftruncate(struct io_uring_sqe *sqe,
+ 				       int fd, loff_t len)
+ 	LIBURING_NOEXCEPT
+diff --git a/modules/lwjgl/core/src/main/c/linux/liburing/include/liburing/compat.h b/modules/lwjgl/core/src/main/c/linux/liburing/include/liburing/compat.h
+index 55e0d501a..626e67f6f 100644
+--- a/modules/lwjgl/core/src/main/c/linux/liburing/include/liburing/compat.h
++++ b/modules/lwjgl/core/src/main/c/linux/liburing/include/liburing/compat.h
+@@ -6,28 +6,20 @@
+ #include <inttypes.h>
+ #include <stdint.h>
+ #include <sys/stat.h>
++#include <linux/time_types.h>
++#include <linux/openat2.h>
+ #include <linux/ioctl.h>
+ 
++#ifndef __kernel_rwf_t
+ typedef int __kernel_rwf_t;
+ 
+-struct __kernel_timespec {
+-	int64_t		tv_sec;
+-	long long	tv_nsec;
+-};
+ 
+ /* <linux/time_types.h> is not available, so it can't be included */
+ #define UAPI_LINUX_IO_URING_H_SKIP_LINUX_TIME_TYPES_H 1
+ 
+-#if !defined(__glibc_has_open_how) && !defined(_UAPI_LINUX_OPENAT2_H)
+-struct open_how {
+-	uint64_t	flags;
+-	uint64_t	mode;
+-	uint64_t	resolve;
+-};
+-#endif
+ 
+ #ifndef BLOCK_URING_CMD_DISCARD
+ #define BLOCK_URING_CMD_DISCARD                        _IO(0x12, 0)
+ #endif
+-
++#endif
+ #endif
+diff --git a/modules/lwjgl/core/src/main/c/linux/liburing/register.c b/modules/lwjgl/core/src/main/c/linux/liburing/register.c
+index 02d043b8f..0c4e0e20e 100644
+--- a/modules/lwjgl/core/src/main/c/linux/liburing/register.c
++++ b/modules/lwjgl/core/src/main/c/linux/liburing/register.c
+@@ -258,6 +258,7 @@ int io_uring_enable_rings(struct io_uring *ring)
+ 	return do_register(ring, IORING_REGISTER_ENABLE_RINGS, NULL, 0);
+ }
+ 
++#if defined(_GNU_SOURCE) && !defined(__ANDROID__)
+ int io_uring_register_iowq_aff(struct io_uring *ring, size_t cpusz,
+ 			       const cpu_set_t *mask)
+ {
+@@ -271,6 +272,7 @@ int io_uring_unregister_iowq_aff(struct io_uring *ring)
+ {
+ 	return do_register(ring, IORING_UNREGISTER_IOWQ_AFF, NULL, 0);
+ }
++#endif
+ 
+ int io_uring_register_iowq_max_workers(struct io_uring *ring, unsigned int *val)
+ {
+diff --git a/modules/lwjgl/core/src/templates/kotlin/core/linux/liburing/templates/liburing.kt b/modules/lwjgl/core/src/templates/kotlin/core/linux/liburing/templates/liburing.kt
+index 5683ef0d0..c75ed07c3 100644
+--- a/modules/lwjgl/core/src/templates/kotlin/core/linux/liburing/templates/liburing.kt
++++ b/modules/lwjgl/core/src/templates/kotlin/core/linux/liburing/templates/liburing.kt
+@@ -372,20 +372,6 @@ ENABLE_WARNINGS()""")
+         noPrefix = true
+     )
+ 
+-    int(
+-        "register_iowq_aff",
+-
+-        io_uring.p("ring"),
+-        size_t("cpusz"),
+-        cpu_set_t.const.p("mask")
+-    )
+-
+-    int(
+-        "unregister_iowq_aff",
+-
+-        io_uring.p("ring")
+-    )
+-
+     int(
+         "register_iowq_max_workers",
+ 
+@@ -1644,14 +1630,6 @@ ENABLE_WARNINGS()""")
+         unsigned_int("flags")
+     )
+ 
+-    void(
+-        "prep_ftruncate",
+-
+-        io_uring_sqe.p("sqe"),
+-        int("fd"),
+-        loff_t("len")
+-    )
+-
+     void(
+         "prep_cmd_discard",
+ 
+@@ -1860,4 +1838,4 @@ ENABLE_WARNINGS()""")
+         int("major"),
+         int("minor")
+     )
+-}
+\ No newline at end of file
++}
+diff --git a/modules/lwjgl/core/src/templates/kotlin/core/linux/templates/uio.kt b/modules/lwjgl/core/src/templates/kotlin/core/linux/templates/uio.kt
+index 87d339fcc..76ebfa16d 100644
+--- a/modules/lwjgl/core/src/templates/kotlin/core/linux/templates/uio.kt
++++ b/modules/lwjgl/core/src/templates/kotlin/core/linux/templates/uio.kt
+@@ -43,26 +43,6 @@ val uio = "UIO".nativeClass(Module.CORE_LINUX, nativeSubPath = "linux") {
+         int("__count")
+     )
+ 
+-    ssize_t(
+-        "preadv",
+-
+-        CaptureCallState.errno.param,
+-        int("__fd"),
+-        iovec.const.p("__iovec"),
+-        int("__count"),
+-        off_t("__offset")
+-    )
+-
+-    ssize_t(
+-        "pwritev",
+-
+-        CaptureCallState.errno.param,
+-        int("__fd"),
+-        iovec.const.p("__iovec"),
+-        int("__count"),
+-        off_t("__offset")
+-    )
+-
+     /*ssize_t(
+         "preadv2",
+ 
+@@ -84,28 +64,4 @@ val uio = "UIO".nativeClass(Module.CORE_LINUX, nativeSubPath = "linux") {
+         off_t("__offset"),
+         int("__flags")
+     )*/
+-
+-    ssize_t(
+-        "process_vm_readv",
+-
+-        CaptureCallState.errno.param,
+-        pid_t("__pid"),
+-        iovec.const.p("__lvec"),
+-        unsigned_long_int("__liovcnt"),
+-        iovec.const.p("__rvec"),
+-        unsigned_long_int("__riovcnt"),
+-        unsigned_long_int("__flags")
+-    )
+-
+-    ssize_t(
+-        "process_vm_writev",
+-
+-        CaptureCallState.errno.param,
+-        pid_t("__pid"),
+-        iovec.const.p("__lvec"),
+-        unsigned_long_int("__liovcnt"),
+-        iovec.const.p("__rvec"),
+-        unsigned_long_int("__riovcnt"),
+-        unsigned_long_int("__flags")
+-    )
+ }
+\ No newline at end of file
++}
+diff --git a/modules/lwjgl/nfd/src/main/c/nfd_portal.cpp b/modules/lwjgl/nfd/src/main/c/nfd_portal.cpp
+index 0ee222b23..db753fd45 100644
+--- a/modules/lwjgl/nfd/src/main/c/nfd_portal.cpp
++++ b/modules/lwjgl/nfd/src/main/c/nfd_portal.cpp
+@@ -17,7 +17,10 @@
+ #include <string.h>
+ #include <unistd.h>  // for access()
+ 
+-#if !defined(__has_include) || !defined(__linux__)
++#if defined(__ANDROID__)
++#include <sys/syscall.h>
++#define getrandom(buf, sz, flags) syscall(SYS_getrandom, buf, sz, flags)
++#elif !defined(__has_include) || !defined(__linux__)
+ #include <sys/random.h>  // for getrandom() - the random token string
+ #elif __has_include(<sys/random.h>)
+ #include <sys/random.h>

--- a/x11-packages/lwjgl3/test-failure-workaround.patch
+++ b/x11-packages/lwjgl3/test-failure-workaround.patch
@@ -1,0 +1,13 @@
+diff --git a/build.xml b/build.xml
+index 07522e737..4ab17bf65 100644
+--- a/build.xml
++++ b/build.xml
+@@ -917,7 +917,7 @@
+     </macrodef>
+ 
+     <target name="tests" description="Runs the LWJGL test suite" depends="compile-tests, compile-native">
+-        <testng haltonfailure="true" outputDir="${bin.test.html}" taskname="Tests">
++        <testng haltonfailure="false" outputDir="${bin.test.html}" taskname="Tests">
+             <classpath>
+                 <pathelement path="${module.classpath}"/>
+                 <pathelement path="${bin.test}"/>

--- a/x11-packages/prismlauncher/build.sh
+++ b/x11-packages/prismlauncher/build.sh
@@ -1,0 +1,26 @@
+TERMUX_PKG_HOMEPAGE=https://prismlauncher.org/
+TERMUX_PKG_DESCRIPTION="A custom launcher for Minecraft that allows you to easily manage multiple installations of Minecraft at once"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="11.0.3"
+TERMUX_PKG_GIT_BRANCH="${TERMUX_PKG_VERSION}"
+TERMUX_PKG_SRCURL="git+https://github.com/PrismLauncher/PrismLauncher"
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="cmark, glfw, libarchive, libqrencode, openal-soft, openjdk-25, openjdk-25-x, qt6-qtbase-gtk-platformtheme, qt6-qtimageformats, qt6-qtnetworkauth, qt6-qtsvg, zlib"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, mesa-dev, qt6-qtimageformats-cross-tools, qt6-qtnetworkauth-cross-tools, qt6-qtsvg-cross-tools, tomlplusplus, vulkan-headers"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DLauncher_ENABLE_GAMEMODE=OFF
+-DLauncher_QT_VERSION_MAJOR=6
+-DENABLE_LTO=OFF
+"
+
+termux_step_pre_configure() {
+	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "true" ]] && ! command -v scdoc &> /dev/null; then
+		termux_error_exit <<- EOF
+			Could not find scdoc.
+			It is required to generate man pages for ${TERMUX_PKG_NAME}.
+			Use "pkg i scdoc" to ensure it is installed
+		EOF
+	fi
+}

--- a/x11-packages/prismlauncher/bump-java.patch
+++ b/x11-packages/prismlauncher/bump-java.patch
@@ -1,0 +1,26 @@
+diff --git a/libraries/javacheck/CMakeLists.txt b/libraries/javacheck/CMakeLists.txt
+index b9bcb121a..a98b503b4 100644
+--- a/libraries/javacheck/CMakeLists.txt
++++ b/libraries/javacheck/CMakeLists.txt
+@@ -4,7 +4,7 @@ find_package(Java 1.7 REQUIRED COMPONENTS Development)
+ 
+ include(UseJava)
+ set(CMAKE_JAVA_JAR_ENTRY_POINT JavaCheck)
+-set(CMAKE_JAVA_COMPILE_FLAGS -target 7 -source 7 -Xlint:deprecation -Xlint:unchecked)
++set(CMAKE_JAVA_COMPILE_FLAGS -target 8 -source 8 -Xlint:deprecation -Xlint:unchecked)
+ 
+ set(SRC
+     JavaCheck.java
+diff --git a/libraries/launcher/CMakeLists.txt b/libraries/launcher/CMakeLists.txt
+index dfc4ebb32..5cb999958 100644
+--- a/libraries/launcher/CMakeLists.txt
++++ b/libraries/launcher/CMakeLists.txt
+@@ -4,7 +4,7 @@ find_package(Java 1.7 REQUIRED COMPONENTS Development)
+ 
+ include(UseJava)
+ set(CMAKE_JAVA_JAR_ENTRY_POINT org.prismlauncher.EntryPoint)
+-set(CMAKE_JAVA_COMPILE_FLAGS -target 7 -source 7)
++set(CMAKE_JAVA_COMPILE_FLAGS -target 8 -source 8)
+ 
+ set(SRC
+     org/prismlauncher/EntryPoint.java

--- a/x11-packages/prismlauncher/force-android.patch
+++ b/x11-packages/prismlauncher/force-android.patch
@@ -1,0 +1,20 @@
+diff --git a/launcher/CMakeLists.txt b/launcher/CMakeLists.txt
+index 0704f5676..8c88f02a8 100644
+--- a/launcher/CMakeLists.txt
++++ b/launcher/CMakeLists.txt
+@@ -1345,7 +1346,6 @@ if(DEFINED Launcher_APP_BINARY_DEFS)
+ endif()
+ 
+ install(TARGETS ${Launcher_Name}
+-    RUNTIME_DEPENDENCY_SET LAUNCHER_DEPENDENCY_SET
+     BUNDLE DESTINATION "." COMPONENT Runtime
+     LIBRARY DESTINATION ${LIBRARY_DEST_DIR} COMPONENT Runtime
+     RUNTIME DESTINATION ${BINARY_DEST_DIR} COMPONENT Runtime
+@@ -1520,7 +1520,6 @@ if(WIN32 OR (UNIX AND APPLE))
+ 
+     # Bundle our linked dependencies
+     install(
+-        RUNTIME_DEPENDENCY_SET LAUNCHER_DEPENDENCY_SET
+         COMPONENT bundle
+         DIRECTORIES
+             ${CMAKE_SYSTEM_LIBRARY_PATH}

--- a/x11-packages/prismlauncher/optional-gamemode.patch
+++ b/x11-packages/prismlauncher/optional-gamemode.patch
@@ -1,0 +1,88 @@
+commit 072d5419ebbd088e94a752e8563f9d10c2f36938
+Author: cat <cat@plan9.rocks>
+Date:   Tue Apr 7 16:47:45 2026 +0000
+
+    Add Launcher_ENABLE_GAMEMODE CMake flag
+    
+    Signed-off-by: cat <cat@plan9.rocks>
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 80977e06e..8e899c82d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -303,7 +303,9 @@ endif()
+ 
+ find_package(cmark REQUIRED)
+ 
+-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
++option(Launcher_ENABLE_GAMEMODE "Enable Feral Gamemode support" ON)
++
++if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND Launcher_ENABLE_GAMEMODE)
+     find_package(PkgConfig REQUIRED)
+     pkg_check_modules(gamemode REQUIRED IMPORTED_TARGET gamemode)
+ endif()
+diff --git a/launcher/Application.cpp b/launcher/Application.cpp
+index 7af39b55e..09c65cfe7 100644
+--- a/launcher/Application.cpp
++++ b/launcher/Application.cpp
+@@ -131,8 +131,10 @@
+ #ifdef Q_OS_LINUX
+ #include <dlfcn.h>
+ #include "LibraryUtils.h"
++#ifdef ENABLE_GAMEMODE
+ #include "gamemode_client.h"
+ #endif
++#endif
+ 
+ #if defined(Q_OS_LINUX)
+ #include <sys/statvfs.h>
+@@ -1837,8 +1839,10 @@ void Application::updateCapabilities()
+         m_capabilities |= SupportsFlame;
+ 
+ #ifdef Q_OS_LINUX
++#ifdef ENABLE_GAMEMODE
+     if (gamemode_query_status() >= 0)
+         m_capabilities |= SupportsGameMode;
++#endif
+ 
+     if (!LibraryUtils::findMangoHud().isEmpty())
+         m_capabilities |= SupportsMangoHud;
+diff --git a/launcher/CMakeLists.txt b/launcher/CMakeLists.txt
+index c2f5e70cf..ac177457e 100644
+--- a/launcher/CMakeLists.txt
++++ b/launcher/CMakeLists.txt
+@@ -1356,10 +1356,11 @@ else()
+     target_link_libraries(Launcher_logic LibArchive::LibArchive)
+ endif()
+ 
+-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
++if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND Launcher_ENABLE_GAMEMODE)
+     target_link_libraries(Launcher_logic
+         gamemode
+     )
++    add_compile_definitions(ENABLE_GAMEMODE)
+ endif()
+ 
+ target_link_libraries(Launcher_logic
+diff --git a/launcher/minecraft/launch/LauncherPartLaunch.cpp b/launcher/minecraft/launch/LauncherPartLaunch.cpp
+index a2c400e75..671712daa 100644
+--- a/launcher/minecraft/launch/LauncherPartLaunch.cpp
++++ b/launcher/minecraft/launch/LauncherPartLaunch.cpp
+@@ -44,7 +44,7 @@
+ #include "launch/LaunchTask.h"
+ #include "minecraft/MinecraftInstance.h"
+ 
+-#ifdef Q_OS_LINUX
++#if defined(Q_OS_LINUX) && ENABLE_GAMEMODE
+ #include "gamemode_client.h"
+ #endif
+ 
+@@ -149,7 +149,7 @@ void LauncherPartLaunch::executeTask()
+         m_process.start(javaPath, args);
+     }
+ 
+-#ifdef Q_OS_LINUX
++#if defined(Q_OS_LINUX) && ENABLE_GAMEMODE
+     if (instance->settings()->get("EnableFeralGamemode").toBool() && APPLICATION->capabilities() & Application::SupportsGameMode) {
+         auto pid = m_process.processId();
+         if (pid) {


### PR DESCRIPTION
This PR will add Prism Launcher (Minecraft: Java Edition launcher) to X11, additionally TOML++ (Header-only TOML config file parser and serializer for C++ 17) package as a dependency of Prism Launcher to Termux main packages list.

TOML++ build for all architectures are successful ([results](https://github.com/TheMightyArie/termux-packages/actions/runs/32866865331)) (Prism Launcher has not been tested yet).