### PR TITLE
Add shell completions for some packages 

### DIFF
--- a/packages/bacon/build.sh
+++ b/packages/bacon/build.sh
@@ -3,7 +3,8 @@ TERMUX_PKG_DESCRIPTION="A background code checker for Rust, designed for minimal
 TERMUX_PKG_LICENSE="AGPL-3.0"
 TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
 TERMUX_PKG_VERSION="3.25.0"
-TERMUX_PKG_SRCURL=https://github.com/Canop/bacon/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://github.com/Canop/bacon/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=6657e968d189dd5c165dd6c9b97f667140baea87d126d765a2d5f1e97b007b26
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -20,4 +21,12 @@ termux_step_make_install() {
 	install -Dm755 \
 		"target/${CARGO_TARGET_NAME}/release/bacon" \
 		"$TERMUX_PREFIX/bin/bacon"
+
+	mkdir -p "${TERMUX_PREFIX}/share/bash-completion/completions"
+	mkdir -p "${TERMUX_PREFIX}/share/zsh/site-functions"
+	mkdir -p "${TERMUX_PREFIX}/share/fish/vendor_completions.d"
+
+	COMPLETE=bash cargo run --release > "${TERMUX_PREFIX}/share/bash-completion/completions/bacon"
+	COMPLETE=zsh  cargo run --release > "${TERMUX_PREFIX}/share/zsh/site-functions/_bacon"
+	COMPLETE=fish cargo run --release > "${TERMUX_PREFIX}/share/fish/vendor_completions.d/bacon.fish"
 }

--- a/packages/gitleaks/build.sh
+++ b/packages/gitleaks/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Detect secrets like passwords, API keys, and tokens in g
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
 TERMUX_PKG_VERSION="8.30.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/gitleaks/gitleaks/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=e90fb266d75837e75894c778bf594ab8e2787f12dce5a62651f21b893eaf9abb
 TERMUX_PKG_AUTO_UPDATE=true
