### PR TITLE
bump(main/python-llvmlite): 0.49.0

### DIFF
--- a/packages/python-llvmlite/build.sh
+++ b/packages/python-llvmlite/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_LICENSE="BSD 2-Clause, Apache-2.0"
 TERMUX_PKG_LICENSE_FILE="LICENSE, LICENSE.thirdparty"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=(
-	"0.48.0"
+	"0.49.0"
 	"22.1.8"
 )
 TERMUX_PKG_REVISION=3
@@ -14,7 +14,7 @@ TERMUX_PKG_SRCURL=(
 	"https://github.com/llvm/llvm-project/releases/download/llvmorg-${TERMUX_PKG_VERSION[1]}/llvm-project-${TERMUX_PKG_VERSION[1]}.src.tar.xz"
 )
 TERMUX_PKG_SHA256=(
-	a15971f69eb17e07718be1a7d18185918c298d3b0f82f0bf08e9a5893b2f53ca
+	e73ad74110d60ec3eef076431b8853a5e8f940a83bd544cbff4c02d4c544ada0
 	922f1817a0df7b1489272d18134ee0087a8b068828f87ac63b9861b1a9965888
 )
 TERMUX_PKG_DEPENDS="libc++, libffi, python, python-pip"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/31359