### PR TITLE
 bump(x11/atril): 1.28.7

### DIFF
--- a/x11-packages/atril/build.sh
+++ b/x11-packages/atril/build.sh
@@ -2,13 +2,13 @@ TERMUX_PKG_HOMEPAGE=https://mate-desktop.org
 TERMUX_PKG_DESCRIPTION="MATE document viewer"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="1.28.6"
+TERMUX_PKG_VERSION="1.28.7"
 # https://pub.mate-desktop.org/releases/${TERMUX_PKG_VERSION%.*}/atril-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SRCURL="https://github.com/mate-desktop/atril/releases/download/v${TERMUX_PKG_VERSION}/atril-${TERMUX_PKG_VERSION}.tar.xz"
-TERMUX_PKG_SHA256=814427e0d5a2dc4e4b060b99ac3c80d8ef39052984d04df49d39135f424c624a
+TERMUX_PKG_SHA256=91942545e858cb0036b52e2f5d4372cdea813d9fde9702daefdf84854e6bb667
 TERMUX_PKG_AUTO_UPDATE=true
 # links with poppler-glib, not poppler
-TERMUX_PKG_DEPENDS="atk, djvulibre, gdk-pixbuf, glib, gtk3, harfbuzz, libarchive, libc++, libcairo, libice, libsecret, libsm, libspectre, libsoup3, libtiff, libxml2, mate-desktop, pango, poppler, texlive-bin, webkit2gtk-4.1, zlib"
+TERMUX_PKG_DEPENDS="atk, djvulibre, gdk-pixbuf, glib, gtk3, harfbuzz, libarchive, libc++, libcairo, libgepub, libice, libsecret, libsm, libspectre, libsoup3, libtiff, libxml2, mate-desktop, pango, poppler, texlive-bin, webkit2gtk-4.1, zlib"
 TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, glib-cross"
 TERMUX_PKG_VERSIONED_GIR=false
 TERMUX_PKG_DISABLE_GIR=false

--- a/x11-packages/libgepub/build.sh
+++ b/x11-packages/libgepub/build.sh
@@ -1,0 +1,13 @@
+TERMUX_PKG_HOMEPAGE=https://gitlab.gnome.org/GNOME/libgepub
+TERMUX_PKG_DESCRIPTION="GObject-based library for handling and rendering epub documents"
+TERMUX_PKG_LICENSE="LGPL-2.1-or-later"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.7.3"
+TERMUX_PKG_SRCURL="https://download.gnome.org/sources/libgepub/${TERMUX_PKG_VERSION%.*}/libgepub-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256=5a56695aa8a9132d67c0792a40f252ce0a48d9d032b4e1a8a6ce98af14fd5e1b
+TERMUX_PKG_DEPENDS="glib, libarchive, libsoup3, libxml2, webkit2gtk-4.1"
+TERMUX_PKG_BUILD_DEPENDS="gobject-introspection"
+
+termux_step_pre_configure() {
+	termux_setup_gir
+}

--- a/x11-packages/libgepub/gir/0.7.3/Gepub-0.7.xml
+++ b/x11-packages/libgepub/gir/0.7.3/Gepub-0.7.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<dump>
+  <class name="GepubArchive" get-type="gepub_archive_get_type" parents="GObject">
+  </class>
+  <class name="GepubDoc" get-type="gepub_doc_get_type" parents="GObject">
+    <implements name="GInitable"/>
+    <property name="path" type="gchararray" flags="235" default-value="NULL"/>
+    <property name="chapter" type="gint" flags="227" default-value="0"/>
+  </class>
+  <class name="GepubTextChunk" get-type="gepub_text_chunk_get_type" parents="GObject">
+  </class>
+  <class name="GepubWidget" get-type="gepub_widget_get_type" parents="WebKitWebView,WebKitWebViewBase,GtkContainer,GtkWidget,GInitiallyUnowned,GObject">
+    <implements name="AtkImplementorIface"/>
+    <implements name="GtkBuildable"/>
+    <property name="doc" type="GepubDoc" flags="227"/>
+    <property name="paginate" type="gboolean" flags="3" default-value="FALSE"/>
+    <property name="chapter" type="gint" flags="3" default-value="0"/>
+    <property name="nchapters" type="gint" flags="1" default-value="0"/>
+    <property name="chapter-pos" type="gfloat" flags="3" default-value="0.000000"/>
+  </class>
+</dump>

--- a/x11-packages/tumbler/build.sh
+++ b/x11-packages/tumbler/build.sh
@@ -3,10 +3,13 @@ TERMUX_PKG_DESCRIPTION="Tumbler is a D-Bus service for applications to request t
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="4.20.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://archive.xfce.org/src/xfce/tumbler/${TERMUX_PKG_VERSION%.*}/tumbler-$TERMUX_PKG_VERSION.tar.bz2
 TERMUX_PKG_SHA256=aa77fd90a88b83467cd8d2b39d80e4518ba2903d2e4ca50d32d1b96996685015
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="freetype, gdk-pixbuf, glib, libcurl, libjpeg-turbo, libpng, libxfce4util"
+TERMUX_PKG_BUILD_DEPENDS="libgepub"
+TERMUX_PKG_SUGGESTS="libgepub"
 TERMUX_PKG_RM_AFTER_INSTALL="lib/systemd"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-debug


### PR DESCRIPTION
- Fixes #31354

- addpkg(x11/libgepub): 0.7.3
  - build dependency of `atril` 1.28.7
  - enable in `tumbler`