### PR TITLE
addpkg(root/veracrypt): 1.26.29

### DIFF
--- a/root-packages/veracrypt/build.sh
+++ b/root-packages/veracrypt/build.sh
@@ -1,0 +1,47 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/veracrypt/VeraCrypt
+TERMUX_PKG_DESCRIPTION="VeraCrypt disk encryption manager for Termux"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_LICENSE_FILE="License.txt"
+TERMUX_PKG_MAINTAINER="Infiniti151 <43163551+Infiniti151@users.noreply.github.com>"
+TERMUX_PKG_VERSION="1.26.29"
+TERMUX_PKG_SRCURL="https://github.com/veracrypt/VeraCrypt/releases/download/VeraCrypt_${TERMUX_PKG_VERSION}/VeraCrypt_${TERMUX_PKG_VERSION}_Source.tar.bz2"
+TERMUX_PKG_SHA256="60826731e2982b4bd231e3930e85a44391169638671a1b200c518f8c8b46cb2a"
+TERMUX_PKG_DEPENDS="libfuse3, libpcsclite, libdevmapper, wxwidgets"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make() {
+	WX_FLAGS="$("$TERMUX_PREFIX/bin/wx-config" --cxxflags)"
+	local EXTRA_MAKE_FLAGS=""
+	local EXTRA_CFLAGS=""
+
+	if [[ "$TERMUX_ARCH" == "aarch64" ]]; then
+		# -Oz causes Crypto++ CPU_QueryAES/CPU_QuerySHA2 linker failures.
+		ARM_FLAGS="-march=armv8-a+crypto -O2"
+	fi
+
+	if [[ "$TERMUX_ARCH" == "i686" ]]; then
+		# Android forbids text relocations from non-PIC x86 assembly.
+		EXTRA_MAKE_FLAGS="NOASM=1 NOAESNI=1"
+		EXTRA_CFLAGS="-DCRYPTOPP_DISABLE_SHANI  -DCRYPTOPP_DISABLE_AESNI"
+	fi
+
+	# Prevent execution on host
+	sed -i 's|./$(APPNAME)|true|g' Main/Main.make
+
+	# Neutralize strip everywhere
+	sed -i 's|\bstrip\b|true|g' Main/Main.make
+
+	make -j$TERMUX_PKG_MAKE_PROCESSES \
+		WITHFUSE3=1 \
+		ARCH=$TERMUX_ARCH \
+		PLATFORM_ARCH=$TERMUX_ARCH \
+		WX_CONFIG="$TERMUX_PREFIX/bin/wx-config" \
+		TC_EXTRA_CFLAGS="$CFLAGS $WX_FLAGS ${ARM_FLAGS-} ${EXTRA_CFLAGS-}" \
+		TC_EXTRA_CXXFLAGS="$CXXFLAGS $WX_FLAGS ${ARM_FLAGS-} ${EXTRA_CFLAGS-}" \
+		TC_EXTRA_LFLAGS="$LDFLAGS" \
+		$EXTRA_MAKE_FLAGS
+}
+
+termux_step_make_install() {
+	install -Dm755 "Main/veracrypt" "$TERMUX_PREFIX/bin/veracrypt"
+}

