### PR TITLE
Add war-dodger

### DIFF
--- a/packages/war-dodger/build.sh
+++ b/packages/war-dodger/build.sh
@@ -1,0 +1,23 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/PepeDiedrich/war-dodge
+TERMUX_PKG_DESCRIPTION="Location-aware monitor for U.S. State Department travel advisory changes"
+TERMUX_PKG_VERSION=0.1.2
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=https://github.com/PepeDiedrich/war-dodge/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=7bca689bd18883fede94582179fd0e9905a2e09fd480e98febdfdd3dc48820aa
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@PepeDiedrich"
+TERMUX_PKG_DEPENDS="termux-api"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+    termux_setup_rust
+}
+
+termux_step_make() {
+    cargo build --target "${CARGO_TARGET_NAME}" --release
+}
+
+termux_step_make_install() {
+    install -Dm755 "target/${CARGO_TARGET_NAME}/release/war-dodger" \
+        "${TERMUX_PREFIX}/bin/war-dodger"
+}

--- a/packages/war-dodger/build.sh
+++ b/packages/war-dodger/build.sh
@@ -1,9 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/PepeDiedrich/war-dodge
 TERMUX_PKG_DESCRIPTION="Location-aware monitor for U.S. State Department travel advisory changes"
-TERMUX_PKG_VERSION=0.1.2
+TERMUX_PKG_VERSION=0.1.3
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/PepeDiedrich/war-dodge/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=7bca689bd18883fede94582179fd0e9905a2e09fd480e98febdfdd3dc48820aa
+TERMUX_PKG_SHA256=beab8aaaa6d87dd7f4ee6a1d219a91ef9afe91a379f66332a76794c92abcdce3
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@PepeDiedrich"
 TERMUX_PKG_DEPENDS="termux-api"

--- a/packages/war-dodger/build.sh
+++ b/packages/war-dodger/build.sh
@@ -1,9 +1,8 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/PepeDiedrich/war-dodge
 TERMUX_PKG_DESCRIPTION="Location-aware monitor for U.S. State Department travel advisory changes"
-TERMUX_PKG_VERSION=0.1.3
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_VERSION=0.1.4
 TERMUX_PKG_SRCURL=https://github.com/PepeDiedrich/war-dodge/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=beab8aaaa6d87dd7f4ee6a1d219a91ef9afe91a379f66332a76794c92abcdce3
+TERMUX_PKG_SHA256=68deaf92007713c3e039f0d40206b19e3786e54b787815f04bc05ccc93d1fda2
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@PepeDiedrich"
 TERMUX_PKG_DEPENDS="termux-api"


### PR DESCRIPTION
Adds war-dodger, a location-aware monitor for U.S. State Department Travel Advisory changes.

Version 0.1.4 adds notification self-testing, automatic Termux:Boot script setup, fail-fast offline detection, expanded tests and benchmarks, and comprehensive setup/troubleshooting documentation.

Runtime dependency: termux-api. Optional Android integration: Termux:Boot for restart after reboot.

Source release: https://github.com/PepeDiedrich/war-dodge/releases/tag/v0.1.4
Source SHA-256: 68deaf92007713c3e039f0d40206b19e3786e54b787815f04bc05ccc93d1fda2