### PR TITLE
bump(main/turbo): 2.10.1

### DIFF
--- a/packages/turbo/build.sh
+++ b/packages/turbo/build.sh
@@ -2,17 +2,52 @@ TERMUX_PKG_HOMEPAGE=https://turborepo.dev/
 TERMUX_PKG_DESCRIPTION="High-performance build system for JS/TS"
 TERMUX_PKG_MAINTAINER="@xingguangcuican6666"
 TERMUX_PKG_LICENSE="MIT"
-TERMUX_PKG_VERSION="2.10.0"
+TERMUX_PKG_VERSION="2.10.1"
 TERMUX_PKG_SRCURL="https://github.com/vercel/turborepo/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256=0d1449fcf19af574e369a0e7dd6b9f4c033385c8df23e399447c454ab12d53c6
+TERMUX_PKG_SHA256=e6e8189769aa0f5d77796a2b544560525bfd6718dad238932be468d44796d26a
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE=latest-release-tag
+# turborepo-ghostty-sys's build.rs (crates/turborepo-ghostty-sys/build.rs,
+# zig_target()) hardcodes support to only the "aarch64-linux-android" and
+# "x86_64-linux-android" Rust target triples, and panics with "unsupported
+# Rust target for vendored build" for anything else. Termux builds arm as
+# "armv7-linux-androideabi" and i686 as "i686-linux-android", neither of
+# which is in that match list, so these arches cannot build turbo >= 2.10.1
+# until upstream adds support. See: vercel/turborepo crates/turborepo-ghostty-sys/build.rs
+#
+# x86_64 is excluded too, for a different reason: the vendored ghostty/
+# simdutf code (compiled via Zig) ends up with a thread_local variable on
+# the x86_64 CPU-dispatch codepath. Android bionic only provides
+# __tls_get_addr (real ELF TLS) starting at API 29; below that it needs
+# emulated TLS (__emutls_get_address). Zig fixed this for Android
+# (ziglang/zig#24236, merged for 0.15.0 via #24355), but that fix only
+# covers arm/aarch64-android by default in LLVM — x86_64-android is not in
+# LLVM's default emulated-TLS target list — so x86_64 binaries still emit
+# __tls_get_addr and fail Termux's undefined-symbol check at Termux's
+# API 24 baseline. No known Termux-side flag forces emulated TLS for this
+# target; re-enable once upstream Zig/LLVM covers x86_64-android too.
+TERMUX_PKG_EXCLUDED_ARCHES="arm, i686, x86_64"
 
 termux_step_make() {
 	termux_setup_rust
 	termux_setup_capnp
 	termux_setup_protobuf
+
+	# ghostty (vendored via turborepo-ghostty-sys) hard-requires Zig 0.15.x
+	# (patch >= 2). Termux's default zig package is 0.16.0, which fails
+	# ghostty's requireZig() compile-time check, so pin the version here.
+	TERMUX_ZIG_VERSION="0.15.2"
+	termux_setup_zig
+
+	# ghostty's build.zig cross-compiles a simdutf dependency and needs to
+	# locate the Android NDK itself (it only checks ANDROID_NDK_HOME /
+	# ANDROID_HOME / ANDROID_SDK_ROOT). Termux's build system sets $NDK to
+	# the actual NDK install dir, but doesn't always export it to child
+	# processes, and $ANDROID_HOME points at the SDK root (not the NDK), so
+	# point ghostty at the real NDK path explicitly.
+	export ANDROID_NDK_HOME="${NDK}"
+
 	cargo build --release --package turbo --target "$CARGO_TARGET_NAME"
 }
 


### PR DESCRIPTION
Closes #30380

### Summary
Updates `turbo` from `2.10.0` → `2.10.1` and fixes the build, which was failing because the new `turborepo-ghostty-sys` crate (vendors `ghostty`'s `libghostty-vt` via Zig) had several unmet build-time requirements in the Termux cross-compile environment. Only `aarch64` is buildable for now — see exclusions below.

### Changes
- **Version bump**: `2.10.0` → `2.10.1`, with SHA256 verified against the upstream release tarball.
- **Add `termux_setup_zig`**: `turborepo-ghostty-sys`'s build script shells out to `zig build`, but `zig` wasn't set up in `termux_step_make()`.
- **Pin `TERMUX_ZIG_VERSION=0.15.2`**: ghostty's `requireZig()` enforces an exact `major.minor` match (`0.15.x`, patch ≥ 2). Termux's default zig package (`0.16.0`) fails this compile-time check due to breaking stdlib API changes (e.g. `Io/Dir.zig` `readFileAlloc` signature).
- **Export `ANDROID_NDK_HOME`**: ghostty's vendored `simdutf` dependency cross-compiles for Android and needs the NDK path. It only checks `ANDROID_NDK_HOME` / `ANDROID_HOME` / `ANDROID_SDK_ROOT`, but Termux's `$ANDROID_HOME` points at the SDK root (not the NDK itself), and `$NDK` isn't always exported to child processes. Explicitly exporting `ANDROID_NDK_HOME="${NDK}"` fixes discovery.
- **Exclude `arm` and `i686`**: `turborepo-ghostty-sys`'s `zig_target()` (`crates/turborepo-ghostty-sys/build.rs`) hardcodes support to only `aarch64-linux-android` and `x86_64-linux-android`, and panics with `"unsupported Rust target for vendored build"` for anything else. Termux's `armv7-linux-androideabi` (arm) and `i686-linux-android` (i686) triples aren't in that list, so these arches can't build turbo ≥ 2.10.1 until upstream adds support.
- **Exclude `x86_64`**: separate root cause. The vendored ghostty/`simdutf` code (built via Zig) hits a `thread_local` on the x86_64 CPU-dispatch codepath, requiring `__tls_get_addr` (real ELF TLS), which Android bionic only provides at API 29+. Zig fixed missing emulated-TLS support for Android in `ziglang/zig#24236` (merged for 0.15.0 via `#24355`), but that fix only covers `arm`/`aarch64`-android by default in LLVM — `x86_64`-android isn't in LLVM's default emulated-TLS target list — so `x86_64` binaries still emit `__tls_get_addr` and fail Termux's undefined-symbol check at Termux's API 24 baseline. No known Termux-side flag forces emulated TLS here.

### Testing
Built successfully for `aarch64` in the package-builder container (12m). `arm`, `i686`, and `x86_64` fail for the upstream reasons above and are excluded via `TERMUX_PKG_EXCLUDED_ARCHES`.

### Notes for reviewers
- `turborepo-ghostty-sys` significantly increases build time/disk usage (clones `ghostty` source, compiles via Zig, cross-compiles `simdutf` against the Android NDK) — worth flagging in case CI runners need more disk space allocated for this package going forward.
- The `arm`/`i686` and `x86_64` exclusions are upstream limitations, not Termux packaging bugs. Re-enabling them requires either upstream `turborepo-ghostty-sys` adding those Rust targets to `zig_target()`, or upstream Zig/LLVM adding `x86_64-android` to its default emulated-TLS target list. Happy to open tracking issues against `vercel/turborepo` and/or `ziglang/zig` if that's useful — let me know.