### PR TITLE
golang: fix net interface enumeration on Android 11+ (API 30+)

### DIFF
--- a/packages/golang/build.sh
+++ b/packages/golang/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Go programming language compiler"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3:1.27.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://go.dev/dl/go${TERMUX_PKG_VERSION#*:}.src.tar.gz"
 TERMUX_PKG_SHA256=7002403d7cc44529ef6d26f69a44818263395ead7c16c05a5808ae047ebeb0e5
 TERMUX_PKG_DEPENDS="clang"
@@ -15,6 +16,7 @@ termux_step_post_get_source() {
 	. "$TERMUX_PKG_BUILDER_DIR/patch-script/fix-hardcoded-etc-resolv-conf.sh"
 	. "$TERMUX_PKG_BUILDER_DIR/patch-script/remove-pidfd.sh"
 	. "$TERMUX_PKG_BUILDER_DIR/patch-script/remove-futex_time64.sh"
+	. "$TERMUX_PKG_BUILDER_DIR/patch-script/fix-android-netlink.sh"
 }
 
 termux_step_make_install() {

--- a/packages/golang/patch-script/fix-android-netlink.diff
+++ b/packages/golang/patch-script/fix-android-netlink.diff
@@ -1,0 +1,226 @@
+https://github.com/golang/go/issues/40569
+https://developer.android.com/training/articles/user-data-ids#mac-11-plus
+https://github.com/wlynxg/anet
+
+net, syscall: fix interface enumeration on Android 11+
+
+Since Android 11, ordinary applications are denied bind(2) on netlink
+sockets and RTM_GETLINK dumps, so net.Interfaces fails with
+"netlinkrib: permission denied". Fall back to an RTM_GETADDR dump
+plus SIOCGIF* ioctls, as github.com/wlynxg/anet does.
+
+Fixes #40569
+
+--- a/src/syscall/netlink_linux.go
++++ b/src/syscall/netlink_linux.go
+@@ -2,6 +2,8 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
++//go:build linux && !android
++
+ // Netlink sockets and messages
+ 
+ package syscall
+--- a/src/syscall/netlink_android.go
++++ b/src/syscall/netlink_android.go
+@@ -2,6 +2,8 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
++//go:build android
++
+ // Netlink sockets and messages
+ 
+ package syscall
+@@ -65,7 +67,11 @@
+ 	defer Close(s)
+ 	sa := &SockaddrNetlink{Family: AF_NETLINK}
+ 	if err := Bind(s, sa); err != nil {
+-		return nil, err
++		if err != EPERM && err != EACCES {
++			return nil, err
++		}
++		// Android 11+ denies bind(2) on netlink sockets; the kernel
++		// assigns the port ID of an unbound socket on the first send.
+ 	}
+ 	wb := newNetlinkRouteRequest(proto, 1, family)
+ 	if err := Sendto(s, wb, 0, sa); err != nil {
+--- a/src/net/interface_linux.go
++++ b/src/net/interface_linux.go
+@@ -2,6 +2,8 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
++//go:build linux && !android
++
+ package net
+ 
+ import (
+--- a/src/net/interface_android.go
++++ b/src/net/interface_android.go
+@@ -2,9 +2,12 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
++//go:build android
++
+ package net
+ 
+ import (
++	"bytes"
+ 	"os"
+ 	"syscall"
+ 	"unsafe"
+@@ -16,7 +19,9 @@
+ func interfaceTable(ifindex int) ([]Interface, error) {
+ 	tab, err := syscall.NetlinkRIB(syscall.RTM_GETLINK, syscall.AF_UNSPEC)
+ 	if err != nil {
+-		return nil, os.NewSyscallError("netlinkrib", err)
++		// RTM_GETLINK dumps are denied on Android 11+; fall back to
++		// RTM_GETADDR plus SIOCGIF* ioctls.
++		return fallbackLinkTable(ifindex)
+ 	}
+ 	msgs, err := syscall.ParseNetlinkMessage(tab)
+ 	if err != nil {
+@@ -45,6 +50,64 @@
+ 	return ift, nil
+ }
+ 
++// fallbackLinkTable enumerates interfaces via an RTM_GETADDR dump
++// plus SIOCGIF* ioctls when RTM_GETLINK is denied. Interfaces
++// without any address are not reported.
++func fallbackLinkTable(ifindex int) ([]Interface, error) {
++	tab, err := syscall.NetlinkRIB(syscall.RTM_GETADDR, syscall.AF_UNSPEC)
++	if err != nil {
++		return nil, os.NewSyscallError("netlinkrib", err)
++	}
++	msgs, err := syscall.ParseNetlinkMessage(tab)
++	if err != nil {
++		return nil, os.NewSyscallError("parsenetlinkmessage", err)
++	}
++
++	var ift []Interface
++	im := make(map[uint32]struct{})
++loop:
++	for _, m := range msgs {
++		switch m.Header.Type {
++		case syscall.NLMSG_DONE:
++			break loop
++		case syscall.RTM_NEWADDR:
++			ifam := (*syscall.IfAddrmsg)(unsafe.Pointer(&m.Data[0]))
++			if _, ok := im[ifam.Index]; ok {
++				continue
++			}
++			im[ifam.Index] = struct{}{}
++
++			if ifindex == 0 || ifindex == int(ifam.Index) {
++				ifi := newIoctlLink(ifam.Index)
++				if ifi != nil {
++					ift = append(ift, *ifi)
++				}
++				if ifindex == int(ifam.Index) {
++					break loop
++				}
++			}
++		}
++	}
++	return ift, nil
++}
++
++// newIoctlLink returns the Interface for the given index using
++// ioctls, or nil if its name cannot be determined.
++func newIoctlLink(index uint32) *Interface {
++	name, err := indexToName(index)
++	if err != nil {
++		return nil
++	}
++	ifi := &Interface{Index: int(index), Name: name}
++	if mtu, err := nameToMTU(name); err == nil {
++		ifi.MTU = mtu
++	}
++	if flags, err := nameToFlags(name); err == nil {
++		ifi.Flags = flags
++	}
++	return ifi
++}
++
+ const (
+ 	// See linux/if_arp.h.
+ 	// Note that Linux doesn't support IPv4 over IPv6 tunneling.
+@@ -255,3 +318,75 @@
+ 	}
+ 	return ifmat
+ }
++
++// ifReq is large enough to hold a struct ifreq.
++type ifReq [40]byte
++
++func ioctl(fd int, req uint, arg unsafe.Pointer) error {
++	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(req), uintptr(arg))
++	if errno != 0 {
++		return errno
++	}
++	return nil
++}
++
++// indexToName returns the name of the interface with the given index.
++func indexToName(index uint32) (string, error) {
++	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM|syscall.SOCK_CLOEXEC, 0)
++	if err != nil {
++		return "", err
++	}
++	defer syscall.Close(fd)
++
++	var ifr ifReq
++	*(*uint32)(unsafe.Pointer(&ifr[syscall.IFNAMSIZ])) = index
++	if err := ioctl(fd, syscall.SIOCGIFNAME, unsafe.Pointer(&ifr[0])); err != nil {
++		return "", err
++	}
++
++	return string(bytes.Trim(ifr[:syscall.IFNAMSIZ], "\x00")), nil
++}
++
++// nameToMTU returns the MTU of the interface with the given name.
++func nameToMTU(name string) (int, error) {
++	// Leave room for terminating NULL byte.
++	if len(name) >= syscall.IFNAMSIZ {
++		return -1, syscall.EINVAL
++	}
++
++	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM|syscall.SOCK_CLOEXEC, 0)
++	if err != nil {
++		return -1, err
++	}
++	defer syscall.Close(fd)
++
++	var ifr ifReq
++	copy(ifr[:], name)
++	if err := ioctl(fd, syscall.SIOCGIFMTU, unsafe.Pointer(&ifr[0])); err != nil {
++		return -1, err
++	}
++
++	return int(*(*int32)(unsafe.Pointer(&ifr[syscall.IFNAMSIZ]))), nil
++}
++
++// nameToFlags returns the flags of the interface with the given name.
++func nameToFlags(name string) (Flags, error) {
++	// Leave room for terminating NULL byte.
++	if len(name) >= syscall.IFNAMSIZ {
++		return 0, syscall.EINVAL
++	}
++
++	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM|syscall.SOCK_CLOEXEC, 0)
++	if err != nil {
++		return 0, err
++	}
++	defer syscall.Close(fd)
++
++	var ifr ifReq
++	copy(ifr[:], name)
++	if err := ioctl(fd, syscall.SIOCGIFFLAGS, unsafe.Pointer(&ifr[0])); err != nil {
++		return 0, err
++	}
++
++	return linkFlags(*(*uint32)(unsafe.Pointer(&ifr[syscall.IFNAMSIZ]))), nil
++}

