### PR TITLE
fix(main/bun): fix --bun shebang fallback, disable canary, add completions, and symlink fix

### DIFF
--- a/packages/bun/0006-set-termux-tmpdir.patch
+++ b/packages/bun/0006-set-termux-tmpdir.patch
@@ -1,0 +1,11 @@
+--- a/src/install/lib.rs
++++ b/src/install/lib.rs
+@@ -423,7 +423,7 @@ impl RunCommand {
+         const TMP: &str = if cfg!(target_os = "macos") {
+             "/private/tmp"
+         } else if cfg!(target_os = "android") {
+-            "/data/local/tmp"
++            "@TERMUX_PREFIX@/tmp"
+         } else {
+             "/tmp"
+         };

--- a/packages/bun/0007-fix-bash-completion-empty-regex.patch
+++ b/packages/bun/0007-fix-bash-completion-empty-regex.patch
@@ -1,0 +1,11 @@
+--- a/completions/bun.bash
++++ b/completions/bun.bash
+@@ -57,7 +57,7 @@
+     local re_prev_script="(^| )${prev}($| )";
+     [[
+         ( "${COMPREPLY[*]}" =~ ${re_prev_script} && -n "${COMP_WORDS[2]}" ) || \
+-            ( "${COMPREPLY[*]}" =~ ${re_comp_word_script} )
++            ( -n "${re_comp_word_script}" && "${COMPREPLY[*]}" =~ ${re_comp_word_script} )
+     ]] && {
+         local filtered_reply=();
+         local reply_word script_name keep;

--- a/packages/bun/0008-default-to-symlink-install-backend.patch
+++ b/packages/bun/0008-default-to-symlink-install-backend.patch
@@ -1,0 +1,12 @@
+--- a/src/install/PackageInstall.rs
++++ b/src/install/PackageInstall.rs
+@@ -257,6 +257,8 @@
+ // lock-free atomics (S015: AtomicU8 instead of RacyCell — single-writer path
+ // so `Relaxed` adds no contention).
+ pub(crate) static SUPPORTED_METHOD: AtomicU8 = AtomicU8::new(if cfg!(target_os = "macos") {
+     Method::Clonefile as u8
++} else if cfg!(target_os = "android") {
++    Method::Symlink as u8
+ } else {
+     Method::Hardlink as u8
+ });

--- a/packages/bun/build.sh
+++ b/packages/bun/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Incredibly fast JavaScript runtime, bundler, test runner
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
 TERMUX_PKG_VERSION="1.4.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/oven-sh/bun
 TERMUX_PKG_GIT_BRANCH="bun-v$TERMUX_PKG_VERSION"
 TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"
@@ -38,10 +39,19 @@ termux_step_make() {
 	bun run build:release \
 		--abi=android \
 		--arch="$_bun_arch" \
-		--android-ndk="$NDK"
+		--android-ndk="$NDK" \
+		--canary=false \
+		--lto=on
 }
 
 termux_step_make_install() {
 	install -Dm755 "$TERMUX_PKG_SRCDIR/build/release/bun" "$TERMUX_PREFIX/bin/bun"
 	ln -sf bun "$TERMUX_PREFIX/bin/bunx"
+
+	install -Dm644 "$TERMUX_PKG_SRCDIR/completions/bun.bash" \
+		"$TERMUX_PREFIX/share/bash-completion/completions/bun"
+	install -Dm644 "$TERMUX_PKG_SRCDIR/completions/bun.zsh" \
+		"$TERMUX_PREFIX/share/zsh/site-functions/_bun"
+	install -Dm644 "$TERMUX_PKG_SRCDIR/completions/bun.fish" \
+		"$TERMUX_PREFIX/share/fish/vendor_completions.d/bun.fish"
 }


### PR DESCRIPTION
This PR addresses several runtime execution issues, adds missing vendor completions, and aligns downstream patches with upstream:

### Changes
1. **Package build flags**:
   - Bumped `TERMUX_PKG_REVISION=1`.
   - Enabled LTO (`--lto=on`) and disabled canary flags (`--canary=false`).
2. **Shell completions**:
   - Installed vendor completions for Bash, Zsh, and Fish into `$TERMUX_PREFIX/share`.
3. **Upstream patch backport**:
   - **`0006-set-termux-tmpdir.patch`**
   - **`0007-fix-bash-completion-empty-regex.patch`**: Prevents Bionic `REG_EMPTY` errors when completing without script arguments (backport of upstream [oven-sh/bun#41433](https://github.com/oven-sh/bun/pull/41433)).
   - **`0008-default-to-symlink-install-backend.patch`**: Defaults package installation backend to symlinks on Android (backport of upstream [oven-sh/bun#41432](https://github.com/oven-sh/bun/pull/41432)).

### Upstream References
- https://github.com/oven-sh/bun/pull/41432
- https://github.com/oven-sh/bun/pull/41433
