### PR TITLE
fix(ndk): reserve identifiers in patched stdio headers

### DIFF
--- a/ndk-patches/23c/stdio.h.patch
+++ b/ndk-patches/23c/stdio.h.patch
@@ -39,10 +39,10 @@
 +#define __sferror(p)    (((p)->_flags & __SERR) != 0)
  
 +/* Used by perl, fish, and others. */
-+static __inline__ char* ctermid(char* s) {
-+	if (s == 0) return (char*) "/dev/tty";
-+	strcpy(s, "/dev/tty");
-+	return s;
++static __inline__ char* ctermid(char* __termux_s) {
++	if (__termux_s == 0) return (char*) "/dev/tty";
++	strcpy(__termux_s, "/dev/tty");
++	return __termux_s;
 +}
  
  FILE* fdopen(int __fd, const char* __mode);
@@ -54,23 +54,23 @@
 +int open(const char*, int, ...);
 +extern pid_t getpid();
 +extern int unlink(const char*);
-+void free(void* p);
++void free(void*);
 +uint32_t arc4random(void);
 +static __inline__ FILE* tmpfile() {
-+	int p = getpid();
-+	char* path;
-+	int i;
-+	for (i = 0; i < 100; i++) {
-+		unsigned int r = arc4random();
-+		if (asprintf(&path, "@TERMUX_PREFIX@/tmp/tmpfile.%d-%u", p, r) == -1) return NULL;
-+		int fd = open(path, O_RDWR | O_CREAT | O_EXCL | O_LARGEFILE, 0600);
-+		if (fd >= 0) {
-+			FILE* result = fdopen(fd, "w+");
-+			unlink(path);
-+			free(path);
-+			return result;
++	int __termux_pid = getpid();
++	char* __termux_path;
++	int __termux_i;
++	for (__termux_i = 0; __termux_i < 100; __termux_i++) {
++		unsigned int __termux_random = arc4random();
++		if (asprintf(&__termux_path, "@TERMUX_PREFIX@/tmp/tmpfile.%d-%u", __termux_pid, __termux_random) == -1) return NULL;
++		int __termux_fd = open(__termux_path, O_RDWR | O_CREAT | O_EXCL | O_LARGEFILE, 0600);
++		if (__termux_fd >= 0) {
++			FILE* __termux_result = fdopen(__termux_fd, "w+");
++			unlink(__termux_path);
++			free(__termux_path);
++			return __termux_result;
 +		}
-+		free(path);
++		free(__termux_path);
 +	}
 +	return NULL;
 +}

--- a/ndk-patches/29/stdio.h.patch
+++ b/ndk-patches/29/stdio.h.patch
@@ -43,10 +43,10 @@ diff -u -r /home/builder/lib/android-ndk-r28b/toolchains/llvm/prebuilt/linux-x86
 + 
 +/* Used by perl, fish, and others. */
 +#if !defined(__swift__)
-+static __inline__ char* _Nonnull ctermid(char* _Nullable s) {
-+	if (s == 0) return (char*) "/dev/tty";
-+	strcpy(s, "/dev/tty");
-+	return s;
++static __inline__ char* _Nonnull ctermid(char* _Nullable __termux_s) {
++	if (__termux_s == 0) return (char*) "/dev/tty";
++	strcpy(__termux_s, "/dev/tty");
++	return __termux_s;
 +}
 +#endif
  
@@ -59,23 +59,23 @@ diff -u -r /home/builder/lib/android-ndk-r28b/toolchains/llvm/prebuilt/linux-x86
 +int open(const char*, int, ...);
 +extern pid_t getpid();
 +extern int unlink(const char*);
-+void free(void* p);
++void free(void*);
 +uint32_t arc4random(void);
 +static __inline__ FILE* _Nullable tmpfile() {
-+	int p = getpid();
-+	char* path;
-+	int i;
-+	for (i = 0; i < 100; i++) {
-+		unsigned int r = arc4random();
-+		if (asprintf(&path, "@TERMUX_PREFIX@/tmp/tmpfile.%d-%u", p, r) == -1) return NULL;
-+		int fd = open(path, O_RDWR | O_CREAT | O_EXCL | O_LARGEFILE, 0600);
-+		if (fd >= 0) {
-+			FILE* result = fdopen(fd, "w+");
-+			unlink(path);
-+			free(path);
-+			return result;
++	int __termux_pid = getpid();
++	char* __termux_path;
++	int __termux_i;
++	for (__termux_i = 0; __termux_i < 100; __termux_i++) {
++		unsigned int __termux_random = arc4random();
++		if (asprintf(&__termux_path, "@TERMUX_PREFIX@/tmp/tmpfile.%d-%u", __termux_pid, __termux_random) == -1) return NULL;
++		int __termux_fd = open(__termux_path, O_RDWR | O_CREAT | O_EXCL | O_LARGEFILE, 0600);
++		if (__termux_fd >= 0) {
++			FILE* __termux_result = fdopen(__termux_fd, "w+");
++			unlink(__termux_path);
++			free(__termux_path);
++			return __termux_result;
 +		}
-+		free(path);
++		free(__termux_path);
 +	}
 +	return NULL;
 +}

--- a/scripts/build/termux_step_setup_toolchain.sh
+++ b/scripts/build/termux_step_setup_toolchain.sh
@@ -7,10 +7,10 @@ termux_step_setup_toolchain() {
 		# toolchain setup to ensure that everyone gets an updated
 		# toolchain
 		if [ "${TERMUX_NDK_VERSION}" = "29" ]; then
-			TERMUX_STANDALONE_TOOLCHAIN+="-v4"
+			TERMUX_STANDALONE_TOOLCHAIN+="-v5"
 			termux_setup_toolchain_29
 		elif [ "${TERMUX_NDK_VERSION}" = 23c ]; then
-			TERMUX_STANDALONE_TOOLCHAIN+="-v11"
+			TERMUX_STANDALONE_TOOLCHAIN+="-v12"
 			termux_setup_toolchain_23c
 		else
 			termux_error_exit "We do not have a setup_toolchain function for NDK version $TERMUX_NDK_VERSION"


### PR DESCRIPTION
## Summary

Fixes #30545 by moving Termux-added identifiers in the patched NDK `stdio.h` implementations into the implementation-reserved namespace.

The change is limited to:

- `ndk-patches/23c/stdio.h.patch`
- `ndk-patches/29/stdio.h.patch`

It renames the local/parameter identifiers used by the Termux-provided `ctermid()` and `tmpfile()` implementations and removes the unnecessary parameter name from the added `free()` declaration. Runtime behavior is otherwise unchanged.

## Why

These declarations and inline definitions are injected into implementation headers. Names such as `p`, `path`, `i`, `r`, `fd`, `result`, and `s` can therefore collide with macros defined by application code before including `<stdio.h>`.

Using implementation-reserved `__termux_*` identifiers prevents those user-space macro definitions from rewriting the Termux-added header implementation.

## Validation

- `git diff --check`: pass
- only the two intended NDK `stdio.h` patch files changed
- original macro collision reproduced before the fix
- collision compile passes after the fix for `result`, `path`, `p`, `i`, `r`, `fd`, and `s`
- NDK 29 patch application: pass
- NDK 23c patch application: pass
- NDK 23c collision compile: pass
- Termux Packages workflow dispatch rebuilding `hello` with the patched NDK 29 toolchain: pass on aarch64, arm, i686, and x86_64

Validation workflow run: `EchoEe247/termux-packages` Actions run `33747516112`.
