### PR TITLE
chore(main/dua): exclude dua-core tags to fix auto-update

### DIFF
--- a/packages/dua/build.sh
+++ b/packages/dua/build.sh
@@ -6,6 +6,7 @@ TERMUX_PKG_VERSION="2.43.0"
 TERMUX_PKG_SRCURL=https://github.com/Byron/dua-cli/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=0bdce37da1f5a3c04cb6b72e22fe3b02863367199c0af25201438ea101ab55e2
 TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_VERSION_REGEXP='v\d+\.\d+\.\d+'
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_pre_configure() {


### PR DESCRIPTION
* Fixes #31363 