### PR TITLE
addpkg(root/dislocker): 2026.08.31

### DIFF
--- a/root-packages/dislocker/android-link-libiconv.patch
+++ b/root-packages/dislocker/android-link-libiconv.patch
@@ -1,0 +1,14 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index b8dfdd7..c73750e 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -89,6 +89,9 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+ 	# Don't use `-read_only_relocs' here as it seems to only work for 32 bits
+ 	# binaries
+ 	set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-bind_at_load")
++endif()
++
++if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin" OR "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
+ 	# Library for libiconv
+ 	set (LIB ${LIB} iconv)
+ else()

--- a/root-packages/dislocker/build.sh
+++ b/root-packages/dislocker/build.sh
@@ -1,0 +1,37 @@
+TERMUX_PKG_HOMEPAGE="https://github.com/Aorimn/dislocker"
+TERMUX_PKG_DESCRIPTION="Tool for accessing BitLocker-encrypted volumes"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="Infiniti151 <43163551+Infiniti151@users.noreply.github.com>"
+TERMUX_PKG_SRCURL="git+https://github.com/Aorimn/dislocker"
+TERMUX_PKG_GIT_BRANCH="master"
+_COMMIT="0706462db88efe8df88150e4c3e4332b808f4581"
+TERMUX_PKG_VERSION="2026.08.31"
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="libfuse3, libiconv, mbedtls, ruby"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DRuby_INCLUDE_DIR=$TERMUX_PREFIX/include/ruby-4.0.0
+-DRuby_CONFIG_INCLUDE_DIR=$TERMUX_PREFIX/include/ruby-4.0.0/$TERMUX_HOST_PLATFORM
+-DRuby_LIBRARY=$TERMUX_PREFIX/lib/libruby.so
+-DWITH_RUBY=ON
+"
+
+termux_step_post_get_source() {
+	git fetch --unshallow || git fetch
+	git checkout "$_COMMIT"
+
+	local version="$(git log -1 --format=%cs | sed 's/-/./g')"
+	if [ "$version" != "$TERMUX_PKG_VERSION" ]; then
+		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
+		echo " is different from what is expected to be: \"$version\""
+		return 1
+	fi
+}
+
+termux_step_pre_configure() {
+	# Dislocker's CMake configuration expects man pages to be available for
+	# the selected target. The source tree does not provide an Android
+	# man-page directory, so reuse the existing man pages to satisfy CMake
+	# when building for Android.
+	mkdir -p "$TERMUX_PKG_SRCDIR/man/android"
+	cp "$TERMUX_PKG_SRCDIR/man/linux/"*.1 "$TERMUX_PKG_SRCDIR/man/android/" 2>/dev/null || true
+}

--- a/root-packages/dislocker/remove-cmake-source-dir-guard.patch
+++ b/root-packages/dislocker/remove-cmake-source-dir-guard.patch
@@ -1,0 +1,15 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index b8dfdd7..63ce251 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -17,10 +17,6 @@
+ # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ # USA.
+ 
+-if("${CMAKE_SOURCE_DIR}" MATCHES "src/?$")
+-	message(FATAL_ERROR "\nPlease execute cmake from the directory above, not the src/ directory.")
+-	return()
+-endif()
+ 
+ # On OSX, frameworks are found before installed libraries (cf. https://gitlab.kitware.com/cmake/cmake/-/issues/16427)
+ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")

--- a/root-packages/dislocker/use-pkg-config-for-mbedtls.patch
+++ b/root-packages/dislocker/use-pkg-config-for-mbedtls.patch
@@ -1,0 +1,21 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index b8dfdd7..15810c3 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -217,12 +217,13 @@ add_library(dislocker_crypto_backend INTERFACE)
+ 
+ message(STATUS "Crypto backend: ${CRYPTO_BACKEND}")
+ if(CRYPTO_BACKEND STREQUAL "mbedtls")
+-  find_package (MbedTLS 3 REQUIRED)
++  find_package(PkgConfig REQUIRED)
++  pkg_check_modules(MBEDCRYPTO REQUIRED IMPORTED_TARGET mbedcrypto)
+   target_link_libraries(${PROJECT_NAME}
+     PRIVATE
+-      MbedTLS::mbedcrypto
++      PkgConfig::MBEDCRYPTO
+   )
+-  target_link_libraries(dislocker_crypto_backend INTERFACE MbedTLS::mbedcrypto)
++  target_link_libraries(dislocker_crypto_backend INTERFACE PkgConfig::MBEDCRYPTO)
+   target_include_directories(${PROJECT_NAME}
+     PUBLIC
+     ${CMAKE_SOURCE_DIR}/include/${PROJECT_NAME}/encryption/mbedtls


### PR DESCRIPTION
## Description

Add [dislocker](https://github.com/Aorimn/dislocker), a tool for accessing BitLocker-encrypted volumes.

### Changes

* Package Dislocker `2026.08.31` from upstream commit `0706462db88efe8df88150e4c3e4332b808f4581`.
* Add `libfuse3`, `libiconv`, and `mbedtls` runtime dependencies.
* Add Android-specific patches to:

  * Link against Termux's standalone `libiconv` on Android.
  * Use `pkg-config` for MbedTLS instead of its CMake package configuration, which references unavailable static libraries.
  * Remove Dislocker's CMake source-directory guard that is incompatible with the Termux build system.
* Provide the existing man pages under the Android target directory to satisfy Dislocker's CMake configuration.

Ruby bindings are disabled automatically when the required Ruby development files are unavailable.
