### PR TITLE
bump(x11/firefox): 154.0.1

### DIFF
--- a/x11-packages/firefox/0031-Bug-2053518-Handle-the-oe-linux-rust-targets-added-in.patch
+++ b/x11-packages/firefox/0031-Bug-2053518-Handle-the-oe-linux-rust-targets-added-in.patch
@@ -1,0 +1,107 @@
+From 1ecaa12836a69896dd6702fb5ed5e13979399371 Mon Sep 17 00:00:00 2001
+From: Jesse Schwartzentruber <truber@mozilla.com>
+Date: Tue, 28 Jul 2026 17:26:38 +0000
+Subject: [PATCH] Bug 2053518 - Handle the *-oe-linux-* rust targets added in
+ rustc 1.98 in rust target detection.
+ r=firefox-build-system-reviewers,glandium
+
+Differential Revision: https://phabricator.services.mozilla.com/D311145
+---
+ build/moz.configure/rust.configure            | 29 ++++++++++++++++---
+ .../configure/test_toolchain_configure.py     | 15 ++++++++++
+ 2 files changed, 40 insertions(+), 4 deletions(-)
+
+diff --git a/build/moz.configure/rust.configure b/build/moz.configure/rust.configure
+index 5525c26a184da..35cb30416c647 100644
+--- a/build/moz.configure/rust.configure
++++ b/build/moz.configure/rust.configure
+@@ -298,6 +298,10 @@ def detect_rustc_target(host_or_target, arm_target, rust_supported_targets):
+         elif not candidates:
+             return None
+ 
++        # config.guess uses the "pc" vendor for x86/x86_64 where rust uses its
++        # generic "unknown" vendor; normalize so we correlate on the right one.
++        vendor = "unknown" if host_or_target.vendor == "pc" else host_or_target.vendor
++
+         # We have multiple candidates. There are two cases where we can try to
+         # narrow further down using extra information from the build system.
+         # - For windows targets, correlate with the ABI
+@@ -360,11 +364,19 @@ def detect_rustc_target(host_or_target, arm_target, rust_supported_targets):
+             else:
+                 suffix = ""
+             for p in prefixes:
+-                for c in candidates:
+-                    if c.rust_target.startswith(
+-                        "{}-".format(p)
+-                    ) and c.rust_target.endswith(suffix):
++                matches = [
++                    c
++                    for c in candidates
++                    if c.rust_target.startswith("{}-".format(p))
++                    and c.rust_target.endswith(suffix)
++                ]
++                if not matches:
++                    continue
++                # As below, correlate on the (normalized) vendor.
++                for c in matches:
++                    if c.target.vendor == vendor:
+                         return c.rust_target
++                return matches[0].rust_target
+ 
+         # See if we can narrow down on the exact alias.
+         # We use the sub_configure_alias to keep support mingw32 triplets as input.
+@@ -393,6 +405,15 @@ def detect_rustc_target(host_or_target, arm_target, rust_supported_targets):
+             elif narrowed:
+                 candidates = narrowed
+ 
++        # Correlate on the (normalized) vendor, so vendor-specific targets (e.g.
++        # the *-oe-linux-gnu targets added in rust 1.98) don't shadow the
++        # generic ones for aliases whose vendor doesn't match a rust target.
++        narrowed = [c for c in candidates if c.target.vendor == vendor]
++        if len(narrowed) == 1:
++            return narrowed[0].rust_target
++        elif narrowed:
++            candidates = narrowed
++
+         # See if we can narrow down with the raw OS and raw CPU
+         narrowed = [
+             c
+diff --git a/python/mozbuild/mozbuild/test/configure/test_toolchain_configure.py b/python/mozbuild/mozbuild/test/configure/test_toolchain_configure.py
+index 58a736ee85fcc..7dfb0efb9201c 100644
+--- a/python/mozbuild/mozbuild/test/configure/test_toolchain_configure.py
++++ b/python/mozbuild/mozbuild/test/configure/test_toolchain_configure.py
+@@ -1779,6 +1779,15 @@ def invoke_rustc(stdin, args):
+                 "xtensa-esp32s3-espidf",
+                 "xtensa-esp32s3-none-elf",
+             ]
++            # Additional targets from 1.98
++            if Version(version) >= "1.98.0":
++                rust_targets += [
++                    "aarch64-oe-linux-gnu",
++                    "armv7-oe-linux-gnueabihf",
++                    "i686-oe-linux-gnu",
++                    "riscv64-oe-linux-gnu",
++                    "x86_64-oe-linux-gnu",
++                ]
+             return 0, "\n".join(sorted(rust_targets)), ""
+         if (
+             len(args) == 6
+@@ -1869,6 +1878,7 @@ def test_rust_target(self):
+             ("x86_64-unknown-linux-android", "x86_64-linux-android"),
+             ("x86_64-unknown-linux-android21", "x86_64-linux-android"),
+             ("x86_64-pc-linux-gnu", "x86_64-unknown-linux-gnu"),
++            ("riscv64-unknown-linux-gnu", "riscv64gc-unknown-linux-gnu"),
+             ("sparcv9-sun-solaris2", "sparcv9-sun-solaris"),
+             ("x86_64-sun-solaris2", "x86_64-pc-solaris"),
+             ("x86_64-apple-darwin23.3.0", "x86_64-apple-darwin"),
+@@ -1970,5 +1980,10 @@ def test_rust_wasi_target(self):
+         self.assertEqual(self.get_rust_target("wasm32-unknown-wasi"), "wasm32-wasip1")
+ 
+ 
++# Exercises the vendor-specific *-oe-linux-* targets added in rust 1.98.
++class Rust198Test(RustTest):
++    VERSION = "1.98.0"
++
++
+ if __name__ == "__main__":
+     main()

--- a/x11-packages/firefox/0032-rename-success-x11success.patch
+++ b/x11-packages/firefox/0032-rename-success-x11success.patch
@@ -1,0 +1,26 @@
+From c327de0a238df79e1397373cd87824965d327b32 Mon Sep 17 00:00:00 2001
+From: Rong Bao <webmaster@csmantle.top>
+Date: Tue, 25 Aug 2026 10:30:04 +0000
+Subject: [PATCH] Bug 2065815 - Rename usage of macro Success to X11Success in
+ nsXRemoteServer.cpp. r=mossop
+
+This is a fixup to Bug 2065007.
+
+Differential Revision: https://phabricator.services.mozilla.com/D321140
+---
+ toolkit/components/remote/nsXRemoteServer.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/toolkit/components/remote/nsXRemoteServer.cpp b/toolkit/components/remote/nsXRemoteServer.cpp
+index 41fa7fa18290d..3e9f149368d14 100644
+--- a/toolkit/components/remote/nsXRemoteServer.cpp
++++ b/toolkit/components/remote/nsXRemoteServer.cpp
+@@ -110,7 +110,7 @@ bool nsXRemoteServer::HandleNewProperty(XID aWindowId, Display* aDisplay,
+ 
+     // Failed to get property off the window or
+     // got a part only
+-    if (result != Success || bytes_after != 0) {
++    if (result != X11Success || bytes_after != 0) {
+       return false;
+     }
+ 

--- a/x11-packages/firefox/build.sh
+++ b/x11-packages/firefox/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.mozilla.org/firefox
 TERMUX_PKG_DESCRIPTION="Mozilla Firefox web browser"
 TERMUX_PKG_LICENSE="MPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="154.0"
+TERMUX_PKG_VERSION="154.0.1"
 TERMUX_PKG_SRCURL="https://archive.mozilla.org/pub/firefox/releases/${TERMUX_PKG_VERSION#*really}/source/firefox-${TERMUX_PKG_VERSION#*really}.source.tar.xz"
-TERMUX_PKG_SHA256=36cec5b3688a60f78a6d20dcaee15b598f84e03c66f6587056aead6cb498b99a
+TERMUX_PKG_SHA256=9cbe191fc74b46108376b1d9bf607c0a40288074e0f2333671253789d6ebbd15
 # ffmpeg and pulseaudio are dependencies through dlopen(3):
 TERMUX_PKG_DEPENDS="ffmpeg, fontconfig, freetype, gdk-pixbuf, glib, gtk3, libandroid-shmem, libandroid-spawn, libc++, libcairo, libevent, libffi, libice, libicu, libjpeg-turbo, libnspr, libnss, libpixman, libsm, libvpx, libwebp, libx11, libxcb, libxcomposite, libxdamage, libxext, libxfixes, libxrandr, libxtst, pango, pulseaudio, zlib"
 TERMUX_PKG_BUILD_DEPENDS="libcpufeatures, libice, libsm"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/31311

- `0031-Bug-2053518-Handle-the-oe-linux-rust-targets-added-in.patch` for `firefox` like `thunderbird` in https://github.com/termux/termux-packages/pull/31134