### PR TITLE
fix(main/djvulibre): constrain repology version matching (fixes #31334)

### DIFF
--- a/packages/djvulibre/build.sh
+++ b/packages/djvulibre/build.sh
@@ -6,6 +6,7 @@ TERMUX_PKG_VERSION="3.5.30"
 TERMUX_PKG_SRCURL=http://downloads.sourceforge.net/djvu/djvulibre-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=ee5e457d4cfebe566f94b99e5e3d3cc7f5c79ddb741c2ac2ba2e456f00329644
 TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_VERSION_REGEXP="^[0-9]+\.[0-9]+\.[0-9]+"
 TERMUX_PKG_DEPENDS="libc++, libjpeg-turbo, libtiff"
 
 termux_step_pre_configure() {


### PR DESCRIPTION
Fixes #31334

The auto-updater tried to bump `djvulibre` to `3.5.30.1` based on repology data, but no tarball for that version exists at the SourceForge download URL used by this package (`downloads.sourceforge.net/djvu/djvulibre-3.5.30.1.tar.gz` returns 404). The latest tarball actually published in SourceForge's `Files/DjVuLibre/` release area is still `3.5.30` (released 2026-05-05).

The `3.5.30.1` string traces back to Arch Linux's `djvulibre` package, which builds from a git tag (`release.3.5.30.1`) in the upstream `djvulibre-git` repo rather than from a tarball release — Manjaro, Artix, and Parabola all inherit this from Arch's `extra` repo, which is why repology sees several repos agreeing on it.

This PR adds `TERMUX_PKG_UPDATE_VERSION_REGEXP` so the updater only accepts a plain three-component `X.Y.Z` version from repology, filtering out distro-only version strings like `3.5.30.1`. This prevents the same auto-update failure from recurring on the next scheduled run.

Once SourceForge publishes a real `3.5.30.1` (or later) tarball upstream, the regexp will match it normally and auto-update will resume.