### PR TITLE
fix(main/flint): prepend `@TERMUX_PREFIX@` to instance of absolute path `/tmp`

### DIFF
--- a/packages/flint/build.sh
+++ b/packages/flint/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="C library for doing number theory"
 TERMUX_PKG_LICENSE="LGPL-3.0-only"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="3.6.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/flintlib/flint/releases/download/v$TERMUX_PKG_VERSION/flint-$TERMUX_PKG_VERSION.tar.gz"
 TERMUX_PKG_SHA256=b95e2c7792f5eea4a1c8d2d42c4098434756832e57a094b295eb5dfdc9b4c36b
 TERMUX_PKG_DEPENDS="blas-openblas, libgmp, libmpfr"

--- a/packages/flint/prepend-prefix-to-tmpdir.patch
+++ b/packages/flint/prepend-prefix-to-tmpdir.patch
@@ -1,0 +1,11 @@
+--- a/src/qsieve/factor.c
++++ b/src/qsieve/factor.c
+@@ -234,7 +234,7 @@ void qsieve_factor_with_tune(fmpz_factor_t factors, const fmpz_t n,
+     if (qs_inf->siqs == NULL)
+         flint_throw(FLINT_ERROR, "fopen failed\n");
+ #else
+-    strcpy(qs_inf->fname, "/tmp/siqsXXXXXX"); /* must be shorter than fname_alloc_size in init.c */
++    strcpy(qs_inf->fname, "@TERMUX_PREFIX@/tmp/siqsXXXXXX"); /* must be shorter than fname_alloc_size in init.c */
+     fd = mkstemp(qs_inf->fname);
+     if (fd == -1)
+         flint_throw(FLINT_ERROR, "mkstemp failed\n");


### PR DESCRIPTION
- Fixes https://github.com/termux/termux-packages/issues/31536