### PR TITLE
enhance(main/7zip): enable auto-updates

### DIFF
--- a/packages/7zip/build.sh
+++ b/packages/7zip/build.sh
@@ -8,17 +8,17 @@ DOC/unRarLicense.txt
 "
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="26.02"
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=(
-	"https://www.7-zip.org/a/7z${TERMUX_PKG_VERSION//./}-src.tar.xz"
-	"https://www.7-zip.org/a/7z${TERMUX_PKG_VERSION//./}-linux-arm.tar.xz" # for manual, arm is smallest
+	"https://github.com/ip7z/7zip/releases/download/${TERMUX_PKG_VERSION}/7z${TERMUX_PKG_VERSION//./}-src.tar.xz"
+	"https://github.com/ip7z/7zip/releases/download/${TERMUX_PKG_VERSION}/7z${TERMUX_PKG_VERSION//./}-linux-arm.tar.xz" # for manual, arm is smallest
 )
 TERMUX_PKG_SHA256=(
 	cf967c98bca02a4b8b16375f441825a8e141362f14be1969bbec8e1ca0bff9dd
 	81b7f04b3528852fac10f5becf9f15870a5da4cb94fbcb8a138197eb937468bf
 )
 TERMUX_PKG_BUILD_DEPENDS="dos2unix"
-TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_CONFLICTS="p7zip"
 TERMUX_PKG_PROVIDES="p7zip"
@@ -27,7 +27,8 @@ TERMUX_PKG_REPLACES="p7zip"
 # The original "termux_extract_src_archive" always strips the first components
 # but the source of 7zip is directly under the root directory of the tar file
 termux_extract_src_archive() {
-	local file="$TERMUX_PKG_CACHEDIR/$(basename "$TERMUX_PKG_SRCURL")"
+	local file
+	file="$TERMUX_PKG_CACHEDIR/$(basename "$TERMUX_PKG_SRCURL")"
 	mkdir -p "$TERMUX_PKG_SRCDIR"
 	tar -xf "$file" -C "$TERMUX_PKG_SRCDIR"
 }
@@ -40,10 +41,8 @@ termux_step_post_get_source() {
 			. "$TERMUX_SCRIPTDIR/packages/dos2unix/build.sh"
 			. "$TERMUX_SCRIPTDIR/scripts/build/get_source/termux_unpack_src_archive.sh"
 			TERMUX_PKG_SRCDIR="$DOS2UNIX" termux_step_get_source
+			cd "$DOS2UNIX" && make dos2unix
 		)
-		pushd "$DOS2UNIX"
-		make dos2unix
-		popd # DOS2UNIX
 		export PATH="$DOS2UNIX:$PATH"
 	fi
 
@@ -58,12 +57,12 @@ termux_step_pre_configure() {
 }
 
 termux_step_make() {
-	local optim_args
+	local -a optim_args=()
 	case "$TERMUX_ARCH" in
-		x86_64)  optim_args='-f ../../cmpl_clang_x64.mak' ;;
-		i686)    optim_args='-f ../../cmpl_clang_x86.mak' ;;
-		arm)     optim_args='-f ../../cmpl_clang.mak PLATFORM=arm USE_ASM=1' ;;
-		aarch64) optim_args='-f ../../cmpl_clang_arm64.mak' ;;
+		aarch64) optim_args=("-f" "../../cmpl_clang_arm64.mak") ;;
+		arm)     optim_args=("-f" "../../cmpl_clang.mak" "PLATFORM=arm" "USE_ASM=1") ;;
+		i686)    optim_args=("-f" "../../cmpl_clang_x86.mak") ;;
+		x86_64)  optim_args=("-f" "../../cmpl_clang_x64.mak") ;;
 	esac
 
 	# from https://git.alpinelinux.org/aports/tree/community/7zip/APKBUILD?id=b4601c88f608662c75422311b7ca3c26fab4b1f4
@@ -74,7 +73,7 @@ termux_step_make() {
 			CC="$CC $CFLAGS $LDFLAGS -D_GNU_SOURCE" \
 			CXX="$CXX $CXXFLAGS $LDFLAGS -D_GNU_SOURCE" \
 			O=b/c \
-			$optim_args \
+			"${optim_args[@]}" \
 			--jobs "$TERMUX_PKG_MAKE_PROCESSES"
 	done
 }
@@ -95,6 +94,7 @@ termux_step_make_install() {
 	install -Dm0644 \
 		-t "$TERMUX_PREFIX"/share/doc/"$TERMUX_PKG_NAME" \
 		"$TERMUX_PKG_BUILDDIR"/DOC/{7zC,7zFormat,lzma,Methods,readme,src-history}.txt
+	# shellcheck disable=SC2031
 	tar -C "$TERMUX_PREFIX"/share/doc/"$TERMUX_PKG_NAME" \
 		-xvf "$TERMUX_PKG_CACHEDIR/$(basename "${TERMUX_PKG_SRCURL[1]}")" MANUAL
 	# Remove carriage returns from docs


### PR DESCRIPTION
Auto-updates were previously disabled for `7zip` in 59de609, we can work around the repology version problem mentioned in that commit by building from the source tarballs provided via the GitHub mirror of 7Zip.
See also: https://7-zip.org/links.html

I've also included some minor shellcheck warning cleanup while we're here.