### PR TITLE
fix(scripts/updates/utils/termux_pkg_is_update_needed): exit after printing --help

### DIFF
--- a/scripts/updates/utils/termux_pkg_is_update_needed.sh
+++ b/scripts/updates/utils/termux_pkg_is_update_needed.sh
@@ -39,6 +39,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 				<second-version> - second version to compare
 				[version-regex] - optional regular expression to filter version numbers from given versions
 		EOF
+		exit 0
 	fi
 
 	# Print in human readable format.


### PR DESCRIPTION
I ran `scripts/bin/apt-compare-versions --help` and noticed it doesn't stop after printing the usage text. Execution falls through to the comparison code with `--help` as the first version and an empty second version, so the output ends with an error and the exit status is 1:

```
$ scripts/bin/apt-compare-versions --help; echo "exit=$?"
Usage: apt-compare-versions [--help] <first-version> <second-version>] [version-regex]
--help - show this help message and exit
<first-version> - first version to compare
<second-version> - second version to compare
[version-regex] - optional regular expression to filter version numbers from given versions
ERROR: scripts/bin/apt-compare-versions: at least 2 arguments expected
exit=1
```

The help text itself says "show this help message and exit", so I added `exit 0` right after the heredoc. With the change, `--help` prints the usage and exits 0 without the error line.

The change only lives inside the `--help` branch. I also checked the normal path against a real `dpkg` and it behaves the same as before: `1.0 1.1` gives `1.0 < 1.1`, `2.0 1.9` gives `2.0 > 1.9`, `1.0 1.0` gives `1.0 = 1.0`, and `v1.2.3 v1.2.4 '[0-9.]+'` gives `1.2.3 < 1.2.4`, all with exit 0.

AI tools used
