### PR TITLE
addpkg(main): libpsl-native, powershell

### DIFF
--- a/packages/libpsl-native/build.sh
+++ b/packages/libpsl-native/build.sh
@@ -1,0 +1,28 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/PowerShell/PowerShell-Native
+TERMUX_PKG_DESCRIPTION="This library provides functionality missing from .NET Core via system calls"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="7.4.0"
+TERMUX_PKG_SRCURL=https://github.com/PowerShell/PowerShell-Native/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=5220f99755442720486e20682269fecdabbbabff9e082c1a51250b66465f40cf
+TERMUX_PKG_DEPENDS="libc++"
+TERMUX_PKG_BUILD_DEPENDS="googletest"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+
+termux_step_pre_configure() {
+	termux_setup_cmake
+	termux_setup_ninja
+
+	export OLD_TERMUX_PKG_SRCDIR="${TERMUX_PKG_SRCDIR}"
+	TERMUX_PKG_SRCDIR="${TERMUX_PKG_SRCDIR}/src/libpsl-native"
+}
+
+termux_step_make_install() {
+	TERMUX_PKG_SRCDIR="${OLD_TERMUX_PKG_SRCDIR}"
+	install -v -Dm644 -t "${TERMUX_PREFIX}/lib" \
+		"${TERMUX_PKG_SRCDIR}/src/powershell-unix/libpsl-native.so"
+	install -v -Dm755 -t "${TERMUX_PREFIX}/bin" \
+		test/psl-native-test
+	unset OLD_TERMUX_PKG_SRCDIR
+}

--- a/packages/libpsl-native/enable-testing-on-arm.patch
+++ b/packages/libpsl-native/enable-testing-on-arm.patch
@@ -1,0 +1,38 @@
+From 39f0266f3326a445b7700310234841e803e78e76 Mon Sep 17 00:00:00 2001
+From: Antoine Martin <dev@ayakael.net>
+Date: Sun, 14 Aug 2022 00:10:32 -0400
+Subject: [PATCH 1/1] enable-testing-on-arm
+
+For some reason, testing suite for arm is disabled at build.
+Patch reenables build of testing suite
+
+---
+ src/libpsl-native/CMakeLists.txt | 15 +++++----------
+ 1 file changed, 5 insertions(+), 10 deletions(-)
+
+diff --git a/src/libpsl-native/CMakeLists.txt b/src/libpsl-native/CMakeLists.txt
+index e4f33cc..61abd96 100644
+--- a/src/libpsl-native/CMakeLists.txt
++++ b/src/libpsl-native/CMakeLists.txt
+@@ -13,13 +13,8 @@ endif()
+ 
+ set(LIBRARY_OUTPUT_PATH "${PROJECT_SOURCE_DIR}/../powershell-unix")
+ 
+-if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
+-    message(STATUS "Building for ARM, no tests")
+-    add_subdirectory(src)
+-else ()
+-    # test in BUILD_DIR
+-    message(STATUS "Tests enabled")
+-    enable_testing()
+-    add_subdirectory(src)
+-    add_subdirectory(test)
+-endif ()
++# test in BUILD_DIR
++message(STATUS "Tests enabled")
++enable_testing()
++add_subdirectory(src)
++add_subdirectory(test)
+-- 
+2.36.2
+

