### PR TITLE
bump(main/yazi): 26.9.1

### DIFF
--- a/packages/yazi/build.sh
+++ b/packages/yazi/build.sh
@@ -2,11 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://yazi-rs.github.io/
 TERMUX_PKG_DESCRIPTION="Blazing fast terminal file manager written in Rust, based on async I/O"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="26.8.15"
-TERMUX_PKG_SRCURL=https://github.com/sxyazi/yazi/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=60bd4ca56398f0f6ea6dcf88cc18e325583bf5328aeec51d396070944a9495c8
-TERMUX_PKG_BUILD_DEPENDS='aosp-libs, imagemagick'
-TERMUX_PKG_RECOMMENDS='7zip, chafa, fd, ffmpeg, fzf, imagemagick, jq, poppler, ripgrep, zoxide'
+TERMUX_PKG_VERSION="26.9.1"
+TERMUX_PKG_SRCURL="https://github.com/sxyazi/yazi/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=66857f1b670469daf258edd0bb2ea51d9ad3e2cab4eea9684028c80059fd6862
+TERMUX_PKG_BUILD_DEPENDS="aosp-libs, imagemagick"
+TERMUX_PKG_RECOMMENDS="7zip, chafa, fd, ffmpeg, fzf, imagemagick, jq, poppler, ripgrep, zoxide"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 
@@ -41,8 +41,7 @@ termux_step_pre_configure() {
 	patch -p1 -d "$dir" < "$patch"
 
 	cat >> Cargo.toml <<-EOF
-
-		[patch.crates-io]
+		# these lines should be appended to [patch.crates-io]
 		trash = { path = "./vendor/trash" }
 		cc = { path = "./vendor/cc" }
 	EOF
@@ -58,12 +57,19 @@ termux_step_make_install() {
 	install -Dm700 -t "$TERMUX_PREFIX/bin" "target/${CARGO_TARGET_NAME}/release/yazi"
 	install -Dm700 -t "$TERMUX_PREFIX/bin" "target/${CARGO_TARGET_NAME}/release/ya"
 
-	# shell completions
+	# yazi completions
 	install -Dm644 yazi-boot/completions/yazi.bash "$TERMUX_PREFIX/share/bash-completion/completions/yazi.bash"
 	install -Dm644 yazi-boot/completions/yazi.elv  "$TERMUX_PREFIX/share/elvish/lib/yazi.elv"
 	install -Dm644 yazi-boot/completions/yazi.fish "$TERMUX_PREFIX/share/fish/vendor_completions.d/yazi.fish"
 	install -Dm644 yazi-boot/completions/yazi.nu   "$TERMUX_PREFIX/share/nushell/vendor/autoload/yazi.nu"
 	install -Dm644 yazi-boot/completions/_yazi     "$TERMUX_PREFIX/share/zsh/site-functions/_yazi"
+
+	# ya completions
+	install -Dm644 yazi-cli/completions/ya.bash "$TERMUX_PREFIX/share/bash-completion/completions/ya.bash"
+	install -Dm644 yazi-cli/completions/ya.elv  "$TERMUX_PREFIX/share/elvish/lib/ya.elv"
+	install -Dm644 yazi-cli/completions/ya.fish "$TERMUX_PREFIX/share/fish/vendor_completions.d/ya.fish"
+	install -Dm644 yazi-cli/completions/ya.nu   "$TERMUX_PREFIX/share/nushell/vendor/autoload/ya.nu"
+	install -Dm644 yazi-cli/completions/_ya     "$TERMUX_PREFIX/share/zsh/site-functions/_ya"
 
 	# desktop entry
 	install -Dm644 assets/yazi.desktop "$TERMUX_PREFIX/share/applications/yazi.desktop"

--- a/packages/yazi/disable-kitty-shm.patch
+++ b/packages/yazi/disable-kitty-shm.patch
@@ -1,0 +1,42 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index 8a6aaa2..2a0515d 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -71,7 +71,7 @@ regex                 = "1.13.1"
+ regex-syntax          = "0.8.11"
+ reqwest               = { version = "0.13.4", default-features = false, features = [ "rustls-no-provider", "stream" ] }
+ rustls                = { version = "0.23.43", default-features = false, features = [ "ring", "std" ] }
+-rustix                = { version = "1.1.4", default-features = false, features = [ "std", "fs", "mm", "shm", "stdio", "termios", "event" ] }
++rustix                = { version = "1.1.4", default-features = false, features = [ "std", "fs", "mm", "stdio", "termios", "event" ] }
+ russh                 = { version = "0.63.1", default-features = false, features = [ "ring", "rsa" ] }
+ scopeguard            = "1.2.0"
+ serde                 = { version = "1.0.229", features = [ "derive" ] }
+diff --git a/yazi-ffi/src/shm/mod.rs b/yazi-ffi/src/shm/mod.rs
+index 7ea6ccd..04d99f3 100644
+--- a/yazi-ffi/src/shm/mod.rs
++++ b/yazi-ffi/src/shm/mod.rs
+@@ -1,10 +1,7 @@
+ yazi_macro::mod_flat!(common);
+ 
+-#[cfg(unix)]
+-yazi_macro::mod_flat!(unix);
+-
+ #[cfg(windows)]
+ yazi_macro::mod_flat!(windows);
+ 
+-#[cfg(not(any(unix, windows)))]
++#[cfg(target_os = "android")]
+ yazi_macro::mod_flat!(unsupported);
+diff --git a/yazi-tty/src/sequence/query.rs b/yazi-tty/src/sequence/query.rs
+index ac5d321..d5edccf 100644
+--- a/yazi-tty/src/sequence/query.rs
++++ b/yazi-tty/src/sequence/query.rs
+@@ -53,7 +53,7 @@ pub struct RequestKgpShm {
+ }
+ 
+ impl RequestKgpShm {
+-	pub fn new() -> Self { Self { shm: NamedSharedMemory::new(&[0; 3]).ok() } }
++	pub fn new() -> Self { Self { shm: None } }
+ }
+ 
+ impl Display for RequestKgpShm {


### PR DESCRIPTION
yazi added shared memory (shm) for faster image loading in kitty,
this can be skipped for not being relevant to termux

will test after the build finishes

- Closes: https://github.com/termux/termux-packages/issues/31433
- Yazi pr that added shm: https://github.com/sxyazi/yazi/pull/4294