### PR TITLE
bump(main/uftrace): 0.20

### DIFF
--- a/packages/uftrace/build.sh
+++ b/packages/uftrace/build.sh
@@ -2,10 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://uftrace.github.io/slide
 TERMUX_PKG_DESCRIPTION="Function (graph) tracer for user-space"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.19"
-TERMUX_PKG_REVISION=3
+TERMUX_PKG_VERSION="0.20"
 TERMUX_PKG_SRCURL="https://github.com/namhyung/uftrace/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256=c35ef25f279684fc7d79dcc250fb29386890870fd2c9f812e587151419ca01af
+TERMUX_PKG_SHA256=03189061130693b274a4d0af47c4a3135d4a496ca111b78233593bfcb3d3720f
 # Hardcoded libpython${TERMUX_PYTHON_VERSION}.so is dlopen(3)ed by uftrace.
 # Please revbump and rebuild when bumping TERMUX_PYTHON_VERSION.
 # libandroid-{execinfo,spawn} are dlopen(3)ed.

--- a/packages/uftrace/cmds-live.c.patch
+++ b/packages/uftrace/cmds-live.c.patch
@@ -1,14 +1,11 @@
 --- a/cmds/live.c
 +++ b/cmds/live.c
-@@ -14,9 +14,9 @@
- #include "utils/utils.h"
+@@ -427,7 +427,7 @@
+ 	int ret;
  
- #define LIVE_NAME "uftrace-live-XXXXXX"
--#define TMP_LIVE_NAME "/tmp/" LIVE_NAME
-+#define TMP_LIVE_NAME "@TERMUX_PREFIX@/tmp/" LIVE_NAME
+ 	if (!opts->record) {
+-		const char *tmpdir = getenv("TMPDIR") ?: "/tmp";
++		const char *tmpdir = getenv("TMPDIR") ?: "@TERMUX_PREFIX@/tmp";
  
--#define TMP_DIR_NAME_SIZE 32
-+#define TMP_DIR_NAME_SIZE (strlen("@TERMUX_PREFIX@") + 32)
- 
- static char tmp_dirname[TMP_DIR_NAME_SIZE];
- static void cleanup_tempdir(void)
+ 		snprintf(tmp_dirname, sizeof(tmp_dirname), "%s/" LIVE_NAME, tmpdir);
+ 		umask(022);


### PR DESCRIPTION
TMP_DIR_NAME_SIZE is big enough to hold full TMPDIR path.
* Fixes #31393 