### PR TITLE
enhance(ndk-multilib): Adding more shared libraries.

### DIFF
--- a/packages/ndk-multilib/build.sh
+++ b/packages/ndk-multilib/build.sh
@@ -5,13 +5,21 @@ TERMUX_PKG_MAINTAINER="@termux"
 # Version should be equal to TERMUX_NDK_{VERSION_NUM,REVISION} in
 # scripts/properties.sh
 TERMUX_PKG_VERSION=29
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://dl.google.com/android/repository/android-ndk-r${TERMUX_PKG_VERSION}-linux.zip
 TERMUX_PKG_SHA256=4abbbcdc842f3d4879206e9695d52709603e52dd68d3c1fff04b3b5e7a308ecf
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_PLATFORM_INDEPENDENT=true
 TERMUX_PKG_NO_STATICSPLIT=true
 TERMUX_PKG_BUILD_IN_SRC=true
+NDK_MULTILIB_SHARED_LIBS=(
+	lib{android,c,dl,log,m}.so
+	lib{EGL,GLESv1_CM,GLESv2,GLESv3}.so
+	lib{vulkan,OpenMAXAL,OpenSLES}.so
+)
+NDK_MULTILIB_STATIC_LIBS=(
+	lib{c,dl,m}.a
+)
 
 termux_step_get_source() {
 	mkdir -p "$TERMUX_PKG_SRCDIR"
@@ -43,14 +51,20 @@ prepare_libs() {
 	mkdir -p $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/opt/ndk-multilib/$SUFFIX/lib
 	local BASEDIR=toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/$SUFFIX/
 	cp $BASEDIR/${TERMUX_PKG_API_LEVEL}/*.o $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib
-	cp $BASEDIR/${TERMUX_PKG_API_LEVEL}/lib{c,dl,log,m}.so $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/opt/ndk-multilib/$SUFFIX/lib
+
+	local f
+	for f in "${NDK_MULTILIB_SHARED_LIBS[@]}"; do
+		cp $BASEDIR/${TERMUX_PKG_API_LEVEL}/${f} $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/opt/ndk-multilib/$SUFFIX/lib
+	done
+
 	cp $BASEDIR/libc++_shared.so $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib
-	cp $BASEDIR/lib{c,dl,m}.a $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/opt/ndk-multilib/$SUFFIX/lib
+	for f in "${NDK_MULTILIB_STATIC_LIBS[@]}"; do
+		cp $BASEDIR/${f} $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/opt/ndk-multilib/$SUFFIX/lib
+	done
 	cp $BASEDIR/lib{c++_static,c++abi,c++experimental}.a $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib
 	echo 'INPUT(-lc++_static -lc++abi)' > $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib/libc++_shared.a
 
-	local f
-	for f in lib{c,dl,log,m}.so lib{c,dl,m}.a; do
+	for f in "${NDK_MULTILIB_SHARED_LIBS[@]}" "${NDK_MULTILIB_STATIC_LIBS[@]}"; do
 		ln -sfT $TERMUX_PREFIX/opt/ndk-multilib/$SUFFIX/lib/${f} \
 			$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/$SUFFIX/lib/${f}
 	done
@@ -86,7 +100,7 @@ termux_step_make_install() {
 termux_step_post_massage() {
 	local triple f
 	for triple in aarch64-linux-android arm-linux-androideabi i686-linux-android x86_64-linux-android; do
-		for f in lib{c,dl,log,m}.so lib{c,dl,m}.a; do
+		for f in "${NDK_MULTILIB_SHARED_LIBS[@]}" "${NDK_MULTILIB_STATIC_LIBS[@]}"; do
 			rm -f ${triple}/lib/${f}
 		done
 	done
@@ -99,9 +113,15 @@ termux_step_create_debscripts() {
 			-e "s|@TERMUX_PACKAGE_FORMAT@|${TERMUX_PACKAGE_FORMAT}|g" \
 			$TERMUX_PKG_BUILDER_DIR/postinst-header.in > "${f}"
 	done
-	sed 's|@COMMAND@|ln -sf "'$TERMUX_PREFIX'/opt/ndk-multilib/$triple/lib/$so" "'$TERMUX_PREFIX'/\$triple/lib"|' \
-		$TERMUX_PKG_BUILDER_DIR/postinst-alien.in >> postinst
-	sed 's|@COMMAND@|rm -f "'$TERMUX_PREFIX'/$triple/lib/$so"|' \
-		$TERMUX_PKG_BUILDER_DIR/postinst-alien.in >> prerm
+
+	ndk_multilib_alien() {
+		sed -e "s|@COMMAND@|${1}|" \
+			-e "s|@NDK_MULTILIB_SHARED_LIBS@|${NDK_MULTILIB_SHARED_LIBS[*]}|g" \
+			-e "s|@NDK_MULTILIB_STATIC_LIBS@|${NDK_MULTILIB_STATIC_LIBS[*]}|g" \
+			$TERMUX_PKG_BUILDER_DIR/postinst-alien.in
+	}
+	ndk_multilib_alien 'ln -sf "'$TERMUX_PREFIX'/opt/ndk-multilib/$triple/lib/$so" "'$TERMUX_PREFIX'/\$triple/lib"' >> postinst
+	ndk_multilib_alien 'rm -f "'$TERMUX_PREFIX'/$triple/lib/$so"' >> prerm
+
 	chmod 0700 postinst prerm
 }

--- a/packages/ndk-multilib/ndk-multilib-native-static.subpackage.sh
+++ b/packages/ndk-multilib/ndk-multilib-native-static.subpackage.sh
@@ -6,31 +6,23 @@ TERMUX_SUBPKG_INCLUDE=
 
 case "$TERMUX_ARCH" in
 	aarch64 )
-		TERMUX_SUBPKG_INCLUDE+="
-			aarch64-linux-android/lib/libc.a
-			aarch64-linux-android/lib/libdl.a
-			aarch64-linux-android/lib/libm.a
-		"
+		for lib in "${NDK_MULTILIB_STATIC_LIBS[@]}"; do
+			TERMUX_SUBPKG_INCLUDE+=" aarch64-linux-android/lib/$lib"
+		done
 		;& # fallthrough
 	arm )
-		TERMUX_SUBPKG_INCLUDE+="
-			arm-linux-androideabi/lib/libc.a
-			arm-linux-androideabi/lib/libdl.a
-			arm-linux-androideabi/lib/libm.a
-		"
+		for lib in "${NDK_MULTILIB_STATIC_LIBS[@]}"; do
+			TERMUX_SUBPKG_INCLUDE+=" arm-linux-androideabi/lib/$lib"
+		done
 		;;
 	x86_64 )
-		TERMUX_SUBPKG_INCLUDE+="
-			x86_64-linux-android/lib/libc.a
-			x86_64-linux-android/lib/libdl.a
-			x86_64-linux-android/lib/libm.a
-		"
+		for lib in "${NDK_MULTILIB_STATIC_LIBS[@]}"; do
+			TERMUX_SUBPKG_INCLUDE+=" x86_64-linux-android/lib/$lib"
+		done
 		;& # fallthrough
 	i686 )
-		TERMUX_SUBPKG_INCLUDE+="
-			i686-linux-android/lib/libc.a
-			i686-linux-android/lib/libdl.a
-			i686-linux-android/lib/libm.a
-		"
+		for lib in "${NDK_MULTILIB_STATIC_LIBS[@]}"; do
+			TERMUX_SUBPKG_INCLUDE+=" i686-linux-android/lib/$lib"
+		done
 		;;
 esac

--- a/packages/ndk-multilib/ndk-multilib-native-stubs.subpackage.sh
+++ b/packages/ndk-multilib/ndk-multilib-native-stubs.subpackage.sh
@@ -4,35 +4,23 @@ TERMUX_SUBPKG_INCLUDE=
 
 case "$TERMUX_ARCH" in
 	aarch64 )
-		TERMUX_SUBPKG_INCLUDE+="
-			aarch64-linux-android/lib/libc.so
-			aarch64-linux-android/lib/libdl.so
-			aarch64-linux-android/lib/liblog.so
-			aarch64-linux-android/lib/libm.so
-		"
+		for lib in "${NDK_MULTILIB_SHARED_LIBS[@]}"; do
+			TERMUX_SUBPKG_INCLUDE+=" aarch64-linux-android/lib/$lib"
+		done
 		;& # fallthrough
 	arm )
-		TERMUX_SUBPKG_INCLUDE+="
-			arm-linux-androideabi/lib/libc.so
-			arm-linux-androideabi/lib/libdl.so
-			arm-linux-androideabi/lib/liblog.so
-			arm-linux-androideabi/lib/libm.so
-		"
+		for lib in "${NDK_MULTILIB_SHARED_LIBS[@]}"; do
+			TERMUX_SUBPKG_INCLUDE+=" arm-linux-androideabi/lib/$lib"
+		done
 		;;
 	x86_64 )
-		TERMUX_SUBPKG_INCLUDE+="
-			x86_64-linux-android/lib/libc.so
-			x86_64-linux-android/lib/libdl.so
-			x86_64-linux-android/lib/liblog.so
-			x86_64-linux-android/lib/libm.so
-		"
+		for lib in "${NDK_MULTILIB_SHARED_LIBS[@]}"; do
+			TERMUX_SUBPKG_INCLUDE+=" x86_64-linux-android/lib/$lib"
+		done
 		;& # fallthrough
 	i686 )
-		TERMUX_SUBPKG_INCLUDE+="
-			i686-linux-android/lib/libc.so
-			i686-linux-android/lib/libdl.so
-			i686-linux-android/lib/liblog.so
-			i686-linux-android/lib/libm.so
-		"
+		for lib in "${NDK_MULTILIB_SHARED_LIBS[@]}"; do
+			TERMUX_SUBPKG_INCLUDE+=" i686-linux-android/lib/$lib"
+		done
 		;;
 esac

--- a/packages/ndk-multilib/postinst-alien.in
+++ b/packages/ndk-multilib/postinst-alien.in
@@ -5,9 +5,10 @@ for triple in aarch64-linux-android arm-linux-androideabi i686-linux-android x86
 	   { [ x"$native_triple" = x"x86_64-linux-android" ] && [ "$triple" = "i686-linux-android" ]; }; then
 		continue
 	fi
-	for so in libc.so libdl.so liblog.so libm.so libc.a libdl.a libm.a; do
-		@COMMAND@
-	done
+
+    for so in @NDK_MULTILIB_SHARED_LIBS@ @NDK_MULTILIB_STATIC_LIBS@; do
+        @COMMAND@
+    done
 done
 
 exit 0


### PR DESCRIPTION
Add libraries supported since Android 7 (API 24).

Adds libandroid, EGL, GLES (v1, v2, v3), Vulkan, camera2ndk, mediandk, jnigraphics,
OpenMAXAL, and OpenSLES.

Only libandroid and the GLES libs were needed for what I ran into,
but adding the rest now saves having to touch this again later.

See https://developer.android.com/ndk/guides/stable_apis

Closes: #25201