--- a/packages/libpsl-native/fix-testing-suite.patch
+++ b/packages/libpsl-native/fix-testing-suite.patch
@@ -1,0 +1,8 @@
+--- a/src/libpsl-native/test/CMakeLists.txt
++++ b/src/libpsl-native/test/CMakeLists.txt
+@@ -1,5 +1,3 @@
+-add_subdirectory(googletest)
+-
+ add_executable(psl-native-test
+   test-getfileowner.cpp
+   test-locale.cpp

--- a/packages/libpsl-native/new-gtest.patch
+++ b/packages/libpsl-native/new-gtest.patch
@@ -1,0 +1,13 @@
+diff --git a/src/libpsl-native/CMakeLists.txt b/src/libpsl-native/CMakeLists.txt
+index 4a612f5bcd4..7ecc20b7ed7 100644
+--- a/src/libpsl-native/CMakeLists.txt
++++ b/src/libpsl-native/CMakeLists.txt
+@@ -3,7 +3,7 @@ project(PSL-NATIVE)
+ 
+ # Can't use add_compile_options with 2.8.11
+ set(CMAKE_BUILD_TYPE "Release")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror -fstack-protector-strong -fpie -D_FORTIFY_SOURCE=2")
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Wall -Werror -fstack-protector-strong -fpie -D_FORTIFY_SOURCE=2")
+ 
+ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,relro,-z,now")

--- a/packages/libpsl-native/psl-native-test.subpackage.sh
+++ b/packages/libpsl-native/psl-native-test.subpackage.sh
@@ -1,0 +1,3 @@
+TERMUX_SUBPKG_DESCRIPTION="psl-native-test"
+TERMUX_SUBPKG_DEPENDS="googletest, libc++"
+TERMUX_SUBPKG_INCLUDE="bin/psl-native-test"

--- a/packages/powershell/0001-treat-warnings-as-errors.patch
+++ b/packages/powershell/0001-treat-warnings-as-errors.patch
@@ -1,0 +1,8 @@
+--- a/PowerShell.Common.props
++++ b/PowerShell.Common.props
+@@ -148,3 +148,4 @@
+ 
+-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
++    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
++    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/packages/powershell/0002-fix-nuget-sources.patch
+++ b/packages/powershell/0002-fix-nuget-sources.patch
@@ -1,0 +1,14 @@
+--- a/nuget.config
++++ b/nuget.config
+@@ -4,3 +4,4 @@
+     <clear />
+     <add key="powershell" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShell/nuget/v3/index.json" />
++    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+   </packageSources>
+--- a/src/Modules/nuget.config
++++ b/src/Modules/nuget.config
+@@ -4,3 +4,4 @@
+     <clear />
+     <add key="powershell" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShell/nuget/v3/index.json" />
++    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+   </packageSources>

--- a/packages/powershell/0003-runtime-identifiers.patch
+++ b/packages/powershell/0003-runtime-identifiers.patch
@@ -1,0 +1,7 @@
+--- a/src/powershell-unix/powershell-unix.csproj
++++ b/src/powershell-unix/powershell-unix.csproj
+@@ -11,3 +11,3 @@
+     <TieredCompilationQuickJitForLoops>true</TieredCompilationQuickJitForLoops>
+-    <RuntimeIdentifiers>linux-x64;osx-x64;</RuntimeIdentifiers>
++    <RuntimeIdentifiers>linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
+   </PropertyGroup>

--- a/packages/powershell/build.sh
+++ b/packages/powershell/build.sh
@@ -1,0 +1,150 @@
+TERMUX_PKG_HOMEPAGE=https://learn.microsoft.com/en-us/powershell/
+TERMUX_PKG_DESCRIPTION="Cross-platform automation and configuration tool/framework"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="7.4.19"
+TERMUX_PKG_SRCURL=git+https://github.com/PowerShell/PowerShell
+TERMUX_PKG_GIT_BRANCH="v${TERMUX_PKG_VERSION}"
+TERMUX_PKG_DEPENDS="dotnet-host, dotnet-runtime-8.0, libc++, libpsl-native, openssl, zlib"
+TERMUX_PKG_BUILD_DEPENDS="dotnet-sdk-8.0, dotnet-targeting-pack-8.0"
+TERMUX_DOTNET_VERSION=8.0
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"
+TERMUX_PKG_AUTO_UPDATE=true
+
+termux_pkg_auto_update() {
+	local api_url="https://api.github.com/repos/PowerShell/PowerShell/git/refs/tags"
+	local latest_refs_tags=$(curl -s "${api_url}" | jq .[].ref | sed -ne "s|.*/v\(.*\)\"|\1|p")
+	if [[ -z "${latest_refs_tags}" ]]; then
+		echo "WARN: Unable to get latest refs tags from upstream. Try again later." >&2
+		return
+	fi
+	local latest_version=$(echo "${latest_refs_tags}" | grep -E '^7\.4\.' | grep -v preview | sort -V | tail -n1)
+
+	termux_pkg_upgrade_version "${latest_version}"
+}
+
+termux_step_pre_configure() {
+	rm -f global.json
+
+	termux_setup_dotnet
+
+	# Setup dependency-gatherer targets for TypeCatalogGen
+	mkdir -p src/Microsoft.PowerShell.SDK/obj
+	cat <<- TARGETS > src/Microsoft.PowerShell.SDK/obj/Microsoft.PowerShell.SDK.csproj.TypeCatalog.targets
+	<Project>
+	    <Target Name="_GetDependencies"
+	            DependsOnTargets="ResolveAssemblyReferencesDesignTime">
+	        <ItemGroup>
+	            <_RefAssemblyPath Include="%(_ReferencesFromRAR.OriginalItemSpec)%3B" Condition=" '%(_ReferencesFromRAR.NuGetPackageId)' != 'Microsoft.Management.Infrastructure' "/>
+	        </ItemGroup>
+	        <WriteLinesToFile File="\$(_DependencyFile)" Lines="@(_RefAssemblyPath)" Overwrite="true" />
+	    </Target>
+	</Project>
+	TARGETS
+}
+
+termux_step_make() {
+	termux_setup_dotnet
+
+	# Restore projects
+	dotnet restore src/Modules/PSGalleryModules.csproj
+	dotnet restore src/ResGen
+	dotnet restore src/TypeCatalogGen
+	dotnet restore src/powershell-unix
+
+	# Generate resource bindings
+	(
+		cd src/ResGen
+		dotnet run --no-restore
+	)
+
+	# Generate type catalog
+	dotnet msbuild src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj \
+		/t:_GetDependencies \
+		"/property:DesignTimeBuild=true;_DependencyFile=${TERMUX_PKG_SRCDIR}/src/TypeCatalogGen/powershell.inc" \
+		-m:1 -nodeReuse:false -p:UseSharedCompilation=false /nologo
+
+	(
+		cd src/TypeCatalogGen
+		dotnet run --no-restore ../System.Management.Automation/CoreCLR/CorePsTypeCatalog.cs powershell.inc
+	)
+
+	# Publish PowerShell Core
+	dotnet publish src/powershell-unix \
+		--configuration Release \
+		--output "${TERMUX_PKG_BUILDDIR}/publish" \
+		--framework "net${TERMUX_DOTNET_VERSION}" \
+		--no-self-contained \
+		-m:1 -nodeReuse:false -p:UseSharedCompilation=false -p:PublishReadyToRun=false \
+		/nologo
+
+	# Populate bundled modules from NuGet cache
+	local NUGET_CACHE
+	NUGET_CACHE="$(dotnet nuget locals global-packages -l | awk '{print $2}')"
+	if [[ -z "${NUGET_CACHE}" || ! -d "${NUGET_CACHE}" ]]; then
+		NUGET_CACHE="${HOME}/.nuget/packages"
+	fi
+
+	local modules="
+		PackageManagement:packagemanagement
+		PowerShellGet:powershellget
+		Microsoft.PowerShell.PSResourceGet:microsoft.powershell.psresourceget
+		Microsoft.PowerShell.Archive:microsoft.powershell.archive
+		PSReadLine:psreadline
+		ThreadJob:threadjob
+	"
+
+	local mod_dest="${TERMUX_PKG_BUILDDIR}/publish/Modules"
+	mkdir -p "${mod_dest}"
+
+	for entry in $modules; do
+		local name="${entry%%:*}"
+		local pkg="${entry##*:}"
+		local ver_dir
+		ver_dir="$(find "${NUGET_CACHE}/${pkg}" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -n 1)"
+		if [[ -n "${ver_dir}" && -d "${ver_dir}" ]]; then
+			rm -rf "${mod_dest}/${name}"
+			mkdir -p "${mod_dest}/${name}"
+			cp -r "${ver_dir}"/* "${mod_dest}/${name}/"
+			rm -f "${mod_dest}/${name}"/*.nupkg* "${mod_dest}/${name}"/*.nuspec "${mod_dest}/${name}/System.Runtime.InteropServices.RuntimeInformation.dll"
+			rm -rf "${mod_dest}/${name}/fullclr" "${mod_dest}/${name}/_manifest"
+		fi
+	done
+
+	# Ensure PSReadLine Polyfiller is in the module root so it resolves properly
+	if [[ -f "${mod_dest}/PSReadLine/net6plus/Microsoft.PowerShell.PSReadLine.Polyfiller.dll" ]]; then
+		cp -f "${mod_dest}/PSReadLine/net6plus/Microsoft.PowerShell.PSReadLine.Polyfiller.dll" "${mod_dest}/PSReadLine/"
+	fi
+
+	dotnet build-server shutdown
+	termux_dotnet_kill
+}
+
+termux_step_make_install() {
+	rm -rf "${TERMUX_PREFIX}/lib/powershell"
+	mkdir -p "${TERMUX_PREFIX}/lib/powershell"
+
+	# Fix file permissions and copy
+	find "${TERMUX_PKG_BUILDDIR}/publish" -name "*.a" -exec chmod a-x "{}" \;
+	find "${TERMUX_PKG_BUILDDIR}/publish" -name "*.dll" -exec chmod a-x "{}" \;
+	find "${TERMUX_PKG_BUILDDIR}/publish" -name "*.so" -exec chmod a-x "{}" \;
+	rm -fv "${TERMUX_PKG_BUILDDIR}/publish/libSystem.IO.Ports.Native.so"
+
+	cp -r "${TERMUX_PKG_BUILDDIR}/publish"/* "${TERMUX_PREFIX}/lib/powershell/"
+
+	# Stub libpsl-native.so
+	ln -fsv ../libpsl-native.so "${TERMUX_PREFIX}/lib/powershell/libpsl-native.so"
+
+	# Symlinks for OpenSSL
+	ln -fsv ../libcrypto.so "${TERMUX_PREFIX}/lib/powershell/libcrypto.so"
+	ln -fsv ../libssl.so "${TERMUX_PREFIX}/lib/powershell/libssl.so"
+
+	# Launcher script
+	cat <<- EOL > "${TERMUX_PREFIX}/bin/pwsh"
+	#!${TERMUX_PREFIX}/bin/sh
+	export LD_LIBRARY_PATH="${TERMUX_PREFIX}/lib/powershell:\${LD_LIBRARY_PATH}"
+	exec "${TERMUX_PREFIX}/lib/powershell/pwsh" "\$@"
+	EOL
+	chmod +x "${TERMUX_PREFIX}/bin/pwsh"
+}


### PR DESCRIPTION
Supersedes and closes #20423.
Closes #1729.

### Changes & Resolves Blockers from #20423
- **Rebase & Bump**: Cleanly rebased onto latest `master` and updated PowerShell to `7.4.19` (LTS).
- **Native .NET Build (`termux_setup_dotnet`)**:
  - Replaced the previous `sudo apt install` Ubuntu deb bootstrap hack with native Termux `termux_setup_dotnet` (`net8.0`).
  - Implemented the native code-generation steps (`ResGen` resource strings and `TypeCatalogGen` CorePsTypeCatalog generation).
  - Configured MSBuild with `-m:1 -nodeReuse:false -p:UseSharedCompilation=false` to prevent multi-process crashes under Android Bionic.
- **Fixed PSReadLine & Terminal Input**:
  - Resolved the crash loading `PSReadLine`: The NuGet package places `Microsoft.PowerShell.PSReadLine.Polyfiller.dll` in a `net6plus/` subdirectory. At runtime, PowerShell's module loader failed to resolve it from the module root. Copying the polyfiller to the module root fixes module loading.
  - This automatically resolves the duplicate echo, broken Tab completion, and arrow keys reported in #20423 (which were side effects of falling back to `ConsoleHostUserInterface.cs` fallback cooked mode when PSReadLine was missing).
- **libpsl-native**:
  - Added `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` for modern CMake (>= 3.31).
  - Updated `new-gtest.patch` to use `-std=c++17` for compatibility with googletest 1.18.
- **Architectures**: Excluded unsupported architectures (`arm, i686`).

Tested on `aarch64` Android: both packages build, install, and pass module/command execution tests cleanly.