### PR TITLE
Add mano package

### DIFF
--- a/packages/mano/build.sh
+++ b/packages/mano/build.sh
@@ -1,0 +1,19 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/46Neon/Mano_versi-n_c
+TERMUX_PKG_DESCRIPTION="Spanish-language data analysis tool for occupational safety and health statistics and preventive analysis"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@46Neon"
+TERMUX_PKG_VERSION=0.1.1
+TERMUX_PKG_SRCURL=https://codeload.github.com/46Neon/Mano_versi-n_c/legacy.tar.gz/refs/tags/v0.1.1
+TERMUX_PKG_SHA256=e79fa9b949ba81ac6f4f87a3951d36f93e331b246e5290aab62dc6e0dd214450
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make() {
+    make CC="$CC"
+}
+
+termux_step_make_install() {
+    install -Dm755 mano "$TERMUX_PREFIX/bin/mano"
+    install -Dm644 README.md "$TERMUX_PREFIX/share/doc/mano/README.md"
+    mkdir -p "$TERMUX_PREFIX/share/doc/mano/examples"
+    cp -R examples/. "$TERMUX_PREFIX/share/doc/mano/examples/"
+}


### PR DESCRIPTION
## Summary

Adds the `mano` package, a C17 command-line data analysis tool focused on occupational safety and health statistics and preventive analysis.

Package request: #31530

## Package details

- License: MIT
- Source version: 0.1.1
- No root privileges required
- Installs the `mano` executable into `$TERMUX_PREFIX/bin`
- Uses the upstream Makefile and Clang
- Source checksum is pinned in `packages/mano/build.sh`

## Validation

- Upstream C17 unit and integration tests pass.
- Synthetic-data analysis tests pass.
- SST modules are covered by tests.
- The package was built locally on Termux for aarch64.

The recipe is intentionally limited to packaging; it does not modify the upstream project code.