### PR TITLE
pgcli: add package, split libpq out of postgresql

### DIFF
--- a/packages/pgcli/build.sh
+++ b/packages/pgcli/build.sh
@@ -22,5 +22,5 @@ termux_step_make_install() {
 	# GitHub tarballs have no .git dir, so setuptools-scm can't infer the
 	# version on its own; pin it explicitly to TERMUX_PKG_VERSION.
 	export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PGCLI="$TERMUX_PKG_VERSION"
-	cross-pip install --prefix="$TERMUX_PREFIX" "$TERMUX_PKG_SRCDIR"
+	cross-pip install --no-deps --prefix="$TERMUX_PREFIX" "$TERMUX_PKG_SRCDIR"
 }

--- a/packages/pgcli/build.sh
+++ b/packages/pgcli/build.sh
@@ -1,0 +1,26 @@
+TERMUX_PKG_HOMEPAGE=https://www.pgcli.com
+TERMUX_PKG_DESCRIPTION="Postgres CLI with autocompletion and syntax highlighting"
+TERMUX_PKG_LICENSE="BSD 3-Clause"
+TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
+TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
+TERMUX_PKG_VERSION="4.6.0"
+TERMUX_PKG_SRCURL=https://github.com/dbcli/pgcli/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=33dbae8a3fc1608edc12b257ed4e065adf63d5ab9c849906247428f471cd7895
+TERMUX_PKG_AUTO_UPDATE=true
+# pgcli only pushes git tags, it doesn't publish GitHub Releases, so the
+# default "latest-release-tag" method 404s against the releases API.
+TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
+TERMUX_PKG_DEPENDS="python, python-pip, libpq"
+TERMUX_PKG_PYTHON_COMMON_BUILD_DEPS="setuptools>=64, setuptools-scm>=8, wheel"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make() {
+	:
+}
+
+termux_step_make_install() {
+	# GitHub tarballs have no .git dir, so setuptools-scm can't infer the
+	# version on its own; pin it explicitly to TERMUX_PKG_VERSION.
+	export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PGCLI="$TERMUX_PKG_VERSION"
+	cross-pip install --prefix="$TERMUX_PREFIX" "$TERMUX_PKG_SRCDIR"
+}

--- a/packages/postgresql/build.sh
+++ b/packages/postgresql/build.sh
@@ -4,9 +4,10 @@ TERMUX_PKG_LICENSE="PostgreSQL"
 TERMUX_PKG_LICENSE_FILE="COPYRIGHT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="18.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://ftp.postgresql.org/pub/source/v$TERMUX_PKG_VERSION/postgresql-$TERMUX_PKG_VERSION.tar.bz2
 TERMUX_PKG_SHA256=5245bd1b79700d55b8e0575be0325ef61e7bbef627e6a616e4cf36ad4687be36
-TERMUX_PKG_DEPENDS="libandroid-execinfo, libandroid-shmem, libicu, libuuid, libxml2, openssl, readline, zlib"
+TERMUX_PKG_DEPENDS="libandroid-execinfo, libandroid-shmem, libicu, libpq, libuuid, libxml2, openssl, readline, zlib"
 # - pgac_cv_prog_cc_LDFLAGS_EX_BE__Wl___export_dynamic: Needed to fix PostgreSQL 16 that
 #   causes initdb failure: cannot locate symbol
 # - pgac_cv_prog_cc_LDFLAGS__Wl___as_needed: Inform that the linker supports as-needed. It's

--- a/packages/postgresql/libpq-static.subpackage.sh
+++ b/packages/postgresql/libpq-static.subpackage.sh
@@ -1,0 +1,15 @@
+TERMUX_SUBPKG_DESCRIPTION="Static library for libpq"
+TERMUX_SUBPKG_INCLUDE="lib/libpq.a lib/libpq.la"
+# Depend on libpq (the shared-lib package), not the full postgresql server
+# stack, matching libpq.subpackage.sh.
+TERMUX_SUBPKG_DEPENDS="libpq"
+# Without this, the default behaviour would make this depend on the full
+# postgresql package, same reasoning as in libpq.subpackage.sh.
+TERMUX_SUBPKG_DEPEND_ON_PARENT=false
+# Previously libpq.a shipped inside postgresql-static (built by the
+# automatic TERMUX_PKG_NO_STATICSPLIT=false split of the parent package).
+# Since this subpackage.sh is processed before that virtual one, it moves
+# lib/libpq.a out first, so postgresql-static no longer contains it -- old
+# postgresql-static installs must be replaced to avoid a stale file clash.
+TERMUX_SUBPKG_BREAKS="postgresql-static (<< 18.2-1)"
+TERMUX_SUBPKG_REPLACES="postgresql-static (<< 18.2-1)"

--- a/packages/postgresql/libpq.subpackage.sh
+++ b/packages/postgresql/libpq.subpackage.sh
@@ -1,0 +1,12 @@
+TERMUX_SUBPKG_DESCRIPTION="PostgreSQL client library (libpq) without the server"
+TERMUX_SUBPKG_INCLUDE="lib/libpq.so*"
+# libpq is only linked against openssl (built --with-openssl); the other
+# postgresql deps (libicu, libxml2, libuuid, readline, libandroid-shmem,
+# libandroid-execinfo) are needed by the backend/contribs, not by the client
+# library, so they must not leak into this lightweight subpackage.
+TERMUX_SUBPKG_DEPENDS="openssl"
+# Without this, the default behaviour would make libpq depend on the full
+# postgresql package again -- defeating the whole point of the split.
+TERMUX_SUBPKG_DEPEND_ON_PARENT=false
+TERMUX_SUBPKG_BREAKS="postgresql (<< 18.2-1)"
+TERMUX_SUBPKG_REPLACES="postgresql (<< 18.2-1)"


### PR DESCRIPTION
## postgresql: split libpq into a separate subpackage

`libpq` was always bundled inside the full `postgresql` package
(server + all contrib modules). Client-only tools now need to depend
on the whole server stack just to get one shared library.

This splits `libpq.so*` into its own subpackage:
- `libpq` depends only on `openssl` (not the rest of postgresql's deps).
- `TERMUX_SUBPKG_DEPEND_ON_PARENT=false`, so it doesn't pull the full
  `postgresql` package back in.
- `postgresql` now explicitly depends on `libpq`, since `psql`,
  `pg_dump`, etc. link against it.