### PR TITLE
addpkg(main/pnpm): 12.3.4

### DIFF
--- a/packages/pnpm/build.sh
+++ b/packages/pnpm/build.sh
@@ -1,0 +1,52 @@
+TERMUX_PKG_HOMEPAGE=https://pnpm.io
+TERMUX_PKG_DESCRIPTION="Fast, disk space efficient package manager for JavaScript"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
+TERMUX_PKG_VERSION="12.3.4"
+TERMUX_PKG_SRCURL="https://github.com/pnpm/pnpm/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=4f400669b36259278efe44278e4adfc7f449fbccb4c255670c66332a7a792aa1
+TERMUX_PKG_DEPENDS="git, nodejs | nodejs-lts"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+
+termux_step_pre_configure() {
+	termux_setup_rust
+
+	# The workspace pins an exact toolchain via rust-toolchain.toml
+	# Termux's rust package is generally newer and
+	# perfectly capable of building this, but rustup would otherwise try
+	# to fetch/switch to that exact pinned version. Drop the pin so the
+	# toolchain rustup/termux_setup_rust already configured (with the
+	# Android target already added) is used instead.
+	rm -f rust-toolchain.toml rust-toolchain
+
+	if [[ "$TERMUX_ARCH" == "i686" ]]; then
+		local patch="$TERMUX_PKG_BUILDER_DIR/sha2-no-asm.diff"
+		echo "Applying patch: $(basename "$patch")"
+		patch -p1 < "$patch"
+	fi
+}
+
+termux_step_make_install() {
+	local CARGO_DEBUG_FLAG=''
+	if [[ "$TERMUX_DEBUG_BUILD" == "true" ]]; then
+		CARGO_DEBUG_FLAG='--debug'
+	fi
+
+	cargo install \
+		--path pnpm/crates/cli \
+		--bin pnpm \
+		--jobs "$TERMUX_PKG_MAKE_PROCESSES" \
+		--force \
+		--locked \
+		--no-track \
+		--target "$CARGO_TARGET_NAME" \
+		--root "$TERMUX_PREFIX" \
+		$CARGO_DEBUG_FLAG
+}
+
+termux_step_post_make_install() {
+	# cargo install also drops a .crates.toml/.crates2.json receipt in
+	# $TERMUX_PREFIX - not wanted in the package.
+	rm -f "${TERMUX_PREFIX}/.crates.toml" "${TERMUX_PREFIX}/.crates2.json"
+}

--- a/packages/pnpm/sha2-no-asm.diff
+++ b/packages/pnpm/sha2-no-asm.diff
@@ -1,0 +1,22 @@
+--- a/pnpm/crates/crypto-hash/Cargo.toml
++++ b/pnpm/crates/crypto-hash/Cargo.toml
+@@ -18,7 +18,7 @@ ssri   = { workspace = true }
+ # Match pnpm-store-dir's MSVC-aware feature gate so this crate
+ # inherits the `asm` backend on every target where it compiles.
+ [target.'cfg(not(target_env = "msvc"))'.dependencies]
+-sha2 = { workspace = true, features = ["asm"] }
++sha2 = { workspace = true }
+ 
+ [dev-dependencies]
+ tempfile = { workspace = true }
+--- a/pnpm/crates/store-dir/Cargo.toml
++++ b/pnpm/crates/store-dir/Cargo.toml
+@@ -42,7 +42,7 @@ url           = { workspace = true }
+ # Non-MSVC Windows (e.g. windows-gnu via mingw) would work, but we
+ # build with MSVC in CI so gate it off there specifically.
+ [target.'cfg(not(target_env = "msvc"))'.dependencies]
+-sha2 = { workspace = true, features = ["asm"] }
++sha2 = { workspace = true }
+ 
+ [dev-dependencies]
+ pipe-trait        = { workspace = true }


### PR DESCRIPTION
Reason behind adding this:

```shell
~ $ pnpm -V
Downloading the pnpm 12.3.4 binary for android-arm64...
Could not download the pnpm 12.3.4 binary: Sorry! pnpm does not provide a pre-built binary for android.
```