### PR TITLE
ci(packages): use github action job queue system

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -32,6 +32,8 @@ concurrency:
   group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_id }}
   # only cancel in-progress when it’s a PR
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # invalid when cancel-in-progress: true and queue: max
+  queue: ${{ github.event_name == 'pull_request' && 'single' || 'max' }}
 
 jobs:
   build:


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-queueing-multiple-pending-runs-1

This changes from outstanding upload jobs outright canceled to being queued, up to 100 jobs, while waiting one upload job to finish

Fix "upload: Canceling since a higher priority waiting request for Packages exists"

Latest example: https://github.com/termux/termux-packages/actions/runs/34314117823/attempts/1