--- a/packages/golang/patch-script/fix-android-netlink.sh
+++ b/packages/golang/patch-script/fix-android-netlink.sh
@@ -1,0 +1,12 @@
+for f in src/net/interface_android.go src/syscall/netlink_android.go; do
+	if [ -e "${f}" ]; then
+		termux_error_exit "file ${f} already exists."
+	fi
+done
+
+cp -T src/syscall/netlink_linux.go src/syscall/netlink_android.go
+cp -T src/net/interface_linux.go src/net/interface_android.go
+
+sed -e "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|" \
+	${TERMUX_SCRIPTDIR}/packages/golang/patch-script/fix-android-netlink.diff \
+	| patch --silent -p1

--- a/scripts/build/setup/termux_setup_golang.sh
+++ b/scripts/build/setup/termux_setup_golang.sh
@@ -14,7 +14,7 @@ termux_setup_golang() {
 			TERMUX_BUILDGO_FOLDER=${TERMUX_COMMON_CACHEDIR}/${TERMUX_GO_VERSION}
 		fi
 
-		TERMUX_BUILDGO_FOLDER+="-r1"
+		TERMUX_BUILDGO_FOLDER+="-r2"
 
 		export GOROOT=$TERMUX_BUILDGO_FOLDER
 		export PATH=${GOROOT}/bin:${PATH}
@@ -39,6 +39,7 @@ termux_setup_golang() {
 			. "${TERMUX_SCRIPTDIR}/packages/golang/patch-script/fix-hardcoded-etc-resolv-conf.sh"
 			. "${TERMUX_SCRIPTDIR}/packages/golang/patch-script/remove-pidfd.sh"
 			. "${TERMUX_SCRIPTDIR}/packages/golang/patch-script/remove-futex_time64.sh"
+			. "${TERMUX_SCRIPTDIR}/packages/golang/patch-script/fix-android-netlink.sh"
 		)
 	else
 		if [[ "$TERMUX_APP_PACKAGE_MANAGER" = "apt" && "$(dpkg-query -W -f '${db:Status-Status}\n' golang 2>/dev/null)" != "installed" ]] ||


### PR DESCRIPTION
Apply a new patch-script, fix-android-netlink.sh, to the Go toolchain in both packages/golang (build) and termux_setup_golang (cross-build toolchain, cache revision bumped r1 -> r2 so existing cached toolchains are re-patched).

Modeled on github.com/wlynxg/anet: syscall.NetlinkRIB continues without an explicit bind when the kernel denies it, and net.interfaceTable falls back to an RTM_GETADDR dump plus SIOCGIFNAME/SIOCGIFMTU/SIOCGIFFLAGS ioctls when RTM_GETLINK dumps are denied. Linux builds are unaffected (build tags only).