### PR TITLE
bump(main/proton-pass-cli): 2.3.3

### DIFF
--- a/packages/proton-pass-cli/0003-increase-recursion-limit.patch
+++ b/packages/proton-pass-cli/0003-increase-recursion-limit.patch
@@ -1,0 +1,28 @@
+Raise the query recursion limit for the pass-cli binary crate.
+
+Since v2.3.3, release builds fail on all Termux targets (arm, i686,
+aarch64) with:
+
+    error: queries overflow the depth limit!
+      = help: consider increasing the recursion limit by adding a
+        `#![recursion_limit = "256"]` attribute to your crate (`pass_cli`)
+      = note: query depth increased by 130 when computing layout of
+        `{async block@pass-cli/src/commands/secret_resolver.rs:222:5: 222:10}`
+
+The `#[async_trait(?Send)]` usage in secret_resolver.rs, combined with
+the crate's other async trait objects, produces a deeply nested type
+that exceeds rustc's default query recursion limit (128) when
+computing layout in a release (non-incremental) build. Follow rustc's
+own suggestion and raise the limit.
+
+--- a/pass-cli/src/main.rs
++++ b/pass-cli/src/main.rs
+@@ -15,6 +15,8 @@
+  *
+  */
+ 
++#![recursion_limit = "512"]
++
+ #[macro_use]
+ extern crate tracing;
+ 

--- a/packages/proton-pass-cli/build.sh
+++ b/packages/proton-pass-cli/build.sh
@@ -2,11 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://protonpass.github.io/pass-cli/
 TERMUX_PKG_DESCRIPTION="Proton Pass Command Line Interface (CLI)"
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
-TERMUX_PKG_VERSION="2.3.2"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION="2.3.3"
 TERMUX_PKG_SRCURL="https://github.com/protonpass/pass-cli/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256=9b15641124c6a29eb7015f510cabc8f209fdef9274ace2821085eb02e37997ff
+TERMUX_PKG_SHA256=a064b89fc4fb5d2db47a99e46e1782b7672dc1078e2ecbb881d0910c01947611
 TERMUX_PKG_DEPENDS="openssl, protobuf, sqlcipher, zlib"
+TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_pre_configure() {


### PR DESCRIPTION
## Release note

[Upstream release](https://github.com/protonpass/pass-cli/releases/tag/2.3.3)

## Why this patch is needed

Bumping `pass-cli` to `2.3.3` breaks CI on **all architectures** with a compiler-internal recursion limit
overflow during the release build:

```
error: queries overflow the depth limit!
  = help: consider increasing the recursion limit by adding a
    `#![recursion_limit = "256"]` attribute to your crate (`pass_cli`)
  = note: query depth increased by 130 when computing layout of
    `{async block@pass-cli/src/commands/secret_resolver.rs:222:5: 222:10}`

error: could not compile `pass-cli` (bin "pass-cli") due to 1 previous error
```

It's a new issue introduced by upstream
code added in `2.3.3`. The new `secret_resolver.rs` module uses
`#[async_trait(?Send)]`, and the resulting nested async/trait-object
types push rustc's query recursion depth past its default limit (128)
while computing type layout in a release build. rustc itself suggests
the fix in the error output.

`0003-increase-recursion-limit.patch` adds `#![recursion_limit = "512"]`
to the crate root (`pass-cli/src/main.rs`), which resolves the overflow.
It's a purely compiler-facing change with no behavioral effect on the
binary.