@@ -20,4 +21,14 @@ termux_step_make() {
 
 termux_step_make_install() {
 	install -Dm755 gitleaks "$TERMUX_PREFIX/bin/gitleaks"
+
+	mkdir -p "${TERMUX_PREFIX}/share/bash-completion/completions"
+	mkdir -p "${TERMUX_PREFIX}/share/zsh/site-functions"
+	mkdir -p "${TERMUX_PREFIX}/share/fish/vendor_completions.d"
+
+	unset GOOS GOARCH CGO_LDFLAGS
+	unset CC CXX CFLAGS CXXFLAGS LDFLAGS
+	go run . completion bash > "${TERMUX_PREFIX}/share/bash-completion/completions/gitleaks"
+	go run . completion zsh  > "${TERMUX_PREFIX}/share/zsh/site-functions/_gitleaks"
+	go run . completion fish > "${TERMUX_PREFIX}/share/fish/vendor_completions.d/gitleaks.fish"
 }

--- a/packages/go-task/build.sh
+++ b/packages/go-task/build.sh
@@ -3,7 +3,8 @@ TERMUX_PKG_DESCRIPTION="A task runner / simpler Make alternative written in Go"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
 TERMUX_PKG_VERSION="3.53.1"
-TERMUX_PKG_SRCURL=https://github.com/go-task/task/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://github.com/go-task/task/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=dd22395f4548ba58bc3adf83cb9ce33f1c5fad7e7c5f0a229bb2709af439fa9a
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -19,4 +20,17 @@ termux_step_make() {
 
 termux_step_make_install() {
 	install -Dm755 task "$TERMUX_PREFIX/bin/go-task"
+
+	mkdir -p "${TERMUX_PREFIX}/share/bash-completion/completions"
+	mkdir -p "${TERMUX_PREFIX}/share/zsh/site-functions"
+	mkdir -p "${TERMUX_PREFIX}/share/fish/vendor_completions.d"
+
+	unset GOOS GOARCH CGO_LDFLAGS
+	unset CC CXX CFLAGS CXXFLAGS LDFLAGS
+	# the binary is installed as "go-task" (not "task"), TASK_EXE tells it
+	# what name to bake into the generated completion scripts
+	export TASK_EXE=go-task
+	go run ./cmd/task --completion bash > "${TERMUX_PREFIX}/share/bash-completion/completions/go-task"
+	go run ./cmd/task --completion zsh  > "${TERMUX_PREFIX}/share/zsh/site-functions/_go-task"
+	go run ./cmd/task --completion fish > "${TERMUX_PREFIX}/share/fish/vendor_completions.d/go-task.fish"
 }

--- a/packages/golangci-lint/build.sh
+++ b/packages/golangci-lint/build.sh
@@ -3,7 +3,8 @@ TERMUX_PKG_DESCRIPTION="Fast linters runner for Go, aggregating many Go linters 
 TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
 TERMUX_PKG_VERSION="2.13.2"
-TERMUX_PKG_SRCURL=https://github.com/golangci/golangci-lint/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://github.com/golangci/golangci-lint/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=a79a7a1faad9c1538e3f7f8b32843a53bbeedfa9ead45d9e8ca3bb210d55ece0
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -21,4 +22,14 @@ termux_step_make() {
 termux_step_make_install() {
 	install -Dm755 golangci-lint "$TERMUX_PREFIX/bin/golangci-lint"
 	install -Dm644 README.md "$TERMUX_PREFIX/share/doc/golangci-lint/README.md"
+
+	mkdir -p "${TERMUX_PREFIX}/share/bash-completion/completions"
+	mkdir -p "${TERMUX_PREFIX}/share/zsh/site-functions"
+	mkdir -p "${TERMUX_PREFIX}/share/fish/vendor_completions.d"
+
+	unset GOOS GOARCH CGO_LDFLAGS
+	unset CC CXX CFLAGS CXXFLAGS LDFLAGS
+	go run ./cmd/golangci-lint completion bash > "${TERMUX_PREFIX}/share/bash-completion/completions/golangci-lint"
+	go run ./cmd/golangci-lint completion zsh  > "${TERMUX_PREFIX}/share/zsh/site-functions/_golangci-lint"
+	go run ./cmd/golangci-lint completion fish > "${TERMUX_PREFIX}/share/fish/vendor_completions.d/golangci-lint.fish"
 }

--- a/packages/goreleaser/build.sh
+++ b/packages/goreleaser/build.sh
@@ -3,7 +3,8 @@ TERMUX_PKG_DESCRIPTION="Deliver Go binaries as fast and easily as possible"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
 TERMUX_PKG_VERSION="2.18.1"
-TERMUX_PKG_SRCURL=https://github.com/goreleaser/goreleaser/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://github.com/goreleaser/goreleaser/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=5f47712f272842b1b51f599403a266e1a304b9689cfb31da22bd279c79af5afc
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -20,6 +21,17 @@ termux_step_make() {
 		-o goreleaser \
 		.
 }
+
 termux_step_make_install() {
 	install -Dm755 goreleaser "$TERMUX_PREFIX/bin/goreleaser"
+
+	mkdir -p "${TERMUX_PREFIX}/share/bash-completion/completions"
+	mkdir -p "${TERMUX_PREFIX}/share/zsh/site-functions"
+	mkdir -p "${TERMUX_PREFIX}/share/fish/vendor_completions.d"
+
+	unset GOOS GOARCH CGO_LDFLAGS
+	unset CC CXX CFLAGS CXXFLAGS LDFLAGS
+	go run . completion bash > "${TERMUX_PREFIX}/share/bash-completion/completions/goreleaser"
+	go run . completion zsh  > "${TERMUX_PREFIX}/share/zsh/site-functions/_goreleaser"
+	go run . completion fish > "${TERMUX_PREFIX}/share/fish/vendor_completions.d/goreleaser.fish"
 }

--- a/packages/gtrash/build.sh
+++ b/packages/gtrash/build.sh
@@ -3,7 +3,8 @@ TERMUX_PKG_DESCRIPTION="A featureful trash CLI manager, alternative to rm and tr
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
 TERMUX_PKG_VERSION="0.0.6"
-TERMUX_PKG_SRCURL=https://github.com/umlx5h/gtrash/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://github.com/umlx5h/gtrash/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=66003276073d9da03cbb4347a4b161f89c81f3706012b77c3e91a154c91f3586
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -19,4 +20,14 @@ termux_step_make() {
 
 termux_step_make_install() {
 	install -Dm755 gtrash "$TERMUX_PREFIX/bin/gtrash"
+
+	mkdir -p "${TERMUX_PREFIX}/share/bash-completion/completions"
+	mkdir -p "${TERMUX_PREFIX}/share/zsh/site-functions"
+	mkdir -p "${TERMUX_PREFIX}/share/fish/vendor_completions.d"
+
+	unset GOOS GOARCH CGO_LDFLAGS
+	unset CC CXX CFLAGS CXXFLAGS LDFLAGS
+	go run . completion bash > "${TERMUX_PREFIX}/share/bash-completion/completions/gtrash"
+	go run . completion zsh  > "${TERMUX_PREFIX}/share/zsh/site-functions/_gtrash"
+	go run . completion fish > "${TERMUX_PREFIX}/share/fish/vendor_completions.d/gtrash.fish"
 }

--- a/packages/iredis/build.sh
+++ b/packages/iredis/build.sh
@@ -3,8 +3,8 @@ TERMUX_PKG_DESCRIPTION="Interactive CLI for Redis with auto-completion and synta
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
 TERMUX_PKG_VERSION="1.16.1"
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://github.com/laixintao/iredis/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_REVISION=2
+TERMUX_PKG_SRCURL="https://github.com/laixintao/iredis/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=c9d6794b21eaa78a5647e0d2b98907a31d0243728290a80ca2937efd09ee07bb
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="python, python-pip"
@@ -17,4 +17,20 @@ termux_step_make() {
 
 termux_step_make_install() {
 	cross-pip install --no-deps --prefix="$TERMUX_PREFIX" "$TERMUX_PKG_SRCDIR"
+}
+
+termux_step_create_debscripts() {
+	cat <<-EOF >./postinst
+	#!${TERMUX_PREFIX}/bin/sh
+	_IREDIS_COMPLETE=bash_source iredis > "${TERMUX_PREFIX}/share/bash-completion/completions/iredis"
+	_IREDIS_COMPLETE=zsh_source  iredis > "${TERMUX_PREFIX}/share/zsh/site-functions/_iredis"
+	_IREDIS_COMPLETE=fish_source iredis > "${TERMUX_PREFIX}/share/fish/vendor_completions.d/iredis.fish"
+	EOF
+
+	cat <<-EOF >./prerm
+	#!${TERMUX_PREFIX}/bin/sh
+	rm -f "${TERMUX_PREFIX}/share/bash-completion/completions/iredis"
+	rm -f "${TERMUX_PREFIX}/share/zsh/site-functions/_iredis"
+	rm -f "${TERMUX_PREFIX}/share/fish/vendor_completions.d/iredis.fish"
+	EOF
 }

--- a/packages/litecli/build.sh
+++ b/packages/litecli/build.sh
@@ -1,11 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://litecli.com
 TERMUX_PKG_DESCRIPTION="CLI for SQLite databases with auto-completion and syntax highlighting"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
-TERMUX_PKG_LICENSE_FILE="LICENSE"
 TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
 TERMUX_PKG_VERSION="1.17.1"
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://github.com/dbcli/litecli/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_REVISION=2
+TERMUX_PKG_SRCURL="https://github.com/dbcli/litecli/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=f02a1014add7c581e4ee720a146005d3099d561d2079f2d7c850977e6ac35a4c
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="python, python-pip"
@@ -21,4 +20,20 @@ termux_step_make_install() {
 	# version on its own; pin it explicitly to TERMUX_PKG_VERSION.
 	export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LITECLI="$TERMUX_PKG_VERSION"
 	cross-pip install --no-deps --prefix="$TERMUX_PREFIX" "$TERMUX_PKG_SRCDIR"
+}
+
+termux_step_create_debscripts() {
+	cat <<-EOF >./postinst
+	#!${TERMUX_PREFIX}/bin/sh
+	_LITECLI_COMPLETE=bash_source litecli > "${TERMUX_PREFIX}/share/bash-completion/completions/litecli"
+	_LITECLI_COMPLETE=zsh_source  litecli > "${TERMUX_PREFIX}/share/zsh/site-functions/_litecli"
+	_LITECLI_COMPLETE=fish_source litecli > "${TERMUX_PREFIX}/share/fish/vendor_completions.d/litecli.fish"
+	EOF
+
+	cat <<-EOF >./prerm
+	#!${TERMUX_PREFIX}/bin/sh
+	rm -f "${TERMUX_PREFIX}/share/bash-completion/completions/litecli"
+	rm -f "${TERMUX_PREFIX}/share/zsh/site-functions/_litecli"
+	rm -f "${TERMUX_PREFIX}/share/fish/vendor_completions.d/litecli.fish"
+	EOF
 }

--- a/packages/mycli/build.sh
+++ b/packages/mycli/build.sh
@@ -1,10 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://mycli.net
 TERMUX_PKG_DESCRIPTION="CLI for MySQL/MariaDB with auto-completion and syntax highlighting"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
-TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
 TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
 TERMUX_PKG_VERSION="2.23.0"
-TERMUX_PKG_SRCURL=https://github.com/dbcli/mycli/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://github.com/dbcli/mycli/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=93487d1e532099b1d4289fee23abff373e216a85faa30a58f04a2086e853bf50
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_DEPENDS="python, python-pip, python-cryptography, python-pycryptodomex"
@@ -21,4 +21,20 @@ termux_step_make_install() {
 	# version on its own; pin it explicitly to TERMUX_PKG_VERSION.
 	export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_MYCLI="$TERMUX_PKG_VERSION"
 	cross-pip install --no-deps --prefix="$TERMUX_PREFIX" "$TERMUX_PKG_SRCDIR"
+}
+
+termux_step_create_debscripts() {
+	cat <<-EOF >./postinst
+	#!${TERMUX_PREFIX}/bin/sh
+	_MYCLI_COMPLETE=bash_source mycli > "${TERMUX_PREFIX}/share/bash-completion/completions/mycli"
+	_MYCLI_COMPLETE=zsh_source  mycli > "${TERMUX_PREFIX}/share/zsh/site-functions/_mycli"
+	_MYCLI_COMPLETE=fish_source mycli > "${TERMUX_PREFIX}/share/fish/vendor_completions.d/mycli.fish"
+	EOF
+
+	cat <<-EOF >./prerm
+	#!${TERMUX_PREFIX}/bin/sh
+	rm -f "${TERMUX_PREFIX}/share/bash-completion/completions/mycli"
+	rm -f "${TERMUX_PREFIX}/share/zsh/site-functions/_mycli"
+	rm -f "${TERMUX_PREFIX}/share/fish/vendor_completions.d/mycli.fish"
+	EOF
 }

--- a/packages/pgcli/build.sh
+++ b/packages/pgcli/build.sh
@@ -1,10 +1,10 @@
 TERMUX_PKG_HOMEPAGE=https://www.pgcli.com
 TERMUX_PKG_DESCRIPTION="Postgres CLI with autocompletion and syntax highlighting"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
-TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
 TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
 TERMUX_PKG_VERSION="4.6.0"
-TERMUX_PKG_SRCURL=https://github.com/dbcli/pgcli/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://github.com/dbcli/pgcli/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=33dbae8a3fc1608edc12b257ed4e065adf63d5ab9c849906247428f471cd7895
 TERMUX_PKG_AUTO_UPDATE=true
 # pgcli only pushes git tags, it doesn't publish GitHub Releases, so the
@@ -23,4 +23,20 @@ termux_step_make_install() {
 	# version on its own; pin it explicitly to TERMUX_PKG_VERSION.
 	export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PGCLI="$TERMUX_PKG_VERSION"
 	cross-pip install --no-deps --prefix="$TERMUX_PREFIX" "$TERMUX_PKG_SRCDIR"
+}
+
+termux_step_create_debscripts() {
+	cat <<-EOF >./postinst
+	#!${TERMUX_PREFIX}/bin/sh
+	_PGCLI_COMPLETE=bash_source pgcli > "${TERMUX_PREFIX}/share/bash-completion/completions/pgcli"
+	_PGCLI_COMPLETE=zsh_source  pgcli > "${TERMUX_PREFIX}/share/zsh/site-functions/_pgcli"
+	_PGCLI_COMPLETE=fish_source pgcli > "${TERMUX_PREFIX}/share/fish/vendor_completions.d/pgcli.fish"
+	EOF
+
+	cat <<-EOF >./prerm
+	#!${TERMUX_PREFIX}/bin/sh
+	rm -f "${TERMUX_PREFIX}/share/bash-completion/completions/pgcli"
+	rm -f "${TERMUX_PREFIX}/share/zsh/site-functions/_pgcli"
+	rm -f "${TERMUX_PREFIX}/share/fish/vendor_completions.d/pgcli.fish"
+	EOF
 }

--- a/packages/sqlc/build.sh
+++ b/packages/sqlc/build.sh
@@ -3,7 +3,8 @@ TERMUX_PKG_DESCRIPTION="Generate type-safe code from SQL"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
 TERMUX_PKG_VERSION="1.31.1"
-TERMUX_PKG_SRCURL=https://github.com/sqlc-dev/sqlc/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://github.com/sqlc-dev/sqlc/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
 TERMUX_PKG_SHA256=de82593a200e4130dc2a0413a808f93fc30fdc7b5ecd402913ed08a8fea06c4a
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -22,4 +23,15 @@ termux_step_make() {
 
 termux_step_make_install() {
 	install -Dm755 sqlc "$TERMUX_PREFIX/bin/sqlc"
+
+	mkdir -p "${TERMUX_PREFIX}/share/bash-completion/completions"
+	mkdir -p "${TERMUX_PREFIX}/share/zsh/site-functions"
+	mkdir -p "${TERMUX_PREFIX}/share/fish/vendor_completions.d"
+
+	unset GOOS GOARCH CGO_LDFLAGS
+	unset CC CXX CFLAGS CXXFLAGS LDFLAGS
+	export CGO_CFLAGS="-D_GNU_SOURCE"
+	go run ./cmd/sqlc completion bash > "${TERMUX_PREFIX}/share/bash-completion/completions/sqlc"
+	go run ./cmd/sqlc completion zsh  > "${TERMUX_PREFIX}/share/zsh/site-functions/_sqlc"
+	go run ./cmd/sqlc completion fish > "${TERMUX_PREFIX}/share/fish/vendor_completions.d/sqlc.fish"
 }


### PR DESCRIPTION
- [`iredis`](https://github.com/GourangaDasSamrat/termux-packages/tree/add-shell-completions/packages/iredis)
- [`pgcli`](https://github.com/GourangaDasSamrat/termux-packages/tree/add-shell-completions/packages/pgcli)
- [`mycli`](https://github.com/GourangaDasSamrat/termux-packages/tree/add-shell-completions/packages/mycli)
- [`litecli`](https://github.com/GourangaDasSamrat/termux-packages/tree/add-shell-completions/packages/litecli)
- [`go-task`](https://github.com/GourangaDasSamrat/termux-packages/tree/add-shell-completions/packages/go-task)
- [`bacon`](https://github.com/GourangaDasSamrat/termux-packages/tree/add-shell-completions/packages/bacon)
- [`golangci-lint`](https://github.com/GourangaDasSamrat/termux-packages/tree/add-shell-completions/packages/golangci-lint)
- [`gtrash`](https://github.com/GourangaDasSamrat/termux-packages/tree/add-shell-completions/packages/gtrash)
- [`sqlc`](https://github.com/GourangaDasSamrat/termux-packages/tree/add-shell-completions/packages/sqlc)
- [`gitleaks`](https://github.com/GourangaDasSamrat/termux-packages/tree/add-shell-completions/packages/gitleaks)
- [`goreleaser`](https://github.com/GourangaDasSamrat/termux-packages/tree/add-shell-completions/packages/goreleaser)
