### PR TITLE
chore(main/llama.cpp): follow upstream versionning change

### DIFF
--- a/packages/llama-cpp/build.sh
+++ b/packages/llama-cpp/build.sh
@@ -2,10 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://github.com/ggml-org/llama.cpp
 TERMUX_PKG_DESCRIPTION="LLM inference in C/C++"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER=@termux
-TERMUX_PKG_VERSION="0.0.0-v0.3.0"
-TERMUX_PKG_SRCURL="https://github.com/ggml-org/llama.cpp/archive/refs/tags/${TERMUX_PKG_VERSION#*-}.tar.gz"
+TERMUX_PKG_VERSION="0.3.0"
+TERMUX_PKG_SRCURL="https://github.com/ggml-org/llama.cpp/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=d94c02d86db22d68692f6bb5b3854763d5091e52142868dc7251995517c666d1
-TERMUX_PKG_REPOLOGY_METADATA_VERSION="${TERMUX_PKG_VERSION#*-}"
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="libandroid-spawn, libc++, libcurl"
 TERMUX_PKG_BUILD_DEPENDS="ocl-icd, opencl-headers, spirv-headers, vulkan-headers"
@@ -23,54 +22,6 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 # XXX: llama.cpp uses `int64_t`, but on 32-bit Android `size_t` is `int32_t`.
 # XXX: I don't think it will work if we simply casting it.
 TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"
-
-# This auto update function throttles the update frequency
-# of the package to set `$update_interval`, this is useful
-# for packages that make very frequent tags like `jackett`
-# or `llama-cpp` to not spam the commit history, CI and repos.
-termux_pkg_auto_update() {
-	local origin_url last_autoupdate
-	# Throttle auto updates to once every 2 weeks.
-	local update_interval="$((14 * 86400))"
-
-	# Get the git history
-	if origin_url="$(git config --get remote.origin.url)"; then
-		git fetch --quiet "${origin_url}" || {
-			echo "WARN: Unable to fetch '${origin_url}'"
-			echo "WARN: Skipping auto update for '$TERMUX_PKG_NAME'"
-			return
-		}
-	fi
-
-	# When was `llama-cpp` last autoupdated? (Unix epoch timestamp)
-	last_autoupdate="$(
-		git log \
-		--author="Termux Github Actions <contact@termux.dev>" \
-		-n1 \
-		--pretty=format:%at \
-		-- "$TERMUX_PKG_BUILDER_DIR/build.sh"
-	)"
-
-
-	if (( last_autoupdate > EPOCHSECONDS - update_interval )); then
-		local t days hrs mins secs
-		(( t = EPOCHSECONDS - last_autoupdate, days = t/86400, t %= 86400, secs= t%60, t /= 60, mins = t%60, hrs = t/60 ))
-
-		printf 'INFO: Last updated %dd%dh%02dm%02ds ago.\n' "$days" "$hrs" "$mins" "$secs"
-		printf 'INFO: Which is less than the desired %sd minimum update interval.\n' "$(( update_interval / 86400 ))"
-		return
-	fi
-
-	local latest_tag
-	latest_tag="$(
-		termux_github_api_get_tag "${TERMUX_PKG_SRCURL}" "${TERMUX_PKG_UPDATE_TAG_TYPE}"
-	)"
-
-	if [[ -z "${latest_tag}" ]]; then
-		termux_error_exit "Unable to get tag from ${TERMUX_PKG_SRCURL}"
-	fi
-	termux_pkg_upgrade_version "0.0.0-${latest_tag}"
-}
 
 termux_step_pre_configure() {
 	export PATH="$NDK/shader-tools/linux-x86_64:$PATH"


### PR DESCRIPTION
llama.cpp have changed its versioning model to SemVer for stable releases, so we no longer need to implement a specific auto-update script for this package and package version can follow upstream.