### PR TITLE
bump(main/fish): 4.9.0

### DIFF
--- a/packages/fish/0007-revert-c1f3d93.patch
+++ b/packages/fish/0007-revert-c1f3d93.patch
@@ -40,7 +40,7 @@ error[E0425]: cannot find value `MNT_LOCAL` in crate `libc`
                          DirRemoteness::Remote
                      }
                  } else {
--                    let mut buf = MaybeUninit::uninit();
+-                    let mut buf = std::mem::MaybeUninit::uninit();
 -                    if unsafe { libc::statfs(narrow.as_ptr(), buf.as_mut_ptr()) } < 0 {
 -                        return DirRemoteness::Unknown;
 -                    }
@@ -66,7 +66,7 @@ error[E0425]: cannot find value `MNT_LOCAL` in crate `libc`
 +                        if is_local_flag == 0 {
 +                            return DirRemoteness::Unknown;
 +                        }
-+                        let mut buf = MaybeUninit::uninit();
++                        let mut buf = std::mem::MaybeUninit::uninit();
 +                        if unsafe { (statfn)(path.as_ptr(), buf.as_mut_ptr()) } < 0 {
 +                            return DirRemoteness::Unknown;
 +                        }

--- a/packages/fish/build.sh
+++ b/packages/fish/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://fishshell.com/
 TERMUX_PKG_DESCRIPTION="The user-friendly command line shell"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="4.8.1"
+TERMUX_PKG_VERSION="4.9.0"
 TERMUX_PKG_SRCURL="https://github.com/fish-shell/fish-shell/releases/download/$TERMUX_PKG_VERSION/fish-${TERMUX_PKG_VERSION}.tar.xz"
-TERMUX_PKG_SHA256=0eb86a851e865e934a7c2091a73d7695225e78f0e00a7bb96d5f877d76c65782
+TERMUX_PKG_SHA256=49d86d655cfcc82c7d13d66c6c30a3351600d44b40fb2b6218fbb8fb0e635122
 # fish calls 'tput' from ncurses-utils, at least when cancelling (Ctrl+C) a command line.
 # man is needed since fish calls apropos during command completion.
 TERMUX_PKG_DEPENDS="bc, libandroid-support, libc++, mandoc, ncurses, ncurses-utils, pcre2"


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/31480

- Rebase `0007-revert-c1f3d93.patch`