--- a/root-packages/veracrypt/dmsetup-path-override.patch
+++ b/root-packages/veracrypt/dmsetup-path-override.patch
@@ -1,0 +1,47 @@
+--- a/Core/Unix/Linux/CoreLinux.cpp
++++ b/Core/Unix/Linux/CoreLinux.cpp
+@@ -124,7 +124,7 @@
+ 			{
+ 				try
+ 				{
+-					Process::Execute ("dmsetup", dmsetupArgs);
++					Process::Execute ("@TERMUX_PREFIX@/bin/dmsetup", dmsetupArgs);
+ 				}
+ 				catch (ExecutedProcessFailed&)
+ 				{
+@@ -138,7 +138,7 @@
+
+ 						try
+ 						{
+-							Process::Execute ("dmsetup", deferredFallbackArgs);
++							Process::Execute ("@TERMUX_PREFIX@/bin/dmsetup", deferredFallbackArgs);
+ 						}
+ 						catch (ExecutedProcessFailed&)
+ 						{
+@@ -148,7 +148,7 @@
+ 								{
+ 									try
+ 									{
+-										Process::Execute ("dmsetup", fallbackArgs);
++										Process::Execute ("@TERMUX_PREFIX@/bin/dmsetup", fallbackArgs);
+ 										break;
+ 									}
+ 									catch (...)
+@@ -171,7 +171,7 @@
+ 				{
+ 					try
+ 					{
+-						Process::Execute ("dmsetup", dmsetupArgs);
++						Process::Execute ("@TERMUX_PREFIX@/bin/dmsetup", dmsetupArgs);
+ 						break;
+ 					}
+ 					catch (...)
+@@ -387,7 +387,7 @@
+ 				execArgs.push_back ("create");
+ 				execArgs.push_back (nativeDevName.str());
+
+-				Process::Execute ("dmsetup", execArgs, -1, nullptr, &dmCreateArgsBuf);
++				Process::Execute ("@TERMUX_PREFIX@/bin/dmsetup", execArgs, -1, nullptr, &dmCreateArgsBuf);
+
+ 				// Wait for the device to be created
+ 				for (int t = 0; true; t++)

--- a/root-packages/veracrypt/pcsc-path-override.patch
+++ b/root-packages/veracrypt/pcsc-path-override.patch
@@ -1,0 +1,19 @@
+--- a/Common/SCardLoader.cpp
++++ b/Common/SCardLoader.cpp
+@@ -1,3 +1,4 @@
++#include <unistd.h>
+ #include "SCardLoader.h"
+ #include "PCSCException.h"
+
+@@ -87,7 +88,10 @@
+
+ 		if (pcscPath == "")
+ 		{
+-			pcscPath = "libpcsclite.so";
++			// Termux-specific override
++			pcscPath = "@TERMUX_PREFIX@/lib/libpcsclite_real.so";
++			if (access(pcscPath.c_str(), F_OK) != 0)
++				pcscPath = "@TERMUX_PREFIX@/lib/libpcsclite.so";
+ 		}
+
+ 		return pcscPath;

--- a/root-packages/veracrypt/remove-x86-simd-flags.patch
+++ b/root-packages/veracrypt/remove-x86-simd-flags.patch
@@ -1,0 +1,23 @@
+--- a/Makefile
++++ b/Makefile
+@@ -213,8 +213,8 @@
+ 	endif
+
+ 	ifeq "$(SIMD_SUPPORTED)" "1"
+-		CFLAGS += -msse2
+-		CXXFLAGS += -msse2
++		# CFLAGS += -msse2
++		# CXXFLAGS += -msse2
+
+ 		GCC_GTEQ_440 := $(shell expr `$(CC) -dumpversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/' -e 's/^[0-9]\{1,2\}$$/&0000/'` \>= 40400)
+ 		GCC_GTEQ_430 := $(shell expr `$(CC) -dumpversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/' -e 's/^[0-9]\{1,2\}$$/&0000/'` \>= 40300)
+@@ -226,8 +226,8 @@
+ 			CXXFLAGS += -mno-aes -DCRYPTOPP_DISABLE_AESNI
+ 		else
+ 			ifeq "$(GCC_GTEQ_440)" "1"
+-				CFLAGS += -maes
+-				CXXFLAGS += -maes
++				# CFLAGS += -maes
++				# CXXFLAGS += -maes
+ 			endif
+ 		endif


### PR DESCRIPTION
This package provides the VeraCrypt command-line utilities and uses the existing Termux FUSE 3 userspace tools provided by the `libfuse3` package.

Although Termux provides `cryptsetup` with VeraCrypt (TrueCrypt) support, `cryptsetup` relies on the Linux `AF_ALG` kernel crypto API for VeraCrypt, which is generally disabled or heavily restricted on Android kernels (even though `dm-crypt` itself is present). Termux also provides `tcplay-veracrypt` which only implements TrueCrypt compatibility and a subset of VeraCrypt’s header format. It does not support the full VeraCrypt feature set (PIM, cascaded algorithms, newer VC header formats). This custom-compiled VeraCrypt bypasses that limitation by handling the cryptography entirely in userspace, allowing access to VeraCrypt volumes and containers on rooted Android devices.